### PR TITLE
CBD-5711: Update 'build' SHA in 3.2.0 manifest

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="3f3d1e973566724a16060b4eb013ae5fa895308a">
+  <project name="build" path="cbbuild" remote="couchbase" revision="cedf9d4ec929eac7e61f8e86488aeac5402c8563">
     <annotation name="VERSION" value="3.2.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
CBD-5711

Brings in build script change to sort metrics_metadata.json content.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged
