### PR TITLE
[3.1.3 backport] CBG-3685 remove validation for max_age on a database level

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -762,10 +762,6 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		}
 	}
 
-	if dbConfig.CORS != nil && dbConfig.CORS.MaxAge != 0 {
-		multiError = multiError.Append(fmt.Errorf("cors.max_age can not be set on a database level"))
-
-	}
 	if dbConfig.DeprecatedPool != nil {
 		base.WarnfCtx(ctx, `"pool" config option is not supported. The pool will be set to "default". The option should be removed from config file.`)
 	}


### PR DESCRIPTION
backports CBG-3684 remove validation for max_age on a database level (#6608)
