### PR TITLE
CBG-3576: BlipTestClient support for HLV and rev tree modes

### DIFF
--- a/db/access_test.go
+++ b/db/access_test.go
@@ -44,7 +44,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Create a document in channel chan1
 	doc1Body := Body{"channel": "chan1", "greeting": "hello"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc1", doc1Body, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc1", doc1Body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify user cannot access document
@@ -54,7 +54,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Write access granting document
 	grantingBody := Body{"type": "setaccess", "owner": "user1", "channel": "chan1"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant1", grantingBody, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant1", grantingBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify reloaded user can access document
@@ -66,12 +66,12 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Create a document in channel chan2
 	doc2Body := Body{"channel": "chan2", "greeting": "hello"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc2", doc2Body, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc2", doc2Body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Write access granting document for chan2 (tests invalidation when channels/inval_seq exists)
 	grantingBody = Body{"type": "setaccess", "owner": "user1", "channel": "chan2"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant2", grantingBody, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant2", grantingBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify user can now access both documents

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -73,7 +73,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	var rev2Body Body
 	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 	rev2ID := "2-abc"
 
@@ -201,7 +201,7 @@ func TestAttachments(t *testing.T) {
 	rev2Bstr := `{"_attachments": {"bye.txt": {"stub":true,"revpos":1,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}, "_rev": "2-f000"}`
 	var body2B Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev2Bstr), &body2B))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body2B, []string{"2-f000", rev1id}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body2B, []string{"2-f000", rev1id}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't update document")
 }
 
@@ -285,7 +285,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 			rev2Data := `{"prop1":"value2", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 			require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 			require.NoError(t, err)
 
 			log.Printf("Done creating rev 2 for key %s", key)
@@ -316,7 +316,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 	var rev3Body Body
 	rev3Data := `{"prop1":"value3", "_attachments": {"hello.txt": {"revpos":2,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev3Data), &rev3Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	log.Printf("rev 3 done")
@@ -348,7 +348,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 			rev2Data := `{"prop1":"value2"}`
 			require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 			require.NoError(t, err)
 
 			log.Printf("Done creating rev 2 for key %s", key)
@@ -379,7 +379,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 	var rev3Body Body
 	rev3Data := `{"prop1":"value3", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev3Data), &rev3Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	log.Printf("rev 3 done")
@@ -568,7 +568,7 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 	// Create document (rev 1)
 	text := `{"key": "value", "version": "1a"}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
-	doc, revID, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
+	doc, revID, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
@@ -576,49 +576,49 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 	text = `{"key": "value", "version": "2a", "_attachments": {"att1.txt": {"data": "YXR0MS50eHQ="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-a", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "4a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-a", "3-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "5a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"5-a", "4-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"5-a", "4-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "6a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"6-a", "5-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"6-a", "5-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3b", "type": "pruned"}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3b", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1183,9 +1183,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
 	if bh.conflictResolver != nil {
-		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc)
+		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	} else {
-		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc)
+		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	}
 	if err != nil {
 		return err

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -497,7 +497,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.Remove(docID, syncData.CurrentRev)
+		collection.revisionCache.RemoveWithRev(docID, syncData.CurrentRev)
 	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -478,14 +478,14 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 		// Create child rev 1
 		docBody["child"] = "A"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-A", revId}, false)
+		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-A", revId}, false, ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			b.Fatalf("Error creating child1 rev: %v", err)
 		}
 
 		// Create child rev 2
 		docBody["child"] = "B"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-B", revId}, false)
+		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-B", revId}, false, ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			b.Fatalf("Error creating child2 rev: %v", err)
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1969,14 +1969,6 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			// update the mutate in options based on the above logic
 			updatedSpec = doc.SyncData.HLV.computeMacroExpansions()
 
-			// update the HLV values
-			doc, err = db.updateHLV(doc, docUpdateEvent)
-			if err != nil {
-				return
-			}
-			// update the mutate in options based on the above logic
-			updatedSpec = doc.SyncData.HLV.computeMacroExpansions()
-
 			deleteDoc = currentRevFromHistory.Deleted
 
 			// Return the new raw document value for the bucket to store.

--- a/db/crud.go
+++ b/db/crud.go
@@ -1061,7 +1061,6 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 		return nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 
-	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()
 	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -75,7 +75,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Flush the cache
@@ -116,7 +116,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -127,7 +127,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	rev2a_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -153,7 +153,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	rev2b_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -251,7 +251,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a with legacy attachment.
@@ -280,7 +280,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -315,7 +315,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -326,7 +326,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -345,7 +345,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -388,7 +388,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
 	rev3b_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 	rev3b_body[BodyId] = doc.ID
 	rev3b_body[BodyRev] = newRev
 	rev3b_body[BodyDeleted] = true
@@ -425,7 +425,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2c_body := Body{}
 	rev2c_body["key1"] = prop_1000_bytes
 	rev2c_body["version"] = "2c"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"2-c", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"2-c", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2c_body[BodyId] = doc.ID
 	rev2c_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-c")
@@ -447,7 +447,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3c_body["version"] = "3c"
 	rev3c_body["key1"] = prop_1000_bytes
 	rev3c_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-c"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-c"}, false, ExistingVersionWithUpdateToHLV)
 	rev3c_body[BodyId] = doc.ID
 	rev3c_body[BodyRev] = newRev
 	rev3c_body[BodyDeleted] = true
@@ -476,7 +476,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3a_body := Body{}
 	rev3a_body["key1"] = prop_1000_bytes
 	rev3a_body["version"] = "3a"
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"3-a", "2-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a")
 
 	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
@@ -499,7 +499,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -510,7 +510,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -529,7 +529,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -574,7 +574,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev3b_body["version"] = "3b"
 	rev3b_body["key1"] = prop_1000_bytes
 	rev3b_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 	rev3b_body[BodyId] = doc.ID
 	rev3b_body[BodyRev] = newRev
 	rev3b_body[BodyDeleted] = true
@@ -609,17 +609,17 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	activeRevBody := Body{}
 	activeRevBody["version"] = "...a"
 	activeRevBody["key1"] = prop_1000_bytes
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"3-a", "2-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"4-a", "3-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 4-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"5-a", "4-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"5-a", "4-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 5-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"6-a", "5-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"6-a", "5-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 6-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"7-a", "6-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"7-a", "6-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 7-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"8-a", "7-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"8-a", "7-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 8-a")
 
 	// Verify that 3-b is still present at this point
@@ -628,7 +628,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	assert.NoError(t, err, "Rev 3-b should still exist")
 
 	// Add one more rev that triggers pruning since gen(9-3) > revsLimit
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"9-a", "8-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"9-a", "8-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 9-a")
 
 	// Verify that 3-b has been pruned
@@ -657,7 +657,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a", "large": prop_1000_bytes}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -666,7 +666,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "version": "2a", "large": prop_1000_bytes}
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
@@ -686,7 +686,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "version": "3a", "large": prop_1000_bytes}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-a")
 	rev3a_body[BodyId] = doc.ID
 	rev3a_body[BodyRev] = newRev
@@ -705,7 +705,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "version": "2b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
@@ -728,7 +728,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "version": "6a", "large": prop_1000_bytes}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 6-a")
 	rev6a_body[BodyId] = doc.ID
 	rev6a_body[BodyRev] = newRev
@@ -753,7 +753,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "version": "3b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-b")
 
 	// Same again and again
@@ -772,12 +772,12 @@ func TestOldRevisionStorage(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "version": "3c", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-c")
 
 	log.Printf("Create rev 3-d")
 	rev3d_body := Body{"key1": "value2", "version": "3d", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-d")
 
 	// Create new winning revision on 'b' branch.  Triggers movement of 6-a to inline storage.  Force cas retry, check document contents
@@ -796,7 +796,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	//     7-b
 	log.Printf("Create rev 7-b")
 	rev7b_body := Body{"key1": "value2", "version": "7b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 7-b")
 
 }
@@ -817,7 +817,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "v": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -826,7 +826,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "v": "2a"}
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -845,7 +845,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "v": "3a"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev3a_body[BodyId] = doc.ID
 	rev3a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 3-a")
@@ -858,7 +858,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "v": "2b"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -883,7 +883,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "v": "6a"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev6a_body[BodyId] = doc.ID
 	rev6a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 6-a")
@@ -909,7 +909,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "v": "3b"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-b")
 
 	// Same again
@@ -929,7 +929,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-c")
 
 }
@@ -946,7 +946,7 @@ func TestLargeSequence(t *testing.T) {
 
 	// Write a doc via SG
 	body := Body{"key1": "largeSeqTest"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "largeSeqDoc", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "largeSeqDoc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add largeSeqDoc")
 
 	syncData, err := collection.GetDocSyncData(ctx, "largeSeqDoc")
@@ -1021,7 +1021,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	// 6-a
 	log.Printf("Attempt to create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-c")
 }
 
@@ -1033,16 +1033,16 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
 	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1061,9 +1061,9 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1090,16 +1090,16 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
 	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1118,9 +1118,9 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1148,7 +1148,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	getDelta := func(newDoc *Document) {
 		deltaSrcRev, _ := collection.GetRev(ctx, "doc1", "1-a", false, nil)
@@ -1197,18 +1197,18 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	_, rev, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"1-a"}, false)
+	_, rev, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	ancestor := rev // Ancestor revision
 
 	// Create the second revision of the document with attachment reference;
 	payload = `{"sku":"6213101","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	_, rev, err = collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"2-a", "1-a"}, false)
+	_, rev, err = collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	parent := rev // Immediate ancestor or parent revision
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213102","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	doc, _, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"3-a", "2-a"}, false)
+	doc, _, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get available attachments by immediate ancestor revision or parent revision
@@ -1235,11 +1235,11 @@ func TestGet1xRevAndChannels(t *testing.T) {
 
 	docId := "dd6d2dcc679d12b9430a9787bab45b33"
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc1, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false)
+	doc1, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213101","_attachments":{"lens.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc2, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	doc2, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get the 1x revision from document with list revision enabled
@@ -1298,7 +1298,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	// Create the first revision of the document
 	docId := "356779a9a1696714480f57fa3fb66d4c"
 	payload := `{"city":"Los Angeles"}`
-	doc, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false)
+	doc, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "1-a", rev1, "Provided input revision ID should be returned")
@@ -1321,7 +1321,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 
 	// Create the second revision of the document
 	payload = `{"city":"Hollywood"}`
-	doc, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	doc, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "2-a", rev2, "Provided input revision ID should be returned")

--- a/db/database.go
+++ b/db/database.go
@@ -49,6 +49,14 @@ const (
 )
 
 const (
+	Import DocUpdateType = iota
+	NewVersion
+	ExistingVersion
+)
+
+type DocUpdateType uint32
+
+const (
 	DefaultRevsLimitNoConflicts = 50
 	DefaultRevsLimitConflicts   = 100
 
@@ -88,6 +96,7 @@ type DatabaseContext struct {
 	MetadataStore               base.DataStore     // Storage for database metadata (anything that isn't an end-user's/customer's documents)
 	Bucket                      base.Bucket        // Storage
 	BucketSpec                  base.BucketSpec    // The BucketSpec
+	BucketUUID                  string             // The bucket UUID for the bucket the database is created against
 	BucketLock                  sync.RWMutex       // Control Access to the underlying bucket object
 	mutationListener            changeListener     // Caching feed listener
 	ImportListener              *importListener    // Import feed listener
@@ -396,6 +405,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		metadataStore = bucket.DefaultDataStore()
 	}
 
+	bucketUUID, err := bucket.UUID()
+	if err != nil {
+		return nil, err
+	}
+
 	// Register the cbgt pindex type for the configGroup
 	RegisterImportPindexImpl(ctx, options.GroupID)
 
@@ -404,6 +418,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		UUID:                cbgt.NewUUID(),
 		MetadataStore:       metadataStore,
 		Bucket:              bucket,
+		BucketUUID:          bucketUUID,
 		StartTime:           time.Now(),
 		autoImport:          autoImport,
 		Options:             options,

--- a/db/database.go
+++ b/db/database.go
@@ -52,6 +52,7 @@ const (
 	Import DocUpdateType = iota
 	NewVersion
 	ExistingVersion
+	ExistingVersionWithUpdateToHLV
 )
 
 type DocUpdateType uint32

--- a/db/document.go
+++ b/db/document.go
@@ -177,11 +177,12 @@ type Document struct {
 	Cas          uint64 // Document cas
 	rawUserXattr []byte // Raw user xattr as retrieved from the bucket
 
-	Deleted        bool
-	DocExpiry      uint32
-	RevID          string
-	DocAttachments AttachmentsMeta
-	inlineSyncData bool
+	Deleted            bool
+	DocExpiry          uint32
+	RevID              string
+	DocAttachments     AttachmentsMeta
+	inlineSyncData     bool
+	currentRevChannels base.Set // A base.Set of the current revision's channels (determined by SyncData.Channels at UnmarshalJSON time)
 }
 
 type historyOnlySyncData struct {
@@ -969,6 +970,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 			doc.updateChannelHistory(channel, doc.Sequence, true)
 		}
 	}
+	doc.currentRevChannels = newChannels
 	if changed != nil {
 		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)
@@ -1076,6 +1078,17 @@ func (doc *Document) UnmarshalJSON(data []byte) error {
 	}
 	if syncData.SyncData != nil {
 		doc.SyncData = *syncData.SyncData
+	}
+
+	// determine current revision's channels and store in-memory (avoids doc.Channels iteration at access-check time)
+	if len(doc.Channels) > 0 {
+		ch := base.SetOf()
+		for channelName, channelRemoval := range doc.Channels {
+			if channelRemoval == nil || channelRemoval.Seq == 0 {
+				ch.Add(channelName)
+			}
+		}
+		doc.currentRevChannels = ch
 	}
 
 	// Unmarshal the rest of the doc body as map[string]interface{}
@@ -1223,4 +1236,18 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 	}
 
 	return data, xdata, nil
+}
+
+// HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
+func (d *Document) HasCurrentVersion(cv CurrentVersionVector) error {
+	if d.HLV == nil {
+		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
+	}
+
+	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
+	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
+	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.VersionCAS {
+		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
+	}
+	return nil
 }

