### PR TITLE
CBG-3255: CBL Push replication for V4 subprotocol

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -84,6 +84,7 @@ const (
 	StatAddedVersion3dot1dot2     = "3.1.2"
 	StatAddedVersion3dot1dot3dot1 = "3.1.3.1"
 	StatAddedVersion3dot2dot0     = "3.2.0"
+	StatAddedVersion4dot0dot0     = "4.0.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
 	StatDeprecatedVersion3dot2dot0     = "3.2.0"

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -209,6 +209,9 @@ func TestUseXattrs() bool {
 	if err != nil {
 		panic(fmt.Sprintf("unable to parse %q value %q: %v", TestEnvSyncGatewayUseXattrs, useXattrs, err))
 	}
+	if !val {
+		panic("sync gateway requires xattrs to be enabled")
+	}
 
 	return val
 }

--- a/base/version.go
+++ b/base/version.go
@@ -19,8 +19,8 @@ import (
 const (
 	ProductName = "Couchbase Sync Gateway"
 
-	ProductAPIVersionMajor = "3"
-	ProductAPIVersionMinor = "2"
+	ProductAPIVersionMajor = "4"
+	ProductAPIVersionMinor = "0"
 	ProductAPIVersion      = ProductAPIVersionMajor + "." + ProductAPIVersionMinor
 )
 

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -60,13 +60,15 @@ type LogEntry struct {
 
 func (l LogEntry) String() string {
 	return fmt.Sprintf(
-		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d",
+		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d source: %s version: %d",
 		l.Sequence,
 		l.DocID,
 		l.RevID,
 		l.VbNo,
 		l.Type,
 		l.CollectionID,
+		l.SourceID,
+		l.Version,
 	)
 }
 

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -54,6 +54,8 @@ type LogEntry struct {
 	PrevSequence uint64       // Sequence of previous active revision
 	IsPrincipal  bool         // Whether the log-entry is a tracking entry for a principal doc
 	CollectionID uint32       // Collection ID
+	SourceID     string       // SourceID allocated to the doc's Current Version on the HLV
+	Version      uint64       // Version allocated to the doc's Current Version on the HLV
 }
 
 func (l LogEntry) String() string {

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -44,7 +44,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Create a document in channel chan1
 	doc1Body := Body{"channel": "chan1", "greeting": "hello"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc1", doc1Body, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc1", doc1Body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify user cannot access document
@@ -54,7 +54,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Write access granting document
 	grantingBody := Body{"type": "setaccess", "owner": "user1", "channel": "chan1"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant1", grantingBody, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant1", grantingBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify reloaded user can access document
@@ -66,12 +66,12 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Create a document in channel chan2
 	doc2Body := Body{"channel": "chan2", "greeting": "hello"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc2", doc2Body, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc2", doc2Body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Write access granting document for chan2 (tests invalidation when channels/inval_seq exists)
 	grantingBody = Body{"type": "setaccess", "owner": "user1", "channel": "chan2"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant2", grantingBody, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant2", grantingBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify user can now access both documents

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -208,7 +208,13 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	arc.replicationStats.NumConnectAttempts.Add(1)
 
 	var originPatterns []string // no origin headers for ISGR
-	blipContext, err := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix, originPatterns)
+
+	// Commented out following line pending work to get ISGR workiong woth Version Vectors.
+	//blipContext, err := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix, originPatterns)
+
+	// force use of V3 and below subprotocol versions
+	protocols := []string{"CBMobile_3", "CBMobile_2"}
+	blipContext, err := NewSGBlipContextWithProtocols(arc.ctx, arc.config.ID+idSuffix, originPatterns, protocols)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -209,11 +209,12 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 
 	var originPatterns []string // no origin headers for ISGR
 
-	// Commented out following line pending work to get ISGR workiong woth Version Vectors.
-	//blipContext, err := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix, originPatterns)
+	// TODO: CBG-3661 ActiveReplicator subprotocol versions
+	// - make this configurable for testing mixed-version replications
+	// - if unspecified, default to v2 and v3 until VV is supported with ISGR, then also include v4
+	protocols := []string{CBMobileReplicationV2.SubprotocolString(), CBMobileReplicationV3.SubprotocolString()}
 
-	// force use of V3 and below subprotocol versions
-	protocols := []string{"CBMobile_3", "CBMobile_2"}
+	//blipContext, err := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix, originPatterns)
 	blipContext, err := NewSGBlipContextWithProtocols(arc.ctx, arc.config.ID+idSuffix, originPatterns, protocols)
 	if err != nil {
 		return nil, nil, err

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -72,7 +72,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	var rev2Body Body
 	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 	rev2ID := "2-abc"
 
@@ -200,7 +200,7 @@ func TestAttachments(t *testing.T) {
 	rev2Bstr := `{"_attachments": {"bye.txt": {"stub":true,"revpos":1,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}, "_rev": "2-f000"}`
 	var body2B Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev2Bstr), &body2B))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body2B, []string{"2-f000", rev1id}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body2B, []string{"2-f000", rev1id}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't update document")
 }
 
@@ -284,7 +284,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 			rev2Data := `{"prop1":"value2", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 			require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 			require.NoError(t, err)
 
 			log.Printf("Done creating rev 2 for key %s", key)
@@ -315,7 +315,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 	var rev3Body Body
 	rev3Data := `{"prop1":"value3", "_attachments": {"hello.txt": {"revpos":2,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev3Data), &rev3Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	log.Printf("rev 3 done")
@@ -347,7 +347,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 			rev2Data := `{"prop1":"value2"}`
 			require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 			require.NoError(t, err)
 
 			log.Printf("Done creating rev 2 for key %s", key)
@@ -378,7 +378,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 	var rev3Body Body
 	rev3Data := `{"prop1":"value3", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev3Data), &rev3Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	log.Printf("rev 3 done")
@@ -567,7 +567,7 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 	// Create document (rev 1)
 	text := `{"key": "value", "version": "1a"}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
-	doc, revID, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
+	doc, revID, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
@@ -575,49 +575,49 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 	text = `{"key": "value", "version": "2a", "_attachments": {"att1.txt": {"data": "YXR0MS50eHQ="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-a", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "4a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-a", "3-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "5a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"5-a", "4-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"5-a", "4-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "6a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"6-a", "5-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"6-a", "5-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3b", "type": "pruned"}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3b", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -992,7 +992,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 
 	var history []string
 	if bh.activeCBMobileSubprotocol < CBMobileReplicationV4 {
-		// include current rev propery in history
+		// include current rev property in history
 		history = append(history, rev)
 	}
 	var versionVectorStr string
@@ -1028,7 +1028,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 
 		//  TODO: Doing a GetRevCopy here duplicates some rev cache retrieval effort, since deltaRevSrc is always
 		//        going to be the current rev (no conflicts), and PutExistingRev will need to retrieve the
-		//        current rev over again.  Should push this handling down PutExistingRev and use the rev
+		//        current rev over again.  Should push this handling down PutExistingRev and use the version
 		//        returned via callback in WriteUpdate, but blocked by moving attachment metadata to a rev property first
 		//        (otherwise we don't have information needed to do downloadOrVerifyAttachments below prior to PutExistingRev)
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1183,9 +1183,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
 	if bh.conflictResolver != nil {
-		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc)
+		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	} else {
-		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc)
+		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	}
 	if err != nil {
 		return err

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1038,8 +1038,8 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		//       revisions to malicious actors (in the scenario where that user has write but not read access).
 		var deltaSrcRev DocumentRevision
 		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
-			cv := SourceAndVersion{}
-			cv.SourceID, cv.Version = incomingHLV.GetCurrentVersion()
+			cv := Version{}
+			cv.SourceID, cv.Value = incomingHLV.GetCurrentVersion()
 			// swap for GetCV once merged (CBG-3212)
 			deltaSrcRev, err = bh.collection.revisionCache.GetWithCV(bh.loggingCtx, docID, &cv, RevCacheOmitBody, RevCacheOmitDelta)
 		} else {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -785,7 +785,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 
 	for i, change := range changeList {
 		docID := change[0].(string)
-		version := change[1].(string)
+		rev := change[1].(string) // rev can represent a RevTree entry ID or HLV Version
 		parentRevID := ""
 		if len(change) > 2 {
 			parentRevID = change[2].(string)
@@ -793,9 +793,9 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 		var status ProposedRevStatus
 		var currentRev string
 		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
-			status, currentRev = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, version)
+			status, currentRev = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, rev)
 		} else {
-			status, currentRev = bh.collection.CheckProposedRev(bh.loggingCtx, docID, version, parentRevID)
+			status, currentRev = bh.collection.CheckProposedRev(bh.loggingCtx, docID, rev, parentRevID)
 		}
 		if status == ProposedRev_OK_IsNew {
 			// Remember that the doc doesn't exist locally, in order to optimize the upcoming Put:

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -995,6 +995,10 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		// include current rev property in history
 		history = append(history, rev)
 	}
+
+	// TODO: Extract/parse HLV from history for MV and PV
+	// CV kept in rev property on its own
+
 	var versionVectorStr string
 	if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" && bh.activeCBMobileSubprotocol < CBMobileReplicationV4 {
 		history = append(history, strings.Split(historyStr, ",")...)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -793,7 +793,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 		var status ProposedRevStatus
 		var currentRev string
 		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
-			status, _ = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, version)
+			status, currentRev = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, version)
 		} else {
 			status, currentRev = bh.collection.CheckProposedRev(bh.loggingCtx, docID, version, parentRevID)
 		}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -499,6 +499,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	if len(rawUserXattr) > 0 {
 		collection.revisionCache.RemoveWithRev(docID, syncData.CurrentRev)
 	}
+
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,
 		DocID:        docID,
@@ -508,6 +509,10 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		TimeSaved:    syncData.TimeSaved,
 		Channels:     syncData.Channels,
 		CollectionID: event.CollectionID,
+	}
+	if syncData.HLV != nil {
+		change.SourceID = syncData.HLV.SourceID
+		change.Version = syncData.HLV.Version
 	}
 
 	millisecondLatency := int(feedLatency / time.Millisecond)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -120,6 +120,14 @@ func (entry *LogEntry) SetDeleted() {
 	entry.Flags |= channels.Deleted
 }
 
+func (entry *LogEntry) SetRevAndVersion(rv RevAndVersion) {
+	entry.RevID = rv.RevTreeID
+	if rv.CurrentSource != "" {
+		entry.SourceID = rv.CurrentSource
+		entry.Version = base.HexCasToUint64(rv.CurrentVersion)
+	}
+}
+
 type LogEntries []*LogEntry
 
 // A priority-queue of LogEntries, kept ordered by increasing sequence #.

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -497,7 +497,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.Remove(docID, syncData.CurrentRev)
+		collection.revisionCache.RemoveWithRev(docID, syncData.CurrentRev)
 	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -74,6 +74,24 @@ func logEntry(seq uint64, docid string, revid string, channelNames []string, col
 	return entry
 }
 
+func testLogEntryWithCV(seq uint64, docid string, revid string, channelNames []string, collectionID uint32, sourceID string, version uint64) *LogEntry {
+	entry := &LogEntry{
+		Sequence:     seq,
+		DocID:        docid,
+		RevID:        revid,
+		TimeReceived: time.Now(),
+		CollectionID: collectionID,
+		SourceID:     sourceID,
+		Version:      version,
+	}
+	channelMap := make(channels.ChannelMap)
+	for _, channelName := range channelNames {
+		channelMap[channelName] = nil
+	}
+	entry.Channels = channelMap
+	return entry
+}
+
 func TestSkippedSequenceList(t *testing.T) {
 
 	skipList := NewSkippedSequenceList()

--- a/db/changes.go
+++ b/db/changes.go
@@ -57,7 +57,7 @@ type ChangeEntry struct {
 	principalDoc   bool         // Used to indicate _user/_role docs
 	Revoked        bool         `json:"revoked,omitempty"`
 	collectionID   uint32
-	CurrentVersion *Version `json:"current_version,omitempty"` // the current version of the change entry
+	CurrentVersion *Version `json:"-"` // the current version of the change entry.  (Not marshalled, pending REST support for cv)
 }
 
 const (

--- a/db/changes.go
+++ b/db/changes.go
@@ -57,7 +57,7 @@ type ChangeEntry struct {
 	principalDoc   bool         // Used to indicate _user/_role docs
 	Revoked        bool         `json:"revoked,omitempty"`
 	collectionID   uint32
-	CurrentVersion *SourceAndVersion `json:"current_version,omitempty"` // the current version of the change entry
+	CurrentVersion *Version `json:"current_version,omitempty"` // the current version of the change entry
 }
 
 const (
@@ -486,7 +486,7 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channel channels.ID) 
 	// This allows current version to be nil in event of CV not being populated on log entry
 	// allowing omitempty to work as expected
 	if logEntry.SourceID != "" && logEntry.Version != 0 {
-		change.CurrentVersion = &SourceAndVersion{SourceID: logEntry.SourceID, Version: logEntry.Version}
+		change.CurrentVersion = &Version{SourceID: logEntry.SourceID, Value: logEntry.Version}
 	}
 	if logEntry.Flags&channels.Removed != 0 {
 		change.Removed = base.SetOf(channel.Name)
@@ -1289,8 +1289,8 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 	row.SetBranched((populatedDoc.Flags & channels.Branched) != 0)
 
 	if populatedDoc.HLV != nil {
-		cv := SourceAndVersion{}
-		cv.SourceID, cv.Version = populatedDoc.HLV.GetCurrentVersion()
+		cv := Version{}
+		cv.SourceID, cv.Value = populatedDoc.HLV.GetCurrentVersion()
 		row.CurrentVersion = &cv
 	}
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -320,7 +320,7 @@ func TestCVPopulationOnChangeEntry(t *testing.T) {
 
 	assert.Equal(t, doc.ID, changes[0].ID)
 	assert.Equal(t, bucketUUID, changes[0].CurrentVersion.SourceID)
-	assert.Equal(t, doc.Cas, changes[0].CurrentVersion.Version)
+	assert.Equal(t, doc.Cas, changes[0].CurrentVersion.Value)
 }
 
 func TestDocDeletionFromChannelCoalesced(t *testing.T) {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -478,14 +478,14 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 		// Create child rev 1
 		docBody["child"] = "A"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-A", revId}, false)
+		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-A", revId}, false, ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			b.Fatalf("Error creating child1 rev: %v", err)
 		}
 
 		// Create child rev 2
 		docBody["child"] = "B"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-B", revId}, false)
+		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-B", revId}, false, ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			b.Fatalf("Error creating child2 rev: %v", err)
 		}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -290,6 +290,39 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	printChanges(changes)
 }
 
+func TestCVPopulationOnChangeEntry(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	collectionID := collection.GetCollectionID()
+	bucketUUID := db.BucketUUID
+
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	authenticator := db.Authenticator(base.TestCtx(t))
+	user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+	require.NoError(t, err)
+	require.NoError(t, authenticator.Save(user))
+
+	collection.user, _ = authenticator.GetUser("alice")
+
+	// Make channel active
+	_, err = db.channelCache.GetChanges(ctx, channels.NewID("A", collectionID), getChangesOptionsWithZeroSeq(t))
+	require.NoError(t, err)
+
+	_, doc, err := collection.Put(ctx, "doc1", Body{"channels": []string{"A"}})
+	require.NoError(t, err)
+
+	require.NoError(t, collection.WaitForPendingChanges(base.TestCtx(t)))
+
+	changes, err := collection.GetChanges(ctx, base.SetOf("A"), getChangesOptionsWithZeroSeq(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, doc.ID, changes[0].ID)
+	assert.Equal(t, bucketUUID, changes[0].CurrentVersion.SourceID)
+	assert.Equal(t, doc.Cas, changes[0].CurrentVersion.Version)
+}
+
 func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	if base.TestUseXattrs() {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Same error as TestDocDeletionFromChannelCoalescedRemoved")

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -25,7 +25,7 @@ type channelsViewRow struct {
 	ID    string
 	Key   []interface{} // Actually [channelName, sequence]
 	Value struct {
-		Rev   string
+		Rev   RevAndVersion
 		Flags uint8
 	}
 }
@@ -42,13 +42,12 @@ func nextChannelViewEntry(ctx context.Context, results sgbucket.QueryResultItera
 	entry := &LogEntry{
 		Sequence:     uint64(viewRow.Key[1].(float64)),
 		DocID:        viewRow.ID,
-		RevID:        viewRow.Value.Rev,
 		Flags:        viewRow.Value.Flags,
 		TimeReceived: time.Now(),
 		CollectionID: collectionID,
 	}
+	entry.SetRevAndVersion(viewRow.Value.Rev)
 	return entry, true
-
 }
 
 func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIterator, collectionID uint32) (*LogEntry, bool) {
@@ -61,11 +60,11 @@ func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIter
 	entry := &LogEntry{
 		Sequence:     queryRow.Sequence,
 		DocID:        queryRow.Id,
-		RevID:        queryRow.Rev,
 		Flags:        queryRow.Flags,
 		TimeReceived: time.Now(),
 		CollectionID: collectionID,
 	}
+	entry.SetRevAndVersion(queryRow.Rev)
 
 	if queryRow.RemovalRev != "" {
 		entry.RevID = queryRow.RemovalRev

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -951,6 +951,23 @@ func verifyChannelDocIDs(entries []*LogEntry, docIDs []string) bool {
 	return true
 }
 
+type cvValues struct {
+	source  string
+	version uint64
+}
+
+func verifyCVEntries(entries []*LogEntry, cvs []cvValues) bool {
+	for index, cv := range cvs {
+		if entries[index].SourceID != cv.source {
+			return false
+		}
+		if entries[index].Version != cv.version {
+			return false
+		}
+	}
+	return true
+}
+
 func writeEntries(entries []*LogEntry) {
 	for index, entry := range entries {
 		log.Printf("%d:seq=%d, docID=%s, revID=%s", index, entry.Sequence, entry.DocID, entry.RevID)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2787,8 +2787,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 	incomingDocCV := SourceAndVersion{SourceID: incomingHLV.SourceID, Version: incomingHLV.Version}
 
 	localDocCV := SourceAndVersion{}
-	level := DocUnmarshalVV
-	doc, err := db.GetDocSyncDataNoImport(ctx, docid, level)
+	doc, err := db.GetDocSyncDataNoImport(ctx, docid, DocUnmarshalVV)
 	if doc.HLV != nil {
 		localDocCV.SourceID, localDocCV.Version = doc.HLV.GetCurrentVersion()
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -2762,10 +2762,11 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 }
 
 const (
-	xattrMacroCas           = "cas"
-	xattrMacroValueCrc32c   = "value_crc32c"
-	versionVectorVrsMacro   = "_vv.vrs"
-	versionVectorCVCASMacro = "_vv.cvCas"
+	xattrMacroCas               = "cas"          // SyncData.Cas
+	xattrMacroValueCrc32c       = "value_crc32c" // SyncData.Crc32c
+	xattrMacroCurrentRevVersion = "rev.vrs"      // SyncDataJSON.RevAndVersion.CurrentVersion
+	versionVectorVrsMacro       = "_vv.vrs"      // PersistedHybridLogicalVector.Version
+	versionVectorCVCASMacro     = "_vv.cvCas"    // PersistedHybridLogicalVector.CurrentVersionCAS
 )
 
 func macroExpandSpec(xattrName string) []sgbucket.MacroExpansionSpec {
@@ -2783,6 +2784,10 @@ func xattrCasPath(xattrKey string) string {
 
 func xattrCrc32cPath(xattrKey string) string {
 	return xattrKey + "." + xattrMacroValueCrc32c
+}
+
+func xattrCurrentRevVersionPath(xattrKey string) string {
+	return xattrKey + "." + xattrMacroCurrentRevVersion
 }
 
 func xattrCurrentVersionPath(xattrKey string) string {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1059,6 +1059,103 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	return newRevID, doc, err
 }
 
+func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, docHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *SourceAndVersion, newRevID string, err error) {
+	var matchRev string
+	if existingDoc != nil {
+		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattr, existingDoc.UserXattr, existingDoc.Cas, DocUnmarshalRev)
+		if unmarshalErr != nil {
+			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling exsiting doc")
+		}
+		matchRev = doc.CurrentRev
+	}
+	generation, _ := ParseRevID(ctx, matchRev)
+	if generation < 0 {
+		return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
+	}
+	generation++
+
+	docUpdateEvent := ExistingVersion
+	allowImport := db.UseXattrs()
+	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+		// (Be careful: this block can be invoked multiple times if there are races!)
+
+		var isSgWrite bool
+		var crc32Match bool
+
+		// Is this doc an sgWrite?
+		if doc != nil {
+			isSgWrite, crc32Match, _ = doc.IsSGWrite(ctx, nil)
+			if crc32Match {
+				db.dbStats().Database().Crc32MatchCount.Add(1)
+			}
+		}
+
+		// If the existing doc isn't an SG write, import prior to updating
+		if doc != nil && !isSgWrite && db.UseXattrs() {
+			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, newDoc.Deleted)
+			if err != nil {
+				return nil, nil, false, nil, err
+			}
+		}
+
+		// Conflict check here
+		// if doc has no HLV defined this is a new doc we haven't seen before, skip conflict check
+		if doc.HLV == nil {
+			doc.HLV = &HybridLogicalVector{}
+			addNewerVersionsErr := doc.HLV.AddNewerVersions(docHLV)
+			if addNewerVersionsErr != nil {
+				return nil, nil, false, nil, addNewerVersionsErr
+			}
+		} else {
+			if !docHLV.IsInConflict(*doc.HLV) {
+				// update hlv for all newer incoming source version pairs
+				addNewerVersionsErr := doc.HLV.AddNewerVersions(docHLV)
+				if addNewerVersionsErr != nil {
+					return nil, nil, false, nil, addNewerVersionsErr
+				}
+			} else {
+				base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s", base.UD(doc.ID))
+				// cancel rest of update, HLV needs to be sent back to client with merge versions populated
+				return nil, nil, false, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
+			}
+		}
+
+		// Process the attachments, replacing bodies with digests.
+		newAttachments, err := db.storeAttachments(ctx, doc, newDoc.DocAttachments, generation, matchRev, nil)
+		if err != nil {
+			return nil, nil, false, nil, err
+		}
+
+		// generate rev id for new arriving doc
+		strippedBody, _ := stripInternalProperties(newDoc._body)
+		encoding, err := base.JSONMarshalCanonical(strippedBody)
+		if err != nil {
+			return nil, nil, false, nil, err
+		}
+		newRev := CreateRevIDWithBytes(generation, matchRev, encoding)
+
+		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: newDoc.Deleted}); err != nil {
+			base.InfofCtx(ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(newDoc.ID), err)
+			return nil, nil, false, nil, base.ErrRevTreeAddRevFailure
+		}
+
+		newDoc.RevID = newRev
+
+		return newDoc, newAttachments, false, nil, nil
+	})
+
+	if doc != nil && doc.HLV != nil {
+		if cv == nil {
+			cv = &SourceAndVersion{}
+		}
+		source, version := doc.HLV.GetCurrentVersion()
+		cv.SourceID = source
+		cv.Version = version
+	}
+
+	return doc, cv, newRevID, err
+}
+
 // Adds an existing revision to a document along with its history (list of rev IDs.)
 func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument, docUpdateEvent DocUpdateType) (doc *Document, newRevID string, err error) {
 	return db.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc, docUpdateEvent)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2781,7 +2781,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 	incomingDocCV := Version{SourceID: incomingHLV.SourceID, Value: incomingHLV.Version}
 
 	localDocCV := Version{}
-	doc, err := db.GetDocSyncDataNoImport(ctx, docid, DocUnmarshalVV)
+	doc, err := db.GetDocSyncDataNoImport(ctx, docid, DocUnmarshalNoHistory)
 	if doc.HLV != nil {
 		localDocCV.SourceID, localDocCV.Value = doc.HLV.GetCurrentVersion()
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -876,19 +876,37 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 	case ExistingVersion:
 		// preserve any other logic on the HLV that has been done by the client, only update to cvCAS will be needed
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+		d.HLV.ImportCAS = 0 // remove importCAS for non-imports to save space
 	case Import:
-		// work to be done to decide if the VV needs updating here, pending CBG-3503
+		if d.HLV.CurrentVersionCAS == d.Cas {
+			// if cvCAS = document CAS, the HLV has already been updated for this mutation by another HLV-aware peer.
+			// Set ImportCAS to the previous document CAS, but don't otherwise modify HLV
+			d.HLV.ImportCAS = d.Cas
+		} else {
+			// Otherwise this is an SDK mutation made by the local cluster that should be added to HLV.
+			newVVEntry := SourceAndVersion{}
+			newVVEntry.SourceID = db.dbCtx.BucketUUID
+			newVVEntry.Version = hlvExpandMacroCASValue
+			err := d.SyncData.HLV.AddVersion(newVVEntry)
+			if err != nil {
+				return nil, err
+			}
+			d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+			d.HLV.ImportCAS = d.Cas
+		}
+
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
-		newVVEntry := CurrentVersionVector{}
+		newVVEntry := SourceAndVersion{}
 		newVVEntry.SourceID = db.dbCtx.BucketUUID
-		newVVEntry.VersionCAS = hlvExpandMacroCASValue
+		newVVEntry.Version = hlvExpandMacroCASValue
 		err := d.SyncData.HLV.AddVersion(newVVEntry)
 		if err != nil {
 			return nil, err
 		}
 		// update the cvCAS on the SGWrite event too
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+		d.HLV.ImportCAS = 0 // remove importCAS for non-imports to save space
 	}
 	return d, nil
 }
@@ -2075,7 +2093,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
-			CV:               &CurrentVersionVector{VersionCAS: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+			CV:               &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 		}
 
 		if createNewRevIDSkipped {

--- a/db/crud.go
+++ b/db/crud.go
@@ -317,7 +317,7 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 	if revid != "" {
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
-		revision, err = db.revisionCache.Get(ctx, docid, revid, includeBody, RevCacheOmitDelta)
+		revision, err = db.revisionCache.GetWithRev(ctx, docid, revid, includeBody, RevCacheOmitDelta)
 	} else {
 		// No rev ID given, so load active revision
 		revision, err = db.revisionCache.GetActive(ctx, docid, includeBody)
@@ -381,7 +381,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		return nil, nil, nil
 	}
 
-	fromRevision, err := db.revisionCache.Get(ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+	fromRevision, err := db.revisionCache.GetWithRev(ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 
 	// If the fromRevision is a removal cache entry (no body), but the user has access to that removal, then just
 	// return 404 missing to indicate that the body of the revision is no longer available.
@@ -421,7 +421,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		// db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheMisses, 1)
 		db.dbStats().DeltaSync().DeltaCacheMiss.Add(1)
-		toRevision, err := db.revisionCache.Get(ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		toRevision, err := db.revisionCache.GetWithRev(ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -878,7 +878,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
 	case Import:
 		// work to be done to decide if the VV needs updating here, pending CBG-3503
-	case NewVersion:
+	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
 		newVVEntry := CurrentVersionVector{}
 		newVVEntry.SourceID = db.dbCtx.BucketUUID
@@ -1042,8 +1042,8 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 }
 
 // Adds an existing revision to a document along with its history (list of rev IDs.)
-func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
-	return db.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc)
+func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument, docUpdateEvent DocUpdateType) (doc *Document, newRevID string, err error) {
+	return db.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc, docUpdateEvent)
 }
 
 // PutExistingRevWithConflictResolution Adds an existing revision to a document along with its history (list of rev IDs.)
@@ -1051,14 +1051,13 @@ func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc
 //  1. If noConflicts == false, the revision will be added to the rev tree as a conflict
 //  2. If noConflicts == true and a conflictResolverFunc is not provided, a 409 conflict error will be returned
 //  3. If noConflicts == true and a conflictResolverFunc is provided, conflicts will be resolved and the result added to the document.
-func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, conflictResolver *ConflictResolver, forceAllowConflictingTombstone bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
+func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, conflictResolver *ConflictResolver, forceAllowConflictingTombstone bool, existingDoc *sgbucket.BucketDocument, docUpdateEvent DocUpdateType) (doc *Document, newRevID string, err error) {
 	newRev := docHistory[0]
 	generation, _ := ParseRevID(ctx, newRev)
 	if generation < 0 {
 		return nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 
-	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()
 	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
@@ -1159,7 +1158,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 	return doc, newRev, err
 }
 
-func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context, docid string, body Body, docHistory []string, noConflicts bool) (doc *Document, newRev string, err error) {
+func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context, docid string, body Body, docHistory []string, noConflicts bool, docUpdateEvent DocUpdateType) (doc *Document, newRev string, err error) {
 	err = validateAPIDocUpdate(body)
 	if err != nil {
 		return nil, "", err
@@ -1184,7 +1183,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context
 
 	newDoc.UpdateBody(body)
 
-	doc, newRevID, putExistingRevErr := db.PutExistingRev(ctx, newDoc, docHistory, noConflicts, false, nil)
+	doc, newRevID, putExistingRevErr := db.PutExistingRev(ctx, newDoc, docHistory, noConflicts, false, nil, docUpdateEvent)
 
 	if putExistingRevErr != nil {
 		return nil, "", putExistingRevErr
@@ -2003,7 +2002,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Remove(doc.ID, doc.CurrentRev)
+				db.revisionCache.RemoveWithRev(doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
@@ -2017,6 +2016,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 		} else if doc != nil {
 			doc.Cas = casOut
+			// update the doc's HLV defined post macro expansion
+			doc = postWriteUpdateHLV(doc, casOut)
 		}
 	}
 
@@ -2074,6 +2075,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
+			CV:               &CurrentVersionVector{VersionCAS: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 		}
 
 		if createNewRevIDSkipped {
@@ -2134,6 +2136,19 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 	// Mark affected users/roles as needing to recompute their channel access:
 	db.MarkPrincipalsChanged(ctx, docid, newRevID, changedAccessPrincipals, changedRoleAccessUsers, doc.Sequence)
 	return doc, newRevID, nil
+}
+
+func postWriteUpdateHLV(doc *Document, casOut uint64) *Document {
+	if doc.HLV == nil {
+		return doc
+	}
+	if doc.HLV.Version == hlvExpandMacroCASValue {
+		doc.HLV.Version = casOut
+	}
+	if doc.HLV.CurrentVersionCAS == hlvExpandMacroCASValue {
+		doc.HLV.CurrentVersionCAS = casOut
+	}
+	return doc
 }
 
 func getAttachmentIDsForLeafRevisions(ctx context.Context, db *DatabaseCollectionWithUser, doc *Document, newRevID string) (map[string]struct{}, error) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -2795,16 +2794,10 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 
 		return ProposedRev_Exists, ""
 	} else if doc.HLV.IsInConflict(incomingHLV) {
-		return ProposedRev_Conflict, cvToString(localDocCV)
-	} else {
-		return ProposedRev_OK, ""
+		return ProposedRev_Conflict, localDocCV.String()
 	}
 
-}
-
-// cvToString converts Version struct to Blip CV string format
-func cvToString(cv Version) string {
-	return strconv.FormatUint(cv.Value, 10) + "@" + cv.SourceID
+	return ProposedRev_OK, ""
 }
 
 const (

--- a/db/crud.go
+++ b/db/crud.go
@@ -2778,12 +2778,12 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 	if err != nil {
 		return ProposedRev_Error, ""
 	}
-	incomingDocCV := SourceAndVersion{SourceID: incomingHLV.SourceID, Version: incomingHLV.Version}
+	incomingDocCV := Version{SourceID: incomingHLV.SourceID, Value: incomingHLV.Version}
 
-	localDocCV := SourceAndVersion{}
+	localDocCV := Version{}
 	doc, err := db.GetDocSyncDataNoImport(ctx, docid, DocUnmarshalVV)
 	if doc.HLV != nil {
-		localDocCV.SourceID, localDocCV.Version = doc.HLV.GetCurrentVersion()
+		localDocCV.SourceID, localDocCV.Value = doc.HLV.GetCurrentVersion()
 	}
 	if err != nil {
 		if !base.IsDocNotFoundError(err) && err != base.ErrXattrNotFound {
@@ -2802,9 +2802,9 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 
 }
 
-// cvToString converts SourceAndVersion struct to Blip CV string format
-func cvToString(cv SourceAndVersion) string {
-	return strconv.FormatUint(cv.Version, 10) + "@" + cv.SourceID
+// cvToString converts Version struct to Blip CV string format
+func cvToString(cv Version) string {
+	return strconv.FormatUint(cv.Value, 10) + "@" + cv.SourceID
 }
 
 const (

--- a/db/crud.go
+++ b/db/crud.go
@@ -866,6 +866,33 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 	return nil
 }
 
+// updateHLV updates the HLV in the sync data appropriately based on what type of document update event we are encountering
+func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocUpdateType) (*Document, error) {
+
+	if d.HLV == nil {
+		d.HLV = &HybridLogicalVector{}
+	}
+	switch docUpdateEvent {
+	case ExistingVersion:
+		// preserve any other logic on the HLV that has been done by the client, only update to cvCAS will be needed
+		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+	case Import:
+		// work to be done to decide if the VV needs updating here, pending CBG-3503
+	case NewVersion:
+		// add a new entry to the version vector
+		newVVEntry := CurrentVersionVector{}
+		newVVEntry.SourceID = db.dbCtx.BucketUUID
+		newVVEntry.VersionCAS = hlvExpandMacroCASValue
+		err := d.SyncData.HLV.AddVersion(newVVEntry)
+		if err != nil {
+			return nil, err
+		}
+		// update the cvCAS on the SGWrite event too
+		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+	}
+	return d, nil
+}
+
 // Updates or creates a document.
 // The new body's BodyRev property must match the current revision's, if any.
 func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, body Body) (newRevID string, doc *Document, err error) {
@@ -905,8 +932,9 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 		return "", nil, err
 	}
 
+	docUpdateEvent := NewVersion
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &expiry, nil, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &expiry, nil, docUpdateEvent, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		var isSgWrite bool
 		var crc32Match bool
 
@@ -1030,8 +1058,9 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 		return nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 
+	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()
-	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -1836,7 +1865,7 @@ type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAtta
 //  1. Receive the updated document body in the response
 //  2. Specify the existing document body/xattr/cas, to avoid initial retrieval of the doc in cases that the current contents are already known (e.g. import).
 //     On cas failure, the document will still be reloaded from the bucket as usual.
-func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry *uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
+func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry *uint32, opts *sgbucket.MutateInOptions, docUpdateEvent DocUpdateType, existingDoc *sgbucket.BucketDocument, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
 	key := realDocID(docid)
 	if key == "" {
 		return nil, "", base.HTTPErrorf(400, "Invalid doc ID")
@@ -1945,6 +1974,14 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				err = base.RedactErrorf("WriteUpdateWithXattr() not able to find revision (%v) in history of doc: %+v.  Cannot update doc.", doc.CurrentRev, base.UD(doc))
 				return
 			}
+
+			// update the HLV values
+			doc, err = db.updateHLV(doc, docUpdateEvent)
+			if err != nil {
+				return
+			}
+			// update the mutate in options based on the above logic
+			updatedSpec = doc.SyncData.HLV.computeMacroExpansions()
 
 			deleteDoc = currentRevFromHistory.Deleted
 
@@ -2595,8 +2632,10 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 }
 
 const (
-	xattrMacroCas         = "cas"
-	xattrMacroValueCrc32c = "value_crc32c"
+	xattrMacroCas           = "cas"
+	xattrMacroValueCrc32c   = "value_crc32c"
+	versionVectorVrsMacro   = "_vv.vrs"
+	versionVectorCVCASMacro = "_vv.cvCas"
 )
 
 func macroExpandSpec(xattrName string) []sgbucket.MacroExpansionSpec {
@@ -2614,4 +2653,12 @@ func xattrCasPath(xattrKey string) string {
 
 func xattrCrc32cPath(xattrKey string) string {
 	return xattrKey + "." + xattrMacroValueCrc32c
+}
+
+func xattrCurrentVersionPath(xattrKey string) string {
+	return xattrKey + "." + versionVectorVrsMacro
+}
+
+func xattrCurrentVersionCASPath(xattrKey string) string {
+	return xattrKey + "." + versionVectorCVCASMacro
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1744,7 +1744,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	require.NoError(t, err)
 	// assert on returned CV
 	assert.Equal(t, "test", cv.SourceID)
-	assert.Equal(t, incomingVersion, cv.Version)
+	assert.Equal(t, incomingVersion, cv.Value)
 	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
 
 	// assert on the sync data from the above update to the doc
@@ -1851,7 +1851,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	assert.NotNil(t, doc)
 	// assert on returned CV value
 	assert.Equal(t, "test", cv.SourceID)
-	assert.Equal(t, incomingVersion, cv.Version)
+	assert.Equal(t, incomingVersion, cv.Value)
 	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
 
 	// assert on the sync data from the above update to the doc

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1867,3 +1867,12 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
 	assert.Equal(t, "1-3a208ea66e84121b528f05b5457d1134", syncData.CurrentRev)
 }
+
+func TestCVToString(t *testing.T) {
+	cv := SourceAndVersion{
+		Version:  33,
+		SourceID: "test",
+	}
+	expectedStr := "33@test"
+	assert.Equal(t, expectedStr, cvToString(cv))
+}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1869,8 +1869,8 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 }
 
 func TestCVToString(t *testing.T) {
-	cv := SourceAndVersion{
-		Version:  33,
+	cv := Version{
+		Value:    33,
 		SourceID: "test",
 	}
 	expectedStr := "33@test"

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1867,12 +1867,3 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
 	assert.Equal(t, "1-3a208ea66e84121b528f05b5457d1134", syncData.CurrentRev)
 }
-
-func TestCVToString(t *testing.T) {
-	cv := Version{
-		Value:    33,
-		SourceID: "test",
-	}
-	expectedStr := "33@test"
-	assert.Equal(t, expectedStr, cvToString(cv))
-}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1674,4 +1675,195 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 	expectedReleasedSequenceCount := otherClusterSequenceOffset
 	releasedSequenceCount := db.DbStats.Database().SequenceReleasedCount.Value() - startReleasedSequenceCount
 	assert.Equal(t, int64(expectedReleasedSequenceCount), releasedSequenceCount)
+}
+
+// TestPutExistingCurrentVersion:
+//   - Put a document in a db
+//   - Assert on the update to HLV after that PUT
+//   - Construct a HLV to represent the doc created locally being updated on a client
+//   - Call PutExistingCurrentVersion simulating doc update arriving over replicator
+//   - Assert that the doc's HLV in the bucket has been updated correctly with the CV, PV and cvCAS
+func TestPutExistingCurrentVersion(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	bucketUUID := db.BucketUUID
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	// create a new doc
+	key := "doc1"
+	body := Body{"key1": "value1"}
+
+	rev, _, err := collection.Put(ctx, key, body)
+	require.NoError(t, err)
+
+	// assert on HLV on that above PUT
+	syncData, err := collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// store the cas version allocated to the above doc creation for creation of incoming HLV later in test
+	originalDocVersion := syncData.HLV.Version
+
+	// PUT an update to the above doc
+	body = Body{"key1": "value11"}
+	body[BodyRev] = rev
+	_, _, err = collection.Put(ctx, key, body)
+	require.NoError(t, err)
+
+	// grab the new version for the above update to assert against later in test
+	syncData, err = collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	docUpdateVersion := syncData.HLV.Version
+
+	// construct a mock doc update coming over a replicator
+	body = Body{"key1": "value2"}
+	newDoc := createTestDocument(key, "", body, false, 0)
+
+	// construct a HLV that simulates a doc update happening on a client
+	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV
+	pv := make(map[string]uint64)
+	pv[bucketUUID] = originalDocVersion
+	// create a version larger than the allocated version above
+	incomingVersion := docUpdateVersion + 10
+	incomingHLV := HybridLogicalVector{
+		SourceID:         "test",
+		Version:          incomingVersion,
+		PreviousVersions: pv,
+	}
+
+	// grab the raw doc from the bucket to pass into the PutExistingCurrentVersion function for the above simulation of
+	// doc update arriving over replicator
+	_, rawDoc, err := collection.GetDocumentWithRaw(ctx, key, DocUnmarshalSync)
+	require.NoError(t, err)
+
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, rawDoc)
+	require.NoError(t, err)
+	// assert on returned CV
+	assert.Equal(t, "test", cv.SourceID)
+	assert.Equal(t, incomingVersion, cv.Version)
+	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
+
+	// assert on the sync data from the above update to the doc
+	// CV should be equal to CV of update on client but the cvCAS should be updated with the new update and
+	// PV should contain the old CV pair
+	syncData, err = collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, "test", syncData.HLV.SourceID)
+	assert.Equal(t, incomingVersion, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	// update the pv map so we can assert we have correct pv map in HLV
+	pv[bucketUUID] = docUpdateVersion
+	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
+	assert.Equal(t, "3-60b024c44c283b369116c2c2570e8088", syncData.CurrentRev)
+}
+
+// TestPutExistingCurrentVersionWithConflict:
+//   - Put a document in a db
+//   - Assert on the update to HLV after that PUT
+//   - Construct a HLV to represent the doc created locally being updated on a client
+//   - Call PutExistingCurrentVersion simulating doc update arriving over replicator
+//   - Assert conflict between the local HLV for the doc and the incoming mutation is correctly identified
+//   - Assert that the doc's HLV in the bucket hasn't been updated
+func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	bucketUUID := db.BucketUUID
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	// create a new doc
+	key := "doc1"
+	body := Body{"key1": "value1"}
+
+	_, _, err := collection.Put(ctx, key, body)
+	require.NoError(t, err)
+
+	// assert on the HLV values after the above creation of the doc
+	syncData, err := collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// create a new doc update to simulate a doc update arriving over replicator from, client
+	body = Body{"key1": "value2"}
+	newDoc := createTestDocument(key, "", body, false, 0)
+	incomingHLV := HybridLogicalVector{
+		SourceID: "test",
+		Version:  1234,
+	}
+
+	// grab the raw doc from the bucket to pass into the PutExistingCurrentVersion function
+	_, rawDoc, err := collection.GetDocumentWithRaw(ctx, key, DocUnmarshalSync)
+	require.NoError(t, err)
+
+	// assert that a conflict is correctly identified and the resulting doc and cv are nil
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, rawDoc)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Document revision conflict")
+	assert.Nil(t, cv)
+	assert.Nil(t, doc)
+
+	// assert persisted doc hlv hasn't been updated
+	syncData, err = collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}
+
+// TestPutExistingCurrentVersionWithNoExistingDoc:
+//   - Purpose of this test is to test PutExistingRevWithBody code pathway where an
+//     existing doc is not provided from the bucket into the function simulating a new, not seen
+//     before doc entering this code path
+func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	bucketUUID := db.BucketUUID
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	// construct a mock doc update coming over a replicator
+	body := Body{"key1": "value2"}
+	newDoc := createTestDocument("doc2", "", body, false, 0)
+
+	// construct a HLV that simulates a doc update happening on a client
+	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV
+	pv := make(map[string]uint64)
+	pv[bucketUUID] = 2
+	// create a version larger than the allocated version above
+	incomingVersion := uint64(2 + 10)
+	incomingHLV := HybridLogicalVector{
+		SourceID:         "test",
+		Version:          incomingVersion,
+		PreviousVersions: pv,
+	}
+	// call PutExistingCurrentVersion with empty existing doc
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{})
+	require.NoError(t, err)
+	assert.NotNil(t, doc)
+	// assert on returned CV value
+	assert.Equal(t, "test", cv.SourceID)
+	assert.Equal(t, incomingVersion, cv.Version)
+	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
+
+	// assert on the sync data from the above update to the doc
+	// CV should be equal to CV of update on client but the cvCAS should be updated with the new update and
+	// PV should contain the old CV pair
+	syncData, err := collection.GetDocSyncData(ctx, "doc2")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+	assert.Equal(t, "test", syncData.HLV.SourceID)
+	assert.Equal(t, incomingVersion, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	// update the pv map so we can assert we have correct pv map in HLV
+	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
+	assert.Equal(t, "1-3a208ea66e84121b528f05b5457d1134", syncData.CurrentRev)
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -75,7 +75,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Flush the cache
@@ -116,7 +116,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -127,7 +127,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	rev2a_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -153,7 +153,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	rev2b_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -251,7 +251,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a with legacy attachment.
@@ -280,7 +280,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -315,7 +315,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -326,7 +326,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -345,7 +345,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -388,7 +388,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
 	rev3b_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 	rev3b_body[BodyId] = doc.ID
 	rev3b_body[BodyRev] = newRev
 	rev3b_body[BodyDeleted] = true
@@ -425,7 +425,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2c_body := Body{}
 	rev2c_body["key1"] = prop_1000_bytes
 	rev2c_body["version"] = "2c"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"2-c", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"2-c", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2c_body[BodyId] = doc.ID
 	rev2c_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-c")
@@ -447,7 +447,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3c_body["version"] = "3c"
 	rev3c_body["key1"] = prop_1000_bytes
 	rev3c_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-c"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-c"}, false, ExistingVersionWithUpdateToHLV)
 	rev3c_body[BodyId] = doc.ID
 	rev3c_body[BodyRev] = newRev
 	rev3c_body[BodyDeleted] = true
@@ -476,7 +476,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3a_body := Body{}
 	rev3a_body["key1"] = prop_1000_bytes
 	rev3a_body["version"] = "3a"
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"3-a", "2-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a")
 
 	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
@@ -499,7 +499,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -510,7 +510,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -529,7 +529,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -574,7 +574,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev3b_body["version"] = "3b"
 	rev3b_body["key1"] = prop_1000_bytes
 	rev3b_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 	rev3b_body[BodyId] = doc.ID
 	rev3b_body[BodyRev] = newRev
 	rev3b_body[BodyDeleted] = true
@@ -609,17 +609,17 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	activeRevBody := Body{}
 	activeRevBody["version"] = "...a"
 	activeRevBody["key1"] = prop_1000_bytes
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"3-a", "2-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"4-a", "3-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 4-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"5-a", "4-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"5-a", "4-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 5-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"6-a", "5-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"6-a", "5-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 6-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"7-a", "6-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"7-a", "6-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 7-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"8-a", "7-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"8-a", "7-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 8-a")
 
 	// Verify that 3-b is still present at this point
@@ -628,7 +628,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	assert.NoError(t, err, "Rev 3-b should still exist")
 
 	// Add one more rev that triggers pruning since gen(9-3) > revsLimit
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"9-a", "8-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"9-a", "8-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 9-a")
 
 	// Verify that 3-b has been pruned
@@ -657,7 +657,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a", "large": prop_1000_bytes}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -666,7 +666,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "version": "2a", "large": prop_1000_bytes}
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
@@ -686,7 +686,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "version": "3a", "large": prop_1000_bytes}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-a")
 	rev3a_body[BodyId] = doc.ID
 	rev3a_body[BodyRev] = newRev
@@ -705,7 +705,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "version": "2b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
@@ -728,7 +728,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "version": "6a", "large": prop_1000_bytes}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 6-a")
 	rev6a_body[BodyId] = doc.ID
 	rev6a_body[BodyRev] = newRev
@@ -753,7 +753,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "version": "3b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-b")
 
 	// Same again and again
@@ -772,12 +772,12 @@ func TestOldRevisionStorage(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "version": "3c", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-c")
 
 	log.Printf("Create rev 3-d")
 	rev3d_body := Body{"key1": "value2", "version": "3d", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-d")
 
 	// Create new winning revision on 'b' branch.  Triggers movement of 6-a to inline storage.  Force cas retry, check document contents
@@ -796,7 +796,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	//     7-b
 	log.Printf("Create rev 7-b")
 	rev7b_body := Body{"key1": "value2", "version": "7b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 7-b")
 
 }
@@ -817,7 +817,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "v": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -826,7 +826,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "v": "2a"}
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -845,7 +845,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "v": "3a"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev3a_body[BodyId] = doc.ID
 	rev3a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 3-a")
@@ -858,7 +858,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "v": "2b"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -883,7 +883,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "v": "6a"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev6a_body[BodyId] = doc.ID
 	rev6a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 6-a")
@@ -909,7 +909,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "v": "3b"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-b")
 
 	// Same again
@@ -929,7 +929,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-c")
 
 }
@@ -946,7 +946,7 @@ func TestLargeSequence(t *testing.T) {
 
 	// Write a doc via SG
 	body := Body{"key1": "largeSeqTest"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "largeSeqDoc", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "largeSeqDoc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add largeSeqDoc")
 
 	syncData, err := collection.GetDocSyncData(ctx, "largeSeqDoc")
@@ -1021,7 +1021,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	// 6-a
 	log.Printf("Attempt to create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-c")
 }
 
@@ -1033,16 +1033,16 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
 	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1061,9 +1061,9 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1090,16 +1090,16 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
 	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1118,9 +1118,9 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1148,7 +1148,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	getDelta := func(newDoc *Document) {
 		deltaSrcRev, _ := collection.GetRev(ctx, "doc1", "1-a", false, nil)
@@ -1197,18 +1197,18 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	_, rev, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"1-a"}, false)
+	_, rev, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	ancestor := rev // Ancestor revision
 
 	// Create the second revision of the document with attachment reference;
 	payload = `{"sku":"6213101","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	_, rev, err = collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"2-a", "1-a"}, false)
+	_, rev, err = collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	parent := rev // Immediate ancestor or parent revision
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213102","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	doc, _, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"3-a", "2-a"}, false)
+	doc, _, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get available attachments by immediate ancestor revision or parent revision
@@ -1235,11 +1235,11 @@ func TestGet1xRevAndChannels(t *testing.T) {
 
 	docId := "dd6d2dcc679d12b9430a9787bab45b33"
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc1, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false)
+	doc1, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213101","_attachments":{"lens.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc2, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	doc2, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get the 1x revision from document with list revision enabled
@@ -1298,7 +1298,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	// Create the first revision of the document
 	docId := "356779a9a1696714480f57fa3fb66d4c"
 	payload := `{"city":"Los Angeles"}`
-	doc, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false)
+	doc, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "1-a", rev1, "Provided input revision ID should be returned")
@@ -1321,7 +1321,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 
 	// Create the second revision of the document
 	payload = `{"city":"Hollywood"}`
-	doc, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	doc, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "2-a", rev2, "Provided input revision ID should be returned")

--- a/db/database.go
+++ b/db/database.go
@@ -49,6 +49,14 @@ const (
 )
 
 const (
+	Import DocUpdateType = iota
+	NewVersion
+	ExistingVersion
+)
+
+type DocUpdateType uint32
+
+const (
 	DefaultRevsLimitNoConflicts = 50
 	DefaultRevsLimitConflicts   = 100
 
@@ -88,6 +96,7 @@ type DatabaseContext struct {
 	MetadataStore               base.DataStore     // Storage for database metadata (anything that isn't an end-user's/customer's documents)
 	Bucket                      base.Bucket        // Storage
 	BucketSpec                  base.BucketSpec    // The BucketSpec
+	BucketUUID                  string             // The bucket UUID for the bucket the database is created against
 	BucketLock                  sync.RWMutex       // Control Access to the underlying bucket object
 	mutationListener            changeListener     // Caching feed listener
 	ImportListener              *importListener    // Import feed listener
@@ -396,6 +405,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		metadataStore = bucket.DefaultDataStore()
 	}
 
+	bucketUUID, err := bucket.UUID()
+	if err != nil {
+		return nil, err
+	}
+
 	// Register the cbgt pindex type for the configGroup
 	RegisterImportPindexImpl(ctx, options.GroupID)
 
@@ -404,6 +418,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		UUID:                cbgt.NewUUID(),
 		MetadataStore:       metadataStore,
 		Bucket:              bucket,
+		BucketUUID:          bucketUUID,
 		StartTime:           time.Now(),
 		autoImport:          autoImport,
 		Options:             options,

--- a/db/database.go
+++ b/db/database.go
@@ -970,7 +970,7 @@ func (c *DatabaseCollection) processForEachDocIDResults(ctx context.Context, cal
 			found = results.Next(ctx, &viewRow)
 			if found {
 				docid = viewRow.Key
-				revid = viewRow.Value.RevID
+				revid = viewRow.Value.RevID.RevTreeID
 				seq = viewRow.Value.Sequence
 				channels = viewRow.Value.Channels
 			}
@@ -978,7 +978,7 @@ func (c *DatabaseCollection) processForEachDocIDResults(ctx context.Context, cal
 			found = results.Next(ctx, &queryRow)
 			if found {
 				docid = queryRow.Id
-				revid = queryRow.RevID
+				revid = queryRow.RevID.RevTreeID
 				seq = queryRow.Sequence
 				channels = make([]string, 0)
 				// Query returns all channels, but we only want to return active channels

--- a/db/database.go
+++ b/db/database.go
@@ -52,6 +52,7 @@ const (
 	Import DocUpdateType = iota
 	NewVersion
 	ExistingVersion
+	ExistingVersionWithUpdateToHLV
 )
 
 type DocUpdateType uint32

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1138,7 +1138,7 @@ func TestConflicts(t *testing.T) {
 		Changes:        []ChangeRev{{"rev": "2-b"}, {"rev": "2-a"}},
 		branched:       true,
 		collectionID:   collectionID,
-		CurrentVersion: &SourceAndVersion{SourceID: bucketUUID, Version: fetchedDoc.Cas},
+		CurrentVersion: &Version{SourceID: bucketUUID, Value: fetchedDoc.Cas},
 	}, changes[0],
 	)
 
@@ -1174,7 +1174,7 @@ func TestConflicts(t *testing.T) {
 		Changes:        []ChangeRev{{"rev": "2-a"}, {"rev": rev3}},
 		branched:       true,
 		collectionID:   collectionID,
-		CurrentVersion: &SourceAndVersion{SourceID: bucketUUID, Version: doc.Cas},
+		CurrentVersion: &Version{SourceID: bucketUUID, Value: doc.Cas},
 	}, changes[0])
 
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1828,6 +1828,84 @@ func TestChannelView(t *testing.T) {
 		log.Printf("View Query returned entry (%d): %v", i, entry)
 	}
 	assert.Equal(t, 1, len(entries))
+	require.Equal(t, "doc1", entries[0].DocID)
+	collection.RequireCurrentVersion(t, "doc1", entries[0].SourceID, entries[0].Version)
+}
+
+func TestChannelQuery(t *testing.T) {
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	_, err := collection.UpdateSyncFun(ctx, `function(doc, oldDoc) {
+		channel(doc.channels);
+	}`)
+	require.NoError(t, err)
+
+	// Create doc
+	body := Body{"key1": "value1", "key2": 1234, "channels": "ABC"}
+	rev1ID, _, err := collection.Put(ctx, "doc1", body)
+	require.NoError(t, err, "Couldn't create doc1")
+
+	// Create a doc to test removal handling.  Needs three revisions so that the removal rev (2) isn't
+	// the current revision
+	removedDocID := "removed_doc"
+	removedDocRev1, _, err := collection.Put(ctx, removedDocID, body)
+	require.NoError(t, err, "Couldn't create removed_doc")
+	removalSource, removalVersion := collection.GetDocumentCurrentVersion(t, removedDocID)
+
+	updatedChannelBody := Body{"_rev": removedDocRev1, "key1": "value1", "key2": 1234, "channels": "DEF"}
+	removalRev, _, err := collection.Put(ctx, removedDocID, updatedChannelBody)
+	require.NoError(t, err, "Couldn't update removed_doc")
+
+	updatedChannelBody = Body{"_rev": removalRev, "key1": "value1", "key2": 2345, "channels": "DEF"}
+	removedDocRev3, _, err := collection.Put(ctx, removedDocID, updatedChannelBody)
+	require.NoError(t, err, "Couldn't update removed_doc")
+
+	var entries LogEntries
+
+	// Test query retrieval via star channel and named channel (queries use different indexes)
+	testCases := []struct {
+		testName    string
+		channelName string
+	}{
+		{
+			testName:    "star channel",
+			channelName: "*",
+		},
+		{
+			testName:    "named channel",
+			channelName: "ABC",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			entries, err = collection.getChangesInChannelFromQuery(ctx, testCase.channelName, 0, 100, 0, false)
+			require.NoError(t, err)
+
+			for i, entry := range entries {
+				log.Printf("Channel Query returned entry (%d): %v", i, entry)
+			}
+			require.Len(t, entries, 2)
+			require.Equal(t, "doc1", entries[0].DocID)
+			require.Equal(t, rev1ID, entries[0].RevID)
+			collection.RequireCurrentVersion(t, "doc1", entries[0].SourceID, entries[0].Version)
+
+			removedDocEntry := entries[1]
+			require.Equal(t, removedDocID, removedDocEntry.DocID)
+			if testCase.channelName == "*" {
+				require.Equal(t, removedDocRev3, removedDocEntry.RevID)
+				collection.RequireCurrentVersion(t, removedDocID, removedDocEntry.SourceID, removedDocEntry.Version)
+			} else {
+				require.Equal(t, removalRev, removedDocEntry.RevID)
+				// TODO: Pending channel removal rev handling, CBG-3213
+				log.Printf("removal rev check of removal cv %s@%d is pending CBG-3213", removalSource, removalVersion)
+				//require.Equal(t, removalSource, removedDocEntry.SourceID)
+				//require.Equal(t, removalVersion, removedDocEntry.Version)
+			}
+		})
+	}
 
 }
 
@@ -2451,7 +2529,7 @@ func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
 	assert.NoError(t, err)
 
 	var doc Body
-	var xattr Body
+	var xattr SyncData
 
 	// Ensure document has been added
 	waitAndAssertCondition(t, func() bool {
@@ -2462,8 +2540,8 @@ func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
 	assert.Equal(t, int64(1), db.DbStats.SharedBucketImport().ImportCount.Value())
 
 	assert.Nil(t, doc)
-	assert.Equal(t, "1-2cac91faf7b3f5e5fd56ff377bdb5466", xattr["rev"])
-	assert.Equal(t, float64(2), xattr["sequence"])
+	assert.Equal(t, "1-2cac91faf7b3f5e5fd56ff377bdb5466", xattr.CurrentRev)
+	assert.Equal(t, uint64(2), xattr.Sequence)
 }
 
 func TestResyncUpdateAllDocChannels(t *testing.T) {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -336,7 +336,7 @@ func TestCheckProposedVersion(t *testing.T) {
 	assert.Equal(t, ProposedRev_Exists, status)
 
 	// non conflict new version scenario
-	hlvString = fmt.Sprint(100, "@", bucketUUID, ";", hlvString)
+	hlvString = fmt.Sprint(vrs+100, "@", bucketUUID, ";", hlvString)
 	status, _ = collection.CheckProposedVersion(ctx, "doc1", hlvString)
 	assert.Equal(t, ProposedRev_OK, status)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -313,6 +313,7 @@ func TestDatabase(t *testing.T) {
 //   - Run doc ID through CheckProposedVersion with the non conflict hlv present
 //   - Run new doc ID through CheckProposedVersion
 //   - Run doc ID through CheckProposedVersion with conflicting hlv
+//   - Run doc ID through CheckProposedVersion with invalid HLV string
 //   - Assert all above scenarios return appropriate status
 func TestCheckProposedVersion(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
@@ -345,9 +346,14 @@ func TestCheckProposedVersion(t *testing.T) {
 	assert.Equal(t, ProposedRev_OK_IsNew, status)
 
 	// conflict scenario
-	hlvString = fmt.Sprint(4, "@", "cluster2", ";", 1, "cluster2")
+	hlvString = fmt.Sprint(4, "@", "cluster2", ";", 1, "@", "cluster2")
 	status, _ = collection.CheckProposedVersion(ctx, "doc1", hlvString)
 	assert.Equal(t, ProposedRev_Conflict, status)
+
+	// test error scenario
+	hlvString = fmt.Sprint("")
+	status, _ = collection.CheckProposedVersion(ctx, "doc1", hlvString)
+	assert.Equal(t, ProposedRev_Error, status)
 
 }
 

--- a/db/document.go
+++ b/db/document.go
@@ -177,11 +177,12 @@ type Document struct {
 	Cas          uint64 // Document cas
 	rawUserXattr []byte // Raw user xattr as retrieved from the bucket
 
-	Deleted        bool
-	DocExpiry      uint32
-	RevID          string
-	DocAttachments AttachmentsMeta
-	inlineSyncData bool
+	Deleted            bool
+	DocExpiry          uint32
+	RevID              string
+	DocAttachments     AttachmentsMeta
+	inlineSyncData     bool
+	currentRevChannels base.Set // A base.Set of the current revision's channels (determined by SyncData.Channels at UnmarshalJSON time)
 }
 
 type historyOnlySyncData struct {
@@ -969,6 +970,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 			doc.updateChannelHistory(channel, doc.Sequence, true)
 		}
 	}
+	doc.currentRevChannels = newChannels
 	if changed != nil {
 		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)
@@ -1076,6 +1078,17 @@ func (doc *Document) UnmarshalJSON(data []byte) error {
 	}
 	if syncData.SyncData != nil {
 		doc.SyncData = *syncData.SyncData
+	}
+
+	// determine current revision's channels and store in-memory (avoids doc.Channels iteration at access-check time)
+	if len(doc.Channels) > 0 {
+		ch := base.SetOf()
+		for channelName, channelRemoval := range doc.Channels {
+			if channelRemoval == nil || channelRemoval.Seq == 0 {
+				ch.Add(channelName)
+			}
+		}
+		doc.currentRevChannels = ch
 	}
 
 	// Unmarshal the rest of the doc body as map[string]interface{}
@@ -1223,4 +1236,18 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 	}
 
 	return data, xdata, nil
+}
+
+// HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
+func (d *Document) HasCurrentVersion(cv CurrentVersionVector) error {
+	if d.HLV == nil {
+		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
+	}
+
+	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
+	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
+	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.VersionCAS {
+		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
+	}
+	return nil
 }

--- a/db/document.go
+++ b/db/document.go
@@ -65,7 +65,7 @@ type ChannelSetEntry struct {
 
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
 type SyncData struct {
-	CurrentRev        string               `json:"rev"`
+	CurrentRev        string               `json:"-"`                 // CurrentRev.  Persisted as RevAndVersion in SyncDataJSON
 	NewestRev         string               `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
 	Flags             uint8                `json:"flags,omitempty"`
 	Sequence          uint64               `json:"sequence,omitempty"`
@@ -192,7 +192,7 @@ type historyOnlySyncData struct {
 
 type revOnlySyncData struct {
 	casOnlySyncData
-	CurrentRev string `json:"rev"`
+	CurrentRev RevAndVersion `json:"rev"`
 }
 
 type casOnlySyncData struct {
@@ -1160,7 +1160,7 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
 		doc.SyncData = SyncData{
-			CurrentRev: historyOnlyMeta.CurrentRev,
+			CurrentRev: historyOnlyMeta.CurrentRev.RevTreeID,
 			History:    historyOnlyMeta.History,
 			Cas:        historyOnlyMeta.Cas,
 		}
@@ -1173,7 +1173,7 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
 		doc.SyncData = SyncData{
-			CurrentRev: revOnlyMeta.CurrentRev,
+			CurrentRev: revOnlyMeta.CurrentRev.RevTreeID,
 			Cas:        revOnlyMeta.Cas,
 		}
 		doc._rawBody = data
@@ -1230,7 +1230,7 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 		}
 	}
 
-	xdata, err = base.JSONMarshal(doc.SyncData)
+	xdata, err = base.JSONMarshal(&doc.SyncData)
 	if err != nil {
 		return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
 	}
@@ -1250,4 +1250,83 @@ func (d *Document) HasCurrentVersion(cv Version) error {
 		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
 	}
 	return nil
+}
+
+// SyncDataAlias is an alias for SyncData that doesn't define custom MarshalJSON/UnmarshalJSON
+type SyncDataAlias SyncData
+
+// SyncDataJSON is the persisted form of SyncData, with RevAndVersion populated at marshal time
+type SyncDataJSON struct {
+	*SyncDataAlias
+	RevAndVersion RevAndVersion `json:"rev"`
+}
+
+// MarshalJSON populates RevAndVersion using CurrentRev and the HLV (current) source and version.
+// Marshals using SyncDataAlias to avoid recursion, and SyncDataJSON to add the combined RevAndVersion.
+func (s SyncData) MarshalJSON() (data []byte, err error) {
+
+	var sdj SyncDataJSON
+	var sd SyncDataAlias
+	sd = (SyncDataAlias)(s)
+	sdj.SyncDataAlias = &sd
+	sdj.RevAndVersion.RevTreeID = s.CurrentRev
+	if s.HLV != nil {
+		sdj.RevAndVersion.CurrentSource = s.HLV.SourceID
+		sdj.RevAndVersion.CurrentVersion = string(base.Uint64CASToLittleEndianHex(s.HLV.Version))
+	}
+	return base.JSONMarshal(sdj)
+}
+
+// UnmarshalJSON unmarshals using SyncDataJSON, then sets currentRev on SyncData based on the value in RevAndVersion.
+// The HLV's current version stored in RevAndVersion is ignored at unmarshal time - the value in the HLV is the source
+// of truth.
+func (s *SyncData) UnmarshalJSON(data []byte) error {
+
+	var sdj *SyncDataJSON
+	err := base.JSONUnmarshal(data, &sdj)
+	if err != nil {
+		return err
+	}
+	*s = SyncData(*sdj.SyncDataAlias)
+	s.CurrentRev = sdj.RevAndVersion.RevTreeID
+	return nil
+}
+
+// RevAndVersion is used to store both revTreeID and currentVersion in a single property, for backwards compatibility
+// with existing indexes using rev.  When only RevTreeID is specified, is marshalled/unmarshalled as a string.  Otherwise
+// marshalled normally.
+type RevAndVersion struct {
+	RevTreeID      string `json:"rev,omitempty"`
+	CurrentSource  string `json:"src,omitempty"`
+	CurrentVersion string `json:"vrs,omitempty"` // String representation of version
+}
+
+// RevAndVersionJSON aliases RevAndVersion to support conditional unmarshalling from either string (revTreeID) or
+// map (RevAndVersion) representations
+type RevAndVersionJSON RevAndVersion
+
+// Marshals RevAndVersion as simple string when only RevTreeID is specified - otherwise performs standard
+// marshalling
+func (rv RevAndVersion) MarshalJSON() (data []byte, err error) {
+
+	if rv.CurrentSource == "" {
+		return base.JSONMarshal(rv.RevTreeID)
+	}
+	return base.JSONMarshal(RevAndVersionJSON(rv))
+}
+
+// Unmarshals either from string (legacy, revID only) or standard RevAndVersion unmarshalling.
+func (rv *RevAndVersion) UnmarshalJSON(data []byte) error {
+
+	if len(data) == 0 {
+		return nil
+	}
+	switch data[0] {
+	case '"':
+		return base.JSONUnmarshal(data, &rv.RevTreeID)
+	case '{':
+		return base.JSONUnmarshal(data, (*RevAndVersionJSON)(rv))
+	default:
+		return fmt.Errorf("unrecognized JSON format for RevAndVersion: %s", data)
+	}
 }

--- a/db/document.go
+++ b/db/document.go
@@ -1239,14 +1239,14 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
-func (d *Document) HasCurrentVersion(cv CurrentVersionVector) error {
+func (d *Document) HasCurrentVersion(cv SourceAndVersion) error {
 	if d.HLV == nil {
 		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
 	}
 
 	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
 	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
-	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.VersionCAS {
+	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Version {
 		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
 	}
 	return nil

--- a/db/document.go
+++ b/db/document.go
@@ -1239,14 +1239,14 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
-func (d *Document) HasCurrentVersion(cv SourceAndVersion) error {
+func (d *Document) HasCurrentVersion(cv Version) error {
 	if d.HLV == nil {
 		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
 	}
 
 	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
 	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
-	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Version {
+	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Value {
 		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
 	}
 	return nil

--- a/db/document.go
+++ b/db/document.go
@@ -37,11 +37,10 @@ type DocumentUnmarshalLevel uint8
 const (
 	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals sync metadata and body
 	DocUnmarshalSync                                     // Unmarshals all sync metadata
-	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding history
-	DocUnmarshalHistory                                  // Unmarshals history + rev + CAS only
+	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding revtree history
+	DocUnmarshalHistory                                  // Unmarshals revtree history + rev + CAS only
 	DocUnmarshalRev                                      // Unmarshals rev + CAS only
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
-	DocUnmarshalVV                                       // Unmarshals Version Vector only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )
 
@@ -1187,14 +1186,6 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		doc.SyncData = SyncData{
 			Cas: casOnlyMeta.Cas,
 		}
-		doc._rawBody = data
-	case DocUnmarshalVV:
-		tmpData := SyncData{}
-		unmarshalErr := base.JSONUnmarshal(xdata, &tmpData)
-		if unmarshalErr != nil {
-			return base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalVV).  Error: %w", base.UD(doc.ID), unmarshalErr)
-		}
-		doc.SyncData.HLV = tmpData.HLV
 		doc._rawBody = data
 	}
 

--- a/db/document.go
+++ b/db/document.go
@@ -41,6 +41,7 @@ const (
 	DocUnmarshalHistory                                  // Unmarshals history + rev + CAS only
 	DocUnmarshalRev                                      // Unmarshals rev + CAS only
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
+	DocUnmarshalVV                                       // Unmarshals Version Vector only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )
 
@@ -64,23 +65,24 @@ type ChannelSetEntry struct {
 
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
 type SyncData struct {
-	CurrentRev        string              `json:"rev"`
-	NewestRev         string              `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
-	Flags             uint8               `json:"flags,omitempty"`
-	Sequence          uint64              `json:"sequence,omitempty"`
-	UnusedSequences   []uint64            `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
-	RecentSequences   []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
-	Channels          channels.ChannelMap `json:"channels,omitempty"`
-	Access            UserAccessMap       `json:"access,omitempty"`
-	RoleAccess        UserAccessMap       `json:"role_access,omitempty"`
-	Expiry            *time.Time          `json:"exp,omitempty"`                     // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
-	Cas               string              `json:"cas"`                               // String representation of a cas value, populated via macro expansion
-	Crc32c            string              `json:"value_crc32c"`                      // String representation of crc32c hash of doc body, populated via macro expansion
-	Crc32cUserXattr   string              `json:"user_xattr_value_crc32c,omitempty"` // String representation of crc32c hash of user xattr
-	TombstonedAt      int64               `json:"tombstoned_at,omitempty"`           // Time the document was tombstoned.  Used for view compaction
-	Attachments       AttachmentsMeta     `json:"attachments,omitempty"`
-	ChannelSet        []ChannelSetEntry   `json:"channel_set"`
-	ChannelSetHistory []ChannelSetEntry   `json:"channel_set_history"`
+	CurrentRev        string               `json:"rev"`
+	NewestRev         string               `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
+	Flags             uint8                `json:"flags,omitempty"`
+	Sequence          uint64               `json:"sequence,omitempty"`
+	UnusedSequences   []uint64             `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
+	RecentSequences   []uint64             `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
+	Channels          channels.ChannelMap  `json:"channels,omitempty"`
+	Access            UserAccessMap        `json:"access,omitempty"`
+	RoleAccess        UserAccessMap        `json:"role_access,omitempty"`
+	Expiry            *time.Time           `json:"exp,omitempty"`                     // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
+	Cas               string               `json:"cas"`                               // String representation of a cas value, populated via macro expansion
+	Crc32c            string               `json:"value_crc32c"`                      // String representation of crc32c hash of doc body, populated via macro expansion
+	Crc32cUserXattr   string               `json:"user_xattr_value_crc32c,omitempty"` // String representation of crc32c hash of user xattr
+	TombstonedAt      int64                `json:"tombstoned_at,omitempty"`           // Time the document was tombstoned.  Used for view compaction
+	Attachments       AttachmentsMeta      `json:"attachments,omitempty"`
+	ChannelSet        []ChannelSetEntry    `json:"channel_set"`
+	ChannelSetHistory []ChannelSetEntry    `json:"channel_set_history"`
+	HLV               *HybridLogicalVector `json:"_vv,omitempty"`
 
 	// Only used for performance metrics:
 	TimeSaved time.Time `json:"time_saved,omitempty"` // Timestamp of save.
@@ -1130,7 +1132,6 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		if unmarshalLevel == DocUnmarshalAll && len(data) > 0 {
 			return doc._body.Unmarshal(data)
 		}
-
 	case DocUnmarshalNoHistory:
 		// Unmarshal sync metadata only, excluding history
 		doc.SyncData = SyncData{}
@@ -1173,6 +1174,14 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		doc.SyncData = SyncData{
 			Cas: casOnlyMeta.Cas,
 		}
+		doc._rawBody = data
+	case DocUnmarshalVV:
+		tmpData := SyncData{}
+		unmarshalErr := base.JSONUnmarshal(xdata, &tmpData)
+		if unmarshalErr != nil {
+			return base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalVV).  Error: %w", base.UD(doc.ID), unmarshalErr)
+		}
+		doc.SyncData.HLV = tmpData.HLV
 		doc._rawBody = data
 	}
 

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"log"
+	"reflect"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -188,6 +189,106 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 			}
 		})
 	}
+}
+
+const doc_meta_with_vv = `{
+    "rev": "3-89758294abc63157354c2b08547c2d21",
+    "sequence": 7,
+    "recent_sequences": [
+      5,
+      6,
+      7
+    ],
+    "history": {
+      "revs": [
+        "1-fc591a068c153d6c3d26023d0d93dcc1",
+        "2-0eab03571bc55510c8fc4bfac9fe4412",
+        "3-89758294abc63157354c2b08547c2d21"
+      ],
+      "parents": [
+        -1,
+        0,
+        1
+      ],
+      "channels": [
+        [
+          "ABC",
+          "DEF"
+        ],
+        [
+          "ABC",
+          "DEF",
+          "GHI"
+        ],
+        [
+          "ABC",
+          "GHI"
+        ]
+      ]
+    },
+    "channels": {
+      "ABC": null,
+      "DEF": {
+        "seq": 7,
+        "rev": "3-89758294abc63157354c2b08547c2d21"
+      },
+      "GHI": null
+    },
+	"_vv":{
+   		"cvCas":"0x40e2010000000000",
+   		"src":"cb06dc003846116d9b66d2ab23887a96",
+   		"vrs":"0x40e2010000000000",
+   		"mv":{
+      		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
+      		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
+		},
+		"pv":{
+      		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
+   		}
+	},
+    "cas": "",
+    "time_saved": "2017-10-25T12:45:29.622450174-07:00"
+  }`
+
+func TestParseVersionVectorSyncData(t *testing.T) {
+	mv := make(map[string]uint64)
+	pv := make(map[string]uint64)
+	mv["s_LhRPsa7CpjEvP5zeXTXEBA"] = 1628620455147864000
+	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = 1628620455139868700
+	pv["s_YZvBpEaztom9z5V/hDoeIw"] = 1628620455135215600
+
+	ctx := base.TestCtx(t)
+
+	doc_meta := []byte(doc_meta_with_vv)
+	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalVV)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
+
+	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalAll)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
+
+	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 }
 
 func TestParseXattr(t *testing.T) {

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -291,6 +291,96 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 }
 
