### PR TITLE
CBG-3271 remove persistent rosmar buckets

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -58,9 +58,9 @@ func (b *LeakyBucket) SetIgnoreClose(value bool) {
 	b.config.IgnoreClose = value
 }
 
-func (b *LeakyBucket) CloseAndDelete() error {
+func (b *LeakyBucket) CloseAndDelete(ctx context.Context) error {
 	if bucket, ok := b.bucket.(sgbucket.DeleteableStore); ok {
-		return bucket.CloseAndDelete()
+		return bucket.CloseAndDelete(ctx)
 	}
 	return nil
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -108,12 +108,6 @@ func GetTestBucket(t testing.TB) *TestBucket {
 	return getTestBucket(t, false)
 }
 
-// GetTestBucket returns a test bucket from a pool.  If running with walrus buckets, will persist bucket data
-// across bucket close.
-func GetPersistentTestBucket(t testing.TB) *TestBucket {
-	return getTestBucket(t, true)
-}
-
 // getTestBucket returns a bucket from the bucket pool.  Persistent flag determines behaviour for walrus
 // buckets only - Couchbase bucket behaviour is defined by the bucket pool readier/init.
 func getTestBucket(t testing.TB, persistent bool) *TestBucket {
@@ -208,29 +202,6 @@ func rosmarUriFromPath(path string) string {
 		}
 	}
 	return uri + strings.ReplaceAll(path, `\`, `/`)
-}
-
-// Gets a Walrus bucket which will be persisted to a temporary directory
-// Returns both the test bucket which is persisted and a function which can be used to remove the created temporary
-// directory once the test has finished with it.
-func GetPersistentWalrusBucket(t testing.TB) (*TestBucket, func()) {
-	tempDir, err := os.MkdirTemp("", "walrustemp")
-	require.NoError(t, err)
-
-	bucket, spec, closeFn := GTestBucketPool.GetWalrusTestBucket(t, rosmarUriFromPath(tempDir))
-
-	// Return this separate to closeFn as we want to avoid this being removed on database close (/_offline handling)
-	removeFileFunc := func() {
-		err := os.RemoveAll(tempDir)
-		require.NoError(t, err)
-	}
-
-	return &TestBucket{
-		Bucket:     bucket,
-		BucketSpec: spec,
-		closeFn:    closeFn,
-		t:          t,
-	}, removeFileFunc
 }
 
 // Should Sync Gateway use XATTRS functionality when running unit tests?

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.2.8
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e
+	github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20231108144220-c0c6c76bb267
+	github.com/couchbaselabs/rosmar v0.0.0-20231116232326-adb4806d011e
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.3
 	github.com/google/uuid v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.2.8
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148
+	github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20231003104919-6d4a3e8a6db6
+	github.com/couchbaselabs/rosmar v0.0.0-20231108144220-c0c6c76bb267
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.3
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9B
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
 github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e h1:IFv4HcdpvKFEaaszv6f1WcEbWmU276rFzOaJgarw5gw=
 github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
+github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483 h1:K6y82On0A3coA+GwW+HGKIwpCpca6ZSvTAJwwTmzCrg=
+github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=
@@ -62,6 +64,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/rosmar v0.0.0-20231108144220-c0c6c76bb267 h1:dIYPzphKBskYB0viAtWHX/nHOimFuxyVwK9cFA103eA=
 github.com/couchbaselabs/rosmar v0.0.0-20231108144220-c0c6c76bb267/go.mod h1:AY2mDCIVElNv3rdOAyFeb7g8phFbv821FuMxX4S6MzI=
+github.com/couchbaselabs/rosmar v0.0.0-20231116232326-adb4806d011e h1:6DyLYnzHE4dMfuyz0UEWiBOB/PfUXrxRUy1A4478k6A=
+github.com/couchbaselabs/rosmar v0.0.0-20231116232326-adb4806d011e/go.mod h1:+AjMZkAOGCeQRLjIBwehXKyWsNCPFrMKYz6lIaZ1idc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,11 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0 h1:u/LLAOFgsMv7HmNL4Qufg58y+qElGOt5qv0z1mURkRY=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0/go.mod h1:2e8rMJtl2+2j+HXbTBwnyGpm5Nou7KhvSfxOq8JpTag=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/aws/aws-sdk-go v1.44.299 h1:HVD9lU4CAFHGxleMJp95FV/sRhtg7P4miHD1v88JAQk=
@@ -38,8 +41,8 @@ github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUl
 github.com/couchbase/gomemcached v0.2.1/go.mod h1:mxliKQxOv84gQ0bJWbI+w9Wxdpt9HjDvgW9MjCym5Vo=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148 h1:9E3u0yA+be219iLLOjuYgagOfM7UqtZ0YIhMXysJVKs=
-github.com/couchbase/sg-bucket v0.0.0-20231003103030-627c70e18148/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
+github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e h1:IFv4HcdpvKFEaaszv6f1WcEbWmU276rFzOaJgarw5gw=
+github.com/couchbase/sg-bucket v0.0.0-20231108134134-545ec7bf1a9e/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=
@@ -57,8 +60,8 @@ github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259 h1:2T
 github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
 github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDoZihsiwNigA=
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
-github.com/couchbaselabs/rosmar v0.0.0-20231003104919-6d4a3e8a6db6 h1:TeqaJ0zV0omrnvQfw4DF6o+UQQbFdBNPJVod1Y7ovQo=
-github.com/couchbaselabs/rosmar v0.0.0-20231003104919-6d4a3e8a6db6/go.mod h1:+HMmQTjaINo51eSZFeCKreXYSIu6jbIp+EV9keoKl3E=
+github.com/couchbaselabs/rosmar v0.0.0-20231108144220-c0c6c76bb267 h1:dIYPzphKBskYB0viAtWHX/nHOimFuxyVwK9cFA103eA=
+github.com/couchbaselabs/rosmar v0.0.0-20231108144220-c0c6c76bb267/go.mod h1:AY2mDCIVElNv3rdOAyFeb7g8phFbv821FuMxX4S6MzI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -97,6 +100,7 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd h1:1FjCyPC+syAzJ5/2S8fqdZK1R22vvA0J7JZKcuOIQ7Y=
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
@@ -125,6 +129,7 @@ github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B
 github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -254,6 +259,7 @@ google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbRxng+XOj5ITVgY24WcbNnQopyfKoYQ=
@@ -265,6 +271,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1472,6 +1472,7 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyConfig)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// configure the interval time to pick up new configs from the bucket to every 1 seconds
@@ -1556,6 +1557,7 @@ func TestBadConfigInsertionToBucket(t *testing.T) {
 	base.TestsRequireBootstrapConnection(t)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// configure the interval time to pick up new configs from the bucket to every 1 seconds
@@ -1605,8 +1607,12 @@ func TestBadConfigInsertionToBucket(t *testing.T) {
 func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
 	base.TestsRequireBootstrapConnection(t)
 	base.RequireNumTestBuckets(t, 2)
+	ctx := base.TestCtx(t)
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close(ctx)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// configure the interval time to pick up new configs from the bucket to every 1 seconds
@@ -1622,9 +1628,6 @@ func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
 
 	// wait for db to come online
 	require.NoError(t, rt.WaitForDBOnline())
-	ctx := base.TestCtx(t)
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close(ctx)
 	badName := tb1.GetName()
 	dbConfig.Bucket = &badName
 

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1472,7 +1472,6 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyConfig)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetPersistentTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// configure the interval time to pick up new configs from the bucket to every 1 seconds
@@ -1557,7 +1556,6 @@ func TestBadConfigInsertionToBucket(t *testing.T) {
 	base.TestsRequireBootstrapConnection(t)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetPersistentTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// configure the interval time to pick up new configs from the bucket to every 1 seconds
@@ -1607,12 +1605,8 @@ func TestBadConfigInsertionToBucket(t *testing.T) {
 func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
 	base.TestsRequireBootstrapConnection(t)
 	base.RequireNumTestBuckets(t, 2)
-	ctx := base.TestCtx(t)
-	tb1 := base.GetPersistentTestBucket(t)
-	defer tb1.Close(ctx)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: base.GetPersistentTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// configure the interval time to pick up new configs from the bucket to every 1 seconds
@@ -1628,6 +1622,9 @@ func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
 
 	// wait for db to come online
 	require.NoError(t, rt.WaitForDBOnline())
+	ctx := base.TestCtx(t)
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close(ctx)
 	badName := tb1.GetName()
 	dbConfig.Bucket = &badName
 
@@ -1643,11 +1640,11 @@ func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
 	base.TestsRequireBootstrapConnection(t)
 	base.RequireNumTestBuckets(t, 3)
 	ctx := base.TestCtx(t)
-	tb1 := base.GetPersistentTestBucket(t)
+	tb1 := base.GetTestBucket(t)
 	defer tb1.Close(ctx)
-	tb2 := base.GetPersistentTestBucket(t)
+	tb2 := base.GetTestBucket(t)
 	defer tb2.Close(ctx)
-	tb3 := base.GetPersistentTestBucket(t)
+	tb3 := base.GetTestBucket(t)
 	defer tb3.Close(ctx)
 
 	const groupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
@@ -1722,9 +1719,9 @@ func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 3)
 	ctx := base.TestCtx(t)
-	tb1 := base.GetPersistentTestBucket(t)
+	tb1 := base.GetTestBucket(t)
 	defer tb1.Close(ctx)
-	tb2 := base.GetPersistentTestBucket(t)
+	tb2 := base.GetTestBucket(t)
 	defer tb2.Close(ctx)
 
 	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
@@ -1792,9 +1789,9 @@ func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
 	base.TestsRequireBootstrapConnection(t)
 
 	ctx := base.TestCtx(t)
-	tb1 := base.GetPersistentTestBucket(t)
+	tb1 := base.GetTestBucket(t)
 	defer tb1.Close(ctx)
-	tb2 := base.GetPersistentTestBucket(t)
+	tb2 := base.GetTestBucket(t)
 	defer tb2.Close(ctx)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -179,7 +179,6 @@ func TestRequireResync(t *testing.T) {
 	base.RequireNumTestDataStores(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &rest.RestTesterConfig{
-		CustomTestBucket: base.GetPersistentTestBucket(t),
 		PersistentConfig: true,
 	}
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -258,7 +258,7 @@ func (h *handler) handleFlush() error {
 		name := h.db.Name
 		config := h.server.GetDatabaseConfig(name)
 		h.server.RemoveDatabase(h.ctx(), name)
-		err := bucket.CloseAndDelete()
+		err := bucket.CloseAndDelete(h.ctx())
 		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), config.DatabaseConfig)
 		if err == nil {
 			err = err2

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -28,7 +28,7 @@ func TestMultiCollectionImportFilter(t *testing.T) {
 	base.RequireNumTestDataStores(t, 3)
 
 	ctx := base.TestCtx(t)
-	testBucket := base.GetPersistentTestBucket(t)
+	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
 	scopesConfig := rest.GetCollectionsConfig(t, testBucket, 2)
@@ -250,7 +250,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	base.RequireNumTestDataStores(t, 2)
 
 	ctx := base.TestCtx(t)
-	testBucket := base.GetPersistentTestBucket(t)
+	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
 	rtConfig := &rest.RestTesterConfig{
@@ -346,7 +346,7 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 	base.RequireNumTestDataStores(t, numCollections)
 
 	ctx := base.TestCtx(t)
-	testBucket := base.GetPersistentTestBucket(t)
+	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
 	rtConfig := &rest.RestTesterConfig{

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2039,7 +2039,7 @@ func assertDocProperty(t *testing.T, getDocResponse *rest.TestResponse, property
 	err := base.JSONUnmarshal(getDocResponse.Body.Bytes(), &responseBody)
 	assert.NoError(t, err, "Error unmarshalling document response")
 	value, ok := responseBody[propertyName]
-	require.True(t, ok, fmt.Sprintf("Expected property %s not found in response %s", propertyName, getDocResponse.Body.Bytes()))
+	assert.True(t, ok, fmt.Sprintf("Expected property %s not found in response %s", propertyName, getDocResponse.Body.Bytes()))
 	assert.Equal(t, expectedPropertyValue, value)
 }
 
@@ -2734,7 +2734,12 @@ func TestImportRollback(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyDCP)
 
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
 		PersistentConfig: false,
 	})
 
@@ -2763,9 +2768,9 @@ func TestImportRollback(t *testing.T) {
 	}()
 
 	// fetch the checkpoint for the document's vbucket, modify the checkpoint values to a higher sequence
-	vbNo, err := base.GetVbucketForKey(rt.TestBucket, key)
+	vbNo, err := base.GetVbucketForKey(bucket, key)
 	require.NoError(t, err)
-	metaStore := rt.TestBucket.GetMetadataStore()
+	metaStore := bucket.GetMetadataStore()
 	checkpointKey := fmt.Sprintf("%s%d", checkpointPrefix, vbNo)
 	var checkpointData dcpMetaData
 	checkpointBytes, _, err := metaStore.GetRaw(checkpointKey)
@@ -2784,6 +2789,7 @@ func TestImportRollback(t *testing.T) {
 
 	// Reopen the db, expect DCP rollback
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: bucket.NoCloseClone(),
 		PersistentConfig: false,
 	})
 	defer rt2.Close()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -840,11 +840,7 @@ func TestOfflineDatabaseStartup(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	ctx := base.TestCtx(t)
-	bucket := base.GetPersistentTestBucket(t)
-	defer bucket.Close(ctx)
 	rt := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: bucket.NoCloseClone(),
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				StartOffline: base.BoolPtr(true),

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -898,20 +898,9 @@ func TestResyncRegenerateSequences(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	var testBucket *base.TestBucket
-
-	if base.UnitTestUrlIsWalrus() {
-		var closeFn func()
-		testBucket, closeFn = base.GetPersistentWalrusBucket(t)
-		defer closeFn()
-	} else {
-		testBucket = base.GetTestBucket(t)
-	}
-
 	rt := NewRestTester(t,
 		&RestTesterConfig{
-			SyncFn:           syncFn,
-			CustomTestBucket: testBucket,
+			SyncFn: syncFn,
 		},
 	)
 	defer rt.Close()

--- a/rest/upgradetest/remove_collection_test.go
+++ b/rest/upgradetest/remove_collection_test.go
@@ -27,11 +27,8 @@ func TestRemoveCollection(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.RequireNumTestBuckets(t, 2)
 	numCollections := 2
-	bucket := base.GetPersistentTestBucket(t)
-	defer bucket.Close(base.TestCtx(t))
 	base.RequireNumTestDataStores(t, numCollections)
 	rtConfig := &rest.RestTesterConfig{
-		CustomTestBucket:             bucket.NoCloseClone(),
 		PersistentConfig:             true,
 		GroupID:                      base.StringPtr(t.Name()),
 		AdminInterfaceAuthentication: true,
@@ -52,7 +49,7 @@ func TestRemoveCollection(t *testing.T) {
 	deletedDataStore := dataStores[1]
 
 	defer func() {
-		assert.NoError(t, bucket.CreateDataStore(base.TestCtx(t), deletedDataStore))
+		assert.NoError(t, rt.TestBucket.CreateDataStore(base.TestCtx(t), deletedDataStore))
 
 	}()
 	// drop a data store
@@ -61,7 +58,7 @@ func TestRemoveCollection(t *testing.T) {
 
 	rt.Close()
 	rtConfig = &rest.RestTesterConfig{
-		CustomTestBucket:             bucket.NoCloseClone(),
+		CustomTestBucket:             rt.TestBucket,
 		PersistentConfig:             true,
 		GroupID:                      base.StringPtr(t.Name()),
 		AdminInterfaceAuthentication: true,

--- a/rest/upgradetest/remove_collection_test.go
+++ b/rest/upgradetest/remove_collection_test.go
@@ -27,8 +27,11 @@ func TestRemoveCollection(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.RequireNumTestBuckets(t, 2)
 	numCollections := 2
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(base.TestCtx(t))
 	base.RequireNumTestDataStores(t, numCollections)
 	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket:             bucket.NoCloseClone(),
 		PersistentConfig:             true,
 		GroupID:                      base.StringPtr(t.Name()),
 		AdminInterfaceAuthentication: true,
@@ -49,7 +52,7 @@ func TestRemoveCollection(t *testing.T) {
 	deletedDataStore := dataStores[1]
 
 	defer func() {
-		assert.NoError(t, rt.TestBucket.CreateDataStore(base.TestCtx(t), deletedDataStore))
+		assert.NoError(t, bucket.CreateDataStore(base.TestCtx(t), deletedDataStore))
 
 	}()
 	// drop a data store
@@ -58,7 +61,7 @@ func TestRemoveCollection(t *testing.T) {
 
 	rt.Close()
 	rtConfig = &rest.RestTesterConfig{
-		CustomTestBucket:             rt.TestBucket,
+		CustomTestBucket:             bucket.NoCloseClone(),
 		PersistentConfig:             true,
 		GroupID:                      base.StringPtr(t.Name()),
 		AdminInterfaceAuthentication: true,

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -189,9 +189,11 @@ func getDbConfigFromLegacyConfig(rt *rest.RestTester) string {
 }
 func TestLegacyMetadataID(t *testing.T) {
 
+	tb1 := base.GetTestBucket(t)
 	// Create a non-persistent rest tester.  Standard RestTester
 	// creates a database 'db' targeting the default collection (when !TestUseNamedCollections)
 	legacyRT := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb1.NoCloseClone(),
 		PersistentConfig: false,
 	})
 
@@ -203,13 +205,13 @@ func TestLegacyMetadataID(t *testing.T) {
 	legacyRT.Close()
 
 	persistentRT := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
-		CustomTestBucket: legacyRT.TestBucket,
+		CustomTestBucket: tb1,
 		PersistentConfig: true,
 	})
 	defer persistentRT.Close()
 
 	resp = persistentRT.SendAdminRequest("PUT", "/db/", dbConfigString)
-	rest.RequireStatus(t, resp, http.StatusCreated)
+	assert.Equal(t, http.StatusCreated, resp.Code)
 
 	// check if database is online
 	dbRoot := persistentRT.GetDatabaseRoot("db")
@@ -252,9 +254,11 @@ func TestMetadataIDRenameDatabase(t *testing.T) {
 // Verifies that matching metadataIDs are computed if two config groups for the same database are upgraded
 func TestMetadataIDWithConfigGroups(t *testing.T) {
 
+	tb1 := base.GetTestBucket(t)
 	// Create a non-persistent rest tester.  Standard RestTester
 	// creates a database 'db' targeting the default collection for legacy config.
 	legacyRT := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb1.NoCloseClone(),
 		PersistentConfig: false,
 	})
 
@@ -266,14 +270,14 @@ func TestMetadataIDWithConfigGroups(t *testing.T) {
 	legacyRT.Close()
 
 	group1RT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: legacyRT.TestBucket,
+		CustomTestBucket: tb1,
 		PersistentConfig: true,
 		GroupID:          base.StringPtr("group1"),
 	})
 	defer group1RT.Close()
 
 	group2RT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: legacyRT.TestBucket,
+		CustomTestBucket: tb1,
 		PersistentConfig: true,
 		GroupID:          base.StringPtr("group2"),
 	})

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -189,11 +189,9 @@ func getDbConfigFromLegacyConfig(rt *rest.RestTester) string {
 }
 func TestLegacyMetadataID(t *testing.T) {
 
-	tb1 := base.GetPersistentTestBucket(t)
 	// Create a non-persistent rest tester.  Standard RestTester
 	// creates a database 'db' targeting the default collection (when !TestUseNamedCollections)
 	legacyRT := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1.NoCloseClone(),
 		PersistentConfig: false,
 	})
 
@@ -205,13 +203,13 @@ func TestLegacyMetadataID(t *testing.T) {
 	legacyRT.Close()
 
 	persistentRT := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
+		CustomTestBucket: legacyRT.TestBucket,
 		PersistentConfig: true,
 	})
 	defer persistentRT.Close()
 
 	resp = persistentRT.SendAdminRequest("PUT", "/db/", dbConfigString)
-	assert.Equal(t, http.StatusCreated, resp.Code)
+	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// check if database is online
 	dbRoot := persistentRT.GetDatabaseRoot("db")
@@ -254,11 +252,9 @@ func TestMetadataIDRenameDatabase(t *testing.T) {
 // Verifies that matching metadataIDs are computed if two config groups for the same database are upgraded
 func TestMetadataIDWithConfigGroups(t *testing.T) {
 
-	tb1 := base.GetPersistentTestBucket(t)
 	// Create a non-persistent rest tester.  Standard RestTester
 	// creates a database 'db' targeting the default collection for legacy config.
 	legacyRT := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1.NoCloseClone(),
 		PersistentConfig: false,
 	})
 
@@ -270,14 +266,14 @@ func TestMetadataIDWithConfigGroups(t *testing.T) {
 	legacyRT.Close()
 
 	group1RT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
+		CustomTestBucket: legacyRT.TestBucket,
 		PersistentConfig: true,
 		GroupID:          base.StringPtr("group1"),
 	})
 	defer group1RT.Close()
 
 	group2RT := rest.NewRestTester(t, &rest.RestTesterConfig{
-		CustomTestBucket: tb1,
+		CustomTestBucket: legacyRT.TestBucket,
 		PersistentConfig: true,
 		GroupID:          base.StringPtr("group2"),
 	})

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1530,7 +1530,7 @@ func TestGetUserCollectionAccess(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
-	testBucket := base.GetPersistentTestBucket(t)
+	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	scopesConfig := GetCollectionsConfig(t, testBucket, 2)
 
@@ -1616,7 +1616,7 @@ func TestGetUserCollectionAccess(t *testing.T) {
 func TestPutUserCollectionAccess(t *testing.T) {
 	base.RequireNumTestDataStores(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	testBucket := base.GetPersistentTestBucket(t)
+	testBucket := base.GetTestBucket(t)
 
 	scopesConfig := GetCollectionsConfig(t, testBucket, 2)
 	rtConfig := &RestTesterConfig{

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -166,11 +166,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	// If we have a TestBucket defined on the RestTesterConfig, use that instead of requesting a new one.
 	testBucket := rt.RestTesterConfig.CustomTestBucket
 	if testBucket == nil {
-		if rt.PersistentConfig {
-			testBucket = base.GetPersistentTestBucket(rt.TB)
-		} else {
-			testBucket = base.GetTestBucket(rt.TB)
-		}
+		testBucket = base.GetTestBucket(rt.TB)
 		if rt.leakyBucketConfig != nil {
 			leakyConfig := *rt.leakyBucketConfig
 			// Ignore closures to avoid double closing panics

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -261,7 +261,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	}
 	base.RequireNumTestBuckets(t, 2)
 	ctx := base.TestCtx(t)
-	bucket2 := base.GetPersistentTestBucket(t)
+	bucket2 := base.GetTestBucket(t)
 	defer bucket2.Close(ctx)
 	dbConfig = DbConfig{
 		Scopes: GetCollectionsConfig(rt.TB, bucket2, numCollections),


### PR DESCRIPTION
- rosmar now supports persisting in memory buckets, so keep the buckets in memory until the buckets are closed. This eliminates NoCloseClone in many cases. Another PR might be able to remove even more of these.
- this is prep for being able to run a bootstrap connection.

https://github.com/couchbase/sg-bucket/pull/110
https://github.com/couchbaselabs/rosmar/pull/16

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2164/