--- a/db/document.go
+++ b/db/document.go
@@ -41,6 +41,7 @@ const (
 	DocUnmarshalHistory                                  // Unmarshals history + rev + CAS only
 	DocUnmarshalRev                                      // Unmarshals rev + CAS only
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
+	DocUnmarshalVV                                       // Unmarshals Version Vector only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )
 
@@ -64,23 +65,24 @@ type ChannelSetEntry struct {
 
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
 type SyncData struct {
-	CurrentRev        string              `json:"rev"`
-	NewestRev         string              `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
-	Flags             uint8               `json:"flags,omitempty"`
-	Sequence          uint64              `json:"sequence,omitempty"`
-	UnusedSequences   []uint64            `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
-	RecentSequences   []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
-	Channels          channels.ChannelMap `json:"channels,omitempty"`
-	Access            UserAccessMap       `json:"access,omitempty"`
-	RoleAccess        UserAccessMap       `json:"role_access,omitempty"`
-	Expiry            *time.Time          `json:"exp,omitempty"`                     // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
-	Cas               string              `json:"cas"`                               // String representation of a cas value, populated via macro expansion
-	Crc32c            string              `json:"value_crc32c"`                      // String representation of crc32c hash of doc body, populated via macro expansion
-	Crc32cUserXattr   string              `json:"user_xattr_value_crc32c,omitempty"` // String representation of crc32c hash of user xattr
-	TombstonedAt      int64               `json:"tombstoned_at,omitempty"`           // Time the document was tombstoned.  Used for view compaction
-	Attachments       AttachmentsMeta     `json:"attachments,omitempty"`
-	ChannelSet        []ChannelSetEntry   `json:"channel_set"`
-	ChannelSetHistory []ChannelSetEntry   `json:"channel_set_history"`
+	CurrentRev        string               `json:"rev"`
+	NewestRev         string               `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
+	Flags             uint8                `json:"flags,omitempty"`
+	Sequence          uint64               `json:"sequence,omitempty"`
+	UnusedSequences   []uint64             `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
+	RecentSequences   []uint64             `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
+	Channels          channels.ChannelMap  `json:"channels,omitempty"`
+	Access            UserAccessMap        `json:"access,omitempty"`
+	RoleAccess        UserAccessMap        `json:"role_access,omitempty"`
+	Expiry            *time.Time           `json:"exp,omitempty"`                     // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
+	Cas               string               `json:"cas"`                               // String representation of a cas value, populated via macro expansion
+	Crc32c            string               `json:"value_crc32c"`                      // String representation of crc32c hash of doc body, populated via macro expansion
+	Crc32cUserXattr   string               `json:"user_xattr_value_crc32c,omitempty"` // String representation of crc32c hash of user xattr
+	TombstonedAt      int64                `json:"tombstoned_at,omitempty"`           // Time the document was tombstoned.  Used for view compaction
+	Attachments       AttachmentsMeta      `json:"attachments,omitempty"`
+	ChannelSet        []ChannelSetEntry    `json:"channel_set"`
+	ChannelSetHistory []ChannelSetEntry    `json:"channel_set_history"`
+	HLV               *HybridLogicalVector `json:"_vv,omitempty"`
 
 	// Only used for performance metrics:
 	TimeSaved time.Time `json:"time_saved,omitempty"` // Timestamp of save.
@@ -1130,7 +1132,6 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		if unmarshalLevel == DocUnmarshalAll && len(data) > 0 {
 			return doc._body.Unmarshal(data)
 		}
-
 	case DocUnmarshalNoHistory:
 		// Unmarshal sync metadata only, excluding history
 		doc.SyncData = SyncData{}
@@ -1173,6 +1174,14 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		doc.SyncData = SyncData{
 			Cas: casOnlyMeta.Cas,
 		}
+		doc._rawBody = data
+	case DocUnmarshalVV:
+		tmpData := SyncData{}
+		unmarshalErr := base.JSONUnmarshal(xdata, &tmpData)
+		if unmarshalErr != nil {
+			return base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalVV).  Error: %w", base.UD(doc.ID), unmarshalErr)
+		}
+		doc.SyncData.HLV = tmpData.HLV
 		doc._rawBody = data
 	}
 

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"log"
+	"reflect"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -188,6 +189,106 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 			}
 		})
 	}
+}
+
+const doc_meta_with_vv = `{
+    "rev": "3-89758294abc63157354c2b08547c2d21",
+    "sequence": 7,
+    "recent_sequences": [
+      5,
+      6,
+      7
+    ],
+    "history": {
+      "revs": [
+        "1-fc591a068c153d6c3d26023d0d93dcc1",
+        "2-0eab03571bc55510c8fc4bfac9fe4412",
+        "3-89758294abc63157354c2b08547c2d21"
+      ],
+      "parents": [
+        -1,
+        0,
+        1
+      ],
+      "channels": [
+        [
+          "ABC",
+          "DEF"
+        ],
+        [
+          "ABC",
+          "DEF",
+          "GHI"
+        ],
+        [
+          "ABC",
+          "GHI"
+        ]
+      ]
+    },
+    "channels": {
+      "ABC": null,
+      "DEF": {
+        "seq": 7,
+        "rev": "3-89758294abc63157354c2b08547c2d21"
+      },
+      "GHI": null
+    },
+	"_vv":{
+   		"cvCas":"0x40e2010000000000",
+   		"src":"cb06dc003846116d9b66d2ab23887a96",
+   		"vrs":"0x40e2010000000000",
+   		"mv":{
+      		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
+      		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
+		},
+		"pv":{
+      		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
+   		}
+	},
+    "cas": "",
+    "time_saved": "2017-10-25T12:45:29.622450174-07:00"
+  }`
+
+func TestParseVersionVectorSyncData(t *testing.T) {
+	mv := make(map[string]uint64)
+	pv := make(map[string]uint64)
+	mv["s_LhRPsa7CpjEvP5zeXTXEBA"] = 1628620455147864000
+	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = 1628620455139868700
+	pv["s_YZvBpEaztom9z5V/hDoeIw"] = 1628620455135215600
+
+	ctx := base.TestCtx(t)
+
+	doc_meta := []byte(doc_meta_with_vv)
+	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalVV)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
+
+	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalAll)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
+
+	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 }
 
 func TestParseXattr(t *testing.T) {

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -10,9 +10,14 @@ package db
 
 import (
 	"fmt"
+	"math"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
+
+// hlvExpandMacroCASValue causes the field to be populated by CAS value by macro expansion
+const hlvExpandMacroCASValue = math.MaxUint64
 
 type HybridLogicalVector struct {
 	CurrentVersionCAS uint64            // current version cas (or cvCAS) stores the current CAS at the time of replication
@@ -34,10 +39,6 @@ type PersistedHybridLogicalVector struct {
 	Version           string            `json:"vrs,omitempty"`
 	MergeVersions     map[string]string `json:"mv,omitempty"`
 	PreviousVersions  map[string]string `json:"pv,omitempty"`
-}
-
-type PersistedVersionVector struct {
-	PersistedHybridLogicalVector `json:"_vv"`
 }
 
 // NewHybridLogicalVector returns a HybridLogicalVector struct with maps initialised in the struct
@@ -67,7 +68,13 @@ func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bo
 // previous versions on the HLV if needed
 func (hlv *HybridLogicalVector) AddVersion(newVersion CurrentVersionVector) error {
 	if newVersion.VersionCAS < hlv.Version {
-		return fmt.Errorf("attempting to add new verison vector entry with a CAS that is less than the current version CAS value")
+		return fmt.Errorf("attempting to add new verison vector entry with a CAS that is less than the current version CAS value. Current cas: %d new cas %d", hlv.Version, newVersion.VersionCAS)
+	}
+	// check if this is the first time we're adding a source - version pair
+	if hlv.SourceID == "" {
+		hlv.Version = newVersion.VersionCAS
+		hlv.SourceID = newVersion.SourceID
+		return nil
 	}
 	// if new entry has the same source we simple just update the version
 	if newVersion.SourceID == hlv.SourceID {
@@ -75,6 +82,9 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion CurrentVersionVector) erro
 		return nil
 	}
 	// if we get here this is a new version from a different sourceID thus need to move current sourceID to previous versions and update current version
+	if hlv.PreviousVersions == nil {
+		hlv.PreviousVersions = make(map[string]uint64)
+	}
 	hlv.PreviousVersions[hlv.SourceID] = hlv.Version
 	hlv.Version = newVersion.VersionCAS
 	hlv.SourceID = newVersion.SourceID
@@ -170,7 +180,7 @@ func (hlv *HybridLogicalVector) GetVersion(sourceID string) uint64 {
 	return latestVersion
 }
 
-func (hlv *HybridLogicalVector) MarshalJSON() ([]byte, error) {
+func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
 
 	persistedHLV, err := hlv.convertHLVToPersistedFormat()
 	if err != nil {
@@ -181,7 +191,7 @@ func (hlv *HybridLogicalVector) MarshalJSON() ([]byte, error) {
 }
 
 func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
-	persistedJSON := PersistedVersionVector{}
+	persistedJSON := PersistedHybridLogicalVector{}
 	err := base.JSONUnmarshal(inputjson, &persistedJSON)
 	if err != nil {
 		return err
@@ -191,13 +201,16 @@ func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
 	return nil
 }
 
-func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedVersionVector, error) {
-	persistedHLV := PersistedVersionVector{}
+func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridLogicalVector, error) {
+	persistedHLV := PersistedHybridLogicalVector{}
 	var cvCasByteArray []byte
+	var vrsCasByteArray []byte
 	if hlv.CurrentVersionCAS != 0 {
 		cvCasByteArray = base.Uint64CASToLittleEndianHex(hlv.CurrentVersionCAS)
 	}
-	vrsCasByteArray := base.Uint64CASToLittleEndianHex(hlv.Version)
+	if hlv.Version != 0 {
+		vrsCasByteArray = base.Uint64CASToLittleEndianHex(hlv.Version)
+	}
 
 	pvPersistedFormat, err := convertMapToPersistedFormat(hlv.PreviousVersions)
 	if err != nil {
@@ -216,7 +229,7 @@ func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedVersion
 	return &persistedHLV, nil
 }
 
-func (hlv *HybridLogicalVector) convertPersistedHLVToInMemoryHLV(persistedJSON PersistedVersionVector) {
+func (hlv *HybridLogicalVector) convertPersistedHLVToInMemoryHLV(persistedJSON PersistedHybridLogicalVector) {
 	hlv.CurrentVersionCAS = base.HexCasToUint64(persistedJSON.CurrentVersionCAS)
 	hlv.SourceID = persistedJSON.SourceID
 	// convert the hex cas to uint64 cas
@@ -255,4 +268,18 @@ func convertMapToInMemoryFormat(persistedMap map[string]string) map[string]uint6
 		returnedMap[key] = base.HexCasToUint64(value)
 	}
 	return returnedMap
+}
+
+// computeMacroExpansions returns the mutate in spec needed for the document update based off the outcome in updateHLV
+func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansionSpec {
+	var outputSpec []sgbucket.MacroExpansionSpec
+	if hlv.Version == hlvExpandMacroCASValue {
+		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionPath(base.SyncXattrName), sgbucket.MacroCas)
+		outputSpec = append(outputSpec, spec)
+	}
+	if hlv.CurrentVersionCAS == hlvExpandMacroCASValue {
+		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.SyncXattrName), sgbucket.MacroCas)
+		outputSpec = append(outputSpec, spec)
+	}
+	return outputSpec
 }

--- a/db/import.go
+++ b/db/import.go
@@ -139,7 +139,8 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		existingDoc.Expiry = *expiry
 	}
 
-	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, existingDoc.Expiry, mutationOptions, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	docUpdateEvent := Import
+	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, existingDoc.Expiry, mutationOptions, docUpdateEvent, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.
 		if doc.Cas != existingDoc.Cas {

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -372,7 +372,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create 10 added documents
 	for i := 1; i <= 10; i++ {
 		id := "created" + strconv.Itoa(i)
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "1-a", revId)
 		docIdFlagMap[doc.ID] = uint8(0x0)
@@ -385,12 +385,12 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create 10 deleted documents
 	for i := 1; i <= 10; i++ {
 		id := "deleted" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "1-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "2-a", revId, "Couldn't create tombstone revision")
 
@@ -402,22 +402,22 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
@@ -429,27 +429,27 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched|deleted" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
 		body[BodyDeleted] = true
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-b", "2-b"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-b", revId, "Couldn't create tombstone revision")
 
@@ -461,17 +461,17 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched|conflict" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -30,8 +30,8 @@ func NewBypassRevisionCache(backingStore RevisionCacheBackingStore, bypassStat *
 	}
 }
 
-// Get fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (docRev DocumentRevision, err error) {
+// GetWithRev fetches the revision for the given docID and revID immediately from the bucket.
+func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
@@ -45,7 +45,33 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, inc
 	docRev = DocumentRevision{
 		RevID: revID,
 	}
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, revID)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.CV, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, revID)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	rc.bypassStat.Add(1)
+
+	return docRev, nil
+}
+
+// GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+
+	unmarshalLevel := DocUnmarshalSync
+	if includeBody {
+		unmarshalLevel = DocUnmarshalAll
+	}
+	docRev = DocumentRevision{
+		CV: cv,
+	}
+
+	doc, err := rc.backingStore.GetDocument(ctx, docID, unmarshalLevel)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, err = revCacheLoaderForDocumentCV(ctx, rc.backingStore, doc, *cv)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -71,7 +97,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, incl
 		RevID: doc.CurrentRev,
 	}
 
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, doc.SyncData.CurrentRev)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.CV, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -96,7 +122,11 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Remove(docID, revID string) {
+func (rc *BypassRevisionCache) RemoveWithRev(docID, revID string) {
+	// nop
+}
+
+func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
 	// nop
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -28,10 +28,15 @@ const (
 
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
-	// Get returns the given revision, and stores if not already cached.
+	// GetWithRev returns the given revision, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (DocumentRevision, error)
+	GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (DocumentRevision, error)
+
+	// GetWithCV returns the given revision by CV, and stores if not already cached.
+	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
+	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
+	GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
@@ -46,8 +51,11 @@ type RevisionCache interface {
 	// Update will remove existing value and re-create new one
 	Upsert(ctx context.Context, docRev DocumentRevision)
 
-	// Remove eliminates a revision in the cache.
-	Remove(docID, revID string)
+	// RemoveWithRev evicts a revision from the cache using its revID.
+	RemoveWithRev(docID, revID string)
+
+	// RemoveWithCV evicts a revision from the cache using its current version.
+	RemoveWithCV(docID string, cv *CurrentVersionVector)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)
@@ -104,6 +112,7 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 type RevisionCacheBackingStore interface {
 	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
 	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error)
+	getCurrentVersion(ctx context.Context, doc *Document) ([]byte, Body, AttachmentsMeta, error)
 }
 
 // DocumentRevision stored and returned by the rev cache
@@ -119,6 +128,7 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
+	CV          *CurrentVersionVector
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
@@ -223,6 +233,12 @@ type IDAndRev struct {
 	RevID string
 }
 
+type IDandCV struct {
+	DocID   string
+	Version uint64
+	Source  string
+}
+
 // RevisionDelta stores data about a delta between a revision and ToRevID.
 type RevisionDelta struct {
 	ToRevID               string                  // Target revID for the delta
@@ -246,44 +262,104 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *CurrentVersionVector, err error) {
 	var doc *Document
 	unmarshalLevel := DocUnmarshalSync
 	if unmarshalBody {
 		unmarshalLevel = DocUnmarshalAll
 	}
 	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
-		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, err
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, fetchedCV, err
 	}
 
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
+// revCacheLoaderForCv will load a document from the bucket using the CV, comapre the fetched doc and the CV specified in the function,
+// and will still return revid for purpose of populating the Rev ID lookup map on the cache
+func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+	cv := CurrentVersionVector{
+		VersionCAS: id.Version,
+		SourceID:   id.Source,
+	}
+	var doc *Document
+	unmarshalLevel := DocUnmarshalSync
+	if unmarshalBody {
+		unmarshalLevel = DocUnmarshalAll
+	}
+	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, revid, err
+	}
+
+	return revCacheLoaderForDocumentCV(ctx, backingStore, doc, cv)
+}
+
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *CurrentVersionVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
 		if isRemovalErr != nil {
-			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
+			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, fetchedCV, isRemovalErr
 		}
 
 		if isRemoval {
-			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
+			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, fetchedCV, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
-			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, err
+			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, fetchedCV, err
 		}
 	}
 	deleted = doc.History[revid].Deleted
 
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
-		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
+		return bodyBytes, body, history, channels, removed, nil, deleted, nil, fetchedCV, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
+	if doc.HLV != nil {
+		fetchedCV = &CurrentVersionVector{SourceID: doc.HLV.SourceID, VersionCAS: doc.HLV.Version}
+	}
 
-	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, fetchedCV, err
+}
+
+// revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
+func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv CurrentVersionVector) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
+		// we need implementation of IsChannelRemoval for CV here.
+		// pending CBG-3213 support of channel removal for CV
+	}
+
+	if err = doc.HasCurrentVersion(cv); err != nil {
+		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+	}
+	channels = doc.currentRevChannels
+	revid = doc.CurrentRev
+
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+}
+
+func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {
+	bodyBytes, err = doc.BodyBytes(ctx)
+	if err != nil {
+		base.WarnfCtx(ctx, "Marshal error when retrieving active current version body: %v", err)
+		return nil, nil, nil, err
+	}
+
+	body = doc._body
+	attachments = doc.Attachments
+
+	// handle backup revision inline attachments, or pre-2.5 meta
+	if inlineAtts, cleanBodyBytes, cleanBody, err := extractInlineAttachments(bodyBytes); err != nil {
+		return nil, nil, nil, err
+	} else if len(inlineAtts) > 0 {
+		// we found some inline attachments, so merge them with attachments, and update the bodies
+		attachments = mergeAttachments(inlineAtts, attachments)
+		bodyBytes = cleanBodyBytes
+		body = cleanBody
+	}
+	return bodyBytes, body, attachments, err
 }

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -45,8 +45,12 @@ func (sc *ShardedLRURevisionCache) getShard(docID string) *LRURevisionCache {
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 
-func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).Get(ctx, docID, revID, includeBody, includeDelta)
+func (sc *ShardedLRURevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetWithRev(ctx, docID, revID, includeBody, includeDelta)
+}
+
+func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetWithCV(ctx, docID, cv, includeBody, includeDelta)
 }
 
 func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID, revID string) (docRev DocumentRevision, found bool) {
@@ -69,14 +73,19 @@ func (sc *ShardedLRURevisionCache) Upsert(ctx context.Context, docRev DocumentRe
 	sc.getShard(docRev.DocID).Upsert(ctx, docRev)
 }
 
-func (sc *ShardedLRURevisionCache) Remove(docID, revID string) {
-	sc.getShard(docID).Remove(docID, revID)
+func (sc *ShardedLRURevisionCache) RemoveWithRev(docID, revID string) {
+	sc.getShard(docID).RemoveWithRev(docID, revID)
+}
+
+func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+	sc.getShard(docID).RemoveWithCV(docID, cv)
 }
 
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	backingStore RevisionCacheBackingStore
 	cache        map[IDAndRev]*list.Element
+	hlvCache     map[IDandCV]*list.Element
 	lruList      *list.List
 	cacheHits    *base.SgwIntStat
 	cacheMisses  *base.SgwIntStat
@@ -93,7 +102,9 @@ type revCacheValue struct {
 	attachments AttachmentsMeta
 	delta       *RevisionDelta
 	body        Body
-	key         IDAndRev
+	id          string
+	cv          CurrentVersionVector
+	revID       string
 	bodyBytes   []byte
 	lock        sync.RWMutex
 	deleted     bool
@@ -105,6 +116,7 @@ func NewLRURevisionCache(capacity uint32, backingStore RevisionCacheBackingStore
 
 	return &LRURevisionCache{
 		cache:        map[IDAndRev]*list.Element{},
+		hlvCache:     map[IDandCV]*list.Element{},
 		lruList:      list.New(),
 		capacity:     capacity,
 		backingStore: backingStore,
@@ -117,14 +129,18 @@ func NewLRURevisionCache(capacity uint32, backingStore RevisionCacheBackingStore
 // Returns the body of the revision, its history, and the set of channels it's in.
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
-func (rc *LRURevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (DocumentRevision, error) {
-	return rc.getFromCache(ctx, docID, revID, true, includeBody, includeDelta)
+func (rc *LRURevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (DocumentRevision, error) {
+	return rc.getFromCacheByRev(ctx, docID, revID, true, includeBody, includeDelta)
+}
+
+func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error) {
+	return rc.getFromCacheByCV(ctx, docID, cv, true, includeBody, includeDelta)
 }
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
 // present in the cache.
 func (rc *LRURevisionCache) Peek(ctx context.Context, docID, revID string) (docRev DocumentRevision, found bool) {
-	docRev, err := rc.getFromCache(ctx, docID, revID, false, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err := rc.getFromCacheByRev(ctx, docID, revID, false, RevCacheOmitBody, RevCacheOmitDelta)
 	if err != nil {
 		return DocumentRevision{}, false
 	}
@@ -140,18 +156,42 @@ func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string
 	}
 }
 
-func (rc *LRURevisionCache) getFromCache(ctx context.Context, docID, revID string, loadOnCacheMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID string, loadOnCacheMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
 	value := rc.getValue(docID, revID, loadOnCacheMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
 	}
 
-	docRev, statEvent, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
-	rc.statsRecorderFunc(statEvent)
+	docRev, cacheHit, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
+	rc.statsRecorderFunc(cacheHit)
 
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
+	if !cacheHit {
+		rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV)
+	}
+
+	return docRev, err
+}
+
+func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *CurrentVersionVector, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+	value := rc.getValueByCV(docID, cv, loadCacheOnMiss)
+	if value == nil {
+		return DocumentRevision{}, nil
+	}
+
+	docRev, cacheHit, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
+	rc.statsRecorderFunc(cacheHit)
+
+	if err != nil {
+		rc.removeValue(value) // don't keep failed loads in the cache
+	}
+
+	if !cacheHit {
+		rc.addToRevMapPostLoad(docID, docRev.RevID, docRev.CV)
+	}
+
 	return docRev, err
 }
 
@@ -162,15 +202,16 @@ func (rc *LRURevisionCache) LoadInvalidRevFromBackingStore(ctx context.Context, 
 	var docRevBody Body
 
 	value := revCacheValue{
-		key: key,
+		id:    key.DocID,
+		revID: key.RevID,
 	}
 
 	// If doc has been passed in use this to grab values. Otherwise run revCacheLoader which will grab the Document
 	// first
 	if doc != nil {
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, key.RevID)
+		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, _, value.err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, key.RevID)
 	} else {
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoader(ctx, rc.backingStore, key, includeBody)
+		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, _, value.err = revCacheLoader(ctx, rc.backingStore, key, includeBody)
 	}
 
 	if includeDelta {
@@ -210,12 +251,15 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, include
 	// Retrieve from or add to rev cache
 	value := rc.getValue(docID, bucketDoc.CurrentRev, true)
 
-	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStore, bucketDoc, includeBody)
-	rc.statsRecorderFunc(statEvent)
+	docRev, cacheHit, err := value.loadForDoc(ctx, rc.backingStore, bucketDoc, includeBody)
+	rc.statsRecorderFunc(cacheHit)
 
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
+	// add successfully fetched value to cv lookup map too
+	rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV)
+
 	return docRev, err
 }
 
@@ -234,30 +278,43 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision) {
 		// TODO: CBG-1948
 		panic("Missing history for RevisionCache.Put")
 	}
-	value := rc.getValue(docRev.DocID, docRev.RevID, true)
+	// doc should always have a cv present in a PUT operation on the cache (update HLV is called before hand in doc update process)
+	// thus we can call getValueByCV directly the update the rev lookup post this
+	value := rc.getValueByCV(docRev.DocID, docRev.CV, true)
+	// store the created value
 	value.store(docRev)
+
+	// add new doc version to the rev id lookup map
+	rc.addToRevMapPostLoad(docRev.DocID, docRev.RevID, docRev.CV)
 }
 
 // Upsert a revision in the cache.
 func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision) {
-	key := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
+	var value *revCacheValue
+	// similar to PUT operation we should have the CV defined by this point (updateHLV is called before calling this)
+	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.VersionCAS}
+	legacyKey := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
 
 	rc.lock.Lock()
-	// If element exists remove from lrulist
-	if elem := rc.cache[key]; elem != nil {
+	// lookup for element in hlv lookup map, if not found for some reason try rev lookup map
+	if elem := rc.hlvCache[key]; elem != nil {
+		rc.lruList.Remove(elem)
+	} else if elem = rc.cache[legacyKey]; elem != nil {
 		rc.lruList.Remove(elem)
 	}
 
 	// Add new value and overwrite existing cache key, pushing to front to maintain order
-	value := &revCacheValue{key: key}
-	rc.cache[key] = rc.lruList.PushFront(value)
+	// also ensure we add to rev id lookup map too
+	value = &revCacheValue{id: docRev.DocID, cv: *docRev.CV}
+	elem := rc.lruList.PushFront(value)
+	rc.hlvCache[key] = elem
+	rc.cache[legacyKey] = elem
 
-	// Purge oldest item if required
-	for len(rc.cache) > int(rc.capacity) {
+	for rc.lruList.Len() > int(rc.capacity) {
 		rc.purgeOldest_()
 	}
 	rc.lock.Unlock()
-
+	// store upsert value
 	value.store(docRev)
 }
 
@@ -272,9 +329,9 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 		rc.lruList.MoveToFront(elem)
 		value = elem.Value.(*revCacheValue)
 	} else if create {
-		value = &revCacheValue{key: key}
+		value = &revCacheValue{id: docID, revID: revID}
 		rc.cache[key] = rc.lruList.PushFront(value)
-		for len(rc.cache) > int(rc.capacity) {
+		for rc.lruList.Len() > int(rc.capacity) {
 			rc.purgeOldest_()
 		}
 	}
@@ -282,8 +339,116 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 	return
 }
 
+// getValueByCV gets a value from rev cache by CV, if not found and create is true, will add the value to cache and both lookup maps
+func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector, create bool) (value *revCacheValue) {
+	if docID == "" || cv == nil {
+		return nil
+	}
+
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	rc.lock.Lock()
+	if elem := rc.hlvCache[key]; elem != nil {
+		rc.lruList.MoveToFront(elem)
+		value = elem.Value.(*revCacheValue)
+	} else if create {
+		value = &revCacheValue{id: docID, cv: *cv}
+		newElem := rc.lruList.PushFront(value)
+		rc.hlvCache[key] = newElem
+		for rc.lruList.Len() > int(rc.capacity) {
+			rc.purgeOldest_()
+		}
+	}
+	rc.lock.Unlock()
+	return
+}
+
+// addToRevMapPostLoad will generate and entry in the Rev lookup map for a new document entering the cache
+func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+	legacyKey := IDAndRev{DocID: docID, RevID: revID}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// check for existing value in rev cache map (due to concurrent fetch by rev ID)
+	cvElem, cvFound := rc.hlvCache[key]
+	revElem, revFound := rc.cache[legacyKey]
+	if !cvFound {
+		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
+		// need to return doc revision to caller still but no need repopulate the cache
+		return
+	}
+	// Check if another goroutine has already updated the rev map
+	if revFound {
+		if cvElem == revElem {
+			// already match, return
+			return
+		}
+		// if CV map and rev map are targeting different list elements, update to have both use the cv map element
+		rc.cache[legacyKey] = cvElem
+		rc.lruList.Remove(revElem)
+	} else {
+		// if not found we need to add the element to the rev lookup (for PUT code path)
+		rc.cache[legacyKey] = cvElem
+	}
+}
+
+// addToHLVMapPostLoad will generate and entry in the CV lookup map for a new document entering the cache
+func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+	legacyKey := IDAndRev{DocID: docID, RevID: revID}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// check for existing value in rev cache map (due to concurrent fetch by rev ID)
+	cvElem, cvFound := rc.hlvCache[key]
+	revElem, revFound := rc.cache[legacyKey]
+	if !revFound {
+		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
+		// need to return doc revision to caller still but no need repopulate the cache
+		return
+	}
+	// Check if another goroutine has already updated the cv map
+	if cvFound {
+		if cvElem == revElem {
+			// already match, return
+			return
+		}
+		// if CV map and rev map are targeting different list elements, update to have both use the cv map element
+		rc.cache[legacyKey] = cvElem
+		rc.lruList.Remove(revElem)
+	}
+}
+
 // Remove removes a value from the revision cache, if present.
-func (rc *LRURevisionCache) Remove(docID, revID string) {
+func (rc *LRURevisionCache) RemoveWithRev(docID, revID string) {
+	rc.removeFromCacheByRev(docID, revID)
+}
+
+// RemoveWithCV removes a value from rev cache by CV reference if present
+func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+	rc.removeFromCacheByCV(docID, cv)
+}
+
+// removeFromCacheByCV removes an entry from rev cache by CV
+func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *CurrentVersionVector) {
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	element, ok := rc.hlvCache[key]
+	if !ok {
+		return
+	}
+	// grab the revid key from the value to enable us to remove the reference from the rev lookup map too
+	elem := element.Value.(*revCacheValue)
+	legacyKey := IDAndRev{DocID: docID, RevID: elem.revID}
+	rc.lruList.Remove(element)
+	delete(rc.hlvCache, key)
+	// remove from rev lookup map too
+	delete(rc.cache, legacyKey)
+}
+
+// removeFromCacheByRev removes an entry from rev cache by revID
+func (rc *LRURevisionCache) removeFromCacheByRev(docID, revID string) {
 	key := IDAndRev{DocID: docID, RevID: revID}
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -291,23 +456,38 @@ func (rc *LRURevisionCache) Remove(docID, revID string) {
 	if !ok {
 		return
 	}
+	// grab the cv key key from the value to enable us to remove the reference from the rev lookup map too
+	elem := element.Value.(*revCacheValue)
+	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.VersionCAS}
 	rc.lruList.Remove(element)
 	delete(rc.cache, key)
+	// remove from CV lookup map too
+	delete(rc.hlvCache, hlvKey)
 }
 
 // removeValue removes a value from the revision cache, if present and the value matches the the value. If there's an item in the revision cache with a matching docID and revID but the document is different, this item will not be removed from the rev cache.
 func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 	rc.lock.Lock()
-	if element := rc.cache[value.key]; element != nil && element.Value == value {
+	defer rc.lock.Unlock()
+	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+	if element := rc.cache[revKey]; element != nil && element.Value == value {
 		rc.lruList.Remove(element)
-		delete(rc.cache, value.key)
+		delete(rc.cache, revKey)
 	}
-	rc.lock.Unlock()
+	// need to also check hlv lookup cache map
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	if element := rc.hlvCache[hlvKey]; element != nil && element.Value == value {
+		rc.lruList.Remove(element)
+		delete(rc.hlvCache, hlvKey)
+	}
 }
 
 func (rc *LRURevisionCache) purgeOldest_() {
 	value := rc.lruList.Remove(rc.lruList.Back()).(*revCacheValue)
-	delete(rc.cache, value.key)
+	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	delete(rc.cache, revKey)
+	delete(rc.hlvCache, hlvKey)
 }
 
 // Gets the body etc. out of a revCacheValue. If they aren't present already, the loader func
@@ -319,6 +499,8 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	// to reduce locking when includeDelta=false
 	var delta *RevisionDelta
 	var docRevBody Body
+	var fetchedCV *CurrentVersionVector
+	var revid string
 
 	// Attempt to read cached value.
 	value.lock.RLock()
@@ -349,12 +531,24 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 		// If body is requested and not already present in cache, populate value.body from value.BodyBytes
 		if includeBody && value.body == nil && value.err == nil {
 			if err := value.body.Unmarshal(value.bodyBytes); err != nil {
-				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 			}
 		}
 	} else {
 		cacheHit = false
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoader(ctx, backingStore, value.key, includeBody)
+		if value.revID == "" {
+			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForCv(ctx, backingStore, hlvKey, includeBody)
+			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
+			value.revID = revid
+		} else {
+			revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, fetchedCV, value.err = revCacheLoader(ctx, backingStore, revKey, includeBody)
+			// based off the revision load we need to populate the hlv key with what has been fetched from the bucket (for use of populating the opposite lookup map)
+			if fetchedCV != nil {
+				value.cv = *fetchedCV
+			}
+		}
 	}
 
 	if includeDelta {
@@ -374,7 +568,7 @@ func (value *revCacheValue) updateBody(ctx context.Context) (err error) {
 	var body Body
 	if err := body.Unmarshal(value.bodyBytes); err != nil {
 		// On unmarshal error, warn return docRev without body
-		base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+		base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 		return err
 	}
 
@@ -391,8 +585,8 @@ func (value *revCacheValue) updateBody(ctx context.Context) (err error) {
 func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) (DocumentRevision, error) {
 
 	docRev := DocumentRevision{
-		DocID:       value.key.DocID,
-		RevID:       value.key.RevID,
+		DocID:       value.id,
+		RevID:       value.revID,
 		BodyBytes:   value.bodyBytes,
 		History:     value.history,
 		Channels:    value.channels,
@@ -400,6 +594,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 		Attachments: value.attachments.ShallowCopy(), // Avoid caller mutating the stored attachments
 		Deleted:     value.deleted,
 		Removed:     value.removed,
+		CV:          &CurrentVersionVector{VersionCAS: value.cv.VersionCAS, SourceID: value.cv.SourceID},
 	}
 	if body != nil {
 		docRev._shallowCopyBody = body.ShallowCopy()
@@ -414,6 +609,8 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, includeBody bool) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	var docRevBody Body
+	var fetchedCV *CurrentVersionVector
+	var revid string
 	value.lock.RLock()
 	if value.bodyBytes != nil || value.err != nil {
 		if includeBody {
@@ -443,13 +640,22 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 		// If body is requested and not already present in cache, attempt to generate from bytes and insert into cache
 		if includeBody && value.body == nil {
 			if err := value.body.Unmarshal(value.bodyBytes); err != nil {
-				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 			}
 		}
 	} else {
 		cacheHit = false
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.key.RevID)
+		if value.revID == "" {
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForDocumentCV(ctx, backingStore, doc, value.cv)
+			value.revID = revid
+		} else {
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, fetchedCV, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.revID)
+			if fetchedCV != nil {
+				value.cv = *fetchedCV
+			}
+		}
 	}
+
 	if includeBody {
 		docRevBody = value.body
 	}
@@ -462,7 +668,7 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 func (value *revCacheValue) store(docRev DocumentRevision) {
 	value.lock.Lock()
 	if value.bodyBytes == nil {
-		// value already has doc id/rev id in key
+		value.revID = docRev.RevID
 		value.bodyBytes = docRev.BodyBytes
 		value.history = docRev.History
 		value.channels = docRev.Channels

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -131,7 +131,7 @@ func TestBackupOldRevision(t *testing.T) {
 
 	// create rev 2 and check backups for both revs
 	rev2ID := "2-abc"
-	_, _, err = collection.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// now in all cases we'll have rev 1 backed up (for at least 5 minutes)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2746,6 +2746,97 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "null doc body for doc")
 }
 
+// TestPutDocUpdateVersionVector:
+//   - Put a doc and assert that the versions and the source for the hlv is correctly updated
+//   - Update that doc and assert HLV has also been updated
+//   - Delete the doc and assert that the HLV has been updated in deletion event
+func TestPutDocUpdateVersionVector(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"key": "value"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Put a new revision of this doc and assert that the version vector SourceID and Version is updated
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, `{"key1": "value1"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Delete doc and assert that the version vector SourceID and Version is updated
+	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}
+
+// TestHLVOnPutWithImportRejection:
+//   - Put a doc successfully and assert the HLV is updated correctly
+//   - Put a doc that will be rejected by the custom import filter
+//   - Assert that the HLV values on the sync data are still correctly updated/preserved
+func TestHLVOnPutWithImportRejection(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
+	importFilter := `function (doc) { return doc.type == "mobile"}`
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:   false,
+			ImportFilter: &importFilter,
+		}},
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"type": "mobile"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Put a doc that will be rejected by the import filter on the attempt to perform on demand import for write
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"type": "not-mobile"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// assert that the hlv is correctly updated and in tact after the import was cancelled on the doc
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc2")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}
+
 func TestTombstoneCompactionAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -1060,6 +1060,7 @@ func TestAttachmentContentType(t *testing.T) {
 }
 
 func TestBasicAttachmentRemoval(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
 	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
@@ -2223,6 +2224,7 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 }
 
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2262,184 +2262,188 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 }
 func TestUpdateExistingAttachment(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
 
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
 	)
-	doc1Version := rt.PutDoc(doc1ID, `{}`)
-	doc2Version := rt.PutDoc(doc2ID, `{}`)
 
-	require.NoError(t, rt.WaitForPendingChanges())
+	btc.Run(func(t *testing.T) {
+		// Add doc1 and doc2
+		doc1Version := rt.PutDoc(doc1ID, `{}`)
+		doc2Version := rt.PutDoc(doc2ID, `{}`)
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, ok)
-	_, ok = btc.WaitForVersion(doc2ID, doc2Version)
-	require.True(t, ok)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
-	attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
-	attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
+		err := btc.StartOneshotPull()
+		assert.NoError(t, err)
+		_, ok := btc.WaitForVersion(doc1ID, doc1Version)
+		require.True(t, ok)
+		_, ok = btc.WaitForVersion(doc2ID, doc2Version)
+		require.True(t, ok)
 
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
-	require.NoError(t, err)
-	doc2Version, err = btc.PushRev(doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
-	require.NoError(t, err)
+		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
+		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
 
-	assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
-	assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
+		doc1Version, err = btc.PushRev("doc1", doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+		require.NoError(t, err)
+		doc2Version, err = btc.PushRev("doc2", doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
+		require.NoError(t, err)
 
-	_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
-	require.NoError(t, err)
-	_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
-	require.NoError(t, err)
+		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
 
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
-	require.NoError(t, err)
+		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		require.NoError(t, err)
+		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
+		require.NoError(t, err)
 
-	assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		doc1Version, err = btc.PushRev("doc1", doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
+		require.NoError(t, err)
 
-	doc1, err := rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
-	assert.NoError(t, err)
+		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
 
-	assert.Equal(t, "sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=", doc1.Attachments["attachment"].(map[string]interface{})["digest"])
+		doc1, err := btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		assert.NoError(t, err)
 
-	req := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
-	assert.Equal(t, "attachmentB", string(req.BodyBytes()))
+		assert.Equal(t, "sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=", doc1.Attachments["attachment"].(map[string]interface{})["digest"])
+
+		req := btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
+		assert.Equal(t, "attachmentB", string(req.BodyBytes()))
+	}, t, rtConfig)
 }
 
 // TestPushUnknownAttachmentAsStub sets revpos to an older generation, for an attachment that doesn't exist on the server.
 // Verifies that getAttachment is triggered, and attachment is properly persisted.
 func TestPushUnknownAttachmentAsStub(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	assert.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
 
 	const doc1ID = "doc1"
-	doc1Version := rt.PutDoc(doc1ID, `{}`)
 
-	require.NoError(t, rt.WaitForPendingChanges())
+	btc.Run(func(t *testing.T) {
+		// Add doc1 and doc2
+		doc1Version := rt.PutDoc(doc1ID, `{}`)
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
-	_, ok := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, ok)
+		err := btc.StartOneshotPull()
+		assert.NoError(t, err)
 
-	// force attachment into test client's store to validate it's fetched
-	attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
-	contentType := "text/plain"
+		_, ok := btc.WaitForVersion(doc1ID, doc1Version)
+		require.True(t, ok)
 
-	length, digest, err := btc.saveAttachment(contentType, attachmentAData)
-	require.NoError(t, err)
-	// Update doc1, include reference to non-existing attachment with recent revpos
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"content_type":"%s","stub":true,"revpos":1}}}`, digest, length, contentType)))
-	require.NoError(t, err)
+		// force attachment into test client's store to validate it's fetched
+		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
+		contentType := "text/plain"
 
-	require.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		length, digest, err := btc.saveAttachment(contentType, attachmentAData)
+		require.NoError(t, err)
+		// Update doc1, include reference to non-existing attachment with recent revpos
+		doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"content_type":"%s","stub":true,"revpos":1}}}`, digest, length, contentType)))
+		require.NoError(t, err)
 
-	// verify that attachment exists on document and was persisted
-	attResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
-	assert.Equal(t, 200, attResponse.Code)
-	assert.Equal(t, "attachmentA", string(attResponse.BodyBytes()))
+		require.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
 