+// TestRevAndVersion tests marshalling and unmarshalling rev and current version
+func TestRevAndVersion(t *testing.T) {
+
+	ctx := base.TestCtx(t)
+	testCases := []struct {
+		testName  string
+		revTreeID string
+		source    string
+		version   uint64
+	}{
+		{
+			testName:  "rev_and_version",
+			revTreeID: "1-abc",
+			source:    "source1",
+			version:   1,
+		},
+		{
+			testName:  "both_empty",
+			revTreeID: "",
+			source:    "",
+			version:   0,
+		},
+		{
+			testName:  "revTreeID_only",
+			revTreeID: "1-abc",
+			source:    "",
+			version:   0,
+		},
+		{
+			testName:  "currentVersion_only",
+			revTreeID: "",
+			source:    "source1",
+			version:   1,
+		},
+	}
+
+	var expectedSequence = uint64(100)
+	for _, test := range testCases {
+		t.Run(test.testName, func(t *testing.T) {
+			syncData := &SyncData{
+				CurrentRev: test.revTreeID,
+				Sequence:   expectedSequence,
+			}
+			if test.source != "" {
+				syncData.HLV = &HybridLogicalVector{
+					SourceID: test.source,
+					Version:  test.version,
+				}
+			}
+			// SyncData test
+			marshalledSyncData, err := base.JSONMarshal(syncData)
+			require.NoError(t, err)
+			log.Printf("marshalled:%s", marshalledSyncData)
+
+			var newSyncData SyncData
+			err = base.JSONUnmarshal(marshalledSyncData, &newSyncData)
+			require.NoError(t, err)
+			require.Equal(t, test.revTreeID, newSyncData.CurrentRev)
+			require.Equal(t, expectedSequence, newSyncData.Sequence)
+			if test.source != "" {
+				require.NotNil(t, newSyncData.HLV)
+				require.Equal(t, test.source, newSyncData.HLV.SourceID)
+				require.Equal(t, test.version, newSyncData.HLV.Version)
+			}
+
+			// Document test
+			document := NewDocument("docID")
+			document.SyncData.CurrentRev = test.revTreeID
+			document.SyncData.HLV = &HybridLogicalVector{
+				SourceID: test.source,
+				Version:  test.version,
+			}
+			marshalledDoc, marshalledXattr, err := document.MarshalWithXattr()
+			require.NoError(t, err)
+
+			newDocument := NewDocument("docID")
+			err = newDocument.UnmarshalWithXattr(ctx, marshalledDoc, marshalledXattr, DocUnmarshalAll)
+			require.NoError(t, err)
+			require.Equal(t, test.revTreeID, newDocument.CurrentRev)
+			require.Equal(t, expectedSequence, newSyncData.Sequence)
+			if test.source != "" {
+				require.NotNil(t, newDocument.HLV)
+				require.Equal(t, test.source, newDocument.HLV.SourceID)
+				require.Equal(t, test.version, newDocument.HLV.Version)
+			}
+			//require.Equal(t, test.expectedCombinedVersion, newDocument.RevAndVersion)
+		})
+	}
+}
+
 func TestParseXattr(t *testing.T) {
 	zeroByte := byte(0)
 	// Build payload for single xattr pair and body

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -260,7 +260,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	ctx := base.TestCtx(t)
 
 	doc_meta := []byte(doc_meta_with_vv)
-	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalVV)
+	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	// assert on doc version vector values

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -402,6 +402,7 @@ func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64
 }
 
 // extractHLVFromBlipMessage extracts the full HLV a string in the format seen over Blip
