### PR TITLE
CBG-3695 implement Couchbase Server bucket to bucket XDCR

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -68,8 +68,8 @@ type CouchbaseBucketStore interface {
 	// a map of UUIDS and a map of high sequence numbers (map from vbno -> seq)
 	GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error)
 
-	// mgmtRequest uses the CouchbaseBucketStore's http client to make an http request against a management endpoint.
-	mgmtRequest(ctx context.Context, method, uri, contentType string, body io.Reader) (*http.Response, error)
+	// MgmtRequest uses the CouchbaseBucketStore's http client to make an http request against a management endpoint.
+	MgmtRequest(ctx context.Context, method, uri, contentType string, body io.Reader) (*http.Response, error)
 }
 
 func AsCouchbaseBucketStore(b Bucket) (CouchbaseBucketStore, bool) {
@@ -452,7 +452,7 @@ func getMaxTTL(ctx context.Context, store CouchbaseBucketStore) (int, error) {
 	}
 
 	uri := fmt.Sprintf("/pools/default/buckets/%s", store.GetSpec().BucketName)
-	resp, err := store.mgmtRequest(ctx, http.MethodGet, uri, "application/json", nil)
+	resp, err := store.MgmtRequest(ctx, http.MethodGet, uri, "application/json", nil)
 	if err != nil {
 		return -1, err
 	}
@@ -473,7 +473,7 @@ func getMaxTTL(ctx context.Context, store CouchbaseBucketStore) (int, error) {
 
 // Get the Server UUID of the bucket, this is also known as the Cluster UUID
 func GetServerUUID(ctx context.Context, store CouchbaseBucketStore) (uuid string, err error) {
-	resp, err := store.mgmtRequest(ctx, http.MethodGet, "/pools", "application/json", nil)
+	resp, err := store.MgmtRequest(ctx, http.MethodGet, "/pools", "application/json", nil)
 	if err != nil {
 		return "", err
 	}
@@ -528,7 +528,7 @@ func retrievePurgeInterval(ctx context.Context, bucket CouchbaseBucketStore, uri
 		PurgeInterval float64 `json:"purgeInterval,omitempty"`
 	}
 
-	resp, err := bucket.mgmtRequest(ctx, http.MethodGet, uri, "application/json", nil)
+	resp, err := bucket.MgmtRequest(ctx, http.MethodGet, uri, "application/json", nil)
 	if err != nil {
 		return 0, err
 	}

--- a/base/collection.go
+++ b/base/collection.go
@@ -461,10 +461,9 @@ func (b *GocbV2Bucket) BucketName() string {
 	return b.GetName()
 }
 
-func (b *GocbV2Bucket) mgmtRequest(ctx context.Context, method, uri, contentType string, body io.Reader) (*http.Response, error) {
+func (b *GocbV2Bucket) MgmtRequest(ctx context.Context, method, uri, contentType string, body io.Reader) (*http.Response, error) {
 	if contentType == "" && body != nil {
-		// TODO: CBG-1948
-		panic("Content-type must be specified for non-null body.")
+		return nil, errors.New("Content-type must be specified for non-null body.")
 	}
 
 	mgmtEp, err := GoCBBucketMgmtEndpoint(b)
@@ -485,7 +484,6 @@ func (b *GocbV2Bucket) mgmtRequest(ctx context.Context, method, uri, contentType
 		username, password, _ := b.Spec.Auth.GetCredentials()
 		req.SetBasicAuth(username, password)
 	}
-
 	return b.HttpClient(ctx).Do(req)
 }
 

--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -29,6 +29,10 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: $0 [-m] [-h] containername"
             exit 1
             ;;
+        --non-dockerhub)
+            DOCKERHUB=false
+            shift
+            ;;
         *)
             COUCHBASE_DOCKER_IMAGE_NAME="$1"
             shift
@@ -59,7 +63,7 @@ docker rm ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
 # --volume: Makes and mounts a CBS folder for storing a CBCollect if needed
 
 # use dockerhub if no registry is specified, allows for pre-release images from alternative registries
-if [[ "${COUCHBASE_DOCKER_IMAGE_NAME}" != *"/"* ]]; then
+if [ "${DOCKERHUB:-}" != "false" ]; then
     COUCHBASE_DOCKER_IMAGE_NAME="couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME}"
 fi
 

--- a/xdcr/cbs_xdcr.go
+++ b/xdcr/cbs_xdcr.go
@@ -1,0 +1,185 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package xdcr
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+const (
+	cbsRemoteClustersEndpoint = "/pools/default/remoteClusters"
+	xdcrClusterName           = "sync_gateway_xdcr"
+)
+
+// couchbaseServerXDCR implements a XDCR setup cluster on Couchbase Server.
+type CouchbaseServerXDCR struct {
+	fromBucket    *base.GocbV2Bucket
+	toBucket      *base.GocbV2Bucket
+	replicationID string
+}
+
+// mgmtRequest makes a request to the Couchbase Server management API in the format for xdcr.
+func mgmtRequest(ctx context.Context, bucket *base.GocbV2Bucket, method, url string, body io.Reader) ([]byte, int, error) {
+	resp, err := bucket.MgmtRequest(ctx, method, url, "application/x-www-form-urlencoded", body)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	output, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("Could not read body from %s", url)
+	}
+	return output, resp.StatusCode, nil
+}
+
+// isClusterPresent returns true if the XDCR cluster is present, false if it is not present, and an error if it could not be determined.
+func isClusterPresent(ctx context.Context, bucket *base.GocbV2Bucket) (bool, error) {
+	method := http.MethodGet
+	url := cbsRemoteClustersEndpoint
+	output, statusCode, err := mgmtRequest(ctx, bucket, http.MethodGet, url, nil)
+	if err != nil {
+		return false, err
+	}
+	if statusCode != http.StatusOK {
+		return false, fmt.Errorf("Could not determine anything about XDCR cluster: %s. %s %s -> (%d) %s", xdcrClusterName, method, url, statusCode, output)
+	}
+	type clusterOutput struct {
+		Name string `json:"name"`
+	}
+	var clusters []clusterOutput
+	err = base.JSONUnmarshal(output, &clusters)
+	if err != nil {
+		return false, err
+	}
+	for _, cluster := range clusters {
+		if cluster.Name == xdcrClusterName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// deleteCluster deletes an XDCR cluster. The cluster must be present in order to delete it.
+func deleteCluster(ctx context.Context, bucket *base.GocbV2Bucket) error {
+	method := http.MethodDelete
+	url := "/pools/default/remoteClusters/" + xdcrClusterName
+	output, statusCode, err := mgmtRequest(ctx, bucket, method, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("Could not delete xdcr cluster: %s. %s %s -> (%d) %s", xdcrClusterName, http.MethodDelete, method, statusCode, output)
+	}
+	return nil
+}
+
+// createCluster deletes an XDCR cluster. The cluster must be present in order to delete it.
+func createCluster(ctx context.Context, bucket *base.GocbV2Bucket) error {
+	serverURL, err := url.Parse(base.UnitTestUrl())
+	if err != nil {
+		return err
+	}
+
+	method := http.MethodPost
+	body := url.Values{}
+	body.Add("name", xdcrClusterName)
+	body.Add("hostname", serverURL.Hostname())
+	body.Add("username", base.TestClusterUsername())
+	body.Add("password", base.TestClusterPassword())
+	body.Add("secure", "full")
+	url := cbsRemoteClustersEndpoint
+	output, statusCode, err := mgmtRequest(ctx, bucket, method, url, strings.NewReader(body.Encode()))
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("Could not create xdcr cluster: %s. %s %s -> (%d) %s", xdcrClusterName, method, url, statusCode, output)
+	}
+	return nil
+}
+
+// NewCouchbaseServerXDCR creates an instance of XDCR backed by Couchbase Server. This is not started until Start is called.
+func NewCouchbaseServerXDCR(ctx context.Context, fromBucket *base.GocbV2Bucket, toBucket *base.GocbV2Bucket) (*CouchbaseServerXDCR, error) {
+	isPresent, err := isClusterPresent(ctx, fromBucket)
+	if err != nil {
+		return nil, err
+
+	}
+	if isPresent {
+		err := deleteCluster(ctx, fromBucket)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = createCluster(ctx, fromBucket)
+	if err != nil {
+		return nil, err
+	}
+	return &CouchbaseServerXDCR{
+		fromBucket: fromBucket,
+		toBucket:   toBucket,
+	}, nil
+}
+
+// Start starts the XDCR replication.
+func (x *CouchbaseServerXDCR) Start(ctx context.Context) error {
+	method := http.MethodPost
+	body := url.Values{}
+	body.Add("name", xdcrClusterName)
+	body.Add("fromBucket", x.fromBucket.GetName())
+	body.Add("toBucket", x.toBucket.GetName())
+	body.Add("toCluster", xdcrClusterName)
+	body.Add("replicationType", "continuous")
+	// filters all sync docs, except binary docs (attachments)
+	body.Add("filterExpression", fmt.Sprintf("NOT REGEXP_CONTAINS(META().id, \"^%s\") OR REGEXP_CONTAINS(META().id, \"^%s\")", base.SyncDocPrefix, base.Att2Prefix))
+	url := "/controller/createReplication"
+	output, statusCode, err := mgmtRequest(ctx, x.fromBucket, method, url, strings.NewReader(body.Encode()))
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("Could not create xdcr cluster: %s. %s %s -> (%d) %s", xdcrClusterName, method, url, statusCode, output)
+	}
+	type replicationOutput struct {
+		ID string `json:"id"`
+	}
+	id := replicationOutput{}
+	err = base.JSONUnmarshal(output, &id)
+	if err != nil {
+		return err
+	}
+	x.replicationID = id.ID
+	if x.replicationID == "" {
+		return fmt.Errorf("Could not determine replication ID from output: %s", output)
+	}
+	return nil
+}
+
+// Stop starts the XDCR replication and deletes the replication from Couchbase Server.
+func (x *CouchbaseServerXDCR) Stop(ctx context.Context) error {
+	method := http.MethodDelete
+	url := "/controller/cancelXDCR/" + url.PathEscape(x.replicationID)
+	output, statusCode, err := mgmtRequest(ctx, x.fromBucket, method, url, nil)
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("Could not cancel XDCR replication: %s. %s %s -> (%d) %s", x.replicationID, method, url, statusCode, output)
+	}
+	x.replicationID = ""
+	return nil
+}

--- a/xdcr/cbs_xdcr_test.go
+++ b/xdcr/cbs_xdcr_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package xdcr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCBSXDCR(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test is testing Couchbase Server XDCR")
+	}
+	ctx := base.TestCtx(t)
+	bucket1 := base.GetTestBucket(t)
+	bucket2 := base.GetTestBucket(t)
+	defer bucket1.Close(ctx)
+	defer bucket2.Close(ctx)
+
+	fromBucket, err := base.AsGocbV2Bucket(bucket1)
+	require.NoError(t, err)
+	toBucket, err := base.AsGocbV2Bucket(bucket2)
+	require.NoError(t, err)
+
+	xdcr, err := NewCouchbaseServerXDCR(ctx, fromBucket, toBucket)
+	require.NoError(t, err)
+	err = xdcr.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, xdcr.Stop(ctx))
+	}()
+	const (
+		syncDoc       = "_sync:doc1doc2"
+		attachmentDoc = "_sync:att2:foo"
+		normalDoc     = "doc2"
+		exp           = 0
+		body          = `{"key":"value"}`
+	)
+	for _, doc := range []string{syncDoc, attachmentDoc, normalDoc} {
+		_, err = bucket1.DefaultDataStore().Add(doc, exp, body)
+		require.NoError(t, err)
+	}
+	// make sure attachments are copied
+	for _, doc := range []string{normalDoc, attachmentDoc} {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			var value string
+			_, err = bucket2.DefaultDataStore().Get(doc, &value)
+			assert.NoError(c, err, "Could not get doc %s", doc)
+			assert.Equal(c, body, value)
+		}, time.Second*5, time.Millisecond*100)
+	}
+	var value string
+	_, err = bucket2.DefaultDataStore().Get(syncDoc, &value)
+	require.True(t, base.IsKeyNotFoundError(bucket2.DefaultDataStore(), err))
+}

