### PR TITLE
CBG-3271 Implement bootstrap connection for rosmar

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -355,6 +355,9 @@ func (cc *CouchbaseCluster) WriteMetadataDocument(ctx context.Context, location,
 	if cc == nil {
 		return 0, errors.New("nil CouchbaseCluster")
 	}
+	if cas == 0 {
+		return 0, RedactErrorf("CAS for %q in bucket %q must be non-zero", docID, location)
+	}
 
 	b, teardown, err := cc.getBucket(ctx, location)
 	if err != nil {

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -48,6 +48,9 @@ type BootstrapConnection interface {
 	// Returns exists=false if key is not found, returns error for any other error.
 	GetDocument(ctx context.Context, bucket, docID string, rv interface{}) (exists bool, err error)
 
+	// SetConnectionStringServerless sets the connection string to use serverless mode, needs to be called before any connection occurs.
+	SetConnectionStringServerless() error
+
 	// Returns the bootstrap connection's cluster connection as N1QLStore for the specified bucket/scope/collection.
 	// Does NOT establish a bucket connection, the bucketName/scopeName/collectionName is for query scoping only
 	GetClusterN1QLStore(bucketName, scopeName, collectionName string) (*ClusterOnlyN1QLStore, error)

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -356,7 +356,7 @@ func (cc *CouchbaseCluster) WriteMetadataDocument(ctx context.Context, location,
 		return 0, errors.New("nil CouchbaseCluster")
 	}
 	if cas == 0 {
-		return 0, RedactErrorf("CAS for %q in bucket %q must be non-zero", docID, location)
+		return 0, RedactErrorf("CAS for %q in bucket %q must be non-zero", UD(docID), MD(location))
 	}
 
 	b, teardown, err := cc.getBucket(ctx, location)

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -356,7 +356,7 @@ func (cc *CouchbaseCluster) WriteMetadataDocument(ctx context.Context, location,
 		return 0, errors.New("nil CouchbaseCluster")
 	}
 	if cas == 0 {
-		return 0, RedactErrorf("CAS for %q in bucket %q must be non-zero", UD(docID), MD(location))
+		return 0, RedactErrorf("CAS for %q in bucket %q must be non-zero to call WriteMetadataDocument, to add a new document use InsertMetadataDocument", UD(docID), MD(location))
 	}
 
 	b, teardown, err := cc.getBucket(ctx, location)

--- a/base/constants.go
+++ b/base/constants.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"os"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/couchbaselabs/rosmar"
@@ -229,12 +228,6 @@ func UnitTestUrl() string {
 // UnitTestUrlIsWalrus returns true if we're running with a Walrus test URL.
 func UnitTestUrlIsWalrus() bool {
 	return ServerIsWalrus(UnitTestUrl())
-}
-
-func TestsRequireBootstrapConnection(t *testing.T) {
-	if UnitTestUrlIsWalrus() {
-		t.Skipf("Tests requiring a bootstrap connection are not supporting using rosmar yet - CBG-3271")
-	}
 }
 
 // ServerIsTLS returns true if the server URL is using an accepted secure protocol as it's prefix

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -1,0 +1,188 @@
+package base
+
+import (
+	"context"
+	"errors"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbaselabs/rosmar"
+)
+
+var _ BootstrapConnection = &RosmarCluster{}
+
+// RosmarCluster implements BootstrapConnection and is used for connecting to a rosmar cluster
+type RosmarCluster struct {
+	serverURL string
+}
+
+// NewRosmarCluster creates a from a given URL
+func NewRosmarCluster(serverURL string) *RosmarCluster {
+	return &RosmarCluster{
+		serverURL: serverURL,
+	}
+}
+
+// GetConfigBuckets returns all the buckets registered in rosmar.
+func (c *RosmarCluster) GetConfigBuckets() ([]string, error) {
+	return rosmar.GetBucketNames(), nil
+}
+
+// GetMetadataDocument returns a metadata document from the default collection for the specified bucket.
+func (c *RosmarCluster) GetMetadataDocument(ctx context.Context, location, docID string, valuePtr interface{}) (cas uint64, err error) {
+	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	if err != nil {
+		return 0, err
+	}
+	defer bucket.Close(ctx)
+
+	return bucket.DefaultDataStore().Get(docID, valuePtr)
+}
+
+// InsertMetadataDocument inserts a metadata document, and fails if it already exists or returns a CasMismatchError
+func (c *RosmarCluster) InsertMetadataDocument(ctx context.Context, location, key string, value interface{}) (newCAS uint64, err error) {
+	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	if err != nil {
+		return 0, err
+	}
+	defer bucket.Close(ctx)
+
+	return bucket.DefaultDataStore().WriteCas(key, 0, 0, 0, value, 0)
+}
+
+// WriteMetadataDocument writes a metadata document, and fails on CAS mismatch
+func (c *RosmarCluster) WriteMetadataDocument(ctx context.Context, location, docID string, cas uint64, value interface{}) (newCAS uint64, err error) {
+	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	if err != nil {
+		return 0, err
+	}
+	defer bucket.Close(ctx)
+
+	return c.writeWithOptionalCas(bucket.DefaultDataStore(), docID, cas, value)
+}
+
+// TouchMetadataDocument sets the specified property in a bootstrap metadata document for a given bucket and key.  Used to
+// trigger CAS update on the document, to block any racing updates. Does not retry on CAS failure.
+
+func (c *RosmarCluster) TouchMetadataDocument(ctx context.Context, location, docID string, property, value string, cas uint64) (newCAS uint64, err error) {
+	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	if err != nil {
+		return 0, err
+	}
+	defer bucket.Close(ctx)
+
+	// FIXME to not touch the whole document?
+	return bucket.DefaultDataStore().Touch(docID, 0)
+}
+
+// writeWithOptionalCas writes a document, optionally using a CAS value if provided.  If the document already exists, the CAS value must match the existing CAS value. This is a workaround for behavior of WriteCas and has race conditions on getting cas if the document is updated after Set and before Get when cas = 0.
+func (c *RosmarCluster) writeWithOptionalCas(dataStore DataStore, docID string, cas uint64, value any) (uint64, error) {
+	var unused any
+	_, err := dataStore.Get(docID, &unused)
+	if err != nil {
+		return 0, err
+	}
+	newDoc := IsDocNotFoundError(err)
+	if cas != 0 && !newDoc {
+		return dataStore.WriteCas(docID, 0, 0, cas, value, 0)
+
+	}
+	err = dataStore.Set(docID, 0, nil, value)
+	if err != nil {
+		return 0, err
+	}
+	return dataStore.Get(docID, &unused)
+}
+
+// DeleteMetadataDocument deletes an existing bootstrap metadata document for a given bucket and key.
+func (c *RosmarCluster) DeleteMetadataDocument(ctx context.Context, location, key string, cas uint64) error {
+	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	if err != nil {
+		return err
+	}
+	defer bucket.Close(ctx)
+
+	_, err = bucket.DefaultDataStore().Remove(key, cas)
+	return err
+}
+
+// UpdateMetadataDocument retries on CAS mismatch
+func (c *RosmarCluster) UpdateMetadataDocument(ctx context.Context, location, docID string, updateCallback func(bucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error)) (newCAS uint64, err error) {
+	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	if err != nil {
+		return 0, err
+	}
+	defer bucket.Close(ctx)
+	for {
+		var bucketValue []byte
+		cas, err := bucket.DefaultDataStore().Get(docID, &bucketValue)
+		if err != nil {
+			return 0, err
+		}
+		newConfig, err := updateCallback(bucketValue, cas)
+		if err != nil {
+			return 0, err
+		}
+		// handle delete when updateCallback returns nil
+		if newConfig == nil {
+			removeCasOut, err := bucket.DefaultDataStore().Remove(docID, cas)
+			if err != nil {
+				// retry on cas failure
+				if errors.As(err, &sgbucket.CasMismatchErr{}) {
+					continue
+				}
+				return 0, err
+			}
+			return removeCasOut, nil
+		}
+
+		replaceCfgCasOut, err := bucket.DefaultDataStore().WriteCas(docID, 0, 0, cas, newConfig, 0)
+		if err != nil {
+			if errors.As(err, &sgbucket.CasMismatchErr{}) {
+				// retry on cas failure
+				continue
+			}
+			return 0, err
+		}
+
+		return replaceCfgCasOut, nil
+	}
+
+}
+
+// KeyExists checks whether a key exists in the default collection for the specified bucket
+func (c *RosmarCluster) KeyExists(ctx context.Context, location, docID string) (exists bool, err error) {
+	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	if err != nil {
+		return false, err
+	}
+	defer bucket.Close(ctx)
+
+	return bucket.DefaultDataStore().Exists(docID)
+}
+
+// GetDocument fetches a document from the default collection.  Does not use configPersistence - callers
+// requiring configPersistence handling should use GetMetadataDocument.
+func (c *RosmarCluster) GetDocument(ctx context.Context, bucketName, docID string, rv interface{}) (exists bool, err error) {
+	bucket, err := rosmar.OpenBucket(c.serverURL, bucketName, rosmar.CreateOrOpen)
+	if err != nil {
+		return false, err
+	}
+	defer bucket.Close(ctx)
+
+	_, err = bucket.DefaultDataStore().Get(docID, rv)
+	if IsDocNotFoundError(err) {
+		return false, nil
+	}
+	return err != nil, err
+
+}
+
+// Close calls teardown for any cached buckets and removes from cachedBucketConnections
+func (c *RosmarCluster) Close() {
+}
+
+func (c *RosmarCluster) SetConnectionStringServerless() error { return nil }
+
+func (c *RosmarCluster) GetClusterN1QLStore(bucketName, scopeName, collectionName string) (*ClusterOnlyN1QLStore, error) {
+	return nil, errors.New("rosmar doesn't support a N1QL store")
+}

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -1,3 +1,11 @@
+// Copyright 2023-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3309,9 +3309,6 @@ func TestSwitchDbConfigCollectionName(t *testing.T) {
 }
 
 func TestPutDBConfigOIDC(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
@@ -3642,9 +3639,6 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 
 // TestDbConfigPersistentSGVersions ensures that cluster-wide config updates are not applied to older nodes to avoid pushing invalid configuration.
 func TestDbConfigPersistentSGVersions(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyConfig)
 
@@ -3944,7 +3938,7 @@ func TestDisablePasswordAuthThroughAdminAPI(t *testing.T) {
 
 // CBG-1790: Deleting a database that targets the same bucket as another causes a panic in legacy
 func TestDeleteDatabasePointingAtSameBucket(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {
+	if !base.TestUseXattrs() {
 		t.Skip("This test only works against Couchbase Server with xattrs")
 	}
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1468,15 +1468,14 @@ func TestResyncStop(t *testing.T) {
 //     on the config now matches the rest tester bucket name
 func TestCorruptDbConfigHandling(t *testing.T) {
 	base.LongRunningTest(t)
-	base.TestsRequireBootstrapConnection(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyConfig)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
-			// configure the interval time to pick up new configs from the bucket to every 1 seconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+			// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
 		},
 	})
 	defer rt.Close()
@@ -1554,14 +1553,13 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 //   - assert that the db config is picked up as an invalid db config
 //   - assert that a call to the db endpoint will fail with correct error message
 func TestBadConfigInsertionToBucket(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
-			// configure the interval time to pick up new configs from the bucket to every 1 seconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+			// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Second)
 		},
 		DatabaseConfig: nil,
 	})
@@ -1605,7 +1603,6 @@ func TestBadConfigInsertionToBucket(t *testing.T) {
 //   - attempt to update the config to change the bucket name on the config to a mismatched bucket name
 //   - assert the request fails
 func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t)
 	base.RequireNumTestBuckets(t, 2)
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
@@ -1615,8 +1612,8 @@ func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
 		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
-			// configure the interval time to pick up new configs from the bucket to every 1 seconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+			// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
 		},
 	})
 	defer rt.Close()
@@ -1640,7 +1637,6 @@ func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
 //   - in bucketA and bucketB, write two db configs with bucket name as bucketC
 //   - Start new rest tester and ensure they aren't picked up as valid configs
 func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t)
 	base.RequireNumTestBuckets(t, 3)
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
@@ -1686,8 +1682,8 @@ func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
 		PersistentConfig: true,
 		CustomTestBucket: tb3,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
