### PR TITLE
standardize error reporting from persistent and non persistent config

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4367,3 +4367,14 @@ func TestDeleteDatabaseCBGTTeardown(t *testing.T) {
 		time.Sleep(1 * time.Second) // some time for polling
 	}
 }
+
+func TestDatabaseCreationErrorCode(t *testing.T) {
+	for _, persistentConfig := range []bool{true, false} {
+		rt := rest.NewRestTester(t, &rest.RestTesterConfig{PersistentConfig: persistentConfig})
+		defer rt.Close()
+
+		rt.CreateDatabase("db", rt.NewDbConfig())
+		resp := rt.SendAdminRequest(http.MethodPut, "/db/", `{"bucket": "irrelevant"}`)
+		rest.RequireStatus(t, resp, http.StatusPreconditionFailed)
+	}
+}


### PR DESCRIPTION
In this case, the non persistent config would return 500 for any errors that are already HTTPError type. This happens for errors that are not 412 duplicate DB but this was easiest to write a test for.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2234/