+		// verify that attachment exists on document and was persisted
+		attResponse := btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
+		assert.Equal(t, 200, attResponse.Code)
+		assert.Equal(t, "attachmentA", string(attResponse.BodyBytes()))
+	}, t, rtConfig)
 }
 
 func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				AllowConflicts: base.BoolPtr(true),
 			},
 		},
-	})
-	defer rt.Close()
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
 
-	// Push an initial rev with attachment data
 	const docID = "doc"
-	initialVersion := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-	err = rt.WaitForPendingChanges()
-	assert.NoError(t, err)
 
-	// Replicate data to client and ensure doc arrives
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, found := btc.WaitForVersion(docID, initialVersion)
-	assert.True(t, found)
+	btc.Run(func(t *testing.T) {
+		// Push an initial rev with attachment data
+		initialVersion := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		err = rt.WaitForPendingChanges()
+		assert.NoError(t, err)
 
-	// Push a revision with a bunch of history simulating doc updated on mobile device
-	// Note this references revpos 1 and therefore SGW has it - Shouldn't need proveAttachment
-	proveAttachmentBefore := btc.pushReplication.replicationStats.ProveAttachment.Value()
-	revid, err := btc.PushRevWithHistory(docID, initialVersion.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
-	assert.NoError(t, err)
-	proveAttachmentAfter := btc.pushReplication.replicationStats.ProveAttachment.Value()
-	assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
+		// Replicate data to client and ensure doc arrives
+		err = btc.StartOneshotPull()
+		assert.NoError(t, err)
+		_, found := btc.WaitForVersion(docID, initialVersion)
+		assert.True(t, found)
 
-	// Push another bunch of history
-	_, err = btc.PushRevWithHistory(docID, revid, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
-	assert.NoError(t, err)
-	proveAttachmentAfter = btc.pushReplication.replicationStats.ProveAttachment.Value()
-	assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
+		// Push a revision with a bunch of history simulating doc updated on mobile device
+		// Note this references revpos 1 and therefore SGW has it - Shouldn't need proveAttachment
+		proveAttachmentBefore := btc.pushReplication.replicationStats.ProveAttachment.Value()
+		revid, err := btc.PushRevWithHistory(docID, initialVersion.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
+		assert.NoError(t, err)
+		proveAttachmentAfter := btc.pushReplication.replicationStats.ProveAttachment.Value()
+		assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
+
+		// Push another bunch of history
+		_, err = btc.PushRevWithHistory(docID, revid, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
+		assert.NoError(t, err)
+		proveAttachmentAfter = btc.pushReplication.replicationStats.ProveAttachment.Value()
+		assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
+	}, t, rtConfig)
 }
 func TestAttachmentWithErroneousRevPos(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
 
-	// Create rev 1 with the hello.txt attachment
-	const docID = "doc"
-	version := rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-	err = rt.WaitForPendingChanges()
-	assert.NoError(t, err)
+	btc.Run(func(t *testing.T) {
+		// Create rev 1 with the hello.txt attachment
+		const docID = "doc"
+		version := rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		err := rt.WaitForPendingChanges()
+		assert.NoError(t, err)
 
-	// Pull rev and attachment down to client
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, found := btc.WaitForVersion(docID, version)
-	assert.True(t, found)
+		// Pull rev and attachment down to client
+		err = btc.StartOneshotPull()
+		assert.NoError(t, err)
+		_, found := btc.WaitForVersion(docID, version)
+		assert.True(t, found)
 
-	// Add an attachment to client
-	btc.AttachmentsLock().Lock()
-	btc.Attachments()["sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="] = []byte("goodbye cruel world")
-	btc.AttachmentsLock().Unlock()
+		// Add an attachment to client
+		btc.AttachmentsLock().Lock()
+		btc.Attachments()["sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="] = []byte("goodbye cruel world")
+		btc.AttachmentsLock().Unlock()
 
-	// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
-	_, err = btc.PushRevWithHistory(docID, version.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
-	require.NoError(t, err)
+		// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
+		_, err = btc.PushRevWithHistory(docID, version.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
+		require.NoError(t, err)
 
-	// Ensure message and attachment is pushed up
-	_, ok := btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		// Ensure message and attachment is pushed up
+		_, ok := btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	// Get the attachment and ensure the data is updated
-	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc/hello.txt", "")
-	RequireStatus(t, resp, http.StatusOK)
-	assert.Equal(t, "goodbye cruel world", string(resp.BodyBytes()))
+		// Get the attachment and ensure the data is updated
+		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc/hello.txt", "")
+		RequireStatus(t, resp, http.StatusOK)
+		assert.Equal(t, "goodbye cruel world", string(resp.BodyBytes()))
+	}, t, rtConfig)
 }
 
 // CBG-2004: Test that prove attachment over Blip works correctly when receiving a ErrAttachmentNotFound
@@ -2580,74 +2584,74 @@ func TestPutInvalidAttachment(t *testing.T) {
 // validates that proveAttachment isn't being invoked when the attachment is already present and the
 // digest doesn't change, regardless of revpos.
 func TestCBLRevposHandling(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	assert.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
 
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
 	)
-	doc1Version := rt.PutDoc(doc1ID, `{}`)
-	doc2Version := rt.PutDoc(doc2ID, `{}`)
-	require.NoError(t, rt.WaitForPendingChanges())
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, ok)
-	_, ok = btc.WaitForVersion(doc2ID, doc2Version)
-	require.True(t, ok)
+	btc.Run(func(t *testing.T) {
+		doc1Version := rt.PutDoc(doc1ID, `{}`)
+		doc2Version := rt.PutDoc(doc2ID, `{}`)
+		require.NoError(t, rt.WaitForPendingChanges())
 
-	attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
-	attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
+		err := btc.StartOneshotPull()
+		assert.NoError(t, err)
+		_, ok := btc.WaitForVersion(doc1ID, doc1Version)
+		require.True(t, ok)
+		_, ok = btc.WaitForVersion(doc2ID, doc2Version)
+		require.True(t, ok)
 
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
-	require.NoError(t, err)
-	doc2Version, err = btc.PushRev(doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
-	require.NoError(t, err)
+		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
+		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
 
-	assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
-	assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
+		doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+		require.NoError(t, err)
+		doc2Version, err = btc.PushRev(doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
+		require.NoError(t, err)
 
-	_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
-	require.NoError(t, err)
-	_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
-	require.NoError(t, err)
+		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
 
-	// Update doc1, don't change attachment, use correct revpos
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":2}}}`))
-	require.NoError(t, err)
+		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		require.NoError(t, err)
+		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
+		require.NoError(t, err)
 
-	assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		// Update doc1, don't change attachment, use correct revpos
+		doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":2}}}`))
+		require.NoError(t, err)
 
-	// Update doc1, don't change attachment, use revpos=generation of revid, as CBL 2.x does.  Should not proveAttachment on digest match.
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":4}}}`))
-	require.NoError(t, err)
+		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
 
-	// Validate attachment exists
-	attResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
-	assert.Equal(t, 200, attResponse.Code)
-	assert.Equal(t, "attachmentA", string(attResponse.BodyBytes()))
+		// Update doc1, don't change attachment, use revpos=generation of revid, as CBL 2.x does.  Should not proveAttachment on digest match.
+		doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":4}}}`))
+		require.NoError(t, err)
 
-	attachmentPushCount := rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
-	// Update doc1, change attachment digest with CBL revpos=generation.  Should getAttachment
-	_, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":5}}}`))
-	require.NoError(t, err)
+		// Validate attachment exists
+		attResponse := btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
+		assert.Equal(t, 200, attResponse.Code)
+		assert.Equal(t, "attachmentA", string(attResponse.BodyBytes()))
 
-	// Validate attachment exists and is updated
-	attResponse = rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
-	assert.Equal(t, 200, attResponse.Code)
-	assert.Equal(t, "attachmentB", string(attResponse.BodyBytes()))
+		attachmentPushCount := btc.rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
+		// Update doc1, change attachment digest with CBL revpos=generation.  Should getAttachment
+		_, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":5}}}`))
+		require.NoError(t, err)
 
-	attachmentPushCountAfter := rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
-	assert.Equal(t, attachmentPushCount+1, attachmentPushCountAfter)
+		// Validate attachment exists and is updated
+		attResponse = btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
+		assert.Equal(t, 200, attResponse.Code)
+		assert.Equal(t, "attachmentB", string(attResponse.BodyBytes()))
 
+		attachmentPushCountAfter := btc.rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
+		assert.Equal(t, attachmentPushCount+1, attachmentPushCountAfter)
+	}, t, rtConfig)
 }
 
 // Helper_Functions

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2276,8 +2276,8 @@ func TestUpdateExistingAttachment(t *testing.T) {
 
 	btc.Run(func(t *testing.T) {
 		// Add doc1 and doc2
-		doc1Version := rt.PutDoc(doc1ID, `{}`)
-		doc2Version := rt.PutDoc(doc2ID, `{}`)
+		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
+		doc2Version := btc.rt.PutDoc(doc2ID, `{}`)
 
 		require.NoError(t, btc.rt.WaitForPendingChanges())
 
@@ -2296,8 +2296,8 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		doc2Version, err = btc.PushRev("doc2", doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
 		require.NoError(t, err)
 
-		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
-		assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
+		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, btc.rt.WaitForVersion(doc2ID, doc2Version))
 
 		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
 		require.NoError(t, err)
@@ -2307,7 +2307,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		doc1Version, err = btc.PushRev("doc1", doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
 		require.NoError(t, err)
 
-		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
 
 		doc1, err := btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
 		assert.NoError(t, err)
@@ -2333,7 +2333,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 
 	btc.Run(func(t *testing.T) {
 		// Add doc1 and doc2
-		doc1Version := rt.PutDoc(doc1ID, `{}`)
+		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
 
 		require.NoError(t, btc.rt.WaitForPendingChanges())
 
@@ -2353,7 +2353,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 		doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"content_type":"%s","stub":true,"revpos":1}}}`, digest, length, contentType)))
 		require.NoError(t, err)
 
-		require.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		require.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
 
 		// verify that attachment exists on document and was persisted
 		attResponse := btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
@@ -2380,8 +2380,8 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 
 	btc.Run(func(t *testing.T) {
 		// Push an initial rev with attachment data
-		initialVersion := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-		err = rt.WaitForPendingChanges()
+		initialVersion := btc.rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		err := btc.rt.WaitForPendingChanges()
 		assert.NoError(t, err)
 
 		// Replicate data to client and ensure doc arrives
@@ -2416,8 +2416,8 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	btc.Run(func(t *testing.T) {
 		// Create rev 1 with the hello.txt attachment
 		const docID = "doc"
-		version := rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-		err := rt.WaitForPendingChanges()
+		version := btc.rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		err := btc.rt.WaitForPendingChanges()
 		assert.NoError(t, err)
 
 		// Pull rev and attachment down to client
@@ -2597,9 +2597,9 @@ func TestCBLRevposHandling(t *testing.T) {
 	)
 
 	btc.Run(func(t *testing.T) {
-		doc1Version := rt.PutDoc(doc1ID, `{}`)
-		doc2Version := rt.PutDoc(doc2ID, `{}`)
-		require.NoError(t, rt.WaitForPendingChanges())
+		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
+		doc2Version := btc.rt.PutDoc(doc2ID, `{}`)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
 		err := btc.StartOneshotPull()
 		assert.NoError(t, err)
@@ -2616,8 +2616,8 @@ func TestCBLRevposHandling(t *testing.T) {
 		doc2Version, err = btc.PushRev(doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
 		require.NoError(t, err)
 
-		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
-		assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
+		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, btc.rt.WaitForVersion(doc2ID, doc2Version))
 
 		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
 		require.NoError(t, err)
@@ -2628,7 +2628,7 @@ func TestCBLRevposHandling(t *testing.T) {
 		doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":2}}}`))
 		require.NoError(t, err)
 
-		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
 
 		// Update doc1, don't change attachment, use revpos=generation of revid, as CBL 2.x does.  Should not proveAttachment on digest match.
 		doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":4}}}`))

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2266,7 +2266,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 
 	const (
@@ -2326,7 +2326,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 
 	const doc1ID = "doc1"
@@ -2373,7 +2373,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		},
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 
 	const docID = "doc"
@@ -2410,7 +2410,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 
 	btc.Run(func(t *testing.T) {
@@ -2588,7 +2588,7 @@ func TestCBLRevposHandling(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 
 	const (

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -43,56 +43,57 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 		},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
 	opts := &BlipTesterClientOpts{}
 	opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, opts)
-	require.NoError(t, err)
+	// given this test is for v2 protocol, skip version vector test
+	opts.SkipVersionVectorInitialization = true
+	btc := NewBlipTesterClientOptsWithRT(opts)
 	defer btc.Close()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
 	const docID = "doc1"
 
-	// Create doc revision with attachment on SG.
-	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	version := rt.PutDoc(docID, bodyText)
+	btc.Run(func(t *testing.T) {
+		err := btc.StartPull()
+		assert.NoError(t, err)
 
-	data, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	require.JSONEq(t, bodyTextExpected, string(data))
+		// Create doc revision with attachment on SG.
+		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		version := rt.PutDoc(docID, bodyText)
 
-	// Update the replicated doc at client along with keeping the same attachment stub.
-	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	version, err = btc.PushRev(docID, version, []byte(bodyText))
-	require.NoError(t, err)
+		data, ok := btc.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		require.JSONEq(t, bodyTextExpected, string(data))
 
-	// Wait for the document to be replicated at SG
-	_, ok = btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		// Update the replicated doc at client along with keeping the same attachment stub.
+		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		version, err = btc.PushRev(docID, version, []byte(bodyText))
+		require.NoError(t, err)
 
-	respBody := rt.GetDocVersion(docID, version)
+		// Wait for the document to be replicated at SG
+		_, ok = btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+		respBody := rt.GetDocVersion(docID, version)
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 1)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(1), hello["revpos"])
-	assert.True(t, hello["stub"].(bool))
+		assert.Equal(t, docID, respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
 
-	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
-	assert.Equal(t, int64(11), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 1)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(1), hello["revpos"])
+		assert.True(t, hello["stub"].(bool))
+
+		assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+		assert.Equal(t, int64(11), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+	}, t, &rtConfig)
 }
 
 // Test pushing and pulling v2 attachments with v3 client
@@ -113,54 +114,53 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 		},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
 	const docID = "doc1"
 
-	// Create doc revision with attachment on SG.
-	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	version := rt.PutDoc(docID, bodyText)
+	btc.Run(func(t *testing.T) {
+		err := btc.StartPull()
+		assert.NoError(t, err)
 
-	data, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	require.JSONEq(t, bodyTextExpected, string(data))
+		// Create doc revision with attachment on SG.
+		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		version := rt.PutDoc(docID, bodyText)
 
-	// Update the replicated doc at client along with keeping the same attachment stub.
-	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	version, err = btc.PushRev(docID, version, []byte(bodyText))
-	require.NoError(t, err)
+		data, ok := btc.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		require.JSONEq(t, bodyTextExpected, string(data))
 
-	// Wait for the document to be replicated at SG
-	_, ok = btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		// Update the replicated doc at client along with keeping the same attachment stub.
+		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		version, err = btc.PushRev(docID, version, []byte(bodyText))
+		require.NoError(t, err)
 
-	respBody := rt.GetDocVersion(docID, version)
+		// Wait for the document to be replicated at SG
+		_, ok = btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+		respBody := rt.GetDocVersion(docID, version)
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 1)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(1), hello["revpos"])
-	assert.True(t, hello["stub"].(bool))
+		assert.Equal(t, docID, respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
 
-	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
-	assert.Equal(t, int64(11), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 1)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(1), hello["revpos"])
+		assert.True(t, hello["stub"].(bool))
+
+		assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+		assert.Equal(t, int64(11), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+	}, t, &rtConfig)
 }
 
 // TestBlipProveAttachmentV2 ensures that CBL's proveAttachment for deduplication is working correctly even for v2 attachments which aren't de-duped on the server side.
@@ -169,17 +169,12 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+		SupportedBLIPProtocols:          []string{db.BlipCBMobileReplicationV2},
+		SkipVersionVectorInitialization: true,
 	})
-	require.NoError(t, err)
 	defer btc.Close()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
 
 	const (
 		doc1ID = "doc1"
@@ -196,29 +191,34 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 		attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
 	)
 
-	// Create two docs with the same attachment data on SG - v2 attachments intentionally result in two copies,
-	// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
-	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	doc1Version := rt.PutDoc(doc1ID, doc1Body)
+	btc.Run(func(t *testing.T) {
+		err := btc.StartPull()
+		assert.NoError(t, err)
 
-	data, ok := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, ok)
-	bodyTextExpected := fmt.Sprintf(`{"greetings":[{"hi":"alice"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
-	require.JSONEq(t, bodyTextExpected, string(data))
+		// Create two docs with the same attachment data on SG - v2 attachments intentionally result in two copies,
+		// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
+		doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+		doc1Version := rt.PutDoc(doc1ID, doc1Body)
 
-	// create doc2 now that we know the client has the attachment
-	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	doc2Version := rt.PutDoc(doc2ID, doc2Body)
+		data, ok := btc.WaitForVersion(doc1ID, doc1Version)
+		require.True(t, ok)
+		bodyTextExpected := fmt.Sprintf(`{"greetings":[{"hi":"alice"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
+		require.JSONEq(t, bodyTextExpected, string(data))
 
-	data, ok = btc.WaitForVersion(doc2ID, doc2Version)
-	require.True(t, ok)
-	bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
-	require.JSONEq(t, bodyTextExpected, string(data))
+		// create doc2 now that we know the client has the attachment
+		doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+		doc2Version := rt.PutDoc(doc2ID, doc2Body)
 
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value())
-	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPull().RevErrorCount.Value())
-	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullCount.Value())
-	assert.Equal(t, int64(len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullBytes.Value())
+		data, ok = btc.WaitForRev(doc2ID, doc2RevID)
+		require.True(t, ok)
+		bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
+		require.JSONEq(t, bodyTextExpected, string(data))
+
+		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value())
+		assert.Equal(t, int64(0), btc.rt.GetDatabase().DbStats.CBLReplicationPull().RevErrorCount.Value())
+		assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullCount.Value())
+		assert.Equal(t, int64(len(attachmentData)), btc.rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullBytes.Value())
+	}, t, &rtConfig)
 }
 
 // TestBlipProveAttachmentV2Push ensures that CBL's attachment deduplication is ignored for push replications - resulting in new server-side digests and duplicated attachment data (v2 attachment format).
@@ -227,13 +227,11 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+		SupportedBLIPProtocols:          []string{db.BlipCBMobileReplicationV2},
+		SkipVersionVectorInitialization: true,
 	})
-	require.NoError(t, err)
 	defer btc.Close()
 
 	const (
@@ -250,27 +248,28 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 		attachmentDataB64 = base64.StdEncoding.EncodeToString([]byte(attachmentData))
 		// attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
 	)
+	btc.Run(func(t *testing.T) {
+		// Create two docs with the same attachment data on the client - v2 attachments intentionally result in two copies stored on the server, despite the client being able to share the data for both.
+		doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+		doc1Version, err := btc.PushRev(doc1ID, EmptyDocVersion(), []byte(doc1Body))
+		require.NoError(t, err)
 
-	// Create two docs with the same attachment data on the client - v2 attachments intentionally result in two copies stored on the server, despite the client being able to share the data for both.
-	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	doc1Version, err := btc.PushRev(doc1ID, EmptyDocVersion(), []byte(doc1Body))
-	require.NoError(t, err)
+		err = rt.WaitForVersion(doc1ID, doc1Version)
+		require.NoError(t, err)
 
-	err = rt.WaitForVersion(doc1ID, doc1Version)
-	require.NoError(t, err)
+		// create doc2 now that we know the server has the attachment - SG should still request the attachment data from the client.
+		doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+		doc2Version, err := btc.PushRev(doc2ID, EmptyDocVersion(), []byte(doc2Body))
+		require.NoError(t, err)
 
-	// create doc2 now that we know the server has the attachment - SG should still request the attachment data from the client.
-	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	doc2Version, err := btc.PushRev(doc2ID, EmptyDocVersion(), []byte(doc2Body))
-	require.NoError(t, err)
+		err = rt.WaitForVersion(doc2ID, doc2Version)
+		require.NoError(t, err)
 
-	err = rt.WaitForVersion(doc2ID, doc2Version)
-	require.NoError(t, err)
-
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
-	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
-	assert.Equal(t, int64(2*len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
+		assert.Equal(t, int64(0), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
+		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+		assert.Equal(t, int64(2*len(attachmentData)), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+	}, t, &rtConfig)
 }
 
 func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
@@ -278,130 +277,133 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
 
-	err = btc.StartPull()
-	assert.NoError(t, err)
 	const docID = "doc1"
 
-	// CBL creates revisions 1-abc,2-abc on the client, with an attachment associated with rev 2.
-	bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	err = btc.StoreRevOnClient(docID, "2-abc", []byte(bodyText))
-	require.NoError(t, err)
+	btc.Run(func(t *testing.T) {
+		err := btc.StartPull()
+		assert.NoError(t, err)
 
-	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err := btc.PushRevWithHistory(docID, "", []byte(bodyText), 2, 0)
-	require.NoError(t, err)
-	assert.Equal(t, "2-abc", revId)
+		// CBL creates revisions 1-abc,2-abc on the client, with an attachment associated with rev 2.
+		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		err = btc.StoreRevOnClient(docID, "2-abc", []byte(bodyText))
+		require.NoError(t, err)
 
-	// Wait for the documents to be replicated at SG
-	_, ok := btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		response := btc.rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc/_blipsync", "")
+		fmt.Println(response.Code, response.Body.String())
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-	assert.Equal(t, http.StatusOK, resp.Code)
+		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		revId, err := btc.PushRevWithHistory(docID, "", []byte(bodyText), 2, 0)
+		require.NoError(t, err)
+		assert.Equal(t, "2-abc", revId)
 
-	// CBL updates the doc w/ two more revisions, 3-abc, 4-abc,
-	// these are sent to SG as 4-abc, history:[4-abc,3-abc,2-abc], the attachment has revpos=2
-	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err = btc.PushRevWithHistory(docID, revId, []byte(bodyText), 2, 0)
-	require.NoError(t, err)
-	assert.Equal(t, "4-abc", revId)
+		// Wait for the documents to be replicated at SG
+		_, ok := btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	// Wait for the document to be replicated at SG
-	_, ok = btc.pushReplication.WaitForMessage(4)
-	assert.True(t, ok)
+		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
+		assert.Equal(t, http.StatusOK, resp.Code)
 
-	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-	assert.Equal(t, http.StatusOK, resp.Code)
+		// CBL updates the doc w/ two more revisions, 3-abc, 4-abc,
+		// these are sent to SG as 4-abc, history:[4-abc,3-abc,2-abc], the attachment has revpos=2
+		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		revId, err = btc.PushRevWithHistory(docID, revId, []byte(bodyText), 2, 0)
+		require.NoError(t, err)
+		assert.Equal(t, "4-abc", revId)
 
-	var respBody db.Body
-	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
+		// Wait for the document to be replicated at SG
+		_, ok = btc.pushReplication.WaitForMessage(4)
+		assert.True(t, ok)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	assert.Equal(t, "4-abc", respBody[db.BodyRev])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+		resp = btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
+		assert.Equal(t, http.StatusOK, resp.Code)
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 1)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(2), hello["revpos"])
-	assert.True(t, hello["stub"].(bool))
+		var respBody db.Body
+		assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
 
-	// Check the number of sendProveAttachment/sendGetAttachment calls.
-	require.NotNil(t, btc.pushReplication.replicationStats)
-	assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
-	assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
+		assert.Equal(t, docID, respBody[db.BodyId])
+		assert.Equal(t, "4-abc", respBody[db.BodyRev])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 1)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(2), hello["revpos"])
+		assert.True(t, hello["stub"].(bool))
+
+		// Check the number of sendProveAttachment/sendGetAttachment calls.
+		require.NotNil(t, btc.pushReplication.replicationStats)
+		assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
+		assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
+	}, t, &rtConfig)
 }
 func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
 
-	err = btc.StartPull()
-	assert.NoError(t, err)
 	const docID = "doc1"
 
-	// CBL creates revisions 1-abc, 2-abc, 3-abc, 4-abc on the client, with an attachment associated with rev 2.
-	// rev tree pruning on the CBL side, so 1-abc no longer exists.
-	// CBL replicates, sends to client as 4-abc history:[4-abc, 3-abc, 2-abc], attachment has revpos=2
-	bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	err = btc.StoreRevOnClient(docID, "2-abc", []byte(bodyText))
-	require.NoError(t, err)
+	btc.Run(func(t *testing.T) {
+		err := btc.StartPull()
+		assert.NoError(t, err)
 
-	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err := btc.PushRevWithHistory(docID, "2-abc", []byte(bodyText), 2, 0)
-	require.NoError(t, err)
-	assert.Equal(t, "4-abc", revId)
+		// CBL creates revisions 1-abc, 2-abc, 3-abc, 4-abc on the client, with an attachment associated with rev 2.
+		// rev tree pruning on the CBL side, so 1-abc no longer exists.
+		// CBL replicates, sends to client as 4-abc history:[4-abc, 3-abc, 2-abc], attachment has revpos=2
+		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		err = btc.StoreRevOnClient(docID, "2-abc", []byte(bodyText))
+		require.NoError(t, err)
 
-	// Wait for the document to be replicated at SG
-	_, ok := btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		revId, err := btc.PushRevWithHistory(docID, "2-abc", []byte(bodyText), 2, 0)
+		require.NoError(t, err)
+		assert.Equal(t, "4-abc", revId)
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-	assert.Equal(t, http.StatusOK, resp.Code)
+		// Wait for the document to be replicated at SG
+		_, ok := btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	var respBody db.Body
-	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
+		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
+		assert.Equal(t, http.StatusOK, resp.Code)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	assert.Equal(t, "4-abc", respBody[db.BodyRev])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
+		var respBody db.Body
+		assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 1)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(4), hello["revpos"])
-	assert.True(t, hello["stub"].(bool))
+		assert.Equal(t, docID, respBody[db.BodyId])
+		assert.Equal(t, "4-abc", respBody[db.BodyRev])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
 
-	// Check the number of sendProveAttachment/sendGetAttachment calls.
-	require.NotNil(t, btc.pushReplication.replicationStats)
-	assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
-	assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 1)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(4), hello["revpos"])
+		assert.True(t, hello["stub"].(bool))
+
+		// Check the number of sendProveAttachment/sendGetAttachment calls.
+		require.NotNil(t, btc.pushReplication.replicationStats)
+		assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
+		assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
+	}, t, &rtConfig)
 }
 
 // Test Attachment replication behavior described here: https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol
@@ -507,163 +509,164 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 
 // TestBlipAttachNameChange tests CBL handling - attachments with changed names are sent as stubs, and not new attachments
 func TestBlipAttachNameChange(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
+	}
 
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client1 := NewBlipTesterClientOptsWithRT(nil)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
 
