### PR TITLE
CBG-3576: changes to BlipTesterClient to to run in VV and non VV protocol versions

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2260,184 +2260,205 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 }
 func TestUpdateExistingAttachment(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
+	btcRunner := NewBlipTesterClientRunner(t)
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
 	)
-	doc1Version := rt.PutDoc(doc1ID, `{}`)
-	doc2Version := rt.PutDoc(doc2ID, `{}`)
 
-	require.NoError(t, rt.WaitForPendingChanges())
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, ok)
-	_, ok = btc.WaitForVersion(doc2ID, doc2Version)
-	require.True(t, ok)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
-	attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
+		doc1Version := rt.PutDoc(doc1ID, `{}`)
+		doc2Version := rt.PutDoc(doc2ID, `{}`)
 
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
-	require.NoError(t, err)
-	doc2Version, err = btc.PushRev(doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
-	require.NoError(t, err)
+		require.NoError(t, rt.WaitForPendingChanges())
 
-	assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
-	assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
+		err := btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
+		_, ok := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
+		require.True(t, ok)
+		_, ok = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
+		require.True(t, ok)
 
-	_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
-	require.NoError(t, err)
-	_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
-	require.NoError(t, err)
+		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
+		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
 
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
-	require.NoError(t, err)
+		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+		require.NoError(t, err)
+		doc2Version, err = btcRunner.PushRev(btc.id, doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
+		require.NoError(t, err)
 
-	assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
 
-	doc1, err := rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
-	assert.NoError(t, err)
+		_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		require.NoError(t, err)
+		_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
+		require.NoError(t, err)
 
-	assert.Equal(t, "sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=", doc1.Attachments["attachment"].(map[string]interface{})["digest"])
+		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
+		require.NoError(t, err)
 
-	req := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
-	assert.Equal(t, "attachmentB", string(req.BodyBytes()))
+		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+
+		doc1, err := rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=", doc1.Attachments["attachment"].(map[string]interface{})["digest"])
+
+		req := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
+		assert.Equal(t, "attachmentB", string(req.BodyBytes()))
+	})
 }
 
 // TestPushUnknownAttachmentAsStub sets revpos to an older generation, for an attachment that doesn't exist on the server.
 // Verifies that getAttachment is triggered, and attachment is properly persisted.
 func TestPushUnknownAttachmentAsStub(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	assert.NoError(t, err)
-	defer btc.Close()
-
+	}
 	const doc1ID = "doc1"
-	doc1Version := rt.PutDoc(doc1ID, `{}`)
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	require.NoError(t, rt.WaitForPendingChanges())
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
+		opts := BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
+		defer btc.Close()
+		// Add doc1 and doc2
+		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
 
-	_, ok := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, ok)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
-	// force attachment into test client's store to validate it's fetched
-	attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
-	contentType := "text/plain"
+		err := btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
 
-	length, digest, err := btc.saveAttachment(contentType, attachmentAData)
-	require.NoError(t, err)
-	// Update doc1, include reference to non-existing attachment with recent revpos
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"content_type":"%s","stub":true,"revpos":1}}}`, digest, length, contentType)))
-	require.NoError(t, err)
+		_, ok := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
+		require.True(t, ok)
 
-	require.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		// force attachment into test client's store to validate it's fetched
+		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
+		contentType := "text/plain"
 
-	// verify that attachment exists on document and was persisted
-	attResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
-	assert.Equal(t, 200, attResponse.Code)
-	assert.Equal(t, "attachmentA", string(attResponse.BodyBytes()))
+		length, digest, err := btcRunner.saveAttachment(btc.id, contentType, attachmentAData)
+		require.NoError(t, err)
+		// Update doc1, include reference to non-existing attachment with recent revpos
+		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"content_type":"%s","stub":true,"revpos":1}}}`, digest, length, contentType)))
+		require.NoError(t, err)
 
+		require.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
+
+		// verify that attachment exists on document and was persisted
+		attResponse := btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
+		assert.Equal(t, 200, attResponse.Code)
+		assert.Equal(t, "attachmentA", string(attResponse.BodyBytes()))
+	})
 }
 
 func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				AllowConflicts: base.BoolPtr(true),
 			},
 		},
-	})
-	defer rt.Close()
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	// Push an initial rev with attachment data
+	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc"
-	initialVersion := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-	err = rt.WaitForPendingChanges()
-	assert.NoError(t, err)
 
-	// Replicate data to client and ensure doc arrives
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, found := btc.WaitForVersion(docID, initialVersion)
-	assert.True(t, found)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	// Push a revision with a bunch of history simulating doc updated on mobile device
-	// Note this references revpos 1 and therefore SGW has it - Shouldn't need proveAttachment
-	proveAttachmentBefore := btc.pushReplication.replicationStats.ProveAttachment.Value()
-	revid, err := btc.PushRevWithHistory(docID, initialVersion.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
-	assert.NoError(t, err)
-	proveAttachmentAfter := btc.pushReplication.replicationStats.ProveAttachment.Value()
-	assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
+		opts := BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
+		defer btc.Close()
+		// Push an initial rev with attachment data
+		initialVersion := btc.rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		err := btc.rt.WaitForPendingChanges()
+		assert.NoError(t, err)
 
-	// Push another bunch of history
-	_, err = btc.PushRevWithHistory(docID, revid, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
-	assert.NoError(t, err)
-	proveAttachmentAfter = btc.pushReplication.replicationStats.ProveAttachment.Value()
-	assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
+		// Replicate data to client and ensure doc arrives
+		err = btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
+		_, found := btcRunner.WaitForVersion(btc.id, docID, initialVersion)
+		assert.True(t, found)
+
+		// Push a revision with a bunch of history simulating doc updated on mobile device
+		// Note this references revpos 1 and therefore SGW has it - Shouldn't need proveAttachment
+		proveAttachmentBefore := btc.pushReplication.replicationStats.ProveAttachment.Value()
+		revid, err := btcRunner.PushRevWithHistory(btc.id, docID, initialVersion.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
+		assert.NoError(t, err)
+		proveAttachmentAfter := btc.pushReplication.replicationStats.ProveAttachment.Value()
+		assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
+
+		// Push another bunch of history
+		_, err = btcRunner.PushRevWithHistory(btc.id, docID, revid, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
+		assert.NoError(t, err)
+		proveAttachmentAfter = btc.pushReplication.replicationStats.ProveAttachment.Value()
+		assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
+	})
 }
+
 func TestAttachmentWithErroneousRevPos(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		opts := BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
+		defer btc.Close()
+		// Create rev 1 with the hello.txt attachment
+		const docID = "doc"
+		version := btc.rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		err := btc.rt.WaitForPendingChanges()
+		assert.NoError(t, err)
+
+		// Pull rev and attachment down to client
+		err = btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
+		_, found := btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, found)
+
+		// Add an attachment to client
+		btcRunner.AttachmentsLock(btc.id).Lock()
+		btcRunner.Attachments(btc.id)["sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="] = []byte("goodbye cruel world")
+		btcRunner.AttachmentsLock(btc.id).Unlock()
+
+		// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
+		_, err = btcRunner.PushRevWithHistory(btc.id, docID, version.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
+		require.NoError(t, err)
+
+		// Ensure message and attachment is pushed up
+		_, ok := btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
+
+		// Get the attachment and ensure the data is updated
+		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc/hello.txt", "")
+		RequireStatus(t, resp, http.StatusOK)
+		assert.Equal(t, "goodbye cruel world", string(resp.BodyBytes()))
 	})
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	// Create rev 1 with the hello.txt attachment
-	const docID = "doc"
-	version := rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-	err = rt.WaitForPendingChanges()
-	assert.NoError(t, err)
-
-	// Pull rev and attachment down to client
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, found := btc.WaitForVersion(docID, version)
-	assert.True(t, found)
-
-	// Add an attachment to client
-	btc.AttachmentsLock().Lock()
-	btc.Attachments()["sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="] = []byte("goodbye cruel world")
-	btc.AttachmentsLock().Unlock()
-
-	// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
-	_, err = btc.PushRevWithHistory(docID, version.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
-	require.NoError(t, err)
-
-	// Ensure message and attachment is pushed up
-	_, ok := btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
-
-	// Get the attachment and ensure the data is updated
-	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc/hello.txt", "")
-	RequireStatus(t, resp, http.StatusOK)
-	assert.Equal(t, "goodbye cruel world", string(resp.BodyBytes()))
 }
 
 // CBG-2004: Test that prove attachment over Blip works correctly when receiving a ErrAttachmentNotFound
@@ -2578,74 +2599,79 @@ func TestPutInvalidAttachment(t *testing.T) {
 // validates that proveAttachment isn't being invoked when the attachment is already present and the
 // digest doesn't change, regardless of revpos.
 func TestCBLRevposHandling(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
+	}
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	assert.NoError(t, err)
-	defer btc.Close()
-
+	btcRunner := NewBlipTesterClientRunner(t)
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
 	)
-	doc1Version := rt.PutDoc(doc1ID, `{}`)
-	doc2Version := rt.PutDoc(doc2ID, `{}`)
-	require.NoError(t, rt.WaitForPendingChanges())
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, ok)
-	_, ok = btc.WaitForVersion(doc2ID, doc2Version)
-	require.True(t, ok)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
-	attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
+		opts := BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
+		defer btc.Close()
 
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
-	require.NoError(t, err)
-	doc2Version, err = btc.PushRev(doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
-	require.NoError(t, err)
+		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
+		doc2Version := btc.rt.PutDoc(doc2ID, `{}`)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
-	assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
-	assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
+		err := btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
+		_, ok := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
+		require.True(t, ok)
+		_, ok = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
+		require.True(t, ok)
 
-	_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
-	require.NoError(t, err)
-	_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
-	require.NoError(t, err)
+		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
+		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
 
-	// Update doc1, don't change attachment, use correct revpos
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":2}}}`))
-	require.NoError(t, err)
+		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+		require.NoError(t, err)
+		doc2Version, err = btcRunner.PushRev(btc.id, doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
+		require.NoError(t, err)
 
-	assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
+		assert.NoError(t, btc.rt.WaitForVersion(doc2ID, doc2Version))
 
-	// Update doc1, don't change attachment, use revpos=generation of revid, as CBL 2.x does.  Should not proveAttachment on digest match.
-	doc1Version, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":4}}}`))
-	require.NoError(t, err)
+		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		require.NoError(t, err)
+		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
+		require.NoError(t, err)
 
-	// Validate attachment exists
-	attResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
-	assert.Equal(t, 200, attResponse.Code)
-	assert.Equal(t, "attachmentA", string(attResponse.BodyBytes()))
+		// Update doc1, don't change attachment, use correct revpos
+		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":2}}}`))
+		require.NoError(t, err)
 
-	attachmentPushCount := rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
-	// Update doc1, change attachment digest with CBL revpos=generation.  Should getAttachment
-	_, err = btc.PushRev(doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":5}}}`))
-	require.NoError(t, err)
+		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
 
-	// Validate attachment exists and is updated
-	attResponse = rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
-	assert.Equal(t, 200, attResponse.Code)
-	assert.Equal(t, "attachmentB", string(attResponse.BodyBytes()))
+		// Update doc1, don't change attachment, use revpos=generation of revid, as CBL 2.x does.  Should not proveAttachment on digest match.
+		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":4}}}`))
+		require.NoError(t, err)
 
-	attachmentPushCountAfter := rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
-	assert.Equal(t, attachmentPushCount+1, attachmentPushCountAfter)
+		// Validate attachment exists
+		attResponse := btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
+		assert.Equal(t, 200, attResponse.Code)
+		assert.Equal(t, "attachmentA", string(attResponse.BodyBytes()))
 
+		attachmentPushCount := btc.rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
+		// Update doc1, change attachment digest with CBL revpos=generation.  Should getAttachment
+		_, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":5}}}`))
+		require.NoError(t, err)
+
+		// Validate attachment exists and is updated
+		attResponse = btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
+		assert.Equal(t, 200, attResponse.Code)
+		assert.Equal(t, "attachmentB", string(attResponse.BodyBytes()))
+
+		attachmentPushCountAfter := btc.rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
+		assert.Equal(t, attachmentPushCount+1, attachmentPushCountAfter)
+	})
 }
 
 // Helper_Functions

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -43,56 +43,63 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 		},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	opts := &BlipTesterClientOpts{}
-	opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, opts)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
+	btcRunner := NewBlipTesterClientRunner(t)
+	// given this test is for v2 protocol, skip version vector test
+	btcRunner.SkipVersionVectorInitialization = true
 	const docID = "doc1"
 
-	// Create doc revision with attachment on SG.
-	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	version := rt.PutDoc(docID, bodyText)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	data, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	require.JSONEq(t, bodyTextExpected, string(data))
+		opts := &BlipTesterClientOpts{}
+		opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}
 
-	// Update the replicated doc at client along with keeping the same attachment stub.
-	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	version, err = btc.PushRev(docID, version, []byte(bodyText))
-	require.NoError(t, err)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	// Wait for the document to be replicated at SG
-	_, ok = btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		err := btcRunner.StartPull(btc.id)
+		assert.NoError(t, err)
 
-	respBody := rt.GetDocVersion(docID, version)
+		// Create doc revision with attachment on SG.
+		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		version := btc.rt.PutDoc(docID, bodyText)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+		data, ok := btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, ok)
+		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		require.JSONEq(t, bodyTextExpected, string(data))
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 1)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(1), hello["revpos"])
-	assert.True(t, hello["stub"].(bool))
+		// Update the replicated doc at client along with keeping the same attachment stub.
+		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		version, err = btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
+		require.NoError(t, err)
 
-	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
-	assert.Equal(t, int64(11), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+		// Wait for the document to be replicated at SG
+		_, ok = btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
+
+		respBody := btc.rt.GetDocVersion(docID, version)
+
+		assert.Equal(t, docID, respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 1)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(1), hello["revpos"])
+		assert.True(t, hello["stub"].(bool))
+
+		assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+		assert.Equal(t, int64(11), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+	})
 }
 
 // Test pushing and pulling v2 attachments with v3 client
@@ -113,54 +120,59 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 		},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
+	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc1"
 
-	// Create doc revision with attachment on SG.
-	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	version := rt.PutDoc(docID, bodyText)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	data, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	require.JSONEq(t, bodyTextExpected, string(data))
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	// Update the replicated doc at client along with keeping the same attachment stub.
-	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	version, err = btc.PushRev(docID, version, []byte(bodyText))
-	require.NoError(t, err)
+		err := btcRunner.StartPull(btc.id)
+		assert.NoError(t, err)
 
-	// Wait for the document to be replicated at SG
-	_, ok = btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		// Create doc revision with attachment on SG.
+		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		version := btc.rt.PutDoc(docID, bodyText)
 
-	respBody := rt.GetDocVersion(docID, version)
+		data, ok := btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, ok)
+		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		require.JSONEq(t, bodyTextExpected, string(data))
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+		// Update the replicated doc at client along with keeping the same attachment stub.
+		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		version, err = btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
+		require.NoError(t, err)
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 1)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(1), hello["revpos"])
-	assert.True(t, hello["stub"].(bool))
+		// Wait for the document to be replicated at SG
+		_, ok = btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
-	assert.Equal(t, int64(11), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+		respBody := btc.rt.GetDocVersion(docID, version)
+
+		assert.Equal(t, docID, respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 1)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(1), hello["revpos"])
+		assert.True(t, hello["stub"].(bool))
+
+		assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+		assert.Equal(t, int64(11), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+	})
 }
 
 // TestBlipProveAttachmentV2 ensures that CBL's proveAttachment for deduplication is working correctly even for v2 attachments which aren't de-duped on the server side.
@@ -169,56 +181,59 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
-	})
-	require.NoError(t, err)
-	defer btc.Close()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
 
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
 	)
-
 	const (
 		attachmentName = "hello.txt"
 		attachmentData = "hello world"
 	)
-
 	var (
 		attachmentDataB64 = base64.StdEncoding.EncodeToString([]byte(attachmentData))
 		attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
 	)
 
-	// Create two docs with the same attachment data on SG - v2 attachments intentionally result in two copies,
-	// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
-	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	doc1Version := rt.PutDoc(doc1ID, doc1Body)
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipVersionVectorInitialization = true // v2 protocol test
 
-	data, ok := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, ok)
-	bodyTextExpected := fmt.Sprintf(`{"greetings":[{"hi":"alice"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
-	require.JSONEq(t, bodyTextExpected, string(data))
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	// create doc2 now that we know the client has the attachment
-	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	doc2Version := rt.PutDoc(doc2ID, doc2Body)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+		})
+		defer btc.Close()
 
-	data, ok = btc.WaitForVersion(doc2ID, doc2Version)
-	require.True(t, ok)
-	bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
-	require.JSONEq(t, bodyTextExpected, string(data))
+		err := btcRunner.StartPull(btc.id)
+		assert.NoError(t, err)
 
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value())
-	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPull().RevErrorCount.Value())
-	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullCount.Value())
-	assert.Equal(t, int64(len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullBytes.Value())
+		// Create two docs with the same attachment data on SG - v2 attachments intentionally result in two copies,
+		// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
+		doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+		doc1Version := btc.rt.PutDoc(doc1ID, doc1Body)
+
+		data, ok := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
+		require.True(t, ok)
+		bodyTextExpected := fmt.Sprintf(`{"greetings":[{"hi":"alice"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
+		require.JSONEq(t, bodyTextExpected, string(data))
+
+		// create doc2 now that we know the client has the attachment
+		doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+		doc2Version := btc.rt.PutDoc(doc2ID, doc2Body)
+
+		data, ok = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
+		require.True(t, ok)
+		bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
+		require.JSONEq(t, bodyTextExpected, string(data))
+
+		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value())
+		assert.Equal(t, int64(0), btc.rt.GetDatabase().DbStats.CBLReplicationPull().RevErrorCount.Value())
+		assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullCount.Value())
+		assert.Equal(t, int64(len(attachmentData)), btc.rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullBytes.Value())
+	})
 }
 
 // TestBlipProveAttachmentV2Push ensures that CBL's attachment deduplication is ignored for push replications - resulting in new server-side digests and duplicated attachment data (v2 attachment format).
@@ -227,50 +242,51 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
-	})
-	require.NoError(t, err)
-	defer btc.Close()
-
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
 	)
-
 	const (
 		attachmentName = "hello.txt"
 		attachmentData = "hello world"
 	)
-
 	var (
 		attachmentDataB64 = base64.StdEncoding.EncodeToString([]byte(attachmentData))
 		// attachmentDigest  = "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="
 	)
 
-	// Create two docs with the same attachment data on the client - v2 attachments intentionally result in two copies stored on the server, despite the client being able to share the data for both.
-	doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	doc1Version, err := btc.PushRev(doc1ID, EmptyDocVersion(), []byte(doc1Body))
-	require.NoError(t, err)
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipVersionVectorInitialization = true // v2 protocol test
 