+// TODO: CBG-3662 - Optimise once we've settled on and tested the format with CBL
 func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, error) {
 	hlv := HybridLogicalVector{}
 

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -104,6 +104,15 @@ func (hlv *HybridLogicalVector) GetCurrentVersionString() string {
 	return version.String()
 }
 
+// IsVersionInConflict tests to see if a given version would be in conflict with the in memory HLV.
+func (hlv *HybridLogicalVector) IsVersionInConflict(version Version) bool {
+	// TODO: Complete
+	if hlv.isVersionDominating(version) {
+		return false
+	}
+	return true
+}
+
 // IsInConflict tests to see if in memory HLV is conflicting with another HLV
 func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bool {
 	// test if either HLV(A) or HLV(B) are dominating over each other. If so they are not in conflict
@@ -176,6 +185,22 @@ func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bo
 		return true
 	}
 	// HLV A is not dominating over HLV B
+	return false
+}
+
+// isVersionDominating tests if in memory HLV is dominating the given version
+func (hlv *HybridLogicalVector) isVersionDominating(version Version) bool {
+	// Dominating Criteria:
+	// HLV A dominates HLV B if source(A) == source(B) and version(A) > version(B)
+	// If there is an entry in pv(B) for A's current source and version(A) > B's version for that pv entry then A is dominating
+	// if there is an entry in mv(B) for A's current source and version(A) > B's version for that pv entry then A is dominating
+
+	// Grab the latest CAS version for HLV(A)'s sourceID in HLV(B), if HLV(A) version CAS is > HLV(B)'s then it is dominating
+	// If 0 CAS is returned then the sourceID does not exist on HLV(B)
+	if hlv.Version > version.Value {
+		return true
+	}
+	// HLV A is not dominating over version
 	return false
 }
 

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -413,13 +413,13 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 
 	// add current version (should always be present)
 	cvStr := vectorFields[0]