-	attachmentA := []byte("attachmentA")
-	attachmentAData := base64.StdEncoding.EncodeToString(attachmentA)
-	digest := db.Sha1DigestKey(attachmentA)
+	client1.Run(func(t *testing.T) {
+		attachmentA := []byte("attachmentA")
+		attachmentAData := base64.StdEncoding.EncodeToString(attachmentA)
+		digest := db.Sha1DigestKey(attachmentA)
 
-	// Push initial attachment data
-	version, err := client1.PushRev("doc", EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
-	require.NoError(t, err)
+		// Push initial attachment data
+		version, err := client1.PushRev("doc", EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
+		require.NoError(t, err)
 
-	// Confirm attachment is in the bucket
-	attachmentAKey := db.MakeAttachmentKey(2, "doc", digest)
-	bucketAttachmentA, _, err := rt.GetSingleDataStore().GetRaw(attachmentAKey)
-	require.NoError(t, err)
-	require.EqualValues(t, bucketAttachmentA, attachmentA)
+		// Confirm attachment is in the bucket
+		attachmentAKey := db.MakeAttachmentKey(2, "doc", digest)
+		bucketAttachmentA, _, err := client1.rt.GetSingleDataStore().GetRaw(attachmentAKey)
+		require.NoError(t, err)
+		require.EqualValues(t, bucketAttachmentA, attachmentA)
 
-	// Simulate changing only the attachment name over CBL
-	// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
-	version, err = client1.PushRev("doc", version, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
-	require.NoError(t, err)
-	err = rt.WaitForVersion("doc", version)
-	require.NoError(t, err)
+		// Simulate changing only the attachment name over CBL
+		// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
+		version, err = client1.PushRev("doc", version, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
+		require.NoError(t, err)
+		err = rt.WaitForVersion("doc", version)
+		require.NoError(t, err)
 
-	// Check if attachment is still in bucket
-	bucketAttachmentA, _, err = rt.GetSingleDataStore().GetRaw(attachmentAKey)
-	assert.NoError(t, err)
-	assert.Equal(t, bucketAttachmentA, attachmentA)
+		// Check if attachment is still in bucket
+		bucketAttachmentA, _, err = client1.rt.GetSingleDataStore().GetRaw(attachmentAKey)
+		assert.NoError(t, err)
+		assert.Equal(t, bucketAttachmentA, attachmentA)
 
-	resp := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
-	RequireStatus(t, resp, http.StatusOK)
-	assert.Equal(t, attachmentA, resp.BodyBytes())
+		resp := client1.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
+		RequireStatus(t, resp, http.StatusOK)
+		assert.Equal(t, attachmentA, resp.BodyBytes())
+	}, t, rtConfig)
 }
 
 // TestBlipLegacyAttachNameChange ensures that CBL name changes for legacy attachments are handled correctly
 func TestBlipLegacyAttachNameChange(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	}
+	client1 := NewBlipTesterClientOptsWithRT(nil)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
 
-	// Create document in the bucket with a legacy attachment
-	docID := "doc"
-	attBody := []byte(`hi`)
-	digest := db.Sha1DigestKey(attBody)
-	attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
-	rawDoc := rawDocWithAttachmentAndSyncMeta()
+	client1.Run(func(t *testing.T) {
+		// Create document in the bucket with a legacy attachment
+		docID := "doc"
+		attBody := []byte(`hi`)
+		digest := db.Sha1DigestKey(attBody)
+		attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
+		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
-	// Create a document with legacy attachment.
-	CreateDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
+		// Create a document with legacy attachment.
+		CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDoc, attKey, attBody)
 
-	// Get the document and grab the revID.
-	docVersion, _ := rt.GetDoc(docID)
+		// Get the document and grab the revID.
+		docVersion, _ := rt.GetDoc(docID)
 
-	// Store the document and attachment on the test client
-	err = client1.StoreRevOnClient(docID, docVersion.RevID, rawDoc)
+		// Store the document and attachment on the test client
+		err = client1.StoreRevOnClient(docID, docVersion.RevID, rawDoc)
 
-	require.NoError(t, err)
-	client1.AttachmentsLock().Lock()
-	client1.Attachments()[digest] = attBody
-	client1.AttachmentsLock().Unlock()
+		require.NoError(t, err)
+		client1.AttachmentsLock().Lock()
+		client1.Attachments()[digest] = attBody
+		client1.AttachmentsLock().Unlock()
 
-	// Confirm attachment is in the bucket
-	attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
-	bucketAttachmentA, _, err := rt.GetSingleDataStore().GetRaw(attachmentAKey)
-	require.NoError(t, err)
-	require.EqualValues(t, bucketAttachmentA, attBody)
+		// Confirm attachment is in the bucket
+		attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
+		bucketAttachmentA, _, err := client1.rt.GetSingleDataStore().GetRaw(attachmentAKey)
+		require.NoError(t, err)
+		require.EqualValues(t, bucketAttachmentA, attBody)
 
-	// Simulate changing only the attachment name over CBL
-	// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
-	docVersion, err = client1.PushRev("doc", docVersion, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
-	require.NoError(t, err)
+		// Simulate changing only the attachment name over CBL
+		// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
+		docVersion, err = client1.PushRev("doc", docVersion, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
+		require.NoError(t, err)
 
-	err = rt.WaitForVersion("doc", docVersion)
-	require.NoError(t, err)
+		err = rt.WaitForVersion("doc", docVersion)
+		require.NoError(t, err)
 
-	resp := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
-	RequireStatus(t, resp, http.StatusOK)
-	assert.Equal(t, attBody, resp.BodyBytes())
+		resp := client1.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
+		RequireStatus(t, resp, http.StatusOK)
+		assert.Equal(t, attBody, resp.BodyBytes())
+	}, t, rtConfig)
 }
 
 // TestBlipLegacyAttachDocUpdate ensures that CBL updates for documents associated with legacy attachments are handled correctly
 func TestBlipLegacyAttachDocUpdate(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	}
+
+	client1 := NewBlipTesterClientOptsWithRT(nil)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
 
-	// Create document in the bucket with a legacy attachment.  Properties here align with rawDocWithAttachmentAndSyncMeta
-	docID := "doc"
-	attBody := []byte(`hi`)
-	digest := db.Sha1DigestKey(attBody)
-	attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
-	attName := "hi.txt"
-	rawDoc := rawDocWithAttachmentAndSyncMeta()
+	client1.Run(func(t *testing.T) {
+		// Create document in the bucket with a legacy attachment.  Properties here align with rawDocWithAttachmentAndSyncMeta
+		docID := "doc"
+		attBody := []byte(`hi`)
+		digest := db.Sha1DigestKey(attBody)
+		attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
+		attName := "hi.txt"
+		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
-	// Create a document with legacy attachment.
-	CreateDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
+		// Create a document with legacy attachment.
+		CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDoc, attKey, attBody)
 
-	version, _ := rt.GetDoc(docID)
+		version, _ := rt.GetDoc(docID)
 
-	// Store the document and attachment on the test client
-	err = client1.StoreRevOnClient(docID, version.RevID, rawDoc)
-	require.NoError(t, err)
-	client1.AttachmentsLock().Lock()
-	client1.Attachments()[digest] = attBody
-	client1.AttachmentsLock().Unlock()
+		// Store the document and attachment on the test client
+		err = client1.StoreRevOnClient(docID, version.RevID, rawDoc)
+		require.NoError(t, err)
+		client1.AttachmentsLock().Lock()
+		client1.Attachments()[digest] = attBody
+		client1.AttachmentsLock().Unlock()
 
-	// Confirm attachment is in the bucket
-	attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
-	dataStore := rt.GetSingleDataStore()
-	bucketAttachmentA, _, err := dataStore.GetRaw(attachmentAKey)
-	require.NoError(t, err)
-	require.EqualValues(t, bucketAttachmentA, attBody)
+		// Confirm attachment is in the bucket
+		attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
+		dataStore := client1.rt.GetSingleDataStore()
+		bucketAttachmentA, _, err := dataStore.GetRaw(attachmentAKey)
+		require.NoError(t, err)
+		require.EqualValues(t, bucketAttachmentA, attBody)
 
-	// Update the document, leaving body intact
-	version, err = client1.PushRev("doc", version, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
-	require.NoError(t, err)
+		// Update the document, leaving body intact
+		version, err = client1.PushRev("doc", version, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
+		require.NoError(t, err)
 
-	err = rt.WaitForVersion("doc", version)
-	require.NoError(t, err)
+		err = rt.WaitForVersion("doc", version)
+		require.NoError(t, err)
 
-	resp := rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/doc/%s", attName), "")
-	RequireStatus(t, resp, http.StatusOK)
-	assert.Equal(t, attBody, resp.BodyBytes())
+		resp := client1.rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/doc/%s", attName), "")
+		RequireStatus(t, resp, http.StatusOK)
+		assert.Equal(t, attBody, resp.BodyBytes())
 
-	// Validate that the attachment hasn't been migrated to V2
-	v1Key := db.MakeAttachmentKey(1, "doc", digest)
-	v1Body, _, err := dataStore.GetRaw(v1Key)
-	require.NoError(t, err)
-	require.EqualValues(t, attBody, v1Body)
+		// Validate that the attachment hasn't been migrated to V2
+		v1Key := db.MakeAttachmentKey(1, "doc", digest)
+		v1Body, _, err := dataStore.GetRaw(v1Key)
+		require.NoError(t, err)
+		require.EqualValues(t, attBody, v1Body)
 
-	v2Key := db.MakeAttachmentKey(2, "doc", digest)
-	_, _, err = dataStore.GetRaw(v2Key)
-	require.Error(t, err)
-	// Confirm correct type of error for both integration test and Walrus
-	if !errors.Is(err, sgbucket.MissingError{Key: v2Key}) {
-		var keyValueErr *gocb.KeyValueError
-		require.True(t, errors.As(err, &keyValueErr))
-		//require.Equal(t, keyValueErr.StatusCode, memd.StatusKeyNotFound)
-		require.Equal(t, keyValueErr.DocumentID, v2Key)
-	}
+		v2Key := db.MakeAttachmentKey(2, "doc", digest)
+		_, _, err = dataStore.GetRaw(v2Key)
+		require.Error(t, err)
+		// Confirm correct type of error for both integration test and Walrus
+		if !errors.Is(err, sgbucket.MissingError{Key: v2Key}) {
+			var keyValueErr *gocb.KeyValueError
+			require.True(t, errors.As(err, &keyValueErr))
+			//require.Equal(t, keyValueErr.StatusCode, memd.StatusKeyNotFound)
+			require.Equal(t, keyValueErr.DocumentID, v2Key)
+		}
+	}, t, rtConfig)
 }
 
 // TestAttachmentComputeStat:
@@ -676,31 +679,28 @@ func TestAttachmentComputeStat(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	opts := &BlipTesterClientOpts{}
-	opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, opts)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
-	syncProcessCompute := btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
 	const docID = "doc1"
 
-	// Create doc revision with attachment on SG.
-	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	version := rt.PutDoc(docID, bodyText)
+	btc.Run(func(t *testing.T) {
+		syncProcessCompute := btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 
-	// Wait for the document to be replicated to client.
-	data, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	require.JSONEq(t, bodyTextExpected, string(data))
+		err := btc.StartPull()
+		assert.NoError(t, err)
 
-	// assert the attachment read compute stat is incremented
-	require.Greater(t, btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncProcessCompute)
+		// Create doc revision with attachment on SG.
+		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		version := rt.PutDoc(docID, bodyText)
 
+		// Wait for the document to be replicated to client.
+		data, ok := btc.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		require.JSONEq(t, bodyTextExpected, string(data))
+
+		// assert the attachment read compute stat is incremented
+		require.Greater(t, btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncProcessCompute)
+	}, t, &rtConfig)
 }

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -48,7 +48,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 	opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}
 	// given this test is for v2 protocol, skip version vector test
 	opts.SkipVersionVectorInitialization = true
-	btc := NewBlipTesterClientOptsWithRT(opts)
+	btc := NewBlipTesterClientOpts(opts)
 	defer btc.Close()
 	const docID = "doc1"
 
@@ -115,7 +115,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 	const docID = "doc1"
 
@@ -170,7 +170,7 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		SupportedBLIPProtocols:          []string{db.BlipCBMobileReplicationV2},
 		SkipVersionVectorInitialization: true,
 	})
@@ -228,7 +228,7 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		SupportedBLIPProtocols:          []string{db.BlipCBMobileReplicationV2},
 		SkipVersionVectorInitialization: true,
 	})
@@ -278,7 +278,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 
 	const docID = "doc1"
@@ -349,7 +349,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 
 	const docID = "doc1"
@@ -510,7 +510,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client1 := NewBlipTesterClientOptsWithRT(nil)
+	client1 := NewBlipTesterClientOpts(nil)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
 
@@ -552,7 +552,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
-	client1 := NewBlipTesterClientOptsWithRT(nil)
+	client1 := NewBlipTesterClientOpts(nil)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
 
@@ -604,7 +604,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client1 := NewBlipTesterClientOptsWithRT(nil)
+	client1 := NewBlipTesterClientOpts(nil)
 	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
 
@@ -677,7 +677,7 @@ func TestAttachmentComputeStat(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 	const docID = "doc1"
 

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -29,7 +29,7 @@ func TestBlipGetCollections(t *testing.T) {
 
 	const defaultScopeAndCollection = "_default._default"
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		SkipCollectionsInitialization: true,
 		NumCollectionsRequired:        1,
 	})
@@ -149,7 +149,7 @@ func TestBlipReplicationNoDefaultCollection(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		SkipVersionVectorInitialization: true, // no need for version vector test here
 	})
 	defer btc.Close()
@@ -179,7 +179,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		SkipVersionVectorInitialization: true, // no need for version vector test here
 	})
 	defer btc.Close()
@@ -239,7 +239,7 @@ func TestCollectionsReplication(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 	const docID = "doc1"
 
@@ -262,7 +262,7 @@ func TestBlipReplicationMultipleCollections(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{NumCollectionsRequired: 2})
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{NumCollectionsRequired: 2})
 	defer btc.Close()
 
 	btc.Run(func(t *testing.T) {
@@ -299,7 +299,7 @@ func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{NumCollectionsRequired: 2})
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{NumCollectionsRequired: 2})
 	defer btc.Close()
 
 	btc.Run(func(t *testing.T) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1836,35 +1836,34 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
 	client.ClientDeltas = true
-
-	err = client.StartPull()
-	assert.NoError(t, err)
-
 	const docID = "doc1"
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-	version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok := client.WaitForVersion(docID, version1)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	client.Run(func(t *testing.T) {
+		err := client.StartPull()
+		assert.NoError(t, err)
 
-	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok = client.WaitForVersion(docID, version2)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+		data, ok := client.WaitForVersion(docID, version1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	msg, ok := client.pullReplication.WaitForMessage(5)
-	assert.True(t, ok)
-	assert.Equal(t, version1.RevID, msg.Properties[db.RevMessageHistory]) // CBG-3268 update to use version
+		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
+		version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+
+		data, ok = client.WaitForVersion(docID, version2)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+
+		msg, ok := client.pullReplication.WaitForMessage(5)
+		assert.True(t, ok)
+		assert.Equal(t, version1.RevID, msg.Properties[db.RevMessageHistory]) // CBG-3268 update to use version
+	}, t, &rtConfig)
 }
 
 // Reproduces CBG-617 (a client using activeOnly for the initial replication, and then still expecting to get subsequent tombstones afterwards)
@@ -1872,28 +1871,28 @@ func TestActiveOnlyContinuous(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
-	defer rt.Close()
+	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
-
 	const docID = "doc1"
-	version := rt.PutDoc(docID, `{"test":true}`)
 
-	// start an initial pull
-	require.NoError(t, btc.StartPullSince("true", "0", "true"))
-	rev, found := btc.WaitForVersion(docID, version)
-	assert.True(t, found)
-	assert.Equal(t, `{"test":true}`, string(rev))
+	btc.Run(func(t *testing.T) {
+		version := rt.PutDoc(docID, `{"test":true}`)
 
-	// delete the doc and make sure the client still gets the tombstone replicated
-	deletedVersion := rt.DeleteDocReturnVersion(docID, version)
+		// start an initial pull
+		require.NoError(t, btc.StartPullSince("true", "0", "true"))
+		rev, found := btc.WaitForVersion(docID, version)
+		assert.True(t, found)
+		assert.Equal(t, `{"test":true}`, string(rev))
 
-	rev, found = btc.WaitForVersion(docID, deletedVersion)
-	assert.True(t, found)
-	assert.Equal(t, `{}`, string(rev))
+		// delete the doc and make sure the client still gets the tombstone replicated
+		deletedVersion := rt.DeleteDocReturnVersion(docID, version)
+
+		rev, found = btc.WaitForVersion(docID, deletedVersion)
+		assert.True(t, found)
+		assert.Equal(t, `{}`, string(rev))
+	}, t, rtConfig)
 }
 
 // Test that exercises Sync Gateway's norev handler
@@ -1901,34 +1900,36 @@ func TestBlipNorev(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
-	defer rt.Close()
+	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+		SkipVersionVectorInitialization: true, // no rev has different handling for VV
+	})
 	defer btc.Close()
 
-	norevMsg := db.NewNoRevMessage()
-	norevMsg.SetId("docid")
-	norevMsg.SetRev("1-a")
-	norevMsg.SetSequence(db.SequenceID{Seq: 50})
-	norevMsg.SetError("404")
-	norevMsg.SetReason("couldn't send xyz")
-	btc.addCollectionProperty(norevMsg.Message)
+	btc.Run(func(t *testing.T) {
+		norevMsg := db.NewNoRevMessage()
+		norevMsg.SetId("docid")
+		norevMsg.SetRev("1-a")
+		norevMsg.SetSequence(db.SequenceID{Seq: 50})
+		norevMsg.SetError("404")
+		norevMsg.SetReason("couldn't send xyz")
+		btc.addCollectionProperty(norevMsg.Message)
 
-	// Couchbase Lite always sends noreply=true for norev messages
-	// but set to false so we can block waiting for a reply
-	norevMsg.SetNoReply(false)
+		// Couchbase Lite always sends noreply=true for norev messages
+		// but set to false so we can block waiting for a reply
+		norevMsg.SetNoReply(false)
 
-	// Request that the handler used to process the message is sent back in the response
-	norevMsg.Properties[db.SGShowHandler] = "true"
+		// Request that the handler used to process the message is sent back in the response
+		norevMsg.Properties[db.SGShowHandler] = "true"
 
-	assert.NoError(t, btc.pushReplication.sendMsg(norevMsg.Message))
+		assert.NoError(t, btc.pushReplication.sendMsg(norevMsg.Message))
 
-	// Check that the response we got back was processed by the norev handler
-	resp := norevMsg.Response()
-	assert.NotNil(t, resp)
-	assert.Equal(t, "handleNoRev", resp.Properties[db.SGHandler])
+		// Check that the response we got back was processed by the norev handler
+		resp := norevMsg.Response()
+		assert.NotNil(t, resp)
+		assert.Equal(t, "handleNoRev", resp.Properties[db.SGHandler])
+	}, t, rtConfig)
 }
 
 // TestNoRevSetSeq makes sure the correct string is used with the corresponding function
@@ -1949,99 +1950,95 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
+	rtConfig := &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
 
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
-	RequireStatus(t, resp, http.StatusCreated)
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
 		SendRevocations: true,
 	})
-	require.NoError(t, err)
 	defer btc.Close()
-
 	const docID = "doc"
-	version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
-
-	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, "doc", changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-
-	version = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
-
-	changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, docID, changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok = btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-
-	version = rt.UpdateDoc(docID, version, `{"channels": []}`)
 	const docMarker = "docmarker"
-	docMarkerVersion := rt.PutDoc(docMarker, `{"channels": ["!"]}`)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
-	require.NoError(t, err)
-	assert.Len(t, changes.Results, 2)
-	assert.Equal(t, "doc", changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-	assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
-	assert.False(t, changes.Results[0].Revoked)
-	assert.Equal(t, "docmarker", changes.Results[1].ID)
-	RequireChangeRevVersion(t, docMarkerVersion, changes.Results[1].Changes[0])
-	assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
-	assert.False(t, changes.Results[1].Revoked)
+	btc.Run(func(t *testing.T) {
+		version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok = btc.WaitForVersion(docMarker, docMarkerVersion)
-	assert.True(t, ok)
-
-	messages := btc.pullReplication.GetMessages()
-
-	var highestMsgSeq uint32
-	var highestSeqMsg blip.Message
-	// Grab most recent changes message
-	for _, message := range messages {
-		messageBody, err := message.Body()
+		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		require.NoError(t, err)
-		if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
-			if highestMsgSeq < uint32(message.SerialNumber()) {
-				highestMsgSeq = uint32(message.SerialNumber())
-				highestSeqMsg = message
+		assert.Equal(t, 1, len(changes.Results))
+		assert.Equal(t, "doc", changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+
+		err = btc.StartOneshotPull()
+		assert.NoError(t, err)
+		_, ok := btc.WaitForVersion(docID, version)
+		assert.True(t, ok)
+
+		version = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
+
+		changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(changes.Results))
+		assert.Equal(t, docID, changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+
+		err = btc.StartOneshotPull()
+		assert.NoError(t, err)
+		_, ok = btc.WaitForVersion(docID, version)
+		assert.True(t, ok)
+
+		version = rt.UpdateDoc(docID, version, `{"channels": []}`)
+		docMarkerVersion := rt.PutDoc(docMarker, `{"channels": ["!"]}`)
+
+		changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
+		require.NoError(t, err)
+		assert.Len(t, changes.Results, 2)
+		assert.Equal(t, "doc", changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
+		assert.False(t, changes.Results[0].Revoked)
+		assert.Equal(t, "docmarker", changes.Results[1].ID)
+		RequireChangeRevVersion(t, docMarkerVersion, changes.Results[1].Changes[0])
+		assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
+		assert.False(t, changes.Results[1].Revoked)
+
+		err = btc.StartOneshotPull()
+		assert.NoError(t, err)
+		_, ok = btc.WaitForVersion(docMarker, docMarkerVersion)
+		assert.True(t, ok)
+
+		messages := btc.pullReplication.GetMessages()
+
+		var highestMsgSeq uint32
+		var highestSeqMsg blip.Message
+		// Grab most recent changes message
+		for _, message := range messages {
+			messageBody, err := message.Body()
+			require.NoError(t, err)
+			if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
+				if highestMsgSeq < uint32(message.SerialNumber()) {
+					highestMsgSeq = uint32(message.SerialNumber())
+					highestSeqMsg = message
+				}
 			}
 		}
-	}
 
-	var messageBody []interface{}
-	err = highestSeqMsg.ReadJSONBody(&messageBody)
-	assert.NoError(t, err)
-	require.Len(t, messageBody, 3)
-	require.Len(t, messageBody[0], 4) // Rev 2 of doc, being sent as removal from channel A
-	require.Len(t, messageBody[1], 4) // Rev 3 of doc, being sent as removal from channel B
-	require.Len(t, messageBody[2], 3)
+		var messageBody []interface{}
+		err = highestSeqMsg.ReadJSONBody(&messageBody)
+		assert.NoError(t, err)
+		require.Len(t, messageBody, 3)
+		require.Len(t, messageBody[0], 4) // Rev 2 of doc, being sent as removal from channel A
+		require.Len(t, messageBody[1], 4) // Rev 3 of doc, being sent as removal from channel B
+		require.Len(t, messageBody[2], 3)
 
-	deletedFlags, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
-	id := messageBody[0].([]interface{})[1]
-	require.NoError(t, err)
-	assert.Equal(t, "doc", id)
-	assert.Equal(t, int64(4), deletedFlags)
+		deletedFlags, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
+		id := messageBody[0].([]interface{})[1]
+		require.NoError(t, err)
+		assert.Equal(t, "doc", id)
+		assert.Equal(t, int64(4), deletedFlags)
+	}, t, rtConfig)
 }
 
 // TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication tests the following scenario:
@@ -2057,91 +2054,93 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
+	rtConfig := &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
 
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
-	RequireStatus(t, resp, http.StatusCreated)
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
 		SendRevocations: true,
 	})
-	require.NoError(t, err)
 	defer btc.Close()
-
 	const (
-		docID = "doc"
+		docID    = "doc"
+		markerID = "docmarker"
 	)
-	version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
-	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, docID, changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+	btc.Run(func(t *testing.T) {
+		// can we remove?
+		collection := btc.rt.GetSingleTestDatabaseCollection()
+		resp := btc.rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
+		RequireStatus(t, resp, http.StatusOK)
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
+		version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
-	version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
-	require.NoError(t, rt.WaitForPendingChanges())
-	// At this point changes should send revocation, as document isn't in any of the user's channels
-	changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, docID, changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-	err = btc.StartOneshotPullFiltered("A")
-	assert.NoError(t, err)
-	_, ok = btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-
-	_ = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
-	markerID := "docmarker"
-	markerVersion := rt.PutDoc(markerID, `{"channels": ["A"]}`)
-	require.NoError(t, rt.WaitForPendingChanges())
-
-	// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
-	changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
-	require.NoError(t, err)
-	assert.Len(t, changes.Results, 2) // _changes still gets two results, as we don't support 3.0 removal handling over REST API
-	assert.Equal(t, "doc", changes.Results[0].ID)
-	assert.Equal(t, markerID, changes.Results[1].ID)
-
-	err = btc.StartOneshotPullFiltered("A")
-	assert.NoError(t, err)
-	_, ok = btc.WaitForVersion(markerID, markerVersion)
-	assert.True(t, ok)
-
-	messages := btc.pullReplication.GetMessages()
-
-	var highestMsgSeq uint32
-	var highestSeqMsg blip.Message
-	// Grab most recent changes message
-	for _, message := range messages {
-		messageBody, err := message.Body()
+		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		require.NoError(t, err)
-		if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
-			if highestMsgSeq < uint32(message.SerialNumber()) {
-				highestMsgSeq = uint32(message.SerialNumber())
-				highestSeqMsg = message
+		assert.Equal(t, 1, len(changes.Results))
+		assert.Equal(t, docID, changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+
+		err = btc.StartOneshotPull()
+		assert.NoError(t, err)
+		_, ok := btc.WaitForVersion(docID, version)
+		assert.True(t, ok)
+
+		version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
+		require.NoError(t, rt.WaitForPendingChanges())
+
+		// At this point changes should send revocation, as document isn't in any of the user's channels
+		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(changes.Results))
+		assert.Equal(t, docID, changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+
+		err = btc.StartOneshotPullFiltered("A")
+		assert.NoError(t, err)
+		_, ok = btc.WaitForVersion(docID, version)
+		assert.True(t, ok)
+
+		_ = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
+		markerVersion := rt.PutDoc(markerID, `{"channels": ["A"]}`)
+		require.NoError(t, rt.WaitForPendingChanges())
+
+		// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
+		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
+		require.NoError(t, err)
+		assert.Len(t, changes.Results, 2) // _changes still gets two results, as we don't support 3.0 removal handling over REST API
+		assert.Equal(t, "doc", changes.Results[0].ID)
+		assert.Equal(t, markerID, changes.Results[1].ID)
+
+		err = btc.StartOneshotPullFiltered("A")
+		assert.NoError(t, err)
+		_, ok = btc.WaitForVersion(markerID, markerVersion)
+		assert.True(t, ok)
+
+		messages := btc.pullReplication.GetMessages()
+
+		var highestMsgSeq uint32
+		var highestSeqMsg blip.Message
+		// Grab most recent changes message
+		for _, message := range messages {
+			messageBody, err := message.Body()
+			require.NoError(t, err)
+			if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
+				if highestMsgSeq < uint32(message.SerialNumber()) {
+					highestMsgSeq = uint32(message.SerialNumber())
+					highestSeqMsg = message
+				}
 			}
 		}
-	}
 
-	var messageBody []interface{}
-	err = highestSeqMsg.ReadJSONBody(&messageBody)
-	assert.NoError(t, err)
-	require.Len(t, messageBody, 1)
-	require.Len(t, messageBody[0], 3) // marker doc
-	require.Equal(t, "docmarker", messageBody[0].([]interface{})[1])
+		var messageBody []interface{}
+		err = highestSeqMsg.ReadJSONBody(&messageBody)
+		assert.NoError(t, err)
+		require.Len(t, messageBody, 1)
+		require.Len(t, messageBody[0], 3) // marker doc
+		require.Equal(t, "docmarker", messageBody[0].([]interface{})[1])
+	}, t, rtConfig)
 }
 
 // Make sure that a client cannot open multiple subChanges subscriptions on a single blip context (SG #3222)