-	err = rt.WaitForVersion(doc1ID, doc1Version)
-	require.NoError(t, err)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	// create doc2 now that we know the server has the attachment - SG should still request the attachment data from the client.
-	doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-	doc2Version, err := btc.PushRev(doc2ID, EmptyDocVersion(), []byte(doc2Body))
-	require.NoError(t, err)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+		})
+		defer btc.Close()
+		// Create two docs with the same attachment data on the client - v2 attachments intentionally result in two copies stored on the server, despite the client being able to share the data for both.
+		doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+		doc1Version, err := btcRunner.PushRev(btc.id, doc1ID, EmptyDocVersion(), []byte(doc1Body))
+		require.NoError(t, err)
 
-	err = rt.WaitForVersion(doc2ID, doc2Version)
-	require.NoError(t, err)
+		err = btc.rt.WaitForVersion(doc1ID, doc1Version)
+		require.NoError(t, err)
 
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
-	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
-	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
-	assert.Equal(t, int64(2*len(attachmentData)), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+		// create doc2 now that we know the server has the attachment - SG should still request the attachment data from the client.
+		doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
+		doc2Version, err := btcRunner.PushRev(btc.id, doc2ID, EmptyDocVersion(), []byte(doc2Body))
+		require.NoError(t, err)
+
+		err = btc.rt.WaitForVersion(doc2ID, doc2Version)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
+		assert.Equal(t, int64(0), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
+		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+		assert.Equal(t, int64(2*len(attachmentData)), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+	})
 }
 
 func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
@@ -278,130 +294,139 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
+	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc1"
 
-	// CBL creates revisions 1-abc,2-abc on the client, with an attachment associated with rev 2.
-	bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	err = btc.StoreRevOnClient(docID, "2-abc", []byte(bodyText))
-	require.NoError(t, err)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err := btc.PushRevWithHistory(docID, "", []byte(bodyText), 2, 0)
-	require.NoError(t, err)
-	assert.Equal(t, "2-abc", revId)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	// Wait for the documents to be replicated at SG
-	_, ok := btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		err := btcRunner.StartPull(btc.id)
+		assert.NoError(t, err)
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-	assert.Equal(t, http.StatusOK, resp.Code)
+		// CBL creates revisions 1-abc,2-abc on the client, with an attachment associated with rev 2.
+		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		err = btcRunner.StoreRevOnClient(btc.id, docID, "2-abc", []byte(bodyText))
+		require.NoError(t, err)
 
-	// CBL updates the doc w/ two more revisions, 3-abc, 4-abc,
-	// these are sent to SG as 4-abc, history:[4-abc,3-abc,2-abc], the attachment has revpos=2
-	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err = btc.PushRevWithHistory(docID, revId, []byte(bodyText), 2, 0)
-	require.NoError(t, err)
-	assert.Equal(t, "4-abc", revId)
+		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		revId, err := btcRunner.PushRevWithHistory(btc.id, docID, "", []byte(bodyText), 2, 0)
+		require.NoError(t, err)
+		assert.Equal(t, "2-abc", revId)
 
-	// Wait for the document to be replicated at SG
-	_, ok = btc.pushReplication.WaitForMessage(4)
-	assert.True(t, ok)
+		// Wait for the documents to be replicated at SG
+		_, ok := btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-	assert.Equal(t, http.StatusOK, resp.Code)
+		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
+		assert.Equal(t, http.StatusOK, resp.Code)
 
-	var respBody db.Body
-	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
+		// CBL updates the doc w/ two more revisions, 3-abc, 4-abc,
+		// these are sent to SG as 4-abc, history:[4-abc,3-abc,2-abc], the attachment has revpos=2
+		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		revId, err = btcRunner.PushRevWithHistory(btc.id, docID, revId, []byte(bodyText), 2, 0)
+		require.NoError(t, err)
+		assert.Equal(t, "4-abc", revId)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	assert.Equal(t, "4-abc", respBody[db.BodyRev])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+		// Wait for the document to be replicated at SG
+		_, ok = btc.pushReplication.WaitForMessage(4)
+		assert.True(t, ok)
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 1)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(2), hello["revpos"])
-	assert.True(t, hello["stub"].(bool))
+		resp = btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
+		assert.Equal(t, http.StatusOK, resp.Code)
 
-	// Check the number of sendProveAttachment/sendGetAttachment calls.
-	require.NotNil(t, btc.pushReplication.replicationStats)
-	assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
-	assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
+		var respBody db.Body
+		assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
+
+		assert.Equal(t, docID, respBody[db.BodyId])
+		assert.Equal(t, "4-abc", respBody[db.BodyRev])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 1)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(2), hello["revpos"])
+		assert.True(t, hello["stub"].(bool))
+
+		// Check the number of sendProveAttachment/sendGetAttachment calls.
+		require.NotNil(t, btc.pushReplication.replicationStats)
+		assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
+		assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
+	})
 }
 func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
 	const docID = "doc1"
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	// CBL creates revisions 1-abc, 2-abc, 3-abc, 4-abc on the client, with an attachment associated with rev 2.
-	// rev tree pruning on the CBL side, so 1-abc no longer exists.
-	// CBL replicates, sends to client as 4-abc history:[4-abc, 3-abc, 2-abc], attachment has revpos=2
-	bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	err = btc.StoreRevOnClient(docID, "2-abc", []byte(bodyText))
-	require.NoError(t, err)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	revId, err := btc.PushRevWithHistory(docID, "2-abc", []byte(bodyText), 2, 0)
-	require.NoError(t, err)
-	assert.Equal(t, "4-abc", revId)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+		err := btcRunner.StartPull(btc.id)
+		assert.NoError(t, err)
 
-	// Wait for the document to be replicated at SG
-	_, ok := btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		// CBL creates revisions 1-abc, 2-abc, 3-abc, 4-abc on the client, with an attachment associated with rev 2.
+		// rev tree pruning on the CBL side, so 1-abc no longer exists.
+		// CBL replicates, sends to client as 4-abc history:[4-abc, 3-abc, 2-abc], attachment has revpos=2
+		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		err = btcRunner.StoreRevOnClient(btc.id, docID, "2-abc", []byte(bodyText))
+		require.NoError(t, err)
 
-	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-	assert.Equal(t, http.StatusOK, resp.Code)
+		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		revId, err := btcRunner.PushRevWithHistory(btc.id, docID, "2-abc", []byte(bodyText), 2, 0)
+		require.NoError(t, err)
+		assert.Equal(t, "4-abc", revId)
 
-	var respBody db.Body
-	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
+		// Wait for the document to be replicated at SG
+		_, ok := btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	assert.Equal(t, "4-abc", respBody[db.BodyRev])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
+		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
+		assert.Equal(t, http.StatusOK, resp.Code)
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 1)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(4), hello["revpos"])
-	assert.True(t, hello["stub"].(bool))
+		var respBody db.Body
+		assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
 
-	// Check the number of sendProveAttachment/sendGetAttachment calls.
-	require.NotNil(t, btc.pushReplication.replicationStats)
-	assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
-	assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
+		assert.Equal(t, docID, respBody[db.BodyId])
+		assert.Equal(t, "4-abc", respBody[db.BodyRev])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
+
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 1)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(4), hello["revpos"])
+		assert.True(t, hello["stub"].(bool))
+
+		// Check the number of sendProveAttachment/sendGetAttachment calls.
+		require.NotNil(t, btc.pushReplication.replicationStats)
+		assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
+		assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
+	})
 }
 
 // Test Attachment replication behavior described here: https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol
@@ -507,163 +532,181 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 
 // TestBlipAttachNameChange tests CBL handling - attachments with changed names are sent as stubs, and not new attachments
 func TestBlipAttachNameChange(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled: true,
-	})
-	defer rt.Close()
-
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
+	rtConfig := &RestTesterConfig{
+		GuestEnabled: true,
+	}
 
-	attachmentA := []byte("attachmentA")
-	attachmentAData := base64.StdEncoding.EncodeToString(attachmentA)
-	digest := db.Sha1DigestKey(attachmentA)
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	// Push initial attachment data
-	version, err := client1.PushRev("doc", EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
-	require.NoError(t, err)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	// Confirm attachment is in the bucket
-	attachmentAKey := db.MakeAttachmentKey(2, "doc", digest)
-	bucketAttachmentA, _, err := rt.GetSingleDataStore().GetRaw(attachmentAKey)
-	require.NoError(t, err)
-	require.EqualValues(t, bucketAttachmentA, attachmentA)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client1.Close()
 
-	// Simulate changing only the attachment name over CBL
-	// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
-	version, err = client1.PushRev("doc", version, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
-	require.NoError(t, err)
-	err = rt.WaitForVersion("doc", version)
-	require.NoError(t, err)
+		attachmentA := []byte("attachmentA")
+		attachmentAData := base64.StdEncoding.EncodeToString(attachmentA)
+		digest := db.Sha1DigestKey(attachmentA)
 
-	// Check if attachment is still in bucket
-	bucketAttachmentA, _, err = rt.GetSingleDataStore().GetRaw(attachmentAKey)
-	assert.NoError(t, err)
-	assert.Equal(t, bucketAttachmentA, attachmentA)
+		// Push initial attachment data
+		version, err := btcRunner.PushRev(client1.id, "doc", EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
+		require.NoError(t, err)
 
-	resp := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
-	RequireStatus(t, resp, http.StatusOK)
-	assert.Equal(t, attachmentA, resp.BodyBytes())
+		// Confirm attachment is in the bucket
+		attachmentAKey := db.MakeAttachmentKey(2, "doc", digest)
+		bucketAttachmentA, _, err := client1.rt.GetSingleDataStore().GetRaw(attachmentAKey)
+		require.NoError(t, err)
+		require.EqualValues(t, bucketAttachmentA, attachmentA)
+
+		// Simulate changing only the attachment name over CBL
+		// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
+		version, err = btcRunner.PushRev(client1.id, "doc", version, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
+		require.NoError(t, err)
+		err = client1.rt.WaitForVersion("doc", version)
+		require.NoError(t, err)
+
+		// Check if attachment is still in bucket
+		bucketAttachmentA, _, err = client1.rt.GetSingleDataStore().GetRaw(attachmentAKey)
+		assert.NoError(t, err)
+		assert.Equal(t, bucketAttachmentA, attachmentA)
+
+		resp := client1.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
+		RequireStatus(t, resp, http.StatusOK)
+		assert.Equal(t, attachmentA, resp.BodyBytes())
+	})
 }
 
 // TestBlipLegacyAttachNameChange ensures that CBL name changes for legacy attachments are handled correctly
 func TestBlipLegacyAttachNameChange(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled: true,
-	})
-	defer rt.Close()
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
+	rtConfig := &RestTesterConfig{
+		GuestEnabled: true,
+	}
 
-	// Create document in the bucket with a legacy attachment
-	docID := "doc"
-	attBody := []byte(`hi`)
-	digest := db.Sha1DigestKey(attBody)
-	attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
-	rawDoc := rawDocWithAttachmentAndSyncMeta()
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	// Create a document with legacy attachment.
-	CreateDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	// Get the document and grab the revID.
-	docVersion, _ := rt.GetDoc(docID)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client1.Close()
+		// Create document in the bucket with a legacy attachment
+		docID := "doc"
+		attBody := []byte(`hi`)
+		digest := db.Sha1DigestKey(attBody)
+		attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
+		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
-	// Store the document and attachment on the test client
-	err = client1.StoreRevOnClient(docID, docVersion.RevID, rawDoc)
+		// Create a document with legacy attachment.
+		CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDoc, attKey, attBody)
 
-	require.NoError(t, err)
-	client1.AttachmentsLock().Lock()
-	client1.Attachments()[digest] = attBody
-	client1.AttachmentsLock().Unlock()
+		// Get the document and grab the revID.
+		docVersion, _ := client1.rt.GetDoc(docID)
 
-	// Confirm attachment is in the bucket
-	attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
-	bucketAttachmentA, _, err := rt.GetSingleDataStore().GetRaw(attachmentAKey)
-	require.NoError(t, err)
-	require.EqualValues(t, bucketAttachmentA, attBody)
+		// Store the document and attachment on the test client
+		err := btcRunner.StoreRevOnClient(client1.id, docID, docVersion.RevID, rawDoc)
 
-	// Simulate changing only the attachment name over CBL
-	// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
-	docVersion, err = client1.PushRev("doc", docVersion, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
-	require.NoError(t, err)
+		require.NoError(t, err)
+		btcRunner.AttachmentsLock(client1.id).Lock()
+		btcRunner.Attachments(client1.id)[digest] = attBody
+		btcRunner.AttachmentsLock(client1.id).Unlock()
 
-	err = rt.WaitForVersion("doc", docVersion)
-	require.NoError(t, err)
+		// Confirm attachment is in the bucket
+		attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
+		bucketAttachmentA, _, err := client1.rt.GetSingleDataStore().GetRaw(attachmentAKey)
+		require.NoError(t, err)
+		require.EqualValues(t, bucketAttachmentA, attBody)
 
-	resp := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
-	RequireStatus(t, resp, http.StatusOK)
-	assert.Equal(t, attBody, resp.BodyBytes())
+		// Simulate changing only the attachment name over CBL
+		// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
+		docVersion, err = btcRunner.PushRev(client1.id, "doc", docVersion, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
+		require.NoError(t, err)
+
+		err = client1.rt.WaitForVersion("doc", docVersion)
+		require.NoError(t, err)
+
+		resp := client1.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
+		RequireStatus(t, resp, http.StatusOK)
+		assert.Equal(t, attBody, resp.BodyBytes())
+	})
 }
 
 // TestBlipLegacyAttachDocUpdate ensures that CBL updates for documents associated with legacy attachments are handled correctly
 func TestBlipLegacyAttachDocUpdate(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled: true,
-	})
-	defer rt.Close()
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client1.Close()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
-
-	// Create document in the bucket with a legacy attachment.  Properties here align with rawDocWithAttachmentAndSyncMeta
-	docID := "doc"
-	attBody := []byte(`hi`)
-	digest := db.Sha1DigestKey(attBody)
-	attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
-	attName := "hi.txt"
-	rawDoc := rawDocWithAttachmentAndSyncMeta()
-
-	// Create a document with legacy attachment.
-	CreateDocWithLegacyAttachment(t, rt, docID, rawDoc, attKey, attBody)
-
-	version, _ := rt.GetDoc(docID)
-
-	// Store the document and attachment on the test client
-	err = client1.StoreRevOnClient(docID, version.RevID, rawDoc)
-	require.NoError(t, err)
-	client1.AttachmentsLock().Lock()
-	client1.Attachments()[digest] = attBody
-	client1.AttachmentsLock().Unlock()
-
-	// Confirm attachment is in the bucket
-	attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
-	dataStore := rt.GetSingleDataStore()
-	bucketAttachmentA, _, err := dataStore.GetRaw(attachmentAKey)
-	require.NoError(t, err)
-	require.EqualValues(t, bucketAttachmentA, attBody)
-
-	// Update the document, leaving body intact
-	version, err = client1.PushRev("doc", version, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
-	require.NoError(t, err)
-
-	err = rt.WaitForVersion("doc", version)
-	require.NoError(t, err)
-
-	resp := rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/doc/%s", attName), "")
-	RequireStatus(t, resp, http.StatusOK)
-	assert.Equal(t, attBody, resp.BodyBytes())
-
-	// Validate that the attachment hasn't been migrated to V2
-	v1Key := db.MakeAttachmentKey(1, "doc", digest)
-	v1Body, _, err := dataStore.GetRaw(v1Key)
-	require.NoError(t, err)
-	require.EqualValues(t, attBody, v1Body)
-
-	v2Key := db.MakeAttachmentKey(2, "doc", digest)
-	_, _, err = dataStore.GetRaw(v2Key)
-	require.Error(t, err)
-	// Confirm correct type of error for both integration test and Walrus
-	if !errors.Is(err, sgbucket.MissingError{Key: v2Key}) {
-		var keyValueErr *gocb.KeyValueError
-		require.True(t, errors.As(err, &keyValueErr))
-		//require.Equal(t, keyValueErr.StatusCode, memd.StatusKeyNotFound)
-		require.Equal(t, keyValueErr.DocumentID, v2Key)
+	rtConfig := &RestTesterConfig{
+		GuestEnabled: true,
 	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client1.Close()
+		// Create document in the bucket with a legacy attachment.  Properties here align with rawDocWithAttachmentAndSyncMeta
+		docID := "doc"
+		attBody := []byte(`hi`)
+		digest := db.Sha1DigestKey(attBody)
+		attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
+		attName := "hi.txt"
+		rawDoc := rawDocWithAttachmentAndSyncMeta()
+
+		// Create a document with legacy attachment.
+		CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDoc, attKey, attBody)
+
+		version, _ := client1.rt.GetDoc(docID)
+
+		// Store the document and attachment on the test client
+		err := btcRunner.StoreRevOnClient(client1.id, docID, version.RevID, rawDoc)
+		require.NoError(t, err)
+		btcRunner.AttachmentsLock(client1.id).Lock()
+		btcRunner.Attachments(client1.id)[digest] = attBody
+		btcRunner.AttachmentsLock(client1.id).Unlock()
+
+		// Confirm attachment is in the bucket
+		attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
+		dataStore := client1.rt.GetSingleDataStore()
+		bucketAttachmentA, _, err := dataStore.GetRaw(attachmentAKey)
+		require.NoError(t, err)
+		require.EqualValues(t, bucketAttachmentA, attBody)
+
+		// Update the document, leaving body intact
+		version, err = btcRunner.PushRev(client1.id, "doc", version, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
+		require.NoError(t, err)
+
+		err = client1.rt.WaitForVersion("doc", version)
+		require.NoError(t, err)
+
+		resp := client1.rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/doc/%s", attName), "")
+		RequireStatus(t, resp, http.StatusOK)
+		assert.Equal(t, attBody, resp.BodyBytes())
+
+		// Validate that the attachment hasn't been migrated to V2
+		v1Key := db.MakeAttachmentKey(1, "doc", digest)
+		v1Body, _, err := dataStore.GetRaw(v1Key)
+		require.NoError(t, err)
+		require.EqualValues(t, attBody, v1Body)
+
+		v2Key := db.MakeAttachmentKey(2, "doc", digest)
+		_, _, err = dataStore.GetRaw(v2Key)
+		require.Error(t, err)
+		// Confirm correct type of error for both integration test and Walrus
+		if !errors.Is(err, sgbucket.MissingError{Key: v2Key}) {
+			var keyValueErr *gocb.KeyValueError
+			require.True(t, errors.As(err, &keyValueErr))
+			//require.Equal(t, keyValueErr.StatusCode, memd.StatusKeyNotFound)
+			require.Equal(t, keyValueErr.DocumentID, v2Key)
+		}
+	})
 }
 
 // TestAttachmentComputeStat:
