### PR TITLE
CBG-3642 make sure channelCache is closed correctly in case of DCP failure to start

### DIFF
--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -70,19 +70,22 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 					continue
 				}
 				scopeFound = true
+				collectionsFound := make(map[string]struct{})
 				// should be less than or equal number of args.collections than cm.scope.collections, so iterate this way so that the inner loop completes quicker on average
 				for _, manifestCollection := range manifestScope.Collections {
-					found := false
 					for _, collectionName := range collections {
 						if collectionName != manifestCollection.Name {
 							continue
 						}
 						collectionIDs = append(collectionIDs, manifestCollection.UID)
-						found = true
-						break
+						collectionsFound[collectionName] = struct{}{}
 					}
-					if !found {
-						return RedactErrorf("collection %s not found in scope %s", MD(manifestCollection.Name), MD(manifestScope.Name))
+				}
+				if len(collectionsFound) != len(collections) {
+					for _, collectionName := range collections {
+						if _, ok := collectionsFound[collectionName]; !ok {
+							return RedactErrorf("collection %s not found in scope %s %+v", MD(collectionName), MD(manifestScope.Name), manifestScope.Collections)
+						}
 					}
 				}
 				break

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -64,19 +64,29 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 
 		// should only be one args.Scope so cheaper to iterate this way around
 		for scopeName, collections := range args.Scopes {
+			scopeFound := false
 			for _, manifestScope := range cm.Scopes {
 				if scopeName != manifestScope.Name {
 					continue
 				}
 				// should be less than or equal number of args.collections than cm.scope.collections, so iterate this way so that the inner loop completes quicker on average
 				for _, manifestCollection := range manifestScope.Collections {
+					found := false
 					for _, collectionName := range collections {
 						if collectionName != manifestCollection.Name {
 							continue
 						}
 						collectionIDs = append(collectionIDs, manifestCollection.UID)
+						found = true
+						break
+					}
+					if !found {
+						return RedactErrorf("collection %s not found in scope %s", MD(manifestCollection.Name), MD(manifestScope.Name))
 					}
 				}
+			}
+			if !scopeFound {
+				return RedactErrorf("scope %s not found", MD(scopeName))
 			}
 		}
 	}

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -69,6 +69,7 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 				if scopeName != manifestScope.Name {
 					continue
 				}
+				scopeFound = true
 				// should be less than or equal number of args.collections than cm.scope.collections, so iterate this way so that the inner loop completes quicker on average
 				for _, manifestCollection := range manifestScope.Collections {
 					found := false
@@ -84,6 +85,7 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 						return RedactErrorf("collection %s not found in scope %s", MD(manifestCollection.Name), MD(manifestScope.Name))
 					}
 				}
+				break
 			}
 			if !scopeFound {
 				return RedactErrorf("scope %s not found", MD(scopeName))

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -110,10 +110,12 @@ func (listener *changeListener) Start(ctx context.Context, bucket base.Bucket, d
 	return listener.StartMutationFeed(ctx, bucket, dbStats)
 }
 
-func (listener *changeListener) StartMutationFeed(ctx context.Context, bucket base.Bucket, dbStats *expvar.Map) error {
+func (listener *changeListener) StartMutationFeed(ctx context.Context, bucket base.Bucket, dbStats *expvar.Map) (err error) {
 
 	defer func() {
-		listener.started.Set(true)
+		if err == nil {
+			listener.started.Set(true)
+		}
 	}()
 
 	// Uses DCP by default, unless TAP is explicitly specified

--- a/db/database.go
+++ b/db/database.go
@@ -2230,6 +2230,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 		cleanupFunctions = append(cleanupFunctions, func() {
 			db.Heartbeater.Stop(ctx)
+			db.Heartbeater = nil
 		})
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -582,10 +582,8 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	context.sequences.Stop(ctx)
 	context.mutationListener.Stop(ctx)
 	context.changeCache.Stop(ctx)
-	// Stop the channel cache and it's background tasks.
-	if context.channelCache != nil {
-		context.channelCache.Stop(ctx)
-	}
+	// Stop the channel cache and its background tasks.
+	context.channelCache.Stop(ctx)
 	context.ImportListener.Stop()
 	if context.Heartbeater != nil {
 		context.Heartbeater.Stop(ctx)
@@ -2251,10 +2249,6 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	base.InfofCtx(ctx, base.KeyChanges, "Starting mutation feed on bucket %v", base.MD(db.Bucket.GetName()))
 	cacheFeedStatsMap := db.DbStats.Database().CacheFeedMapStats
 	if err := db.mutationListener.Start(ctx, db.Bucket, cacheFeedStatsMap.Map, db.Scopes, db.MetadataStore); err != nil {
-		cleanupFunctions = append(cleanupFunctions, func() {
-			db.channelCache.Stop(ctx)
-			db.channelCache = nil
-		})
 		return err
 	}
 


### PR DESCRIPTION
- If the mutation feed fails to start, the channelCache would be set to nil. Previously, this actually would leak background processes, so stop before setting to nil.
- Set channelCache to nil, because the terminator is not initialized unless changeCache is initialized.

Added validation for finding the collectionIDs in the manifest to cause StartDCPFeed to fail in the case of gocb (this already failed in rosmar).

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2233/
