### PR TITLE
Fix a race condition in GetDatabase in adding Context

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1073,8 +1073,12 @@ func (rt *RestTester) Context() context.Context {
 	if svrctx := rt.ServerContext(); svrctx != nil {
 		ctx = svrctx.AddServerLogContext(ctx)
 	}
-	if len(rt.ServerContext().AllDatabases()) == 1 {
-		ctx = rt.GetDatabase().AddDatabaseLogContext(ctx)
+	// this has the possibility of adding an ambiguous database log context if there is a database being created at this time.
+	databases := rt.ServerContext().AllDatabases()
+	if len(databases) == 1 {
+		for _, database := range databases {
+			ctx = database.AddDatabaseLogContext(ctx)
+		}
 	}
 	return ctx
 }


### PR DESCRIPTION
This is a fix for:

```
--- FAIL: TestMultipleBucketWithBadDbConfigScenario3 (0.41s)
10:24:08     utilities_testing.go:480: 
10:24:08         	Error Trace:	/Users/couchbase/workspace/sgw-unix-build/3.2.0/community/sync_gateway/rest/utilities_testing.go:480
10:24:08         	            				/Users/couchbase/workspace/sgw-unix-build/3.2.0/community/sync_gateway/rest/utilities_testing.go:1077
10:24:08         	            				/Users/couchbase/workspace/sgw-unix-build/3.2.0/community/sync_gateway/rest/utilities_testing.go:828
10:24:08         	            				/Users/couchbase/workspace/sgw-unix-build/3.2.0/community/sync_gateway/rest/adminapitest/admin_api_test.go:1830
10:24:08         	Error:      	"map[]" should have 1 item(s), but has 0
10:24:08         	Test:       	TestMultipleBucketWithBadDbConfigScenario3
10:24:08 2023/11/30 07:21:45 Taking DB offline
```

which was immediately caused by https://github.com/couchbase/sync_gateway/commit/1cf9ac4f5ac38daeaa746c24b2389ed695cede79

There is a potential when calling rt.Context() that it might add the wrong database if a database is being created at the exact same time as the function is called, but this is only used for test logging and I think is OK. This would only affect a small number of tests. `rt.Context()` is used by `WaitForConditionWithOptions` and I'm reluctant to remove or change this call. There are probably other assertions that use `rt.Context()` that are not yet identified in tests.