@@ -676,31 +719,33 @@ func TestAttachmentComputeStat(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-
-	opts := &BlipTesterClientOpts{}
-	opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, opts)
-	require.NoError(t, err)
-	defer btc.Close()
-	syncProcessCompute := btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
-
-	err = btc.StartPull()
-	assert.NoError(t, err)
 	const docID = "doc1"
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	// Create doc revision with attachment on SG.
-	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	version := rt.PutDoc(docID, bodyText)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	// Wait for the document to be replicated to client.
-	data, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	require.JSONEq(t, bodyTextExpected, string(data))
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	// assert the attachment read compute stat is incremented
-	require.Greater(t, btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncProcessCompute)
+		syncProcessCompute := btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
 
+		err := btcRunner.StartPull(btc.id)
+		assert.NoError(t, err)
+
+		// Create doc revision with attachment on SG.
+		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		version := btc.rt.PutDoc(docID, bodyText)
+
+		// Wait for the document to be replicated to client.
+		data, ok := btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, ok)
+		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		require.JSONEq(t, bodyTextExpected, string(data))
+
+		// assert the attachment read compute stat is incremented
+		require.Greater(t, btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncProcessCompute)
+	})
 }

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -28,322 +28,344 @@ func TestBlipGetCollections(t *testing.T) {
 	// checkpointIDWithError := "checkpointError"
 
 	const defaultScopeAndCollection = "_default._default"
-	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{GuestEnabled: true}, 1)
-	defer rt.Close()
+	rtConfig := &RestTesterConfig{GuestEnabled: true}
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt,
-		&BlipTesterClientOpts{
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTesterMultipleCollections(t, rtConfig, 1)
+		defer rt.Close()
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			SkipCollectionsInitialization: true,
-		},
-	)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	checkpointID1 := "checkpoint1"
-	checkpoint1Body := db.Body{"seq": "123"}
-	collection := rt.GetSingleTestDatabaseCollection()
-	scopeAndCollection := fmt.Sprintf("%s.%s", collection.ScopeName, collection.Name)
-	revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
-	require.NoError(t, err)
-	checkpoint1RevID := "0-1"
-	require.Equal(t, checkpoint1RevID, revID)
-	testCases := []struct {
-		name        string
-		requestBody db.GetCollectionsRequestBody
-		resultBody  []db.Body
-		errorCode   string
-	}{
-		{
-			name: "noDocInDefaultCollection",
-			requestBody: db.GetCollectionsRequestBody{
-				CheckpointIDs: []string{"id"},
-				Collections:   []string{defaultScopeAndCollection},
-			},
-			resultBody: []db.Body{nil},
-			errorCode:  "",
-		},
-		{
-			name: "mismatchedLengthOnInput",
-			requestBody: db.GetCollectionsRequestBody{
-				CheckpointIDs: []string{"id", "id2"},
-				Collections:   []string{defaultScopeAndCollection},
-			},
-			resultBody: []db.Body{nil},
-			errorCode:  fmt.Sprintf("%d", http.StatusBadRequest),
-		},
-		{
-			name: "inDefaultCollection",
-			requestBody: db.GetCollectionsRequestBody{
-				CheckpointIDs: []string{checkpointID1},
-				Collections:   []string{defaultScopeAndCollection},
-			},
-			resultBody: []db.Body{nil},
-			errorCode:  "",
-		},
-		{
-			name: "badScopeSpecificationEmptyString",
-			// bad scope specification - empty string
-			requestBody: db.GetCollectionsRequestBody{
-				CheckpointIDs: []string{checkpointID1},
-				Collections:   []string{""},
-			},
-			resultBody: []db.Body{nil},
-			errorCode:  fmt.Sprintf("%d", http.StatusBadRequest),
-		},
-		{
-			name: "presentNonDefaultCollection",
-			requestBody: db.GetCollectionsRequestBody{
-				CheckpointIDs: []string{checkpointID1},
-				Collections:   []string{scopeAndCollection},
-			},
-			resultBody: []db.Body{checkpoint1Body},
-			errorCode:  "",
-		},
-		{
-			name: "unseenInNonDefaultCollection",
-			requestBody: db.GetCollectionsRequestBody{
-				CheckpointIDs: []string{"id"},
-				Collections:   []string{scopeAndCollection},
-			},
-			resultBody: []db.Body{db.Body{}},
-			errorCode:  "",
-		},
-		// {
-		//	name: "checkpointExistsWithErrorInNonDefaultCollection",
-		//	requestBody: db.GetCollectionsRequestBody{
-		//		CheckpointIDs: []string{checkpointIDWithError},
-		//		Collections:   []string{scopeAndCollection},
-		//	},
-		//	resultBody: []db.Body{nil},
-		//	errorCode:  "",
-		// },
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			getCollectionsRequest, err := db.NewGetCollectionsMessage(testCase.requestBody)
-			require.NoError(t, err)
-
-			require.NoError(t, btc.pushReplication.sendMsg(getCollectionsRequest))
-
-			// Check that the response we got back was processed by the norev handler
-			resp := getCollectionsRequest.Response()
-			require.NotNil(t, resp)
-			errorCode, hasErrorCode := resp.Properties[db.BlipErrorCode]
-			require.Equal(t, hasErrorCode, testCase.errorCode != "", "Request returned unexpected error %+v", resp.Properties)
-			require.Equal(t, errorCode, testCase.errorCode)
-			if testCase.errorCode != "" {
-				return
-			}
-			var checkpoints []db.Body
-			err = resp.ReadJSONBody(&checkpoints)
-			require.NoErrorf(t, err, "Actual error %+v", checkpoints)
-
-			require.Equal(t, testCase.resultBody, checkpoints)
+			SupportedBLIPProtocols:        SupportedBLIPProtocols,
 		})
-	}
+		defer btc.Close()
+
+		checkpointID1 := "checkpoint1"
+		checkpoint1Body := db.Body{"seq": "123"}
+		collection := btc.rt.GetSingleTestDatabaseCollection()
+		scopeAndCollection := fmt.Sprintf("%s.%s", collection.ScopeName, collection.Name)
+		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
+		require.NoError(t, err)
+		checkpoint1RevID := "0-1"
+		require.Equal(t, checkpoint1RevID, revID)
+		testCases := []struct {
+			name        string
+			requestBody db.GetCollectionsRequestBody
+			resultBody  []db.Body
+			errorCode   string
+		}{
+			{
+				name: "noDocInDefaultCollection",
+				requestBody: db.GetCollectionsRequestBody{
+					CheckpointIDs: []string{"id"},
+					Collections:   []string{defaultScopeAndCollection},
+				},
+				resultBody: []db.Body{nil},
+				errorCode:  "",
+			},
+			{
+				name: "mismatchedLengthOnInput",
+				requestBody: db.GetCollectionsRequestBody{
+					CheckpointIDs: []string{"id", "id2"},
+					Collections:   []string{defaultScopeAndCollection},
+				},
+				resultBody: []db.Body{nil},
+				errorCode:  fmt.Sprintf("%d", http.StatusBadRequest),
+			},
+			{
+				name: "inDefaultCollection",
+				requestBody: db.GetCollectionsRequestBody{
+					CheckpointIDs: []string{checkpointID1},
+					Collections:   []string{defaultScopeAndCollection},
+				},
+				resultBody: []db.Body{nil},
+				errorCode:  "",
+			},
+			{
+				name: "badScopeSpecificationEmptyString",
+				// bad scope specification - empty string
+				requestBody: db.GetCollectionsRequestBody{
+					CheckpointIDs: []string{checkpointID1},
+					Collections:   []string{""},
+				},
+				resultBody: []db.Body{nil},
+				errorCode:  fmt.Sprintf("%d", http.StatusBadRequest),
+			},
+			{
+				name: "presentNonDefaultCollection",
+				requestBody: db.GetCollectionsRequestBody{
+					CheckpointIDs: []string{checkpointID1},
+					Collections:   []string{scopeAndCollection},
+				},
+				resultBody: []db.Body{checkpoint1Body},
+				errorCode:  "",
+			},
+			{
+				name: "unseenInNonDefaultCollection",
+				requestBody: db.GetCollectionsRequestBody{
+					CheckpointIDs: []string{"id"},
+					Collections:   []string{scopeAndCollection},
+				},
+				resultBody: []db.Body{db.Body{}},
+				errorCode:  "",
+			},
+			// {
+			//	name: "checkpointExistsWithErrorInNonDefaultCollection",
+			//	requestBody: db.GetCollectionsRequestBody{
+			//		CheckpointIDs: []string{checkpointIDWithError},
+			//		Collections:   []string{scopeAndCollection},
+			//	},
+			//	resultBody: []db.Body{nil},
+			//	errorCode:  "",
+			// },
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				getCollectionsRequest, err := db.NewGetCollectionsMessage(testCase.requestBody)
+				require.NoError(t, err)
+
+				require.NoError(t, btc.pushReplication.sendMsg(getCollectionsRequest))
+
+				// Check that the response we got back was processed by the norev handler
+				resp := getCollectionsRequest.Response()
+				require.NotNil(t, resp)
+				errorCode, hasErrorCode := resp.Properties[db.BlipErrorCode]
+				require.Equal(t, hasErrorCode, testCase.errorCode != "", "Request returned unexpected error %+v", resp.Properties)
+				require.Equal(t, errorCode, testCase.errorCode)
+				if testCase.errorCode != "" {
+					return
+				}
+				var checkpoints []db.Body
+				err = resp.ReadJSONBody(&checkpoints)
+				require.NoErrorf(t, err, "Actual error %+v", checkpoints)
+
+				require.Equal(t, testCase.resultBody, checkpoints)
+			})
+		}
+	})
 }
 
 func TestBlipReplicationNoDefaultCollection(t *testing.T) {
 	base.TestRequiresCollections(t)
 
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+		checkpointID1 := "checkpoint1"
+		checkpoint1Body := db.Body{"seq": "123"}
+		collection := btc.rt.GetSingleTestDatabaseCollection()
+		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
+		require.NoError(t, err)
+		checkpoint1RevID := "0-1"
+		require.Equal(t, checkpoint1RevID, revID)
+
+		subChangesRequest := blip.NewRequest()
+		subChangesRequest.SetProfile(db.MessageSubChanges)
+
+		require.NoError(t, btc.pullReplication.sendMsg(subChangesRequest))
+		resp := subChangesRequest.Response()
+		require.Equal(t, strconv.Itoa(http.StatusBadRequest), resp.Properties[db.BlipErrorCode])
 	})
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	checkpointID1 := "checkpoint1"
-	checkpoint1Body := db.Body{"seq": "123"}
-	collection := rt.GetSingleTestDatabaseCollection()
-	revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
-	require.NoError(t, err)
-	checkpoint1RevID := "0-1"
-	require.Equal(t, checkpoint1RevID, revID)
-
-	subChangesRequest := blip.NewRequest()
-	subChangesRequest.SetProfile(db.MessageSubChanges)
-
-	require.NoError(t, btc.pullReplication.sendMsg(subChangesRequest))
-	resp := subChangesRequest.Response()
-	require.Equal(t, strconv.Itoa(http.StatusBadRequest), resp.Properties[db.BlipErrorCode])
 }
 
 func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 	base.TestRequiresCollections(t)
 
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+
+		checkpointID1 := "checkpoint1"
+		checkpoint1Body := db.Body{"seq": "123"}
+		collection := btc.rt.GetSingleTestDatabaseCollection()
+		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
+		require.NoError(t, err)
+		checkpoint1RevID := "0-1"
+		require.Equal(t, checkpoint1RevID, revID)
+		getCollectionsRequest, err := db.NewGetCollectionsMessage(db.GetCollectionsRequestBody{
+			CheckpointIDs: []string{checkpointID1},
+			Collections:   []string{fmt.Sprintf("%s.%s", collection.ScopeName, collection.Name)},
+		})
+
+		require.NoError(t, err)
+
+		require.NoError(t, btc.pushReplication.sendMsg(getCollectionsRequest))
+
+		// Check that the response we got back was processed by the GetCollections
+		resp := getCollectionsRequest.Response()
+		require.NotNil(t, resp)
+		errorCode, hasErrorCode := resp.Properties[db.BlipErrorCode]
+		require.False(t, hasErrorCode)
+		require.Equal(t, errorCode, "")
+		var checkpoints []db.Body
+		err = resp.ReadJSONBody(&checkpoints)
+		require.NoErrorf(t, err, "Actual error %+v", checkpoints)
+		require.Equal(t, []db.Body{checkpoint1Body}, checkpoints)
+
+		// make sure other functions get called
+
+		requestGetCheckpoint := blip.NewRequest()
+		requestGetCheckpoint.SetProfile(db.MessageGetCheckpoint)
+		requestGetCheckpoint.Properties[db.BlipClient] = checkpointID1
+		requestGetCheckpoint.Properties[db.BlipCollection] = "0"
+		require.NoError(t, btc.pushReplication.sendMsg(requestGetCheckpoint))
+		resp = requestGetCheckpoint.Response()
+		require.NotNil(t, resp)
+		errorCode, hasErrorCode = resp.Properties[db.BlipErrorCode]
+		require.Equal(t, errorCode, "")
+		require.False(t, hasErrorCode)
+		var checkpoint db.Body
+		err = resp.ReadJSONBody(&checkpoint)
+		require.NoErrorf(t, err, "Actual error %+v", checkpoint)
+
+		require.Equal(t, db.Body{"seq": "123"}, checkpoint)
 	})
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	checkpointID1 := "checkpoint1"
-	checkpoint1Body := db.Body{"seq": "123"}
-	collection := rt.GetSingleTestDatabaseCollection()
-	revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
-	require.NoError(t, err)
-	checkpoint1RevID := "0-1"
-	require.Equal(t, checkpoint1RevID, revID)
-	getCollectionsRequest, err := db.NewGetCollectionsMessage(db.GetCollectionsRequestBody{
-		CheckpointIDs: []string{checkpointID1},
-		Collections:   []string{fmt.Sprintf("%s.%s", collection.ScopeName, collection.Name)},
-	})
-
-	require.NoError(t, err)
-
-	require.NoError(t, btc.pushReplication.sendMsg(getCollectionsRequest))
-
-	// Check that the response we got back was processed by the GetCollections
-	resp := getCollectionsRequest.Response()
-	require.NotNil(t, resp)
-	errorCode, hasErrorCode := resp.Properties[db.BlipErrorCode]
-	require.False(t, hasErrorCode)
-	require.Equal(t, errorCode, "")
-	var checkpoints []db.Body
-	err = resp.ReadJSONBody(&checkpoints)
-	require.NoErrorf(t, err, "Actual error %+v", checkpoints)
-	require.Equal(t, []db.Body{checkpoint1Body}, checkpoints)
-
-	// make sure other functions get called
-
-	requestGetCheckpoint := blip.NewRequest()
-	requestGetCheckpoint.SetProfile(db.MessageGetCheckpoint)
-	requestGetCheckpoint.Properties[db.BlipClient] = checkpointID1
-	requestGetCheckpoint.Properties[db.BlipCollection] = "0"
-	require.NoError(t, btc.pushReplication.sendMsg(requestGetCheckpoint))
-	resp = requestGetCheckpoint.Response()
-	require.NotNil(t, resp)
-	errorCode, hasErrorCode = resp.Properties[db.BlipErrorCode]
-	require.Equal(t, errorCode, "")
-	require.False(t, hasErrorCode)
-	var checkpoint db.Body
-	err = resp.ReadJSONBody(&checkpoint)
-	require.NoErrorf(t, err, "Actual error %+v", checkpoint)
-
-	require.Equal(t, db.Body{"seq": "123"}, checkpoint)
-
 }
 
 func TestCollectionsReplication(t *testing.T) {
 	base.TestRequiresCollections(t)
 
-	rt := NewRestTester(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	})
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
+	}
 	const docID = "doc1"
-	version := rt.PutDoc(docID, "{}")
-	require.NoError(t, rt.WaitForPendingChanges())
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcCollection := btc.SingleCollection()
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	err = btcCollection.StartOneshotPull()
-	require.NoError(t, err)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	_, ok := btcCollection.WaitForVersion(docID, version)
-	require.True(t, ok)
+		version := btc.rt.PutDoc(docID, "{}")
+		require.NoError(t, btc.rt.WaitForPendingChanges())
+
+		btcCollection := btcRunner.SingleCollection(btc.id)
+
+		err := btcCollection.StartOneshotPull()
+		require.NoError(t, err)
+
+		_, ok := btcCollection.WaitForVersion(docID, version)
+		require.True(t, ok)
+	})
 }
 
 func TestBlipReplicationMultipleCollections(t *testing.T) {
-	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	}, 2)
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
-	docName := "doc1"
-	body := `{"foo":"bar"}`
-	versions := make([]DocVersion, 0, len(rt.GetKeyspaces()))
-	for _, keyspace := range rt.GetKeyspaces() {
-		resp := rt.SendAdminRequest(http.MethodPut, "/"+keyspace+"/"+docName, `{"foo":"bar"}`)
-		RequireStatus(t, resp, http.StatusCreated)
-		versions = append(versions, DocVersionFromPutResponse(t, resp))
-
 	}
-	require.NoError(t, rt.WaitForPendingChanges())
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	// start all the clients first
-	for _, collectionClient := range btc.collectionClients {
-		require.NoError(t, collectionClient.StartPull())
-	}
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
+		defer rt.Close()
 
-	for i, collectionClient := range btc.collectionClients {
-		msg, ok := collectionClient.WaitForVersion(docName, versions[i])
-		require.True(t, ok)
-		require.Equal(t, body, string(msg))
-	}
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	for _, collectionClient := range btc.collectionClients {
-		resp, err := collectionClient.UnsubPullChanges()
-		assert.NoError(t, err, "Error unsubing: %+v", resp)
-	}
+		docName := "doc1"
+		body := `{"foo":"bar"}`
+		versions := make([]DocVersion, 0, len(btc.rt.GetKeyspaces()))
+		for _, keyspace := range btc.rt.GetKeyspaces() {
+			resp := btc.rt.SendAdminRequest(http.MethodPut, "/"+keyspace+"/"+docName, `{"foo":"bar"}`)
+			RequireStatus(t, resp, http.StatusCreated)
+			versions = append(versions, DocVersionFromPutResponse(t, resp))
+		}
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
+		// start all the clients first
+		for _, collectionClient := range btc.collectionClients {
+			require.NoError(t, collectionClient.StartPull())
+		}
+
+		for i, collectionClient := range btc.collectionClients {
+			msg, ok := collectionClient.WaitForVersion(docName, versions[i])
+			require.True(t, ok)
+			require.Equal(t, body, string(msg))
+		}
+
+		for _, collectionClient := range btc.collectionClients {
+			resp, err := collectionClient.UnsubPullChanges()
+			assert.NoError(t, err, "Error unsubing: %+v", resp)
+		}
+	})
 }
 
 func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
-	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
-	}, 2)
-	defer rt.Close()
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
+		defer rt.Close()
 
