### PR TITLE
CBG-3612 Allow import to override existing expiry when set by Sync Function

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2453,9 +2453,6 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 	bucket := GetTestBucket(t)
 	defer bucket.Close(ctx)
 	dataStore := bucket.GetSingleDataStore()
-	if !bucket.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) {
-		t.Skip("Preserve expiry is not supported with this CBS version. Skipping test...")
-	}
 	SetUpTestLogging(t, LevelInfo, KeyAll)
 
 	testCases := []struct {

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2453,6 +2453,9 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 	bucket := GetTestBucket(t)
 	defer bucket.Close(ctx)
 	dataStore := bucket.GetSingleDataStore()
+	if !bucket.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) {
+		t.Skip("Preserve expiry is not supported with this CBS version. Skipping test...")
+	}
 	SetUpTestLogging(t, LevelInfo, KeyAll)
 
 	testCases := []struct {

--- a/base/collection_gocb.go
+++ b/base/collection_gocb.go
@@ -195,7 +195,7 @@ func (c *Collection) Set(k string, exp uint32, opts *sgbucket.UpsertOptions, v i
 		Expiry:     CbsExpiryToDuration(exp),
 		Transcoder: NewSGJSONTranscoder(),
 	}
-	fillUpsertOptions(goCBUpsertOptions, opts)
+	fillUpsertOptions(context.TODO(), goCBUpsertOptions, opts)
 
 	if _, ok := v.([]byte); ok {
 		goCBUpsertOptions.Transcoder = gocb.NewRawJSONTranscoder()
@@ -213,7 +213,7 @@ func (c *Collection) SetRaw(k string, exp uint32, opts *sgbucket.UpsertOptions, 
 		Expiry:     CbsExpiryToDuration(exp),
 		Transcoder: NewSGRawTranscoder(),
 	}
-	fillUpsertOptions(goCBUpsertOptions, opts)
+	fillUpsertOptions(context.TODO(), goCBUpsertOptions, opts)
 
 	_, err := c.Collection.Upsert(k, v, goCBUpsertOptions)
 	return err

--- a/base/collection_gocb_utils.go
+++ b/base/collection_gocb_utils.go
@@ -18,9 +18,7 @@ func fillUpsertOptions(goCBUpsertOptions *gocb.UpsertOptions, upsertOptions *sgb
 	if upsertOptions == nil {
 		return
 	}
-	if goCBUpsertOptions.Expiry == 0 {
-		goCBUpsertOptions.PreserveExpiry = upsertOptions.PreserveExpiry
-	}
+	goCBUpsertOptions.PreserveExpiry = upsertOptions.PreserveExpiry
 }
 
 // Fills in the GoCB MutateInOptions based on the passed in MutateInOptions
@@ -28,7 +26,5 @@ func fillMutateInOptions(goCBMutateInOptions *gocb.MutateInOptions, mutateInOpti
 	if mutateInOptions == nil {
 		return
 	}
-	if goCBMutateInOptions.Expiry == 0 {
-		goCBMutateInOptions.PreserveExpiry = mutateInOptions.PreserveExpiry
-	}
+	goCBMutateInOptions.PreserveExpiry = mutateInOptions.PreserveExpiry
 }

--- a/base/collection_gocb_utils.go
+++ b/base/collection_gocb_utils.go
@@ -21,7 +21,7 @@ func fillUpsertOptions(ctx context.Context, goCBUpsertOptions *gocb.UpsertOption
 		return
 	}
 	goCBUpsertOptions.PreserveExpiry = upsertOptions.PreserveExpiry
-	if goCBUpsertOptions.Expiry != 0 && !upsertOptions.PreserveExpiry {
+	if goCBUpsertOptions.Expiry != 0 && upsertOptions.PreserveExpiry {
 		InfofCtx(ctx, KeyCRUD, "Expiry set on gocb.UpsertOptions, but sgbucket.UpsertOptions.PreserveExpiry is false. Force setting PreserveExpiry to false to allow write to proceed.")
 		goCBUpsertOptions.PreserveExpiry = false
 
@@ -34,7 +34,7 @@ func fillMutateInOptions(ctx context.Context, goCBMutateInOptions *gocb.MutateIn
 		return
 	}
 	goCBMutateInOptions.PreserveExpiry = mutateInOptions.PreserveExpiry
-	if goCBMutateInOptions.Expiry != 0 && !mutateInOptions.PreserveExpiry {
+	if goCBMutateInOptions.Expiry != 0 && mutateInOptions.PreserveExpiry {
 		InfofCtx(ctx, KeyCRUD, "Expiry set on gocb.MutateInOptions, but sgbucket.MutateInOptions.PreserveExpiry is false. Force setting PreserveExpiry to false to allow write to proceed.")
 		goCBMutateInOptions.PreserveExpiry = false
 

--- a/base/collection_gocb_utils.go
+++ b/base/collection_gocb_utils.go
@@ -9,22 +9,35 @@
 package base
 
 import (
+	"context"
+
 	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 )
 
 // Fills in the GoCB UpsertOptions based on the passed in SG Bucket UpsertOptions
-func fillUpsertOptions(goCBUpsertOptions *gocb.UpsertOptions, upsertOptions *sgbucket.UpsertOptions) {
+func fillUpsertOptions(ctx context.Context, goCBUpsertOptions *gocb.UpsertOptions, upsertOptions *sgbucket.UpsertOptions) {
 	if upsertOptions == nil {
 		return
 	}
 	goCBUpsertOptions.PreserveExpiry = upsertOptions.PreserveExpiry
+	if goCBUpsertOptions.Expiry != 0 && !upsertOptions.PreserveExpiry {
+		InfofCtx(ctx, KeyCRUD, "Expiry set on gocb.UpsertOptions, but sgbucket.UpsertOptions.PreserveExpiry is false. Force setting PreserveExpiry to false to allow write to proceed.")
+		goCBUpsertOptions.PreserveExpiry = false
+
+	}
 }
 
 // Fills in the GoCB MutateInOptions based on the passed in MutateInOptions
-func fillMutateInOptions(goCBMutateInOptions *gocb.MutateInOptions, mutateInOptions *sgbucket.MutateInOptions) {
+func fillMutateInOptions(ctx context.Context, goCBMutateInOptions *gocb.MutateInOptions, mutateInOptions *sgbucket.MutateInOptions) {
 	if mutateInOptions == nil {
 		return
 	}
 	goCBMutateInOptions.PreserveExpiry = mutateInOptions.PreserveExpiry
+	if goCBMutateInOptions.Expiry != 0 && !mutateInOptions.PreserveExpiry {
+		InfofCtx(ctx, KeyCRUD, "Expiry set on gocb.MutateInOptions, but sgbucket.MutateInOptions.PreserveExpiry is false. Force setting PreserveExpiry to false to allow write to proceed.")
+		goCBMutateInOptions.PreserveExpiry = false
+
+	}
+
 }

--- a/base/collection_gocb_utils.go
+++ b/base/collection_gocb_utils.go
@@ -18,7 +18,9 @@ func fillUpsertOptions(goCBUpsertOptions *gocb.UpsertOptions, upsertOptions *sgb
 	if upsertOptions == nil {
 		return
 	}
-	goCBUpsertOptions.PreserveExpiry = upsertOptions.PreserveExpiry
+	if goCBUpsertOptions.Expiry == 0 {
+		goCBUpsertOptions.PreserveExpiry = upsertOptions.PreserveExpiry
+	}
 }
 
 // Fills in the GoCB MutateInOptions based on the passed in MutateInOptions
@@ -26,5 +28,7 @@ func fillMutateInOptions(goCBMutateInOptions *gocb.MutateInOptions, mutateInOpti
 	if mutateInOptions == nil {
 		return
 	}
-	goCBMutateInOptions.PreserveExpiry = mutateInOptions.PreserveExpiry
+	if goCBMutateInOptions.Expiry == 0 {
+		goCBMutateInOptions.PreserveExpiry = mutateInOptions.PreserveExpiry
+	}
 }

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -409,7 +409,7 @@ func (c *Collection) UpdateXattr(_ context.Context, k string, xattrKey string, e
 
 // UpdateBodyAndXattr updates the document body and xattr of an existing document. Writes cas and crc32c to the xattr using
 // macro expansion.
-func (c *Collection) UpdateBodyAndXattr(_ context.Context, k string, xattrKey string, exp uint32, cas uint64, opts *sgbucket.MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error) {
+func (c *Collection) UpdateBodyAndXattr(ctx context.Context, k string, xattrKey string, exp uint32, cas uint64, opts *sgbucket.MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error) {
 	c.Bucket.waitForAvailKvOp()
 	defer c.Bucket.releaseKvOp()
 
@@ -424,7 +424,7 @@ func (c *Collection) UpdateBodyAndXattr(_ context.Context, k string, xattrKey st
 		StoreSemantic: gocb.StoreSemanticsUpsert,
 		Cas:           gocb.Cas(cas),
 	}
-	fillMutateInOptions(options, opts)
+	fillMutateInOptions(ctx, options, opts)
 	result, mutateErr := c.Collection.MutateIn(k, mutateOps, options)
 	if mutateErr != nil {
 		return 0, mutateErr

--- a/db/crud.go
+++ b/db/crud.go
@@ -906,7 +906,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	}
 
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, expiry, nil, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &expiry, nil, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		var isSgWrite bool
 		var crc32Match bool
 
@@ -1031,7 +1031,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 	}
 
 	allowImport := db.UseXattrs()
-	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, newDoc.DocExpiry, nil, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -1669,16 +1669,21 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 	return unusedSequences, nil
 }
 
-func (doc *Document) updateExpiry(syncExpiry, updatedExpiry *uint32, expiry uint32) (finalExp *uint32) {
+func (doc *Document) updateExpiry(syncExpiry, updatedExpiry *uint32, expiry *uint32) (finalExp *uint32) {
 	if syncExpiry != nil {
 		finalExp = syncExpiry
 	} else if updatedExpiry != nil {
 		finalExp = updatedExpiry
-	} else {
-		finalExp = &expiry
+	} else if expiry != nil {
+		finalExp = expiry
 	}
 
-	doc.UpdateExpiry(*finalExp)
+	if finalExp != nil {
+		doc.UpdateExpiry(*finalExp)
+	} else {
+		doc.UpdateExpiry(0)
+
+	}
 
 	return finalExp
 
@@ -1736,7 +1741,7 @@ func (db *DatabaseCollectionWithUser) IsIllegalConflict(ctx context.Context, doc
 	return true
 }
 
-func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, createNewRevIDSkipped bool, err error) {
+func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry *uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, createNewRevIDSkipped bool, err error) {
 
 	err = validateExistingDoc(doc, allowImport, docExists)
 	if err != nil {
@@ -1831,8 +1836,7 @@ type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAtta
 //  1. Receive the updated document body in the response
 //  2. Specify the existing document body/xattr/cas, to avoid initial retrieval of the doc in cases that the current contents are already known (e.g. import).
 //     On cas failure, the document will still be reloaded from the bucket as usual.
-func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
-
+func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry *uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
 	key := realDocID(docid)
 	if key == "" {
 		return nil, "", base.HTTPErrorf(400, "Invalid doc ID")
@@ -1856,7 +1860,11 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 	if !db.UseXattrs() {
 		// Update the document, storing metadata in _sync property
-		_, err = db.dataStore.Update(key, expiry, func(currentValue []byte) (raw []byte, syncFuncExpiry *uint32, isDelete bool, err error) {
+		var initialExpiry uint32 // expiry before Update callback happens
+		if expiry != nil {
+			initialExpiry = *expiry
+		}
+		_, err = db.dataStore.Update(key, initialExpiry, func(currentValue []byte) (raw []byte, syncFuncExpiry *uint32, isDelete bool, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocument(docid, currentValue); err != nil {
 				return
@@ -1899,7 +1907,11 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			opts = &sgbucket.MutateInOptions{}
 		}
 		opts.MacroExpansion = macroExpandSpec(base.SyncXattrName)
-		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), expiry, existingDoc, opts, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
+		var initialExpiry uint32
+		if expiry != nil {
+			initialExpiry = *expiry
+		}
+		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), initialExpiry, existingDoc, opts, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, updatedSpec []sgbucket.MacroExpansionSpec, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll); err != nil {
 				return
@@ -1923,7 +1935,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				return
 			}
 			// If importing and the sync function has modified the expiry, allow sgbucket.MutateInOptions to modify the expiry
-			if db.dataStore.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) && syncFuncExpiry != nil && *syncFuncExpiry != expiry {
+			if db.dataStore.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) && syncFuncExpiry != nil {
 				opts.PreserveExpiry = false
 			}
 			docSequence = doc.Sequence

--- a/db/crud.go
+++ b/db/crud.go
@@ -1923,7 +1923,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				return
 			}
 			// If importing and the sync function has modified the expiry, allow sgbucket.MutateInOptions to modify the expiry
-			if allowImport && syncFuncExpiry != nil && *syncFuncExpiry != expiry {
+			if db.dataStore.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) && syncFuncExpiry != nil && *syncFuncExpiry != expiry {
 				opts.PreserveExpiry = false
 			}
 			docSequence = doc.Sequence

--- a/db/crud.go
+++ b/db/crud.go
@@ -1922,6 +1922,10 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			if err != nil {
 				return
 			}
+			// If importing and the sync function has modified the expiry, allow sgbucket.MutateInOptions to modify the expiry
+			if allowImport && syncFuncExpiry != nil && *syncFuncExpiry != expiry {
+				opts.PreserveExpiry = false
+			}
 			docSequence = doc.Sequence
 			inConflict = doc.hasFlag(channels.Conflict)
 			currentRevFromHistory, ok := doc.History[doc.CurrentRev]

--- a/db/import.go
+++ b/db/import.go
@@ -124,7 +124,20 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 	var newRev string
 	var alreadyImportedDoc *Document
 
-	mutationOptions := &sgbucket.MutateInOptions{PreserveExpiry: true}
+	mutationOptions := &sgbucket.MutateInOptions{}
+	if db.dataStore.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) {
+		mutationOptions.PreserveExpiry = true
+	} else {
+		// Get the doc expiry if it wasn't passed in and preserve expiry is not supported
+		if expiry == nil {
+			getExpiry, getExpiryErr := db.dataStore.GetExpiry(ctx, docid)
+			if getExpiryErr != nil {
+				return nil, getExpiryErr
+			}
+			expiry = &getExpiry
+		}
+		existingDoc.Expiry = *expiry
+	}
 
 	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, existingDoc.Expiry, mutationOptions, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
@@ -144,6 +157,16 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 
 				existingDoc = &sgbucket.BucketDocument{
 					Cas: doc.Cas,
+				}
+
+				if !mutationOptions.PreserveExpiry {
+					// Reload the doc expiry if GoCB is not preserving expiry
+					expiry, getExpiryErr := db.dataStore.GetExpiry(ctx, newDoc.ID)
+					if getExpiryErr != nil {
+						return nil, nil, false, nil, getExpiryErr
+					}
+					existingDoc.Expiry = expiry
+					updatedExpiry = &expiry
 				}
 
 				if doc.inlineSyncData {

--- a/db/import.go
+++ b/db/import.go
@@ -139,7 +139,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		existingDoc.Expiry = *expiry
 	}
 
-	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, existingDoc.Expiry, mutationOptions, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, mutationOptions, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.
 		if doc.Cas != existingDoc.Cas {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20231129224427-a2dc9918fa17
+	github.com/couchbaselabs/rosmar v0.0.0-20231201142951-3238beccd96c
 	github.com/elastic/gosigar v0.14.2
 	github.com/felixge/fgprof v0.9.3
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/rosmar v0.0.0-20231129224427-a2dc9918fa17 h1:Tb5mYG9Tg2KPciA9QtWpD5RqAnJf4dMHRY7OgyHvjOE=
 github.com/couchbaselabs/rosmar v0.0.0-20231129224427-a2dc9918fa17/go.mod h1:+AjMZkAOGCeQRLjIBwehXKyWsNCPFrMKYz6lIaZ1idc=
+github.com/couchbaselabs/rosmar v0.0.0-20231201142951-3238beccd96c h1:vJx/eKtme9z6zGBLy8XH+ECSVqjT+hhP5AMxsyRH3e8=
+github.com/couchbaselabs/rosmar v0.0.0-20231201142951-3238beccd96c/go.mod h1:+AjMZkAOGCeQRLjIBwehXKyWsNCPFrMKYz6lIaZ1idc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2856,7 +2856,7 @@ func TestImportUpdateExpiry(t *testing.T) {
 			name:        "no modification to TTL",
 			syncFn:      `function(doc, oldDoc, meta) { }`,
 			startExpiry: 2000,
-			assertion:   require.GreaterOrEqual, // in 6.0, we reset the expiry to a new offset so it can be greater. In 7.0 + this will be an exact match
+			assertion:   require.LessOrEqual, // in 6.0, we reset the expiry to a new offset so it can be slightly less than the original TTL. In 7.0 + this will be an exact match
 		},
 	}
 	for _, test := range testCases {


### PR DESCRIPTION
This is definitely the right thing to do because as is the `gocb.MutateInOptions` and `gocb.UpsertOptions` will be invalid and it allows this type of code to pass where:

1. write a document with TTL via SDK
2. have a sync function that calls `expiry`

However, there's a legacy bug around this code which is harder to fix:

1. write a document with TTL via SDK
2. call `expiry(0)`
3. (bug) document will have TTL set in doc 1 and not remove the TTL 

Should I try to fix the second bug as part of this review, or file a separate ticket for this? Or is this something not likely to actually occur in practice? I worry that this is going to be a complicated fix because I think some interfaces will have to pass `exp` as a pointer to differentiate between explicit 0 and nil.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2199/