-	sourceAndVersion := strings.Split(cvStr, "@")
+	version := strings.Split(cvStr, "@")
 
-	vrs, err := strconv.ParseUint(sourceAndVersion[0], 10, 64)
+	vrs, err := strconv.ParseUint(version[0], 10, 64)
 	if err != nil {
 		return HybridLogicalVector{}, err
 	}
-	err = hlv.AddVersion(SourceAndVersion{SourceID: sourceAndVersion[1], Version: vrs})
+	err = hlv.AddVersion(Version{SourceID: version[1], Value: vrs})
 	if err != nil {
 		return HybridLogicalVector{}, err
 	}
@@ -435,7 +435,7 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 		}
 		hlv.PreviousVersions = make(map[string]uint64)
 		for _, v := range sourceVersionListPV {
-			hlv.PreviousVersions[v.SourceID] = v.Version
+			hlv.PreviousVersions[v.SourceID] = v.Value
 		}
 		return hlv, nil
 	case 3:
@@ -447,14 +447,14 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 			return HybridLogicalVector{}, err
 		}
 		for _, pv := range sourceVersionListPV {
-			hlv.PreviousVersions[pv.SourceID] = pv.Version
+			hlv.PreviousVersions[pv.SourceID] = pv.Value
 		}
 		sourceVersionListMV, err := parseVectorValues(vectorFields[1])
 		if err != nil {
 			return HybridLogicalVector{}, err
 		}
 		for _, mv := range sourceVersionListMV {
-			hlv.MergeVersions[mv.SourceID] = mv.Version
+			hlv.MergeVersions[mv.SourceID] = mv.Value
 		}
 		return hlv, nil
 	default:
@@ -464,7 +464,7 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 
 // parseVectorValues takes a HLV section (for example previous versions) in Blip string form and split that into
 // source and version pairs