-	body := `{"foo":"bar"}`
-	collectionDocIDs := make(map[string][]string)
-	collectionVersions := make(map[string][]DocVersion)
-	require.Len(t, rt.GetKeyspaces(), 2)
-	for i, keyspace := range rt.GetKeyspaces() {
-		// intentionally create collections with different size replications to ensure one collection finishing won't cancel another one
-		docCount := 10
-		if i == 0 {
-			docCount = 1
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+
+		body := `{"foo":"bar"}`
+		collectionDocIDs := make(map[string][]string)
+		collectionVersions := make(map[string][]DocVersion)
+		require.Len(t, btc.rt.GetKeyspaces(), 2)
+		for i, keyspace := range btc.rt.GetKeyspaces() {
+			// intentionally create collections with different size replications to ensure one collection finishing won't cancel another one
+			docCount := 10
+			if i == 0 {
+				docCount = 1
+			}
+			blipName := btc.rt.getCollectionsForBLIP()[i]
+			for j := 0; j < docCount; j++ {
+				docName := fmt.Sprintf("doc%d", j)
+				resp := btc.rt.SendAdminRequest(http.MethodPut, "/"+keyspace+"/"+docName, body)
+				RequireStatus(t, resp, http.StatusCreated)
+
+				version := DocVersionFromPutResponse(t, resp)
+				collectionVersions[blipName] = append(collectionVersions[blipName], version)
+				collectionDocIDs[blipName] = append(collectionDocIDs[blipName], docName)
+			}
 		}
-		blipName := rt.getCollectionsForBLIP()[i]
-		for j := 0; j < docCount; j++ {
-			docName := fmt.Sprintf("doc%d", j)
-			resp := rt.SendAdminRequest(http.MethodPut, "/"+keyspace+"/"+docName, body)
-			RequireStatus(t, resp, http.StatusCreated)
+		require.NoError(t, btc.rt.WaitForPendingChanges())
 
-			version := DocVersionFromPutResponse(t, resp)
-			collectionVersions[blipName] = append(collectionVersions[blipName], version)
-			collectionDocIDs[blipName] = append(collectionDocIDs[blipName], docName)
+		// start all the clients first
+		for _, collectionClient := range btc.collectionClients {
+			require.NoError(t, collectionClient.StartOneshotPull())
 		}
-	}
-	require.NoError(t, rt.WaitForPendingChanges())
 
-	// start all the clients first
-	for _, collectionClient := range btc.collectionClients {
-		require.NoError(t, collectionClient.StartOneshotPull())
-	}
+		for _, collectionClient := range btc.collectionClients {
+			versions := collectionVersions[collectionClient.collection]
+			docIDs := collectionDocIDs[collectionClient.collection]
+			msg, ok := collectionClient.WaitForVersion(docIDs[len(docIDs)-1], versions[len(versions)-1])
+			require.True(t, ok)
+			require.Equal(t, body, string(msg))
+		}
 
-	for _, collectionClient := range btc.collectionClients {
-		versions := collectionVersions[collectionClient.collection]
-		docIDs := collectionDocIDs[collectionClient.collection]
-		msg, ok := collectionClient.WaitForVersion(docIDs[len(docIDs)-1], versions[len(versions)-1])
-		require.True(t, ok)
-		require.Equal(t, body, string(msg))
-	}
-
-	for _, collectionClient := range btc.collectionClients {
-		resp, err := collectionClient.UnsubPullChanges()
-		assert.NoError(t, err, "Error unsubing: %+v", resp)
-	}
-
+		for _, collectionClient := range btc.collectionClients {
+			resp, err := collectionClient.UnsubPullChanges()
+			assert.NoError(t, err, "Error unsubing: %+v", resp)
+		}
+	})
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1974,10 +1974,11 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		RequireStatus(t, resp, http.StatusCreated)
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:        "user",
-			Channels:        []string{"*"},
-			ClientDeltas:    false,
-			SendRevocations: true,
+			Username:               "user",
+			Channels:               []string{"*"},
+			ClientDeltas:           false,
+			SendRevocations:        true,
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
 		})
 		defer btc.Close()
 
@@ -2085,10 +2086,11 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		RequireStatus(t, resp, http.StatusCreated)
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:        "user",
-			Channels:        []string{"*"},
-			ClientDeltas:    false,
-			SendRevocations: true,
+			Username:               "user",
+			Channels:               []string{"*"},
+			ClientDeltas:           false,
+			SendRevocations:        true,
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
 		})
 		defer btc.Close()
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1836,64 +1836,73 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
-	client.ClientDeltas = true
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	err = client.StartPull()
-	assert.NoError(t, err)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+		client.ClientDeltas = true
 
-	const docID = "doc1"
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-	version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+		err := btcRunner.StartPull(client.id)
+		assert.NoError(t, err)
 
-	data, ok := client.WaitForVersion(docID, version1)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		const docID = "doc1"
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+		data, ok := btcRunner.WaitForVersion(client.id, docID, version1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	data, ok = client.WaitForVersion(docID, version2)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
+		version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
 
-	msg, ok := client.pullReplication.WaitForMessage(5)
-	assert.True(t, ok)
-	assert.Equal(t, version1.RevID, msg.Properties[db.RevMessageHistory]) // CBG-3268 update to use version
+		data, ok = btcRunner.WaitForVersion(client.id, docID, version2)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+
+		msg, ok := client.pullReplication.WaitForMessage(5)
+		assert.True(t, ok)
+		assert.Equal(t, version1.RevID, msg.Properties[db.RevMessageHistory]) // CBG-3268 update to use version
+	})
 }
 
 // Reproduces CBG-617 (a client using activeOnly for the initial replication, and then still expecting to get subsequent tombstones afterwards)
 func TestActiveOnlyContinuous(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-
+	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc1"
-	version := rt.PutDoc(docID, `{"test":true}`)
 
-	// start an initial pull
-	require.NoError(t, btc.StartPullSince("true", "0", "true"))
-	rev, found := btc.WaitForVersion(docID, version)
-	assert.True(t, found)
-	assert.Equal(t, `{"test":true}`, string(rev))
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	// delete the doc and make sure the client still gets the tombstone replicated
-	deletedVersion := rt.DeleteDocReturnVersion(docID, version)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	rev, found = btc.WaitForVersion(docID, deletedVersion)
-	assert.True(t, found)
-	assert.Equal(t, `{}`, string(rev))
+		version := rt.PutDoc(docID, `{"test":true}`)
+
+		// start an initial pull
+		require.NoError(t, btcRunner.StartPullSince(btc.id, "true", "0", "true"))
+		rev, found := btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, found)
+		assert.Equal(t, `{"test":true}`, string(rev))
+
+		// delete the doc and make sure the client still gets the tombstone replicated
+		deletedVersion := rt.DeleteDocReturnVersion(docID, version)
+
+		rev, found = btcRunner.WaitForVersion(btc.id, docID, deletedVersion)
+		assert.True(t, found)
+		assert.Equal(t, `{}`, string(rev))
+	})
 }
 
 // Test that exercises Sync Gateway's norev handler
@@ -1901,34 +1910,39 @@ func TestBlipNorev(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
-	defer rt.Close()
+	rtConfig := &RestTesterConfig{GuestEnabled: true}
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	norevMsg := db.NewNoRevMessage()
-	norevMsg.SetId("docid")
-	norevMsg.SetRev("1-a")
-	norevMsg.SetSequence(db.SequenceID{Seq: 50})
-	norevMsg.SetError("404")
-	norevMsg.SetReason("couldn't send xyz")
-	btc.addCollectionProperty(norevMsg.Message)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	// Couchbase Lite always sends noreply=true for norev messages
-	// but set to false so we can block waiting for a reply
-	norevMsg.SetNoReply(false)
+		norevMsg := db.NewNoRevMessage()
+		norevMsg.SetId("docid")
+		norevMsg.SetRev("1-a")
+		norevMsg.SetSequence(db.SequenceID{Seq: 50})
+		norevMsg.SetError("404")
+		norevMsg.SetReason("couldn't send xyz")
+		btc.addCollectionProperty(norevMsg.Message)
 
-	// Request that the handler used to process the message is sent back in the response
-	norevMsg.Properties[db.SGShowHandler] = "true"
+		// Couchbase Lite always sends noreply=true for norev messages
+		// but set to false so we can block waiting for a reply
+		norevMsg.SetNoReply(false)
 
-	assert.NoError(t, btc.pushReplication.sendMsg(norevMsg.Message))
+		// Request that the handler used to process the message is sent back in the response
+		norevMsg.Properties[db.SGShowHandler] = "true"
 
-	// Check that the response we got back was processed by the norev handler
-	resp := norevMsg.Response()
-	assert.NotNil(t, resp)
-	assert.Equal(t, "handleNoRev", resp.Properties[db.SGHandler])
+		assert.NoError(t, btc.pushReplication.sendMsg(norevMsg.Message))
+
+		// Check that the response we got back was processed by the norev handler
+		resp := norevMsg.Response()
+		assert.NotNil(t, resp)
+		assert.Equal(t, "handleNoRev", resp.Properties[db.SGHandler])
+	})
 }
 
 // TestNoRevSetSeq makes sure the correct string is used with the corresponding function
@@ -1949,99 +1963,102 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
-	RequireStatus(t, resp, http.StatusCreated)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+		defer rt.Close()
+		collection := rt.GetSingleTestDatabaseCollection()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username:        "user",
-		Channels:        []string{"*"},
-		ClientDeltas:    false,
-		SendRevocations: true,
-	})
-	require.NoError(t, err)
-	defer btc.Close()
+		resp := rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
+		RequireStatus(t, resp, http.StatusCreated)
 
-	const docID = "doc"
-	version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:        "user",
+			Channels:        []string{"*"},
+			ClientDeltas:    false,
+			SendRevocations: true,
+		})
+		defer btc.Close()
 
-	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, "doc", changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		const docID = "doc"
+		version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-
-	version = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
-
-	changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, docID, changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok = btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-
-	version = rt.UpdateDoc(docID, version, `{"channels": []}`)
-	const docMarker = "docmarker"
-	docMarkerVersion := rt.PutDoc(docMarker, `{"channels": ["!"]}`)
-
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
-	require.NoError(t, err)
-	assert.Len(t, changes.Results, 2)
-	assert.Equal(t, "doc", changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-	assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
-	assert.False(t, changes.Results[0].Revoked)
-	assert.Equal(t, "docmarker", changes.Results[1].ID)
-	RequireChangeRevVersion(t, docMarkerVersion, changes.Results[1].Changes[0])
-	assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
-	assert.False(t, changes.Results[1].Revoked)
-
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok = btc.WaitForVersion(docMarker, docMarkerVersion)
-	assert.True(t, ok)
-
-	messages := btc.pullReplication.GetMessages()
-
-	var highestMsgSeq uint32
-	var highestSeqMsg blip.Message
-	// Grab most recent changes message
-	for _, message := range messages {
-		messageBody, err := message.Body()
+		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		require.NoError(t, err)
-		if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
-			if highestMsgSeq < uint32(message.SerialNumber()) {
-				highestMsgSeq = uint32(message.SerialNumber())
-				highestSeqMsg = message
+		assert.Equal(t, 1, len(changes.Results))
+		assert.Equal(t, "doc", changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+
+		err = btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
+		_, ok := btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, ok)
+
+		version = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
+
+		changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(changes.Results))
+		assert.Equal(t, docID, changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+
+		err = btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
+		_, ok = btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, ok)
+
+		version = rt.UpdateDoc(docID, version, `{"channels": []}`)
+		const docMarker = "docmarker"
+		docMarkerVersion := rt.PutDoc(docMarker, `{"channels": ["!"]}`)
+
+		changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
+		require.NoError(t, err)
+		assert.Len(t, changes.Results, 2)
+		assert.Equal(t, "doc", changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
+		assert.False(t, changes.Results[0].Revoked)
+		assert.Equal(t, "docmarker", changes.Results[1].ID)
+		RequireChangeRevVersion(t, docMarkerVersion, changes.Results[1].Changes[0])
+		assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
+		assert.False(t, changes.Results[1].Revoked)
+
+		err = btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
+		_, ok = btcRunner.WaitForVersion(btc.id, docMarker, docMarkerVersion)
+		assert.True(t, ok)
+
+		messages := btc.pullReplication.GetMessages()
+
+		var highestMsgSeq uint32
+		var highestSeqMsg blip.Message
+		// Grab most recent changes message
+		for _, message := range messages {
+			messageBody, err := message.Body()
+			require.NoError(t, err)
+			if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
+				if highestMsgSeq < uint32(message.SerialNumber()) {
+					highestMsgSeq = uint32(message.SerialNumber())
+					highestSeqMsg = message
+				}
 			}
 		}
-	}
 
-	var messageBody []interface{}
-	err = highestSeqMsg.ReadJSONBody(&messageBody)
-	assert.NoError(t, err)
-	require.Len(t, messageBody, 3)
-	require.Len(t, messageBody[0], 4) // Rev 2 of doc, being sent as removal from channel A
-	require.Len(t, messageBody[1], 4) // Rev 3 of doc, being sent as removal from channel B
-	require.Len(t, messageBody[2], 3)
+		var messageBody []interface{}
+		err = highestSeqMsg.ReadJSONBody(&messageBody)
+		assert.NoError(t, err)
+		require.Len(t, messageBody, 3)
+		require.Len(t, messageBody[0], 4) // Rev 2 of doc, being sent as removal from channel A
+		require.Len(t, messageBody[1], 4) // Rev 3 of doc, being sent as removal from channel B
+		require.Len(t, messageBody[2], 3)
 
-	deletedFlags, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
-	id := messageBody[0].([]interface{})[1]
-	require.NoError(t, err)
-	assert.Equal(t, "doc", id)
-	assert.Equal(t, int64(4), deletedFlags)
+		deletedFlags, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
+		id := messageBody[0].([]interface{})[1]
+		require.NoError(t, err)
+		assert.Equal(t, "doc", id)
+		assert.Equal(t, int64(4), deletedFlags)
+	})
 }
 
 // TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication tests the following scenario:
@@ -2057,91 +2074,94 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	resp := rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
-	RequireStatus(t, resp, http.StatusCreated)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+		defer rt.Close()
+		collection := rt.GetSingleTestDatabaseCollection()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username:        "user",
-		Channels:        []string{"*"},
-		ClientDeltas:    false,
-		SendRevocations: true,
-	})
-	require.NoError(t, err)
-	defer btc.Close()
+		resp := rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "test", "", collection, []string{"A", "B"}, nil))
+		RequireStatus(t, resp, http.StatusCreated)
 
-	const (
-		docID = "doc"
-	)
-	version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:        "user",
+			Channels:        []string{"*"},
+			ClientDeltas:    false,
+			SendRevocations: true,
+		})
+		defer btc.Close()
 
-	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, docID, changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		const (
+			docID = "doc"
+		)
+		version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
-	err = btc.StartOneshotPull()
-	assert.NoError(t, err)
-	_, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-
-	version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
-	require.NoError(t, rt.WaitForPendingChanges())
-	// At this point changes should send revocation, as document isn't in any of the user's channels
-	changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, docID, changes.Results[0].ID)
-	RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
-
-	err = btc.StartOneshotPullFiltered("A")
-	assert.NoError(t, err)
-	_, ok = btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
-
-	_ = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
-	markerID := "docmarker"
-	markerVersion := rt.PutDoc(markerID, `{"channels": ["A"]}`)
-	require.NoError(t, rt.WaitForPendingChanges())
-
-	// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
-	changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
-	require.NoError(t, err)
-	assert.Len(t, changes.Results, 2) // _changes still gets two results, as we don't support 3.0 removal handling over REST API
-	assert.Equal(t, "doc", changes.Results[0].ID)
-	assert.Equal(t, markerID, changes.Results[1].ID)
-
-	err = btc.StartOneshotPullFiltered("A")
-	assert.NoError(t, err)
-	_, ok = btc.WaitForVersion(markerID, markerVersion)
-	assert.True(t, ok)
-
-	messages := btc.pullReplication.GetMessages()
-
-	var highestMsgSeq uint32
-	var highestSeqMsg blip.Message
-	// Grab most recent changes message
-	for _, message := range messages {
-		messageBody, err := message.Body()
+		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		require.NoError(t, err)
-		if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
-			if highestMsgSeq < uint32(message.SerialNumber()) {
-				highestMsgSeq = uint32(message.SerialNumber())
-				highestSeqMsg = message
+		assert.Equal(t, 1, len(changes.Results))
+		assert.Equal(t, docID, changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+
+		err = btcRunner.StartOneshotPull(btc.id)
+		assert.NoError(t, err)
+		_, ok := btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, ok)
+
+		version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
+		require.NoError(t, rt.WaitForPendingChanges())
+		// At this point changes should send revocation, as document isn't in any of the user's channels
+		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(changes.Results))
+		assert.Equal(t, docID, changes.Results[0].ID)
+		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+
+		err = btcRunner.StartOneshotPullFiltered(btc.id, "A")
+		assert.NoError(t, err)
+		_, ok = btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, ok)
+
+		_ = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
+		markerID := "docmarker"
+		markerVersion := rt.PutDoc(markerID, `{"channels": ["A"]}`)
+		require.NoError(t, rt.WaitForPendingChanges())
+
+		// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
+		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
+		require.NoError(t, err)
+		assert.Len(t, changes.Results, 2) // _changes still gets two results, as we don't support 3.0 removal handling over REST API
+		assert.Equal(t, "doc", changes.Results[0].ID)
+		assert.Equal(t, markerID, changes.Results[1].ID)
+
+		err = btcRunner.StartOneshotPullFiltered(btc.id, "A")
+		assert.NoError(t, err)
+		_, ok = btcRunner.WaitForVersion(btc.id, markerID, markerVersion)
+		assert.True(t, ok)
+
+		messages := btc.pullReplication.GetMessages()
+
+		var highestMsgSeq uint32
+		var highestSeqMsg blip.Message
+		// Grab most recent changes message
+		for _, message := range messages {
+			messageBody, err := message.Body()
+			require.NoError(t, err)
+			if message.Properties["Profile"] == db.MessageChanges && string(messageBody) != "null" {
+				if highestMsgSeq < uint32(message.SerialNumber()) {
+					highestMsgSeq = uint32(message.SerialNumber())
+					highestSeqMsg = message
+				}
 			}
 		}
-	}
 
-	var messageBody []interface{}
-	err = highestSeqMsg.ReadJSONBody(&messageBody)
-	assert.NoError(t, err)
-	require.Len(t, messageBody, 1)
-	require.Len(t, messageBody[0], 3) // marker doc
-	require.Equal(t, "docmarker", messageBody[0].([]interface{})[1])
+		var messageBody []interface{}
+		err = highestSeqMsg.ReadJSONBody(&messageBody)
+		assert.NoError(t, err)
+		require.Len(t, messageBody, 1)
+		require.Len(t, messageBody[0], 3) // marker doc
+		require.Equal(t, "docmarker", messageBody[0].([]interface{})[1])
+	})
 }
 
 // Make sure that a client cannot open multiple subChanges subscriptions on a single blip context (SG #3222)
@@ -2361,54 +2381,58 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 		},
 	}
 
-	// Setup
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			GuestEnabled: true,
-		})
-	defer rt.Close()
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		// Setup
+		rt := NewRestTester(t,
+			&RestTesterConfig{
+				GuestEnabled: true,
+			})
+		defer rt.Close()
 
-	// Track last sequence for next changes feed
-	var changes ChangesResults
-	changes.Last_Seq = "0"
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
 
