### PR TITLE
CBG-3607: disable the ability to set shared_bucket_access to false. I…

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -209,6 +209,9 @@ func TestUseXattrs() bool {
 	if err != nil {
 		panic(fmt.Sprintf("unable to parse %q value %q: %v", TestEnvSyncGatewayUseXattrs, useXattrs, err))
 	}
+	if !val {
+		panic("sync gateway requires xattrs to be enabled")
+	}
 
 	return val
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -327,6 +327,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 }
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
+// nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv SourceAndVersion) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
 		// TODO: pending CBG-3213 support of channel removal for CV

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -329,8 +329,8 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv SourceAndVersion) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
+		// TODO: pending CBG-3213 support of channel removal for CV
 		// we need implementation of IsChannelRemoval for CV here.
-		// pending CBG-3213 support of channel removal for CV
 	}
 
 	if err = doc.HasCurrentVersion(cv); err != nil {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2471,7 +2471,7 @@ func TestHandlePutDbConfigWithBackticksCollections(t *testing.T) {
 	reqBodyWithBackticks := `{
         "server": "walrus:",
         "bucket": "backticks",
-		"enable_shared_bucket_access":false,
+		"enable_shared_bucket_access":true,
 		"scopes": {
 			"scope1": {
 			  "collections" : {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2754,7 +2754,7 @@ func TestDatabaseXattrConfigHandlingForDBConfigUpdate(t *testing.T) {
 	base.LongRunningTest(t)
 	const (
 		dbName  = "db1"
-		errResp = "sync gateway requires shared_bucket_access to be enabled"
+		errResp = "sync gateway requires enable_shared_bucket_access=true"
 	)
 
 	testCases := []struct {
@@ -2808,7 +2808,7 @@ func TestCreateDBWithXattrsDisbaled(t *testing.T) {
 	defer rt.Close()
 	const (
 		dbName  = "db1"
-		errResp = "sync gateway requires shared_bucket_access to be enabled"
+		errResp = "sync gateway requires enable_shared_bucket_access=true"
 	)
 
 	dbConfig := rt.NewDbConfig()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2746,6 +2746,10 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "null doc body for doc")
 }
 
+// TestDatabaseXattrConfigHandlingForDBConfigUpdate:
+//   - Create database with xattrs enabled
+//   - Test updating the config to disable the use of xattrs in this database through replacing + upserting the config
+//   - Assert error code is returned and response contains error string
 func TestDatabaseXattrConfigHandlingForDBConfigUpdate(t *testing.T) {
 	base.LongRunningTest(t)
 	const (
@@ -2794,6 +2798,9 @@ func TestDatabaseXattrConfigHandlingForDBConfigUpdate(t *testing.T) {
 	}
 }
 
+// TestCreateDBWithXattrsDisbaled:
+//   - Test that you cannot create a database with xattrs disabled
+//   - Assert error code is returned and response contains error string
 func TestCreateDBWithXattrsDisbaled(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1085,6 +1085,11 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		}
 	}
 
+	// In sync gateway version 4.0+ we do not support the disabling of use of xattrs
+	if !config.UseXattrs() {
+		return db.DatabaseContextOptions{}, fmt.Errorf("sync gateway requires shared_bucket_access to be enabled")
+	}
+
 	// Create a callback function that will be invoked if the database goes offline and comes
 	// back online again
 	dbOnlineCallback := func(dbContext *db.DatabaseContext) {
@@ -1224,7 +1229,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		LocalJWTConfig:                config.LocalJWTConfig,
 		DBOnlineCallback:              dbOnlineCallback,
 		ImportOptions:                 *importOptions,
-		EnableXattr:                   config.UseXattrs(),
+		EnableXattr:                   config.UseXattrs(), //
 		SecureCookieOverride:          secureCookieOverride,
 		SessionCookieName:             config.SessionCookieName,
 		SessionCookieHttpOnly:         base.BoolDefault(config.SessionCookieHTTPOnly, false),

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1229,7 +1229,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		LocalJWTConfig:                config.LocalJWTConfig,
 		DBOnlineCallback:              dbOnlineCallback,
 		ImportOptions:                 *importOptions,
-		EnableXattr:                   config.UseXattrs(), //
+		EnableXattr:                   config.UseXattrs(),
 		SecureCookieOverride:          secureCookieOverride,
 		SessionCookieName:             config.SessionCookieName,
 		SessionCookieHttpOnly:         base.BoolDefault(config.SessionCookieHTTPOnly, false),

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1087,7 +1087,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 
 	// In sync gateway version 4.0+ we do not support the disabling of use of xattrs
 	if !config.UseXattrs() {
-		return db.DatabaseContextOptions{}, fmt.Errorf("sync gateway requires shared_bucket_access to be enabled")
+		return db.DatabaseContextOptions{}, fmt.Errorf("sync gateway requires enable_shared_bucket_access=true")
 	}
 
 	// Create a callback function that will be invoked if the database goes offline and comes

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -319,6 +319,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	assert.NotNil(t, sc.dbConfigs["db"])
 
 	// Update config in bucket to see if unsuspending check for updates
+	sc.dbConfigs["db"].EnableXattrs = base.BoolPtr(true) // xattrs must be enabled
 	cas, err := sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), sc.Config.Bootstrap.ConfigGroupID, "db", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 		config := sc.dbConfigs["db"].ToDatabaseConfig()
 		config.cfgCas = bucketDbConfig.cfgCas


### PR DESCRIPTION
CBG-3607

Disable the ability to set shared_bucket_access to false. In future we will probably look to fully remove the config parameter but for now this will protect against panics in beryllium branch that relate to xattrs not being enabled.

This PR does the following: 
- Returning error inside `dbcOptionsFromConfig` when a false value is detected for `EnableXattrs`
- Disallowing the test environment variable `SG_TEST_USE_XATTRS` to be false
- Couple of test to test the functionality 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2194/
- [x] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2202/ (should fail to start) 