@@ -2362,53 +2361,52 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	}
 
 	// Setup
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			GuestEnabled: true,
-		})
-	defer rt.Close()
+	rtConfig := &RestTesterConfig{
+		GuestEnabled: true,
+	}
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
 
-	// Track last sequence for next changes feed
-	var changes ChangesResults
-	changes.Last_Seq = "0"
+	client.Run(func(t *testing.T) {
+		// Track last sequence for next changes feed
+		var changes ChangesResults
+		changes.Last_Seq = "0"
 
-	for i, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			docID := fmt.Sprintf("test%d", i)
-			rawBody, err := json.Marshal(test.inputBody)
-			require.NoError(t, err)
+		for i, test := range testCases {
+			t.Run(test.name, func(t *testing.T) {
+				docID := fmt.Sprintf("test%d", i)
+				rawBody, err := json.Marshal(test.inputBody)
+				require.NoError(t, err)
 
-			_, err = client.PushRev(docID, EmptyDocVersion(), rawBody)
+				_, err = client.PushRev(docID, EmptyDocVersion(), rawBody)
 
-			if test.expectReject {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-
-			// Wait for rev to be received on RT
-			err = rt.WaitForPendingChanges()
-			require.NoError(t, err)
-			changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "", true)
-			require.NoError(t, err)
-
-			var bucketDoc map[string]interface{}
-			_, err = rt.GetSingleDataStore().Get(docID, &bucketDoc)
-			assert.NoError(t, err)
-			body := rt.GetDocBody(docID)
-			// Confirm input body is in the bucket doc
-			if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
-				for k, v := range test.inputBody {
-					assert.Equal(t, v, bucketDoc[k])
-					assert.Equal(t, v, body[k])
+				if test.expectReject {
+					assert.Error(t, err)
+					return
 				}
-			}
-		})
-	}
+				assert.NoError(t, err)
+
+				// Wait for rev to be received on RT
+				err = client.rt.WaitForPendingChanges()
+				require.NoError(t, err)
+				changes, err = client.rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "", true)
+				require.NoError(t, err)
+
+				var bucketDoc map[string]interface{}
+				_, err = rt.GetSingleDataStore().Get(docID, &bucketDoc)
+				assert.NoError(t, err)
+				body := rt.GetDocBody(docID)
+				// Confirm input body is in the bucket doc
+				if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
+					for k, v := range test.inputBody {
+						assert.Equal(t, v, bucketDoc[k])
+						assert.Equal(t, v, body[k])
+					}
+				}
+			})
+		}
+	}, t, rtConfig)
 }
 
 // CBG-2053: Test that the handleRev stats still increment correctly when going through the processRev function with
@@ -2528,133 +2526,136 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("Skip LeakyBucket test when running in integration")
 	}
-	testCases := []struct {
-		error       error
-		expectNoRev bool
-	}{
-		{
-			error:       gocb.ErrDocumentNotFound,
-			expectNoRev: true,
-		},
-		{
-			error:       gocb.ErrOverload,
-			expectNoRev: false,
-		},
+
+	rtConfig := &RestTesterConfig{
+		GuestEnabled:     true,
+		CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
 	}
-	for _, test := range testCases {
-		t.Run(fmt.Sprintf("%s", test.error), func(t *testing.T) {
-			docName := fmt.Sprintf("%s", test.error)
-			rt := NewRestTester(t,
-				&RestTesterConfig{
-					GuestEnabled:     true,
-					CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
+
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+		SkipVersionVectorInitialization: true, // no rev has different handling for VV
+	})
+	defer btc.Close()
+
+	btc.Run(func(t *testing.T) {
+		leakyDataStore, ok := base.AsLeakyDataStore(btc.rt.Bucket().DefaultDataStore())
+		require.True(t, ok)
+
+		testCases := []struct {
+			error       error
+			expectNoRev bool
+		}{
+			{
+				error:       gocb.ErrDocumentNotFound,
+				expectNoRev: true,
+			},
+			{
+				error:       gocb.ErrOverload,
+				expectNoRev: false,
+			},
+		}
+		for _, test := range testCases {
+			t.Run(fmt.Sprintf("%s", test.error), func(t *testing.T) {
+				docName := fmt.Sprintf("%s", test.error)
+
+				// Change noRev handler so it's known when a noRev is received
+				recievedNoRevs := make(chan *blip.Message)
+				btc.pullReplication.bt.blipContext.HandlerForProfile[db.MessageNoRev] = func(msg *blip.Message) {
+					fmt.Println("Received noRev", msg.Properties)
+					recievedNoRevs <- msg
+				}
+
+				version := rt.PutDoc(docName, `{"foo":"bar"}`)
+
+				// Make the LeakyBucket return an error
+				leakyDataStore.SetGetRawCallback(func(key string) error {
+					return test.error
 				})
-			defer rt.Close()
+				leakyDataStore.SetGetWithXattrCallback(func(key string) error {
+					return test.error
+				})
 
-			leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())
-			require.True(t, ok)
+				// Flush cache so document has to be retrieved from the leaky bucket
+				btc.rt.GetSingleTestDatabaseCollection().FlushRevisionCacheForTest()
 
-			btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-			require.NoError(t, err)
-			defer btc.Close()
+				err := btc.StartPull()
+				require.NoError(t, err)
 
-			// Change noRev handler so it's known when a noRev is received
-			recievedNoRevs := make(chan *blip.Message)
-			btc.pullReplication.bt.blipContext.HandlerForProfile[db.MessageNoRev] = func(msg *blip.Message) {
-				fmt.Println("Received noRev", msg.Properties)
-				recievedNoRevs <- msg
-			}
-
-			version := rt.PutDoc(docName, `{"foo":"bar"}`)
-
-			// Make the LeakyBucket return an error
-			leakyDataStore.SetGetRawCallback(func(key string) error {
-				return test.error
-			})
-			leakyDataStore.SetGetWithXattrCallback(func(key string) error {
-				return test.error
-			})
-
-			// Flush cache so document has to be retrieved from the leaky bucket
-			rt.GetSingleTestDatabaseCollection().FlushRevisionCacheForTest()
-
-			err = btc.StartPull()
-			require.NoError(t, err)
-
-			// Wait 3 seconds for noRev to be received
-			select {
-			case msg := <-recievedNoRevs:
-				if test.expectNoRev {
-					assert.Equal(t, docName, msg.Properties["id"])
-				} else {
-					require.Fail(t, "Received unexpected noRev message", msg)
+				// Wait 3 seconds for noRev to be received
+				select {
+				case msg := <-recievedNoRevs:
+					if test.expectNoRev {
+						assert.Equal(t, docName, msg.Properties["id"])
+					} else {
+						require.Fail(t, "Received unexpected noRev message", msg)
+					}
+				case <-time.After(3 * time.Second):
+					if test.expectNoRev {
+						require.Fail(t, "Didn't receive expected noRev")
+					}
 				}
-			case <-time.After(3 * time.Second):
-				if test.expectNoRev {
-					require.Fail(t, "Didn't receive expected noRev")
-				}
-			}
 
-			// Make sure document did not get replicated
-			_, found := btc.GetVersion(docName, version)
-			assert.False(t, found)
-		})
-	}
+				// Make sure document did not get replicated
+				_, found := btc.GetVersion(docName, version)
+				assert.False(t, found)
+			})
+		}
+	}, t, rtConfig)
 }
 
 func TestUnsubChanges(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
-	// Confirm no error message or panic is returned in response
-	response, err := btc.UnsubPullChanges()
-	assert.NoError(t, err)
-	assert.Empty(t, response)
-
-	// Sub changes
-	err = btc.StartPull()
-	require.NoError(t, err)
 	const (
 		doc1ID = "doc1ID"
 		doc2ID = "doc2ID"
 	)
-	doc1Version := rt.PutDoc(doc1ID, `{"key":"val1"}`)
-	_, found := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, found)
 
-	activeReplStat := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplActiveContinuous
-	require.EqualValues(t, 1, activeReplStat.Value())
+	btc.Run(func(t *testing.T) {
+		// Confirm no error message or panic is returned in response
+		response, err := btc.UnsubPullChanges()
+		assert.NoError(t, err)
+		assert.Empty(t, response)
 
-	// Unsub changes
-	response, err = btc.UnsubPullChanges()
-	assert.NoError(t, err)
-	assert.Empty(t, response)
-	// Wait for unsub changes to stop the sub changes being sent before sending document up
-	base.RequireWaitForStat(t, activeReplStat.Value, 0)
+		// Sub changes
+		err = btc.StartPull()
+		require.NoError(t, err)
+		doc1Version := rt.PutDoc(doc1ID, `{"key":"val1"}`)
+		_, found := btc.WaitForVersion(doc1ID, doc1Version)
+		require.True(t, found)
 
-	// Confirm no more changes are being sent
-	doc2Version := rt.PutDoc(doc2ID, `{"key":"val1"}`)
-	err = rt.WaitForConditionWithOptions(func() bool {
-		_, found = btc.GetVersion("doc2", doc2Version)
-		return found
-	}, 10, 100)
-	assert.Error(t, err)
+		activeReplStat := btc.rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplActiveContinuous
+		require.EqualValues(t, 1, activeReplStat.Value())
 
-	// Confirm no error message is still returned when no subchanges active
-	response, err = btc.UnsubPullChanges()
-	assert.NoError(t, err)
-	assert.Empty(t, response)
+		// Unsub changes
+		response, err = btc.UnsubPullChanges()
+		assert.NoError(t, err)
+		assert.Empty(t, response)
+		// Wait for unsub changes to stop the sub changes being sent before sending document up
+		base.RequireWaitForStat(t, activeReplStat.Value, 0)
 
-	// Confirm the pull replication can be restarted and it syncs doc2
-	err = btc.StartPull()
-	require.NoError(t, err)
-	_, found = btc.WaitForVersion(doc2ID, doc2Version)
-	assert.True(t, found)
+		// Confirm no more changes are being sent
+		doc2Version := rt.PutDoc(doc2ID, `{"key":"val1"}`)
+		err = rt.WaitForConditionWithOptions(func() bool {
+			_, found = btc.GetVersion("doc2", doc2Version)
+			return found
+		}, 10, 100)
+		assert.Error(t, err)
+
+		// Confirm no error message is still returned when no subchanges active
+		response, err = btc.UnsubPullChanges()
+		assert.NoError(t, err)
+		assert.Empty(t, response)
+
+		// Confirm the pull replication can be restarted and it syncs doc2
+		err = btc.StartPull()
+		require.NoError(t, err)
+		_, found = btc.WaitForVersion(doc2ID, doc2Version)
+		assert.True(t, found)
+	}, t, rtConfig)
 }
 
 // TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the replication.
@@ -2671,47 +2672,45 @@ func TestRequestPlusPull(t *testing.T) {
 				}
 			}`,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-	database := rt.GetDatabase()
 
 	// Initialize blip tester client (will create user)
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username: "bernard",
 	})
-	require.NoError(t, err)
 	defer client.Close()
 
-	// Put a doc in channel PBS
-	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
-	RequireStatus(t, response, 201)
+	client.Run(func(t *testing.T) {
+		database := client.rt.GetDatabase()
+		// Put a doc in channel PBS
+		response := client.rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+		RequireStatus(t, response, 201)
 
-	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
-	slowSequence, seqErr := db.AllocateTestSequence(database)
-	require.NoError(t, seqErr)
+		// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+		slowSequence, seqErr := db.AllocateTestSequence(database)
+		require.NoError(t, seqErr)
 
-	// Write a document granting user 'bernard' access to PBS
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
-	RequireStatus(t, response, 201)
+		// Write a document granting user 'bernard' access to PBS
+		response = client.rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+		RequireStatus(t, response, 201)
 
-	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 
-	// Start a regular one-shot pull
-	err = client.StartOneshotPullRequestPlus()
-	assert.NoError(t, err)
+		// Start a regular one-shot pull
+		err := client.StartOneshotPullRequestPlus()
+		assert.NoError(t, err)
 
-	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
-	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
+		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+		require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
 
-	// Release the slow sequence
-	releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
-	require.NoError(t, releaseErr)
+		// Release the slow sequence
+		releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
+		require.NoError(t, releaseErr)
 
-	// The one-shot pull should unblock and replicate the document in the granted channel
-	data, ok := client.WaitForDoc("pbs-1")
-	assert.True(t, ok)
-	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
-
+		// The one-shot pull should unblock and replicate the document in the granted channel
+		data, ok := client.WaitForDoc("pbs-1")
+		assert.True(t, ok)
+		assert.Equal(t, `{"channel":["PBS"]}`, string(data))
+	}, t, &rtConfig)
 }
 
 // TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the db config.
@@ -2733,47 +2732,45 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 			},
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-	database := rt.GetDatabase()
 
 	// Initialize blip tester client (will create user)
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username: "bernard",
 	})
-	require.NoError(t, err)
 	defer client.Close()
 
-	// Put a doc in channel PBS
-	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
-	RequireStatus(t, response, 201)
+	client.Run(func(t *testing.T) {
+		database := client.rt.GetDatabase()
+		// Put a doc in channel PBS
+		response := client.rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+		RequireStatus(t, response, 201)
 
-	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
-	slowSequence, seqErr := db.AllocateTestSequence(database)
-	require.NoError(t, seqErr)
+		// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+		slowSequence, seqErr := db.AllocateTestSequence(database)
+		require.NoError(t, seqErr)
 
-	// Write a document granting user 'bernard' access to PBS
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
-	RequireStatus(t, response, 201)
+		// Write a document granting user 'bernard' access to PBS
+		response = client.rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+		RequireStatus(t, response, 201)
 
-	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 
-	// Start a regular one-shot pull
-	err = client.StartOneshotPull()
-	assert.NoError(t, err)
+		// Start a regular one-shot pull
+		err := client.StartOneshotPull()
+		assert.NoError(t, err)
 
-	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
-	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
+		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+		require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
 
-	// Release the slow sequence
-	releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
-	require.NoError(t, releaseErr)
+		// Release the slow sequence
+		releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
+		require.NoError(t, releaseErr)
 
-	// The one-shot pull should unblock and replicate the document in the granted channel
-	data, ok := client.WaitForDoc("pbs-1")
-	assert.True(t, ok)
-	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
-
+		// The one-shot pull should unblock and replicate the document in the granted channel
+		data, ok := client.WaitForDoc("pbs-1")
+		assert.True(t, ok)
+		assert.Equal(t, `{"channel":["PBS"]}`, string(data))
+	}, t, &rtConfig)
 }
 
 // TestBlipRefreshUser makes sure there is no panic if a user gets deleted during a replication
@@ -2799,12 +2796,10 @@ func TestBlipRefreshUser(t *testing.T) {
 
 	const username = "bernard"
 	// Initialize blip tester client (will create user)
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username: "bernard",
 		Channels: []string{"chan1"},
 	})
-
-	require.NoError(t, err)
 	defer btc.Close()
 
 	// add chan1 explicitly
@@ -2815,7 +2810,7 @@ func TestBlipRefreshUser(t *testing.T) {
 	version := rt.PutDoc(docID, `{"channels":["chan1"]}`)
 
 	// Start a regular one-shot pull
-	err = btc.StartPullSince("true", "0", "false")
+	err := btc.StartPullSince("true", "0", "false")
 	require.NoError(t, err)
 
 	_, ok := btc.WaitForDoc(docID)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1837,7 +1837,7 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 	client.ClientDeltas = true
 	const docID = "doc1"
@@ -1873,7 +1873,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 	const docID = "doc1"
 
@@ -1902,7 +1902,7 @@ func TestBlipNorev(t *testing.T) {
 
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		SkipVersionVectorInitialization: true, // no rev has different handling for VV
 	})
 	defer btc.Close()
@@ -1952,7 +1952,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 	rtConfig := &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
@@ -2060,7 +2060,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 	rtConfig := &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
@@ -2073,7 +2073,6 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	)
 
 	btc.Run(func(t *testing.T) {
-		// can we remove?
 		collection := btc.rt.GetSingleTestDatabaseCollection()
 		resp := btc.rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
 		RequireStatus(t, resp, http.StatusOK)
@@ -2369,7 +2368,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 
 	client.Run(func(t *testing.T) {
@@ -2536,7 +2535,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 		CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		SkipVersionVectorInitialization: true, // no rev has different handling for VV
 	})
 	defer btc.Close()
@@ -2611,7 +2610,7 @@ func TestUnsubChanges(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 	const (
 		doc1ID = "doc1ID"
@@ -2678,7 +2677,7 @@ func TestRequestPlusPull(t *testing.T) {
 	}
 
 	// Initialize blip tester client (will create user)
-	client := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	client := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username: "bernard",
 	})
 	defer client.Close()
@@ -2738,7 +2737,7 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 	}
 
 	// Initialize blip tester client (will create user)
-	client := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	client := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username: "bernard",
 	})
 	defer client.Close()
@@ -2800,7 +2799,7 @@ func TestBlipRefreshUser(t *testing.T) {
 
 	const username = "bernard"
 	// Initialize blip tester client (will create user)
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{ // This test will need refactoring when its getting fixed in CBG-3512
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{ // This test will need refactoring when its getting fixed in CBG-3512
 		Username: "bernard",
 		Channels: []string{"chan1"},
 	})

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1152,53 +1152,8 @@ function(doc, oldDoc) {
 
 // Test send and retrieval of a doc.
 //
-//	Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
-func TestBlipSendAndGetRev(t *testing.T) {
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
-
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
-	btSpec := BlipTesterSpec{
-		connectingUsername: "user1",
-		connectingPassword: "1234",
-	}
-	bt, err := NewBlipTesterFromSpecWithRT(t, &btSpec, rt)
-	require.NoError(t, err, "Unexpected error creating BlipTester")
-	defer bt.Close()
-
-	// Send non-deleted rev
-	sent, _, resp, err := bt.SendRev("sendAndGetRev", "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), blip.Properties{})
-	assert.True(t, sent)
-	assert.NoError(t, err)
-	assert.Equal(t, "", resp.Properties["Error-Code"])
-
-	// Get non-deleted rev
-	response := bt.restTester.SendAdminRequest("GET", "/{{.keyspace}}/sendAndGetRev?rev=1-abc", "")
-	RequireStatus(t, response, 200)
-	var responseBody RestDocument
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
-	_, ok := responseBody[db.BodyDeleted]
-	assert.False(t, ok)
-
-	// Tombstone the document
-	history := []string{"1-abc"}
-	sent, _, resp, err = bt.SendRevWithHistory("sendAndGetRev", "2-bcd", history, []byte(`{"key": "val", "channels": ["user1"]}`), blip.Properties{"deleted": "true"})
-	assert.True(t, sent)
-	assert.NoError(t, err)
-	assert.Equal(t, "", resp.Properties["Error-Code"])
-
-	// Get the tombstoned document
-	response = bt.restTester.SendAdminRequest("GET", "/{{.keyspace}}/sendAndGetRev?rev=2-bcd", "")
-	RequireStatus(t, response, 200)
-	responseBody = RestDocument{}
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
-	deletedValue, deletedOK := responseBody[db.BodyDeleted].(bool)
-	assert.True(t, deletedOK)
-	assert.True(t, deletedValue)
-}
-
-// Test send and retrieval of a doc with a large numeric value.  Ensure proper large number handling.
+//				err := btc.StartPull()
+//				require.NoError(t, err)
 //
 //	Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
@@ -1774,383 +1729,11 @@ func TestGetRemovedDoc(t *testing.T) {
 
 // Reproduce issue SG #3738
 //
-// - Add 5 docs to channel ABC
-// - Purge one doc via _purge REST API
-// - Flush rev cache
-// - Send subChanges request
-// - Reply to all changes saying all docs are wanted
-// - Wait to receive rev messages for all 5 docs
-//   - Expected: receive all 5 docs (4 revs and 1 norev)
-//   - Actual: only receive 4 docs (4 revs)
-func TestMissingNoRev(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
-	defer rt.Close()
-	ctx := rt.Context()
-
-	bt, err := NewBlipTesterFromSpecWithRT(t, nil, rt)
-	require.NoError(t, err, "Unexpected error creating BlipTester")
-	defer bt.Close()
-
-	require.NoError(t, rt.WaitForDBOnline())
-
-	// Create 5 docs
-	for i := 0; i < 5; i++ {
-		docID := fmt.Sprintf("doc-%d", i)
-		docRev := fmt.Sprintf("1-abc%d", i)
-		sent, _, resp, err := bt.SendRev(docID, docRev, []byte(`{"key": "val", "channels": ["ABC"]}`), blip.Properties{})
-		assert.True(t, sent)
-		require.NoError(t, err, "resp is %s", resp)
-	}
-
-	// Pull docs, expect to pull 5 docs since none of them has purged yet.
-	docs, ok := bt.WaitForNumDocsViaChanges(5)
-	require.True(t, ok)
-	assert.Len(t, docs, 5)
-
-	// Purge one doc
-	doc0Id := fmt.Sprintf("doc-%d", 0)
-	err = rt.GetSingleTestDatabaseCollectionWithUser().Purge(ctx, doc0Id)
-	assert.NoError(t, err, "failed")
-
-	// Flush rev cache
-	rt.GetSingleTestDatabaseCollection().FlushRevisionCacheForTest()
-
-	// Pull docs, expect to pull 4 since one was purged.  (also expect to NOT get stuck)
-	docs, ok = bt.WaitForNumDocsViaChanges(4)
-	assert.True(t, ok)
-	assert.Len(t, docs, 4)
-
-}
-
-// TestBlipPullRevMessageHistory tests that a simple pull replication contains history in the rev message.
-func TestBlipPullRevMessageHistory(t *testing.T) {
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
-	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			DeltaSync: &DeltaSyncConfig{
-				Enabled: &sgUseDeltas,
-			},
-		}},
-		GuestEnabled: true,
-	}
-
-	client := NewBlipTesterClientOpts(nil)
-	defer client.Close()
-	client.ClientDeltas = true
-	const docID = "doc1"
-
-	client.Run(func(t *testing.T) {
-		err := client.StartPull()
-		assert.NoError(t, err)
-
-		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-		version1 := client.rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
-
-		data, ok := client.WaitForVersion(docID, version1)
-		assert.True(t, ok)
-		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-
-		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-		version2 := client.rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
-
-		data, ok = client.WaitForVersion(docID, version2)
-		assert.True(t, ok)
-		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
-
-		msg, ok := client.pullReplication.WaitForMessage(5)
-		assert.True(t, ok)
-		assert.Equal(t, version1.RevID, msg.Properties[db.RevMessageHistory]) // CBG-3268 update to use version
-	}, t, &rtConfig)
-}
-
-// Reproduces CBG-617 (a client using activeOnly for the initial replication, and then still expecting to get subsequent tombstones afterwards)
-func TestActiveOnlyContinuous(t *testing.T) {
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
-	rtConfig := &RestTesterConfig{GuestEnabled: true}
-
-	btc := NewBlipTesterClientOpts(nil)
-	defer btc.Close()
-	const docID = "doc1"
-
-	btc.Run(func(t *testing.T) {
-		version := btc.rt.PutDoc(docID, `{"test":true}`)
-
-		// start an initial pull
-		require.NoError(t, btc.StartPullSince("true", "0", "true"))
-		rev, found := btc.WaitForVersion(docID, version)
-		assert.True(t, found)
-		assert.Equal(t, `{"test":true}`, string(rev))
-
-		// delete the doc and make sure the client still gets the tombstone replicated
-		deletedVersion := btc.rt.DeleteDocReturnVersion(docID, version)
-
-		rev, found = btc.WaitForVersion(docID, deletedVersion)
-		assert.True(t, found)
-		assert.Equal(t, `{}`, string(rev))
-	}, t, rtConfig)
-}
-
-// Test that exercises Sync Gateway's norev handler
-func TestBlipNorev(t *testing.T) {
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
-	rtConfig := &RestTesterConfig{GuestEnabled: true}
-
-	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
-		SkipVersionVectorInitialization: true, // no rev has different handling for VV
-	})
-	defer btc.Close()
-
-	btc.Run(func(t *testing.T) {
-		norevMsg := db.NewNoRevMessage()
-		norevMsg.SetId("docid")
-		norevMsg.SetRev("1-a")
-		norevMsg.SetSequence(db.SequenceID{Seq: 50})
-		norevMsg.SetError("404")
-		norevMsg.SetReason("couldn't send xyz")
-		btc.addCollectionProperty(norevMsg.Message)
-
-		// Couchbase Lite always sends noreply=true for norev messages
-		// but set to false so we can block waiting for a reply
-		norevMsg.SetNoReply(false)
-
-		// Request that the handler used to process the message is sent back in the response
-		norevMsg.Properties[db.SGShowHandler] = "true"
-
-		assert.NoError(t, btc.pushReplication.sendMsg(norevMsg.Message))
-
-		// Check that the response we got back was processed by the norev handler
-		resp := norevMsg.Response()
-		assert.NotNil(t, resp)
-		assert.Equal(t, "handleNoRev", resp.Properties[db.SGHandler])
-	}, t, rtConfig)
-}
-
-// TestNoRevSetSeq makes sure the correct string is used with the corresponding function
-func TestNoRevSetSeq(t *testing.T) {
-	norevMsg := db.NewNoRevMessage()
-	assert.Equal(t, "", norevMsg.Properties[db.NorevMessageSeq])
-	assert.Equal(t, "", norevMsg.Properties[db.NorevMessageSequence])
-
-	norevMsg.SetSequence(db.SequenceID{Seq: 50})
-	assert.Equal(t, "50", norevMsg.Properties[db.NorevMessageSequence])
-
-	norevMsg.SetSeq(db.SequenceID{Seq: 60})
-	assert.Equal(t, "60", norevMsg.Properties[db.NorevMessageSeq])
-
-}
-
-func TestRemovedMessageWithAlternateAccess(t *testing.T) {
-	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
-	rtConfig := &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
-
-	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
-		Username:        "user",
-		Channels:        []string{"*"},
-		ClientDeltas:    false,
-		SendRevocations: true,
-	})
-	defer btc.Close()
-	const docID = "doc"
-	const docMarker = "docmarker"
-
-	btc.Run(func(t *testing.T) {
-		collection := btc.rt.GetSingleTestDatabaseCollection()
-		resp := btc.rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
-		RequireStatus(t, resp, http.StatusOK)
-
-		version := btc.rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
-
-		changes, err := btc.rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
-		require.NoError(t, err)
-		assert.Equal(t, 1, len(changes.Results))
-		assert.Equal(t, "doc", changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-		err = btc.StartOneshotPull()
-		assert.NoError(t, err)
-		_, ok := btc.WaitForVersion(docID, version)
-		assert.True(t, ok)
-
-		version = btc.rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
-
-		changes, err = btc.rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
-		require.NoError(t, err)
-		assert.Equal(t, 1, len(changes.Results))
-		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-		err = btc.StartOneshotPull()
-		assert.NoError(t, err)
-		_, ok = btc.WaitForVersion(docID, version)
-		assert.True(t, ok)
-
-		version = btc.rt.UpdateDoc(docID, version, `{"channels": []}`)
-		docMarkerVersion := btc.rt.PutDoc(docMarker, `{"channels": ["!"]}`)
-
-		changes, err = btc.rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, 2)
-		assert.Equal(t, "doc", changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-		assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
-		assert.False(t, changes.Results[0].Revoked)
-		assert.Equal(t, "docmarker", changes.Results[1].ID)
-		RequireChangeRevVersion(t, docMarkerVersion, changes.Results[1].Changes[0])
-		assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
-		assert.False(t, changes.Results[1].Revoked)
-
-		err = btc.StartOneshotPull()
-		assert.NoError(t, err)
-		_, ok = btc.WaitForVersion(docMarker, docMarkerVersion)
-		assert.True(t, ok)
-
-		messages := btc.pullReplication.GetMessages()
-
-		var highestMsgSeq uint32
-		var highestSeqMsg blip.Message
-		// Grab most recent changes message
-		for _, message := range messages {
-			messageBody, err := message.Body()
-			require.NoError(t, err)
-			if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
-				if highestMsgSeq < uint32(message.SerialNumber()) {
-					highestMsgSeq = uint32(message.SerialNumber())
-					highestSeqMsg = message
-				}
-			}
-		}
-
-		var messageBody []interface{}
-		err = highestSeqMsg.ReadJSONBody(&messageBody)
-		assert.NoError(t, err)
-		require.Len(t, messageBody, 3)
-		require.Len(t, messageBody[0], 4) // Rev 2 of doc, being sent as removal from channel A
-		require.Len(t, messageBody[1], 4) // Rev 3 of doc, being sent as removal from channel B
-		require.Len(t, messageBody[2], 3)
-
-		deletedFlags, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
-		id := messageBody[0].([]interface{})[1]
-		require.NoError(t, err)
-		assert.Equal(t, "doc", id)
-		assert.Equal(t, int64(4), deletedFlags)
-	}, t, rtConfig)
-}
-
-// TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication tests the following scenario:
-//   User has access to channel A and B
-//     Document rev 1 is in A and B
-//     Document rev 2 is in channel C
-//     Document rev 3 is in channel B
-//   User issues changes requests with since=0 for channel A
-//     Revocation should not be issued because the user currently has access to channel B, even though they didn't
-//     have access to the removal revision (rev 2).  CBG-2277
-
-func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testing.T) {
-	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
-	rtConfig := &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction}
-
-	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
-		Username:        "user",
-		Channels:        []string{"*"},
-		ClientDeltas:    false,
-		SendRevocations: true,
-	})
-	defer btc.Close()
-	const (
-		docID    = "doc"
-		markerID = "docmarker"
-	)
-
-	btc.Run(func(t *testing.T) {
-		collection := btc.rt.GetSingleTestDatabaseCollection()
-		resp := btc.rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
-		RequireStatus(t, resp, http.StatusOK)
-
-		version := btc.rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
-
-		changes, err := btc.rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
-		require.NoError(t, err)
-		assert.Equal(t, 1, len(changes.Results))
-		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-		err = btc.StartOneshotPull()
-		assert.NoError(t, err)
-		_, ok := btc.WaitForVersion(docID, version)
-		assert.True(t, ok)
-
-		version = btc.rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
-		require.NoError(t, btc.rt.WaitForPendingChanges())
-
-		// At this point changes should send revocation, as document isn't in any of the user's channels
-		changes, err = btc.rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
-		require.NoError(t, err)
-		assert.Equal(t, 1, len(changes.Results))
-		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-		err = btc.StartOneshotPullFiltered("A")
-		assert.NoError(t, err)
-		_, ok = btc.WaitForVersion(docID, version)
-		assert.True(t, ok)
-
-		_ = btc.rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
-		markerVersion := btc.rt.PutDoc(markerID, `{"channels": ["A"]}`)
-		require.NoError(t, btc.rt.WaitForPendingChanges())
-
-		// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
-		changes, err = btc.rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, 2) // _changes still gets two results, as we don't support 3.0 removal handling over REST API
-		assert.Equal(t, "doc", changes.Results[0].ID)
-		assert.Equal(t, markerID, changes.Results[1].ID)
-
-		err = btc.StartOneshotPullFiltered("A")
-		assert.NoError(t, err)
-		_, ok = btc.WaitForVersion(markerID, markerVersion)
-		assert.True(t, ok)
-
-		messages := btc.pullReplication.GetMessages()
-
-		var highestMsgSeq uint32
-		var highestSeqMsg blip.Message
-		// Grab most recent changes message
-		for _, message := range messages {
-			messageBody, err := message.Body()
-			require.NoError(t, err)
-			if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
-				if highestMsgSeq < uint32(message.SerialNumber()) {
-					highestMsgSeq = uint32(message.SerialNumber())
-					highestSeqMsg = message
-				}
-			}
-		}
-
-		var messageBody []interface{}
-		err = highestSeqMsg.ReadJSONBody(&messageBody)
-		assert.NoError(t, err)
-		require.Len(t, messageBody, 1)
-		require.Len(t, messageBody[0], 3) // marker doc
-		require.Equal(t, "docmarker", messageBody[0].([]interface{})[1])
-	}, t, rtConfig)
-}
-
-// Make sure that a client cannot open multiple subChanges subscriptions on a single blip context (SG #3222)
-// - Open a one-off subChanges request, ensure it works.
-// - Open a subsequent continuous request, and ensure it works.
-// - Open another continuous subChanges, and asserts that it gets an error on the 2nd one, because the first is still running.
-// - Open another one-off subChanges request, assert we still get an error.
+//	btc.Run(func(t *testing.T) {
+//		// Confirm no error message or panic is returned in response
+//		response, err := btc.UnsubPullChanges()
+//		assert.NoError(t, err)
+//		assert.Empty(t, response)
 //
 // Asserts on stats to test for regression of CBG-1824: Make sure SubChangesOneShotActive gets decremented when one shot
 // sub changes request has completed
@@ -2367,11 +1950,16 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	client := NewBlipTesterClientOpts(nil)
-	defer client.Close()
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	client.Run(func(t *testing.T) {
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
 		// Track last sequence for next changes feed
 		var changes ChangesResults
 		changes.Last_Seq = "0"
@@ -2382,7 +1970,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 				rawBody, err := json.Marshal(test.inputBody)
 				require.NoError(t, err)
 
-				_, err = client.PushRev(docID, EmptyDocVersion(), rawBody)
+				_, err = btcRunner.PushRev(client.id, docID, EmptyDocVersion(), rawBody)
 
 				if test.expectReject {
 					assert.Error(t, err)
@@ -2409,7 +1997,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 				}
 			})
 		}
-	}, t, rtConfig)
+	})
 }
 
 // CBG-2053: Test that the handleRev stats still increment correctly when going through the processRev function with
@@ -2534,13 +2122,16 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 		GuestEnabled:     true,
 		CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
 	}
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipVersionVectorInitialization = true // test is for norev handling, this will be different in version vector subprotocol
 
-	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
-		SkipVersionVectorInitialization: true, // no rev has different handling for VV
-	})
-	defer btc.Close()
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	btc.Run(func(t *testing.T) {
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 		leakyDataStore, ok := base.AsLeakyDataStore(btc.rt.Bucket().DefaultDataStore())
 		require.True(t, ok)
 
@@ -2581,7 +2172,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 				// Flush cache so document has to be retrieved from the leaky bucket
 				btc.rt.GetSingleTestDatabaseCollection().FlushRevisionCacheForTest()
 
-				err := btc.StartPull()
+				err := btcRunner.StartPull(btc.id)
 				require.NoError(t, err)
 
 				// Wait 3 seconds for noRev to be received
@@ -2599,42 +2190,47 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 				}
 
 				// Make sure document did not get replicated
-				_, found := btc.GetVersion(docName, version)
+				_, found := btcRunner.GetVersion(btc.id, docName, version)
 				assert.False(t, found)
 			})
 		}
-	}, t, rtConfig)
+	})
 }
 
 func TestUnsubChanges(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
-
-	btc := NewBlipTesterClientOpts(nil)
-	defer btc.Close()
 	const (
 		doc1ID = "doc1ID"
 		doc2ID = "doc2ID"
 	)
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	btc.Run(func(t *testing.T) {
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+
 		// Confirm no error message or panic is returned in response
-		response, err := btc.UnsubPullChanges()
+		response, err := btcRunner.UnsubPullChanges(btc.id)
 		assert.NoError(t, err)
 		assert.Empty(t, response)
 
 		// Sub changes
-		err = btc.StartPull()
+		err = btcRunner.StartPull(btc.id)
 		require.NoError(t, err)
 		doc1Version := btc.rt.PutDoc(doc1ID, `{"key":"val1"}`)
-		_, found := btc.WaitForVersion(doc1ID, doc1Version)
+		_, found := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 		require.True(t, found)
 
 		activeReplStat := btc.rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplActiveContinuous
 		require.EqualValues(t, 1, activeReplStat.Value())
 
 		// Unsub changes
-		response, err = btc.UnsubPullChanges()
+		response, err = btcRunner.UnsubPullChanges(btc.id)
 		assert.NoError(t, err)
 		assert.Empty(t, response)
 		// Wait for unsub changes to stop the sub changes being sent before sending document up
@@ -2643,22 +2239,22 @@ func TestUnsubChanges(t *testing.T) {
 		// Confirm no more changes are being sent
 		doc2Version := btc.rt.PutDoc(doc2ID, `{"key":"val1"}`)
 		err = btc.rt.WaitForConditionWithOptions(func() bool {
-			_, found = btc.GetVersion("doc2", doc2Version)
+			_, found = btcRunner.GetVersion(btc.id, "doc2", doc2Version)
 			return found
 		}, 10, 100)
 		assert.Error(t, err)
 
 		// Confirm no error message is still returned when no subchanges active
-		response, err = btc.UnsubPullChanges()
+		response, err = btcRunner.UnsubPullChanges(btc.id)
 		assert.NoError(t, err)
 		assert.Empty(t, response)
 
 		// Confirm the pull replication can be restarted and it syncs doc2
-		err = btc.StartPull()
+		err = btcRunner.StartPull(btc.id)
 		require.NoError(t, err)
-		_, found = btc.WaitForVersion(doc2ID, doc2Version)
+		_, found = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
 		assert.True(t, found)
-	}, t, rtConfig)
+	})
 }
 
 // TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the replication.
@@ -2675,14 +2271,17 @@ func TestRequestPlusPull(t *testing.T) {
 				}
 			}`,
 	}
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	// Initialize blip tester client (will create user)
-	client := NewBlipTesterClientOpts(&BlipTesterClientOpts{
-		Username: "bernard",
-	})
-	defer client.Close()
-
-	client.Run(func(t *testing.T) {
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+		// Initialize blip tester client (will create user)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "bernard",
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer client.Close()
 		database := client.rt.GetDatabase()
 		// Put a doc in channel PBS
 		response := client.rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
@@ -2699,7 +2298,7 @@ func TestRequestPlusPull(t *testing.T) {
 		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 
 		// Start a regular one-shot pull
-		err := client.StartOneshotPullRequestPlus()
+		err := btcRunner.StartOneshotPullRequestPlus(client.id)
 		assert.NoError(t, err)
 
 		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
@@ -2710,10 +2309,10 @@ func TestRequestPlusPull(t *testing.T) {
 		require.NoError(t, releaseErr)
 
 		// The one-shot pull should unblock and replicate the document in the granted channel
-		data, ok := client.WaitForDoc("pbs-1")
+		data, ok := btcRunner.WaitForDoc(client.id, "pbs-1")
 		assert.True(t, ok)
 		assert.Equal(t, `{"channel":["PBS"]}`, string(data))
-	}, t, &rtConfig)
+	})
 }
 
 // TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the db config.
