### PR TITLE
Refactor: Rename ComparableVersion to ComparableBuildVersion

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -28,7 +28,7 @@ const DefaultImportPartitions = 16
 const DefaultImportPartitionsServerless = 6
 
 // firstVersionToSupportCollections represents the earliest Sync Gateway release that supports collections.
-var firstVersionToSupportCollections = &ComparableVersion{
+var firstVersionToSupportCollections = &ComparableBuildVersion{
 	epoch: 0,
 	major: 3,
 	minor: 1,
@@ -38,7 +38,7 @@ var firstVersionToSupportCollections = &ComparableVersion{
 // nodeExtras is the contents of the JSON value of the cbgt.NodeDef.Extras field as used by Sync Gateway.
 type nodeExtras struct {
 	// Version is the node's version.
-	Version *ComparableVersion `json:"v"`
+	Version *ComparableBuildVersion `json:"v"`
 }
 
 // CbgtContext holds the two handles we have for CBGT-related functionality.
@@ -376,7 +376,7 @@ func (c *CbgtContext) StartManager(ctx context.Context, dbName string, configGro
 
 // getNodeVersion returns the version of the node from its Extras field, or nil if none is stored. Returns an error if
 // the extras could not be parsed.
-func getNodeVersion(def *cbgt.NodeDef) (*ComparableVersion, error) {
+func getNodeVersion(def *cbgt.NodeDef) (*ComparableBuildVersion, error) {
 	if len(def.Extras) == 0 {
 		return nil, nil
 	}
@@ -388,7 +388,7 @@ func getNodeVersion(def *cbgt.NodeDef) (*ComparableVersion, error) {
 }
 
 // getMinNodeVersion returns the version of the oldest node currently in the cluster.
-func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableVersion, error) {
+func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableBuildVersion, error) {
 	nodes, _, err := cbgt.CfgGetNodeDefs(cfg, cbgt.NODE_DEFS_KNOWN)
 	if err != nil {
 		return nil, err
@@ -397,14 +397,14 @@ func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableVersion, error) {
 		// If there are no nodes at all, it's likely we're the first node in the cluster.
 		return ProductVersion, nil
 	}
-	var minVersion *ComparableVersion
+	var minVersion *ComparableBuildVersion
 	for _, node := range nodes.NodeDefs {
 		nodeVersion, err := getNodeVersion(node)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get version of node %v: %w", MD(node.HostPort).Redact(), err)
 		}
 		if nodeVersion == nil {
-			nodeVersion = zeroComparableVersion()
+			nodeVersion = zeroComparableBuildVersion()
 		}
 		if minVersion == nil || nodeVersion.Less(minVersion) {
 			minVersion = nodeVersion

--- a/base/version.go
+++ b/base/version.go
@@ -27,7 +27,7 @@ const (
 // populated via init() below
 var (
 	// ProductVersion describes the specific version information of the build.
-	ProductVersion *ComparableVersion
+	ProductVersion *ComparableBuildVersion
 
 	// VersionString appears in the "Server:" header of HTTP responses.
 	// CBL 1.x parses the header to determine whether it's talking to Sync Gateway (vs. CouchDB) and what version.
@@ -109,7 +109,7 @@ func init() {
 	editionStr = productEditionShortName
 
 	var err error
-	ProductVersion, err = NewComparableVersion(majorStr, minorStr, patchStr, otherStr, buildStr, editionStr)
+	ProductVersion, err = NewComparableBuildVersion(majorStr, minorStr, patchStr, otherStr, buildStr, editionStr)
 	if err != nil {
 		panic(err)
 	}

--- a/base/version_comparable_build.go
+++ b/base/version_comparable_build.go
@@ -15,22 +15,22 @@ import (
 )
 
 const (
-	// comparableVersionEpoch can be incremented when the versioning system or string format changes, whilst maintaining ordering.
+	// comparableBuildVersionEpoch can be incremented when the versioning system or string format changes, whilst maintaining ordering.
 	// i.e. It's a version number version
 	// e.g: version system change from semver to dates: 0:30.2.1@45-EE < 1:22-3-25@33-EE
-	comparableVersionEpoch = 0
+	comparableBuildVersionEpoch = 0
 )
 
-// ComparableVersion is an [epoch:]major.minor.patch[.other][@build][-edition] version that has methods to reliably extract information.
-type ComparableVersion struct {
+// ComparableBuildVersion is an [epoch:]major.minor.patch[.other][@build][-edition] version that has methods to reliably extract information.
+type ComparableBuildVersion struct {
 	epoch, major, minor, patch, other uint8
 	build                             uint16
 	edition                           productEdition
 	str                               string
 }
 
-func zeroComparableVersion() *ComparableVersion {
-	v := &ComparableVersion{
+func zeroComparableBuildVersion() *ComparableBuildVersion {
+	v := &ComparableBuildVersion{
 		epoch:   0,
 		major:   0,
 		minor:   0,
@@ -39,18 +39,18 @@ func zeroComparableVersion() *ComparableVersion {
 		build:   0,
 		edition: "",
 	}
-	v.str = v.formatComparableVersion()
+	v.str = v.formatComparableBuildVersion()
 	return v
 }
 
-// NewComparableVersionFromString parses a ComparableVersion from the given version string.
+// NewComparableBuildVersionFromString parses a ComparableBuildVersion from the given version string.
 // Expected format: `[epoch:]major.minor.patch[.other][@build][-edition]`
-func NewComparableVersionFromString(version string) (*ComparableVersion, error) {
-	epoch, major, minor, patch, other, build, edition, err := parseComparableVersion(version)
+func NewComparableBuildVersionFromString(version string) (*ComparableBuildVersion, error) {
+	epoch, major, minor, patch, other, build, edition, err := parseComparableBuildVersion(version)
 	if err != nil {
 		return nil, err
 	}
-	v := &ComparableVersion{
+	v := &ComparableBuildVersion{
 		epoch:   epoch,
 		major:   major,
 		minor:   minor,
@@ -59,20 +59,20 @@ func NewComparableVersionFromString(version string) (*ComparableVersion, error) 
 		build:   build,
 		edition: edition,
 	}
-	v.str = v.formatComparableVersion()
+	v.str = v.formatComparableBuildVersion()
 	if v.str != version {
 		return nil, fmt.Errorf("version string %q is not equal to formatted version string %q", version, v.str)
 	}
 	return v, nil
 }
 
-func NewComparableVersion(majorStr, minorStr, patchStr, otherStr, buildStr, editionStr string) (*ComparableVersion, error) {
-	_, major, minor, patch, other, build, edition, err := parseComparableVersionComponents("", majorStr, minorStr, patchStr, otherStr, buildStr, editionStr)
+func NewComparableBuildVersion(majorStr, minorStr, patchStr, otherStr, buildStr, editionStr string) (*ComparableBuildVersion, error) {
+	_, major, minor, patch, other, build, edition, err := parseComparableBuildVersionComponents("", majorStr, minorStr, patchStr, otherStr, buildStr, editionStr)
 	if err != nil {
 		return nil, err
 	}
-	v := &ComparableVersion{
-		epoch:   comparableVersionEpoch,
+	v := &ComparableBuildVersion{
+		epoch:   comparableBuildVersionEpoch,
 		major:   major,
 		minor:   minor,
 		patch:   patch,
@@ -80,12 +80,12 @@ func NewComparableVersion(majorStr, minorStr, patchStr, otherStr, buildStr, edit
 		build:   build,
 		edition: edition,
 	}
-	v.str = v.formatComparableVersion()
+	v.str = v.formatComparableBuildVersion()
 	return v, nil
 }
 
 // Equal returns true if pv is equal to b
-func (pv *ComparableVersion) Equal(b *ComparableVersion) bool {
+func (pv *ComparableBuildVersion) Equal(b *ComparableBuildVersion) bool {
 	return pv.epoch == b.epoch &&
 		pv.major == b.major &&
 		pv.minor == b.minor &&
@@ -96,7 +96,7 @@ func (pv *ComparableVersion) Equal(b *ComparableVersion) bool {
 }
 
 // Less returns true if a is less than b
-func (a *ComparableVersion) Less(b *ComparableVersion) bool {
+func (a *ComparableBuildVersion) Less(b *ComparableBuildVersion) bool {
 	if a.epoch < b.epoch {
 		return true
 	} else if a.epoch > b.epoch {
@@ -138,7 +138,7 @@ func (a *ComparableVersion) Less(b *ComparableVersion) bool {
 }
 
 // AtLeastMinorDowngrade returns true there is a major or minor downgrade from a to b.
-func (a *ComparableVersion) AtLeastMinorDowngrade(b *ComparableVersion) bool {
+func (a *ComparableBuildVersion) AtLeastMinorDowngrade(b *ComparableBuildVersion) bool {
 	if a.epoch != b.epoch {
 		return a.epoch > b.epoch
 	}
@@ -148,82 +148,82 @@ func (a *ComparableVersion) AtLeastMinorDowngrade(b *ComparableVersion) bool {
 	return a.minor > b.minor
 }
 
-func (pv ComparableVersion) String() string {
+func (pv ComparableBuildVersion) String() string {
 	return pv.str
 }
 
-// MarshalJSON implements json.Marshaler for ComparableVersion. The JSON representation is the version string.
-func (pv *ComparableVersion) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements json.Marshaler for ComparableBuildVersion. The JSON representation is the version string.
+func (pv *ComparableBuildVersion) MarshalJSON() ([]byte, error) {
 	return JSONMarshal(pv.String())
 }
 
-func (pv *ComparableVersion) UnmarshalJSON(val []byte) error {
+func (pv *ComparableBuildVersion) UnmarshalJSON(val []byte) error {
 	var strVal string
 	err := JSONUnmarshal(val, &strVal)
 	if err != nil {
 		return err
 	}
 	if strVal != "" {
-		pv.epoch, pv.major, pv.minor, pv.patch, pv.other, pv.build, pv.edition, err = parseComparableVersion(strVal)
+		pv.epoch, pv.major, pv.minor, pv.patch, pv.other, pv.build, pv.edition, err = parseComparableBuildVersion(strVal)
 	}
 
-	pv.str = pv.formatComparableVersion()
+	pv.str = pv.formatComparableBuildVersion()
 	return err
 }
 
 const (
-	comparableVersionSep        = '.'
-	comparableVersionSepEpoch   = ':'
-	comparableVersionSepBuild   = '@'
-	comparableVersionSepEdition = '-'
+	comparableBuildVersionSep        = '.'
+	comparableBuildVersionSepEpoch   = ':'
+	comparableBuildVersionSepBuild   = '@'
+	comparableBuildVersionSepEdition = '-'
 )
 
-// formatComparableVersion returns the string representation of the given version.
+// formatComparableBuildVersion returns the string representation of the given version.
 // format: `[epoch:]major.minor.patch[.other][@build][-edition]`
-func (pv *ComparableVersion) formatComparableVersion() string {
+func (pv *ComparableBuildVersion) formatComparableBuildVersion() string {
 	if pv == nil {
 		return "0.0.0"
 	}
 
 	epochStr := ""
 	if pv.epoch > 0 {
-		epochStr = strconv.FormatUint(uint64(pv.epoch), 10) + string(comparableVersionSepEpoch)
+		epochStr = strconv.FormatUint(uint64(pv.epoch), 10) + string(comparableBuildVersionSepEpoch)
 	}
 
 	semverStr := strconv.FormatUint(uint64(pv.major), 10) +
-		string(comparableVersionSep) +
+		string(comparableBuildVersionSep) +
 		strconv.FormatUint(uint64(pv.minor), 10) +
-		string(comparableVersionSep) +
+		string(comparableBuildVersionSep) +
 		strconv.FormatUint(uint64(pv.patch), 10)
 
 	otherStr := ""
 	if pv.other > 0 {
-		otherStr = string(comparableVersionSep) +
+		otherStr = string(comparableBuildVersionSep) +
 			strconv.FormatUint(uint64(pv.other), 10)
 	}
 
 	buildStr := ""
 	if pv.build > 0 {
-		buildStr = string(comparableVersionSepBuild) + strconv.FormatUint(uint64(pv.build), 10)
+		buildStr = string(comparableBuildVersionSepBuild) + strconv.FormatUint(uint64(pv.build), 10)
 	}
 
 	editionStr := ""
 	if ed := pv.edition.String(); ed != "" {
-		editionStr = string(comparableVersionSepEdition) + ed
+		editionStr = string(comparableBuildVersionSepEdition) + ed
 	}
 
 	return epochStr + semverStr + otherStr + buildStr + editionStr
 }
 
-func parseComparableVersion(version string) (epoch, major, minor, patch, other uint8, build uint16, edition productEdition, err error) {
-	epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, edtionStr, err := extractComparableVersionComponents(version)
+func parseComparableBuildVersion(version string) (epoch, major, minor, patch, other uint8, build uint16, edition productEdition, err error) {
+	epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, edtionStr, err := extractComparableBuildVersionComponents(version)
 	if err != nil {
 		return 0, 0, 0, 0, 0, 0, "", err
 	}
-	return parseComparableVersionComponents(epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, edtionStr)
+	return parseComparableBuildVersionComponents(epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, edtionStr)
 }
 
-func parseComparableVersionComponents(epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, editionStr string) (epoch, major, minor, patch, other uint8, build uint16, edition productEdition, err error) {
+func parseComparableBuildVersionComponents(epochStr, majorStr, minorStr, patchStr, otherStr, buildStr, editionStr string) (epoch, major, minor, patch, other uint8, build uint16, edition productEdition, err error) {
 	if epochStr != "" {
 		tmp, err := strconv.ParseUint(epochStr, 10, 8)
 		if err != nil {
@@ -282,8 +282,8 @@ func parseComparableVersionComponents(epochStr, majorStr, minorStr, patchStr, ot
 	return epoch, major, minor, patch, other, build, edition, nil
 }
 
-// extractComparableVersionComponents takes a version string and returns each component as a string
-func extractComparableVersionComponents(version string) (epoch, major, minor, patch, other, build, edition string, err error) {
+// extractComparableBuildVersionComponents takes a version string and returns each component as a string
+func extractComparableBuildVersionComponents(version string) (epoch, major, minor, patch, other, build, edition string, err error) {
 
 	var remainder string
 
@@ -291,18 +291,18 @@ func extractComparableVersionComponents(version string) (epoch, major, minor, pa
 	// and still iterating over the entire string only once, albeit in small chunks.
 
 	// prefixes
-	epoch, remainder = safeCutBefore(version, string(comparableVersionSepEpoch))
+	epoch, remainder = safeCutBefore(version, string(comparableBuildVersionSepEpoch))
 
 	// suffixes
-	edition, remainder = safeCutAfter(remainder, string(comparableVersionSepEdition))
-	build, remainder = safeCutAfter(remainder, string(comparableVersionSepBuild))
+	edition, remainder = safeCutAfter(remainder, string(comparableBuildVersionSepEdition))
+	build, remainder = safeCutAfter(remainder, string(comparableBuildVersionSepBuild))
 
 	// major.minor.patch[.other]
-	major, remainder = safeCutBefore(remainder, string(comparableVersionSep))
-	minor, remainder = safeCutBefore(remainder, string(comparableVersionSep))
+	major, remainder = safeCutBefore(remainder, string(comparableBuildVersionSep))
+	minor, remainder = safeCutBefore(remainder, string(comparableBuildVersionSep))
 
 	// handle optional [.other]
-	if before, after, ok := strings.Cut(remainder, string(comparableVersionSep)); !ok {
+	if before, after, ok := strings.Cut(remainder, string(comparableBuildVersionSep)); !ok {
 		patch = remainder
 	} else {
 		patch = before

--- a/base/version_comparable_build_test.go
+++ b/base/version_comparable_build_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestComparableVersion(t *testing.T) {
+func TestComparableBuildVersion(t *testing.T) {
 	// An *ascending* list of valid versions (order is required for comparison testing)
-	testDataComparableVersions := []struct {
+	testDataComparableBuildVersions := []struct {
 		str string
 	}{
 		{"0.0.0"}, // min
@@ -48,9 +48,9 @@ func TestComparableVersion(t *testing.T) {
 		{"255:255.255.255.255@65535-EE"}, // max
 	}
 
-	for i, test := range testDataComparableVersions {
+	for i, test := range testDataComparableBuildVersions {
 		t.Run(test.str, func(t *testing.T) {
-			current, err := NewComparableVersionFromString(test.str)
+			current, err := NewComparableBuildVersionFromString(test.str)
 			require.NoError(t, err)
 
 			// string->version->string round-trip
@@ -58,8 +58,8 @@ func TestComparableVersion(t *testing.T) {
 
 			// comparisons (Less/Equal)
 			if i > 1 {
-				prevStr := testDataComparableVersions[i-1].str
-				previous, err := NewComparableVersionFromString(prevStr)
+				prevStr := testDataComparableBuildVersions[i-1].str
+				previous, err := NewComparableBuildVersionFromString(prevStr)
 				require.NoError(t, err)
 
 				assert.Truef(t, previous.Less(current), "incorrect comparison: expected %q < %q", prevStr, test.str)
@@ -70,8 +70,8 @@ func TestComparableVersion(t *testing.T) {
 	}
 }
 
-func TestInvalidComparableVersion(t *testing.T) {
-	// A list of invalid ComparableVersion
+func TestInvalidComparableBuildVersion(t *testing.T) {
+	// A list of invalid ComparableBuildVersion
 	tests := []struct {
 		ver string
 	}{
@@ -108,29 +108,29 @@ func TestInvalidComparableVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.ver, func(t *testing.T) {
-			ver, err := NewComparableVersionFromString(test.ver)
+			ver, err := NewComparableBuildVersionFromString(test.ver)
 			assert.Error(t, err)
 			assert.Nil(t, ver)
 		})
 	}
 }
 
-func TestComparableVersionJSONRoundTrip(t *testing.T) {
+func TestComparableBuildVersionJSONRoundTrip(t *testing.T) {
 	json, err := JSONMarshal(ProductVersion)
 	require.NoError(t, err)
-	var version ComparableVersion
+	var version ComparableBuildVersion
 	err = JSONUnmarshal(json, &version)
 	require.NoError(t, err)
 	require.True(t, ProductVersion.Equal(&version))
 	require.Equal(t, ProductVersion.String(), version.String())
 }
 
-func TestComparableVersionEmptyStringJSON(t *testing.T) {
-	var version ComparableVersion
+func TestComparableBuildVersionEmptyStringJSON(t *testing.T) {
+	var version ComparableBuildVersion
 	err := JSONUnmarshal([]byte(`""`), &version)
 	require.NoError(t, err)
-	require.True(t, zeroComparableVersion().Equal(&version))
-	require.Equal(t, "0.0.0", zeroComparableVersion().String())
+	require.True(t, zeroComparableBuildVersion().Equal(&version))
+	require.Equal(t, "0.0.0", zeroComparableBuildVersion().String())
 	require.Equal(t, "0.0.0", version.String())
 }
 
@@ -224,30 +224,30 @@ func TestAtLeastMinorDowngradeVersion(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(fmt.Sprintf("%s->%s", test.versionA, test.versionB), func(t *testing.T) {
-			versionA, err := NewComparableVersionFromString(test.versionA)
+			versionA, err := NewComparableBuildVersionFromString(test.versionA)
 			require.NoError(t, err)
 
-			versionB, err := NewComparableVersionFromString(test.versionB)
+			versionB, err := NewComparableBuildVersionFromString(test.versionB)
 			require.NoError(t, err)
 			require.Equal(t, test.minorDowngrade, versionA.AtLeastMinorDowngrade(versionB))
 		})
 	}
 }
 
-func BenchmarkComparableVersion(b *testing.B) {
+func BenchmarkComparableBuildVersion(b *testing.B) {
 	const str = "8:7.6.5.4@3-EE"
 
-	current, err := NewComparableVersionFromString(str)
+	current, err := NewComparableBuildVersionFromString(str)
 	require.NoError(b, err)
 
-	b.Run("parseComparableVersion", func(b *testing.B) {
+	b.Run("parseComparableBuildVersion", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, _, _, _, _, _, _, _ = parseComparableVersion(str)
+			_, _, _, _, _, _, _, _ = parseComparableBuildVersion(str)
 		}
 	})
-	b.Run("formatComparableVersion", func(b *testing.B) {
+	b.Run("formatComparableBuildVersion", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = current.formatComparableVersion()
+			_ = current.formatComparableBuildVersion()
 		}
 	})
 }

--- a/db/blip.go
+++ b/db/blip.go
@@ -13,18 +13,26 @@ package db
 import (
 	"context"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
 )
 
+const blipCBMobileReplicationPrefix = "CBMobile_"
+
 const (
 	// BlipCBMobileReplicationV2 / BlipCBMobileReplicationV3 is the AppProtocolId part of the BLIP websocket
 	// sub protocol.  One must match identically with one provided by the peer (CBLite / ISGR)
-	BlipCBMobileReplicationV2 = "CBMobile_2"
-	BlipCBMobileReplicationV3 = "CBMobile_3"
+	blipCBMobileReplicationV2 = iota + 2
+	blipCBMobileReplicationV3
+	blipCBMobileReplicationV4 // Version Vectors instead of RevIDs/RevTrees
 )
+
+func BlipCBMobileReplicationSubprotocolVersion(version int) string {
+	return blipCBMobileReplicationPrefix + strconv.Itoa(version)
+}
 
 var (
 	// compressedTypes are MIME types that explicitly indicate they're compressed:
@@ -47,7 +55,7 @@ func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context, err err
 	// V3 is first here as it is the preferred communication method
 	// In the host case this means SGW can accept both V3 and V2 clients
 	// In the client case this means we prefer V3 but can fallback to V2
-	return NewSGBlipContextWithProtocols(ctx, id, BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
+	return NewSGBlipContextWithProtocols(ctx, id, BlipCBMobileReplicationSubprotocolVersion(blipCBMobileReplicationV3), BlipCBMobileReplicationSubprotocolVersion(blipCBMobileReplicationV2))
 }
 
 func NewSGBlipContextWithProtocols(ctx context.Context, id string, protocol ...string) (bc *blip.Context, err error) {

--- a/db/blip.go
+++ b/db/blip.go
@@ -13,26 +13,18 @@ package db
 import (
 	"context"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
 )
 
-const blipCBMobileReplicationPrefix = "CBMobile_"
-
 const (
 	// BlipCBMobileReplicationV2 / BlipCBMobileReplicationV3 is the AppProtocolId part of the BLIP websocket
 	// sub protocol.  One must match identically with one provided by the peer (CBLite / ISGR)
-	blipCBMobileReplicationV2 = iota + 2
-	blipCBMobileReplicationV3
-	blipCBMobileReplicationV4 // Version Vectors instead of RevIDs/RevTrees
+	BlipCBMobileReplicationV2 = "CBMobile_2"
+	BlipCBMobileReplicationV3 = "CBMobile_3"
 )
-
-func BlipCBMobileReplicationSubprotocolVersion(version int) string {
-	return blipCBMobileReplicationPrefix + strconv.Itoa(version)
-}
 
 var (
 	// compressedTypes are MIME types that explicitly indicate they're compressed:
@@ -55,7 +47,7 @@ func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context, err err
 	// V3 is first here as it is the preferred communication method
 	// In the host case this means SGW can accept both V3 and V2 clients
 	// In the client case this means we prefer V3 but can fallback to V2
-	return NewSGBlipContextWithProtocols(ctx, id, BlipCBMobileReplicationSubprotocolVersion(blipCBMobileReplicationV3), BlipCBMobileReplicationSubprotocolVersion(blipCBMobileReplicationV2))
+	return NewSGBlipContextWithProtocols(ctx, id, BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
 }
 
 func NewSGBlipContextWithProtocols(ctx context.Context, id string, protocol ...string) (bc *blip.Context, err error) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1776,7 +1776,7 @@ func (sc *ServerContext) _applyConfig(nonContextStruct base.NonCancellableContex
 		configSGVersionStr = cnf.SGVersion
 	}
 
-	configSGVersion, err := base.NewComparableVersionFromString(configSGVersionStr)
+	configSGVersion, err := base.NewComparableBuildVersionFromString(configSGVersionStr)
 	if err != nil {
 		return false, err
 	}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -32,7 +32,7 @@ type DatabaseConfig struct {
 	// Version is a generated Rev ID used for optimistic concurrency control using ETags/If-Match headers.
 	Version string `json:"version,omitempty"`
 
-	// SGVersion is a base.ComparableVersion of the Sync Gateway node that wrote the config.
+	// SGVersion is a base.ComparableBuildVersion of the Sync Gateway node that wrote the config.
 	SGVersion string `json:"sg_version,omitempty"`
 
 	// MetadataID is the prefix used to store database metadata

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -30,10 +30,10 @@ type ConfigManager interface {
 	DeleteConfig(ctx context.Context, bucket, dbName, groupID string) (err error)
 
 	// CheckMinorDowngrade returns an error the sgVersion represents at least minor version downgrade from the version in the bucket.
-	CheckMinorDowngrade(ctx context.Context, bucketName string, sgVersion base.ComparableVersion) error
+	CheckMinorDowngrade(ctx context.Context, bucketName string, sgVersion base.ComparableBuildVersion) error
 
 	// SetSGVersion updates the Sync Gateway version in the bucket registry
-	SetSGVersion(ctx context.Context, bucketName string, sgVersion base.ComparableVersion) error
+	SetSGVersion(ctx context.Context, bucketName string, sgVersion base.ComparableBuildVersion) error
 }
 
 type dbConfigNameOnly struct {
@@ -590,7 +590,7 @@ func (b *bootstrapContext) getGatewayRegistry(ctx context.Context, bucketName st
 	if registry.SGVersion.String() == "" {
 		// 3.1.0 and 3.1.1 don't write a SGVersion, but everything else will
 		configSGVersionStr := "3.1.0"
-		v, err := base.NewComparableVersionFromString(configSGVersionStr)
+		v, err := base.NewComparableBuildVersionFromString(configSGVersionStr)
 		if err != nil {
 			return nil, err
 		}
@@ -785,7 +785,7 @@ func (b *bootstrapContext) standardMetadataID(dbName string) string {
 }
 
 // CheckMinorDowngrade returns an error the sgVersion represents at least minor version downgrade from the version in the bucket.
-func (b *bootstrapContext) CheckMinorDowngrade(ctx context.Context, bucketName string, sgVersion base.ComparableVersion) error {
+func (b *bootstrapContext) CheckMinorDowngrade(ctx context.Context, bucketName string, sgVersion base.ComparableBuildVersion) error {
 	registry, err := b.getGatewayRegistry(ctx, bucketName)
 	if err != nil {
 		return err
@@ -800,7 +800,7 @@ func (b *bootstrapContext) CheckMinorDowngrade(ctx context.Context, bucketName s
 }
 
 // SetSGVersion will update the registry in a bucket with a version of Sync Gateway. This will not perform a write if the version is already up to date.
-func (b *bootstrapContext) SetSGVersion(ctx context.Context, bucketName string, sgVersion base.ComparableVersion) error {
+func (b *bootstrapContext) SetSGVersion(ctx context.Context, bucketName string, sgVersion base.ComparableBuildVersion) error {
 	registry, err := b.getGatewayRegistry(ctx, bucketName)
 	if err != nil {
 		return err

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -226,7 +226,7 @@ func TestVersionDowngrade(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			syncGatewayVersion, err := base.NewComparableVersionFromString(test.syncGatewayVersion)
+			syncGatewayVersion, err := base.NewComparableBuildVersionFromString(test.syncGatewayVersion)
 			require.NoError(t, err)
 			rt := NewRestTester(t, &RestTesterConfig{
 				PersistentConfig:   true,
@@ -240,7 +240,7 @@ func TestVersionDowngrade(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, syncGatewayVersion.Equal(&registry.SGVersion), "%+v != %+v", syncGatewayVersion, registry.SGVersion)
 
-			metadataConfigVersion, err := base.NewComparableVersionFromString(test.metadataConfigVersion)
+			metadataConfigVersion, err := base.NewComparableBuildVersionFromString(test.metadataConfigVersion)
 			registry.SGVersion = *metadataConfigVersion
 			require.NoError(t, err)
 			require.NoError(t, bootstrapContext.setGatewayRegistry(rt.Context(), rt.Bucket().GetName(), registry))
@@ -258,7 +258,7 @@ func TestVersionDowngrade(t *testing.T) {
 			registry, err = bootstrapContext.getGatewayRegistry(rt.Context(), rt.Bucket().GetName())
 			require.NoError(t, err)
 
-			expectedRegistryVersion, err := base.NewComparableVersionFromString(test.expectedRegistryVersion)
+			expectedRegistryVersion, err := base.NewComparableBuildVersionFromString(test.expectedRegistryVersion)
 			require.NoError(t, err)
 
 			require.True(t, expectedRegistryVersion.Equal(&registry.SGVersion), "%+v != %+v", expectedRegistryVersion, registry.SGVersion)

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -46,7 +46,7 @@ type GatewayRegistry struct {
 	cas          uint64
 	Version      string                          `json:"version"`       // Registry version
 	ConfigGroups map[string]*RegistryConfigGroup `json:"config_groups"` // Map of config groups, keyed by config group ID
-	SGVersion    base.ComparableVersion          `json:"sg_version"`    // Latest patch version of Sync Gateway that touched the registry
+	SGVersion    base.ComparableBuildVersion     `json:"sg_version"`    // Latest patch version of Sync Gateway that touched the registry
 }
 
 const GatewayRegistryVersion = "1.0"
@@ -84,7 +84,7 @@ type RegistryScope struct {
 var defaultOnlyRegistryScopes = map[string]RegistryScope{base.DefaultScope: {Collections: []string{base.DefaultCollection}}}
 var DefaultOnlyScopesConfig = ScopesConfig{base.DefaultScope: {Collections: map[string]*CollectionConfig{base.DefaultCollection: {}}}}
 
-func NewGatewayRegistry(syncGatewayVersion base.ComparableVersion) *GatewayRegistry {
+func NewGatewayRegistry(syncGatewayVersion base.ComparableBuildVersion) *GatewayRegistry {
 	return &GatewayRegistry{
 		ConfigGroups: make(map[string]*RegistryConfigGroup),
 		Version:      GatewayRegistryVersion,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -89,10 +89,10 @@ const defaultConfigRetryTimeout = 3 * base.DefaultGocbV2OperationTimeout
 
 type bootstrapContext struct {
 	Connection         base.BootstrapConnection
-	configRetryTimeout time.Duration          // configRetryTimeout defines the total amount of time to retry on a registry/config mismatch
-	terminator         chan struct{}          // Used to stop the goroutine handling the bootstrap polling
-	doneChan           chan struct{}          // doneChan is closed when the bootstrap polling goroutine finishes.
-	sgVersion          base.ComparableVersion // version of Sync Gateway
+	configRetryTimeout time.Duration               // configRetryTimeout defines the total amount of time to retry on a registry/config mismatch
+	terminator         chan struct{}               // Used to stop the goroutine handling the bootstrap polling
+	doneChan           chan struct{}               // doneChan is closed when the bootstrap polling goroutine finishes.
+	sgVersion          base.ComparableBuildVersion // version of Sync Gateway
 }
 
 type getOrAddDatabaseConfigOptions struct {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -71,7 +71,7 @@ type RestTesterConfig struct {
 	serverless                      bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
 	collectionConfig                collectionConfiguration
 	numCollections                  int
-	syncGatewayVersion              *base.ComparableVersion // alternate version of Sync Gateway to use on startup
+	syncGatewayVersion              *base.ComparableBuildVersion // alternate version of Sync Gateway to use on startup
 	allowDbConfigEnvVars            *bool
 }
 


### PR DESCRIPTION
No functional changes, only renaming of types/methods/functions/tests.

`ComparableVersion` is intended to be used for SG build versions, and is not suitable for a general versioning system for other things (e.g. replication protocol)

Rename because there's upcoming refactor to allow replication subprotocol version to have an equivalent "comparable" version type/methods.