-func parseVectorValues(vectorStr string) (sourceVersionList []SourceAndVersion, err error) {
+func parseVectorValues(vectorStr string) (sourceVersionList []Version, err error) {
 	vectorPairs := strings.Split(vectorStr, ",")
 
 	// remove any leading whitespace form the string value
@@ -480,7 +480,7 @@ func parseVectorValues(vectorStr string) (sourceVersionList []SourceAndVersion, 
 		if err != nil {
 			return nil, err
 		}
-		sourceVersionList = append(sourceVersionList, SourceAndVersion{SourceID: sourceAndVersion[1], Version: vrs})
+		sourceVersionList = append(sourceVersionList, Version{SourceID: sourceAndVersion[1], Value: vrs})
 	}
 	return sourceVersionList, nil
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -420,6 +420,9 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 		return HybridLogicalVector{}, err
 	}
 	err = hlv.AddVersion(SourceAndVersion{SourceID: sourceAndVersion[1], Version: vrs})
+	if err != nil {
+		return HybridLogicalVector{}, err
+	}
 
 	switch vectorLength {
 	case 1:

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -94,7 +94,19 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion SourceAndVersion) error {
 	if hlv.PreviousVersions == nil {
 		hlv.PreviousVersions = make(map[string]uint64)
 	}
-	hlv.PreviousVersions[hlv.SourceID] = hlv.Version
+	// we need to check if source ID already exists in PV, if so we need to ensure we are only updating with the
+	// sourceID-version pair if incoming version is greater than version already there
+	if currPVVersion, ok := hlv.PreviousVersions[hlv.SourceID]; ok {
+		// if we get here source ID exists in PV, only replace version if it is less than the incoming version
+		if currPVVersion < hlv.Version {
+			hlv.PreviousVersions[hlv.SourceID] = hlv.Version
+		} else {
+			return fmt.Errorf("local hlv has current source in previous versiosn with version greater than current version. Current CAS: %d, PV CAS %d", hlv.Version, currPVVersion)
+		}
+	} else {
+		// source doesn't exist in PV so add
+		hlv.PreviousVersions[hlv.SourceID] = hlv.Version
+	}
 	hlv.Version = newVersion.Version
 	hlv.SourceID = newVersion.SourceID
 	return nil
@@ -119,7 +131,7 @@ func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bo
 
 	// Grab the latest CAS version for HLV(A)'s sourceID in HLV(B), if HLV(A) version CAS is > HLV(B)'s then it is dominating
 	// If 0 CAS is returned then the sourceID does not exist on HLV(B)
-	if latestCAS := otherVector.GetVersion(hlv.SourceID); latestCAS != 0 && hlv.Version > latestCAS {
+	if latestCAS, found := otherVector.GetVersion(hlv.SourceID); found && hlv.Version > latestCAS {
 		return true
 	}
 	// HLV A is not dominating over HLV B
@@ -174,8 +186,12 @@ func (hlv *HybridLogicalVector) equalPreviousVectors(otherVector HybridLogicalVe
 	return true
 }
 
-// GetVersion returns the latest CAS value in the HLV for a given sourceID, if the sourceID is not present in the HLV it will return 0 CAS value
-func (hlv *HybridLogicalVector) GetVersion(sourceID string) uint64 {
+// GetVersion returns the latest CAS value in the HLV for a given sourceID along with boolean value to
+// indicate if sourceID is found in the HLV, if the sourceID is not present in the HLV it will return 0 CAS value and false
+func (hlv *HybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
+	if sourceID == "" {
+		return 0, false
+	}
 	var latestVersion uint64
 	if sourceID == hlv.SourceID {
 		latestVersion = hlv.Version
@@ -186,7 +202,39 @@ func (hlv *HybridLogicalVector) GetVersion(sourceID string) uint64 {
 	if mvEntry := hlv.MergeVersions[sourceID]; mvEntry > latestVersion {
 		latestVersion = mvEntry
 	}
-	return latestVersion
+	// if we have 0 cas value, there is no entry for this source ID in the HLV
+	if latestVersion == 0 {
+		return latestVersion, false
+	}
+	return latestVersion, true
+}
+
+// AddNewerVersions will take a hlv and add any newer source/version pairs found across CV and PV found in the other HLV taken as parameter
+// when both HLV
+func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector) error {
+
+	// create current version for incoming vector and attempt to add it to the local HLV, AddVersion will handle if attempting to add older
+	// version than local HLVs CV pair
+	otherVectorCV := SourceAndVersion{SourceID: otherVector.SourceID, Version: otherVector.Version}
+	err := hlv.AddVersion(otherVectorCV)
+	if err != nil {
+		return err
+	}
+
+	if otherVector.PreviousVersions != nil || len(otherVector.PreviousVersions) != 0 {
+		// Iterate through incoming vector previous versions, update with the version from other vector
+		// for source if the local version for that source is lower
+		for i, v := range otherVector.PreviousVersions {
+			if hlv.PreviousVersions[i] == 0 || hlv.PreviousVersions[i] < v {
+				hlv.setPreviousVersion(i, v)
+			}
+		}
+	}
+	// if current source exists in PV, delete it.
+	if _, ok := hlv.PreviousVersions[hlv.SourceID]; ok {
+		delete(hlv.PreviousVersions, hlv.SourceID)
+	}
+	return nil
 }
 
 func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
@@ -299,4 +347,12 @@ func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansi
 		outputSpec = append(outputSpec, spec)
 	}
 	return outputSpec
+}
+
+// setPreviousVersion will take a source/version pair and add it to the HLV previous versions map
+func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64) {
+	if hlv.PreviousVersions == nil {
+		hlv.PreviousVersions = make(map[string]uint64)
+	}
+	hlv.PreviousVersions[source] = version
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -30,8 +30,8 @@ type HybridLogicalVector struct {
 
 // SourceAndVersion is a structure used to add a new entry to a HLV
 type SourceAndVersion struct {
-	SourceID string
-	Version  uint64
+	SourceID string `json:"source_id"`
+	Version  uint64 `json:"version"`
 }
 
 func CreateVersion(source string, version uint64) SourceAndVersion {

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -21,22 +21,31 @@ const hlvExpandMacroCASValue = math.MaxUint64
 
 type HybridLogicalVector struct {
 	CurrentVersionCAS uint64            // current version cas (or cvCAS) stores the current CAS at the time of replication
+	ImportCAS         uint64            // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
 	SourceID          string            // source bucket uuid of where this entry originated from
 	Version           uint64            // current cas of the current version on the version vector
 	MergeVersions     map[string]uint64 // map of merge versions for fast efficient lookup
 	PreviousVersions  map[string]uint64 // map of previous versions for fast efficient lookup
 }
 
-// CurrentVersionVector is a structure used to add a new sourceID:CAS entry to a HLV
-type CurrentVersionVector struct {
-	VersionCAS uint64
-	SourceID   string
+// SourceAndVersion is a structure used to add a new entry to a HLV
+type SourceAndVersion struct {
+	SourceID string
+	Version  uint64
+}
+
+func CreateVersion(source string, version uint64) SourceAndVersion {
+	return SourceAndVersion{
+		SourceID: source,
+		Version:  version,
+	}
 }
 
 type PersistedHybridLogicalVector struct {
 	CurrentVersionCAS string            `json:"cvCas,omitempty"`
-	SourceID          string            `json:"src,omitempty"`
-	Version           string            `json:"vrs,omitempty"`
+	ImportCAS         string            `json:"importCAS,omitempty"`
+	SourceID          string            `json:"src"`
+	Version           string            `json:"vrs"`
 	MergeVersions     map[string]string `json:"mv,omitempty"`
 	PreviousVersions  map[string]string `json:"pv,omitempty"`
 }
@@ -66,19 +75,19 @@ func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bo
 
 // AddVersion adds a version vector to the in memory representation of a HLV and moves current version vector to
 // previous versions on the HLV if needed
-func (hlv *HybridLogicalVector) AddVersion(newVersion CurrentVersionVector) error {
-	if newVersion.VersionCAS < hlv.Version {
-		return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %d new cas %d", hlv.Version, newVersion.VersionCAS)
+func (hlv *HybridLogicalVector) AddVersion(newVersion SourceAndVersion) error {
+	if newVersion.Version < hlv.Version {
+		return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %d new cas %d", hlv.Version, newVersion.Version)
 	}
 	// check if this is the first time we're adding a source - version pair
 	if hlv.SourceID == "" {
-		hlv.Version = newVersion.VersionCAS
+		hlv.Version = newVersion.Version
 		hlv.SourceID = newVersion.SourceID
 		return nil
 	}
 	// if new entry has the same source we simple just update the version
 	if newVersion.SourceID == hlv.SourceID {
-		hlv.Version = newVersion.VersionCAS
+		hlv.Version = newVersion.Version
 		return nil
 	}
 	// if we get here this is a new version from a different sourceID thus need to move current sourceID to previous versions and update current version
@@ -86,7 +95,7 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion CurrentVersionVector) erro
 		hlv.PreviousVersions = make(map[string]uint64)
 	}
 	hlv.PreviousVersions[hlv.SourceID] = hlv.Version
-	hlv.Version = newVersion.VersionCAS
+	hlv.Version = newVersion.Version
 	hlv.SourceID = newVersion.SourceID
 	return nil
 }
@@ -204,9 +213,13 @@ func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
 func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridLogicalVector, error) {
 	persistedHLV := PersistedHybridLogicalVector{}
 	var cvCasByteArray []byte
+	var importCASBytes []byte
 	var vrsCasByteArray []byte
 	if hlv.CurrentVersionCAS != 0 {
 		cvCasByteArray = base.Uint64CASToLittleEndianHex(hlv.CurrentVersionCAS)
+	}
+	if hlv.ImportCAS != 0 {
+		importCASBytes = base.Uint64CASToLittleEndianHex(hlv.ImportCAS)
 	}
 	if hlv.Version != 0 {
 		vrsCasByteArray = base.Uint64CASToLittleEndianHex(hlv.Version)
@@ -222,6 +235,7 @@ func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridL
 	}
 
 	persistedHLV.CurrentVersionCAS = string(cvCasByteArray)
+	persistedHLV.ImportCAS = string(importCASBytes)
 	persistedHLV.SourceID = hlv.SourceID
 	persistedHLV.Version = string(vrsCasByteArray)
 	persistedHLV.PreviousVersions = pvPersistedFormat
@@ -231,6 +245,9 @@ func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridL
 
 func (hlv *HybridLogicalVector) convertPersistedHLVToInMemoryHLV(persistedJSON PersistedHybridLogicalVector) {
 	hlv.CurrentVersionCAS = base.HexCasToUint64(persistedJSON.CurrentVersionCAS)
+	if persistedJSON.ImportCAS != "" {
+		hlv.ImportCAS = base.HexCasToUint64(persistedJSON.ImportCAS)
+	}
 	hlv.SourceID = persistedJSON.SourceID
 	// convert the hex cas to uint64 cas
 	hlv.Version = base.HexCasToUint64(persistedJSON.Version)

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -465,23 +465,26 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 
 // parseVectorValues takes a HLV section (for example previous versions) in Blip string form and split that into
 // source and version pairs
-func parseVectorValues(vectorStr string) (sourceVersionList []Version, err error) {
-	vectorPairs := strings.Split(vectorStr, ",")
+func parseVectorValues(vectorStr string) (versions []Version, err error) {
+	versionsStr := strings.Split(vectorStr, ",")
+	versions = make([]Version, 0, len(versionsStr))
 
 	// remove any leading whitespace form the string value
-	for i, v := range vectorPairs {
+	// TODO: Can avoid by restricting spec
+	for i, v := range versionsStr {
 		if v[0] == ' ' {
 			v = v[1:]
-			vectorPairs[i] = v
+			versionsStr[i] = v
 		}
 	}
-	for _, v := range vectorPairs {
-		sourceAndVersion := strings.Split(v, "@")
-		vrs, err := strconv.ParseUint(sourceAndVersion[0], 10, 64)
+
+	for _, v := range versionsStr {
+		version, err := CreateVersionFromString(v)
 		if err != nil {
 			return nil, err
 		}
-		sourceVersionList = append(sourceVersionList, Version{SourceID: sourceAndVersion[1], Value: vrs})
+		versions = append(versions, version)
 	}
-	return sourceVersionList, nil
+
+	return versions, nil
 }

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -359,65 +359,6 @@ func (h *HLVAgent) insertWithHLV(ctx context.Context, key string) (casOut uint64
 	return cas
 }
 
-// TestExtractHLVFromChangesMessage:
-//   - Test case 1: CV entry and 1 PV entry
-//   - Test case 2: CV entry and 2 PV entries
-//   - Test case 3: CV entry, 2 MV entries and 2 PV entries
-//   - Test case 4: just CV entry
-//   - Each test case gets run through extractHLVFromBlipMessage and assert that the resulting HLV
-//     is correct to what is expected
-func TestExtractHLVFromChangesMessage(t *testing.T) {
-	testCases := []struct {
-		name             string
-		hlvString        string
-		expectedHLV      []string
-		mergeVersions    bool
-		previousVersions bool
-	}{
-		{
-			name:             "test case 1",
-			hlvString:        "1@Hell0CA; 1@1Hr0k43xS662TToxODDAxQ",
-			expectedHLV:      []string{"Hell0CA@1", "1Hr0k43xS662TToxODDAxQ@1"},
-			previousVersions: true,
-		},
-		{
-			name:             "test case 2",
-			hlvString:        "25@def; 20@abc,18@hij",
-			expectedHLV:      []string{"def@25", "abc@20", "hij@18"},
-			previousVersions: true,
-		},
-		{
-			name:             "test case 3",
-			hlvString:        "25@def; 22@def,21@eff; 20@abc,18@hij",
-			expectedHLV:      []string{"def@25", "abc@20", "hij@18", "m_def@22", "m_eff@21"},
-			mergeVersions:    true,
-			previousVersions: true,
-		},
-		{
-			name:        "test case 4",
-			hlvString:   "24@def",
-			expectedHLV: []string{"def@24"},
-		},
-	}
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			expectedVector := createHLVForTest(t, test.expectedHLV)
-
-			hlv, err := extractHLVFromBlipMessage(test.hlvString)
-			require.NoError(t, err)
-
-			assert.Equal(t, expectedVector.SourceID, hlv.SourceID)
-			assert.Equal(t, expectedVector.Version, hlv.Version)
-			if test.previousVersions {
-				assert.True(t, reflect.DeepEqual(expectedVector.PreviousVersions, hlv.PreviousVersions))
-			}
-			if test.mergeVersions {
-				assert.True(t, reflect.DeepEqual(expectedVector.MergeVersions, hlv.MergeVersions))
-			}
-		})
-	}
-}
-
 // TestInvalidHLVOverChangesMessage:
 //   - Test hlv string that has too many sections to it (parts delimited by ;)
 //   - Test hlv string that is empty
@@ -476,9 +417,29 @@ var extractHLVFromBlipMsgBMarkCases = []struct {
 		hlvString:   "24@def",
 		expectedHLV: []string{"def@24"},
 	},
+	{
+		name:             "test case 6",
+		hlvString:        "1@Hell0CA; 1@1Hr0k43xS662TToxODDAxQ",
+		expectedHLV:      []string{"Hell0CA@1", "1Hr0k43xS662TToxODDAxQ@1"},
+		previousVersions: true,
+	},
+	{
+		name:             "test case 7",
+		hlvString:        "25@def; 22@def,21@eff; 20@abc,18@hij",
+		expectedHLV:      []string{"def@25", "abc@20", "hij@18", "m_def@22", "m_eff@21"},
+		mergeVersions:    true,
+		previousVersions: true,
+	},
 }
 
-func TestBenchmarkHLVMessageCases(t *testing.T) {
+// TestExtractHLVFromChangesMessage:
+//   - Test case 1: CV entry and 1 PV entry
+//   - Test case 2: CV entry and 2 PV entries
+//   - Test case 3: CV entry, 2 MV entries and 2 PV entries
+//   - Test case 4: just CV entry
+//   - Each test case gets run through extractHLVFromBlipMessage and assert that the resulting HLV
+//     is correct to what is expected
+func TestExtractHLVFromChangesMessage(t *testing.T) {
 	for _, test := range extractHLVFromBlipMsgBMarkCases {
 		t.Run(test.name, func(t *testing.T) {
 			expectedVector := createHLVForTest(t, test.expectedHLV)
@@ -502,8 +463,7 @@ func BenchmarkExtractHLVFromBlipMessage(b *testing.B) {
 	for _, bm := range extractHLVFromBlipMsgBMarkCases {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := extractHLVFromBlipMessage(bm.hlvString)
-				require.NoError(b, err)
+				_, _ = extractHLVFromBlipMessage(bm.hlvString)
 			}
 		})
 	}

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -502,7 +502,8 @@ func BenchmarkExtractHLVFromBlipMessage(b *testing.B) {
 	for _, bm := range extractHLVFromBlipMsgBMarkCases {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				extractHLVFromBlipMessage(bm.hlvString)
+				_, err := extractHLVFromBlipMessage(bm.hlvString)
+				require.NoError(b, err)
 			}
 		})
 	}

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -37,13 +37,13 @@ func TestInternalHLVFunctions(t *testing.T) {
 	const newSource = "s_testsource"
 
 	// create a new version vector entry that will error method AddVersion
-	badNewVector := SourceAndVersion{
-		Version:  123345,
+	badNewVector := Version{
+		Value:    123345,
 		SourceID: currSourceId,
 	}
 	// create a new version vector entry that should be added to HLV successfully
-	newVersionVector := SourceAndVersion{
-		Version:  newCAS,
+	newVersionVector := Version{
+		Value:    newCAS,
 		SourceID: currSourceId,
 	}
 

--- a/db/import.go
+++ b/db/import.go
@@ -140,7 +140,8 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		existingDoc.Expiry = *expiry
 	}
 
-	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, mutationOptions, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	docUpdateEvent := Import
+	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, mutationOptions, docUpdateEvent, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.
 		if doc.Cas != existingDoc.Cas {

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -424,14 +424,14 @@ func TestImportNullDocRaw(t *testing.T) {
 }
 
 func assertXattrSyncMetaRevGeneration(t *testing.T, dataStore base.DataStore, key string, expectedRevGeneration int) {
-	xattr := map[string]interface{}{}
-	_, err := dataStore.GetWithXattr(base.TestCtx(t), key, base.SyncXattrName, "", nil, &xattr, nil)
-	assert.NoError(t, err, "Error Getting Xattr")
-	revision, ok := xattr["rev"]
-	assert.True(t, ok)
-	generation, _ := ParseRevID(base.TestCtx(t), revision.(string))
-	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, revision)
-	assert.True(t, generation == expectedRevGeneration)
+
+	var syncData SyncData
+	_, err := dataStore.GetWithXattr(base.TestCtx(t), key, base.SyncXattrName, "", nil, &syncData, nil)
+	require.NoError(t, err, "Error Getting Xattr")
+	require.True(t, syncData.CurrentRev != "")
+	generation, _ := ParseRevID(base.TestCtx(t), syncData.CurrentRev)
+	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, syncData.CurrentRev)
+	assert.Equal(t, generation, expectedRevGeneration)
 }
 
 func TestEvaluateFunction(t *testing.T) {

--- a/db/query.go
+++ b/db/query.go
@@ -154,12 +154,12 @@ var QuerySequences = SGQuery{
 }
 
 type QueryChannelsRow struct {
-	Id         string `json:"id,omitempty"`
-	Rev        string `json:"rev,omitempty"`
-	Sequence   uint64 `json:"seq,omitempty"`
-	Flags      uint8  `json:"flags,omitempty"`
-	RemovalRev string `json:"rRev,omitempty"`
-	RemovalDel bool   `json:"rDel,omitempty"`
+	Id         string        `json:"id,omitempty"`
+	Rev        RevAndVersion `json:"rev,omitempty"`
+	Sequence   uint64        `json:"seq,omitempty"`
+	Flags      uint8         `json:"flags,omitempty"`
+	RemovalRev string        `json:"rRev,omitempty"`
+	RemovalDel bool          `json:"rDel,omitempty"`
 }
 
 var QueryPrincipals = SGQuery{
@@ -688,15 +688,15 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 type AllDocsViewQueryRow struct {
 	Key   string
 	Value struct {
-		RevID    string   `json:"r"`
-		Sequence uint64   `json:"s"`
-		Channels []string `json:"c"`
+		RevID    RevAndVersion `json:"r"`
+		Sequence uint64        `json:"s"`
+		Channels []string      `json:"c"`
 	}
 }
 
 type AllDocsIndexQueryRow struct {
 	Id       string
-	RevID    string              `json:"r"`
+	RevID    RevAndVersion       `json:"r"`
 	Sequence uint64              `json:"s"`
 	Channels channels.ChannelMap `json:"c"`
 }

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -372,7 +372,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create 10 added documents
 	for i := 1; i <= 10; i++ {
 		id := "created" + strconv.Itoa(i)
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "1-a", revId)
 		docIdFlagMap[doc.ID] = uint8(0x0)
@@ -385,12 +385,12 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create 10 deleted documents
 	for i := 1; i <= 10; i++ {
 		id := "deleted" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "1-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "2-a", revId, "Couldn't create tombstone revision")
 
@@ -402,22 +402,22 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
@@ -429,27 +429,27 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched|deleted" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
 		body[BodyDeleted] = true
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-b", "2-b"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-b", revId, "Couldn't create tombstone revision")
 
@@ -461,17 +461,17 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched|conflict" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -30,8 +30,8 @@ func NewBypassRevisionCache(backingStore RevisionCacheBackingStore, bypassStat *
 	}
 }
 
-// Get fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (docRev DocumentRevision, err error) {
+// GetWithRev fetches the revision for the given docID and revID immediately from the bucket.
+func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
@@ -45,7 +45,33 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, inc
 	docRev = DocumentRevision{
 		RevID: revID,
 	}
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, revID)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.CV, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, revID)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	rc.bypassStat.Add(1)
+
+	return docRev, nil
+}
+
+// GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+
+	unmarshalLevel := DocUnmarshalSync
+	if includeBody {
+		unmarshalLevel = DocUnmarshalAll
+	}
+	docRev = DocumentRevision{
+		CV: cv,
+	}
+
+	doc, err := rc.backingStore.GetDocument(ctx, docID, unmarshalLevel)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, err = revCacheLoaderForDocumentCV(ctx, rc.backingStore, doc, *cv)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -71,7 +97,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, incl
 		RevID: doc.CurrentRev,
 	}
 
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, doc.SyncData.CurrentRev)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.CV, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -96,7 +122,11 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Remove(docID, revID string) {
+func (rc *BypassRevisionCache) RemoveWithRev(docID, revID string) {
+	// nop
+}
+
+func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
 	// nop
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -56,7 +56,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 }
 
 // GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
@@ -126,7 +126,7 @@ func (rc *BypassRevisionCache) RemoveWithRev(docID, revID string) {
 	// nop
 }
 
-func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	// nop
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -56,7 +56,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 }
 
 // GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
@@ -126,7 +126,7 @@ func (rc *BypassRevisionCache) RemoveWithRev(docID, revID string) {
 	// nop
 }
 
-func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
+func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *Version) {
 	// nop
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -28,10 +28,15 @@ const (
 
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
-	// Get returns the given revision, and stores if not already cached.
+	// GetWithRev returns the given revision, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (DocumentRevision, error)
+	GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (DocumentRevision, error)
+
+	// GetWithCV returns the given revision by CV, and stores if not already cached.
+	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
+	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
+	GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
@@ -46,8 +51,11 @@ type RevisionCache interface {
 	// Update will remove existing value and re-create new one
 	Upsert(ctx context.Context, docRev DocumentRevision)
 
-	// Remove eliminates a revision in the cache.
-	Remove(docID, revID string)
+	// RemoveWithRev evicts a revision from the cache using its revID.
+	RemoveWithRev(docID, revID string)
+
+	// RemoveWithCV evicts a revision from the cache using its current version.
+	RemoveWithCV(docID string, cv *CurrentVersionVector)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)
@@ -104,6 +112,7 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 type RevisionCacheBackingStore interface {
 	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
 	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error)
+	getCurrentVersion(ctx context.Context, doc *Document) ([]byte, Body, AttachmentsMeta, error)
 }
 
 // DocumentRevision stored and returned by the rev cache
@@ -119,6 +128,7 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
+	CV          *CurrentVersionVector
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
@@ -223,6 +233,12 @@ type IDAndRev struct {
 	RevID string
 }
 
+type IDandCV struct {
+	DocID   string
+	Version uint64
+	Source  string
+}
+
 // RevisionDelta stores data about a delta between a revision and ToRevID.
 type RevisionDelta struct {
 	ToRevID               string                  // Target revID for the delta
@@ -246,44 +262,104 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *CurrentVersionVector, err error) {
 	var doc *Document
 	unmarshalLevel := DocUnmarshalSync
 	if unmarshalBody {
 		unmarshalLevel = DocUnmarshalAll
 	}
 	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
-		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, err
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, fetchedCV, err
 	}
 
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
+// revCacheLoaderForCv will load a document from the bucket using the CV, comapre the fetched doc and the CV specified in the function,
+// and will still return revid for purpose of populating the Rev ID lookup map on the cache
+func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+	cv := CurrentVersionVector{
+		VersionCAS: id.Version,
+		SourceID:   id.Source,
+	}
+	var doc *Document
+	unmarshalLevel := DocUnmarshalSync
+	if unmarshalBody {
+		unmarshalLevel = DocUnmarshalAll
+	}
+	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, revid, err
+	}
+
+	return revCacheLoaderForDocumentCV(ctx, backingStore, doc, cv)
+}
+
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *CurrentVersionVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
 		if isRemovalErr != nil {
-			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
+			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, fetchedCV, isRemovalErr
 		}
 
 		if isRemoval {
-			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
+			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, fetchedCV, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
-			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, err
+			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, fetchedCV, err
 		}
 	}
 	deleted = doc.History[revid].Deleted
 
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
-		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
+		return bodyBytes, body, history, channels, removed, nil, deleted, nil, fetchedCV, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
+	if doc.HLV != nil {
+		fetchedCV = &CurrentVersionVector{SourceID: doc.HLV.SourceID, VersionCAS: doc.HLV.Version}
+	}
 