-			// configure the interval time to pick up new configs from the bucket to every 1 seconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+			// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Second)
 			// configure same config groupID
 			config.Bootstrap.ConfigGroupID = groupID
 		},
@@ -1718,7 +1714,6 @@ func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
 //   - create bucketA and bucketB with db configs that that both list bucket name as bucketA
 //   - start a new rest tester and assert that invalid db config is picked up and the valid one is also picked up
 func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t)
 
 	base.RequireNumTestBuckets(t, 3)
 	ctx := base.TestCtx(t)
@@ -1760,8 +1755,8 @@ func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
 	rt3 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
-			// configure the interval time to pick up new configs from the bucket to every 1 seconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+			// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
 			// configure same config groupID
 			config.Bootstrap.ConfigGroupID = "60ce5544-c368-4b08-b0ed-4ca3b37973f9"
 		},
@@ -1789,7 +1784,6 @@ func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
 //   - persist that db config to another bucket
 //   - assert that is picked up as an invalid db config
 func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t)
 
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
@@ -1801,8 +1795,8 @@ func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
 		CustomTestBucket: tb1,
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
-			// configure the interval time to pick up new configs from the bucket to every 1 seconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(1 * time.Second)
+			// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
 		},
 	})
 	defer rt.Close()
@@ -3186,7 +3180,6 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 }
 
 func TestPersistentConfigConcurrency(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t) // etags require a bootstrap connection
 	rt := rest.NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 
