### PR TITLE
CBG-3513: flaky test fix for TestCorruptDbConfigHandling

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2583,7 +2583,7 @@ func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, expecte
 	require.EqualValues(t, expectedDbNames, dbNames)
 }
 
-// ForceDbConfigsReload forces the reload db cionfiog from bucket process (like the ConfigUpdate background process)
+// ForceDbConfigsReload forces the reload db config from bucket process (like the ConfigUpdate background process)
 func (sc *ServerContext) ForceDbConfigsReload(t *testing.T, ctx context.Context) {
 	_, err := sc.fetchAndLoadConfigs(ctx, false)
 	require.NoError(t, err)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2583,6 +2583,12 @@ func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, expecte
 	require.EqualValues(t, expectedDbNames, dbNames)
 }
 
+// ForceDbConfigsReload forces the reload db cionfiog from bucket process (like the ConfigUpdate background process)
+func (sc *ServerContext) ForceDbConfigsReload(t *testing.T, ctx context.Context) {
+	_, err := sc.fetchAndLoadConfigs(ctx, false)
+	require.NoError(t, err)
+}
+
 // AllInvalidDatabaseNames returns the names of all the databases that have invalid configs. Testing only since this locks the database context.
 func (sc *ServerContext) AllInvalidDatabaseNames(_ *testing.T) []string {
 	sc.invalidDatabaseConfigTracking.m.RLock()


### PR DESCRIPTION
CBG-3513

The underlying issue was the config update interval was way too frequently creating a race between adding the invalid db config the test adds to the bucket and the overwrite of that config. Top combat this I added the following:
- Much higher config interval, essentially it is disabled of the test 
- A function for the test to manually fetch configs from bucket, so no more replying on the interval (to stop racy behaviour in the test) 
- A retry loop for fetching active database on the server context to assert on (after fixing the config), this was due to sometimes the test going too fast for the new updated/fixed db config to become 'active' on the server context. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2235/