-	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, fetchedCV, err
+}
+
+// revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
+func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv CurrentVersionVector) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
+		// we need implementation of IsChannelRemoval for CV here.
+		// pending CBG-3213 support of channel removal for CV
+	}
+
+	if err = doc.HasCurrentVersion(cv); err != nil {
+		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+	}
+	channels = doc.currentRevChannels
+	revid = doc.CurrentRev
+
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+}
+
+func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {
+	bodyBytes, err = doc.BodyBytes(ctx)
+	if err != nil {
+		base.WarnfCtx(ctx, "Marshal error when retrieving active current version body: %v", err)
+		return nil, nil, nil, err
+	}
+
+	body = doc._body
+	attachments = doc.Attachments
+
+	// handle backup revision inline attachments, or pre-2.5 meta
+	if inlineAtts, cleanBodyBytes, cleanBody, err := extractInlineAttachments(bodyBytes); err != nil {
+		return nil, nil, nil, err
+	} else if len(inlineAtts) > 0 {
+		// we found some inline attachments, so merge them with attachments, and update the bodies
+		attachments = mergeAttachments(inlineAtts, attachments)
+		bodyBytes = cleanBodyBytes
+		body = cleanBody
+	}
+	return bodyBytes, body, attachments, err
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -327,12 +327,11 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 }
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
-// Added no lint static check here as function below has empty body to if statement due to needing channel removals for CV to be implemented (CBG-3213)
-// nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
-		// TODO: pending CBG-3213 support of channel removal for CV
-		// we need implementation of IsChannelRemoval for CV here.
+		// need implementation of IsChannelRemoval for CV
+		// TODO: CBG-3213 - pending support of channel removal for CV
+		base.ErrorfCtx(ctx, "pending CBG-3213 support of channel removal for CV: %v", err)
 	}
 
 	if err = doc.HasCurrentVersion(cv); err != nil {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -327,6 +327,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 }
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
+// Added no lint static check here as function below has empty body to if statement due to needing channel removals for CV to be implemented (CBG-3213)
 // nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -36,7 +36,7 @@ type RevisionCache interface {
 	// GetWithCV returns the given revision by CV, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (DocumentRevision, error)
+	GetWithCV(ctx context.Context, docID string, cv *Version, includeBody, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
@@ -55,7 +55,7 @@ type RevisionCache interface {
 	RemoveWithRev(docID, revID string)
 
 	// RemoveWithCV evicts a revision from the cache using its current version.
-	RemoveWithCV(docID string, cv *SourceAndVersion)
+	RemoveWithCV(docID string, cv *Version)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)
@@ -128,7 +128,7 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
-	CV          *SourceAndVersion
+	CV          *Version
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
@@ -262,7 +262,7 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *SourceAndVersion, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *Version, err error) {
 	var doc *Document
 	unmarshalLevel := DocUnmarshalSync
 	if unmarshalBody {
@@ -278,8 +278,8 @@ func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore,
 // revCacheLoaderForCv will load a document from the bucket using the CV, comapre the fetched doc and the CV specified in the function,
 // and will still return revid for purpose of populating the Rev ID lookup map on the cache
 func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
-	cv := SourceAndVersion{
-		Version:  id.Version,
+	cv := Version{
+		Value:    id.Version,
 		SourceID: id.Source,
 	}
 	var doc *Document
@@ -295,7 +295,7 @@ func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingS
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *SourceAndVersion, err error) {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *Version, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
@@ -320,7 +320,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
 	if doc.HLV != nil {
-		fetchedCV = &SourceAndVersion{SourceID: doc.HLV.SourceID, Version: doc.HLV.Version}
+		fetchedCV = &Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}
 	}
 
 	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, fetchedCV, err
@@ -328,7 +328,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
 // nolint:staticcheck
-func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv SourceAndVersion) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
 		// TODO: pending CBG-3213 support of channel removal for CV
 		// we need implementation of IsChannelRemoval for CV here.

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -327,10 +327,11 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 }
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
+// nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv SourceAndVersion) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
+		// TODO: pending CBG-3213 support of channel removal for CV
 		// we need implementation of IsChannelRemoval for CV here.
-		// pending CBG-3213 support of channel removal for CV
 	}
 
 	if err = doc.HasCurrentVersion(cv); err != nil {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -45,8 +45,12 @@ func (sc *ShardedLRURevisionCache) getShard(docID string) *LRURevisionCache {
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 
-func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).Get(ctx, docID, revID, includeBody, includeDelta)
+func (sc *ShardedLRURevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetWithRev(ctx, docID, revID, includeBody, includeDelta)
+}
+
+func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetWithCV(ctx, docID, cv, includeBody, includeDelta)
 }
 
 func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID, revID string) (docRev DocumentRevision, found bool) {
@@ -69,14 +73,19 @@ func (sc *ShardedLRURevisionCache) Upsert(ctx context.Context, docRev DocumentRe
 	sc.getShard(docRev.DocID).Upsert(ctx, docRev)
 }
 
-func (sc *ShardedLRURevisionCache) Remove(docID, revID string) {
-	sc.getShard(docID).Remove(docID, revID)
+func (sc *ShardedLRURevisionCache) RemoveWithRev(docID, revID string) {
+	sc.getShard(docID).RemoveWithRev(docID, revID)
+}
+
+func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+	sc.getShard(docID).RemoveWithCV(docID, cv)
 }
 
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	backingStore RevisionCacheBackingStore
 	cache        map[IDAndRev]*list.Element
+	hlvCache     map[IDandCV]*list.Element
 	lruList      *list.List
 	cacheHits    *base.SgwIntStat
 	cacheMisses  *base.SgwIntStat
@@ -93,7 +102,9 @@ type revCacheValue struct {
 	attachments AttachmentsMeta
 	delta       *RevisionDelta
 	body        Body
-	key         IDAndRev
+	id          string
+	cv          CurrentVersionVector
+	revID       string
 	bodyBytes   []byte
 	lock        sync.RWMutex
 	deleted     bool
@@ -105,6 +116,7 @@ func NewLRURevisionCache(capacity uint32, backingStore RevisionCacheBackingStore
 
 	return &LRURevisionCache{
 		cache:        map[IDAndRev]*list.Element{},
+		hlvCache:     map[IDandCV]*list.Element{},
 		lruList:      list.New(),
 		capacity:     capacity,
 		backingStore: backingStore,
@@ -117,14 +129,18 @@ func NewLRURevisionCache(capacity uint32, backingStore RevisionCacheBackingStore
 // Returns the body of the revision, its history, and the set of channels it's in.
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
-func (rc *LRURevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (DocumentRevision, error) {
-	return rc.getFromCache(ctx, docID, revID, true, includeBody, includeDelta)
+func (rc *LRURevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (DocumentRevision, error) {
+	return rc.getFromCacheByRev(ctx, docID, revID, true, includeBody, includeDelta)
+}
+
+func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error) {
+	return rc.getFromCacheByCV(ctx, docID, cv, true, includeBody, includeDelta)
 }
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
 // present in the cache.
 func (rc *LRURevisionCache) Peek(ctx context.Context, docID, revID string) (docRev DocumentRevision, found bool) {
-	docRev, err := rc.getFromCache(ctx, docID, revID, false, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err := rc.getFromCacheByRev(ctx, docID, revID, false, RevCacheOmitBody, RevCacheOmitDelta)
 	if err != nil {
 		return DocumentRevision{}, false
 	}
@@ -140,18 +156,42 @@ func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string
 	}
 }
 
-func (rc *LRURevisionCache) getFromCache(ctx context.Context, docID, revID string, loadOnCacheMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID string, loadOnCacheMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
 	value := rc.getValue(docID, revID, loadOnCacheMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
 	}
 
-	docRev, statEvent, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
-	rc.statsRecorderFunc(statEvent)
+	docRev, cacheHit, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
+	rc.statsRecorderFunc(cacheHit)
 
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
+	if !cacheHit {
+		rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV)
+	}
+
+	return docRev, err
+}
+
+func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *CurrentVersionVector, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+	value := rc.getValueByCV(docID, cv, loadCacheOnMiss)
+	if value == nil {
+		return DocumentRevision{}, nil
+	}
+
+	docRev, cacheHit, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
+	rc.statsRecorderFunc(cacheHit)
+
+	if err != nil {
+		rc.removeValue(value) // don't keep failed loads in the cache
+	}
+
+	if !cacheHit {
+		rc.addToRevMapPostLoad(docID, docRev.RevID, docRev.CV)
+	}
+
 	return docRev, err
 }
 
@@ -162,15 +202,16 @@ func (rc *LRURevisionCache) LoadInvalidRevFromBackingStore(ctx context.Context, 
 	var docRevBody Body
 
 	value := revCacheValue{
-		key: key,
+		id:    key.DocID,
+		revID: key.RevID,
 	}
 
 	// If doc has been passed in use this to grab values. Otherwise run revCacheLoader which will grab the Document
 	// first
 	if doc != nil {
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, key.RevID)
+		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, _, value.err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, key.RevID)
 	} else {
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoader(ctx, rc.backingStore, key, includeBody)
+		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, _, value.err = revCacheLoader(ctx, rc.backingStore, key, includeBody)
 	}
 
 	if includeDelta {
@@ -210,12 +251,15 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, include
 	// Retrieve from or add to rev cache
 	value := rc.getValue(docID, bucketDoc.CurrentRev, true)
 
-	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStore, bucketDoc, includeBody)
-	rc.statsRecorderFunc(statEvent)
+	docRev, cacheHit, err := value.loadForDoc(ctx, rc.backingStore, bucketDoc, includeBody)
+	rc.statsRecorderFunc(cacheHit)
 
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
+	// add successfully fetched value to cv lookup map too
+	rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV)
+
 	return docRev, err
 }
 
@@ -234,30 +278,43 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision) {
 		// TODO: CBG-1948
 		panic("Missing history for RevisionCache.Put")
 	}
-	value := rc.getValue(docRev.DocID, docRev.RevID, true)
+	// doc should always have a cv present in a PUT operation on the cache (update HLV is called before hand in doc update process)
+	// thus we can call getValueByCV directly the update the rev lookup post this
+	value := rc.getValueByCV(docRev.DocID, docRev.CV, true)
+	// store the created value
 	value.store(docRev)
+
+	// add new doc version to the rev id lookup map
+	rc.addToRevMapPostLoad(docRev.DocID, docRev.RevID, docRev.CV)
 }
 
 // Upsert a revision in the cache.
 func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision) {
-	key := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
+	var value *revCacheValue
+	// similar to PUT operation we should have the CV defined by this point (updateHLV is called before calling this)
+	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.VersionCAS}
+	legacyKey := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
 
 	rc.lock.Lock()
-	// If element exists remove from lrulist
-	if elem := rc.cache[key]; elem != nil {
+	// lookup for element in hlv lookup map, if not found for some reason try rev lookup map
+	if elem := rc.hlvCache[key]; elem != nil {
+		rc.lruList.Remove(elem)
+	} else if elem = rc.cache[legacyKey]; elem != nil {
 		rc.lruList.Remove(elem)
 	}
 
 	// Add new value and overwrite existing cache key, pushing to front to maintain order
-	value := &revCacheValue{key: key}
-	rc.cache[key] = rc.lruList.PushFront(value)
+	// also ensure we add to rev id lookup map too
+	value = &revCacheValue{id: docRev.DocID, cv: *docRev.CV}
+	elem := rc.lruList.PushFront(value)
+	rc.hlvCache[key] = elem
+	rc.cache[legacyKey] = elem
 
-	// Purge oldest item if required
-	for len(rc.cache) > int(rc.capacity) {
+	for rc.lruList.Len() > int(rc.capacity) {
 		rc.purgeOldest_()
 	}
 	rc.lock.Unlock()
-
+	// store upsert value
 	value.store(docRev)
 }
 
@@ -272,9 +329,9 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 		rc.lruList.MoveToFront(elem)
 		value = elem.Value.(*revCacheValue)
 	} else if create {
-		value = &revCacheValue{key: key}
+		value = &revCacheValue{id: docID, revID: revID}
 		rc.cache[key] = rc.lruList.PushFront(value)
-		for len(rc.cache) > int(rc.capacity) {
+		for rc.lruList.Len() > int(rc.capacity) {
 			rc.purgeOldest_()
 		}
 	}
@@ -282,8 +339,116 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 	return
 }
 
+// getValueByCV gets a value from rev cache by CV, if not found and create is true, will add the value to cache and both lookup maps
+func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector, create bool) (value *revCacheValue) {
+	if docID == "" || cv == nil {
+		return nil
+	}
+
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	rc.lock.Lock()
+	if elem := rc.hlvCache[key]; elem != nil {
+		rc.lruList.MoveToFront(elem)
+		value = elem.Value.(*revCacheValue)
+	} else if create {
+		value = &revCacheValue{id: docID, cv: *cv}
+		newElem := rc.lruList.PushFront(value)
+		rc.hlvCache[key] = newElem
+		for rc.lruList.Len() > int(rc.capacity) {
+			rc.purgeOldest_()
+		}
+	}
+	rc.lock.Unlock()
+	return
+}
+
+// addToRevMapPostLoad will generate and entry in the Rev lookup map for a new document entering the cache
+func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+	legacyKey := IDAndRev{DocID: docID, RevID: revID}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// check for existing value in rev cache map (due to concurrent fetch by rev ID)
+	cvElem, cvFound := rc.hlvCache[key]
+	revElem, revFound := rc.cache[legacyKey]
+	if !cvFound {
+		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
+		// need to return doc revision to caller still but no need repopulate the cache
+		return
+	}
+	// Check if another goroutine has already updated the rev map
+	if revFound {
+		if cvElem == revElem {
+			// already match, return
+			return
+		}
+		// if CV map and rev map are targeting different list elements, update to have both use the cv map element
+		rc.cache[legacyKey] = cvElem
+		rc.lruList.Remove(revElem)
+	} else {
+		// if not found we need to add the element to the rev lookup (for PUT code path)
+		rc.cache[legacyKey] = cvElem
+	}
+}
+
+// addToHLVMapPostLoad will generate and entry in the CV lookup map for a new document entering the cache
+func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+	legacyKey := IDAndRev{DocID: docID, RevID: revID}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// check for existing value in rev cache map (due to concurrent fetch by rev ID)
+	cvElem, cvFound := rc.hlvCache[key]
+	revElem, revFound := rc.cache[legacyKey]
+	if !revFound {
+		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
+		// need to return doc revision to caller still but no need repopulate the cache
+		return
+	}
+	// Check if another goroutine has already updated the cv map
+	if cvFound {
+		if cvElem == revElem {
+			// already match, return
+			return
+		}
+		// if CV map and rev map are targeting different list elements, update to have both use the cv map element
+		rc.cache[legacyKey] = cvElem
+		rc.lruList.Remove(revElem)
+	}
+}
+
 // Remove removes a value from the revision cache, if present.
-func (rc *LRURevisionCache) Remove(docID, revID string) {
+func (rc *LRURevisionCache) RemoveWithRev(docID, revID string) {
+	rc.removeFromCacheByRev(docID, revID)
+}
+
+// RemoveWithCV removes a value from rev cache by CV reference if present
+func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+	rc.removeFromCacheByCV(docID, cv)
+}
+
+// removeFromCacheByCV removes an entry from rev cache by CV
+func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *CurrentVersionVector) {
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	element, ok := rc.hlvCache[key]
+	if !ok {
+		return
+	}
+	// grab the revid key from the value to enable us to remove the reference from the rev lookup map too
+	elem := element.Value.(*revCacheValue)
+	legacyKey := IDAndRev{DocID: docID, RevID: elem.revID}
+	rc.lruList.Remove(element)
+	delete(rc.hlvCache, key)
+	// remove from rev lookup map too
+	delete(rc.cache, legacyKey)
+}
+
+// removeFromCacheByRev removes an entry from rev cache by revID
+func (rc *LRURevisionCache) removeFromCacheByRev(docID, revID string) {
 	key := IDAndRev{DocID: docID, RevID: revID}
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -291,23 +456,38 @@ func (rc *LRURevisionCache) Remove(docID, revID string) {
 	if !ok {
 		return
 	}
+	// grab the cv key key from the value to enable us to remove the reference from the rev lookup map too
+	elem := element.Value.(*revCacheValue)
+	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.VersionCAS}
 	rc.lruList.Remove(element)
 	delete(rc.cache, key)
+	// remove from CV lookup map too
+	delete(rc.hlvCache, hlvKey)
 }
 
 // removeValue removes a value from the revision cache, if present and the value matches the the value. If there's an item in the revision cache with a matching docID and revID but the document is different, this item will not be removed from the rev cache.
 func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 	rc.lock.Lock()
-	if element := rc.cache[value.key]; element != nil && element.Value == value {
+	defer rc.lock.Unlock()
+	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+	if element := rc.cache[revKey]; element != nil && element.Value == value {
 		rc.lruList.Remove(element)
-		delete(rc.cache, value.key)
+		delete(rc.cache, revKey)
 	}
-	rc.lock.Unlock()
+	// need to also check hlv lookup cache map
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	if element := rc.hlvCache[hlvKey]; element != nil && element.Value == value {
+		rc.lruList.Remove(element)
+		delete(rc.hlvCache, hlvKey)
+	}
 }
 
 func (rc *LRURevisionCache) purgeOldest_() {
 	value := rc.lruList.Remove(rc.lruList.Back()).(*revCacheValue)
-	delete(rc.cache, value.key)
+	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	delete(rc.cache, revKey)
+	delete(rc.hlvCache, hlvKey)
 }
 
 // Gets the body etc. out of a revCacheValue. If they aren't present already, the loader func
@@ -319,6 +499,8 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	// to reduce locking when includeDelta=false
 	var delta *RevisionDelta
 	var docRevBody Body
+	var fetchedCV *CurrentVersionVector
+	var revid string
 
 	// Attempt to read cached value.
 	value.lock.RLock()
