### PR TITLE
Remove logging due to potential Start/Stop race condition

### DIFF
--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -299,7 +299,11 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks(c *activeReplicat
 
 // Stop stops the pull replication and waits for the sub changes goroutine to finish.
 func (apr *ActivePullReplicator) Stop() error {
+	// lock around apr.ctx which can be updated during Start method
+	apr.lock.Lock()
 	base.TracefCtx(apr.ctx, base.KeyReplicate, "Calling stop and disconnect from Stop()")
+	apr.lock.Unlock()
+
 	if err := apr.stopAndDisconnect(); err != nil {
 		return err
 	}

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -299,11 +299,6 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks(c *activeReplicat
 
 // Stop stops the pull replication and waits for the sub changes goroutine to finish.
 func (apr *ActivePullReplicator) Stop() error {
-	// lock around apr.ctx which can be updated during Start method
-	apr.lock.Lock()
-	base.TracefCtx(apr.ctx, base.KeyReplicate, "Calling stop and disconnect from Stop()")
-	apr.lock.Unlock()
-
 	if err := apr.stopAndDisconnect(); err != nil {
 		return err
 	}


### PR DESCRIPTION
I don't love this fix for https://mobile.jenkins.couchbase.com/job/sgw-unix-build/30553/consoleFull - 

I would consider just dropping this log line like we do in push, especially since it is trace only and `stopAndDisconnect` already has a lock.
 