### PR TITLE
3.1.3: Bump to Go 1.21.4

### DIFF
--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -454,7 +454,7 @@
             "release_name": "Couchbase Sync Gateway 3.1.3",
             "production": true,
             "interval": 120,
-            "go_version": "1.19.5",
+            "go_version": "1.21.4",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
From #6605 - Bump Go 1.21.4 for 3.1.3 builds

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a