### PR TITLE
CBG-3637: Stat definitions use a named object for each stat definition

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -786,30 +786,44 @@ type SgwStat struct {
 	statDesc          *prometheus.Desc
 }
 
+// Name returns the fully qualified name of the stat.
+// Currently only used for the stat metadata exporter tool.
 func (s SgwStat) Name() string {
 	return s.statFQN
 }
 
+// Unit returns the units the stat uses for example, seconds.
+// Currently only used for the stat metadata exporter tool.
 func (s SgwStat) Unit() string {
 	return s.unit
 }
 
+// Help returns the help text for the stat.
+// Currently only used for the stat metadata exporter tool.
 func (s SgwStat) Help() string {
 	return s.help
 }
 
+// AddedVersion returns the version of Sync Gateway this stat was added.
+// Currently only used for the stat metadata exporter tool.
 func (s SgwStat) AddedVersion() string {
 	return s.addedVersion
 }
 
+// DeprecatedVersion returns the version of Sync Gateway this stat was deprecated.
+// Currently only used for the stat metadata exporter tool.
 func (s SgwStat) DeprecatedVersion() string {
 	return s.deprecatedVersion
 }
 
+// Stability returns if there is a commitment to keep this stat stable.
+// Currently only used for the stat metadata exporter tool.
 func (s SgwStat) Stability() string {
 	return s.stability
 }
 
+// LabelKeys returns the label keys for the stat in deterministic order.
+// Currently only used for the stat metadata exporter tool.
 func (s SgwStat) LabelKeys() []string {
 	labelKeys := make([]string, 0, len(s.labels))
 	for labelKey := range s.labels {
@@ -822,6 +836,8 @@ func (s SgwStat) LabelKeys() []string {
 	return labelKeys
 }
 
+// ValueTypeString returns the string representation of the prometheus.ValueType
+// Currently only used for the stat metadata exporter tool.
 func (s SgwStat) ValueTypeString() string {
 	switch s.statValueType {
 	case prometheus.CounterValue:

--- a/base/stats.go
+++ b/base/stats.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -814,6 +815,9 @@ func (s SgwStat) LabelKeys() []string {
 	for labelKey := range s.labels {
 		labelKeys = append(labelKeys, labelKey)
 	}
+
+	// Sort the label keys so that the order is deterministic
+	slices.Sort(labelKeys)
 
 	return labelKeys
 }

--- a/tools/stats-definition-exporter/main.go
+++ b/tools/stats-definition-exporter/main.go
@@ -82,10 +82,10 @@ func getStats(logger *log.Logger) (StatDefinitions, error) {
 
 	// Get all the stats
 	globalStatsDefinitions := traverseAndRetrieveStats(logger, globalStats)
-	dbStatDefinitions :=  traverseAndRetrieveStats(logger, dbStats)
+	dbStatDefinitions := traverseAndRetrieveStats(logger, dbStats)
 
 	// Merge the two maps
-	stats := make(StatDefinitions, len(globalStatsDefinitions) + len(dbStatDefinitions))
+	stats := make(StatDefinitions, len(globalStatsDefinitions)+len(dbStatDefinitions))
 	for k, v := range globalStatsDefinitions {
 		stats[k] = v
 	}

--- a/tools/stats-definition-exporter/stat_definition.go
+++ b/tools/stats-definition-exporter/stat_definition.go
@@ -12,8 +12,10 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+// StatDefinitions is a map of the stats fully qualified name to a StatDefinition
+type StatDefinitions map[string]StatDefinition
+
 type StatDefinition struct {
-	Name              string   `json:"name"`                 // The fully qualified name of the stat
 	Unit              string   `json:"unit,omitempty"`       // What units the stat value is using such as seconds.
 	Labels            []string `json:"labels,omitempty"`     // The labels that Prometheus uses to organise some of the stats such as database, collection, etc
 	Help              string   `json:"help,omitempty"`       // A description of what the stat does
@@ -26,7 +28,6 @@ type StatDefinition struct {
 
 func newStatDefinition(stat base.SgwStatWrapper) StatDefinition {
 	return StatDefinition{
-		Name:         stat.Name(),
 		Unit:         stat.Unit(),
 		Labels:       stat.LabelKeys(),
 		Help:         stat.Help(),

--- a/tools/stats-definition-exporter/stat_traverser.go
+++ b/tools/stats-definition-exporter/stat_traverser.go
@@ -15,8 +15,8 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-func traverseAndRetrieveStats(logger *log.Logger, s any) []StatDefinition {
-	var stats []StatDefinition
+func traverseAndRetrieveStats(logger *log.Logger, s any) StatDefinitions {
+	stats := make(StatDefinitions)
 
 	topLevel := reflect.ValueOf(s)
 	if topLevel.IsNil() {
@@ -40,7 +40,7 @@ func traverseAndRetrieveStats(logger *log.Logger, s any) []StatDefinition {
 		stat := field.Interface()
 		statWrapper, ok := stat.(base.SgwStatWrapper)
 		if ok {
-			stats = append(stats, newStatDefinition(statWrapper))
+			stats[statWrapper.Name()] = newStatDefinition(statWrapper)
 			continue
 		}
 
@@ -56,8 +56,10 @@ func traverseAndRetrieveStats(logger *log.Logger, s any) []StatDefinition {
 			field = values.Value()
 		}
 
-		// Follow to struct down a level
-		stats = append(stats, traverseAndRetrieveStats(logger, field.Interface())...)
+		// Follow to struct down a level and append the stats to the map
+		for k,v  := range  traverseAndRetrieveStats(logger, field.Interface()) {
+			stats[k] = v
+		}
 	}
 
 	return stats

--- a/tools/stats-definition-exporter/stat_traverser.go
+++ b/tools/stats-definition-exporter/stat_traverser.go
@@ -57,7 +57,7 @@ func traverseAndRetrieveStats(logger *log.Logger, s any) StatDefinitions {
 		}
 
 		// Follow to struct down a level and append the stats to the map
-		for k,v  := range  traverseAndRetrieveStats(logger, field.Interface()) {
+		for k, v := range traverseAndRetrieveStats(logger, field.Interface()) {
 			stats[k] = v
 		}
 	}


### PR DESCRIPTION
CBG-3637

Each stat has its own named object instead of having the name as a field in the object. Labels are also now ordered.

Example:
```
	"sgw_replication_sgr_deltas_sent": {
		"labels": [
			"database",
			"replication"
		],
		"help": "The total number of deltas sent.",
		"added": "3.0.0",
		"stability": "committed",
		"type": "counter"
	},
	"sgw_replication_sgr_docs_checked_recv": {
		"labels": [
			"database",
			"replication"
		],
		"help": "The total number of document changes received over changes message.",
		"added": "3.0.0",
		"stability": "committed",
		"type": "counter"
	},
	"sgw_replication_sgr_docs_checked_sent": {
		"labels": [
			"database",
			"replication"
		],
		"help": "The total number of documents checked for changes since replication started. This represents the number of potential change notifications pushed by Sync Gateway. This is not necessarily the number of documents pushed, as a given target might already have the change and this is used by Inter-Sync Gateway and SG Replicate. This metric can be useful when analyzing replication history, and to filter by active replications.",
		"added": "3.0.0",
		"stability": "committed",
		"type": "counter"
	},
	"sgw_replication_sgr_num_attachment_bytes_pulled": {
		"unit": "bytes",
		"labels": [
			"database",
			"replication"
		],
		"help": "The total number of bytes in all the attachments that were pulled since replication started.",
		"added": "3.0.0",
		"stability": "committed",
		"type": "counter"
	},
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