-	for i, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			docID := fmt.Sprintf("test%d", i)
-			rawBody, err := json.Marshal(test.inputBody)
-			require.NoError(t, err)
+		// Track last sequence for next changes feed
+		var changes ChangesResults
+		changes.Last_Seq = "0"
 
-			_, err = client.PushRev(docID, EmptyDocVersion(), rawBody)
+		for i, test := range testCases {
+			t.Run(test.name, func(t *testing.T) {
+				docID := fmt.Sprintf("test%d", i)
+				rawBody, err := json.Marshal(test.inputBody)
+				require.NoError(t, err)
 
-			if test.expectReject {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
+				_, err = btcRunner.PushRev(client.id, docID, EmptyDocVersion(), rawBody)
 
-			// Wait for rev to be received on RT
-			err = rt.WaitForPendingChanges()
-			require.NoError(t, err)
-			changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "", true)
-			require.NoError(t, err)
-
-			var bucketDoc map[string]interface{}
-			_, err = rt.GetSingleDataStore().Get(docID, &bucketDoc)
-			assert.NoError(t, err)
-			body := rt.GetDocBody(docID)
-			// Confirm input body is in the bucket doc
-			if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
-				for k, v := range test.inputBody {
-					assert.Equal(t, v, bucketDoc[k])
-					assert.Equal(t, v, body[k])
+				if test.expectReject {
+					assert.Error(t, err)
+					return
 				}
-			}
-		})
-	}
+				assert.NoError(t, err)
+
+				// Wait for rev to be received on RT
+				err = rt.WaitForPendingChanges()
+				require.NoError(t, err)
+				changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "", true)
+				require.NoError(t, err)
+
+				var bucketDoc map[string]interface{}
+				_, err = rt.GetSingleDataStore().Get(docID, &bucketDoc)
+				assert.NoError(t, err)
+				body := rt.GetDocBody(docID)
+				// Confirm input body is in the bucket doc
+				if test.skipDocContentsVerification == nil || !*test.skipDocContentsVerification {
+					for k, v := range test.inputBody {
+						assert.Equal(t, v, bucketDoc[k])
+						assert.Equal(t, v, body[k])
+					}
+				}
+			})
+		}
+	})
 }
 
 // CBG-2053: Test that the handleRev stats still increment correctly when going through the processRev function with
@@ -2541,120 +2565,129 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 			expectNoRev: false,
 		},
 	}
-	for _, test := range testCases {
-		t.Run(fmt.Sprintf("%s", test.error), func(t *testing.T) {
-			docName := fmt.Sprintf("%s", test.error)
-			rt := NewRestTester(t,
-				&RestTesterConfig{
-					GuestEnabled:     true,
-					CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		for _, test := range testCases {
+			t.Run(fmt.Sprintf("%s", test.error), func(t *testing.T) {
+				docName := fmt.Sprintf("%s", test.error)
+				rt := NewRestTester(t,
+					&RestTesterConfig{
+						GuestEnabled:     true,
+						CustomTestBucket: base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{}),
+					})
+				defer rt.Close()
+
+				leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())
+				require.True(t, ok)
+
+				opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+				defer btc.Close()
+
+				// Change noRev handler so it's known when a noRev is received
+				recievedNoRevs := make(chan *blip.Message)
+				btc.pullReplication.bt.blipContext.HandlerForProfile[db.MessageNoRev] = func(msg *blip.Message) {
+					fmt.Println("Received noRev", msg.Properties)
+					recievedNoRevs <- msg
+				}
+
+				version := rt.PutDoc(docName, `{"foo":"bar"}`)
+
+				// Make the LeakyBucket return an error
+				leakyDataStore.SetGetRawCallback(func(key string) error {
+					return test.error
 				})
-			defer rt.Close()
+				leakyDataStore.SetGetWithXattrCallback(func(key string) error {
+					return test.error
+				})
 
-			leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())
-			require.True(t, ok)
+				// Flush cache so document has to be retrieved from the leaky bucket
+				rt.GetSingleTestDatabaseCollection().FlushRevisionCacheForTest()
 
-			btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-			require.NoError(t, err)
-			defer btc.Close()
+				err := btcRunner.StartPull(btc.id)
+				require.NoError(t, err)
 
-			// Change noRev handler so it's known when a noRev is received
-			recievedNoRevs := make(chan *blip.Message)
-			btc.pullReplication.bt.blipContext.HandlerForProfile[db.MessageNoRev] = func(msg *blip.Message) {
-				fmt.Println("Received noRev", msg.Properties)
-				recievedNoRevs <- msg
-			}
-
-			version := rt.PutDoc(docName, `{"foo":"bar"}`)
-
-			// Make the LeakyBucket return an error
-			leakyDataStore.SetGetRawCallback(func(key string) error {
-				return test.error
-			})
-			leakyDataStore.SetGetWithXattrCallback(func(key string) error {
-				return test.error
-			})
-
-			// Flush cache so document has to be retrieved from the leaky bucket
-			rt.GetSingleTestDatabaseCollection().FlushRevisionCacheForTest()
-
-			err = btc.StartPull()
-			require.NoError(t, err)
-
-			// Wait 3 seconds for noRev to be received
-			select {
-			case msg := <-recievedNoRevs:
-				if test.expectNoRev {
-					assert.Equal(t, docName, msg.Properties["id"])
-				} else {
-					require.Fail(t, "Received unexpected noRev message", msg)
+				// Wait 3 seconds for noRev to be received
+				select {
+				case msg := <-recievedNoRevs:
+					if test.expectNoRev {
+						assert.Equal(t, docName, msg.Properties["id"])
+					} else {
+						require.Fail(t, "Received unexpected noRev message", msg)
+					}
+				case <-time.After(3 * time.Second):
+					if test.expectNoRev {
+						require.Fail(t, "Didn't receive expected noRev")
+					}
 				}
-			case <-time.After(3 * time.Second):
-				if test.expectNoRev {
-					require.Fail(t, "Didn't receive expected noRev")
-				}
-			}
 
-			// Make sure document did not get replicated
-			_, found := btc.GetVersion(docName, version)
-			assert.False(t, found)
-		})
-	}
+				// Make sure document did not get replicated
+				_, found := btcRunner.GetVersion(btc.id, docName, version)
+				assert.False(t, found)
+			})
+		}
+	})
 }
 
 func TestUnsubChanges(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
+	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
-	defer rt.Close()
-
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
-	// Confirm no error message or panic is returned in response
-	response, err := btc.UnsubPullChanges()
-	assert.NoError(t, err)
-	assert.Empty(t, response)
-
-	// Sub changes
-	err = btc.StartPull()
-	require.NoError(t, err)
+	btcRunner := NewBlipTesterClientRunner(t)
 	const (
 		doc1ID = "doc1ID"
 		doc2ID = "doc2ID"
 	)
-	doc1Version := rt.PutDoc(doc1ID, `{"key":"val1"}`)
-	_, found := btc.WaitForVersion(doc1ID, doc1Version)
-	require.True(t, found)
 
-	activeReplStat := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplActiveContinuous
-	require.EqualValues(t, 1, activeReplStat.Value())
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	// Unsub changes
-	response, err = btc.UnsubPullChanges()
-	assert.NoError(t, err)
-	assert.Empty(t, response)
-	// Wait for unsub changes to stop the sub changes being sent before sending document up
-	base.RequireWaitForStat(t, activeReplStat.Value, 0)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+		// Confirm no error message or panic is returned in response
+		response, err := btcRunner.UnsubPullChanges(btc.id)
+		assert.NoError(t, err)
+		assert.Empty(t, response)
 
-	// Confirm no more changes are being sent
-	doc2Version := rt.PutDoc(doc2ID, `{"key":"val1"}`)
-	err = rt.WaitForConditionWithOptions(func() bool {
-		_, found = btc.GetVersion("doc2", doc2Version)
-		return found
-	}, 10, 100)
-	assert.Error(t, err)
+		// Sub changes
+		err = btcRunner.StartPull(btc.id)
+		require.NoError(t, err)
 
-	// Confirm no error message is still returned when no subchanges active
-	response, err = btc.UnsubPullChanges()
-	assert.NoError(t, err)
-	assert.Empty(t, response)
+		doc1Version := rt.PutDoc(doc1ID, `{"key":"val1"}`)
+		_, found := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
+		require.True(t, found)
 
-	// Confirm the pull replication can be restarted and it syncs doc2
-	err = btc.StartPull()
-	require.NoError(t, err)
-	_, found = btc.WaitForVersion(doc2ID, doc2Version)
-	assert.True(t, found)
+		activeReplStat := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplActiveContinuous
+		require.EqualValues(t, 1, activeReplStat.Value())
+
+		// Unsub changes
+		response, err = btcRunner.UnsubPullChanges(btc.id)
+		assert.NoError(t, err)
+		assert.Empty(t, response)
+		// Wait for unsub changes to stop the sub changes being sent before sending document up
+		base.RequireWaitForStat(t, activeReplStat.Value, 0)
+
+		// Confirm no more changes are being sent
+		doc2Version := rt.PutDoc(doc2ID, `{"key":"val1"}`)
+		err = rt.WaitForConditionWithOptions(func() bool {
+			_, found = btcRunner.GetVersion(btc.id, "doc2", doc2Version)
+			return found
+		}, 10, 100)
+		assert.Error(t, err)
+
+		// Confirm no error message is still returned when no subchanges active
+		response, err = btcRunner.UnsubPullChanges(btc.id)
+		assert.NoError(t, err)
+		assert.Empty(t, response)
+
+		// Confirm the pull replication can be restarted and it syncs doc2
+		err = btcRunner.StartPull(btc.id)
+		require.NoError(t, err)
+		_, found = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
+		assert.True(t, found)
+	})
 }
 
 // TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the replication.
@@ -2671,47 +2704,49 @@ func TestRequestPlusPull(t *testing.T) {
 				}
 			}`,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-	database := rt.GetDatabase()
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+		database := rt.GetDatabase()
 
-	// Initialize blip tester client (will create user)
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username: "bernard",
+		// Initialize blip tester client (will create user)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "bernard",
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer client.Close()
+
+		// Put a doc in channel PBS
+		response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+		RequireStatus(t, response, 201)
+
+		// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+		slowSequence, seqErr := db.AllocateTestSequence(database)
+		require.NoError(t, seqErr)
+
+		// Write a document granting user 'bernard' access to PBS
+		response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+		RequireStatus(t, response, 201)
+
+		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+
+		// Start a regular one-shot pull
+		err := btcRunner.StartOneshotPullRequestPlus(client.id)
+		assert.NoError(t, err)
+
+		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+		require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
+
+		// Release the slow sequence
+		releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
+		require.NoError(t, releaseErr)
+
+		// The one-shot pull should unblock and replicate the document in the granted channel
+		data, ok := btcRunner.WaitForDoc(client.id, "pbs-1")
+		assert.True(t, ok)
+		assert.Equal(t, `{"channel":["PBS"]}`, string(data))
 	})
-	require.NoError(t, err)
-	defer client.Close()
-
-	// Put a doc in channel PBS
-	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
-	RequireStatus(t, response, 201)
-
-	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
-	slowSequence, seqErr := db.AllocateTestSequence(database)
-	require.NoError(t, seqErr)
-
-	// Write a document granting user 'bernard' access to PBS
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
-	RequireStatus(t, response, 201)
-
-	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
-
-	// Start a regular one-shot pull
-	err = client.StartOneshotPullRequestPlus()
-	assert.NoError(t, err)
-
-	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
-	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
-
-	// Release the slow sequence
-	releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
-	require.NoError(t, releaseErr)
-
-	// The one-shot pull should unblock and replicate the document in the granted channel
-	data, ok := client.WaitForDoc("pbs-1")
-	assert.True(t, ok)
-	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
-
 }
 
 // TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the db config.
@@ -2733,47 +2768,50 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 			},
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-	database := rt.GetDatabase()
 
-	// Initialize blip tester client (will create user)
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username: "bernard",
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+		database := rt.GetDatabase()
+
+		// Initialize blip tester client (will create user)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "bernard",
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer client.Close()
+
+		// Put a doc in channel PBS
+		response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
+		RequireStatus(t, response, 201)
+
+		// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
+		slowSequence, seqErr := db.AllocateTestSequence(database)
+		require.NoError(t, seqErr)
+
+		// Write a document granting user 'bernard' access to PBS
+		response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
+		RequireStatus(t, response, 201)
+
+		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
+
+		// Start a regular one-shot pull
+		err := btcRunner.StartOneshotPull(client.id)
+		assert.NoError(t, err)
+
+		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
+		require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
+
+		// Release the slow sequence
+		releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
+		require.NoError(t, releaseErr)
+
+		// The one-shot pull should unblock and replicate the document in the granted channel
+		data, ok := btcRunner.WaitForDoc(client.id, "pbs-1")
+		assert.True(t, ok)
+		assert.Equal(t, `{"channel":["PBS"]}`, string(data))
 	})
-	require.NoError(t, err)
-	defer client.Close()
-
-	// Put a doc in channel PBS
-	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-1", `{"channel":["PBS"]}`)
-	RequireStatus(t, response, 201)
-
-	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
-	slowSequence, seqErr := db.AllocateTestSequence(database)
-	require.NoError(t, seqErr)
-
-	// Write a document granting user 'bernard' access to PBS
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"bernard", "accessChannel":"PBS"}`)
-	RequireStatus(t, response, 201)
-
-	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
-
-	// Start a regular one-shot pull
-	err = client.StartOneshotPull()
-	assert.NoError(t, err)
-
-	// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
-	require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
-
-	// Release the slow sequence
-	releaseErr := db.ReleaseTestSequence(base.TestCtx(t), database, slowSequence)
-	require.NoError(t, releaseErr)
-
-	// The one-shot pull should unblock and replicate the document in the granted channel
-	data, ok := client.WaitForDoc("pbs-1")
-	assert.True(t, ok)
-	assert.Equal(t, `{"channel":["PBS"]}`, string(data))
-
 }
 
 // TestBlipRefreshUser makes sure there is no panic if a user gets deleted during a replication
@@ -2794,53 +2832,56 @@ func TestBlipRefreshUser(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-
-	const username = "bernard"
-	// Initialize blip tester client (will create user)
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username: "bernard",
-		Channels: []string{"chan1"},
-	})
-
-	require.NoError(t, err)
-	defer btc.Close()
-
-	// add chan1 explicitly
-	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB, "", RestTesterDefaultUserPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"chan1"}, nil))
-	RequireStatus(t, response, http.StatusOK)
-
 	const docID = "doc1"
-	version := rt.PutDoc(docID, `{"channels":["chan1"]}`)
 
-	// Start a regular one-shot pull
-	err = btc.StartPullSince("true", "0", "false")
-	require.NoError(t, err)
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	_, ok := btc.WaitForDoc(docID)
-	require.True(t, ok)
+		const username = "bernard"
+		// Initialize blip tester client (will create user)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "bernard",
+			Channels:               []string{"chan1"},
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer btc.Close()
 
-	_, ok = btc.GetVersion(docID, version)
-	require.True(t, ok)
+		// add chan1 explicitly
+		response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB, "", RestTesterDefaultUserPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"chan1"}, nil))
+		RequireStatus(t, response, http.StatusOK)
 
-	// delete user with an active blip connection
-	response = rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_user/"+username, "")
-	RequireStatus(t, response, http.StatusOK)
+		version := rt.PutDoc(docID, `{"channels":["chan1"]}`)
 
-	require.NoError(t, rt.WaitForPendingChanges())
+		// Start a regular one-shot pull
+		err := btcRunner.StartPullSince(btc.id, "true", "0", "false")
+		require.NoError(t, err)
 
-	// further requests will 500, but shouldn't panic
-	unsubChangesRequest := blip.NewRequest()
-	unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
-	btc.addCollectionProperty(unsubChangesRequest)
+		_, ok := btcRunner.WaitForDoc(btc.id, docID)
+		require.True(t, ok)
 
-	err = btc.pullReplication.sendMsg(unsubChangesRequest)
-	require.NoError(t, err)
+		_, ok = btcRunner.GetVersion(btc.id, docID, version)
+		require.True(t, ok)
 
-	testResponse := unsubChangesRequest.Response()
-	require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), testResponse.Properties[db.BlipErrorCode])
-	body, err := testResponse.Body()
-	require.NoError(t, err)
-	require.NotContains(t, string(body), "Panic:")
+		// delete user with an active blip connection
+		response = rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_user/"+username, "")
+		RequireStatus(t, response, http.StatusOK)
+
+		require.NoError(t, rt.WaitForPendingChanges())
+
+		// further requests will 500, but shouldn't panic
+		unsubChangesRequest := blip.NewRequest()
+		unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
+		btc.addCollectionProperty(unsubChangesRequest)
+
+		err = btc.pullReplication.sendMsg(unsubChangesRequest)
+		require.NoError(t, err)
+
+		testResponse := unsubChangesRequest.Response()
+		require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), testResponse.Properties[db.BlipErrorCode])
+		body, err := testResponse.Body()
+		require.NoError(t, err)
+		require.NotContains(t, string(body), "Panic:")
+	})
 }

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -435,7 +435,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipVersionVectorInitialization = true
+	btcRunner.SkipVersionVectorInitialization = true // v2 protocol test
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -30,60 +30,63 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.BoolPtr(true),
+			},
+		}},
+		GuestEnabled: true,
+	}
 
 	const docID = "pushAttachmentDoc"
 
-	rt := NewRestTester(t,
-		&RestTesterConfig{
-			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-				DeltaSync: &DeltaSyncConfig{
-					Enabled: base.BoolPtr(true),
-				},
-			}},
-			GuestEnabled: true,
-		})
-	defer rt.Close()
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	// Push first rev
-	version, err := btc.PushRev(docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
-	require.NoError(t, err)
+		// Push first rev
+		version, err := btcRunner.PushRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
+		require.NoError(t, err)
 
-	// Push second rev with an attachment (no delta yet)
-	attData := base64.StdEncoding.EncodeToString([]byte("attach"))
+		// Push second rev with an attachment (no delta yet)
+		attData := base64.StdEncoding.EncodeToString([]byte("attach"))
 
-	version, err = btc.PushRev(docID, version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
-	require.NoError(t, err)
+		version, err = btcRunner.PushRev(btc.id, docID, version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
+		require.NoError(t, err)
 
-	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
-	require.NoError(t, err)
+		syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
+		require.NoError(t, err)
 
-	assert.Len(t, syncData.Attachments, 1)
-	_, found := syncData.Attachments["myAttachment"]
-	assert.True(t, found)
+		assert.Len(t, syncData.Attachments, 1)
+		_, found := syncData.Attachments["myAttachment"]
+		assert.True(t, found)
 
-	// Turn deltas on
-	btc.ClientDeltas = true
+		// Turn deltas on
+		btc.ClientDeltas = true
 
-	// Get existing body with the stub attachment, insert a new property and push as delta.
-	body, found := btc.GetVersion(docID, version)
-	require.True(t, found)
+		// Get existing body with the stub attachment, insert a new property and push as delta.
+		body, found := btcRunner.GetVersion(btc.id, docID, version)
+		require.True(t, found)
 
-	newBody, err := base.InjectJSONPropertiesFromBytes(body, base.KVPairBytes{Key: "update", Val: []byte(`true`)})
-	require.NoError(t, err)
+		newBody, err := base.InjectJSONPropertiesFromBytes(body, base.KVPairBytes{Key: "update", Val: []byte(`true`)})
+		require.NoError(t, err)
 
-	_, err = btc.PushRev(docID, version, newBody)
-	require.NoError(t, err)
+		_, err = btcRunner.PushRev(btc.id, docID, version, newBody)
+		require.NoError(t, err)
 
-	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
-	require.NoError(t, err)
+		syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
+		require.NoError(t, err)
 
-	assert.Len(t, syncData.Attachments, 1)
-	_, found = syncData.Attachments["myAttachment"]
-	assert.True(t, found)
+		assert.Len(t, syncData.Attachments, 1)
+		_, found = syncData.Attachments["myAttachment"]
+		assert.True(t, found)
+	})
 }
 
 // Test pushing and pulling new attachments through delta sync