@@ -349,12 +531,24 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 		// If body is requested and not already present in cache, populate value.body from value.BodyBytes
 		if includeBody && value.body == nil && value.err == nil {
 			if err := value.body.Unmarshal(value.bodyBytes); err != nil {
-				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 			}
 		}
 	} else {
 		cacheHit = false
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoader(ctx, backingStore, value.key, includeBody)
+		if value.revID == "" {
+			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForCv(ctx, backingStore, hlvKey, includeBody)
+			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
+			value.revID = revid
+		} else {
+			revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, fetchedCV, value.err = revCacheLoader(ctx, backingStore, revKey, includeBody)
+			// based off the revision load we need to populate the hlv key with what has been fetched from the bucket (for use of populating the opposite lookup map)
+			if fetchedCV != nil {
+				value.cv = *fetchedCV
+			}
+		}
 	}
 
 	if includeDelta {
@@ -374,7 +568,7 @@ func (value *revCacheValue) updateBody(ctx context.Context) (err error) {
 	var body Body
 	if err := body.Unmarshal(value.bodyBytes); err != nil {
 		// On unmarshal error, warn return docRev without body
-		base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+		base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 		return err
 	}
 
@@ -391,8 +585,8 @@ func (value *revCacheValue) updateBody(ctx context.Context) (err error) {
 func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) (DocumentRevision, error) {
 
 	docRev := DocumentRevision{
-		DocID:       value.key.DocID,
-		RevID:       value.key.RevID,
+		DocID:       value.id,
+		RevID:       value.revID,
 		BodyBytes:   value.bodyBytes,
 		History:     value.history,
 		Channels:    value.channels,
@@ -400,6 +594,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 		Attachments: value.attachments.ShallowCopy(), // Avoid caller mutating the stored attachments
 		Deleted:     value.deleted,
 		Removed:     value.removed,
+		CV:          &CurrentVersionVector{VersionCAS: value.cv.VersionCAS, SourceID: value.cv.SourceID},
 	}
 	if body != nil {
 		docRev._shallowCopyBody = body.ShallowCopy()
@@ -414,6 +609,8 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, includeBody bool) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	var docRevBody Body
+	var fetchedCV *CurrentVersionVector
+	var revid string
 	value.lock.RLock()
 	if value.bodyBytes != nil || value.err != nil {
 		if includeBody {
@@ -443,13 +640,22 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 		// If body is requested and not already present in cache, attempt to generate from bytes and insert into cache
 		if includeBody && value.body == nil {
 			if err := value.body.Unmarshal(value.bodyBytes); err != nil {
-				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 			}
 		}
 	} else {
 		cacheHit = false
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.key.RevID)
+		if value.revID == "" {
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForDocumentCV(ctx, backingStore, doc, value.cv)
+			value.revID = revid
+		} else {
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, fetchedCV, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.revID)
+			if fetchedCV != nil {
+				value.cv = *fetchedCV
+			}
+		}
 	}
+
 	if includeBody {
 		docRevBody = value.body
 	}
@@ -462,7 +668,7 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 func (value *revCacheValue) store(docRev DocumentRevision) {
 	value.lock.Lock()
 	if value.bodyBytes == nil {
-		// value already has doc id/rev id in key
+		value.revID = docRev.RevID
 		value.bodyBytes = docRev.BodyBytes
 		value.history = docRev.History
 		value.channels = docRev.Channels

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -49,7 +49,7 @@ func (sc *ShardedLRURevisionCache) GetWithRev(ctx context.Context, docID, revID 
 	return sc.getShard(docID).GetWithRev(ctx, docID, revID, includeBody, includeDelta)
 }
 
-func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 	return sc.getShard(docID).GetWithCV(ctx, docID, cv, includeBody, includeDelta)
 }
 
@@ -77,7 +77,7 @@ func (sc *ShardedLRURevisionCache) RemoveWithRev(docID, revID string) {
 	sc.getShard(docID).RemoveWithRev(docID, revID)
 }
 
-func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	sc.getShard(docID).RemoveWithCV(docID, cv)
 }
 
@@ -103,7 +103,7 @@ type revCacheValue struct {
 	delta       *RevisionDelta
 	body        Body
 	id          string
-	cv          CurrentVersionVector
+	cv          SourceAndVersion
 	revID       string
 	bodyBytes   []byte
 	lock        sync.RWMutex
@@ -133,7 +133,7 @@ func (rc *LRURevisionCache) GetWithRev(ctx context.Context, docID, revID string,
 	return rc.getFromCacheByRev(ctx, docID, revID, true, includeBody, includeDelta)
 }
 
-func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (DocumentRevision, error) {
 	return rc.getFromCacheByCV(ctx, docID, cv, true, includeBody, includeDelta)
 }
 
@@ -175,7 +175,7 @@ func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID 
 	return docRev, err
 }
 
-func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *CurrentVersionVector, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *SourceAndVersion, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
 	value := rc.getValueByCV(docID, cv, loadCacheOnMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
@@ -292,7 +292,7 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision) {
 func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision) {
 	var value *revCacheValue
 	// similar to PUT operation we should have the CV defined by this point (updateHLV is called before calling this)
-	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.VersionCAS}
+	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.Version}
 	legacyKey := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
 
 	rc.lock.Lock()
@@ -340,12 +340,12 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 }
 
 // getValueByCV gets a value from rev cache by CV, if not found and create is true, will add the value to cache and both lookup maps
-func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector, create bool) (value *revCacheValue) {
+func (rc *LRURevisionCache) getValueByCV(docID string, cv *SourceAndVersion, create bool) (value *revCacheValue) {
 	if docID == "" || cv == nil {
 		return nil
 	}
 
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 	rc.lock.Lock()
 	if elem := rc.hlvCache[key]; elem != nil {
 		rc.lruList.MoveToFront(elem)
@@ -363,9 +363,9 @@ func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector,
 }
 
 // addToRevMapPostLoad will generate and entry in the Rev lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *SourceAndVersion) {
 	legacyKey := IDAndRev{DocID: docID, RevID: revID}
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -393,9 +393,9 @@ func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *Current
 }
 
 // addToHLVMapPostLoad will generate and entry in the CV lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *SourceAndVersion) {
 	legacyKey := IDAndRev{DocID: docID, RevID: revID}
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -425,13 +425,13 @@ func (rc *LRURevisionCache) RemoveWithRev(docID, revID string) {
 }
 
 // RemoveWithCV removes a value from rev cache by CV reference if present
-func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	rc.removeFromCacheByCV(docID, cv)
 }
 
 // removeFromCacheByCV removes an entry from rev cache by CV
-func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *CurrentVersionVector) {
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *SourceAndVersion) {
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	element, ok := rc.hlvCache[key]
@@ -458,7 +458,7 @@ func (rc *LRURevisionCache) removeFromCacheByRev(docID, revID string) {
 	}
 	// grab the cv key key from the value to enable us to remove the reference from the rev lookup map too
 	elem := element.Value.(*revCacheValue)
-	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.Version}
 	rc.lruList.Remove(element)
 	delete(rc.cache, key)
 	// remove from CV lookup map too
@@ -475,7 +475,7 @@ func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 		delete(rc.cache, revKey)
 	}
 	// need to also check hlv lookup cache map
-	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 	if element := rc.hlvCache[hlvKey]; element != nil && element.Value == value {
 		rc.lruList.Remove(element)
 		delete(rc.hlvCache, hlvKey)
@@ -485,7 +485,7 @@ func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 func (rc *LRURevisionCache) purgeOldest_() {
 	value := rc.lruList.Remove(rc.lruList.Back()).(*revCacheValue)
 	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
-	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 	delete(rc.cache, revKey)
 	delete(rc.hlvCache, hlvKey)
 }
@@ -499,7 +499,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	// to reduce locking when includeDelta=false
 	var delta *RevisionDelta
 	var docRevBody Body
-	var fetchedCV *CurrentVersionVector
+	var fetchedCV *SourceAndVersion
 	var revid string
 
 	// Attempt to read cached value.
@@ -537,7 +537,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	} else {
 		cacheHit = false
 		if value.revID == "" {
-			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForCv(ctx, backingStore, hlvKey, includeBody)
 			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
 			value.revID = revid
@@ -594,7 +594,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 		Attachments: value.attachments.ShallowCopy(), // Avoid caller mutating the stored attachments
 		Deleted:     value.deleted,
 		Removed:     value.removed,
-		CV:          &CurrentVersionVector{VersionCAS: value.cv.VersionCAS, SourceID: value.cv.SourceID},
+		CV:          &SourceAndVersion{Version: value.cv.Version, SourceID: value.cv.SourceID},
 	}
 	if body != nil {
 		docRev._shallowCopyBody = body.ShallowCopy()
@@ -609,7 +609,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, includeBody bool) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	var docRevBody Body
-	var fetchedCV *CurrentVersionVector
+	var fetchedCV *SourceAndVersion
 	var revid string
 	value.lock.RLock()
 	if value.bodyBytes != nil || value.err != nil {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -80,7 +80,7 @@ func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document)
 		"testing":         true,
 		BodyId:            doc.ID,
 		BodyRev:           doc.CurrentRev,
-		"current_version": &CurrentVersionVector{VersionCAS: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+		"current_version": &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 	}
 	bodyBytes, err := base.JSONMarshal(b)
 	return bodyBytes, b, nil, err
@@ -110,7 +110,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Get them back out
@@ -127,7 +127,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Add 3 more docs to the now full revcache
 	for i := 10; i < 13; i++ {
 		docID := strconv.Itoa(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Check that the first 3 docs were evicted
@@ -170,7 +170,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// assert that the list has 10 elements along with both lookup maps
@@ -181,7 +181,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Add 3 more docs to the now full rev cache to trigger eviction
 	for docID := 10; docID < 13; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
 	assert.Equal(t, 10, len(cache.hlvCache))
@@ -192,7 +192,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	prevCacheHitCount := cacheHitCounter.Value()
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		cv := CurrentVersionVector{VersionCAS: uint64(i + 3), SourceID: "test"}
+		cv := SourceAndVersion{Version: uint64(i + 3), SourceID: "test"}
 		docRev, err := cache.GetWithCV(ctx, id, &cv, RevCacheOmitBody, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -270,13 +270,13 @@ func TestBackingStoreCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"not_found"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
@@ -287,14 +287,14 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	cv = CurrentVersionVector{SourceID: "test11", VersionCAS: 100}
+	cv = SourceAndVersion{SourceID: "test11", Version: 100}
 	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -557,7 +557,7 @@ func TestSingleLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
 	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", true, false)
 	assert.NoError(t, err)
 }
@@ -567,7 +567,7 @@ func TestConcurrentLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
 
 	// Trigger load into cache
 	var wg sync.WaitGroup
@@ -632,7 +632,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	documentRevision := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -648,7 +648,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
@@ -661,7 +661,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, []byte(`{"test":"12345"}`), docRev.BodyBytes)
 	assert.Equal(t, int64(2), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
@@ -705,7 +705,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// create cv with incorrect version to the one stored in backing store
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 1234}
+	cv := SourceAndVersion{SourceID: "test", Version: 1234}
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	require.Error(t, err)
@@ -735,7 +735,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	go func() {
 		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", RevCacheOmitBody, RevCacheIncludeDelta)
 		require.NoError(t, err)
@@ -773,9 +773,9 @@ func TestGetActive(t *testing.T) {
 	rev1id, doc, err := collection.Put(ctx, "doc", Body{"val": 123})
 	require.NoError(t, err)
 
-	expectedCV := CurrentVersionVector{
-		SourceID:   db.BucketUUID,
-		VersionCAS: doc.Cas,
+	expectedCV := SourceAndVersion{
+		SourceID: db.BucketUUID,
+		Version:  doc.Cas,
 	}
 
 	// remove the entry form the rev cache to force teh cache to not have the active version in it
@@ -801,7 +801,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	docRev := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -80,7 +80,7 @@ func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document)
 		"testing":         true,
 		BodyId:            doc.ID,
 		BodyRev:           doc.CurrentRev,
-		"current_version": &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+		"current_version": &Version{Value: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 	}
 	bodyBytes, err := base.JSONMarshal(b)
 	return bodyBytes, b, nil, err
@@ -110,7 +110,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Get them back out
@@ -127,7 +127,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Add 3 more docs to the now full revcache
 	for i := 10; i < 13; i++ {
 		docID := strconv.Itoa(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Check that the first 3 docs were evicted
@@ -170,7 +170,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// assert that the list has 10 elements along with both lookup maps
@@ -181,7 +181,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Add 3 more docs to the now full rev cache to trigger eviction
 	for docID := 10; docID < 13; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
 	assert.Equal(t, 10, len(cache.hlvCache))
@@ -192,7 +192,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	prevCacheHitCount := cacheHitCounter.Value()
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		cv := SourceAndVersion{Version: uint64(i + 3), SourceID: "test"}
+		cv := Version{Value: uint64(i + 3), SourceID: "test"}
 		docRev, err := cache.GetWithCV(ctx, id, &cv, RevCacheOmitBody, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -270,13 +270,13 @@ func TestBackingStoreCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"not_found"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	cv := SourceAndVersion{SourceID: "test", Version: 123}
+	cv := Version{SourceID: "test", Value: 123}
 	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Version)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
@@ -287,14 +287,14 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Version)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	cv = SourceAndVersion{SourceID: "test11", Version: 100}
+	cv = Version{SourceID: "test11", Value: 100}
 	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -557,7 +557,7 @@ func TestSingleLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
 	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", true, false)
 	assert.NoError(t, err)
 }
@@ -567,7 +567,7 @@ func TestConcurrentLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
 
 	// Trigger load into cache
 	var wg sync.WaitGroup
@@ -632,7 +632,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cv := SourceAndVersion{SourceID: "test", Version: 123}
+	cv := Version{SourceID: "test", Value: 123}
 	documentRevision := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -648,7 +648,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Version)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
@@ -661,7 +661,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Version)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, []byte(`{"test":"12345"}`), docRev.BodyBytes)
 	assert.Equal(t, int64(2), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
@@ -705,7 +705,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// create cv with incorrect version to the one stored in backing store
-	cv := SourceAndVersion{SourceID: "test", Version: 1234}
+	cv := Version{SourceID: "test", Value: 1234}
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	require.Error(t, err)
@@ -735,7 +735,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := SourceAndVersion{SourceID: "test", Version: 123}
+	cv := Version{SourceID: "test", Value: 123}
 	go func() {
 		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", RevCacheOmitBody, RevCacheIncludeDelta)
 		require.NoError(t, err)
@@ -773,9 +773,9 @@ func TestGetActive(t *testing.T) {
 	rev1id, doc, err := collection.Put(ctx, "doc", Body{"val": 123})
 	require.NoError(t, err)
 
-	expectedCV := SourceAndVersion{
+	expectedCV := Version{
 		SourceID: db.BucketUUID,
-		Version:  doc.Cas,
+		Value:    doc.Cas,
 	}
 
 	// remove the entry form the rev cache to force teh cache to not have the active version in it
@@ -801,7 +801,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := SourceAndVersion{SourceID: "test", Version: 123}
+	cv := Version{SourceID: "test", Value: 123}
 	docRev := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -131,7 +131,7 @@ func TestBackupOldRevision(t *testing.T) {
 
 	// create rev 2 and check backups for both revs
 	rev2ID := "2-abc"
-	_, _, err = collection.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// now in all cases we'll have rev 1 backed up (for at least 5 minutes)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -662,3 +662,14 @@ func DefaultMutateInOpts() *sgbucket.MutateInOptions {
 		MacroExpansion: macroExpandSpec(base.SyncXattrName),
 	}
 }
+
+func createTestDocument(docID string, revID string, body Body, deleted bool, expiry uint32) (newDoc *Document) {
+	newDoc = &Document{
+		ID:        docID,
+		Deleted:   deleted,
+		DocExpiry: expiry,
+		RevID:     revID,
+		_body:     body,
+	}
+	return newDoc
+}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -677,3 +677,29 @@ func createTestDocument(docID string, revID string, body Body, deleted bool, exp
 	}
 	return newDoc
 }
+
+// requireCurrentVersion fetches the document by key, and validates that cv matches.
+func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, source string, version uint64) {
+	ctx := base.TestCtx(t)
+	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
+	require.NoError(t, err)
+	if doc.HLV == nil {
+		require.Equal(t, "", source)
+		require.Equal(t, "", version)
+		return
+	}
+
+	require.Equal(t, doc.HLV.SourceID, source)
+	require.Equal(t, doc.HLV.Version, version)
+}
+
+// GetDocumentCurrentVersion fetches the document by key and returns the current version
+func (c *DatabaseCollection) GetDocumentCurrentVersion(t *testing.T, key string) (source string, version uint64) {
+	ctx := base.TestCtx(t)
+	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
+	require.NoError(t, err)
+	if doc.HLV == nil {
+		return "", 0
+	}
+	return doc.HLV.SourceID, doc.HLV.Version
+}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -477,6 +477,10 @@ func (dbc *DatabaseContext) CollectionChannelViewForTest(tb testing.TB, collecti
 	return collection.getChangesInChannelFromQuery(base.TestCtx(tb), channelName, startSeq, endSeq, 0, false)
 }
 
+func (db *DatabaseContext) GetChannelCache() ChannelCache {
+	return db.channelCache
+}
+
 // Test-only version of GetPrincipal that doesn't trigger channel/role recalculation
 func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUser bool) (info *auth.PrincipalConfig, err error) {
 	ctx := base.TestCtx(tb)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2245,7 +2245,7 @@ func TestHandlePutDbConfigWithBackticksCollections(t *testing.T) {
 	reqBodyWithBackticks := `{
         "server": "walrus:",
         "bucket": "backticks",
-		"enable_shared_bucket_access":false,
+		"enable_shared_bucket_access":true,
 		"scopes": {
 			"scope1": {
 			  "collections" : {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1652,10 +1652,10 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 
 	// Fetch the xattr and make sure it contains the above value
 	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	_, err = rt.GetSingleDataStore().GetWithXattr(rt.Context(), "-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
+	var retrievedSyncData db.SyncData
+	_, err = rt.GetSingleDataStore().GetWithXattr(rt.Context(), "-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedSyncData, nil)
 	assert.NoError(t, err, "Unexpected Error")
-	assert.Equal(t, "2-466a1fab90a810dc0a63565b70680e4e", retrievedXattr["rev"])
+	assert.Equal(t, "2-466a1fab90a810dc0a63565b70680e4e", retrievedSyncData.CurrentRev)
 
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2743,6 +2743,97 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "null doc body for doc")
 }
 
+// TestPutDocUpdateVersionVector:
+//   - Put a doc and assert that the versions and the source for the hlv is correctly updated
+//   - Update that doc and assert HLV has also been updated
+//   - Delete the doc and assert that the HLV has been updated in deletion event
+func TestPutDocUpdateVersionVector(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"key": "value"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Put a new revision of this doc and assert that the version vector SourceID and Version is updated
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, `{"key1": "value1"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Delete doc and assert that the version vector SourceID and Version is updated
+	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}
+
+// TestHLVOnPutWithImportRejection:
+//   - Put a doc successfully and assert the HLV is updated correctly
+//   - Put a doc that will be rejected by the custom import filter
+//   - Assert that the HLV values on the sync data are still correctly updated/preserved
+func TestHLVOnPutWithImportRejection(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
+	importFilter := `function (doc) { return doc.type == "mobile"}`
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:   false,
+			ImportFilter: &importFilter,
+		}},
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"type": "mobile"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Put a doc that will be rejected by the import filter on the attempt to perform on demand import for write
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"type": "not-mobile"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// assert that the hlv is correctly updated and in tact after the import was cancelled on the doc
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc2")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}
+
 func TestTombstoneCompactionAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2743,6 +2743,79 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "null doc body for doc")
 }
 
+// TestDatabaseXattrConfigHandlingForDBConfigUpdate:
+//   - Create database with xattrs enabled
+//   - Test updating the config to disable the use of xattrs in this database through replacing + upserting the config
+//   - Assert error code is returned and response contains error string
+func TestDatabaseXattrConfigHandlingForDBConfigUpdate(t *testing.T) {
+	base.LongRunningTest(t)
+	const (
+		dbName  = "db1"
+		errResp = "sync gateway requires enable_shared_bucket_access=true"
+	)
+
+	testCases := []struct {
+		name         string
+		upsertConfig bool
+	}{
+		{
+			name:         "POST update",
+			upsertConfig: true,
+		},
+		{
+			name:         "PUT update",
+			upsertConfig: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rt := NewRestTester(t, &RestTesterConfig{
+				PersistentConfig: true,
+			})
+			defer rt.Close()
+
+			dbConfig := rt.NewDbConfig()
+
+			resp := rt.CreateDatabase(dbName, dbConfig)
+			RequireStatus(t, resp, http.StatusCreated)
+			assert.NoError(t, rt.WaitForDBOnline())
+
+			dbConfig.EnableXattrs = base.BoolPtr(false)
+
+			if testCase.upsertConfig {
+				resp = rt.UpsertDbConfig(dbName, dbConfig)
+				RequireStatus(t, resp, http.StatusInternalServerError)
+				assert.Contains(t, resp.Body.String(), errResp)
+			} else {
+				resp = rt.ReplaceDbConfig(dbName, dbConfig)
+				RequireStatus(t, resp, http.StatusInternalServerError)
+				assert.Contains(t, resp.Body.String(), errResp)
+			}
+		})
+	}
+}
+
+// TestCreateDBWithXattrsDisbaled:
+//   - Test that you cannot create a database with xattrs disabled
+//   - Assert error code is returned and response contains error string
+func TestCreateDBWithXattrsDisbaled(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+	const (
+		dbName  = "db1"
+		errResp = "sync gateway requires enable_shared_bucket_access=true"
+	)
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.EnableXattrs = base.BoolPtr(false)
+
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusInternalServerError)
+	assert.Contains(t, resp.Body.String(), errResp)
+}
+
 // TestPutDocUpdateVersionVector:
 //   - Put a doc and assert that the versions and the source for the hlv is correctly updated
 //   - Update that doc and assert HLV has also been updated

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -1060,7 +1060,6 @@ func TestAttachmentContentType(t *testing.T) {
 }
 
 func TestBasicAttachmentRemoval(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
@@ -2224,7 +2223,6 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 }
 
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -1060,6 +1060,7 @@ func TestAttachmentContentType(t *testing.T) {
 }
 
 func TestBasicAttachmentRemoval(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
 	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
@@ -2223,6 +2224,7 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 }
 
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1699,7 +1699,7 @@ func TestPutRevV4(t *testing.T) {
 	assert.Equal(t, "", resp.Properties["Error-Code"])
 
 	// assert on bucket doc
-	doc, _, err := collection.GetDocWithXattr(base.TestCtx(t), "foo", db.DocUnmarshalVV)
+	doc, _, err := collection.GetDocWithXattr(base.TestCtx(t), "foo", db.DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	// assert the persisted HLV based on what was sent through the blip tester
@@ -1718,7 +1718,7 @@ func TestPutRevV4(t *testing.T) {
 	assert.Equal(t, "", resp.Properties["Error-Code"])
 
 	// assert on bucket doc
-	doc, _, err = collection.GetDocWithXattr(base.TestCtx(t), "boo", db.DocUnmarshalVV)
+	doc, _, err = collection.GetDocWithXattr(base.TestCtx(t), "boo", db.DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	mv := make(map[string]uint64)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -877,7 +877,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 			assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
+			docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -511,7 +511,7 @@ func (h *handler) handleBulkDocs() error {
 				err = base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 			} else {
 				revid = revisions[0]
-				_, _, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, doc, revisions, false)
+				_, _, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, doc, revisions, false, db.ExistingVersionWithUpdateToHLV)
 			}
 		}
 

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -273,3 +273,65 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 	assert.Equal(t, 5, int(atomic.LoadUint32(&WinningRevChangedCount)))
 	assert.Equal(t, 6, int(atomic.LoadUint32(&DocumentChangedCount)))
 }