@@ -3248,8 +3241,6 @@ func TestDbConfigCredentials(t *testing.T) {
 }
 
 func TestInvalidDBConfig(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t) // import_filter / sync function dynamic modification require bootstrap connection
-
 	rt := rest.NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 
@@ -3607,7 +3598,6 @@ func TestDbOfflineConfigLegacy(t *testing.T) {
 }
 
 func TestDbOfflineConfigPersistent(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t) // import_filter / sync function dynamic modification require bootstrap connection
 	importFilter := "function(doc) { return true }"
 	syncFunc := "function(doc){ channel(doc.channels); }"
 
@@ -3775,7 +3765,6 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 }
 
 func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t) // import_filter / sync function dynamic modification require bootstrap connection
 
 	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{
@@ -3828,8 +3817,6 @@ func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
 }
 
 func TestSetFunctionsWhileDbOffline(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t) // import_filter / sync function dynamic modification require bootstrap connection
-
 	importFilter := "function(doc){ return true; }"
 	syncFunc := "function(doc){ channel(doc.channels); }"
 
@@ -4332,9 +4319,9 @@ func TestPerDBCredsOverride(t *testing.T) {
 	}()
 	require.NoError(t, sc.WaitForRESTAPIs(ctx))
 
-	couchbaseCluster, err := rest.CreateCouchbaseClusterFromStartupConfig(ctx, sc.Config, base.PerUseClusterConnections)
+	bootstrapConnection, err := rest.CreateBootstrapConnectionFromStartupConfig(ctx, sc.Config, base.PerUseClusterConnections)
 	require.NoError(t, err)
