### PR TITLE
4.0: Bump SG API version

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -82,6 +82,7 @@ const (
 	StatAddedVersion3dot1dot0 = "3.1.0"
 	StatAddedVersion3dot1dot2 = "3.1.2"
 	StatAddedVersion3dot2dot0 = "3.2.0"
+	StatAddedVersion4dot0dot0 = "4.0.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
 

--- a/base/version.go
+++ b/base/version.go
@@ -19,8 +19,8 @@ import (
 const (
 	ProductName = "Couchbase Sync Gateway"
 
-	ProductAPIVersionMajor = "3"
-	ProductAPIVersionMinor = "2"
+	ProductAPIVersionMajor = "4"
+	ProductAPIVersionMinor = "0"
 	ProductAPIVersion      = ProductAPIVersionMajor + "." + ProductAPIVersionMinor
 )
 


### PR DESCRIPTION
- Bump SG API version to 4.0
- Add placeholder for 4.0.0-added stats