### PR TITLE
put lint timeout in config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.0
-          args: --config=.golangci-strict.yml --timeout=3m
+          version: v1.55.2
+          args: --config=.golangci-strict.yml
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -8,6 +8,8 @@
 
 # config file for golangci-lint
 
+timeout: 3m
+
 linters:
   enable:
     #- bodyclose # checks whether HTTP response body is closed successfully

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,8 @@
 
 # config file for golangci-lint
 
+timeout: 3m
+
 linters:
   enable:
     - bodyclose # checks whether HTTP response body is closed successfully


### PR DESCRIPTION
This means it is automatically picked up by editors in addition to CI. Usually this is fast, but sometimes staticcheck can slow down, especially on mac. Once it is cached, it is quick.

Updated golangci-lint version in github actions.

