### PR TITLE
Make sure GetDatabase always refers to 1 database

### DIFF
--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -271,9 +271,11 @@ func TestRequireResync(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", string(resyncPayload))
 	rest.RequireStatus(t, resp, http.StatusOK)
 
+	db2, err := rt.ServerContext().GetDatabase(rt.Context(), db2Name)
+	require.NoError(t, err)
 	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
 		func(t testing.TB) db.BackgroundProcessState {
-			return rt.GetDatabase().ResyncManager.GetRunState()
+			return db2.ResyncManager.GetRunState()
 		})
 
 	// Attempt online again, should now succeed

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -442,12 +442,14 @@ func TestPutDBBytesRead(t *testing.T) {
 		tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(), base.TestClusterUsername(), base.TestClusterPassword(),
 	)
 
+	db := rt.GetDatabase() // get database before we add a new one
+
 	resp := rt.SendAdminRequestWithAuth(http.MethodPut, "/db1/", input, "MobileSyncGatewayUser", "password")
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// assert the stat hasn't increased (admin request doesn't effect count)
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.PublicRestBytesRead.Value()
+		return db.DbStats.DatabaseStats.PublicRestBytesRead.Value()
 	}, 0)
 
 }


### PR DESCRIPTION
`CreateTestDoc` would write to the the database in `GetDatabase()` but this would return the first database in a map, sometimes resulting in a failure to write the correct doc.

Ensure via a testify requirement that `GetDatabase` always returns 1 database. Only one test and `rt.Context` were relying on this behavior.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2196/