@@ -106,59 +109,63 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer btc.Close()
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	btc.ClientDeltas = true
-	err = btc.StartPull()
-	assert.NoError(t, err)
-	const docID = "doc1"
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
 
-	// Create doc1 rev 1-77d9041e49931ceef58a1eef5fd032e8 on SG with an attachment
-	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-	version := rt.PutDoc(docID, bodyText)
-	data, ok := btc.WaitForVersion(docID, version)
-	assert.True(t, ok)
+		btc.ClientDeltas = true
+		err := btcRunner.StartPull(btc.id)
+		assert.NoError(t, err)
+		const docID = "doc1"
 
-	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-	require.JSONEq(t, bodyTextExpected, string(data))
+		// Create doc1 rev 1-77d9041e49931ceef58a1eef5fd032e8 on SG with an attachment
+		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+		version := rt.PutDoc(docID, bodyText)
+		data, ok := btcRunner.WaitForVersion(btc.id, docID, version)
+		assert.True(t, ok)
 
-	// Update the replicated doc at client by adding another attachment.
-	bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="},"world.txt":{"data":"bGVsbG8gd29ybGQ="}}}`
-	version, err = btc.PushRev(docID, version, []byte(bodyText))
-	require.NoError(t, err)
+		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+		require.JSONEq(t, bodyTextExpected, string(data))
 
-	// Wait for the document to be replicated at SG
-	_, ok = btc.pushReplication.WaitForMessage(2)
-	assert.True(t, ok)
+		// Update the replicated doc at client by adding another attachment.
+		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="},"world.txt":{"data":"bGVsbG8gd29ybGQ="}}}`
+		version, err = btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
+		require.NoError(t, err)
 
-	respBody := rt.GetDocVersion(docID, version)
+		// Wait for the document to be replicated at SG
+		_, ok = btc.pushReplication.WaitForMessage(2)
+		assert.True(t, ok)
 
-	assert.Equal(t, docID, respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 1)
-	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
+		respBody := rt.GetDocVersion(docID, version)
 
-	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, attachments, 2)
-	hello, ok := attachments["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(1), hello["revpos"])
-	assert.Equal(t, true, hello["stub"])
+		assert.Equal(t, docID, respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 1)
+		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
 
-	world, ok := attachments["world.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-qiF39gVoGPFzpRQkNYcY9u3wx9Y=", world["digest"])
-	assert.Equal(t, float64(11), world["length"])
-	assert.Equal(t, float64(2), world["revpos"])
-	assert.Equal(t, true, world["stub"])
+		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, attachments, 2)
+		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(1), hello["revpos"])
+		assert.Equal(t, true, hello["stub"])
+
+		world, ok := attachments["world.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-qiF39gVoGPFzpRQkNYcY9u3wx9Y=", world["digest"])
+		assert.Equal(t, float64(11), world["length"])
+		assert.Equal(t, float64(2), world["revpos"])
+		assert.Equal(t, true, world["stub"])
+	})
 }
 
 // TestBlipDeltaSyncNewAttachmentPull tests that adding a new attachment in SG and replicated via delta sync adds the attachment
@@ -175,84 +182,88 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
-
-	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-
+	btcRunner := NewBlipTesterClientRunner(t)
 	const doc1ID = "doc1"
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-	version := rt.PutDoc(doc1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok := client.WaitForVersion(doc1ID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	// create doc1 rev 2-10000d5ec533b29b117e60274b1e3653 on SG with the first attachment
-	version = rt.UpdateDoc(doc1ID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
 
-	data, ok = client.WaitForVersion(doc1ID, version)
-	assert.True(t, ok)
-	var dataMap map[string]interface{}
-	assert.NoError(t, base.JSONUnmarshal(data, &dataMap))
-	atts, ok := dataMap[db.BodyAttachments].(map[string]interface{})
-	require.True(t, ok)
-	assert.Len(t, atts, 1)
-	hello, ok := atts["hello.txt"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(2), hello["revpos"])
-	assert.Equal(t, true, hello["stub"])
-
-	// message #3 is the getAttachment message that is sent in-between rev processing
-	msg, ok := client.pullReplication.WaitForMessage(3)
-	assert.True(t, ok)
-	assert.NotEqual(t, blip.ErrorType, msg.Type(), "Expected non-error blip message type")
-
-	// Check EE is delta, and CE is full-body replication
-	// msg, ok = client.pullReplication.WaitForMessage(5)
-	msg, ok = client.WaitForBlipRevMessage(doc1ID, version)
-	assert.True(t, ok)
-
-	if base.IsEnterpriseEdition() {
-		// Check the request was sent with the correct deltaSrc property
-		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was the actual delta
-		msgBody, err := msg.Body()
+		client.ClientDeltas = true
+		err := btcRunner.StartPull(client.id)
 		assert.NoError(t, err)
-		assert.Equal(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
-	} else {
-		// Check the request was NOT sent with a deltaSrc property
-		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was NOT the delta
-		msgBody, err := msg.Body()
-		assert.NoError(t, err)
-		assert.NotEqual(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
-		assert.Contains(t, string(msgBody), `"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}`)
-		assert.Contains(t, string(msgBody), `"greetings":[{"hello":"world!"},{"hi":"alice"}]`)
-	}
 
-	respBody := rt.GetDocVersion(doc1ID, version)
-	assert.Equal(t, doc1ID, respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 2)
-	assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
-	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
-	atts = respBody[db.BodyAttachments].(map[string]interface{})
-	assert.Len(t, atts, 1)
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(2), hello["revpos"])
-	assert.Equal(t, true, hello["stub"])
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version := rt.PutDoc(doc1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	// assert.Equal(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}},"_id":"doc1","_rev":"2-10000d5ec533b29b117e60274b1e3653","greetings":[{"hello":"world!"},{"hi":"alice"}]}`, resp.Body.String())
+		data, ok := btcRunner.WaitForVersion(client.id, doc1ID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+
+		// create doc1 rev 2-10000d5ec533b29b117e60274b1e3653 on SG with the first attachment
+		version = rt.UpdateDoc(doc1ID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
+
+		data, ok = btcRunner.WaitForVersion(client.id, doc1ID, version)
+		assert.True(t, ok)
+		var dataMap map[string]interface{}
+		assert.NoError(t, base.JSONUnmarshal(data, &dataMap))
+		atts, ok := dataMap[db.BodyAttachments].(map[string]interface{})
+		require.True(t, ok)
+		assert.Len(t, atts, 1)
+		hello, ok := atts["hello.txt"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(2), hello["revpos"])
+		assert.Equal(t, true, hello["stub"])
+
+		// message #3 is the getAttachment message that is sent in-between rev processing
+		msg, ok := client.pullReplication.WaitForMessage(3)
+		assert.True(t, ok)
+		assert.NotEqual(t, blip.ErrorType, msg.Type(), "Expected non-error blip message type")
+
+		// Check EE is delta, and CE is full-body replication
+		// msg, ok = client.pullReplication.WaitForMessage(5)
+		msg, ok = btcRunner.WaitForBlipRevMessage(client.id, doc1ID, version)
+		assert.True(t, ok)
+
+		if base.IsEnterpriseEdition() {
+			// Check the request was sent with the correct deltaSrc property
+			assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was the actual delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.Equal(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
+		} else {
+			// Check the request was NOT sent with a deltaSrc property
+			assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was NOT the delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.NotEqual(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
+			assert.Contains(t, string(msgBody), `"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}`)
+			assert.Contains(t, string(msgBody), `"greetings":[{"hello":"world!"},{"hi":"alice"}]`)
+		}
+
+		respBody := rt.GetDocVersion(doc1ID, version)
+		assert.Equal(t, doc1ID, respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 2)
+		assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
+		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
+		atts = respBody[db.BodyAttachments].(map[string]interface{})
+		assert.Len(t, atts, 1)
+		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+		assert.Equal(t, float64(11), hello["length"])
+		assert.Equal(t, float64(2), hello["revpos"])
+		assert.Equal(t, true, hello["stub"])
+
+		// assert.Equal(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}},"_id":"doc1","_rev":"2-10000d5ec533b29b117e60274b1e3653","greetings":[{"hello":"world!"},{"hi":"alice"}]}`, resp.Body.String())
+	})
 }
 
 // TestBlipDeltaSyncPull tests that a simple pull replication uses deltas in EE,
@@ -262,7 +273,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			DeltaSync: &DeltaSyncConfig{
 				Enabled: &sgUseDeltas,
@@ -270,66 +281,67 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-
-	var deltaSentCount int64
-
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaSentCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
-
-	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-
 	const docID = "doc1"
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-	version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
-
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-
-	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	version = rt.UpdateDoc(docID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
-
-	data, ok = client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
-	msg, ok := client.WaitForBlipRevMessage(docID, version)
-	assert.True(t, ok)
-
-	// Check EE is delta, and CE is full-body replication
-	if base.IsEnterpriseEdition() {
-		// Check the request was sent with the correct deltaSrc property
-		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was the actual delta
-		msgBody, err := msg.Body()
-		assert.NoError(t, err)
-		assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
-		assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
-	} else {
-		// Check the request was NOT sent with a deltaSrc property
-		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was NOT the delta
-		msgBody, err := msg.Body()
-		assert.NoError(t, err)
-		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
-		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
-
-		var afterDeltaSyncCount int64
+	var deltaSentCount int64
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
 		if rt.GetDatabase().DbStats.DeltaSync() != nil {
-			afterDeltaSyncCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+			deltaSentCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 		}
 
-		assert.Equal(t, deltaSentCount, afterDeltaSyncCount)
-	}
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		client.ClientDeltas = true
+		err := btcRunner.StartPull(client.id)
+		assert.NoError(t, err)
+
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+
+		data, ok := btcRunner.WaitForVersion(client.id, docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+
+		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
+		version = rt.UpdateDoc(docID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+
+		data, ok = btcRunner.WaitForVersion(client.id, docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+		msg, ok := btcRunner.WaitForBlipRevMessage(client.id, docID, version)
+		assert.True(t, ok)
+
+		// Check EE is delta, and CE is full-body replication
+		if base.IsEnterpriseEdition() {
+			// Check the request was sent with the correct deltaSrc property
+			assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was the actual delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+			assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+		} else {
+			// Check the request was NOT sent with a deltaSrc property
+			assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was NOT the delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+			assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
+
+			var afterDeltaSyncCount int64
+			if rt.GetDatabase().DbStats.DeltaSync() != nil {
+				afterDeltaSyncCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+			}
+
+			assert.Equal(t, deltaSentCount, afterDeltaSyncCount)
+		}
+	})
 }
 
 // TestBlipDeltaSyncPullResend tests that a simple pull replication that uses a delta a client rejects will resend the revision in full.
@@ -349,58 +361,61 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			&rtConfig)
+		defer rt.Close()
 
-	docID := "doc1"
-	// create doc1 rev 1
-	docVersion1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+		docID := "doc1"
+		// create doc1 rev 1
+		docVersion1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
 
-	// reject deltas built ontop of rev 1
-	client.rejectDeltasForSrcRev = docVersion1.RevID
+		// reject deltas built ontop of rev 1
+		client.rejectDeltasForSrcRev = docVersion1.RevID
 
-	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-	data, ok := client.WaitForVersion(docID, docVersion1)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		client.ClientDeltas = true
+		err := btcRunner.StartPull(client.id)
+		assert.NoError(t, err)
+		data, ok := btcRunner.WaitForVersion(client.id, docID, docVersion1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	// create doc1 rev 2
-	docVersion2 := rt.UpdateDoc(docID, docVersion1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
+		// create doc1 rev 2
+		docVersion2 := rt.UpdateDoc(docID, docVersion1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
 
-	data, ok = client.WaitForVersion(docID, docVersion2)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
+		data, ok = btcRunner.WaitForVersion(client.id, docID, docVersion2)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
 
-	msg, ok := client.pullReplication.WaitForMessage(5)
-	assert.True(t, ok)
+		msg, ok := client.pullReplication.WaitForMessage(5)
+		assert.True(t, ok)
 
-	// Check the request was initially sent with the correct deltaSrc property
-	assert.Equal(t, docVersion1.RevID, msg.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was the actual delta
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
-	assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+		// Check the request was initially sent with the correct deltaSrc property
+		assert.Equal(t, docVersion1.RevID, msg.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was the actual delta
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+		assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
 
-	msg, ok = client.WaitForBlipRevMessage(docID, docVersion2)
-	assert.True(t, ok)
+		msg, ok = btcRunner.WaitForBlipRevMessage(client.id, docID, docVersion2)
+		assert.True(t, ok)
 
-	// Check the resent request was NOT sent with a deltaSrc property
-	assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was NOT the delta
-	msgBody, err = msg.Body()
-	assert.NoError(t, err)
-	assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
+		// Check the resent request was NOT sent with a deltaSrc property
+		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was NOT the delta
+		msgBody, err = msg.Body()
+		assert.NoError(t, err)
+		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
+	})
 }
 
 // TestBlipDeltaSyncPullRemoved tests a simple pull replication that drops a document out of the user's channel.
@@ -419,43 +434,47 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		},
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username:               "alice",
-		Channels:               []string{"public"},
-		ClientDeltas:           true,
-		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
-	})
-	require.NoError(t, err)
-	defer client.Close()
-
-	err = client.StartPull()
-	assert.NoError(t, err)
-
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipVersionVectorInitialization = true
 	const docID = "doc1"
-	// create doc1 rev 1-1513b53e2738671e634d9dd111f48de0
-	version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			&rtConfig)
+		defer rt.Close()
 
-	// create doc1 rev 2-ff91e11bc1fd12bbb4815a06571859a9
-	version = rt.UpdateDoc(docID, version, `{"channels": ["private"], "greetings": [{"hello": "world!"}, {"hi": "bob"}]}`)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "alice",
+			Channels:               []string{"public"},
+			ClientDeltas:           true,
+			SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
+		})
+		defer client.Close()
 
-	data, ok = client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"_removed":true}`, string(data))
+		err := btcRunner.StartPull(client.id)
+		assert.NoError(t, err)
 
-	msg, ok := client.pullReplication.WaitForMessage(5)
-	assert.True(t, ok)
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{"_removed":true}`, string(msgBody))
+		// create doc1 rev 1-1513b53e2738671e634d9dd111f48de0
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
+
+		data, ok := btcRunner.WaitForVersion(client.id, docID, version)
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+
+		// create doc1 rev 2-ff91e11bc1fd12bbb4815a06571859a9
+		version = rt.UpdateDoc(docID, version, `{"channels": ["private"], "greetings": [{"hello": "world!"}, {"hi": "bob"}]}`)
+
+		data, ok = btcRunner.WaitForVersion(client.id, docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"_removed":true}`, string(data))
+
+		msg, ok := client.pullReplication.WaitForMessage(5)
+		assert.True(t, ok)
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"_removed":true}`, string(msgBody))
+	})
 }
 
 // TestBlipDeltaSyncPullTombstoned tests a simple pull replication that deletes a document.
@@ -473,7 +492,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{
+	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
 				DeltaSync: &DeltaSyncConfig{
@@ -483,78 +502,82 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		},
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
+	btcRunner := NewBlipTesterClientRunner(t)
 
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
 	var deltasRequestedStart int64
 	var deltasSentStart int64
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-		deltaCacheMissesStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
-		deltasRequestedStart = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
-		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username:     "alice",
-		Channels:     []string{"public"},
-		ClientDeltas: true,
+		if rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+			deltaCacheMissesStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+			deltasRequestedStart = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
+			deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}
+
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "alice",
+			Channels:               []string{"public"},
+			ClientDeltas:           true,
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer client.Close()
+
+		err := btcRunner.StartPull(client.id)
+		assert.NoError(t, err)
+
+		const docID = "doc1"
+		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
+		data, ok := btcRunner.WaitForVersion(client.id, docID, version)
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+
+		// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
+		version = rt.DeleteDocReturnVersion(docID, version)
+
+		data, ok = btcRunner.WaitForVersion(client.id, docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+
+		msg, ok := client.pullReplication.WaitForMessage(5)
+		assert.True(t, ok)
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{}`, string(msgBody))
+		assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted])
+
+		var deltaCacheHitsEnd int64
+		var deltaCacheMissesEnd int64
+		var deltasRequestedEnd int64
+		var deltasSentEnd int64
+
+		if rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaCacheHitsEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+			deltaCacheMissesEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+			deltasRequestedEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
+			deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}
+
+		if sgUseDeltas {
+			assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
+			assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
+			assert.Equal(t, deltasRequestedStart+1, deltasRequestedEnd)
+			assert.Equal(t, deltasSentStart, deltasSentEnd) // "_removed" docs are not counted as a delta
+		} else {
+			assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
+			assert.Equal(t, deltaCacheMissesStart, deltaCacheMissesEnd)
+			assert.Equal(t, deltasRequestedStart, deltasRequestedEnd)
+			assert.Equal(t, deltasSentStart, deltasSentEnd)
+		}
 	})
-	require.NoError(t, err)
-	defer client.Close()
-
-	err = client.StartPull()
-	assert.NoError(t, err)
-
-	const docID = "doc1"
-	// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
-	version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
-
-	// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
-	version = rt.DeleteDocReturnVersion(docID, version)
-
-	data, ok = client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
-
-	msg, ok := client.pullReplication.WaitForMessage(5)
-	assert.True(t, ok)
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{}`, string(msgBody))
-	assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted])
-
-	var deltaCacheHitsEnd int64
-	var deltaCacheMissesEnd int64
-	var deltasRequestedEnd int64
-	var deltasSentEnd int64
-
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaCacheHitsEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-		deltaCacheMissesEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
-		deltasRequestedEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
-		deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
-
-	if sgUseDeltas {
-		assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
-		assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
-		assert.Equal(t, deltasRequestedStart+1, deltasRequestedEnd)
-		assert.Equal(t, deltasSentStart, deltasSentEnd) // "_removed" docs are not counted as a delta
-	} else {
-		assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
-		assert.Equal(t, deltaCacheMissesStart, deltaCacheMissesEnd)
-		assert.Equal(t, deltasRequestedStart, deltasRequestedEnd)
-		assert.Equal(t, deltasSentStart, deltasSentEnd)
-	}
 }
 
 // TestBlipDeltaSyncPullTombstonedStarChan tests two clients can perform a simple pull replication that deletes a document when the user has access to the star channel.
