### PR TITLE
CBG-3684 remove validation for max_age on a database level

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -771,10 +771,6 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		}
 	}
 
-	if dbConfig.CORS != nil && dbConfig.CORS.MaxAge != 0 {
-		multiError = multiError.Append(fmt.Errorf("cors.max_age can not be set on a database level"))
-
-	}
 	if dbConfig.DeprecatedPool != nil {
 		base.WarnfCtx(ctx, `"pool" config option is not supported. The pool will be set to "default". The option should be removed from config file.`)
 	}

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/auth"
@@ -208,6 +209,7 @@ func TestCORSNoMux(t *testing.T) {
 	reqHeaders := map[string]string{
 		"Origin": "http://example.com",
 	}
+
 	// this method doesn't exist
 	for _, method := range []string{http.MethodGet, http.MethodOptions} {
 		response := rt.SendRequestWithHeaders(method, "/_notanendpoint/", "", reqHeaders)
@@ -294,6 +296,7 @@ func TestCORSUserNoAccess(t *testing.T) {
 
 func TestCORSOriginPerDatabase(t *testing.T) {
 	// Override the default (example.com) CORS configuration in the DbConfig for /db:
+	const perDBMaxAge = 1234
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
@@ -301,7 +304,7 @@ func TestCORSOriginPerDatabase(t *testing.T) {
 					Origin:      []string{"http://couchbase.com", "http://staging.couchbase.com"},
 					LoginOrigin: []string{"http://couchbase.com"},
 					Headers:     []string{},
-					MaxAge:      1728000,
+					MaxAge:      perDBMaxAge,
 				},
 			},
 		},
@@ -376,6 +379,13 @@ func TestCORSOriginPerDatabase(t *testing.T) {
 					require.Equal(t, http.StatusNoContent, response.Code)
 				}
 				require.Equal(t, test.headerResponse, response.Header().Get("Access-Control-Allow-Origin"))
+				if method == http.MethodOptions {
+					if strings.Contains(test.endpoint, "{{.db}}") {
+						require.Equal(t, strconv.Itoa(perDBMaxAge), response.Header().Get("Access-Control-Max-Age"))
+					} else {
+						require.Equal(t, strconv.Itoa(rt.ServerContext().Config.API.CORS.MaxAge), response.Header().Get("Access-Control-Max-Age"))
+					}
+				}
 			}
 
 		})
@@ -388,36 +398,19 @@ func TestCORSValidation(t *testing.T) {
 	})
 	defer rt.Close()
 
-	// CORS is set to http://example.com by RestTester ServerContext
-	dbName := "corsdb"
-	dbConfig := rt.NewDbConfig()
-	dbConfig.CORS = &auth.CORSConfig{
-		MaxAge: 1000,
-	}
-	resp := rt.CreateDatabase(dbName, dbConfig)
-	RequireStatus(t, resp, http.StatusBadRequest)
-	require.Contains(t, resp.Body.String(), "max_age")
-	nonCORSDbConfig := rt.NewDbConfig()
-	resp = rt.CreateDatabase(dbName, nonCORSDbConfig)
-	RequireStatus(t, resp, http.StatusCreated)
-	resp = rt.UpsertDbConfig(dbName, dbConfig)
-	RequireStatus(t, resp, http.StatusBadRequest)
-	require.Contains(t, resp.Body.String(), "max_age")
-
-	resp = rt.ReplaceDbConfig(dbName, dbConfig)
-	RequireStatus(t, resp, http.StatusBadRequest)
-	require.Contains(t, resp.Body.String(), "max_age")
+	const dbName = "corsdb"
 
 	// make sure you are allowed to set CORS values that aren't max_age
-	originCORSDbConfig := rt.NewDbConfig()
-	originCORSDbConfig.CORS = &auth.CORSConfig{
+	CORSDbConfig := rt.NewDbConfig()
+	CORSDbConfig.CORS = &auth.CORSConfig{
 		Origin: []string{"http://example.com"},
+		MaxAge: 1000,
 	}
 
-	resp = rt.UpsertDbConfig(dbName, originCORSDbConfig)
+	resp := rt.CreateDatabase(dbName, CORSDbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	resp = rt.ReplaceDbConfig(dbName, originCORSDbConfig)
+	resp = rt.ReplaceDbConfig(dbName, CORSDbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 
 }


### PR DESCRIPTION

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

