### PR TITLE
CBG-3212: add api to fetch a document by its CV value

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1112,7 +1112,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 	if existingDoc != nil {
 		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattr, existingDoc.UserXattr, existingDoc.Cas, DocUnmarshalRev)
 		if unmarshalErr != nil {
-			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling exsiting doc")
+			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling existing doc")
 		}
 		matchRev = doc.CurrentRev
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -333,7 +333,7 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Context, docID string, revision DocumentRevision, revID *string, cv *Version, maxHistory int, historyFrom []string) (DocumentRevision, error) {
 	// ensure only one of cv or revID is specified
 	if cv != nil && revID != nil {
-		return DocumentRevision{}, fmt.Errorf("must have one of cv or revID in documentRevisionForRequest (had %v %v)", cv, revID)
+		return DocumentRevision{}, fmt.Errorf("must have one of cv or revID in documentRevisionForRequest (had cv=%v revID=%v)", cv, revID)
 	}
 	var requestedVersion string
 	if revID != nil {

--- a/db/crud.go
+++ b/db/crud.go
@@ -332,8 +332,8 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 // documentRevisionForRequest processes the given DocumentRevision and returns a version of it for a given client request, depending on access, deleted, etc.
 func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Context, docID string, revision DocumentRevision, revID *string, cv *Version, maxHistory int, historyFrom []string) (DocumentRevision, error) {
 	// ensure only one of cv or revID is specified
-	if (cv != nil && revID != nil) || (cv == nil && revID == nil) {
-		return DocumentRevision{}, fmt.Errorf("must have exactly one of cv or revID in documentRevisionForRequest (had %v %v)", cv, revID)
+	if cv != nil && revID != nil {
+		return DocumentRevision{}, fmt.Errorf("must have one of cv or revID in documentRevisionForRequest (had %v %v)", cv, revID)
 	}
 	var requestedVersion string
 	if revID != nil {
@@ -363,8 +363,7 @@ func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Con
 		_, requestedHistory = trimEncodedRevisionsToAncestor(ctx, requestedHistory, historyFrom, maxHistory)
 	}
 
-	revIDStr := base.StringDefault(revID, "")
-	isAuthorized, redactedRevision := db.authorizeUserForChannels(docID, revIDStr, cv, revision.Channels, revision.Deleted, requestedHistory)
+	isAuthorized, redactedRevision := db.authorizeUserForChannels(docID, revision.RevID, cv, revision.Channels, revision.Deleted, requestedHistory)
 	if !isAuthorized {
 		// client just wanted active revision, not a specific one
 		if requestedVersion == "" {

--- a/db/crud.go
+++ b/db/crud.go
@@ -373,7 +373,7 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 	return revision, nil
 }
 
-func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *SourceAndVersion, includeBody bool) (revision DocumentRevision, err error) {
+func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *Version, includeBody bool) (revision DocumentRevision, err error) {
 	if cv != nil {
 		revision, err = db.revisionCache.GetWithCV(ctx, docid, cv, includeBody, RevCacheOmitDelta)
 	} else {
@@ -386,7 +386,7 @@ func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, c
 
 	if revision.BodyBytes == nil {
 		if db.ForceAPIForbiddenErrors() {
-			base.InfofCtx(ctx, base.KeyCRUD, "Doc: %s %s:%s is missing", base.UD(docid), base.MD(cv.SourceID), base.MD(cv.Version))
+			base.InfofCtx(ctx, base.KeyCRUD, "Doc: %s %s:%s is missing", base.UD(docid), base.MD(cv.SourceID), base.MD(cv.Value))
 			return DocumentRevision{}, ErrForbidden
 		}
 		return DocumentRevision{}, ErrMissing
@@ -401,7 +401,7 @@ func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, c
 			return DocumentRevision{}, ErrForbidden
 		}
 		if db.ForceAPIForbiddenErrors() {
-			base.InfofCtx(ctx, base.KeyCRUD, "Not authorized to view doc: %s %s:%s", base.UD(docid), base.MD(cv.SourceID), base.MD(cv.Version))
+			base.InfofCtx(ctx, base.KeyCRUD, "Not authorized to view doc: %s %s:%s", base.UD(docid), base.MD(cv.SourceID), base.MD(cv.Value))
 			return DocumentRevision{}, ErrForbidden
 		}
 		return redactedRevision, nil
@@ -533,7 +533,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 	return nil, nil, nil
 }
 
-func (col *DatabaseCollectionWithUser) authorizeUserForChannels(docID, revID string, cv *SourceAndVersion, channels base.Set, isDeleted bool, history Revisions) (isAuthorized bool, redactedRev DocumentRevision) {
+func (col *DatabaseCollectionWithUser) authorizeUserForChannels(docID, revID string, cv *Version, channels base.Set, isDeleted bool, history Revisions) (isAuthorized bool, redactedRev DocumentRevision) {
 
 	if col.user != nil {
 		if err := col.user.AuthorizeAnyCollectionChannel(col.ScopeName, col.Name, channels); err != nil {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1915,7 +1915,7 @@ func TestGetCVWithDocResidentInCache(t *testing.T) {
 
 			vrs := doc.HLV.Version
 			src := doc.HLV.SourceID
-			sv := &SourceAndVersion{Version: vrs, SourceID: src}
+			sv := &Version{Value: vrs, SourceID: src}
 			revision, err := collection.GetCV(ctx, docID, sv, true)
 			require.NoError(t, err)
 			if testCase.access {
@@ -1972,7 +1972,7 @@ func TestGetByCVForDocNotResidentInCache(t *testing.T) {
 	// get by CV should force a load from bucket and have a cache miss
 	vrs := doc.HLV.Version
 	src := doc.HLV.SourceID
-	sv := &SourceAndVersion{Version: vrs, SourceID: src}
+	sv := &Version{Value: vrs, SourceID: src}
 	revision, err := collection.GetCV(ctx, doc1ID, sv, true)
 	require.NoError(t, err)
 
@@ -2033,7 +2033,7 @@ func TestGetCVActivePathway(t *testing.T) {
 				require.NoError(t, err)
 				vrs := doc.HLV.Version
 				src := doc.HLV.SourceID
-				sv := &SourceAndVersion{Version: vrs, SourceID: src}
+				sv := &Version{Value: vrs, SourceID: src}
 				assert.Equal(t, rev, revision.RevID)
 				assert.Equal(t, sv, revision.CV)
 				assert.Equal(t, docID, revision.DocID)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -20,6 +20,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1866,4 +1867,182 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	// update the pv map so we can assert we have correct pv map in HLV
 	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
 	assert.Equal(t, "1-3a208ea66e84121b528f05b5457d1134", syncData.CurrentRev)
+}
+
+// TestGetCVWithDocResidentInCache:
+//   - Two test cases, one with doc a user will have access to, one without
+//   - Purpose is to have a doc that is resident in rev cache and use the GetCV function to retrieve these docs
+//   - Assert that the doc the user has access to is corrected fetched
+//   - Assert the doc the user doesn't have access to is fetched but correctly redacted
+func TestGetCVWithDocResidentInCache(t *testing.T) {
+	const docID = "doc1"
+
+	testCases := []struct {
+		name        string
+		docChannels []string
+		access      bool
+	}{
+		{
+			name:        "getCVWithUserAccess",
+			docChannels: []string{"A"},
+			access:      true,
+		},
+		{
+			name:        "getCVWithoutUserAccess",
+			docChannels: []string{"B"},
+			access:      false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db, ctx := setupTestDB(t)
+			defer db.Close(ctx)
+			collection := GetSingleDatabaseCollectionWithUser(t, db)
+			collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+			// Create a user with access to channel A
+			authenticator := db.Authenticator(base.TestCtx(t))
+			user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+			require.NoError(t, err)
+			require.NoError(t, authenticator.Save(user))
+			collection.user, err = authenticator.GetUser("alice")
+			require.NoError(t, err)
+
+			// create doc with the channels for the test case
+			docBody := Body{"channels": testCase.docChannels}
+			rev, doc, err := collection.Put(ctx, docID, docBody)
+			require.NoError(t, err)
+
+			vrs := doc.HLV.Version
+			src := doc.HLV.SourceID
+			sv := &SourceAndVersion{Version: vrs, SourceID: src}
+			revision, err := collection.GetCV(ctx, docID, sv, true)
+			require.NoError(t, err)
+			if testCase.access {
+				assert.Equal(t, rev, revision.RevID)
+				assert.Equal(t, sv, revision.CV)
+				assert.Equal(t, docID, revision.DocID)
+				assert.Equal(t, []byte(`{"channels":["A"]}`), revision.BodyBytes)
+			} else {
+				assert.Equal(t, rev, revision.RevID)
+				assert.Equal(t, sv, revision.CV)
+				assert.Equal(t, docID, revision.DocID)
+				assert.Equal(t, []byte(RemovedRedactedDocument), revision.BodyBytes)
+			}
+		})
+	}
+}
+
+// TestGetByCVForDocNotResidentInCache:
+//   - Setup db with rev cache size of 1
+//   - Put two docs forcing eviction of the first doc
+//   - Use GetCV function to fetch the first doc, forcing the rev cache to load the doc from bucket
+//   - Assert the doc revision fetched is correct to the first doc we created
+func TestGetByCVForDocNotResidentInCache(t *testing.T) {
+	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			Size: 1,
+		},
+	})
+	defer db.Close(ctx)
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	// Create a user with access to channel A
+	authenticator := db.Authenticator(base.TestCtx(t))
+	user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+	require.NoError(t, err)
+	require.NoError(t, authenticator.Save(user))
+	collection.user, err = authenticator.GetUser("alice")
+	require.NoError(t, err)
+
+	const (
+		doc1ID = "doc1"
+		doc2ID = "doc2"
+	)
+
+	revBody := Body{"channels": []string{"A"}}
+	rev, doc, err := collection.Put(ctx, doc1ID, revBody)
+	require.NoError(t, err)
+
+	// put another doc that should evict first doc from cache
+	_, _, err = collection.Put(ctx, doc2ID, revBody)
+	require.NoError(t, err)
+
+	// get by CV should force a load from bucket and have a cache miss
+	vrs := doc.HLV.Version
+	src := doc.HLV.SourceID
+	sv := &SourceAndVersion{Version: vrs, SourceID: src}
+	revision, err := collection.GetCV(ctx, doc1ID, sv, true)
+	require.NoError(t, err)
+
+	// assert the fetched doc is the first doc we added and assert that we did in fact get cache miss
+	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
+	assert.Equal(t, rev, revision.RevID)
+	assert.Equal(t, sv, revision.CV)
+	assert.Equal(t, doc1ID, revision.DocID)
+	assert.Equal(t, []byte(`{"channels":["A"]}`), revision.BodyBytes)
+}
+
+// TestGetCVActivePathway:
+//   - Two test cases, one with doc a user will have access to, one without
+//   - Purpose is top specify nil CV to the GetCV function to force the GetActive code pathway
+//   - Assert doc that is created is fetched correctly when user has access to doc
+//   - Assert that correct error is returned when user has no access to the doc
+func TestGetCVActivePathway(t *testing.T) {
+	const docID = "doc1"
+
+	testCases := []struct {
+		name        string
+		docChannels []string
+		access      bool
+	}{
+		{
+			name:        "activeFetchWithUserAccess",
+			docChannels: []string{"A"},
+			access:      true,
+		},
+		{
+			name:        "activeFetchWithoutUserAccess",
+			docChannels: []string{"B"},
+			access:      false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db, ctx := setupTestDB(t)
+			defer db.Close(ctx)
+			collection := GetSingleDatabaseCollectionWithUser(t, db)
+			collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+			// Create a user with access to channel A
+			authenticator := db.Authenticator(base.TestCtx(t))
+			user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+			require.NoError(t, err)
+			require.NoError(t, authenticator.Save(user))
+			collection.user, err = authenticator.GetUser("alice")
+			require.NoError(t, err)
+
+			// test get active path by specifying nil cv
+			revBody := Body{"channels": testCase.docChannels}
+			rev, doc, err := collection.Put(ctx, docID, revBody)
+			require.NoError(t, err)
+			revision, err := collection.GetCV(ctx, docID, nil, true)
+
+			if testCase.access == true {
+				require.NoError(t, err)
+				vrs := doc.HLV.Version
+				src := doc.HLV.SourceID
+				sv := &SourceAndVersion{Version: vrs, SourceID: src}
+				assert.Equal(t, rev, revision.RevID)
+				assert.Equal(t, sv, revision.CV)
+				assert.Equal(t, docID, revision.DocID)
+				assert.Equal(t, []byte(`{"channels":["A"]}`), revision.BodyBytes)
+			} else {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, ErrForbidden.Error())
+				assert.Equal(t, DocumentRevision{}, revision)
+			}
+		})
+	}
 }

--- a/db/document.go
+++ b/db/document.go
@@ -188,12 +188,11 @@ type Document struct {
 	Cas          uint64 // Document cas
 	rawUserXattr []byte // Raw user xattr as retrieved from the bucket
 
-	Deleted            bool
-	DocExpiry          uint32
-	RevID              string
-	DocAttachments     AttachmentsMeta
-	inlineSyncData     bool
-	currentRevChannels base.Set // A base.Set of the current revision's channels (determined by SyncData.Channels at UnmarshalJSON time)
+	Deleted        bool
+	DocExpiry      uint32
+	RevID          string
+	DocAttachments AttachmentsMeta
+	inlineSyncData bool
 }
 
 type historyOnlySyncData struct {
@@ -981,7 +980,6 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 			doc.updateChannelHistory(channel, doc.Sequence, true)
 		}
 	}
-	doc.currentRevChannels = newChannels
 	if changed != nil {
 		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)

--- a/db/document.go
+++ b/db/document.go
@@ -98,6 +98,20 @@ type SyncData struct {
 	removedRevisionBodyKeys map[string]string // keys of non-winning revisions that have been removed (and so may require deletion), indexed by revID
 }
 
+// determine set of current channels based on removal entries.
+func (sd *SyncData) getCurrentChannels() base.Set {
+	if len(sd.Channels) > 0 {
+		ch := base.SetOf()
+		for channelName, channelRemoval := range sd.Channels {
+			if channelRemoval == nil || channelRemoval.Seq == 0 {
+				ch.Add(channelName)
+			}
+		}
+		return ch
+	}
+	return nil
+}
+
 func (sd *SyncData) HashRedact(salt string) SyncData {
 
 	// Creating a new SyncData with the redacted info. We copy all the information which stays the same and create new
@@ -970,7 +984,6 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 			doc.updateChannelHistory(channel, doc.Sequence, true)
 		}
 	}
-	doc.currentRevChannels = newChannels
 	if changed != nil {
 		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)
@@ -1078,17 +1091,6 @@ func (doc *Document) UnmarshalJSON(data []byte) error {
 	}
 	if syncData.SyncData != nil {
 		doc.SyncData = *syncData.SyncData
-	}
-
-	// determine current revision's channels and store in-memory (avoids doc.Channels iteration at access-check time)
-	if len(doc.Channels) > 0 {
-		ch := base.SetOf()
-		for channelName, channelRemoval := range doc.Channels {
-			if channelRemoval == nil || channelRemoval.Seq == 0 {
-				ch.Add(channelName)
-			}
-		}
-		doc.currentRevChannels = ch
 	}
 
 	// Unmarshal the rest of the doc body as map[string]interface{}

--- a/db/document.go
+++ b/db/document.go
@@ -100,16 +100,13 @@ type SyncData struct {
 
 // determine set of current channels based on removal entries.
 func (sd *SyncData) getCurrentChannels() base.Set {
-	if len(sd.Channels) > 0 {
-		ch := base.SetOf()
-		for channelName, channelRemoval := range sd.Channels {
-			if channelRemoval == nil || channelRemoval.Seq == 0 {
-				ch.Add(channelName)
-			}
+	ch := base.SetOf()
+	for channelName, channelRemoval := range sd.Channels {
+		if channelRemoval == nil || channelRemoval.Seq == 0 {
+			ch.Add(channelName)
 		}
-		return ch
 	}
-	return nil
+	return ch
 }
 
 func (sd *SyncData) HashRedact(salt string) SyncData {
@@ -984,6 +981,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 			doc.updateChannelHistory(channel, doc.Sequence, true)
 		}
 	}
+	doc.currentRevChannels = newChannels
 	if changed != nil {
 		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -275,7 +275,7 @@ func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore,
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
-// revCacheLoaderForCv will load a document from the bucket using the CV, comapre the fetched doc and the CV specified in the function,
+// revCacheLoaderForCv will load a document from the bucket using the CV, compare the fetched doc and the CV specified in the function,
 // and will still return revid for purpose of populating the Rev ID lookup map on the cache
 func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	cv := Version{

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -337,10 +337,10 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	if err = doc.HasCurrentVersion(cv); err != nil {
 		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
 	}
-	channels = doc.SyncData.getCurrentChannels()
+	doc.currentRevChannels = doc.SyncData.getCurrentChannels()
 	revid = doc.CurrentRev
 
-	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+	return bodyBytes, body, history, doc.currentRevChannels, removed, attachments, deleted, doc.Expiry, revid, err
 }
 
 func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -337,7 +337,7 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	if err = doc.HasCurrentVersion(cv); err != nil {
 		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
 	}
-	channels = doc.currentRevChannels
+	channels = doc.SyncData.getCurrentChannels()
 	revid = doc.CurrentRev
 
 	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -337,10 +337,10 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	if err = doc.HasCurrentVersion(cv); err != nil {
 		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
 	}
-	doc.currentRevChannels = doc.SyncData.getCurrentChannels()
+	channels = doc.SyncData.getCurrentChannels()
 	revid = doc.CurrentRev
 
-	return bodyBytes, body, history, doc.currentRevChannels, removed, attachments, deleted, doc.Expiry, revid, err
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
 }
 
 func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +51,11 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 			Channels: base.SetOf("*"),
 		},
 	}
-	doc.currentRevChannels = base.SetOf("*")
+	doc.Channels = channels.ChannelMap{
+		"*": &channels.ChannelRemoval{RevID: doc.CurrentRev},
+	}
+	// currentRevChannels usually populated on JSON unmarshal
+	doc.currentRevChannels = doc.getCurrentChannels()
 
 	doc.HLV = &HybridLogicalVector{
 		SourceID: "test",

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -703,7 +703,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 
 // TestLoaderMismatchInCV:
 //   - Get doc that is not in cache by CV to trigger a load from bucket
-//   - Ensure the CV passed into teh GET operation won't match the doc in teh bucket
+//   - Ensure the CV passed into the GET operation won't match the doc in the bucket
 //   - Assert we get error and the value is not loaded into the cache
 func TestLoaderMismatchInCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
@@ -727,7 +727,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 //   - Now perform two concurrent Gets, one by CV and one by revid on a document that doesn't exist in the cache
 //   - This will trigger two concurrent loads from bucket in the CV code path and revid code path
 //   - In doing so we will have two processes trying to update lookup maps at the same time and a race condition will appear
-//   - In doing so will cause us to potentially have two of teh same elements the cache, one with nothing referencing it
+//   - In doing so will cause us to potentially have two of the same elements the cache, one with nothing referencing it
 //   - Assert after both gets are processed, that the cache only has one element in it and that both lookup maps have only one
 //     element
 //   - Grab the single element in the list and assert that both maps point to that element in the cache list
@@ -783,10 +783,10 @@ func TestGetActive(t *testing.T) {
 		Value:    doc.Cas,
 	}
 
-	// remove the entry form the rev cache to force teh cache to not have the active version in it
+	// remove the entry form the rev cache to force the cache to not have the active version in it
 	collection.revisionCache.RemoveWithCV("doc", &expectedCV)
 
-	// call get active to get teh active version from the bucket
+	// call get active to get the active version from the bucket
 	docRev, err := collection.revisionCache.GetActive(base.TestCtx(t), "doc", true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -54,8 +54,6 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 	doc.Channels = channels.ChannelMap{
 		"*": &channels.ChannelRemoval{RevID: doc.CurrentRev},
 	}
-	// currentRevChannels usually populated on JSON unmarshal
-	doc.currentRevChannels = doc.getCurrentChannels()
 
 	doc.HLV = &HybridLogicalVector{
 		SourceID: "test",

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8348,6 +8348,6 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	assert.NoError(t, err)
 	uintCAS = base.HexCasToUint64(syncData.Cas)
 
-	// TODO: assert that the SourceID and Verison pair are preserved correctly pending CBG-3211
+	// TODO: assert that the SourceID and Version pair are preserved correctly pending CBG-3211
 	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
 }


### PR DESCRIPTION
CBG-3212

- Add GetCV function to fetch a document by its specidfied CV 
- Add tests covering the active code opath, the code path where a doc will be resident in the rev cache and the code path where the do will not be resident in the rev cache
- I have removed some code that I added in the rev cache work that took place. It is code I took from Bens PR on channel information. It has changed since then and found it wasn't actually populating the channels correctly on a doc load from the bucket.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2264/
