### PR TITLE
Correct NumReplicationsActive Prometheus stat description

### DIFF
--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -247,7 +247,7 @@ const (
 
 	NumDocWritesDesc = "The total number of documents written by any means (replication, rest API interaction or imports) since Sync Gateway node startup."
 
-	NumReplicationsActiveDesc = "The total number of active replications. This metric only counts continuous pull replications."
+	NumReplicationsActiveDesc = "The total number of active replications."
 
 	NumReplicationsTotalDesc = "The total number of replications created since Sync Gateway node startup."
 


### PR DESCRIPTION
This was already fixed for the expvar description of the stat in #6289, but wasn't updated in the Prometheus stat description added in #6334

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a