@@ -2735,14 +2334,17 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 			},
 		},
 	}
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	// Initialize blip tester client (will create user)
-	client := NewBlipTesterClientOpts(&BlipTesterClientOpts{
-		Username: "bernard",
-	})
-	defer client.Close()
-
-	client.Run(func(t *testing.T) {
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+		// Initialize blip tester client (will create user)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "bernard",
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer client.Close()
 		database := client.rt.GetDatabase()
 		// Put a doc in channel PBS
 		response := client.rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
@@ -2759,7 +2361,7 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 
 		// Start a regular one-shot pull
-		err := client.StartOneshotPull()
+		err := btcRunner.StartOneshotPull(client.id)
 		assert.NoError(t, err)
 
 		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
@@ -2770,10 +2372,10 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 		require.NoError(t, releaseErr)
 
 		// The one-shot pull should unblock and replicate the document in the granted channel
-		data, ok := client.WaitForDoc("pbs-1")
+		data, ok := btcRunner.WaitForDoc(client.id, "pbs-1")
 		assert.True(t, ok)
 		assert.Equal(t, `{"channel":["PBS"]}`, string(data))
-	}, t, &rtConfig)
+	})
 }
 
 // TestBlipRefreshUser makes sure there is no panic if a user gets deleted during a replication
@@ -2794,51 +2396,55 @@ func TestBlipRefreshUser(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-
 	const username = "bernard"
-	// Initialize blip tester client (will create user)
-	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{ // This test will need refactoring when its getting fixed in CBG-3512
-		Username: "bernard",
-		Channels: []string{"chan1"},
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+		// Initialize blip tester client (will create user)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{ // This test will need refactoring when its getting fixed in CBG-3512
+			Username:               username,
+			Channels:               []string{"chan1"},
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer btc.Close()
+
+		// add chan1 explicitly
+		response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB, "", RestTesterDefaultUserPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"chan1"}, nil))
+		RequireStatus(t, response, http.StatusOK)
+
+		const docID = "doc1"
+		version := rt.PutDoc(docID, `{"channels":["chan1"]}`)
+
+		// Start a regular one-shot pull
+		err := btcRunner.StartPullSince(btc.id, "true", "0", "false")
+		require.NoError(t, err)
+
+		_, ok := btcRunner.WaitForDoc(btc.id, docID)
+		require.True(t, ok)
+
+		_, ok = btcRunner.GetVersion(btc.id, docID, version)
+		require.True(t, ok)
+
+		// delete user with an active blip connection
+		response = rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_user/"+username, "")
+		RequireStatus(t, response, http.StatusOK)
+
+		require.NoError(t, rt.WaitForPendingChanges())
+
+		// further requests will 500, but shouldn't panic
+		unsubChangesRequest := blip.NewRequest()
+		unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
+		btc.addCollectionProperty(unsubChangesRequest)
+
+		err = btc.pullReplication.sendMsg(unsubChangesRequest)
+		require.NoError(t, err)
+
+		testResponse := unsubChangesRequest.Response()
+		require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), testResponse.Properties[db.BlipErrorCode])
+		body, err := testResponse.Body()
+		require.NoError(t, err)
+		require.NotContains(t, string(body), "Panic:")
 	})
-	defer btc.Close()
-
-	// add chan1 explicitly
-	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB, "", RestTesterDefaultUserPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"chan1"}, nil))
-	RequireStatus(t, response, http.StatusOK)
-
-	const docID = "doc1"
-	version := rt.PutDoc(docID, `{"channels":["chan1"]}`)
-
-	// Start a regular one-shot pull
-	err := btc.StartPullSince("true", "0", "false")
-	require.NoError(t, err)
-
-	_, ok := btc.WaitForDoc(docID)
-	require.True(t, ok)
-
-	_, ok = btc.GetVersion(docID, version)
-	require.True(t, ok)
-
-	// delete user with an active blip connection
-	response = rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_user/"+username, "")
-	RequireStatus(t, response, http.StatusOK)
-
-	require.NoError(t, rt.WaitForPendingChanges())
-
-	// further requests will 500, but shouldn't panic
-	unsubChangesRequest := blip.NewRequest()
-	unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
-	btc.addCollectionProperty(unsubChangesRequest)
-
-	err = btc.pullReplication.sendMsg(unsubChangesRequest)
-	require.NoError(t, err)
-
-	testResponse := unsubChangesRequest.Response()
-	require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), testResponse.Properties[db.BlipErrorCode])
-	body, err := testResponse.Body()
-	require.NoError(t, err)
-	require.NotContains(t, string(body), "Panic:")
 }

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -42,7 +42,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 
 	btc.Run(func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	btc := NewBlipTesterClientOptsWithRT(nil)
+	btc := NewBlipTesterClientOpts(nil)
 	defer btc.Close()
 	const docID = "doc1"
 
@@ -176,7 +176,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 	const doc1ID = "doc1"
 
@@ -271,7 +271,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	}
 
 	var deltaSentCount int64
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 	const docID = "doc1"
 
@@ -346,7 +346,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 	const docID = "doc1"
 
@@ -414,7 +414,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 
-	client := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	client := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:               "alice",
 		Channels:               []string{"public"},
 		ClientDeltas:           true,
@@ -480,7 +480,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 	var deltasRequestedStart int64
 	var deltasSentStart int64
 
-	client := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	client := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:     "alice",
 		Channels:     []string{"public"},
 		ClientDeltas: true,
@@ -572,14 +572,14 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	var deltasRequestedStart int64
 	var deltasSentStart int64
 
-	client1 := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	client1 := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:     "client1",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
 	})
 	defer client1.Close()
 
-	client2 := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	client2 := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:     "client2",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
@@ -708,10 +708,10 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 
-	client2 := NewBlipTesterClientOptsWithRT(nil)
+	client2 := NewBlipTesterClientOpts(nil)
 	defer client2.Close()
 	const docID = "doc1"
 
@@ -792,7 +792,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 	client.ClientDeltas = true
 	const docID = "doc1"
@@ -895,7 +895,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		GuestEnabled: true,
 	}
 
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 	const docID = "doc1"
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -33,57 +33,59 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 
 	const docID = "pushAttachmentDoc"
 
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-				DeltaSync: &DeltaSyncConfig{
-					Enabled: base.BoolPtr(true),
-				},
-			}},
-			GuestEnabled: true,
-		})
-	defer rt.Close()
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.BoolPtr(true),
+			},
+		}},
+		GuestEnabled: true,
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
 
-	// Push first rev
-	version, err := btc.PushRev(docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
-	require.NoError(t, err)
+	btc.Run(func(t *testing.T) {
+		// Push first rev
+		version, err := btc.PushRev(docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
+		require.NoError(t, err)
 
-	// Push second rev with an attachment (no delta yet)
-	attData := base64.StdEncoding.EncodeToString([]byte("attach"))
+		// Push second rev with an attachment (no delta yet)
+		attData := base64.StdEncoding.EncodeToString([]byte("attach"))
 
-	version, err = btc.PushRev(docID, version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
-	require.NoError(t, err)
+		version, err = btc.PushRev(docID, version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
+		require.NoError(t, err)
 
-	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
-	require.NoError(t, err)
+		syncData, err := btc.rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
+		require.NoError(t, err)
 
-	assert.Len(t, syncData.Attachments, 1)
-	_, found := syncData.Attachments["myAttachment"]
-	assert.True(t, found)
+		assert.Len(t, syncData.Attachments, 1)
+		_, found := syncData.Attachments["myAttachment"]
+		assert.True(t, found)
 
-	// Turn deltas on
-	btc.ClientDeltas = true
+		// Turn deltas on
+		btc.ClientDeltas = true
 
-	// Get existing body with the stub attachment, insert a new property and push as delta.
-	body, found := btc.GetVersion(docID, version)
-	require.True(t, found)
+		// Get existing body with the stub attachment, insert a new property and push as delta.
+		body, found := btc.GetVersion(docID, version)
+		require.True(t, found)
 
-	newBody, err := base.InjectJSONPropertiesFromBytes(body, base.KVPairBytes{Key: "update", Val: []byte(`true`)})
-	require.NoError(t, err)
+		newBody, err := base.InjectJSONPropertiesFromBytes(body, base.KVPairBytes{Key: "update", Val: []byte(`true`)})
+		require.NoError(t, err)
 
-	_, err = btc.PushRev(docID, version, newBody)
-	require.NoError(t, err)
+		_, err = btc.PushRev(docID, version, newBody)
+		require.NoError(t, err)
 
-	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
-	require.NoError(t, err)
+		syncData, err = btc.rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
+		require.NoError(t, err)
 
-	assert.Len(t, syncData.Attachments, 1)
-	_, found = syncData.Attachments["myAttachment"]
-	assert.True(t, found)
+		assert.Len(t, syncData.Attachments, 1)
+		_, found = syncData.Attachments["myAttachment"]
+		assert.True(t, found)
+
+		// set client deltas back to false for next run
+		btc.ClientDeltas = false
+	}, t, rtConfig)
 }
 
 // Test pushing and pulling new attachments through delta sync
@@ -106,59 +108,57 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	btc := NewBlipTesterClientOptsWithRT(nil)
 	defer btc.Close()
-
-	btc.ClientDeltas = true
-	err = btc.StartPull()
-	assert.NoError(t, err)
 	const docID = "doc1"
 
-	// Create doc1 rev 1-77d9041e49931ceef58a1eef5fd032e8 on SG with an attachment
-	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	version := rt.PutDoc(docID, bodyText)
-	data, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
+	btc.Run(func(t *testing.T) {
+		btc.ClientDeltas = true
+		err := btc.StartPull()
+		assert.NoError(t, err)
 
-	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	require.JSONEq(t, bodyTextExpected, string(data))
+		// Create doc1 rev 1-77d9041e49931ceef58a1eef5fd032e8 on SG with an attachment
+		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		version := rt.PutDoc(docID, bodyText)
+		data, ok := btc.WaitForVersion(docID, version)
+		assert.True(t, ok)
 
-	// Update the replicated doc at client by adding another attachment.
-	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="},"world.txt":{"data":"bGVsbG8gd29ybGQ="}}}`
-	version, err = btc.PushRev(docID, version, []byte(bodyText))
-	require.NoError(t, err)
+		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		require.JSONEq(t, bodyTextExpected, string(data))
 
-	// Wait for the document to be replicated at SG
-	_, ok = btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		// Update the replicated doc at client by adding another attachment.
+		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="},"world.txt":{"data":"bGVsbG8gd29ybGQ="}}}`
+		version, err = btc.PushRev(docID, version, []byte(bodyText))
+		require.NoError(t, err)
 
-	respBody := rt.GetDocVersion(docID, version)
+		// Wait for the document to be replicated at SG
+		_, ok = btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
+		respBody := rt.GetDocVersion(docID, version)
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 2)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(1), hello["revpos"])
-	assert.Equal(t, true, hello["stub"])
+		assert.Equal(t, docID, respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
 
-	world, ok := attachments["world.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-qiF39gVoGPFzpRQkNYcY9u3wx9Y=", world["digest"])
-	assert.Equal(t, float64(11), world["length"])
-	assert.Equal(t, float64(2), world["revpos"])
-	assert.Equal(t, true, world["stub"])
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 2)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(1), hello["revpos"])
+		assert.Equal(t, true, hello["stub"])
+
+		world, ok := attachments["world.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-qiF39gVoGPFzpRQkNYcY9u3wx9Y=", world["digest"])
+		assert.Equal(t, float64(11), world["length"])
+		assert.Equal(t, float64(2), world["revpos"])
+		assert.Equal(t, true, world["stub"])
+	}, t, &rtConfig)
 }
 
 // TestBlipDeltaSyncNewAttachmentPull tests that adding a new attachment in SG and replicated via delta sync adds the attachment
