### PR TITLE
CBG-3503 Update HLV on import

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -879,19 +879,37 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 	case ExistingVersion:
 		// preserve any other logic on the HLV that has been done by the client, only update to cvCAS will be needed
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+		d.HLV.ImportCAS = 0 // remove importCAS for non-imports to save space
 	case Import:
-		// work to be done to decide if the VV needs updating here, pending CBG-3503
+		if d.HLV.CurrentVersionCAS == d.Cas {
+			// if cvCAS = document CAS, the HLV has already been updated for this mutation by another HLV-aware peer.
+			// Set ImportCAS to the previous document CAS, but don't otherwise modify HLV
+			d.HLV.ImportCAS = d.Cas
+		} else {
+			// Otherwise this is an SDK mutation made by the local cluster that should be added to HLV.
+			newVVEntry := SourceAndVersion{}
+			newVVEntry.SourceID = db.dbCtx.BucketUUID
+			newVVEntry.Version = hlvExpandMacroCASValue
+			err := d.SyncData.HLV.AddVersion(newVVEntry)
+			if err != nil {
+				return nil, err
+			}
+			d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+			d.HLV.ImportCAS = d.Cas
+		}
+
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
-		newVVEntry := CurrentVersionVector{}
+		newVVEntry := SourceAndVersion{}
 		newVVEntry.SourceID = db.dbCtx.BucketUUID
-		newVVEntry.VersionCAS = hlvExpandMacroCASValue
+		newVVEntry.Version = hlvExpandMacroCASValue
 		err := d.SyncData.HLV.AddVersion(newVVEntry)
 		if err != nil {
 			return nil, err
 		}
 		// update the cvCAS on the SGWrite event too
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+		d.HLV.ImportCAS = 0 // remove importCAS for non-imports to save space
 	}
 	return d, nil
 }
@@ -2062,7 +2080,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
-			CV:               &CurrentVersionVector{VersionCAS: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+			CV:               &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 		}
 
 		if createNewRevIDSkipped {

--- a/db/document.go
+++ b/db/document.go
@@ -1239,14 +1239,14 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
-func (d *Document) HasCurrentVersion(cv CurrentVersionVector) error {
+func (d *Document) HasCurrentVersion(cv SourceAndVersion) error {
 	if d.HLV == nil {
 		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
 	}
 
 	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
 	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
-	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.VersionCAS {
+	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Version {
 		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
 	}
 	return nil

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -56,7 +56,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 }
 
 // GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
@@ -126,7 +126,7 @@ func (rc *BypassRevisionCache) RemoveWithRev(docID, revID string) {
 	// nop
 }
 
-func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	// nop
 }
 

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -49,7 +49,7 @@ func (sc *ShardedLRURevisionCache) GetWithRev(ctx context.Context, docID, revID 
 	return sc.getShard(docID).GetWithRev(ctx, docID, revID, includeBody, includeDelta)
 }
 
-func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 	return sc.getShard(docID).GetWithCV(ctx, docID, cv, includeBody, includeDelta)
 }
 
@@ -77,7 +77,7 @@ func (sc *ShardedLRURevisionCache) RemoveWithRev(docID, revID string) {
 	sc.getShard(docID).RemoveWithRev(docID, revID)
 }
 
-func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	sc.getShard(docID).RemoveWithCV(docID, cv)
 }
 
@@ -103,7 +103,7 @@ type revCacheValue struct {
 	delta       *RevisionDelta
 	body        Body
 	id          string
-	cv          CurrentVersionVector
+	cv          SourceAndVersion
 	revID       string
 	bodyBytes   []byte
 	lock        sync.RWMutex
@@ -133,7 +133,7 @@ func (rc *LRURevisionCache) GetWithRev(ctx context.Context, docID, revID string,
 	return rc.getFromCacheByRev(ctx, docID, revID, true, includeBody, includeDelta)
 }
 
-func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (DocumentRevision, error) {
 	return rc.getFromCacheByCV(ctx, docID, cv, true, includeBody, includeDelta)
 }
 
@@ -175,7 +175,7 @@ func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID 
 	return docRev, err
 }
 