+
+func TestCVPopulationOnChangesViaAPI(t *testing.T) {
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {channel(doc.channels)}`,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	collection := rt.GetSingleTestDatabaseCollection()
+	bucketUUID := rt.GetDatabase().BucketUUID
+	const DocID = "doc1"
+
+	// activate channel cache
+	_, err := rt.WaitForChanges(0, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+DocID, `{"channels": ["ABC"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	require.NoError(t, collection.WaitForPendingChanges(base.TestCtx(t)))
+
+	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	require.NoError(t, err)
+
+	assert.Equal(t, "doc1", changes.Results[0].ID)
+	assert.Equal(t, bucketUUID, changes.Results[0].CurrentVersion.SourceID)
+	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Version)
+}
+
+func TestCVPopulationOnDocIDChanges(t *testing.T) {
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {channel(doc.channels)}`,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	collection := rt.GetSingleTestDatabaseCollection()
+	bucketUUID := rt.GetDatabase().BucketUUID
+	const DocID = "doc1"
+
+	// activate channel cache
+	_, err := rt.WaitForChanges(0, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+DocID, `{"channels": ["ABC"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	require.NoError(t, collection.WaitForPendingChanges(base.TestCtx(t)))
+
+	changes, err := rt.WaitForChanges(1, fmt.Sprintf(`/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=%s`, DocID), "", true)
+	require.NoError(t, err)
+
+	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	require.NoError(t, err)
+
+	assert.Equal(t, "doc1", changes.Results[0].ID)
+	assert.Equal(t, bucketUUID, changes.Results[0].CurrentVersion.SourceID)
+	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Version)
+}

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -302,7 +302,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)
 	assert.Equal(t, bucketUUID, changes.Results[0].CurrentVersion.SourceID)
-	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Version)
+	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Value)
 }
 
 func TestCVPopulationOnDocIDChanges(t *testing.T) {
@@ -333,5 +333,5 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)
 	assert.Equal(t, bucketUUID, changes.Results[0].CurrentVersion.SourceID)
-	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Version)
+	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Value)
 }

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -275,6 +275,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 }
 
 func TestCVPopulationOnChangesViaAPI(t *testing.T) {
+	t.Skip("Disabled until REST support for version is added")
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}
@@ -306,6 +307,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 }
 
 func TestCVPopulationOnDocIDChanges(t *testing.T) {
+	t.Skip("Disabled until REST support for version is added")
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -861,6 +861,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	}
 }`})
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user with access to channel NBC:
 	ctx := rt.Context()
@@ -928,6 +929,10 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	// Write another doc
 	_ = rt.PutDoc("mix-1", `{"channel":["ABC", "PBS", "HBO"]}`)
 
+	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, "mix-1", db.DocUnmarshalSync)
+	require.NoError(t, err)
+	mixSource, mixVersion := fetchedDoc.HLV.GetCurrentVersion()
+
 	cacheWaiter.AddAndWait(1)
 
 	// Issue a changes request with a compound since value from the last changes response
@@ -935,7 +940,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	expectedResults = []string{
 		`{"seq":"8:2","id":"hbo-1","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":8,"id":"grant-1","changes":[{"rev":"1-c5098bb14d12d647c901850ff6a6292a"}]}`,
-		`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}]}`,
+		fmt.Sprintf(`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}], "current_version":{"source_id": "%s", "version": %d}}`, mixSource, mixVersion),
 	}
 
 	rt.Run("grant via existing channel", func(t *testing.T) {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -9,7 +9,6 @@
 package changestest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -901,9 +900,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	changes, err := rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes", "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 	for index, result := range changes.Results {
-		var expectedChange db.ChangeEntry
-		require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-		assert.Equal(t, expectedChange, result)
+		assertChangeEntryMatches(t, expectedResults[index], result)
 	}
 
 	// create doc that dynamically grants both users access to PBS and HBO
@@ -921,9 +918,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 	for index, result := range changes.Results {
-		var expectedChange db.ChangeEntry
-		require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-		assert.Equal(t, expectedChange, result)
+		assertChangeEntryMatches(t, expectedResults[index], result)
 	}
 
 	// Write another doc
@@ -947,9 +942,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		changes, err = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "alice", false)
 		require.NoError(t, err, "Error retrieving changes results for alice")
 		for index, result := range changes.Results {
-			var expectedChange db.ChangeEntry
-			require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-			assert.Equal(t, expectedChange, result)
+			assertChangeEntryMatches(t, expectedResults[index], result)
 		}
 	})
 
@@ -957,11 +950,31 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		changes, err = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "bernard", false)
 		require.NoError(t, err, "Error retrieving changes results for bernard")
 		for index, result := range changes.Results {
-			var expectedChange db.ChangeEntry
-			require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-			assert.Equal(t, expectedChange, result)
+			assertChangeEntryMatches(t, expectedResults[index], result)
 		}
 	})
+}
+
+// TODO: enhance to compare source/version when expectedChanges are updated to include
+func assertChangeEntryMatches(t *testing.T, expectedChangeEntryString string, result db.ChangeEntry) {
+	var expectedChange db.ChangeEntry
+	require.NoError(t, base.JSONUnmarshal([]byte(expectedChangeEntryString), &expectedChange))
+	assert.Equal(t, expectedChange.Seq, result.Seq)
+	assert.Equal(t, expectedChange.ID, result.ID)
+	assert.Equal(t, expectedChange.Changes, result.Changes)
+	assert.Equal(t, expectedChange.Deleted, result.Deleted)
+	assert.Equal(t, expectedChange.Removed, result.Removed)
+
+	if expectedChange.Doc != nil {
+		// result.Doc is json.RawMessage, and properties may not be in the same order for a direct comparison
+		var expectedBody db.Body
+		var resultBody db.Body
+		assert.NoError(t, expectedBody.Unmarshal(expectedChange.Doc))
+		assert.NoError(t, resultBody.Unmarshal(result.Doc))
+		db.AssertEqualBodies(t, expectedBody, resultBody)
+	} else {
+		assert.Equal(t, expectedChange.Doc, result.Doc)
+	}
 }
 
 // Ensures that changes feed goroutines blocked on a ChangeWaiter are closed when the changes feed is terminated.
@@ -2115,26 +2128,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.Equal(t, len(expectedResults), len(changes.Results))
 
 	for index, result := range changes.Results {
-		var expectedChange db.ChangeEntry
-		assert.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-
-		assert.Equal(t, expectedChange.ID, result.ID)
-		assert.Equal(t, expectedChange.Seq, result.Seq)
-		assert.Equal(t, expectedChange.Deleted, result.Deleted)
-		assert.Equal(t, expectedChange.Changes, result.Changes)
-		assert.Equal(t, expectedChange.Err, result.Err)
-		assert.Equal(t, expectedChange.Removed, result.Removed)
-
-		if expectedChange.Doc != nil {
-			// result.Doc is json.RawMessage, and properties may not be in the same order for a direct comparison
-			var expectedBody db.Body
-			var resultBody db.Body
-			assert.NoError(t, expectedBody.Unmarshal(expectedChange.Doc))
-			assert.NoError(t, resultBody.Unmarshal(result.Doc))
-			db.AssertEqualBodies(t, expectedBody, resultBody)
-		} else {
-			assert.Equal(t, expectedChange.Doc, result.Doc)
-		}
+		assertChangeEntryMatches(t, expectedResults[index], result)
 	}
 
 	// Flush the rev cache, and issue changes again to ensure successful handling for rev cache misses
@@ -2150,16 +2144,10 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.Equal(t, len(expectedResults), len(postFlushChanges.Results))
 
 	for index, result := range postFlushChanges.Results {
+
+		assertChangeEntryMatches(t, expectedResults[index], result)
 		var expectedChange db.ChangeEntry
 		assert.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-
-		assert.Equal(t, expectedChange.ID, result.ID)
-		assert.Equal(t, expectedChange.Seq, result.Seq)
-		assert.Equal(t, expectedChange.Deleted, result.Deleted)
-		assert.Equal(t, expectedChange.Changes, result.Changes)
-		assert.Equal(t, expectedChange.Err, result.Err)
-		assert.Equal(t, expectedChange.Removed, result.Removed)
-
 		if expectedChange.Doc != nil {
 			// result.Doc is json.RawMessage, and properties may not be in the same order for a direct comparison
 			var expectedBody db.Body
@@ -2186,14 +2174,12 @@ func TestChangesIncludeDocs(t *testing.T) {
 	expectedStyleAllDocs[9] = `{"seq":26,"id":"doc_resolved_conflict","changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"},{"rev":"3-f25ad98ef169791adec6c1d385717b84"}]}`
 
 	styleAllDocsChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs", "", "user1")
-	var allDocsChanges struct {
-		Results []*json.RawMessage
-	}
+	var allDocsChanges rest.ChangesResults
 	err = base.JSONUnmarshal(styleAllDocsChangesResponse.Body.Bytes(), &allDocsChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, len(expectedStyleAllDocs), len(allDocsChanges.Results))
 	for index, result := range allDocsChanges.Results {
-		assert.Equal(t, expectedStyleAllDocs[index], fmt.Sprintf("%s", *result))
+		assertChangeEntryMatches(t, expectedStyleAllDocs[index], result)
 	}
 
 	// Validate style=all_docs, include_docs=true permutations.  Only modified doc from include_docs test is doc_conflict (adds open revisions)
@@ -2206,26 +2192,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.Equal(t, len(expectedResults), len(combinedChanges.Results))
 
 	for index, result := range combinedChanges.Results {
-		var expectedChange db.ChangeEntry
-		assert.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-
-		assert.Equal(t, expectedChange.ID, result.ID)
-		assert.Equal(t, expectedChange.Seq, result.Seq)
-		assert.Equal(t, expectedChange.Deleted, result.Deleted)
-		assert.Equal(t, expectedChange.Changes, result.Changes)
-		assert.Equal(t, expectedChange.Err, result.Err)
-		assert.Equal(t, expectedChange.Removed, result.Removed)
-
-		if expectedChange.Doc != nil {
-			// result.Doc is json.RawMessage, and properties may not be in the same order for a direct comparison
-			var expectedBody db.Body
-			var resultBody db.Body
-			assert.NoError(t, expectedBody.Unmarshal(expectedChange.Doc))
-			assert.NoError(t, resultBody.Unmarshal(result.Doc))
-			db.AssertEqualBodies(t, expectedBody, resultBody)
-		} else {
-			assert.Equal(t, expectedChange.Doc, result.Doc)
-		}
+		assertChangeEntryMatches(t, expectedResults[index], result)
 	}
 }
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -471,7 +471,7 @@ func (h *handler) handlePutDoc() error {
 		if revisions == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 		}
-		doc, newRev, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false)
+		doc, newRev, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false, db.ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			return err
 		}
@@ -548,7 +548,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		newDoc.UpdateBody(body)
 	}
 
-	doc, rev, err := h.collection.PutExistingRev(h.ctx(), newDoc, history, true, false, nil)
+	doc, rev, err := h.collection.PutExistingRev(h.ctx(), newDoc, history, true, false, nil, db.ExistingVersionWithUpdateToHLV)
 
 	if err != nil {
 		return err

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -424,7 +424,6 @@ func TestXattrDoubleDelete(t *testing.T) {
 }
 
 func TestViewQueryTombstoneRetrieval(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 	base.SkipImportTestsIfNotEnabled(t)
 
 	if !base.TestsDisableGSI() {

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -424,6 +424,9 @@ func TestXattrDoubleDelete(t *testing.T) {
 }
 
 func TestViewQueryTombstoneRetrieval(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
+	base.SkipImportTestsIfNotEnabled(t)
+
 	if !base.TestsDisableGSI() {
 		t.Skip("views tests are not applicable under GSI")
 	}

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1612,7 +1612,7 @@ func TestImportRevisionCopy(t *testing.T) {
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
-	rev1id := rawInsertResponse.Sync.Rev
+	rev1id := rawInsertResponse.Sync.Rev.RevTreeID
 
 	// 3. Update via SDK
 	updatedBody := make(map[string]interface{})
@@ -1673,7 +1673,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
-	rev1id := rawInsertResponse.Sync.Rev
+	rev1id := rawInsertResponse.Sync.Rev.RevTreeID
 
 	// 3. Flush the rev cache (simulates attempted retrieval by a different SG node, since testing framework isn't great
 	//    at simulating multiple SG instances)
@@ -1903,7 +1903,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
-	rev1id := rawInsertResponse.Sync.Rev
+	rev1id := rawInsertResponse.Sync.Rev.RevTreeID
 
 	// 3. Update via SDK
 	updatedBody := make(map[string]interface{})
@@ -2078,13 +2078,12 @@ func rawDocWithSyncMeta() string {
 }
 
 func assertXattrSyncMetaRevGeneration(t *testing.T, dataStore base.DataStore, key string, expectedRevGeneration int) {
-	xattr := map[string]interface{}{}
-	_, err := dataStore.GetWithXattr(base.TestCtx(t), key, base.SyncXattrName, "", nil, &xattr, nil)
+	var syncData db.SyncData
+	_, err := dataStore.GetWithXattr(base.TestCtx(t), key, base.SyncXattrName, "", nil, &syncData, nil)
 	assert.NoError(t, err, "Error Getting Xattr")
-	revision, ok := xattr["rev"]
-	assert.True(t, ok)
-	generation, _ := db.ParseRevID(base.TestCtx(t), revision.(string))
-	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, revision)
+	assert.True(t, syncData.CurrentRev != "")
+	generation, _ := db.ParseRevID(base.TestCtx(t), syncData.CurrentRev)
+	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, syncData.CurrentRev)
 	assert.True(t, generation == expectedRevGeneration)
 }
 
@@ -2109,13 +2108,12 @@ func TestDeletedEmptyDocumentImport(t *testing.T) {
 	// Get the doc and check deleted revision is getting imported
 	response = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docId, "")
 	assert.Equal(t, http.StatusOK, response.Code)
-	rawResponse := make(map[string]interface{})
+	var rawResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawResponse)
 	require.NoError(t, err, "Unable to unmarshal raw response")
 
-	assert.True(t, rawResponse[db.BodyDeleted].(bool))
-	syncMeta := rawResponse["_sync"].(map[string]interface{})
-	assert.Equal(t, "2-5d3308aae9930225ed7f6614cf115366", syncMeta["rev"])
+	assert.True(t, rawResponse.Deleted)
+	assert.Equal(t, "2-5d3308aae9930225ed7f6614cf115366", rawResponse.Sync.Rev.RevTreeID)
 }
 
 // Check deleted document via SDK is getting imported if it is included in through ImportFilter function.
@@ -2149,10 +2147,9 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	endpoint := fmt.Sprintf("/{{.keyspace}}/_raw/%s?redact=false", key)
 	response := rt.SendAdminRequest(http.MethodGet, endpoint, "")
 	assert.Equal(t, http.StatusOK, response.Code)
-	var respBody db.Body
+	var respBody rest.RawResponse
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
-	syncMeta := respBody[base.SyncPropertyName].(map[string]interface{})
-	assert.NotEmpty(t, syncMeta["rev"].(string))
+	assert.NotEmpty(t, respBody.Sync.Rev.RevTreeID)
 
 	// Delete the document via SDK
 	err = dataStore.Delete(key)
@@ -2162,9 +2159,8 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, endpoint, "")
 	assert.Equal(t, http.StatusOK, response.Code)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
-	assert.True(t, respBody[db.BodyDeleted].(bool))
-	syncMeta = respBody[base.SyncPropertyName].(map[string]interface{})
-	assert.NotEmpty(t, syncMeta["rev"].(string))
+	assert.True(t, respBody.Deleted)
+	assert.NotEmpty(t, respBody.Sync.Rev.RevTreeID)
 }
 
 // CBG-1995: Test the support for using an underscore prefix in the top-level body of a document
@@ -2333,7 +2329,7 @@ func TestImportTouch(t *testing.T) {
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	require.NoError(t, err, "Unable to unmarshal raw response")
-	initialRev := rawInsertResponse.Sync.Rev
+	initialRev := rawInsertResponse.Sync.Rev.RevTreeID
 
 	// 2. Test import behaviour after SDK touch
 	_, err = dataStore.Touch(key, 1000000)
@@ -2345,7 +2341,7 @@ func TestImportTouch(t *testing.T) {
 	var rawUpdateResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawUpdateResponse)
 	require.NoError(t, err, "Unable to unmarshal raw response")
-	require.Equal(t, initialRev, rawUpdateResponse.Sync.Rev)
+	require.Equal(t, initialRev, rawUpdateResponse.Sync.Rev.RevTreeID)
 }
 func TestImportingPurgedDocument(t *testing.T) {
 	if !base.TestUseXattrs() {

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -59,7 +59,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	_, err := dataStore.GetXattr(rt.Context(), docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
-	docRev, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
+	docRev, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(docRev.Channels.ToArray()))
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
@@ -79,7 +79,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	_, err = dataStore.GetXattr(rt.Context(), docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
-	docRev2, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
+	docRev2, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.CurrentRev, docRev2.RevID)
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8311,3 +8311,46 @@ func requireBodyEqual(t *testing.T, expected string, doc *db.Document) {
 	require.NoError(t, base.JSONUnmarshal([]byte(expected), &expectedBody))
 	require.Equal(t, expectedBody, doc.Body(base.TestCtx(t)))
 }
+
+// TestReplicatorUpdateHLVOnPut:
+//   - For purpose of testing the PutExistingRev code path
+//   - Put a doc on a active rest tester
+//   - Create replication and wait for the doc to be replicated to passive node
+//   - Assert on the HLV in the metadata of the replicated document
+func TestReplicatorUpdateHLVOnPut(t *testing.T) {
+
+	activeRT, passiveRT, remoteURL, teardown := rest.SetupSGRPeers(t)
+	defer teardown()
+
+	// Grab the bucket UUIDs for both rest testers
+	activeBucketUUID, err := activeRT.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	const rep = "replication"
+
+	// Put a doc and assert on the HLV update in the sync data
+	resp := activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"source": "activeRT"}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := activeRT.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, activeBucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// create the replication to push the doc to the passive node and wait for the doc to be replicated
+	activeRT.CreateReplication(rep, remoteURL, db.ActiveReplicatorTypePush, nil, false, db.ConflictResolverDefault)
+
+	_, err = passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	// assert on the HLV update on the passive node
+	syncData, err = passiveRT.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	// TODO: assert that the SourceID and Verison pair are preserved correctly pending CBG-3211
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1092,6 +1092,11 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		}
 	}
 
+	// In sync gateway version 4.0+ we do not support the disabling of use of xattrs
+	if !config.UseXattrs() {
+		return db.DatabaseContextOptions{}, fmt.Errorf("sync gateway requires enable_shared_bucket_access=true")
+	}
+
 	// Create a callback function that will be invoked if the database goes offline and comes
 	// back online again
 	dbOnlineCallback := func(dbContext *db.DatabaseContext) {

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -319,6 +319,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	assert.NotNil(t, sc.dbConfigs["db"])
 
 	// Update config in bucket to see if unsuspending check for updates
+	sc.dbConfigs["db"].EnableXattrs = base.BoolPtr(true) // xattrs must be enabled
 	cas, err := sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), sc.Config.Bootstrap.ConfigGroupID, "db", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 		config := sc.dbConfigs["db"].ToDatabaseConfig()
 		config.cfgCas = bucketDbConfig.cfgCas

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1036,12 +1036,13 @@ func (rt *RestTester) SetAdminChannels(username string, keyspace string, channel
 
 type SimpleSync struct {
 	Channels map[string]interface{}
-	Rev      string
+	Rev      db.RevAndVersion
 	Sequence uint64
 }
 
 type RawResponse struct {
-	Sync SimpleSync `json:"_sync"`
+	Sync    SimpleSync `json:"_sync"`
+	Deleted bool       `json:"_deleted"`
 }
 
 // GetDocumentSequence looks up the sequence for a document using the _raw endpoint.


### PR DESCRIPTION
CBG-3255

Changes:
- handleProposeChanges has CheckProposedVersion implementation, which does much the same as CheckProposedRev but for HLV 
- Process Rev has some extra logic instead for V4 protocol and above. Given this function can expect revids or version vectors currently.  
- Some tests to show process rev adding the document version correctly to the bucket 
- Tests for CheckProposedVersion behaviour given certain version vectors passed into it  
- Test for extracting a Version vector struct from a string representation in the Blip string form  
- There was a bug where merge versions that were populated where not getting persisted to bucket through PutExistingCurrentVersion. Hence the change to the function there too. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2251/
