### PR TITLE
CBG-3253: Add CBMobileReplicationV4

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -1329,6 +1329,8 @@ func TestAllowedAttachments(t *testing.T) {
 		{"TestAllowedAttachmentsCBMobile2AttVer2", CBMobileReplicationV2, AttVersion2},
 		{"TestAllowedAttachmentsCBMobile3AttVer1", CBMobileReplicationV3, AttVersion1},
 		{"TestAllowedAttachmentsCBMobile3AttVer2", CBMobileReplicationV3, AttVersion2},
+		{"TestAllowedAttachmentsCBMobile4AttVer1", CBMobileReplicationV4, AttVersion1},
+		{"TestAllowedAttachmentsCBMobile4AttVer2", CBMobileReplicationV4, AttVersion2},
 	}
 
 	isAllowedAttachment := func(ctx *BlipSyncContext, key string) bool {

--- a/db/blip_subprotocol.go
+++ b/db/blip_subprotocol.go
@@ -21,6 +21,8 @@ const (
 	CBMobileReplicationV2 CBMobileSubprotocolVersion = iota + 2
 	// CBMobileReplicationV3 minor changes to support revocation and ISGR
 	CBMobileReplicationV3
+	// Version Vectors/HLV
+	CBMobileReplicationV4
 
 	// _nextCBMobileSubprotocolVersions reserved for maxCBMobileSubprotocolVersion
 	_nextCBMobileSubprotocolVersions


### PR DESCRIPTION
- CBG-3253 Add subprotocol version v4 for VV/HLV
- Actual Push/Pull changes will be done separately (CBG-3255 and CBG-3254)

## Dependencies
- [x] #6582 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a 