-func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *CurrentVersionVector, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *SourceAndVersion, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
 	value := rc.getValueByCV(docID, cv, loadCacheOnMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
@@ -292,7 +292,7 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision) {
 func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision) {
 	var value *revCacheValue
 	// similar to PUT operation we should have the CV defined by this point (updateHLV is called before calling this)
-	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.VersionCAS}
+	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.Version}
 	legacyKey := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
 
 	rc.lock.Lock()
@@ -340,12 +340,12 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 }
 
 // getValueByCV gets a value from rev cache by CV, if not found and create is true, will add the value to cache and both lookup maps
-func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector, create bool) (value *revCacheValue) {
+func (rc *LRURevisionCache) getValueByCV(docID string, cv *SourceAndVersion, create bool) (value *revCacheValue) {
 	if docID == "" || cv == nil {
 		return nil
 	}
 
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 	rc.lock.Lock()
 	if elem := rc.hlvCache[key]; elem != nil {
 		rc.lruList.MoveToFront(elem)
@@ -363,9 +363,9 @@ func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector,
 }
 
 // addToRevMapPostLoad will generate and entry in the Rev lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *SourceAndVersion) {
 	legacyKey := IDAndRev{DocID: docID, RevID: revID}
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -393,9 +393,9 @@ func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *Current
 }
 
 // addToHLVMapPostLoad will generate and entry in the CV lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *SourceAndVersion) {
 	legacyKey := IDAndRev{DocID: docID, RevID: revID}
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -425,13 +425,13 @@ func (rc *LRURevisionCache) RemoveWithRev(docID, revID string) {
 }
 
 // RemoveWithCV removes a value from rev cache by CV reference if present
-func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	rc.removeFromCacheByCV(docID, cv)
 }
 
 // removeFromCacheByCV removes an entry from rev cache by CV
-func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *CurrentVersionVector) {
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *SourceAndVersion) {
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	element, ok := rc.hlvCache[key]
@@ -458,7 +458,7 @@ func (rc *LRURevisionCache) removeFromCacheByRev(docID, revID string) {
 	}
 	// grab the cv key key from the value to enable us to remove the reference from the rev lookup map too
 	elem := element.Value.(*revCacheValue)
-	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.Version}
 	rc.lruList.Remove(element)
 	delete(rc.cache, key)
 	// remove from CV lookup map too
@@ -475,7 +475,7 @@ func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 		delete(rc.cache, revKey)
 	}
 	// need to also check hlv lookup cache map