@@ -175,84 +175,84 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
-
-	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-
 	const doc1ID = "doc1"
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-	version := rt.PutDoc(doc1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok := client.WaitForVersion(doc1ID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-
-	// create doc1 rev 2-10000d5ec533b29b117e60274b1e3653 on SG with the first attachment
-	version = rt.UpdateDoc(doc1ID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
-
-	data, ok = client.WaitForVersion(doc1ID, version)
-	assert.True(t, ok)
-	var dataMap map[string]interface{}
-	assert.NoError(t, base.JSONUnmarshal(data, &dataMap))
-	atts, ok := dataMap[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, atts, 1)
-	hello, ok := atts["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(2), hello["revpos"])
-	assert.Equal(t, true, hello["stub"])
-
-	// message #3 is the getAttachment message that is sent in-between rev processing
-	msg, ok := client.pullReplication.WaitForMessage(3)
-	assert.True(t, ok)
-	assert.NotEqual(t, blip.ErrorType, msg.Type(), "Expected non-error blip message type")
-
-	// Check EE is delta, and CE is full-body replication
-	// msg, ok = client.pullReplication.WaitForMessage(5)
-	msg, ok = client.WaitForBlipRevMessage(doc1ID, version)
-	assert.True(t, ok)
-
-	if base.IsEnterpriseEdition() {
-		// Check the request was sent with the correct deltaSrc property
-		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was the actual delta
-		msgBody, err := msg.Body()
+	client.Run(func(t *testing.T) {
+		client.ClientDeltas = true
+		err := client.StartPull()
 		assert.NoError(t, err)
-		assert.Equal(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
-	} else {
-		// Check the request was NOT sent with a deltaSrc property
-		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was NOT the delta
-		msgBody, err := msg.Body()
-		assert.NoError(t, err)
-		assert.NotEqual(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
-		assert.Contains(t, string(msgBody), `"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}`)
-		assert.Contains(t, string(msgBody), `"greetings":[{"hello":"world!"},{"hi":"alice"}]`)
-	}
 
-	respBody := rt.GetDocVersion(doc1ID, version)
-	assert.Equal(t, doc1ID, respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 2)
-	assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
-	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
-	atts = respBody[db.BodyAttachments].(map[string]interface{})
-	assert.Len(t, atts, 1)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(2), hello["revpos"])
-	assert.Equal(t, true, hello["stub"])
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version := rt.PutDoc(doc1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	// assert.Equal(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}},"_id":"doc1","_rev":"2-10000d5ec533b29b117e60274b1e3653","greetings":[{"hello":"world!"},{"hi":"alice"}]}`, resp.Body.String())
+		data, ok := client.WaitForVersion(doc1ID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+
+		// create doc1 rev 2-10000d5ec533b29b117e60274b1e3653 on SG with the first attachment
+		version = rt.UpdateDoc(doc1ID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
+
+		data, ok = client.WaitForVersion(doc1ID, version)
+		assert.True(t, ok)
+		var dataMap map[string]interface{}
+		assert.NoError(t, base.JSONUnmarshal(data, &dataMap))
+		atts, ok := dataMap[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, atts, 1)
+		hello, ok := atts["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(2), hello["revpos"])
+		assert.Equal(t, true, hello["stub"])
+
+		// message #3 is the getAttachment message that is sent in-between rev processing
+		msg, ok := client.pullReplication.WaitForMessage(3)
+		assert.True(t, ok)
+		assert.NotEqual(t, blip.ErrorType, msg.Type(), "Expected non-error blip message type")
+
+		// Check EE is delta, and CE is full-body replication
+		// msg, ok = client.pullReplication.WaitForMessage(5)
+		msg, ok = client.WaitForBlipRevMessage(doc1ID, version)
+		assert.True(t, ok)
+
+		if base.IsEnterpriseEdition() {
+			// Check the request was sent with the correct deltaSrc property
+			assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was the actual delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.Equal(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
+		} else {
+			// Check the request was NOT sent with a deltaSrc property
+			assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was NOT the delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.NotEqual(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
+			assert.Contains(t, string(msgBody), `"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}`)
+			assert.Contains(t, string(msgBody), `"greetings":[{"hello":"world!"},{"hi":"alice"}]`)
+		}
+
+		respBody := rt.GetDocVersion(doc1ID, version)
+		assert.Equal(t, doc1ID, respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 2)
+		assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
+		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
+		atts = respBody[db.BodyAttachments].(map[string]interface{})
+		assert.Len(t, atts, 1)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(2), hello["revpos"])
+		assert.Equal(t, true, hello["stub"])
+
+		// assert.Equal(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}},"_id":"doc1","_rev":"2-10000d5ec533b29b117e60274b1e3653","greetings":[{"hello":"world!"},{"hi":"alice"}]}`, resp.Body.String())
+	}, t, &rtConfig)
 }
 
 // TestBlipDeltaSyncPull tests that a simple pull replication uses deltas in EE,
@@ -262,7 +262,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			DeltaSync: &DeltaSyncConfig{
 				Enabled: &sgUseDeltas,
@@ -270,66 +270,63 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
 
 	var deltaSentCount int64
-
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaSentCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
-
-	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-
 	const docID = "doc1"
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-	version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-
-	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	version = rt.UpdateDoc(docID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
-
-	data, ok = client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
-	msg, ok := client.WaitForBlipRevMessage(docID, version)
-	assert.True(t, ok)
-
-	// Check EE is delta, and CE is full-body replication
-	if base.IsEnterpriseEdition() {
-		// Check the request was sent with the correct deltaSrc property
-		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was the actual delta
-		msgBody, err := msg.Body()
-		assert.NoError(t, err)
-		assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
-		assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
-	} else {
-		// Check the request was NOT sent with a deltaSrc property
-		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was NOT the delta
-		msgBody, err := msg.Body()
-		assert.NoError(t, err)
-		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
-		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
-
-		var afterDeltaSyncCount int64
-		if rt.GetDatabase().DbStats.DeltaSync() != nil {
-			afterDeltaSyncCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+	client.Run(func(t *testing.T) {
+		if client.rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaSentCount = client.rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 		}
 
-		assert.Equal(t, deltaSentCount, afterDeltaSyncCount)
-	}
+		client.ClientDeltas = true
+		err := client.StartPull()
+		assert.NoError(t, err)
+
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+
+		data, ok := client.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+
+		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
+		version = rt.UpdateDoc(docID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+
+		data, ok = client.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+		msg, ok := client.WaitForBlipRevMessage(docID, version)
+		assert.True(t, ok)
+
+		// Check EE is delta, and CE is full-body replication
+		if base.IsEnterpriseEdition() {
+			// Check the request was sent with the correct deltaSrc property
+			assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was the actual delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+			assert.Equal(t, deltaSentCount+1, client.rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+		} else {
+			// Check the request was NOT sent with a deltaSrc property
+			assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was NOT the delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+			assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
+
+			var afterDeltaSyncCount int64
+			if client.rt.GetDatabase().DbStats.DeltaSync() != nil {
+				afterDeltaSyncCount = client.rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+			}
+
+			assert.Equal(t, deltaSentCount, afterDeltaSyncCount)
+		}
+	}, t, rtConfig)
 }
 
 // TestBlipDeltaSyncPullResend tests that a simple pull replication that uses a delta a client rejects will resend the revision in full.
@@ -341,7 +338,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rtConfig := RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			DeltaSync: &DeltaSyncConfig{
 				Enabled: base.BoolPtr(true),
@@ -349,58 +346,56 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
 
-	docID := "doc1"
-	// create doc1 rev 1
-	docVersion1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
-
-	deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
+	const docID = "doc1"
 
-	// reject deltas built ontop of rev 1
-	client.rejectDeltasForSrcRev = docVersion1.RevID
+	client.Run(func(t *testing.T) {
+		// create doc1 rev 1
+		docVersion1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-	data, ok := client.WaitForVersion(docID, docVersion1)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		deltaSentCount := client.rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 
-	// create doc1 rev 2
-	docVersion2 := rt.UpdateDoc(docID, docVersion1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+		// reject deltas built ontop of rev 1
+		client.rejectDeltasForSrcRev = docVersion1.RevID
 
-	data, ok = client.WaitForVersion(docID, docVersion2)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+		client.ClientDeltas = true
+		err = client.StartPull()
+		assert.NoError(t, err)
+		data, ok := client.WaitForVersion(docID, docVersion1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	msg, ok := client.pullReplication.WaitForMessage(5)
-	assert.True(t, ok)
+		// create doc1 rev 2
+		docVersion2 := rt.UpdateDoc(docID, docVersion1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
 
-	// Check the request was initially sent with the correct deltaSrc property
-	assert.Equal(t, docVersion1.RevID, msg.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was the actual delta
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
-	assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+		data, ok = client.WaitForVersion(docID, docVersion2)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
 
-	msg, ok = client.WaitForBlipRevMessage(docID, docVersion2)
-	assert.True(t, ok)
+		msg, ok := client.pullReplication.WaitForMessage(5)
+		assert.True(t, ok)
 
-	// Check the resent request was NOT sent with a deltaSrc property
-	assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was NOT the delta
-	msgBody, err = msg.Body()
-	assert.NoError(t, err)
-	assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
+		// Check the request was initially sent with the correct deltaSrc property
+		assert.Equal(t, docVersion1.RevID, msg.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was the actual delta
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+		assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+
+		msg, ok = client.WaitForBlipRevMessage(docID, docVersion2)
+		assert.True(t, ok)
+
+		// Check the resent request was NOT sent with a deltaSrc property
+		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was NOT the delta
+		msgBody, err = msg.Body()
+		assert.NoError(t, err)
+		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
+	}, t, rtConfig)
 }
 
 // TestBlipDeltaSyncPullRemoved tests a simple pull replication that drops a document out of the user's channel.
@@ -409,7 +404,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				DeltaSync: &DeltaSyncConfig{
@@ -419,43 +414,41 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		},
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:               "alice",
 		Channels:               []string{"public"},
 		ClientDeltas:           true,
 		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
 	})
-	require.NoError(t, err)
 	defer client.Close()
-
-	err = client.StartPull()
-	assert.NoError(t, err)
-
 	const docID = "doc1"
-	// create doc1 rev 1-1513b53e2738671e634d9dd111f48de0
-	version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	client.Run(func(t *testing.T) {
+		err := client.StartPull()
+		assert.NoError(t, err)
 
-	// create doc1 rev 2-ff91e11bc1fd12bbb4815a06571859a9
-	version = rt.UpdateDoc(docID, version, `{"channels": ["private"], "greetings": [{"hello": "world!"}, {"hi": "bob"}]}`)
+		// create doc1 rev 1-1513b53e2738671e634d9dd111f48de0
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
-	data, ok = client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"_removed":true}`, string(data))
+		data, ok := client.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
-	msg, ok := client.pullReplication.WaitForMessage(5)
-	assert.True(t, ok)
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{"_removed":true}`, string(msgBody))
+		// create doc1 rev 2-ff91e11bc1fd12bbb4815a06571859a9
+		version = rt.UpdateDoc(docID, version, `{"channels": ["private"], "greetings": [{"hello": "world!"}, {"hi": "bob"}]}`)
+
+		data, ok = client.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"_removed":true}`, string(data))
+
+		msg, ok := client.pullReplication.WaitForMessage(5)
+		assert.True(t, ok)
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"_removed":true}`, string(msgBody))
+	}, t, rtConfig)
 }
 
 // TestBlipDeltaSyncPullTombstoned tests a simple pull replication that deletes a document.
@@ -473,7 +466,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				DeltaSync: &DeltaSyncConfig{
@@ -483,78 +476,75 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		},
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
 	var deltasRequestedStart int64
 	var deltasSentStart int64
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-		deltaCacheMissesStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
-		deltasRequestedStart = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
-		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:     "alice",
 		Channels:     []string{"public"},
 		ClientDeltas: true,
 	})
-	require.NoError(t, err)
 	defer client.Close()
-
-	err = client.StartPull()
-	assert.NoError(t, err)
-
 	const docID = "doc1"
-	// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
-	version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
-	// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
-	version = rt.DeleteDocReturnVersion(docID, version)
+	client.Run(func(t *testing.T) {
+		if client.rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaCacheHitsStart = client.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+			deltaCacheMissesStart = client.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+			deltasRequestedStart = client.rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
+			deltasSentStart = client.rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}
+		err := client.StartPull()
+		assert.NoError(t, err)
 
-	data, ok = client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
+		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
+		data, ok := client.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
-	msg, ok := client.pullReplication.WaitForMessage(5)
-	assert.True(t, ok)
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{}`, string(msgBody))
-	assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted])
+		// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
+		version = rt.DeleteDocReturnVersion(docID, version)
 
-	var deltaCacheHitsEnd int64
-	var deltaCacheMissesEnd int64
-	var deltasRequestedEnd int64
-	var deltasSentEnd int64
+		data, ok = client.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaCacheHitsEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-		deltaCacheMissesEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
-		deltasRequestedEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
-		deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
+		msg, ok := client.pullReplication.WaitForMessage(5)
+		assert.True(t, ok)
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{}`, string(msgBody))
+		assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted])
 
-	if sgUseDeltas {
-		assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
-		assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
-		assert.Equal(t, deltasRequestedStart+1, deltasRequestedEnd)
-		assert.Equal(t, deltasSentStart, deltasSentEnd) // "_removed" docs are not counted as a delta
-	} else {
-		assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
-		assert.Equal(t, deltaCacheMissesStart, deltaCacheMissesEnd)
-		assert.Equal(t, deltasRequestedStart, deltasRequestedEnd)
-		assert.Equal(t, deltasSentStart, deltasSentEnd)
-	}
+		var deltaCacheHitsEnd int64
+		var deltaCacheMissesEnd int64
+		var deltasRequestedEnd int64
+		var deltasSentEnd int64
+
+		if client.rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaCacheHitsEnd = client.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+			deltaCacheMissesEnd = client.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+			deltasRequestedEnd = client.rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
+			deltasSentEnd = client.rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}
+
+		if sgUseDeltas {
+			assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
+			assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
+			assert.Equal(t, deltasRequestedStart+1, deltasRequestedEnd)
+			assert.Equal(t, deltasSentStart, deltasSentEnd) // "_removed" docs are not counted as a delta
+		} else {
+			assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
+			assert.Equal(t, deltaCacheMissesStart, deltaCacheMissesEnd)
+			assert.Equal(t, deltasRequestedStart, deltasRequestedEnd)
+			assert.Equal(t, deltasSentStart, deltasSentEnd)
+		}
+	}, t, rtConfig)
+
 }
 
 // TestBlipDeltaSyncPullTombstonedStarChan tests two clients can perform a simple pull replication that deletes a document when the user has access to the star channel.
@@ -576,129 +566,127 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
 
+	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
 	var deltasRequestedStart int64
 	var deltasSentStart int64
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-		deltaCacheMissesStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
-		deltasRequestedStart = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
-		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client1 := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:     "client1",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
 	})
-	require.NoError(t, err)
 	defer client1.Close()
 
-	client2, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	client2 := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:     "client2",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
 	})
-	require.NoError(t, err)
 	defer client2.Close()
-
-	err = client1.StartPull()
-	require.NoError(t, err)
-
 	const docID = "doc1"
-	// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
-	version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
-	data, ok := client1.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	client1.RunDualClients(client2, func(t *testing.T) {
+		if client1.rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaCacheHitsStart = client1.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+			deltaCacheMissesStart = client1.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+			deltasRequestedStart = client1.rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
+			deltasSentStart = client1.rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}
 
-	// Have client2 get only rev-1 and then stop replicating
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	data, ok = client2.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+		err := client1.StartPull()
+		require.NoError(t, err)
 
-	// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
-	version = rt.DeleteDocReturnVersion(docID, version)
+		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
-	data, ok = client1.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
-	msg, ok := client1.WaitForBlipRevMessage(docID, version) // docid, revid to get the message
-	assert.True(t, ok)
+		data, ok := client1.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
-	if !assert.Equal(t, db.MessageRev, msg.Profile()) {
-		t.Logf("unexpected profile for message %v in %v",
-			msg.SerialNumber(), client1.pullReplication.GetMessages())
-	}
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	if !assert.Equal(t, `{}`, string(msgBody)) {
-		t.Logf("unexpected body for message %v in %v",
-			msg.SerialNumber(), client1.pullReplication.GetMessages())
-	}
-	if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
-		t.Logf("unexpected deleted property for message %v in %v",
-			msg.SerialNumber(), client1.pullReplication.GetMessages())
-	}
+		// Have client2 get only rev-1 and then stop replicating
+		err = client2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = client2.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
-	// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	data, ok = client2.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
-	msg, ok = client2.WaitForBlipRevMessage(docID, version)
-	assert.True(t, ok)
+		// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
+		version = rt.DeleteDocReturnVersion(docID, version)
 
-	if !assert.Equal(t, db.MessageRev, msg.Profile()) {
-		t.Logf("unexpected profile for message %v in %v",
-			msg.SerialNumber(), client2.pullReplication.GetMessages())
-	}
-	msgBody, err = msg.Body()
-	assert.NoError(t, err)
-	if !assert.Equal(t, `{}`, string(msgBody)) {
-		t.Logf("unexpected body for message %v in %v",
-			msg.SerialNumber(), client2.pullReplication.GetMessages())
-	}
-	if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
-		t.Logf("unexpected deleted property for message %v in %v",
-			msg.SerialNumber(), client2.pullReplication.GetMessages())
-	}
+		data, ok = client1.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+		msg, ok := client1.WaitForBlipRevMessage(docID, version) // docid, revid to get the message
+		assert.True(t, ok)
 
-	var deltaCacheHitsEnd int64
-	var deltaCacheMissesEnd int64
-	var deltasRequestedEnd int64
-	var deltasSentEnd int64
+		if !assert.Equal(t, db.MessageRev, msg.Profile()) {
+			t.Logf("unexpected profile for message %v in %v",
+				msg.SerialNumber(), client1.pullReplication.GetMessages())
+		}
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		if !assert.Equal(t, `{}`, string(msgBody)) {
+			t.Logf("unexpected body for message %v in %v",
+				msg.SerialNumber(), client1.pullReplication.GetMessages())
+		}
+		if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
+			t.Logf("unexpected deleted property for message %v in %v",
+				msg.SerialNumber(), client1.pullReplication.GetMessages())
+		}
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaCacheHitsEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-		deltaCacheMissesEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
-		deltasRequestedEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
-		deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
+		// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
+		err = client2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = client2.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+		msg, ok = client2.WaitForBlipRevMessage(docID, version)
+		assert.True(t, ok)
 
-	if sgUseDeltas {
-		assert.Equal(t, deltaCacheHitsStart+1, deltaCacheHitsEnd)
-		assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
-		assert.Equal(t, deltasRequestedStart+2, deltasRequestedEnd)
-		assert.Equal(t, deltasSentStart+2, deltasSentEnd)
-	} else {
-		assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
-		assert.Equal(t, deltaCacheMissesStart, deltaCacheMissesEnd)
-		assert.Equal(t, deltasRequestedStart, deltasRequestedEnd)
-		assert.Equal(t, deltasSentStart, deltasSentEnd)
-	}
+		if !assert.Equal(t, db.MessageRev, msg.Profile()) {
+			t.Logf("unexpected profile for message %v in %v",
+				msg.SerialNumber(), client2.pullReplication.GetMessages())
+		}
+		msgBody, err = msg.Body()
+		assert.NoError(t, err)
+		if !assert.Equal(t, `{}`, string(msgBody)) {
+			t.Logf("unexpected body for message %v in %v",
+				msg.SerialNumber(), client2.pullReplication.GetMessages())
+		}
+		if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
+			t.Logf("unexpected deleted property for message %v in %v",
+				msg.SerialNumber(), client2.pullReplication.GetMessages())
+		}
+
+		var deltaCacheHitsEnd int64
+		var deltaCacheMissesEnd int64
+		var deltasRequestedEnd int64
+		var deltasSentEnd int64
+
+		if client1.rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaCacheHitsEnd = client1.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+			deltaCacheMissesEnd = client1.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+			deltasRequestedEnd = client1.rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
+			deltasSentEnd = client1.rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}
+
+		if sgUseDeltas {
+			assert.Equal(t, deltaCacheHitsStart+1, deltaCacheHitsEnd)
+			assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
+			assert.Equal(t, deltasRequestedStart+2, deltasRequestedEnd)
+			assert.Equal(t, deltasSentStart+2, deltasSentEnd)
+		} else {
+			assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
+			assert.Equal(t, deltaCacheMissesStart, deltaCacheMissesEnd)
+			assert.Equal(t, deltasRequestedStart, deltasRequestedEnd)
+			assert.Equal(t, deltasSentStart, deltasSentEnd)
+		}
+	}, t, &rtConfig)
 }
 
 // TestBlipDeltaSyncPullRevCache tests that a simple pull replication uses deltas in EE,
@@ -720,79 +708,74 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
 
-	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-
-	const docID = "doc1"
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-	version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
-
-	data, ok := client.WaitForVersion(docID, version1)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-
-	// Perform a one-shot pull as client 2 to pull down the first revision
-
-	client2, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client2 := NewBlipTesterClientOptsWithRT(nil)
 	defer client2.Close()
+	const docID = "doc1"
 
-	client2.ClientDeltas = true
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	data, ok = client2.WaitForVersion(docID, version1)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	client.RunDualClients(client2, func(t *testing.T) {
+		client.ClientDeltas = true
+		err := client.StartPull()
+		assert.NoError(t, err)
 
-	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`)
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok = client.WaitForVersion(docID, version2)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
-	msg, ok := client.WaitForBlipRevMessage(docID, version2)
-	assert.True(t, ok)
+		data, ok := client.WaitForVersion(docID, version1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	// Check EE is delta
-	// Check the request was sent with the correct deltaSrc property
-	assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was the actual delta
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
+		// Perform a one-shot pull as client 2 to pull down the first revision
+		client2.ClientDeltas = true
+		err = client2.StartOneshotPull()
+		assert.NoError(t, err)
+		data, ok = client2.WaitForVersion(docID, version1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	deltaCacheHits := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-	deltaCacheMisses := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
+		version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`)
 
-	// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
-	client2.ClientDeltas = true
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	msg2, ok := client2.WaitForBlipRevMessage(docID, version2)
-	assert.True(t, ok)
+		data, ok = client.WaitForVersion(docID, version2)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
+		msg, ok := client.WaitForBlipRevMessage(docID, version2)
+		assert.True(t, ok)
 
-	// Check the request was sent with the correct deltaSrc property
-	assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg2.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was the actual delta
-	msgBody2, err := msg2.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody2))
+		// Check EE is delta
+		// Check the request was sent with the correct deltaSrc property
+		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was the actual delta
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
-	updatedDeltaCacheHits := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-	updatedDeltaCacheMisses := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+		deltaCacheHits := client.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+		deltaCacheMisses := client.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
 
-	assert.Equal(t, deltaCacheHits+1, updatedDeltaCacheHits)
-	assert.Equal(t, deltaCacheMisses, updatedDeltaCacheMisses)
+		// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
+		client2.ClientDeltas = true
+		err = client2.StartOneshotPull()
+		assert.NoError(t, err)
+		msg2, ok := client2.WaitForBlipRevMessage(docID, version2)
+		assert.True(t, ok)
 
+		// Check the request was sent with the correct deltaSrc property
+		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg2.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was the actual delta
+		msgBody2, err := msg2.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody2))
+
+		updatedDeltaCacheHits := client.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+		updatedDeltaCacheMisses := client.rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+
+		assert.Equal(t, deltaCacheHits+1, updatedDeltaCacheHits)
+		assert.Equal(t, deltaCacheMisses, updatedDeltaCacheMisses)
+	}, t, &rtConfig)
 }
 
 // TestBlipDeltaSyncPush tests that a simple push replication handles deltas in EE,
@@ -801,7 +784,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			DeltaSync: &DeltaSyncConfig{
 				Enabled: &sgUseDeltas,
@@ -809,96 +792,94 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
 	client.ClientDeltas = true
-
-	err = client.StartPull()
-	assert.NoError(t, err)
-
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	const docID = "doc1"
-	version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-	// create doc1 rev 2-abc on client
-	newRev, err := client.PushRev(docID, version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-	assert.NoError(t, err)
-
-	// Check EE is delta, and CE is full-body replication
-	msg, found := client.waitForReplicationMessage(collection, 2)
-	assert.True(t, found)
-
-	if base.IsEnterpriseEdition() {
-		// Check the request was sent with the correct deltaSrc property
-		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was the actual delta
-		msgBody, err := msg.Body()
+	client.Run(func(t *testing.T) {
+		collection := client.rt.GetSingleTestDatabaseCollection()
+		err := client.StartPull()
 		assert.NoError(t, err)
-		assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
-		// Validate that generation of a delta didn't mutate the revision body in the revision cache
-		docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
-		assert.NoError(t, cacheErr)
-		assert.NotContains(t, docRev.BodyBytes, "bob")
-	} else {
-		// Check the request was NOT sent with a deltaSrc property
-		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was NOT the delta
-		msgBody, err := msg.Body()
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+
+		data, ok := client.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 2-abc on client
+		newRev, err := client.PushRev(docID, version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 		assert.NoError(t, err)
-		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
-		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
-	}
 
-	respBody := rt.GetDocVersion(docID, newRev)
-	assert.Equal(t, "doc1", respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 3)
-	assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
-	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
-	assert.Equal(t, map[string]interface{}{"howdy": "bob"}, greetings[2])
+		// Check EE is delta, and CE is full-body replication
+		msg, found := client.waitForReplicationMessage(collection, 2)
+		assert.True(t, found)
 
-	// tombstone doc1 (gets rev 3-f3be6c85e0362153005dae6f08fc68bb)
-	deletedVersion := rt.DeleteDocReturnVersion(docID, newRev)
+		if base.IsEnterpriseEdition() {
+			// Check the request was sent with the correct deltaSrc property
+			assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was the actual delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
-	data, ok = client.WaitForVersion(docID, deletedVersion)
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
+			// Validate that generation of a delta didn't mutate the revision body in the revision cache
+			docRev, cacheErr := client.rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
+			assert.NoError(t, cacheErr)
+			assert.NotContains(t, docRev.BodyBytes, "bob")
+		} else {
+			// Check the request was NOT sent with a deltaSrc property
+			assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was NOT the delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
+			assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
+		}
 
-	var deltaPushDocCountStart int64
+		respBody := rt.GetDocVersion(docID, newRev)
+		assert.Equal(t, "doc1", respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 3)
+		assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
+		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
+		assert.Equal(t, map[string]interface{}{"howdy": "bob"}, greetings[2])
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaPushDocCountStart = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
-	}
+		// tombstone doc1 (gets rev 3-f3be6c85e0362153005dae6f08fc68bb)
+		deletedVersion := rt.DeleteDocReturnVersion(docID, newRev)
 
-	_, err = client.PushRev(docID, deletedVersion, []byte(`{"undelete":true}`))
+		data, ok = client.WaitForVersion(docID, deletedVersion)
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
 
-	if base.IsEnterpriseEdition() {
-		// Now make the client push up a delta that has the parent of the tombstone.
-		// This is not a valid scenario, and is actively prevented on the CBL side.
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Can't use delta. Found tombstone for doc")
-	} else {
-		// Pushing a full body revision on top of a tombstone is valid.
-		// CBL clients should fall back to this. The test client doesn't.
-		assert.NoError(t, err)
-	}
+		var deltaPushDocCountStart int64
 
-	var deltaPushDocCountEnd int64
+		if client.rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaPushDocCountStart = client.rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
+		}
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaPushDocCountEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
-	}
-	assert.Equal(t, deltaPushDocCountStart, deltaPushDocCountEnd)
+		_, err = client.PushRev(docID, deletedVersion, []byte(`{"undelete":true}`))
+
+		if base.IsEnterpriseEdition() {
+			// Now make the client push up a delta that has the parent of the tombstone.
+			// This is not a valid scenario, and is actively prevented on the CBL side.
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "Can't use delta. Found tombstone for doc")
+		} else {
+			// Pushing a full body revision on top of a tombstone is valid.
+			// CBL clients should fall back to this. The test client doesn't.
+			assert.NoError(t, err)
+		}
+
+		var deltaPushDocCountEnd int64
+
+		if client.rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaPushDocCountEnd = client.rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
+		}
+		assert.Equal(t, deltaPushDocCountStart, deltaPushDocCountEnd)
+	}, t, rtConfig)
 }
 
 // TestBlipNonDeltaSyncPush tests that a client that doesn't support deltas can push to a SG that supports deltas (either CE or EE)