--- a/xdcr/main_test.go
+++ b/xdcr/main_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2020-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package xdcr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+func TestMain(m *testing.M) {
+	ctx := context.Background() // start of test process
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	base.TestBucketPoolNoIndexes(ctx, m, tbpOptions)
+}

--- a/xdcr/replication.go
+++ b/xdcr/replication.go
@@ -1,0 +1,22 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+// Package xdcr implements an XDCR between different buckets. This is meant to be used for testing.
+package xdcr
+
+import "context"
+
+// Replication represents a bucket to bucket replication.
+type Replication interface {
+	// Start starts the replication.
+	Start(context.Context) error
+	// Stop terminates the replication.
+	Stop(context.Context) error
+}
+
+var _ Replication = &CouchbaseServerXDCR{}


### PR DESCRIPTION
- allow making requests to management API public
- create xdcr as a separate package because I could, it could be a subpackage of base, or in base.
- create a basic Replication interface to be matched in rosmar
- change integration test script so I can more easily use a toy build

If you try to flush a bucket that has an active replication occuring, the flush will fail. If you delete a bucket that has an active replication, the entire XDCR API (REST/command line) will throw 500s for a bit until it catches up and you can delete the replication. Therefore, we always have to `Stop` the replication before deleting it.

The idea of a cluster in Couchbase Server XDCR is global. You need a cluster to map from A <-> B, before you can map buckets. Only one name can have `A<->B` mapping. This means that running XDCR with CBS will require `-p 1`, but we already require that for our integration tests.

Tested with toy build with some mobile XDCR support + 7.2.3.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2244/

### Setup for toy build usage:

Put `Dockerfile` and `run.sh` below in a directory. Call `run.sh` to start a server against a particular build.

**Dockerfile**
```
FROM couchbase/server

ARG DEB
COPY $DEB /tmp/$DEB
RUN apt-get install -y /tmp/$DEB
```

**run.sh**
```
#!/bin/bash

set -eux

SCRIPT_DIR=$(dirname $0)

cd $SCRIPT_DIR
FULL_PATH_DEB=http://172.23.126.166/builds/latestbuilds/couchbase-server/toybuilds/18191/couchbase-server-enterprise_7.6.0-18191-ubuntu20.04_amd64.deb
DEB=$(basename $FULL_PATH_DEB)

if [ -e $DEB ]; then
    echo "$DEB exists"
else
    http -d $FULL_PATH_DEB
fi

DOCKER_IMAGE=cbsxdcr
docker build --tag $DOCKER_IMAGE --build-arg DEB=$DEB --platform linux/amd64 .

export DOCKER_DEFAULT_PLATFORM=linux/amd64
~/repos/sync_gateway/integration-test/start_server.sh --non-dockerhub $DOCKER_IMAGE:latest
```