@@ -576,129 +599,133 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-
-	var deltaCacheHitsStart int64
-	var deltaCacheMissesStart int64
-	var deltasRequestedStart int64
-	var deltasSentStart int64
-
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-		deltaCacheMissesStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
-		deltasRequestedStart = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
-		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
-	client1, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username:     "client1",
-		Channels:     []string{"*"},
-		ClientDeltas: true,
-	})
-	require.NoError(t, err)
-	defer client1.Close()
-
-	client2, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username:     "client2",
-		Channels:     []string{"*"},
-		ClientDeltas: true,
-	})
-	require.NoError(t, err)
-	defer client2.Close()
-
-	err = client1.StartPull()
-	require.NoError(t, err)
-
+	rtConfig := &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
+	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc1"
-	// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
-	version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
-	data, ok := client1.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
 
-	// Have client2 get only rev-1 and then stop replicating
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	data, ok = client2.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Contains(t, string(data), `"channels":["public"]`)
-	assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
+		var deltaCacheHitsStart int64
+		var deltaCacheMissesStart int64
+		var deltasRequestedStart int64
+		var deltasSentStart int64
 
-	// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
-	version = rt.DeleteDocReturnVersion(docID, version)
+		if rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaCacheHitsStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+			deltaCacheMissesStart = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+			deltasRequestedStart = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
+			deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}
+		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "client1",
+			Channels:               []string{"*"},
+			ClientDeltas:           true,
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer client1.Close()
 
-	data, ok = client1.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
-	msg, ok := client1.WaitForBlipRevMessage(docID, version) // docid, revid to get the message
-	assert.True(t, ok)
+		client2 := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
+			Username:               "client2",
+			Channels:               []string{"*"},
+			ClientDeltas:           true,
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+		})
+		defer client2.Close()
 
-	if !assert.Equal(t, db.MessageRev, msg.Profile()) {
-		t.Logf("unexpected profile for message %v in %v",
-			msg.SerialNumber(), client1.pullReplication.GetMessages())
-	}
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	if !assert.Equal(t, `{}`, string(msgBody)) {
-		t.Logf("unexpected body for message %v in %v",
-			msg.SerialNumber(), client1.pullReplication.GetMessages())
-	}
-	if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
-		t.Logf("unexpected deleted property for message %v in %v",
-			msg.SerialNumber(), client1.pullReplication.GetMessages())
-	}
+		err := btcRunner.StartPull(client1.id)
+		require.NoError(t, err)
 
-	// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	data, ok = client2.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
-	msg, ok = client2.WaitForBlipRevMessage(docID, version)
-	assert.True(t, ok)
+		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
-	if !assert.Equal(t, db.MessageRev, msg.Profile()) {
-		t.Logf("unexpected profile for message %v in %v",
-			msg.SerialNumber(), client2.pullReplication.GetMessages())
-	}
-	msgBody, err = msg.Body()
-	assert.NoError(t, err)
-	if !assert.Equal(t, `{}`, string(msgBody)) {
-		t.Logf("unexpected body for message %v in %v",
-			msg.SerialNumber(), client2.pullReplication.GetMessages())
-	}
-	if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
-		t.Logf("unexpected deleted property for message %v in %v",
-			msg.SerialNumber(), client2.pullReplication.GetMessages())
-	}
+		data, ok := btcRunner.WaitForVersion(client1.id, docID, version)
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
-	var deltaCacheHitsEnd int64
-	var deltaCacheMissesEnd int64
-	var deltasRequestedEnd int64
-	var deltasSentEnd int64
+		// Have client2 get only rev-1 and then stop replicating
+		err = btcRunner.StartOneshotPull(client2.id)
+		assert.NoError(t, err)
+		data, ok = btcRunner.WaitForVersion(client2.id, docID, version)
+		assert.True(t, ok)
+		assert.Contains(t, string(data), `"channels":["public"]`)
+		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaCacheHitsEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-		deltaCacheMissesEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
-		deltasRequestedEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
-		deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
-	}
+		// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
+		version = rt.DeleteDocReturnVersion(docID, version)
 
-	if sgUseDeltas {
-		assert.Equal(t, deltaCacheHitsStart+1, deltaCacheHitsEnd)
-		assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
-		assert.Equal(t, deltasRequestedStart+2, deltasRequestedEnd)
-		assert.Equal(t, deltasSentStart+2, deltasSentEnd)
-	} else {
-		assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
-		assert.Equal(t, deltaCacheMissesStart, deltaCacheMissesEnd)
-		assert.Equal(t, deltasRequestedStart, deltasRequestedEnd)
-		assert.Equal(t, deltasSentStart, deltasSentEnd)
-	}
+		data, ok = btcRunner.WaitForVersion(client1.id, docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+		msg, ok := btcRunner.WaitForBlipRevMessage(client1.id, docID, version) // docid, revid to get the message
+		assert.True(t, ok)
+
+		if !assert.Equal(t, db.MessageRev, msg.Profile()) {
+			t.Logf("unexpected profile for message %v in %v",
+				msg.SerialNumber(), client1.pullReplication.GetMessages())
+		}
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		if !assert.Equal(t, `{}`, string(msgBody)) {
+			t.Logf("unexpected body for message %v in %v",
+				msg.SerialNumber(), client1.pullReplication.GetMessages())
+		}
+		if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
+			t.Logf("unexpected deleted property for message %v in %v",
+				msg.SerialNumber(), client1.pullReplication.GetMessages())
+		}
+
+		// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
+		err = btcRunner.StartOneshotPull(client2.id)
+		assert.NoError(t, err)
+		data, ok = btcRunner.WaitForVersion(client2.id, docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
+		msg, ok = btcRunner.WaitForBlipRevMessage(client2.id, docID, version)
+		assert.True(t, ok)
+
+		if !assert.Equal(t, db.MessageRev, msg.Profile()) {
+			t.Logf("unexpected profile for message %v in %v",
+				msg.SerialNumber(), client2.pullReplication.GetMessages())
+		}
+		msgBody, err = msg.Body()
+		assert.NoError(t, err)
+		if !assert.Equal(t, `{}`, string(msgBody)) {
+			t.Logf("unexpected body for message %v in %v",
+				msg.SerialNumber(), client2.pullReplication.GetMessages())
+		}
+		if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
+			t.Logf("unexpected deleted property for message %v in %v",
+				msg.SerialNumber(), client2.pullReplication.GetMessages())
+		}
+
+		var deltaCacheHitsEnd int64
+		var deltaCacheMissesEnd int64
+		var deltasRequestedEnd int64
+		var deltasSentEnd int64
+
+		if rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaCacheHitsEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+			deltaCacheMissesEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+			deltasRequestedEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
+			deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
+		}
+
+		if sgUseDeltas {
+			assert.Equal(t, deltaCacheHitsStart+1, deltaCacheHitsEnd)
+			assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
+			assert.Equal(t, deltasRequestedStart+2, deltasRequestedEnd)
+			assert.Equal(t, deltasSentStart+2, deltasSentEnd)
+		} else {
+			assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
+			assert.Equal(t, deltaCacheMissesStart, deltaCacheMissesEnd)
+			assert.Equal(t, deltasRequestedStart, deltasRequestedEnd)
+			assert.Equal(t, deltasSentStart, deltasSentEnd)
+		}
+	})
 }
 
 // TestBlipDeltaSyncPullRevCache tests that a simple pull replication uses deltas in EE,
@@ -720,79 +747,80 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
-
-	client.ClientDeltas = true
-	err = client.StartPull()
-	assert.NoError(t, err)
-
 	const docID = "doc1"
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-	version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+	btcRunner := NewBlipTesterClientRunner(t)
 
-	data, ok := client.WaitForVersion(docID, version1)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			&rtConfig)
+		defer rt.Close()
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
 
-	// Perform a one-shot pull as client 2 to pull down the first revision
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
 
-	client2, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client2.Close()
+		client.ClientDeltas = true
+		err := btcRunner.StartPull(client.id)
+		assert.NoError(t, err)
 
-	client2.ClientDeltas = true
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	data, ok = client2.WaitForVersion(docID, version1)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`)
+		data, ok := btcRunner.WaitForVersion(client.id, docID, version1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	data, ok = client.WaitForVersion(docID, version2)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
-	msg, ok := client.WaitForBlipRevMessage(docID, version2)
-	assert.True(t, ok)
+		// Perform a one-shot pull as client 2 to pull down the first revision
+		client2 := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client2.Close()
 
-	// Check EE is delta
-	// Check the request was sent with the correct deltaSrc property
-	assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was the actual delta
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
+		client2.ClientDeltas = true
+		err = btcRunner.StartOneshotPull(client2.id)
+		assert.NoError(t, err)
+		data, ok = btcRunner.WaitForVersion(client2.id, docID, version1)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	deltaCacheHits := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-	deltaCacheMisses := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
+		version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`)
 
-	// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
-	client2.ClientDeltas = true
-	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
-	msg2, ok := client2.WaitForBlipRevMessage(docID, version2)
-	assert.True(t, ok)
+		data, ok = btcRunner.WaitForVersion(client.id, docID, version2)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
+		msg, ok := btcRunner.WaitForBlipRevMessage(client.id, docID, version2)
+		assert.True(t, ok)
 
-	// Check the request was sent with the correct deltaSrc property
-	assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg2.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was the actual delta
-	msgBody2, err := msg2.Body()
-	assert.NoError(t, err)
-	assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody2))
+		// Check EE is delta
+		// Check the request was sent with the correct deltaSrc property
+		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was the actual delta
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
-	updatedDeltaCacheHits := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
-	updatedDeltaCacheMisses := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+		deltaCacheHits := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+		deltaCacheMisses := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
 
-	assert.Equal(t, deltaCacheHits+1, updatedDeltaCacheHits)
-	assert.Equal(t, deltaCacheMisses, updatedDeltaCacheMisses)
+		// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
+		client2.ClientDeltas = true
+		err = btcRunner.StartOneshotPull(client2.id)
+		assert.NoError(t, err)
+		msg2, ok := btcRunner.WaitForBlipRevMessage(client2.id, docID, version2)
+		assert.True(t, ok)
 
+		// Check the request was sent with the correct deltaSrc property
+		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg2.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was the actual delta
+		msgBody2, err := msg2.Body()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody2))
+
+		updatedDeltaCacheHits := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
+		updatedDeltaCacheMisses := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
+
+		assert.Equal(t, deltaCacheHits+1, updatedDeltaCacheHits)
+		assert.Equal(t, deltaCacheMisses, updatedDeltaCacheMisses)
+	})
 }
 
 // TestBlipDeltaSyncPush tests that a simple push replication handles deltas in EE,
@@ -809,96 +837,100 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
-	client.ClientDeltas = true
-
-	err = client.StartPull()
-	assert.NoError(t, err)
-
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc1"
-	version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-	// create doc1 rev 2-abc on client
-	newRev, err := client.PushRev(docID, version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-	assert.NoError(t, err)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			&rtConfig)
+		defer rt.Close()
+		collection := rt.GetSingleTestDatabaseCollection()
 
-	// Check EE is delta, and CE is full-body replication
-	msg, found := client.waitForReplicationMessage(collection, 2)
-	assert.True(t, found)
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+		client.ClientDeltas = true
 
-	if base.IsEnterpriseEdition() {
-		// Check the request was sent with the correct deltaSrc property
-		assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was the actual delta
-		msgBody, err := msg.Body()
+		err := btcRunner.StartPull(client.id)
 		assert.NoError(t, err)
-		assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
-		// Validate that generation of a delta didn't mutate the revision body in the revision cache
-		docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
-		assert.NoError(t, cacheErr)
-		assert.NotContains(t, docRev.BodyBytes, "bob")
-	} else {
-		// Check the request was NOT sent with a deltaSrc property
-		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-		// Check the request body was NOT the delta
-		msgBody, err := msg.Body()
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+
+		data, ok := btcRunner.WaitForVersion(client.id, docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 2-abc on client
+		newRev, err := btcRunner.PushRev(client.id, docID, version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 		assert.NoError(t, err)
-		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
-		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
-	}
 
-	respBody := rt.GetDocVersion(docID, newRev)
-	assert.Equal(t, "doc1", respBody[db.BodyId])
-	greetings := respBody["greetings"].([]interface{})
-	assert.Len(t, greetings, 3)
-	assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
-	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
-	assert.Equal(t, map[string]interface{}{"howdy": "bob"}, greetings[2])
+		// Check EE is delta, and CE is full-body replication
+		msg, found := client.waitForReplicationMessage(collection, 2)
+		assert.True(t, found)
 
-	// tombstone doc1 (gets rev 3-f3be6c85e0362153005dae6f08fc68bb)
-	deletedVersion := rt.DeleteDocReturnVersion(docID, newRev)
+		if base.IsEnterpriseEdition() {
+			// Check the request was sent with the correct deltaSrc property
+			assert.Equal(t, "1-0335a345b6ffed05707ccc4cbc1b67f4", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was the actual delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
-	data, ok = client.WaitForVersion(docID, deletedVersion)
-	assert.True(t, ok)
-	assert.Equal(t, `{}`, string(data))
+			// Validate that generation of a delta didn't mutate the revision body in the revision cache
+			docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
+			assert.NoError(t, cacheErr)
+			assert.NotContains(t, docRev.BodyBytes, "bob")
+		} else {
+			// Check the request was NOT sent with a deltaSrc property
+			assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+			// Check the request body was NOT the delta
+			msgBody, err := msg.Body()
+			assert.NoError(t, err)
+			assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
+			assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
+		}
 
-	var deltaPushDocCountStart int64
+		respBody := rt.GetDocVersion(docID, newRev)
+		assert.Equal(t, "doc1", respBody[db.BodyId])
+		greetings := respBody["greetings"].([]interface{})
+		assert.Len(t, greetings, 3)
+		assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
+		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
+		assert.Equal(t, map[string]interface{}{"howdy": "bob"}, greetings[2])
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaPushDocCountStart = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
-	}
+		// tombstone doc1 (gets rev 3-f3be6c85e0362153005dae6f08fc68bb)
+		deletedVersion := rt.DeleteDocReturnVersion(docID, newRev)
 
-	_, err = client.PushRev(docID, deletedVersion, []byte(`{"undelete":true}`))
+		data, ok = btcRunner.WaitForVersion(client.id, docID, deletedVersion)
+		assert.True(t, ok)
+		assert.Equal(t, `{}`, string(data))
 
-	if base.IsEnterpriseEdition() {
-		// Now make the client push up a delta that has the parent of the tombstone.
-		// This is not a valid scenario, and is actively prevented on the CBL side.
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Can't use delta. Found tombstone for doc")
-	} else {
-		// Pushing a full body revision on top of a tombstone is valid.
-		// CBL clients should fall back to this. The test client doesn't.
-		assert.NoError(t, err)
-	}
+		var deltaPushDocCountStart int64
 
-	var deltaPushDocCountEnd int64
+		if rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaPushDocCountStart = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
+		}
 
-	if rt.GetDatabase().DbStats.DeltaSync() != nil {
-		deltaPushDocCountEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
-	}
-	assert.Equal(t, deltaPushDocCountStart, deltaPushDocCountEnd)
+		_, err = btcRunner.PushRev(client.id, docID, deletedVersion, []byte(`{"undelete":true}`))
+
+		if base.IsEnterpriseEdition() {
+			// Now make the client push up a delta that has the parent of the tombstone.
+			// This is not a valid scenario, and is actively prevented on the CBL side.
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "Can't use delta. Found tombstone for doc")
+		} else {
+			// Pushing a full body revision on top of a tombstone is valid.
+			// CBL clients should fall back to this. The test client doesn't.
+			assert.NoError(t, err)
+		}
+
+		var deltaPushDocCountEnd int64
+
+		if rt.GetDatabase().DbStats.DeltaSync() != nil {
+			deltaPushDocCountEnd = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
+		}
+		assert.Equal(t, deltaPushDocCountStart, deltaPushDocCountEnd)
+	})
 }
 
 // TestBlipNonDeltaSyncPush tests that a client that doesn't support deltas can push to a SG that supports deltas (either CE or EE)
@@ -914,41 +946,45 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	rt := NewRestTester(t,
-		&rtConfig)
-	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
-
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
-
-	client.ClientDeltas = false
-	err = client.StartPull()
-	assert.NoError(t, err)
-
-	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc1"
-	version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-	data, ok := client.WaitForVersion(docID, version)
-	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
-	// create doc1 rev 2-abcxyz on client
-	newRev, err := client.PushRev(docID, version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-	assert.NoError(t, err)
-	// Check EE is delta, and CE is full-body replication
-	msg, found := client.waitForReplicationMessage(collection, 2)
-	assert.True(t, found)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			&rtConfig)
+		defer rt.Close()
+		collection := rt.GetSingleTestDatabaseCollection()
 
-	// Check the request was NOT sent with a deltaSrc property
-	assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
-	// Check the request body was NOT the delta
-	msgBody, err := msg.Body()
-	assert.NoError(t, err)
-	assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
 
-	body := rt.GetDocVersion("doc1", newRev)
-	require.Equal(t, "bob", body["greetings"].([]interface{})[2].(map[string]interface{})["howdy"])
+		client.ClientDeltas = false
+		err := btcRunner.StartPull(client.id)
+		assert.NoError(t, err)
+
+		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
+		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+
+		data, ok := btcRunner.WaitForVersion(client.id, docID, version)
+		assert.True(t, ok)
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		// create doc1 rev 2-abcxyz on client
+		newRev, err := btcRunner.PushRev(client.id, docID, version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
+		assert.NoError(t, err)
+		// Check EE is delta, and CE is full-body replication
+		msg, found := client.waitForReplicationMessage(collection, 2)
+		assert.True(t, found)
+
+		// Check the request was NOT sent with a deltaSrc property
+		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+		// Check the request body was NOT the delta
+		msgBody, err := msg.Body()
+		assert.NoError(t, err)
+		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
+
+		body := rt.GetDocVersion("doc1", newRev)
+		require.Equal(t, "bob", body["greetings"].([]interface{})[2].(map[string]interface{})["howdy"])
+	})
 }

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -44,65 +44,68 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 		GuestEnabled:     true,
 		CustomTestBucket: tb.NoCloseClone(),
 	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
-	require.NoError(t, err)
-	defer client.Close()
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
 
-	var lastPushRevErr atomic.Value
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
 
-	// Wait for the background updates to finish at the end of the test
-	shouldCreateDocs := base.NewAtomicBool(true)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	defer func() {
-		shouldCreateDocs.Set(false)
-		wg.Wait()
-	}()
+		var lastPushRevErr atomic.Value
 
