### PR TITLE
[3.1.3 Backport] CBG-3639: Fully escape JSON strings when using InjectJSONProperties

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1397,10 +1397,11 @@ func InjectJSONProperties(b []byte, kvPairs ...KVPair) (new []byte, err error) {
 			valBytes = []byte(strconv.FormatUint(uint64(v), 10))
 		case uint64:
 			valBytes = []byte(strconv.FormatUint(v, 10))
-		case string:
-			valBytes = []byte(`"` + v + `"`)
 		case bool:
 			valBytes = []byte(strconv.FormatBool(v))
+		// case string:
+		// it's not safe to use strings without marshalling
+		// fall through to default below
 		default:
 			valBytes, err = JSONMarshal(kv.Val)
 		}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -842,10 +842,7 @@ func TestInjectJSONProperties(t *testing.T) {
 			}
 
 			assert.Equal(tt, test.expectedOutput, string(output))
-
-			var m map[string]interface{}
-			err = JSONUnmarshal(output, &m)
-			assert.NoError(tt, err, "produced invalid JSON")
+			assert.NoError(tt, JSONUnmarshal(output, &map[string]interface{}{}), "produced invalid JSON")
 		})
 	}
 }
@@ -945,6 +942,30 @@ func TestInjectJSONPropertiesDiffTypes(t *testing.T) {
 				true,
 			},
 		},
+		{
+			input:  `{"foo": "bar"}`,
+			output: `{"foo": "bar","quoted_string":"\"quoted\""}`,
+			pair: KVPair{
+				"quoted_string",
+				`"quoted"`,
+			},
+		},
+		{
+			input:  `{"foo": "bar"}`,
+			output: `{"foo": "bar","reverse_solidus":"C:\\something\\that\\contains\\backslashes"}`,
+			pair: KVPair{
+				"reverse_solidus",
+				`C:\something\that\contains\backslashes`,
+			},
+		},
+		{
+			input:  `{"foo": "bar"}`,
+			output: `{"foo": "bar","escape":"foo\u0000bar"}`,
+			pair: KVPair{
+				"escape",
+				"foo\x00bar",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -952,6 +973,7 @@ func TestInjectJSONPropertiesDiffTypes(t *testing.T) {
 			output, err := InjectJSONProperties([]byte(test.input), test.pair)
 			assert.NoError(t, err)
 			assert.Equal(t, test.output, string(output))
+			assert.NoErrorf(t, JSONUnmarshal(output, &map[string]interface{}{}), "produced invalid JSON")
 		})
 	}
 }


### PR DESCRIPTION
Backports #6588 to 3.1.3

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
