### PR TITLE
CBG-3643 [3.1.3 Backport] CBG-3612 preserveExpiry fix 

### DIFF
--- a/base/collection_gocb.go
+++ b/base/collection_gocb.go
@@ -190,7 +190,7 @@ func (c *Collection) Set(k string, exp uint32, opts *sgbucket.UpsertOptions, v i
 		Expiry:     CbsExpiryToDuration(exp),
 		Transcoder: NewSGJSONTranscoder(),
 	}
-	fillUpsertOptions(goCBUpsertOptions, opts)
+	fillUpsertOptions(context.TODO(), goCBUpsertOptions, opts)
 
 	if _, ok := v.([]byte); ok {
 		goCBUpsertOptions.Transcoder = gocb.NewRawJSONTranscoder()
@@ -208,7 +208,7 @@ func (c *Collection) SetRaw(k string, exp uint32, opts *sgbucket.UpsertOptions, 
 		Expiry:     CbsExpiryToDuration(exp),
 		Transcoder: NewSGRawTranscoder(),
 	}
-	fillUpsertOptions(goCBUpsertOptions, opts)
+	fillUpsertOptions(context.TODO(), goCBUpsertOptions, opts)
 
 	_, err := c.Collection.Upsert(k, v, goCBUpsertOptions)
 	return err

--- a/base/collection_gocb_utils.go
+++ b/base/collection_gocb_utils.go
@@ -9,22 +9,35 @@
 package base
 
 import (
+	"context"
+
 	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 )
 
 // Fills in the GoCB UpsertOptions based on the passed in SG Bucket UpsertOptions
-func fillUpsertOptions(goCBUpsertOptions *gocb.UpsertOptions, upsertOptions *sgbucket.UpsertOptions) {
+func fillUpsertOptions(ctx context.Context, goCBUpsertOptions *gocb.UpsertOptions, upsertOptions *sgbucket.UpsertOptions) {
 	if upsertOptions == nil {
 		return
 	}
 	goCBUpsertOptions.PreserveExpiry = upsertOptions.PreserveExpiry
+	if goCBUpsertOptions.Expiry != 0 && upsertOptions.PreserveExpiry {
+		InfofCtx(ctx, KeyCRUD, "Expiry set on gocb.UpsertOptions, but sgbucket.UpsertOptions.PreserveExpiry is false. Force setting PreserveExpiry to false to allow write to proceed.")
+		goCBUpsertOptions.PreserveExpiry = false
+
+	}
 }
 
 // Fills in the GoCB MutateInOptions based on the passed in MutateInOptions
-func fillMutateInOptions(goCBMutateInOptions *gocb.MutateInOptions, mutateInOptions *sgbucket.MutateInOptions) {
+func fillMutateInOptions(ctx context.Context, goCBMutateInOptions *gocb.MutateInOptions, mutateInOptions *sgbucket.MutateInOptions) {
 	if mutateInOptions == nil {
 		return
 	}
 	goCBMutateInOptions.PreserveExpiry = mutateInOptions.PreserveExpiry
+	if goCBMutateInOptions.Expiry != 0 && mutateInOptions.PreserveExpiry {
+		InfofCtx(ctx, KeyCRUD, "Expiry set on gocb.MutateInOptions, but sgbucket.MutateInOptions.PreserveExpiry is false. Force setting PreserveExpiry to false to allow write to proceed.")
+		goCBMutateInOptions.PreserveExpiry = false
+
+	}
+
 }

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -418,7 +418,7 @@ func (c *Collection) SubdocUpdateXattr(k string, xattrKey string, exp uint32, ca
 
 // SubdocUpdateBodyAndXattr updates the document body and xattr of an existing document. Writes cas and crc32c to the xattr using
 // macro expansion.
-func (c *Collection) SubdocUpdateBodyAndXattr(k string, xattrKey string, exp uint32, cas uint64, opts *sgbucket.MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error) {
+func (c *Collection) SubdocUpdateBodyAndXattr(ctx context.Context, k string, xattrKey string, exp uint32, cas uint64, opts *sgbucket.MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error) {
 	c.Bucket.waitForAvailKvOp()
 	defer c.Bucket.releaseKvOp()
 
@@ -433,7 +433,7 @@ func (c *Collection) SubdocUpdateBodyAndXattr(k string, xattrKey string, exp uin
 		StoreSemantic: gocb.StoreSemanticsUpsert,
 		Cas:           gocb.Cas(cas),
 	}
-	fillMutateInOptions(options, opts)
+	fillMutateInOptions(ctx, options, opts)
 	result, mutateErr := c.Collection.MutateIn(k, mutateOps, options)
 	if mutateErr != nil {
 		return 0, mutateErr

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -30,7 +30,7 @@ type SubdocXattrStore interface {
 	SubdocInsertBodyAndXattr(k string, xattrKey string, exp uint32, v interface{}, xv interface{}) (casOut uint64, err error)
 	SubdocSetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error)
 	SubdocUpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error)
-	SubdocUpdateBodyAndXattr(k string, xattrKey string, exp uint32, cas uint64, opts *sgbucket.MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error)
+	SubdocUpdateBodyAndXattr(ctx context.Context, k string, xattrKey string, exp uint32, cas uint64, opts *sgbucket.MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error)
 	SubdocUpdateXattrDeleteBody(k, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error)
 	SubdocDeleteXattr(k string, xattrKey string, cas uint64) error
 	SubdocDeleteXattrs(k string, xattrKeys ...string) error
@@ -74,7 +74,7 @@ func WriteCasWithXattr(ctx context.Context, store SubdocXattrStore, k string, xa
 		// Otherwise, replace existing value
 		if v != nil {
 			// Have value and xattr value - update both
-			casOut, err = store.SubdocUpdateBodyAndXattr(k, xattrKey, exp, cas, opts, v, xv)
+			casOut, err = store.SubdocUpdateBodyAndXattr(ctx, k, xattrKey, exp, cas, opts, v, xv)
 			if err != nil {
 				shouldRetry = store.isRecoverableWriteError(err)
 				return shouldRetry, err, uint64(0)

--- a/db/crud.go
+++ b/db/crud.go
@@ -846,7 +846,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	}
 
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, expiry, nil, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &expiry, nil, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		var isSgWrite bool
 		var crc32Match bool
 
@@ -971,7 +971,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 	}
 
 	allowImport := db.UseXattrs()
-	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, newDoc.DocExpiry, nil, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -1609,16 +1609,21 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 	return unusedSequences, nil
 }
 
-func (doc *Document) updateExpiry(syncExpiry, updatedExpiry *uint32, expiry uint32) (finalExp *uint32) {
+func (doc *Document) updateExpiry(syncExpiry, updatedExpiry *uint32, expiry *uint32) (finalExp *uint32) {
 	if syncExpiry != nil {
 		finalExp = syncExpiry
 	} else if updatedExpiry != nil {
 		finalExp = updatedExpiry
-	} else {
-		finalExp = &expiry
+	} else if expiry != nil {
+		finalExp = expiry
 	}
 
-	doc.UpdateExpiry(*finalExp)
+	if finalExp != nil {
+		doc.UpdateExpiry(*finalExp)
+	} else {
+		doc.UpdateExpiry(0)
+
+	}
 
 	return finalExp
 
@@ -1676,7 +1681,7 @@ func (db *DatabaseCollectionWithUser) IsIllegalConflict(ctx context.Context, doc
 	return true
 }
 
-func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, createNewRevIDSkipped bool, err error) {
+func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry *uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, createNewRevIDSkipped bool, err error) {
 
 	err = validateExistingDoc(doc, allowImport, docExists)
 	if err != nil {
@@ -1768,8 +1773,7 @@ type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAtta
 //  1. Receive the updated document body in the response
 //  2. Specify the existing document body/xattr/cas, to avoid initial retrieval of the doc in cases that the current contents are already known (e.g. import).
 //     On cas failure, the document will still be reloaded from the bucket as usual.
-func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
-
+func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry *uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
 	key := realDocID(docid)
 	if key == "" {
 		return nil, "", base.HTTPErrorf(400, "Invalid doc ID")
@@ -1793,7 +1797,11 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 	if !db.UseXattrs() {
 		// Update the document, storing metadata in _sync property
-		_, err = db.dataStore.Update(key, expiry, func(currentValue []byte) (raw []byte, syncFuncExpiry *uint32, isDelete bool, err error) {
+		var initialExpiry uint32 // expiry before Update callback happens
+		if expiry != nil {
+			initialExpiry = *expiry
+		}
+		_, err = db.dataStore.Update(key, initialExpiry, func(currentValue []byte) (raw []byte, syncFuncExpiry *uint32, isDelete bool, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocument(docid, currentValue); err != nil {
 				return
@@ -1832,7 +1840,11 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 	if db.UseXattrs() || upgradeInProgress {
 		var casOut uint64
 		// Update the document, storing metadata in extended attribute
-		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), expiry, opts, existingDoc, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, err error) {
+		var initialExpiry uint32
+		if expiry != nil {
+			initialExpiry = *expiry
+		}
+		casOut, err = db.dataStore.WriteUpdateWithXattr(ctx, key, base.SyncXattrName, db.userXattrKey(), initialExpiry, opts, existingDoc, func(currentValue []byte, currentXattr []byte, currentUserXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll); err != nil {
 				return
@@ -1854,6 +1866,10 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(ctx, docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
+			}
+			// If importing and the sync function has modified the expiry, allow sgbucket.MutateInOptions to modify the expiry
+			if db.dataStore.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) && syncFuncExpiry != nil && opts != nil {
+				opts.PreserveExpiry = false
 			}
 			docSequence = doc.Sequence
 			inConflict = doc.hasFlag(channels.Conflict)

--- a/db/import.go
+++ b/db/import.go
@@ -139,7 +139,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		existingDoc.Expiry = *expiry
 	}
 
-	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, existingDoc.Expiry, &mutationOptions, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, &mutationOptions, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.
 		if doc.Cas != existingDoc.Cas {

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2968,3 +2968,72 @@ type dcpMetaData struct {
 	SnapEnd     uint64     `json:"snapEnd"`
 	FailOverLog [][]uint64 `json:"failOverLog"`
 }
+
+func TestImportUpdateExpiry(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server - needs expiry")
+	}
+	testCases := []struct {
+		name         string
+		syncFn       string
+		startExpiry  uint32
+		assertion    func(t require.TestingT, expected, actual interface{}, msgAndArgs ...interface{})
+		shouldBeZero bool
+	}{
+		{
+			name:        "Decrease expiry",
+			syncFn:      `function(doc, oldDoc, meta) { expiry(1000); }`,
+			startExpiry: 2000,
+			assertion:   require.Less,
+		},
+		{
+			name:        "Increase expiry",
+			syncFn:      `function(doc, oldDoc, meta) { expiry(2000); }`,
+			startExpiry: 1000,
+			assertion:   require.Greater,
+		},
+		{
+			name:         "Unset TTL",
+			syncFn:       `function(doc, oldDoc, meta) { expiry(0); }`,
+			startExpiry:  2000,
+			shouldBeZero: true,
+		},
+		{
+			name:        "no modification to TTL",
+			syncFn:      `function(doc, oldDoc, meta) { }`,
+			startExpiry: 2000,
+			assertion:   require.LessOrEqual, // in 6.0, we reset the expiry to a new offset so it can be slightly less than the original TTL. In 7.0 + this will be an exact match
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: test.syncFn,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						AutoImport: false, // set AutoImport false to allow manually testing error conditions on import
+					},
+				},
+			})
+			defer rt.Close()
+
+			const docID = "doc1"
+			err := rt.GetSingleDataStore().SetRaw(docID, test.startExpiry, nil, []byte(`{"foo": "bar"}`))
+			require.NoError(t, err)
+
+			ctx := base.TestCtx(t)
+			preImportExp, err := rt.GetSingleDataStore().GetExpiry(ctx, docID)
+			require.NoError(t, err)
+			// Attempt to get the document via Sync Gateway, to trigger import. Success is successfully importing the body and not throwing an assertion error.
+			_ = rt.GetDocBody(docID)
+			expiry, err := rt.GetSingleDataStore().GetExpiry(ctx, docID)
+			require.NoError(t, err)
+			if test.shouldBeZero {
+				require.Equal(t, 0, int(expiry))
+			} else {
+				test.assertion(t, int(expiry), int(preImportExp))
+			}
+		})
+	}
+}

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -1172,7 +1172,7 @@ func TestResyncPersistence(t *testing.T) {
 	assert.Equal(t, resp.BodyBytes(), resp2.BodyBytes())
 }
 
-func TestExpiryUpdateSyncFunctionNew(t *testing.T) {
+func TestExpiryUpdateSyncFunction(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server - needs expiry")
 	}

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -36,6 +36,15 @@ func (rt *RestTester) GetDoc(docID string) (body db.Body) {
 	return body
 }
 
+// GetDocBody returns the doc body for the given docID. If the document is not found, t.Fail will be called.
+func (rt *RestTester) GetDocBody(docID string) db.Body {
+	rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")
+	RequireStatus(rt.TB, rawResponse, 200)
+	var body db.Body
+	require.NoError(rt.TB, base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
+	return body
+}
+
 func (rt *RestTester) CreateDoc(t *testing.T, docid string) string {
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/%s/%s", rt.GetSingleKeyspace(), docid), `{"prop":true}`)
 	RequireStatus(t, response, 201)


### PR DESCRIPTION
When the sync function specifies an expiry, do not attempt to preserve the existing expiry (which we would otherwise do for an import).

Required some modification to test handling for 3.1.3, as well as a check for nil opts when disabling PreserveExpiry (opts was changed to non-pointer on latest codeline.

CBG-3643

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2212/
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2221/ (CBS 6.6, TestImportUpdateExpiry)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2222/ (CBS 6.6, TestExpiryUpdateSyncFunction)
