### PR TITLE
Show documents that might be around after N1QL emptying fails

### DIFF
--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -46,18 +46,18 @@ func WaitForPrimaryIndexEmpty(ctx context.Context, store base.N1QLStore) error {
 	)
 	var retryError *base.RetryTimeoutError
 	if errors.As(err, &retryError) {
-		files, err := getPrimaryIndexDocuments(ctx, store, true)
+		documents, err := getPrimaryIndexDocuments(ctx, store, true)
 		if err != nil {
-			return fmt.Errorf("Error getting files from primary index: %w", err)
+			return fmt.Errorf("Error getting documents from primary index: %w", err)
 		}
-		return fmt.Errorf("Documents left behind after waiting for primary index to be emptied: %s", files)
+		return fmt.Errorf("Documents left behind after waiting for primary index to be emptied: %s", documents)
 	}
 	return err
 }
 
 // isPrimaryIndexEmpty returns true if there are no documents in the primary index
 func isPrimaryIndexEmpty(ctx context.Context, store base.N1QLStore) (bool, error) {
-	// only look for a single file to make query faster
+	// only look for a single doc to make query faster
 	docs, err := getPrimaryIndexDocuments(ctx, store, false)
 	if err != nil {
 		return false, err

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -65,7 +65,7 @@ func isPrimaryIndexEmpty(ctx context.Context, store base.N1QLStore) (bool, error
 	return len(docs) == 0, err
 }
 
-// getPrimaryIndexDocuments returs true if there are no documents in the primary index
+// getPrimaryIndexDocuments returs true if there are no documents in the primary index and returns the documents. If allDocuments is false, only check for a single document.
 func getPrimaryIndexDocuments(ctx context.Context, store base.N1QLStore, allDocuments bool) ([]string, error) {
 	// Create the star channel query
 	statement := fmt.Sprintf("SELECT META().id FROM %s", base.KeyspaceQueryToken)


### PR DESCRIPTION
In some weekly-jenkins runs we see errors like:

```
2023-12-14T21:04:28.868Z TEST: b:sg_int_1_1702585440608119514 waiting for empty bucket indexes sg_int_1_1702585440608119514._default._default
2023-12-14T21:09:16.752Z TEST: b:sg_int_1_1702585440608119514 waitForPrimaryIndexEmpty returned an error: RetryLoop for Wait for index to be empty giving up after 61 attempts
2023-12-14T21:09:16.752Z TEST: b:sg_int_1_1702585440608119514 Couldn't ready bucket, got error: RetryLoop for Wait for index to be empty giving up after 61 attempts - Retrying
2023-12-14T21:09:16.752Z [WRN] b:sg_int_1_1702585440608119514 RetryLoop for Wait for index to be empty giving up after 61 attempts -- base.RetryLoop() at util.go:460
2023-12-14T21:09:18.753Z TEST: b:sg_int_1_1702585440608119514 Running bucket through readier function
2023-12-14T21:09:18.753Z TEST: b:sg_int_1_1702585440608119514 emptying bucket via N1QL, readying views and indexes
2023-12-14T21:09:18.765Z TEST: b:sg_int_1_1702585440608119514 Bucket not empty (2 items), emptying bucket via N1QL
2023-12-14T21:09:18.783Z TEST: b:sg_int_1_1702585440608119514 Finished emptying all docs index ... Total docs purged: 0
2023-12-14T21:09:18.792Z TEST: b:sg_int_1_1702585440608119514 waiting for empty bucket indexes sg_int_1_1702585440608119514._default._default
```

You can see here that it has gone on for 61 times and is fact growing documents. https://jenkins.sgwdev.com/job/weekly-matrix/BACKING_STORE=enterprise-7.1.6,QUERY_PROVIDER=gsi-default-collection,SYNC_STORE=inline,label=sgw-amazon-linux2023/100/

In this case, the test that seems to be leaking is: `TestDbConfigPersistentSGVersions` and I have to imagine that is config files that are leaking but I don't see how this test is potentially leaking goroutines. Note, I'm modifying this test in https://github.com/couchbase/sync_gateway/pull/6622 to make it work with rosmar.

Tested by removing N1QL delete in bucketReadier and making sure we get a better log message.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`