-	// Start the test client creating and pushing documents in the background
-	go func() {
-		for i := 0; shouldCreateDocs.IsTrue(); i++ {
-			// this will begin to error when the database is reloaded underneath the replication
-			_, err := client.PushRev(fmt.Sprintf("doc%d", i), EmptyDocVersion(), []byte(fmt.Sprintf(`{"i":%d}`, i)))
-			if err != nil {
-				lastPushRevErr.Store(err)
+		// Wait for the background updates to finish at the end of the test
+		shouldCreateDocs := base.NewAtomicBool(true)
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		defer func() {
+			shouldCreateDocs.Set(false)
+			wg.Wait()
+		}()
+
+		// Start the test client creating and pushing documents in the background
+		go func() {
+			for i := 0; shouldCreateDocs.IsTrue(); i++ {
+				// this will begin to error when the database is reloaded underneath the replication
+				_, err := btcRunner.PushRev(client.id, fmt.Sprintf("doc%d", i), EmptyDocVersion(), []byte(fmt.Sprintf(`{"i":%d}`, i)))
+				if err != nil {
+					lastPushRevErr.Store(err)
+				}
 			}
-		}
-		_ = rt.WaitForPendingChanges()
-		wg.Done()
-	}()
+			_ = rt.WaitForPendingChanges()
+			wg.Done()
+		}()
 
-	// and wait for a few to be done before we proceed with updating database config underneath replication
-	_, err = rt.WaitForChanges(5, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err)
+		// and wait for a few to be done before we proceed with updating database config underneath replication
+		_, err := rt.WaitForChanges(5, "/{{.keyspace}}/_changes", "", true)
+		require.NoError(t, err)
 
-	// just change the sync function to cause the database to reload
-	dbConfig := *rt.ServerContext().GetDbConfig("db")
-	dbConfig.Sync = base.StringPtr(`function(doc){console.log("update");}`)
-	resp := rt.ReplaceDbConfig("db", dbConfig)
-	RequireStatus(t, resp, http.StatusCreated)
+		// just change the sync function to cause the database to reload
+		dbConfig := *rt.ServerContext().GetDbConfig("db")
+		dbConfig.Sync = base.StringPtr(`function(doc){console.log("update");}`)
+		resp := rt.ReplaceDbConfig("db", dbConfig)
+		RequireStatus(t, resp, http.StatusCreated)
 
-	// Did we tell the client to close the connection (via HTTP/503)?
-	// The BlipTesterClient doesn't implement reconnect - but CBL resets the replication connection.
-	WaitAndAssertCondition(t, func() bool {
-		lastErr, ok := lastPushRevErr.Load().(error)
-		if !ok {
-			return false
-		}
-		if lastErr == nil {
-			return false
-		}
-		lastErrMsg := lastErr.Error()
-		if !strings.Contains(lastErrMsg, "HTTP 503") {
-			return false
-		}
-		if !strings.Contains(lastErrMsg, "Sync Gateway database went away - asking client to reconnect") {
-			return false
-		}
-		return true
-	}, "expected HTTP 503 error")
-
+		// Did we tell the client to close the connection (via HTTP/503)?
+		// The BlipTesterClient doesn't implement reconnect - but CBL resets the replication connection.
+		WaitAndAssertCondition(t, func() bool {
+			lastErr, ok := lastPushRevErr.Load().(error)
+			if !ok {
+				return false
+			}
+			if lastErr == nil {
+				return false
+			}
+			lastErrMsg := lastErr.Error()
+			if !strings.Contains(lastErrMsg, "HTTP 503") {
+				return false
+			}
+			if !strings.Contains(lastErrMsg, "Sync Gateway database went away - asking client to reconnect") {
+				return false
+			}
+			return true
+		}, "expected HTTP 503 error")
+	})
 }

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -46,6 +46,7 @@ type BlipTesterClientOpts struct {
 type BlipTesterClient struct {
 	BlipTesterClientOpts
 
+	id              uint32 // unique ID for the client
 	rt              *RestTester
 	pullReplication *BlipTesterReplicator // SG -> CBL replications
 	pushReplication *BlipTesterReplicator // CBL -> SG replications
@@ -69,6 +70,14 @@ type BlipTesterCollectionClient struct {
 	lastReplicatedRevLock sync.RWMutex      // lock for lastReplicatedRev map
 }
 
+// BlipTestClientRunner is for running the blip tester client and its associated methods in test framework
+type BlipTestClientRunner struct {
+	clients                         map[uint32]*BlipTesterClient // map of created BlipTesterClient's
+	t                               *testing.T
+	initialisedInsideRunnerCode     bool // flag to check that the BlipTesterClient is being initialised in the correct area (inside the Run() method)
+	SkipVersionVectorInitialization bool // used to skip the version vector subtest
+}
+
 type BodyMessagePair struct {
 	body    []byte
 	message *blip.Message
@@ -83,6 +92,14 @@ type BlipTesterReplicator struct {
 	messages     map[blip.MessageNumber]*blip.Message // Map of blip messages keyed by message number
 
 	replicationStats *db.BlipSyncStats // Stats of replications
+}
+
+// NewBlipTesterClientRunner creates a BlipTestClientRunner type
+func NewBlipTesterClientRunner(t *testing.T) *BlipTestClientRunner {
+	return &BlipTestClientRunner{
+		t:       t,
+		clients: make(map[uint32]*BlipTesterClient),
+	}
 }
 
 func (btr *BlipTesterReplicator) Close() {
@@ -618,27 +635,94 @@ func NewBlipTesterClient(tb testing.TB, rt *RestTester) (client *BlipTesterClien
 	return createBlipTesterClientOpts(tb, rt, nil)
 }
 
-func NewBlipTesterClientOptsWithRT(tb testing.TB, rt *RestTester, opts *BlipTesterClientOpts) (client *BlipTesterClient, err error) {
-	client, err = createBlipTesterClientOpts(tb, rt, opts)
-	if err != nil {
-		return nil, err
+func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTester, opts *BlipTesterClientOpts) (client *BlipTesterClient) {
+	if !btcRunner.initialisedInsideRunnerCode {
+		btcRunner.t.Fatalf("must initialise BlipTesterClient inside Run() method")
 	}
+	if opts == nil {
+		opts = &BlipTesterClientOpts{}
+	}
+	id, err := uuid.NewRandom()
+	require.NoError(btcRunner.t, err)
 
-	client.pullReplication.bt.avoidRestTesterClose = true
-	client.pushReplication.bt.avoidRestTesterClose = true
+	client = &BlipTesterClient{
+		BlipTesterClientOpts: *opts,
+		rt:                   rt,
+		id:                   id.ID(),
+	}
+	btcRunner.clients[client.id] = client
+	err = client.createBlipTesterReplications()
+	require.NoError(btcRunner.t, err)
 
-	return client, nil
+	return client
 }
 
 func (btc *BlipTesterClient) Close() {
-	btc.pullReplication.Close()
-	btc.pushReplication.Close()
+	btc.tearDownBlipClientReplications()
 	for _, collectionClient := range btc.collectionClients {
 		collectionClient.Close()
 	}
 	if btc.nonCollectionAwareClient != nil {
 		btc.nonCollectionAwareClient.Close()
 	}
+}
+
+func (btcRunner *BlipTestClientRunner) Run(test func(t *testing.T, SupportedBLIPProtocols []string)) {
+	btcRunner.initialisedInsideRunnerCode = true
+	// reset to protect against someone creating a new client after Run() is run
+	defer func() { btcRunner.initialisedInsideRunnerCode = false }()
+	btcRunner.t.Run("revTree", func(t *testing.T) {
+		test(t, []string{db.BlipCBMobileReplicationV3})
+	})
+	// if test is not wanting version vector subprotocol to be run, return before we start this subtest
+	if btcRunner.SkipVersionVectorInitialization {
+		return
+	}
+	btcRunner.t.Run("versionVector", func(t *testing.T) {
+		// bump sub protocol version here and pass into test function pending CBG-3253
+		test(t, nil)
+	})
+}
+
+func (btc *BlipTesterClient) tearDownBlipClientReplications() {
+	btc.pullReplication.Close()
+	btc.pushReplication.Close()
+}
+
+func (btc *BlipTesterClient) createBlipTesterReplications() error {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return err
+	}
+
+	if btc.pushReplication, err = newBlipTesterReplication(btc.rt.TB, "push"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization); err != nil {
+		return err
+	}
+	if btc.pullReplication, err = newBlipTesterReplication(btc.rt.TB, "pull"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization); err != nil {
+		return err
+	}
+
+	collections := getCollectionsForBLIP(btc.rt.TB, btc.rt)
+	if !btc.BlipTesterClientOpts.SkipCollectionsInitialization && len(collections) > 0 {
+		btc.collectionClients = make([]*BlipTesterCollectionClient, len(collections))
+		for i, collection := range collections {
+			if err := btc.initCollectionReplication(collection, i); err != nil {
+				return err
+			}
+		}
+	} else {
+		btc.nonCollectionAwareClient = &BlipTesterCollectionClient{
+			docs:              make(map[string]map[string]*BodyMessagePair),
+			attachments:       make(map[string][]byte),
+			lastReplicatedRev: make(map[string]string),
+			parent:            btc,
+		}
+	}
+
+	btc.pullReplication.bt.avoidRestTesterClose = true
+	btc.pushReplication.bt.avoidRestTesterClose = true
+
+	return nil
 }
 
 func (btc *BlipTesterClient) initCollectionReplication(collection string, collectionIdx int) error {
@@ -668,25 +752,25 @@ func (btc *BlipTesterClient) waitForReplicationMessage(collection *db.DatabaseCo
 }
 
 // SingleCollection returns a single collection blip tester if the RestTester database is configured with only one collection. Otherwise, throw a fatal test error.
-func (btc *BlipTesterClient) SingleCollection() *BlipTesterCollectionClient {
-	if btc.nonCollectionAwareClient != nil {
-		return btc.nonCollectionAwareClient
+func (btcRunner *BlipTestClientRunner) SingleCollection(clientID uint32) *BlipTesterCollectionClient {
+	if btcRunner.clients[clientID].nonCollectionAwareClient != nil {
+		return btcRunner.clients[clientID].nonCollectionAwareClient
 	}
-	require.Equal(btc.rt.TB, 1, len(btc.collectionClients))
-	return btc.collectionClients[0]
+	require.Equal(btcRunner.clients[clientID].rt.TB, 1, len(btcRunner.clients[clientID].collectionClients))
+	return btcRunner.clients[clientID].collectionClients[0]
 }
 
 // Collection return a collection blip tester by name, if configured in the RestTester database. Otherwise, throw a fatal test error.
-func (btc *BlipTesterClient) Collection(collectionName string) *BlipTesterCollectionClient {
-	if collectionName == "_default._default" && btc.nonCollectionAwareClient != nil {
-		return btc.nonCollectionAwareClient
+func (btcRunner *BlipTestClientRunner) Collection(clientID uint32, collectionName string) *BlipTesterCollectionClient {
+	if collectionName == "_default._default" && btcRunner.clients[clientID].nonCollectionAwareClient != nil {
+		return btcRunner.clients[clientID].nonCollectionAwareClient
 	}
-	for _, collectionClient := range btc.collectionClients {
+	for _, collectionClient := range btcRunner.clients[clientID].collectionClients {
 		if collectionClient.collection == collectionName {
 			return collectionClient
 		}
 	}
-	btc.rt.TB.Fatalf("Could not find collection %s in BlipTesterClient", collectionName)
+	btcRunner.clients[clientID].rt.TB.Fatalf("Could not find collection %s in BlipTesterClient", collectionName)
 	return nil
 }
 
@@ -1126,81 +1210,81 @@ func (btc *BlipTesterCollectionClient) GetBlipRevMessage(docID, revID string) (m
 	return nil, false
 }
 
-func (btc *BlipTesterClient) StartPull() error {
-	return btc.SingleCollection().StartPull()
+func (btcRunner *BlipTestClientRunner) StartPull(clientID uint32) error {
+	return btcRunner.SingleCollection(clientID).StartPull()
 }
 
 // WaitForVersion blocks until the given document version has been stored by the client, and returns the data when found.
-func (btc *BlipTesterClient) WaitForVersion(docID string, docVersion DocVersion) (data []byte, found bool) {
-	return btc.SingleCollection().WaitForVersion(docID, docVersion)
+func (btcRunner *BlipTestClientRunner) WaitForVersion(clientID uint32, docID string, docVersion DocVersion) (data []byte, found bool) {
+	return btcRunner.SingleCollection(clientID).WaitForVersion(docID, docVersion)
 }
 
-func (btc *BlipTesterClient) WaitForDoc(docID string) ([]byte, bool) {
-	return btc.SingleCollection().WaitForDoc(docID)
+func (btcRunner *BlipTestClientRunner) WaitForDoc(clientID uint32, docID string) ([]byte, bool) {
+	return btcRunner.SingleCollection(clientID).WaitForDoc(docID)
 }
 
-func (btc *BlipTesterClient) WaitForBlipRevMessage(docID string, docVersion DocVersion) (*blip.Message, bool) {
-	return btc.SingleCollection().WaitForBlipRevMessage(docID, docVersion)
+func (btcRunner *BlipTestClientRunner) WaitForBlipRevMessage(clientID uint32, docID string, docVersion DocVersion) (*blip.Message, bool) {
+	return btcRunner.SingleCollection(clientID).WaitForBlipRevMessage(docID, docVersion)
 }
 
-func (btc *BlipTesterClient) StartOneshotPull() error {
-	return btc.SingleCollection().StartOneshotPull()
+func (btcRunner *BlipTestClientRunner) StartOneshotPull(clientID uint32) error {
+	return btcRunner.SingleCollection(clientID).StartOneshotPull()
 }
 
-func (btc *BlipTesterClient) StartOneshotPullFiltered(channels string) error {
-	return btc.SingleCollection().StartOneshotPullFiltered(channels)
+func (btcRunner *BlipTestClientRunner) StartOneshotPullFiltered(clientID uint32, channels string) error {
+	return btcRunner.SingleCollection(clientID).StartOneshotPullFiltered(channels)
 }
 
-func (btc *BlipTesterClient) StartOneshotPullRequestPlus() error {
-	return btc.SingleCollection().StartOneshotPullRequestPlus()
+func (btcRunner *BlipTestClientRunner) StartOneshotPullRequestPlus(clientID uint32) error {
+	return btcRunner.SingleCollection(clientID).StartOneshotPullRequestPlus()
 }
 
-func (btc *BlipTesterClient) PushRev(docID string, version DocVersion, body []byte) (DocVersion, error) {
-	return btc.SingleCollection().PushRev(docID, version, body)
+func (btcRunner *BlipTestClientRunner) PushRev(clientID uint32, docID string, version DocVersion, body []byte) (DocVersion, error) {
+	return btcRunner.SingleCollection(clientID).PushRev(docID, version, body)
 }
 
-func (btc *BlipTesterClient) StartPullSince(continuous, since, activeOnly string) error {
-	return btc.SingleCollection().StartPullSince(continuous, since, activeOnly, "", "")
+func (btcRunner *BlipTestClientRunner) StartPullSince(clientID uint32, continuous, since, activeOnly string) error {
+	return btcRunner.SingleCollection(clientID).StartPullSince(continuous, since, activeOnly, "", "")
 }
 
-func (btc *BlipTesterClient) StartFilteredPullSince(continuous, since, activeOnly string, channels string) error {
-	return btc.SingleCollection().StartPullSince(continuous, since, activeOnly, channels, "")
+func (btcRunner *BlipTestClientRunner) StartFilteredPullSince(clientID uint32, continuous, since, activeOnly, channels string) error {
+	return btcRunner.SingleCollection(clientID).StartPullSince(continuous, since, activeOnly, channels, "")
 }
 
-func (btc *BlipTesterClient) GetVersion(docID string, docVersion DocVersion) ([]byte, bool) {
-	return btc.SingleCollection().GetVersion(docID, docVersion)
+func (btcRunner *BlipTestClientRunner) GetVersion(clientID uint32, docID string, docVersion DocVersion) ([]byte, bool) {
+	return btcRunner.SingleCollection(clientID).GetVersion(docID, docVersion)
 }
 
-func (btc *BlipTesterClient) saveAttachment(contentType string, attachmentData string) (int, string, error) {
-	return btc.SingleCollection().saveAttachment(contentType, attachmentData)
+func (btcRunner *BlipTestClientRunner) saveAttachment(clientID uint32, contentType string, attachmentData string) (int, string, error) {
+	return btcRunner.SingleCollection(clientID).saveAttachment(contentType, attachmentData)
 }
 
-func (btc *BlipTesterClient) StoreRevOnClient(docID, revID string, body []byte) error {
-	return btc.SingleCollection().StoreRevOnClient(docID, revID, body)
+func (btcRunner *BlipTestClientRunner) StoreRevOnClient(clientID uint32, docID, revID string, body []byte) error {
+	return btcRunner.SingleCollection(clientID).StoreRevOnClient(docID, revID, body)
 }
 
-func (btc *BlipTesterClient) PushRevWithHistory(docID, revID string, body []byte, revCount, prunedRevCount int) (string, error) {
-	return btc.SingleCollection().PushRevWithHistory(docID, revID, body, revCount, prunedRevCount)
+func (btcRunner *BlipTestClientRunner) PushRevWithHistory(clientID uint32, docID, revID string, body []byte, revCount, prunedRevCount int) (string, error) {
+	return btcRunner.SingleCollection(clientID).PushRevWithHistory(docID, revID, body, revCount, prunedRevCount)
 }
 
-func (btc *BlipTesterClient) AttachmentsLock() *sync.RWMutex {
-	return &btc.SingleCollection().attachmentsLock
+func (btcRunner *BlipTestClientRunner) AttachmentsLock(clientID uint32) *sync.RWMutex {
+	return &btcRunner.SingleCollection(clientID).attachmentsLock
 }
 
 func (btc *BlipTesterCollectionClient) AttachmentsLock() *sync.RWMutex {
 	return &btc.attachmentsLock
 }
 
-func (btc *BlipTesterClient) Attachments() map[string][]byte {
-	return btc.SingleCollection().attachments
+func (btcRunner *BlipTestClientRunner) Attachments(clientID uint32) map[string][]byte {
+	return btcRunner.SingleCollection(clientID).attachments
 }
 
 func (btc *BlipTesterCollectionClient) Attachments() map[string][]byte {
 	return btc.attachments
 }
 
-func (btc *BlipTesterClient) UnsubPullChanges() ([]byte, error) {
-	return btc.SingleCollection().UnsubPullChanges()
+func (btcRunner *BlipTestClientRunner) UnsubPullChanges(clientID uint32) ([]byte, error) {
+	return btcRunner.SingleCollection(clientID).UnsubPullChanges()
 }
 
 func (btc *BlipTesterCollectionClient) addCollectionProperty(msg *blip.Message) {


### PR DESCRIPTION
CBG-3576

A redo of https://github.com/couchbase/sync_gateway/pull/6567

Messed up changing base branch from beryllium to master and brought across to master some HLV related things we didn't want on master. Only realised this morning.  


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2172/