-	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 	if element := rc.hlvCache[hlvKey]; element != nil && element.Value == value {
 		rc.lruList.Remove(element)
 		delete(rc.hlvCache, hlvKey)
@@ -485,7 +485,7 @@ func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 func (rc *LRURevisionCache) purgeOldest_() {
 	value := rc.lruList.Remove(rc.lruList.Back()).(*revCacheValue)
 	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
-	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 	delete(rc.cache, revKey)
 	delete(rc.hlvCache, hlvKey)
 }
@@ -499,7 +499,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	// to reduce locking when includeDelta=false
 	var delta *RevisionDelta
 	var docRevBody Body
-	var fetchedCV *CurrentVersionVector
+	var fetchedCV *SourceAndVersion
 	var revid string
 
 	// Attempt to read cached value.
@@ -537,7 +537,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	} else {
 		cacheHit = false
 		if value.revID == "" {
-			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForCv(ctx, backingStore, hlvKey, includeBody)
 			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
 			value.revID = revid
@@ -594,7 +594,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 		Attachments: value.attachments.ShallowCopy(), // Avoid caller mutating the stored attachments
 		Deleted:     value.deleted,
 		Removed:     value.removed,
-		CV:          &CurrentVersionVector{VersionCAS: value.cv.VersionCAS, SourceID: value.cv.SourceID},
+		CV:          &SourceAndVersion{Version: value.cv.Version, SourceID: value.cv.SourceID},
 	}
 	if body != nil {
 		docRev._shallowCopyBody = body.ShallowCopy()
@@ -609,7 +609,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, includeBody bool) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	var docRevBody Body
-	var fetchedCV *CurrentVersionVector
+	var fetchedCV *SourceAndVersion
 	var revid string
 	value.lock.RLock()
 	if value.bodyBytes != nil || value.err != nil {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -80,7 +80,7 @@ func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document)
 		"testing":         true,
 		BodyId:            doc.ID,
 		BodyRev:           doc.CurrentRev,
-		"current_version": &CurrentVersionVector{VersionCAS: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+		"current_version": &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 	}
 	bodyBytes, err := base.JSONMarshal(b)
 	return bodyBytes, b, nil, err
@@ -110,7 +110,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Get them back out
@@ -127,7 +127,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Add 3 more docs to the now full revcache
 	for i := 10; i < 13; i++ {
 		docID := strconv.Itoa(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Check that the first 3 docs were evicted
@@ -170,7 +170,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// assert that the list has 10 elements along with both lookup maps
@@ -181,7 +181,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Add 3 more docs to the now full rev cache to trigger eviction
 	for docID := 10; docID < 13; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
 	assert.Equal(t, 10, len(cache.hlvCache))
@@ -192,7 +192,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	prevCacheHitCount := cacheHitCounter.Value()
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		cv := CurrentVersionVector{VersionCAS: uint64(i + 3), SourceID: "test"}
+		cv := SourceAndVersion{Version: uint64(i + 3), SourceID: "test"}
 		docRev, err := cache.GetWithCV(ctx, id, &cv, RevCacheOmitBody, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -270,13 +270,13 @@ func TestBackingStoreCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"not_found"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
@@ -287,14 +287,14 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	cv = CurrentVersionVector{SourceID: "test11", VersionCAS: 100}
+	cv = SourceAndVersion{SourceID: "test11", Version: 100}
 	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -557,7 +557,7 @@ func TestSingleLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
 	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", true, false)
 	assert.NoError(t, err)
 }
@@ -567,7 +567,7 @@ func TestConcurrentLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
 
 	// Trigger load into cache
 	var wg sync.WaitGroup
@@ -632,7 +632,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	documentRevision := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -648,7 +648,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
@@ -661,7 +661,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, []byte(`{"test":"12345"}`), docRev.BodyBytes)
 	assert.Equal(t, int64(2), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
@@ -705,7 +705,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// create cv with incorrect version to the one stored in backing store
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 1234}
+	cv := SourceAndVersion{SourceID: "test", Version: 1234}
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	require.Error(t, err)
@@ -735,7 +735,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	go func() {
 		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", RevCacheOmitBody, RevCacheIncludeDelta)
 		require.NoError(t, err)
@@ -773,9 +773,9 @@ func TestGetActive(t *testing.T) {
 	rev1id, doc, err := collection.Put(ctx, "doc", Body{"val": 123})
 	require.NoError(t, err)
 
-	expectedCV := CurrentVersionVector{
-		SourceID:   db.BucketUUID,
-		VersionCAS: doc.Cas,
+	expectedCV := SourceAndVersion{
+		SourceID: db.BucketUUID,
+		Version:  doc.Cas,
 	}
 
 	// remove the entry form the rev cache to force teh cache to not have the active version in it
@@ -801,7 +801,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	docRev := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -1060,7 +1060,6 @@ func TestAttachmentContentType(t *testing.T) {
 }
 
 func TestBasicAttachmentRemoval(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
@@ -2224,7 +2223,6 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 }
 
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -424,7 +424,6 @@ func TestXattrDoubleDelete(t *testing.T) {
 }
 
 func TestViewQueryTombstoneRetrieval(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 	base.SkipImportTestsIfNotEnabled(t)
 
 	if !base.TestsDisableGSI() {


### PR DESCRIPTION
CBG-3503

Updates HLV on import.  Includes importCAS handling for HLV already updated by non-SG peers.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2169/