@@ -906,7 +887,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			DeltaSync: &DeltaSyncConfig{
 				Enabled: &sgUseDeltas,
@@ -914,41 +895,39 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
-
-	client.ClientDeltas = false
-	err = client.StartPull()
-	assert.NoError(t, err)
-
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	const docID = "doc1"
-	version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-	// create doc1 rev 2-abcxyz on client
-	newRev, err := client.PushRev(docID, version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-	assert.NoError(t, err)
-	// Check EE is delta, and CE is full-body replication
-	msg, found := client.waitForReplicationMessage(collection, 2)
-	assert.True(t, found)
+	client.Run(func(t *testing.T) {
+		collection := client.rt.GetSingleTestDatabaseCollection()
+		client.ClientDeltas = false
+		err := client.StartPull()
+		assert.NoError(t, err)
 
-	// Check the request was NOT sent with a deltaSrc property
-	assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was NOT the delta
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	body := rt.GetDocVersion("doc1", newRev)
-	require.Equal(t, "bob", body["greetings"].([]interface{})[2].(map[string]interface{})["howdy"])
+		data, ok := client.WaitForVersion(docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 2-abcxyz on client
+		newRev, err := client.PushRev(docID, version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
+		assert.NoError(t, err)
+		// Check EE is delta, and CE is full-body replication
+		msg, found := client.waitForReplicationMessage(collection, 2)
+		assert.True(t, found)
+
+		// Check the request was NOT sent with a deltaSrc property
+		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was NOT the delta
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
+
+		body := rt.GetDocVersion("doc1", newRev)
+		require.Equal(t, "bob", body["greetings"].([]interface{})[2].(map[string]interface{})["howdy"])
+	}, t, rtConfig)
 }

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -846,7 +846,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
 		// Validate that generation of a delta didn't mutate the revision body in the revision cache
-		docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
+		docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
 		assert.NoError(t, cacheErr)
 		assert.NotContains(t, docRev.BodyBytes, "bob")
 	} else {

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -47,7 +47,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client := NewBlipTesterClientOptsWithRT(nil)
+	client := NewBlipTesterClientOpts(nil)
 	defer client.Close()
 
 	var lastPushRevErr atomic.Value

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -47,8 +47,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
+	client := NewBlipTesterClientOptsWithRT(nil)
 	defer client.Close()
 
 	var lastPushRevErr atomic.Value
@@ -76,7 +75,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	}()
 
 	// and wait for a few to be done before we proceed with updating database config underneath replication
-	_, err = rt.WaitForChanges(5, "/{{.keyspace}}/_changes", "", true)
+	_, err := rt.WaitForChanges(5, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
 	// just change the sync function to cause the database to reload

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -573,7 +573,7 @@ func getCollectionsForBLIP(_ testing.TB, rt *RestTester) []string {
 	return collections
 }
 
-func NewBlipTesterClientOptsWithRT(opts *BlipTesterClientOpts) (client *BlipTesterClient) {
+func NewBlipTesterClientOpts(opts *BlipTesterClientOpts) (client *BlipTesterClient) {
 	if opts == nil {
 		opts = &BlipTesterClientOpts{}
 	}
@@ -614,6 +614,7 @@ func (btc *BlipTesterClient) RunDualClients(btc2 *BlipTesterClient, test func(t 
 	})
 	// if test is not wanting version vector subprotocol to be run, return before we start this subtest
 	if btc.SkipVersionVectorInitialization {
+		btc.rt.Close()
 		return
 	}
 	// teardown active replications on blip tester clients
@@ -654,6 +655,7 @@ func (btc *BlipTesterClient) RunWithRevocationTester(test func(t *testing.T, tes
 	})
 	// if test is not wanting version vector subprotocol to be run, return before we start this subtest
 	if btc.SkipVersionVectorInitialization {
+		btc.rt.Close()
 		return
 	}
 	// teardown active replications on blip tester client and start new rest tester for next test run

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -38,7 +38,7 @@ type BlipTesterClientOpts struct {
 	SupportedBLIPProtocols          []string
 	SkipCollectionsInitialization   bool
 	SkipVersionVectorInitialization bool
-	NumCollectionsNeeded            int
+	NumCollectionsRequired          int
 
 	// a deltaSrc rev ID for which to reject a delta
 	rejectDeltasForSrcRev string
@@ -676,8 +676,8 @@ func (btc *BlipTesterClient) RunWithRevocationTester(test func(t *testing.T, tes
 }
 
 func (btc *BlipTesterClient) Run(test func(*testing.T), t *testing.T, rtConfig *RestTesterConfig) {
-	if btc.NumCollectionsNeeded != 0 {
-		btc.rt = NewRestTesterMultipleCollections(t, rtConfig, btc.NumCollectionsNeeded)
+	if btc.NumCollectionsRequired != 0 {
+		btc.rt = NewRestTesterMultipleCollections(t, rtConfig, btc.NumCollectionsRequired)
 	} else {
 		// assume standard rest tester creation
 		btc.rt = NewRestTester(t, rtConfig)
@@ -700,8 +700,8 @@ func (btc *BlipTesterClient) Run(test func(*testing.T), t *testing.T, rtConfig *
 	btc.rt.Close()
 
 	// setup rest tester for new run
-	if btc.NumCollectionsNeeded != 0 {
-		btc.rt = NewRestTesterMultipleCollections(t, rtConfig, btc.NumCollectionsNeeded)
+	if btc.NumCollectionsRequired != 0 {
+		btc.rt = NewRestTesterMultipleCollections(t, rtConfig, btc.NumCollectionsRequired)
 	} else {
 		// assume standard rest tester creation
 		btc.rt = NewRestTester(t, rtConfig)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -605,7 +605,8 @@ func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTes
 		id:                   id.ID(),
 	}
 	btcRunner.clients[client.id] = client
-	client.createBlipTesterReplications()
+	err = client.createBlipTesterReplications()
+	require.NoError(btcRunner.t, err)
 
 	return client
 }

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -515,7 +515,7 @@ func (h *handler) handleBulkDocs() error {
 				err = base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 			} else {
 				revid = revisions[0]
-				_, _, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, doc, revisions, false)
+				_, _, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, doc, revisions, false, db.ExistingVersionWithUpdateToHLV)
 			}
 		}
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -471,7 +471,7 @@ func (h *handler) handlePutDoc() error {
 		if revisions == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 		}
-		doc, newRev, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false)
+		doc, newRev, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false, db.ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			return err
 		}
@@ -548,7 +548,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		newDoc.UpdateBody(body)
 	}
 
-	doc, rev, err := h.collection.PutExistingRev(h.ctx(), newDoc, history, true, false, nil)
+	doc, rev, err := h.collection.PutExistingRev(h.ctx(), newDoc, history, true, false, nil, db.ExistingVersionWithUpdateToHLV)
 
 	if err != nil {
 		return err

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -424,6 +424,9 @@ func TestXattrDoubleDelete(t *testing.T) {
 }
 
 func TestViewQueryTombstoneRetrieval(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
+	base.SkipImportTestsIfNotEnabled(t)
+
 	if !base.TestsDisableGSI() {
 		t.Skip("views tests are not applicable under GSI")
 	}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8320,3 +8320,46 @@ func requireBodyEqual(t *testing.T, expected string, doc *db.Document) {
 	require.NoError(t, base.JSONUnmarshal([]byte(expected), &expectedBody))
 	require.Equal(t, expectedBody, doc.Body(base.TestCtx(t)))
 }
+
+// TestReplicatorUpdateHLVOnPut:
+//   - For purpose of testing the PutExistingRev code path
+//   - Put a doc on a active rest tester
+//   - Create replication and wait for the doc to be replicated to passive node
+//   - Assert on the HLV in the metadata of the replicated document
+func TestReplicatorUpdateHLVOnPut(t *testing.T) {
+
+	activeRT, passiveRT, remoteURL, teardown := rest.SetupSGRPeers(t)
+	defer teardown()
+
+	// Grab the bucket UUIDs for both rest testers
+	activeBucketUUID, err := activeRT.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	const rep = "replication"
+
+	// Put a doc and assert on the HLV update in the sync data
+	resp := activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"source": "activeRT"}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := activeRT.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, activeBucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// create the replication to push the doc to the passive node and wait for the doc to be replicated
+	activeRT.CreateReplication(rep, remoteURL, db.ActiveReplicatorTypePush, nil, false, db.ConflictResolverDefault)
+
+	_, err = passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	// assert on the HLV update on the passive node
+	syncData, err = passiveRT.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	// TODO: assert that the SourceID and Verison pair are preserved correctly pending CBG-3211
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2239,7 +2239,7 @@ func TestRevocationMessage(t *testing.T) {
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
-		version := rt.PutDoc("doc", `{"channels": "A"}`)
+		version := btc.rt.PutDoc("doc", `{"channels": "A"}`)
 
 		require.NoError(t, btc.rt.WaitForPendingChanges())
 
@@ -2254,10 +2254,10 @@ func TestRevocationMessage(t *testing.T) {
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
 
-		version = rt.PutDoc(doc1ID, `{"channels": "!"}`)
+		version = btc.rt.PutDoc(doc1ID, `{"channels": "!"}`)
 
 		revocationTester.fillToSeq(10)
-		version = rt.UpdateDoc(doc1ID, version, "{}")
+		version = btc.rt.UpdateDoc(doc1ID, version, "{}")
 
 		require.NoError(t, btc.rt.WaitForPendingChanges())
 
@@ -2348,7 +2348,7 @@ func TestRevocationNoRev(t *testing.T) {
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
-		version := rt.PutDoc(docID, `{"channels": "A"}`)
+		version := btc.rt.PutDoc(docID, `{"channels": "A"}`)
 
 		require.NoError(t, btc.rt.WaitForPendingChanges())
 		firstOneShotSinceSeq := btc.rt.GetDocumentSequence("doc")
@@ -2363,10 +2363,10 @@ func TestRevocationNoRev(t *testing.T) {
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
 
-		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
+		_ = btc.rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
-		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
-		require.NoError(t, rt.WaitForPendingChanges())
+		waitMarkerVersion := btc.rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
 		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
 		err = btc.StartPullSince("false", lastSeqStr, "false")
@@ -2433,20 +2433,20 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	const waitMarkerID = "docmarker"
 
 	btc.RunWithRevocationTester(func(t *testing.T, revocationTester ChannelRevocationTester) {
-		revocationTester.fillerDocRev = ""
+		revocationTester.fillerDocVersion.RevID = ""
 		// Add channel to role and role to user
 		revocationTester.addRoleChannel("foo", "A")
 		revocationTester.addRole("user", "foo")
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
-		version := rt.PutDoc(docID, `{"channels": "A"}}`)
+		version := btc.rt.PutDoc(docID, `{"channels": "A"}}`)
 
 		require.NoError(t, btc.rt.WaitForPendingChanges())
 		firstOneShotSinceSeq := btc.rt.GetDocumentSequence("doc")
 
 		// OneShot pull to grab doc
-		err = btc.StartOneshotPull()
+		err := btc.StartOneshotPull()
 		assert.NoError(t, err)
 		throw = true
 		_, ok := btc.WaitForVersion(docID, version)
@@ -2455,10 +2455,10 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
 
-		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
+		_ = btc.rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
-		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
-		require.NoError(t, rt.WaitForPendingChanges())
+		waitMarkerVersion := btc.rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
 		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
 		err = btc.StartPullSince("false", lastSeqStr, "false")

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2223,7 +2223,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 func TestRevocationMessage(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
@@ -2331,7 +2331,7 @@ func TestRevocationMessage(t *testing.T) {
 func TestRevocationNoRev(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
@@ -2422,7 +2422,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		},
 	}
 
-	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	btc := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
@@ -2471,7 +2471,8 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 // Regression test for CBG-2183.
 func TestBlipRevokeNonExistentRole(t *testing.T) {
-	bt := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	bt := NewBlipTesterClientOpts(&BlipTesterClientOpts{
 		Username:        "bilbo",
 		SendRevocations: true,
 	})
@@ -2480,10 +2481,7 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 		GuestEnabled: false,
 	}
 	bt.Run(func(t *testing.T) {
-
 		collection := bt.rt.GetSingleTestDatabaseCollection()
-
-		base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 		// 1. Create user with admin_roles including two roles not previously defined (a1 and a2, for example)
 		res := bt.rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/bilbo", bt.rt.GetDatabase().Name), GetUserPayload(t, "bilbo", "test", "", collection, []string{"c1"}, []string{"a1", "a2"}))

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2223,190 +2223,185 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 func TestRevocationMessage(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	revocationTester, rt := InitScenario(t, nil)
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
 		SendRevocations: true,
 	})
-	assert.NoError(t, err)
 	defer btc.Close()
-
-	// Add channel to role and role to user
-	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("user", "foo")
-
-	// Skip to seq 4 and then create doc in channel A
-	revocationTester.fillToSeq(4)
-	version := rt.PutDoc("doc", `{"channels": "A"}`)
-
-	require.NoError(t, rt.WaitForPendingChanges())
-
-	// Start pull
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-
-	// Wait for doc revision to come over
-	_, ok := btc.WaitForBlipRevMessage("doc", version)
-	require.True(t, ok)
-
-	// Remove role from user
-	revocationTester.removeRole("user", "foo")
-
 	const doc1ID = "doc1"
-	version = rt.PutDoc(doc1ID, `{"channels": "!"}`)
 
-	revocationTester.fillToSeq(10)
-	version = rt.UpdateDoc(doc1ID, version, "{}")
+	btc.RunWithRevocationTester(func(t *testing.T, revocationTester ChannelRevocationTester) {
+		// Add channel to role and role to user
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
 
-	require.NoError(t, rt.WaitForPendingChanges())
+		// Skip to seq 4 and then create doc in channel A
+		revocationTester.fillToSeq(4)
+		version := rt.PutDoc("doc", `{"channels": "A"}`)
 
-	// Start a pull since 5 to receive revocation and removal
-	err = btc.StartPullSince("false", "5", "false")
-	assert.NoError(t, err)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
-	// Wait for doc1 rev2 - This is the last rev we expect so we can be sure replication is complete here
-	_, found := btc.WaitForVersion(doc1ID, version)
-	require.True(t, found)
+		// Start pull
+		err := btc.StartOneshotPull()
+		assert.NoError(t, err)
 
-	messages := btc.pullReplication.GetMessages()
+		// Wait for doc revision to come over
+		_, ok := btc.WaitForBlipRevMessage("doc", version)
+		require.True(t, ok)
 
-	testCases := []struct {
-		Name            string
-		DocID           string
-		ExpectedDeleted int64
-	}{
-		{
-			Name:            "Revocation",
-			DocID:           "doc",
-			ExpectedDeleted: int64(2),
-		},
-		{
-			Name:            "Removed",
-			DocID:           "doc1",
-			ExpectedDeleted: int64(4),
-		},
-	}
+		// Remove role from user
+		revocationTester.removeRole("user", "foo")
 
-	for _, testCase := range testCases {
-		t.Run(testCase.Name, func(t *testing.T) {
-			// Verify the deleted property in the changes message is "2" this indicated a revocation
-			for _, msg := range messages {
-				if msg.Properties[db.BlipProfile] == db.MessageChanges {
-					var changesMessages [][]interface{}
-					err = msg.ReadJSONBody(&changesMessages)
-					if err != nil {
-						continue
-					}
+		version = rt.PutDoc(doc1ID, `{"channels": "!"}`)
 
-					if len(changesMessages) != 2 || len(changesMessages[0]) != 4 {
-						continue
-					}
+		revocationTester.fillToSeq(10)
+		version = rt.UpdateDoc(doc1ID, version, "{}")
 
-					criteriaMet := false
-					for _, changesMessage := range changesMessages {
-						castedNum, ok := changesMessage[3].(json.Number)
-						if !ok {
-							continue
-						}
-						intDeleted, err := castedNum.Int64()
+		require.NoError(t, btc.rt.WaitForPendingChanges())
+
+		// Start a pull since 5 to receive revocation and removal
+		err = btc.StartPullSince("false", "5", "false")
+		assert.NoError(t, err)
+
+		// Wait for doc1 rev2 - This is the last rev we expect so we can be sure replication is complete here
+		_, found := btc.WaitForVersion(doc1ID, version)
+		require.True(t, found)
+
+		messages := btc.pullReplication.GetMessages()
+
+		testCases := []struct {
+			Name            string
+			DocID           string
+			ExpectedDeleted int64
+		}{
+			{
+				Name:            "Revocation",
+				DocID:           "doc",
+				ExpectedDeleted: int64(2),
+			},
+			{
+				Name:            "Removed",
+				DocID:           "doc1",
+				ExpectedDeleted: int64(4),
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.Name, func(t *testing.T) {
+				// Verify the deleted property in the changes message is "2" this indicated a revocation
+				for _, msg := range messages {
+					if msg.Properties[db.BlipProfile] == db.MessageChanges {
+						var changesMessages [][]interface{}
+						err = msg.ReadJSONBody(&changesMessages)
 						if err != nil {
 							continue
 						}
-						if docName, ok := changesMessage[1].(string); ok && docName == testCase.DocID && intDeleted == testCase.ExpectedDeleted {
-							criteriaMet = true
-							break
+
+						if len(changesMessages) != 2 || len(changesMessages[0]) != 4 {
+							continue
 						}
+
+						criteriaMet := false
+						for _, changesMessage := range changesMessages {
+							castedNum, ok := changesMessage[3].(json.Number)
+							if !ok {
+								continue
+							}
+							intDeleted, err := castedNum.Int64()
+							if err != nil {
+								continue
+							}
+							if docName, ok := changesMessage[1].(string); ok && docName == testCase.DocID && intDeleted == testCase.ExpectedDeleted {
+								criteriaMet = true
+								break
+							}
+						}
+
+						assert.True(t, criteriaMet)
 					}
-
-					assert.True(t, criteriaMet)
 				}
-			}
-		})
-	}
-
-	assert.NoError(t, err)
+			})
+		}
+		assert.NoError(t, err)
+	}, t, nil)
 }
 
 func TestRevocationNoRev(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 
-	revocationTester, rt := InitScenario(t, nil)
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
 		SendRevocations: true,
 	})
-	assert.NoError(t, err)
 	defer btc.Close()
-
-	// Add channel to role and role to user
-	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("user", "foo")
-
-	// Skip to seq 4 and then create doc in channel A
-	revocationTester.fillToSeq(4)
 	const docID = "doc"
-	version := rt.PutDoc(docID, `{"channels": "A"}`)
-
-	require.NoError(t, rt.WaitForPendingChanges())
-	firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
-
-	// OneShot pull to grab doc
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-
-	_, ok := btc.WaitForVersion(docID, version)
-	require.True(t, ok)
-
-	// Remove role from user
-	revocationTester.removeRole("user", "foo")
-
-	_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
-
 	const waitMarkerID = "docmarker"
-	waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
-	require.NoError(t, rt.WaitForPendingChanges())
 
-	lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
-	err = btc.StartPullSince("false", lastSeqStr, "false")
-	assert.NoError(t, err)
+	btc.RunWithRevocationTester(func(t *testing.T, revocationTester ChannelRevocationTester) {
+		// Add channel to role and role to user
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
 
-	_, ok = btc.WaitForVersion(waitMarkerID, waitMarkerVersion)
-	require.True(t, ok)
+		// Skip to seq 4 and then create doc in channel A
+		revocationTester.fillToSeq(4)
+		version := rt.PutDoc(docID, `{"channels": "A"}`)
 
-	messages := btc.pullReplication.GetMessages()
+		require.NoError(t, btc.rt.WaitForPendingChanges())
+		firstOneShotSinceSeq := btc.rt.GetDocumentSequence("doc")
 
-	var highestMsgSeq uint32
-	var highestSeqMsg blip.Message
-	// Grab most recent changes message
-	for _, message := range messages {
-		messageBody, err := message.Body()
-		require.NoError(t, err)
-		if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
-			if highestMsgSeq < uint32(message.SerialNumber()) {
-				highestMsgSeq = uint32(message.SerialNumber())
-				highestSeqMsg = message
+		// OneShot pull to grab doc
+		err := btc.StartOneshotPull()
+		assert.NoError(t, err)
+
+		_, ok := btc.WaitForVersion(docID, version)
+		require.True(t, ok)
+
+		// Remove role from user
+		revocationTester.removeRole("user", "foo")
+
+		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
+
+		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
+		require.NoError(t, rt.WaitForPendingChanges())
+
+		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
+		err = btc.StartPullSince("false", lastSeqStr, "false")
+		assert.NoError(t, err)
+
+		_, ok = btc.WaitForVersion(waitMarkerID, waitMarkerVersion)
+		require.True(t, ok)
+
+		messages := btc.pullReplication.GetMessages()
+
+		var highestMsgSeq uint32
+		var highestSeqMsg blip.Message
+		// Grab most recent changes message
+		for _, message := range messages {
+			messageBody, err := message.Body()
+			require.NoError(t, err)
+			if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
+				if highestMsgSeq < uint32(message.SerialNumber()) {
+					highestMsgSeq = uint32(message.SerialNumber())
+					highestSeqMsg = message
+				}
 			}
 		}
-	}
 
-	var messageBody []interface{}
-	err = highestSeqMsg.ReadJSONBody(&messageBody)
-	require.NoError(t, err)
-	require.Len(t, messageBody, 2)
-	require.Len(t, messageBody[0], 4)
+		var messageBody []interface{}
+		err = highestSeqMsg.ReadJSONBody(&messageBody)
+		require.NoError(t, err)
+		require.Len(t, messageBody, 2)
+		require.Len(t, messageBody[0], 4)
 
-	deletedFlag, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
-	require.NoError(t, err)
+		deletedFlag, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
+		require.NoError(t, err)
 
-	assert.Equal(t, deletedFlag, int64(2))
+		assert.Equal(t, deletedFlag, int64(2))
+	}, t, nil)
 }
 
 func TestRevocationGetSyncDataError(t *testing.T) {
@@ -2414,106 +2409,103 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	var throw bool
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	// Two callbacks to cover usage with CBS/Xattrs and without
-	revocationTester, rt := InitScenario(
-		t, &RestTesterConfig{
-			leakyBucketConfig: &base.LeakyBucketConfig{
-				GetWithXattrCallback: func(key string) error {
-					return fmt.Errorf("Leaky Bucket GetWithXattrCallback Error")
-				}, GetRawCallback: func(key string) error {
-					if throw {
-						return fmt.Errorf("Leaky Bucket GetRawCallback Error")
-					}
-					return nil
-				},
+	rtConfig := &RestTesterConfig{
+		leakyBucketConfig: &base.LeakyBucketConfig{
+			GetWithXattrCallback: func(key string) error {
+				return fmt.Errorf("Leaky Bucket GetWithXattrCallback Error")
+			}, GetRawCallback: func(key string) error {
+				if throw {
+					return fmt.Errorf("Leaky Bucket GetRawCallback Error")
+				}
+				return nil
 			},
 		},
-	)
+	}
 
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	btc := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:        "user",
 		Channels:        []string{"*"},
 		ClientDeltas:    false,
 		SendRevocations: true,
 	})
-	assert.NoError(t, err)
 	defer btc.Close()
-
-	// Add channel to role and role to user
-	revocationTester.addRoleChannel("foo", "A")
-	revocationTester.addRole("user", "foo")
-
-	// Skip to seq 4 and then create doc in channel A
-	revocationTester.fillToSeq(4)
 	const docID = "doc"
-	version := rt.PutDoc(docID, `{"channels": "A"}}`)
-
-	require.NoError(t, rt.WaitForPendingChanges())
-	firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
-
-	// OneShot pull to grab doc
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	throw = true
-	_, ok := btc.WaitForVersion(docID, version)
-	require.True(t, ok)
-
-	// Remove role from user
-	revocationTester.removeRole("user", "foo")
-
-	_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
-
 	const waitMarkerID = "docmarker"
-	waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
-	require.NoError(t, rt.WaitForPendingChanges())
 
-	lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
-	err = btc.StartPullSince("false", lastSeqStr, "false")
-	assert.NoError(t, err)
+	btc.RunWithRevocationTester(func(t *testing.T, revocationTester ChannelRevocationTester) {
+		revocationTester.fillerDocRev = ""
+		// Add channel to role and role to user
+		revocationTester.addRoleChannel("foo", "A")
+		revocationTester.addRole("user", "foo")
 
-	_, ok = btc.WaitForVersion(waitMarkerID, waitMarkerVersion)
-	require.True(t, ok)
+		// Skip to seq 4 and then create doc in channel A
+		revocationTester.fillToSeq(4)
+		version := rt.PutDoc(docID, `{"channels": "A"}}`)
+
+		require.NoError(t, btc.rt.WaitForPendingChanges())
+		firstOneShotSinceSeq := btc.rt.GetDocumentSequence("doc")
+
+		// OneShot pull to grab doc
+		err = btc.StartOneshotPull()
+		assert.NoError(t, err)
+		throw = true
+		_, ok := btc.WaitForVersion(docID, version)
+		require.True(t, ok)
+
+		// Remove role from user
+		revocationTester.removeRole("user", "foo")
+
+		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
+
+		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
+		require.NoError(t, rt.WaitForPendingChanges())
+
+		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
+		err = btc.StartPullSince("false", lastSeqStr, "false")
+		assert.NoError(t, err)
+
+		_, ok = btc.WaitForVersion(waitMarkerID, waitMarkerVersion)
+		require.True(t, ok)
+	}, t, rtConfig)
 }
 
 // Regression test for CBG-2183.
 func TestBlipRevokeNonExistentRole(t *testing.T) {
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			GuestEnabled: false,
-		})
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
-	// 1. Create user with admin_roles including two roles not previously defined (a1 and a2, for example)
-	res := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/bilbo", rt.GetDatabase().Name), GetUserPayload(t, "bilbo", "test", "", collection, []string{"c1"}, []string{"a1", "a2"}))
-	RequireStatus(t, res, http.StatusCreated)
-
-	// Create a doc so we have something to replicate
-	res = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/testdoc", `{"channels": ["c1"]}`)
-	RequireStatus(t, res, http.StatusCreated)
-
-	// 3. Update the user to not reference one of the roles (update to ['a1'], for example)
-	// [also revoke channel c1 so the doc shows up in the revocation queries]
-	res = rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/bilbo", rt.GetDatabase().Name), GetUserPayload(t, "bilbo", "test", "", collection, []string{}, []string{"a1"}))
-	RequireStatus(t, res, http.StatusOK)
-
-	// 4. Try to sync
-	bt, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
+	bt := NewBlipTesterClientOptsWithRT(&BlipTesterClientOpts{
 		Username:        "bilbo",
 		SendRevocations: true,
 	})
-	require.NoError(t, err)
 	defer bt.Close()
+	rtConfig := &RestTesterConfig{
+		GuestEnabled: false,
+	}
+	bt.Run(func(t *testing.T) {
 
-	require.NoError(t, bt.StartPull())
+		collection := bt.rt.GetSingleTestDatabaseCollection()
 
-	// in the failing case we'll panic before hitting this
-	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
-	}, 1)
+		base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+
+		// 1. Create user with admin_roles including two roles not previously defined (a1 and a2, for example)
+		res := bt.rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/bilbo", bt.rt.GetDatabase().Name), GetUserPayload(t, "bilbo", "test", "", collection, []string{"c1"}, []string{"a1", "a2"}))
+		RequireStatus(t, res, http.StatusOK)
+
+		// Create a doc so we have something to replicate
+		res = bt.rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/testdoc", `{"channels": ["c1"]}`)
+		RequireStatus(t, res, http.StatusCreated)
+
+		// 3. Update the user to not reference one of the roles (update to ['a1'], for example)
+		// [also revoke channel c1 so the doc shows up in the revocation queries]
+		res = bt.rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/%s/_user/bilbo", bt.rt.GetDatabase().Name), GetUserPayload(t, "bilbo", "test", "", collection, []string{}, []string{"a1"}))
+		RequireStatus(t, res, http.StatusOK)
+
+		// 4. Try to sync
+		require.NoError(t, bt.StartPull())
+
+		// in the failing case we'll panic before hitting this
+		base.RequireWaitForStat(t, func() int64 {
+			return bt.rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
+		}, 1)
+	}, t, rtConfig)
 }
 
 func TestReplicatorSwitchPurgeNoReset(t *testing.T) {

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1479,7 +1479,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	_, err := dataStore.GetXattr(rt.Context(), docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
-	docRev, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
+	docRev, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(docRev.Channels.ToArray()))
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
@@ -1499,7 +1499,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	_, err = dataStore.GetXattr(rt.Context(), docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
-	docRev2, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
+	docRev2, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.CurrentRev, docRev2.RevID)
 


### PR DESCRIPTION
CBG-3576

- Added a new struct called BlipTestClientRunner that will be used to run the blip client subtests
- A Method Run() on this type that will run each tests code twice, one for rev tree handling, then (when support is added) for version vector protocol. It does this by passing down the subprotocol version into the test code to be passed into the BlipTesterClient creation. Some tests specifically test certain subprotocol versions, so in these cases the passed down subprotocol version from the Run() function is ignored. 
- Moved the method NewBlipTesterClientWithRT method to run on the BlipTestClientRunner type. So the user cannot call this function without first initialising a BlipTestClientRunner type.
- On BlipTestClientRunner there is a flag to indicate that the Run() method is being used, this allows us to force people to only use this method to create a BlipTesterClient from inside the run code. If a user tries to create a BlipTesterClient outside the Run() method the test will fail immediately.
- Altered method that originally acted upon the BlipTesterClient directly (such as PushRev) to act upon the BlipTestClientRunner type. This along side the the fact you cannot call NewBlipTesterClientWithRT from outside the Run() method, add a lot of protection to force anyone writing BlipTestClient tests to use the Run() method. 
- On the above point, we have tests that use multiple BlipTestClients, so in order to move the functions such as PushRev to act upon BlipTestClientRunner I needed a way to add all these clients to the new type. Thus on BlipTestClientRunner I have a map of clients that are keyed by a unique id, that is assigned to the BlipTesterClient during creation inside NewBlipTesterClientWithRT, this client id is then passed into functions that act upon the BlipTesterClient. Again methods such as PushRev. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2166/