-	sc.BootstrapContext.Connection = couchbaseCluster
+	sc.BootstrapContext.Connection = bootstrapConnection
 
 	dbConfig := `{
 		"bucket": "` + tb1.GetName() + `",

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3309,7 +3309,7 @@ func TestSwitchDbConfigCollectionName(t *testing.T) {
 }
 
 func TestPutDBConfigOIDC(t *testing.T) {
-
+	rest.RequireNonParallelBootstrapTests(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error, 0)
@@ -3422,10 +3422,7 @@ func TestNotExistentDBRequest(t *testing.T) {
 }
 
 func TestConfigsIncludeDefaults(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
+	rest.RequireNonParallelBootstrapTests(t)
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
@@ -3516,9 +3513,8 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 }
 
 func TestLegacyCredentialInheritance(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	rest.RequireNonParallelBootstrapTests(t)
+	rest.RequireBucketSpecificCredentials(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
@@ -3639,7 +3635,7 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 
 // TestDbConfigPersistentSGVersions ensures that cluster-wide config updates are not applied to older nodes to avoid pushing invalid configuration.
 func TestDbConfigPersistentSGVersions(t *testing.T) {
-
+	rest.RequireNonParallelBootstrapTests(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyConfig)
 
 	serverErr := make(chan error, 0)
@@ -4276,9 +4272,7 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 
 // Make sure per DB credentials override per bucket credentials
 func TestPerDBCredsOverride(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	rest.RequireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	// Get test bucket

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1509,7 +1509,7 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	responseConfig := rt.ServerContext().GetDbConfig("db1")
 	assert.Nil(t, responseConfig)
 
-	require.Equal(t, 1, len(rt.ServerContext().AllInvalidDatabases()))
+	require.Len(t, rt.ServerContext().AllInvalidDatabaseNames(t), 1)
 
 	// assert that fetching config fails with the correct error message to the user
 	resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
@@ -1533,7 +1533,7 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	// wait some time for interval to pick up change
 	err = rt.WaitForConditionWithOptions(func() bool {
 		list := rt.ServerContext().AllDatabaseNames()
-		numInvalid := len(rt.ServerContext().AllInvalidDatabases())
+		numInvalid := len(rt.ServerContext().AllInvalidDatabaseNames(t))
 		return len(list) == 1 && numInvalid == 0
 	}, 200, 1000)
 	require.NoError(t, err)
@@ -1559,7 +1559,7 @@ func TestBadConfigInsertionToBucket(t *testing.T) {
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Second)
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
 		},
 		DatabaseConfig: nil,
 	})
@@ -1587,7 +1587,7 @@ func TestBadConfigInsertionToBucket(t *testing.T) {
 
 	// asser that the config is picked up as invalid config on server context
 	err = rt.WaitForConditionWithOptions(func() bool {
-		invalidDatabases := rt.ServerContext().AllInvalidDatabases()
+		invalidDatabases := rt.ServerContext().AllInvalidDatabaseNames(t)
 		return len(invalidDatabases) == 1
 	}, 200, 1000)
 	require.NoError(t, err)
@@ -1683,7 +1683,7 @@ func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
 		CustomTestBucket: tb3,
 		MutateStartupConfig: func(config *rest.StartupConfig) {
 			// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
-			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Second)
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
 			// configure same config groupID
 			config.Bootstrap.ConfigGroupID = groupID
 		},
@@ -1692,7 +1692,7 @@ func TestMultipleBucketWithBadDbConfigScenario1(t *testing.T) {
 
 	// assert the invalid database is picked up with new rest tester
 	err := rt3.WaitForConditionWithOptions(func() bool {
-		invalidDatabases := rt3.ServerContext().AllInvalidDatabases()
+		invalidDatabases := rt3.ServerContext().AllInvalidDatabaseNames(t)
 		return len(invalidDatabases) == 1
 	}, 200, 1000)
 	require.NoError(t, err)
@@ -1765,7 +1765,7 @@ func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
 
 	// assert that the invalid config is picked up by the new rest tester
 	err := rt3.WaitForConditionWithOptions(func() bool {
-		invalidDatabases := rt3.ServerContext().AllInvalidDatabases()
+		invalidDatabases := rt3.ServerContext().AllInvalidDatabaseNames(t)
 		return len(invalidDatabases) == 1
 	}, 200, 1000)
 	require.NoError(t, err)
@@ -1828,7 +1828,7 @@ func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
 
 	// assert the config is picked as invalid db config
 	err = rt.WaitForConditionWithOptions(func() bool {
-		invalidDatabases := rt.ServerContext().AllInvalidDatabases()
+		invalidDatabases := rt.ServerContext().AllInvalidDatabaseNames(t)
 		return len(invalidDatabases) == 1
 	}, 200, 1000)
 	require.NoError(t, err)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -25,10 +25,7 @@ import (
 // Then Sync Gateway restarts to ensure that a subsequent bootstrap picks up the
 // database created in the first step.
 func TestBootstrapRESTAPISetup(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Bootstrap works with Couchbase Server only")
-	}
-
+	RequireNonParallelBootstrapTests(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	// Start SG with no databases
@@ -140,9 +137,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 
 // TestBootstrapDuplicateBucket will attempt to create two databases sharing the same collections and ensure this isn't allowed.
 func TestBootstrapDuplicateCollections(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Bootstrap works with Couchbase Server only")
-	}
+	RequireNonParallelBootstrapTests(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
@@ -187,9 +182,7 @@ func TestBootstrapDuplicateCollections(t *testing.T) {
 
 // TestBootstrapDuplicateDatabase will attempt to create a second database and ensure this isn't allowed.
 func TestBootstrapDuplicateDatabase(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Bootstrap works with Couchbase Server only")
-	}
+	RequireNonParallelBootstrapTests(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1356,8 +1356,13 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 	}
 
 	sc := NewServerContext(ctx, config, persistentConfig)
-	failFast := false
-	if err := sc.initializeCouchbaseServerConnections(ctx, failFast); err != nil {
+	if !base.ServerIsWalrus(sc.Config.Bootstrap.Server) {
+		err := sc.initializeGocbAdminConnection(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := sc.initializeBootstrapConnection(ctx); err != nil {
 		return nil, err
 	}
 	return sc, nil

--- a/rest/config.go
+++ b/rest/config.go
@@ -1356,11 +1356,9 @@ func SetupServerContext(ctx context.Context, config *StartupConfig, persistentCo
 	}
 
 	sc := NewServerContext(ctx, config, persistentConfig)
-	if !base.ServerIsWalrus(config.Bootstrap.Server) {
-		failFast := false
-		if err := sc.initializeCouchbaseServerConnections(ctx, failFast); err != nil {
-			return nil, err
-		}
+	failFast := false
+	if err := sc.initializeCouchbaseServerConnections(ctx, failFast); err != nil {
+		return nil, err
 	}
 	return sc, nil
 }

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -332,7 +332,7 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	sc, _, _, _, err := automaticConfigUpgrade(ctx, configPath)
 	require.NoError(t, err)
 
-	cluster, err := CreateCouchbaseClusterFromStartupConfig(ctx, sc, base.PerUseClusterConnections)
+	cluster, err := CreateBootstrapConnectionFromStartupConfig(ctx, sc, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	bootstrap := bootstrapContext{

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -208,7 +208,6 @@ outer:
 
 	// Step 2. Update the config document
 	docID := PersistentConfigKey(ctx, groupID, dbName)
-	fmt.Println("updatedConfig.cfgCas=", updatedConfig.cfgCas)
 	casOut, err := b.Connection.WriteMetadataDocument(ctx, bucketName, docID, updatedConfig.cfgCas, updatedConfig)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyConfig, "Write for database config %q returned error %v", base.MD(docID), err)

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -208,6 +208,7 @@ outer:
 
 	// Step 2. Update the config document
 	docID := PersistentConfigKey(ctx, groupID, dbName)
+	fmt.Println("updatedConfig.cfgCas=", updatedConfig.cfgCas)
 	casOut, err := b.Connection.WriteMetadataDocument(ctx, bucketName, docID, updatedConfig.cfgCas, updatedConfig)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyConfig, "Write for database config %q returned error %v", base.MD(docID), err)
@@ -293,7 +294,7 @@ outer:
 	} else {
 		writeErr := b.setGatewayRegistry(ctx, bucketName, registry)
 		if writeErr != nil {
-			return fmt.Errorf("!Error persisting removal of previous version of config group: %s, database: %s from registry after successful delete: %w", base.MD(groupID), base.MD(dbName), writeErr)
+			return fmt.Errorf("Error persisting removal of previous version of config group: %s, database: %s from registry after successful delete: %w", base.MD(groupID), base.MD(dbName), writeErr)
 		}
 	}
 

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -19,10 +19,6 @@ import (
 )
 
 func TestBootstrapConfig(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	base.TestRequiresCollections(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyDCP)
@@ -176,10 +172,6 @@ func TestLongMetadataID(t *testing.T) {
 }
 
 func TestVersionDowngrade(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	// rely on AtLeastMinorDowngrade unit test to cover all cases, starting up a db is slow
 	testCases := []struct {
 		syncGatewayVersion      string

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestBootstrapConfig(t *testing.T) {
+	RequireNonParallelBootstrapTests(t)
 	base.TestRequiresCollections(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyDCP)

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -156,7 +156,6 @@ func (r *GatewayRegistry) removeDatabase(configGroupID, dbName string) bool {
 // If in-conflict with an in-flight update to other database(s), returns that set as previousVersionConflicts so that callers
 // can wait and retry.
 func (r *GatewayRegistry) upsertDatabaseConfig(ctx context.Context, configGroupID string, config *DatabaseConfig) (previousVersionConflicts []configGroupAndDatabase, err error) {
-
 	if config == nil {
 		return nil, fmt.Errorf("attempted to upsertDatabaseConfig with nil config")
 	}

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -395,16 +395,11 @@ func TestCORSValidation(t *testing.T) {
 		MaxAge: 1000,
 	}
 	resp := rt.CreateDatabase(dbName, dbConfig)
-	// walrus doesn't set ServerContext.persistentConfig so we miss some validation
-	if base.UnitTestUrlIsWalrus() {
-		RequireStatus(t, resp, http.StatusCreated)
-	} else {
-		RequireStatus(t, resp, http.StatusBadRequest)
-		require.Contains(t, resp.Body.String(), "max_age")
-		nonCORSDbConfig := rt.NewDbConfig()
-		resp := rt.CreateDatabase(dbName, nonCORSDbConfig)
-		RequireStatus(t, resp, http.StatusCreated)
-	}
+	RequireStatus(t, resp, http.StatusBadRequest)
+	require.Contains(t, resp.Body.String(), "max_age")
+	nonCORSDbConfig := rt.NewDbConfig()
+	resp = rt.CreateDatabase(dbName, nonCORSDbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
 	resp = rt.UpsertDbConfig(dbName, dbConfig)
 	RequireStatus(t, resp, http.StatusBadRequest)
 	require.Contains(t, resp.Body.String(), "max_age")

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -74,7 +74,7 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 
 	base.InfofCtx(ctx, base.KeyAll, "Starting new async initialization for database %s ...",
 		base.MD(dbConfig.Name))
-	couchbaseCluster, err := CreateCouchbaseClusterFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
+	couchbaseCluster, err := CreateBootstrapConnectionFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/main.go
+++ b/rest/main.go
@@ -206,7 +206,7 @@ func automaticConfigUpgrade(ctx context.Context, configPath string) (sc *Startup
 	}
 
 	// Attempt to establish connection to server
-	cluster, err := CreateCouchbaseClusterFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
+	cluster, err := CreateBootstrapConnectionFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
 	if err != nil {
 		return nil, false, nil, nil, err
 	}
@@ -368,7 +368,11 @@ func backupCurrentConfigFile(sourcePath string) (string, error) {
 	return backupPath, nil
 }
 
-func CreateCouchbaseClusterFromStartupConfig(ctx context.Context, config *StartupConfig, bucketConnectionMode base.BucketConnectionMode) (*base.CouchbaseCluster, error) {
+func CreateBootstrapConnectionFromStartupConfig(ctx context.Context, config *StartupConfig, bucketConnectionMode base.BucketConnectionMode) (base.BootstrapConnection, error) {
+	if base.ServerIsWalrus(config.Bootstrap.Server) {
+		cluster := base.NewRosmarCluster(config.Bootstrap.Server)
+		return cluster, nil
+	}
 	cluster, err := base.NewCouchbaseCluster(ctx, config.Bootstrap.Server, config.Bootstrap.Username, config.Bootstrap.Password,
 		config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath, config.Bootstrap.CACertPath,
 		config.IsServerless(), config.BucketCredentials, config.Bootstrap.ServerTLSSkipVerify, config.Unsupported.UseXattrConfig, bucketConnectionMode)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -470,6 +470,7 @@ func TestPersistentConfigWithCollectionConflicts(t *testing.T) {
 //  5. UpdateConfig to a different db, with collection conflict with the failed create (should fail with conflict, but succeed after GetDatabaseConfigs runs)
 //  6. DeleteConfig for the same db name (triggers rollback, then returns ErrNotFound for the delete operation)
 func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
+	RequireNonParallelBootstrapTests(t)
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -613,6 +614,7 @@ func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
 //  5. DeleteConfig for the same db name (triggers rollback, then successfully deletes)
 
 func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
+	RequireNonParallelBootstrapTests(t)
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -763,6 +765,7 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 //  4. Attempt recreation of database with earlier version generation, after delete fails.  Should resolve delete and succeed
 //  5. Attempt update of database after delete fails.  Should return "database does not exist" error
 func TestPersistentConfigRegistryRollbackAfterDeleteFailure(t *testing.T) {
+	RequireNonParallelBootstrapTests(t)
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -876,6 +879,7 @@ func TestPersistentConfigRegistryRollbackAfterDeleteFailure(t *testing.T) {
 // triggers rollback before the config document is updated. Verifies that the original create operation
 // fails and returns an appropriate error
 func TestPersistentConfigSlowCreateFailure(t *testing.T) {
+	RequireNonParallelBootstrapTests(t)
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -1121,6 +1125,7 @@ func TestMigratev30PersistentConfigUseXattrStore(t *testing.T) {
 // TestMigratev30PersistentConfigCollision sets up a 3.1 database targeting the default collection, then attempts
 // migration of another database in the 3.0 format (which also targets the default collection)
 func TestMigratev30PersistentConfigCollision(t *testing.T) {
+	RequireNonParallelBootstrapTests(t)
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -1189,6 +1194,7 @@ func TestMigratev30PersistentConfigCollision(t *testing.T) {
 
 // TestLegacyDuplicate tests the behaviour of GetDatabaseConfigs when the same database exists in legacy and non-legacy format
 func TestLegacyDuplicate(t *testing.T) {
+	RequireNonParallelBootstrapTests(t)
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -97,7 +97,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 
 	assert.Equal(t, config, string(writtenBackupFile))
 
-	cbs, err := CreateCouchbaseClusterFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
+	cbs, err := CreateBootstrapConnectionFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	bootstrapContext := &bootstrapContext{
@@ -270,7 +270,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 	startupConfig, _, _, _, err := automaticConfigUpgrade(ctx, updatedConfigPath)
 	require.NoError(t, err)
 
-	cbs, err := CreateCouchbaseClusterFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
+	cbs, err := CreateBootstrapConnectionFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
 	require.NoError(t, err)
 
 	bootstrapContext := &bootstrapContext{
@@ -338,8 +338,7 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 }
 
 func TestImportFilterEndpoint(t *testing.T) {
-	base.SkipImportTestsIfNotEnabled(t)     // import tests don't work without xattrs
-	base.TestsRequireBootstrapConnection(t) // import filter modification requires bootstrap connection CBG-3271
+	base.SkipImportTestsIfNotEnabled(t) // import tests don't work without xattrs
 
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
@@ -381,7 +380,6 @@ func TestImportFilterEndpoint(t *testing.T) {
 }
 
 func TestPersistentConfigWithCollectionConflicts(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t)
 	base.TestRequiresCollections(t)
 
 	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
@@ -1300,7 +1298,6 @@ func makeDbConfig(bucketName string, dbName string, scopesConfig ScopesConfig) D
 }
 
 func TestPersistentConfigNoBucketField(t *testing.T) {
-	base.TestsRequireBootstrapConnection(t)
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyConfig)
@@ -1349,7 +1346,7 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 
 	count, err := rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count, "should have loaded 1 config")
+	require.Equal(t, 1, count, "should have loaded 1 config")
 
 	_, err = rt.UpdatePersistedBucketName(&databaseConfig, &b2Name)
 	require.NoError(t, err)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -470,10 +470,6 @@ func TestPersistentConfigWithCollectionConflicts(t *testing.T) {
 //  5. UpdateConfig to a different db, with collection conflict with the failed create (should fail with conflict, but succeed after GetDatabaseConfigs runs)
 //  6. DeleteConfig for the same db name (triggers rollback, then returns ErrNotFound for the delete operation)
 func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -617,10 +613,6 @@ func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
 //  5. DeleteConfig for the same db name (triggers rollback, then successfully deletes)
 
 func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -771,10 +763,6 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 //  4. Attempt recreation of database with earlier version generation, after delete fails.  Should resolve delete and succeed
 //  5. Attempt update of database after delete fails.  Should return "database does not exist" error
 func TestPersistentConfigRegistryRollbackAfterDeleteFailure(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -888,10 +876,6 @@ func TestPersistentConfigRegistryRollbackAfterDeleteFailure(t *testing.T) {
 // triggers rollback before the config document is updated. Verifies that the original create operation
 // fails and returns an appropriate error
 func TestPersistentConfigSlowCreateFailure(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -1051,7 +1035,7 @@ func TestMigratev30PersistentConfig(t *testing.T) {
 
 func TestMigratev30PersistentConfigUseXattrStore(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+		t.Skip("xattr storage is only enabled with CBS and not RosmarCluster")
 	}
 
 	base.TestRequiresCollections(t)
@@ -1137,10 +1121,6 @@ func TestMigratev30PersistentConfigUseXattrStore(t *testing.T) {
 // TestMigratev30PersistentConfigCollision sets up a 3.1 database targeting the default collection, then attempts
 // migration of another database in the 3.0 format (which also targets the default collection)
 func TestMigratev30PersistentConfigCollision(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
@@ -1209,10 +1189,6 @@ func TestMigratev30PersistentConfigCollision(t *testing.T) {
 
 // TestLegacyDuplicate tests the behaviour of GetDatabaseConfigs when the same database exists in legacy and non-legacy format
 func TestLegacyDuplicate(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7837,6 +7837,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 
 // Tests replications to make sure they are namespaced by group ID
 func TestGroupIDReplications(t *testing.T) {
+	rest.RequireNonParallelBootstrapTests(t)
 	if !base.TestUseXattrs() {
 		t.Skip("This test requires xattrs")
 	}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1839,9 +1839,6 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 
 // Repros CBG-2416
 func TestDBReplicationStatsTeardown(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
 
 	base.RequireNumTestBuckets(t, 2)
 	// Test tests Prometheus stat registration
@@ -1946,10 +1943,6 @@ func TestTakeDbOfflineOngoingPushReplication(t *testing.T) {
 func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 
 	t.Skip("Skipping test - revisit in CBG-1908")
-
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Test does not support Walrus - depends on closing and re-opening persistent bucket")
-	}
 
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
@@ -7844,8 +7837,8 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 
 // Tests replications to make sure they are namespaced by group ID
 func TestGroupIDReplications(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {
-		t.Skip("This test requires xattrs and persistent config")
+	if !base.TestUseXattrs() {
+		t.Skip("This test requires xattrs")
 	}
 	base.RequireNumTestBuckets(t, 2)
 
@@ -7903,8 +7896,11 @@ func TestGroupIDReplications(t *testing.T) {
 				Bucket: base.StringPtr(activeBucket.GetName()),
 			},
 			EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
-			UseViews:     base.BoolPtr(base.TestsDisableGSI()),
 		}
+		if !base.UnitTestUrlIsWalrus() {
+			dbConfig.UseViews = base.BoolPtr(base.TestsDisableGSI())
+		}
+
 		if rt.GetDatabase().OnlyDefaultCollection() {
 			dbConfig.Sync = base.StringPtr(channels.DocChannelsSyncFunction)
 		} else {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -367,12 +367,6 @@ func (sc *ServerContext) AllDatabases() map[string]*db.DatabaseContext {
 	return databases
 }
 
-func (sc *ServerContext) AllInvalidDatabases() map[string]*invalidConfigInfo {
-	sc.invalidDatabaseConfigTracking.m.RLock()
-	defer sc.invalidDatabaseConfigTracking.m.RUnlock()
-	return sc.invalidDatabaseConfigTracking.dbNames
-}
-
 type PostUpgradeResult map[string]PostUpgradeDatabaseResult
 
 type PostUpgradeDatabaseResult struct {

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -21,7 +21,7 @@ import (
 
 // Tests behaviour of CBG-2257 to poll only buckets in BucketCredentials that don't currently have a database
 func TestServerlessPollBuckets(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	// Get test bucket
@@ -89,7 +89,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 
 // Tests behaviour of CBG-2258 to force per bucket credentials to be used when setting up db in serverless mode
 func TestServerlessDBSetupForceCreds(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
@@ -141,7 +141,7 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 // Tests behaviour of CBG-2258 to make sure fetch databases only uses buckets listed on StartupConfig.BucketCredentials
 // when running in serverless mode
 func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
@@ -226,7 +226,7 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 }
 
 func TestServerlessUnsupportedOptions(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 	tests := []struct {
 		name            string
 		expectedConnStr string
@@ -274,7 +274,7 @@ func TestServerlessUnsupportedOptions(t *testing.T) {
 }
 
 func TestServerlessSuspendDatabase(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	// Get test bucket
@@ -349,7 +349,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 
 // Confirms that when the database config is not in sc.dbConfigs, the fetch callback is check if the config is in a bucket
 func TestServerlessUnsuspendFetchFallback(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
@@ -393,7 +393,7 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 
 // Confirms that ServerContext.fetchConfigsWithTTL works correctly
 func TestServerlessFetchConfigsLimited(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
@@ -475,7 +475,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 // Checks what happens to a suspended database when the config is modified by another node and the periodic fetchAndLoadConfigs gets called.
 // Currently, it will be unsuspended however that behaviour may be changed in the future
 func TestServerlessUpdateSuspendedDb(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
@@ -523,7 +523,7 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 
 // Tests scenarios a database is and is not allowed to suspend
 func TestSuspendingFlags(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 	testCases := []struct {
 		name             string
 		serverlessMode   bool
@@ -604,7 +604,7 @@ func TestSuspendingFlags(t *testing.T) {
 
 // Tests the public API unsuspending a database automatically
 func TestServerlessUnsuspendAPI(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 	ctx := base.TestCtx(t)
 	// Get test bucket
 	tb := base.GetTestBucket(t)
@@ -640,7 +640,7 @@ func TestServerlessUnsuspendAPI(t *testing.T) {
 
 // Makes sure admin API calls do not unsuspend DB if they fail authentication
 func TestServerlessUnsuspendAdminAuth(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 	ctx := base.TestCtx(t)
 	// Get test bucket
 	tb := base.GetTestBucket(t)
@@ -683,7 +683,7 @@ func TestServerlessUnsuspendAdminAuth(t *testing.T) {
 }
 
 func TestImportPartitionsServerless(t *testing.T) {
-	requireBucketSpecificCredentials(t)
+	RequireBucketSpecificCredentials(t)
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test requires cbgt")
 	}
@@ -741,12 +741,5 @@ func TestImportPartitionsServerless(t *testing.T) {
 
 			assert.Equal(t, expectedPartitions, dbconf.ImportPartitions)
 		})
-	}
-}
-
-// requireBucketSpecificCredentials skips tests if bucket specific credentials are required
-func requireBucketSpecificCredentials(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server since rosmar has no bucket specific credentials")
 	}
 }

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -21,9 +21,7 @@ import (
 
 // Tests behaviour of CBG-2257 to poll only buckets in BucketCredentials that don't currently have a database
 func TestServerlessPollBuckets(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	// Get test bucket
@@ -91,9 +89,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 
 // Tests behaviour of CBG-2258 to force per bucket credentials to be used when setting up db in serverless mode
 func TestServerlessDBSetupForceCreds(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
@@ -145,9 +141,7 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 // Tests behaviour of CBG-2258 to make sure fetch databases only uses buckets listed on StartupConfig.BucketCredentials
 // when running in serverless mode
 func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
@@ -182,7 +176,7 @@ func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 
 func TestServerlessGoCBConnectionString(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+		t.Skip("This test only works against Couchbase Server due to testing gocb connection strings")
 	}
 	tests := []struct {
 		name            string
@@ -232,9 +226,7 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 }
 
 func TestServerlessUnsupportedOptions(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 	tests := []struct {
 		name            string
 		expectedConnStr string
@@ -282,9 +274,7 @@ func TestServerlessUnsupportedOptions(t *testing.T) {
 }
 
 func TestServerlessSuspendDatabase(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server due to updating database config using a Bootstrap connection")
-	}
+	requireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	// Get test bucket
@@ -330,7 +320,9 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 
 	// Update config in bucket to see if unsuspending check for updates
 	cas, err := sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), sc.Config.Bootstrap.ConfigGroupID, "db", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		return sc.dbConfigs["db"].ToDatabaseConfig(), nil
+		config := sc.dbConfigs["db"].ToDatabaseConfig()
+		config.cfgCas = bucketDbConfig.cfgCas
+		return config, nil
 	})
 	require.NoError(t, err)
 	assert.NotEqual(t, cas, sc.dbConfigs["db"].cfgCas)
@@ -357,9 +349,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 
 // Confirms that when the database config is not in sc.dbConfigs, the fetch callback is check if the config is in a bucket
 func TestServerlessUnsuspendFetchFallback(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
@@ -403,9 +393,7 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 
 // Confirms that ServerContext.fetchConfigsWithTTL works correctly
 func TestServerlessFetchConfigsLimited(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
@@ -442,9 +430,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 	// Update database config in the bucket (increment version)
 	newCas, err := sc.BootstrapContext.UpdateConfig(ctx, tb.GetName(), sc.Config.Bootstrap.ConfigGroupID, "db", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 		bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(rt.Context(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-		if err != nil {
-			return nil, err
-		}
+		require.NoError(t, err)
 		return bucketDbConfig, nil
 	})
 	require.NoError(t, err)
@@ -489,9 +475,7 @@ func TestServerlessFetchConfigsLimited(t *testing.T) {
 // Checks what happens to a suspended database when the config is modified by another node and the periodic fetchAndLoadConfigs gets called.
 // Currently, it will be unsuspended however that behaviour may be changed in the future
 func TestServerlessUpdateSuspendedDb(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
@@ -518,7 +502,9 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 	assert.NoError(t, sc.suspendDatabase(t, rt.Context(), "db"))
 	// Update database config
 	newCas, err := sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), sc.Config.Bootstrap.ConfigGroupID, "db", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		return sc.dbConfigs["db"].ToDatabaseConfig(), nil
+		config := sc.dbConfigs["db"].ToDatabaseConfig()
+		config.cfgCas = bucketDbConfig.cfgCas
+		return config, nil
 	})
 	require.NoError(t, err)
 	// Confirm dbConfig cas did not update yet in SG, or get unsuspended
@@ -537,9 +523,7 @@ func TestServerlessUpdateSuspendedDb(t *testing.T) {
 
 // Tests scenarios a database is and is not allowed to suspend
 func TestSuspendingFlags(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Test only works with CBS")
-	}
+	requireBucketSpecificCredentials(t)
 	testCases := []struct {
 		name             string
 		serverlessMode   bool
@@ -620,9 +604,7 @@ func TestSuspendingFlags(t *testing.T) {
 
 // Tests the public API unsuspending a database automatically
 func TestServerlessUnsuspendAPI(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 	ctx := base.TestCtx(t)
 	// Get test bucket
 	tb := base.GetTestBucket(t)
@@ -658,9 +640,7 @@ func TestServerlessUnsuspendAPI(t *testing.T) {
 
 // Makes sure admin API calls do not unsuspend DB if they fail authentication
 func TestServerlessUnsuspendAdminAuth(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
+	requireBucketSpecificCredentials(t)
 	ctx := base.TestCtx(t)
 	// Get test bucket
 	tb := base.GetTestBucket(t)
@@ -703,8 +683,9 @@ func TestServerlessUnsuspendAdminAuth(t *testing.T) {
 }
 
 func TestImportPartitionsServerless(t *testing.T) {
+	requireBucketSpecificCredentials(t)
 	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+		t.Skip("This test requires cbgt")
 	}
 	if !base.TestUseXattrs() {
 		t.Skip("tests import which is not avaiable without xattrs")
@@ -760,5 +741,12 @@ func TestImportPartitionsServerless(t *testing.T) {
 
 			assert.Equal(t, expectedPartitions, dbconf.ImportPartitions)
 		})
+	}
+}
+
+// requireBucketSpecificCredentials skips tests if bucket specific credentials are required
+func requireBucketSpecificCredentials(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server since rosmar has no bucket specific credentials")
 	}
 }

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -21,18 +21,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func requireBootstrapConnection(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("bootstrap connection requires CBS")
-	}
-}
-
 // TestDefaultMetadataID creates an database using the named collections on the default scope, then modifies that database to use
 // only the default collection. Verifies that metadata documents are still accessible.
 func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	requireBootstrapConnection(t)
 	rtConfig := &rest.RestTesterConfig{
 		PersistentConfig: true,
 	}
@@ -79,7 +72,6 @@ func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
 func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	requireBootstrapConnection(t)
 	rtConfig := &rest.RestTesterConfig{
 		PersistentConfig: true,
 	}
@@ -125,7 +117,6 @@ func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
 func TestUpgradeDatabasePreHelium(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	requireBootstrapConnection(t)
 
 	rtConfig := &rest.RestTesterConfig{
 		PersistentConfig: true,

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -282,16 +282,11 @@ func (rt *RestTester) Bucket() base.Bucket {
 		sc.Bootstrap.X509KeyPath = testBucket.BucketSpec.Keypath
 
 		rt.TestBucket.BucketSpec.TLSSkipVerify = base.TestTLSSkipVerify()
-
-		if err := rt.RestTesterServerContext.initializeCouchbaseServerConnections(ctx, true); err != nil {
-			panic("Couldn't initialize Couchbase Server connection: " + err.Error())
-		}
 	}
+	err := rt.RestTesterServerContext.initializeCouchbaseServerConnections(ctx, true)
+	require.NoError(rt.TB, err, "Couldn't initialize Couchbase Server connection")
 	// Copy this startup config at this point into initial startup config
-	err := base.DeepCopyInefficient(&rt.RestTesterServerContext.initialStartupConfig, &sc)
-	if err != nil {
-		rt.TB.Fatalf("Unable to copy initial startup config: %v", err)
-	}
+	require.NoError(rt.TB, base.DeepCopyInefficient(&rt.RestTesterServerContext.initialStartupConfig, &sc))
 
 	// tests must create their own databases in persistent mode
 	if !rt.PersistentConfig {
@@ -1068,7 +1063,7 @@ func (rt *RestTester) GetDocumentSequence(key string) (sequence uint64) {
 func (rt *RestTester) ReplacePerBucketCredentials(config base.PerBucketCredentialsConfig) {
 	rt.ServerContext().Config.BucketCredentials = config
 	// Update the CouchbaseCluster to include the new bucket credentials
-	couchbaseCluster, err := CreateCouchbaseClusterFromStartupConfig(base.TestCtx(rt.TB), rt.ServerContext().Config, base.PerUseClusterConnections)
+	couchbaseCluster, err := CreateBootstrapConnectionFromStartupConfig(base.TestCtx(rt.TB), rt.ServerContext().Config, base.PerUseClusterConnections)
 	require.NoError(rt.TB, err)
 	rt.ServerContext().BootstrapContext.Connection = couchbaseCluster
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2579,6 +2579,17 @@ func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, expecte
 	require.EqualValues(t, expectedDbNames, dbNames)
 }
 
+// AllInvalidDatabaseNames returns the names of all the databases that have invalid configs. Testing only since this locks the database context.
+func (sc *ServerContext) AllInvalidDatabaseNames(_ *testing.T) []string {
+	sc.invalidDatabaseConfigTracking.m.RLock()
+	defer sc.invalidDatabaseConfigTracking.m.RUnlock()
+	dbs := make([]string, 0, len(sc.invalidDatabaseConfigTracking.dbNames))
+	for db := range sc.invalidDatabaseConfigTracking.dbNames {
+		dbs = append(dbs, db)
+	}
+	return dbs
+}
+
 // Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements
 func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2600,3 +2600,10 @@ func dropAllNonPrimaryIndexes(t *testing.T, dataStore base.DataStore) {
 	err := n1qlStore.CreatePrimaryIndex(ctx, base.PrimaryIndexName, nil)
 	require.NoError(t, err, "Unable to recreate primary index")
 }
+
+// RequireBucketSpecificCredentials skips tests if bucket specific credentials are required
+func RequireBucketSpecificCredentials(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server since rosmar has no bucket specific credentials")
+	}
+}

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -115,3 +115,10 @@ func doBootstrapAdminRequest(t *testing.T, method, host, path, body string, head
 		Header:     resp.Header,
 	}
 }
+
+// RequireNonParallelBootstrapTests is a helper function to skip tests that require serial execution between packages, since bootstrap test setup is fixed on specific port numbers and a collision can happen.
+func RequireNonParallelBootstrapTests(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Requires serial test execution between packages -p 1, not guaranteed under rosmar, is under CBS: CBG-3638")
+	}
+}

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -306,9 +306,10 @@ func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) d
 // UpdatePersistedBucketName will update the persisted config bucket name to name specified in parameters
 func (rt *RestTester) UpdatePersistedBucketName(dbConfig *DatabaseConfig, newBucketName *string) (*DatabaseConfig, error) {
 	updatedDbConfig := DatabaseConfig{}
-	_, err := rt.ServerContext().BootstrapContext.UpdateConfig(base.TestCtx(rt.TB), *dbConfig.Bucket, rt.ServerContext().Config.Bootstrap.ConfigGroupID, dbConfig.Name, func(_ *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+	_, err := rt.ServerContext().BootstrapContext.UpdateConfig(base.TestCtx(rt.TB), *dbConfig.Bucket, rt.ServerContext().Config.Bootstrap.ConfigGroupID, dbConfig.Name, func(originalConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 
 		bucketDbConfig := dbConfig
+		bucketDbConfig.cfgCas = originalConfig.cfgCas
 		bucketDbConfig.Bucket = newBucketName
 
 		return bucketDbConfig, nil

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -201,14 +201,8 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	}
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
-	dbConfig := DbConfig{
-		Scopes: GetCollectionsConfig(rt.TB, rt.TestBucket, numCollections),
-		BucketConfig: BucketConfig{
-			Bucket: base.StringPtr(rt.TestBucket.GetName()),
-		},
-		EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
-		UseViews:     base.BoolPtr(base.TestsDisableGSI()),
-	}
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = GetCollectionsConfig(rt.TB, rt.TestBucket, numCollections)
 	dbOne := "dbone"
 	bucket1Datastore1, err := rt.TestBucket.GetNamedDataStore(0)
 	require.NoError(t, err)
@@ -263,13 +257,10 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket2 := base.GetTestBucket(t)
 	defer bucket2.Close(ctx)
-	dbConfig = DbConfig{
-		Scopes: GetCollectionsConfig(rt.TB, bucket2, numCollections),
-		BucketConfig: BucketConfig{
-			Bucket: base.StringPtr(bucket2.GetName()),
-		},
-		EnableXattrs: base.BoolPtr(base.TestUseXattrs()),
-		UseViews:     base.BoolPtr(base.TestsDisableGSI()),
+	dbConfig = rt.NewDbConfig()
+	dbConfig.Scopes = GetCollectionsConfig(rt.TB, bucket2, numCollections)
+	dbConfig.BucketConfig = BucketConfig{
+		Bucket: base.StringPtr(bucket2.GetName()),
 	}
 	dbTwo := "dbtwo"
 	bucket2Datastore1, err := rt.TestBucket.GetNamedDataStore(0)


### PR DESCRIPTION
- implement and start a BootstrapConnection in RestTester
- create a new bucket object each time since it's a cheap copy option in rosmar

some test fixup:

- use NewDbConfig for rosmar config, which uses a peculiar combination of views and collections, normally disallowed
- make some config polling faster to speed up testing
- change some error reporting to use testify to report trace

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2191/
