### PR TITLE
Jenkinsfile: Add general Coverage Jenkins plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -375,6 +375,8 @@ pipeline {
         always {
             // Publish the cobertura formatted test coverage reports into Jenkins
             cobertura autoUpdateHealth: false, onlyStable: false, autoUpdateStability: false, coberturaReportFile: 'reports/coverage-*.xml', conditionalCoverageTargets: '70, 0, 0', failNoReports: false, failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', sourceEncoding: 'ASCII', zoomCoverageChart: false
+            // record with general Coverage plugin and push coverage back out to GitHub
+            recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'reports/coverage-*.xml']])
 
             // Publish the junit test reports
             junit allowEmptyResults: true, testResults: 'reports/test-*.xml'


### PR DESCRIPTION
- Add [general Coverage Jenkins plugin](https://plugins.jenkins.io/coverage/) which can track "changed code" coverage differences better than cobetura can (which is just full-branch coverage information)
- Allows pushing already collected coverage info for modified lines back to GitHub PRs (Comments/Annotations)
  - e.g. ![](https://raw.githubusercontent.com/jenkinsci/coverage-plugin/main/images/jacoco-coverage-checks-annotations.png)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a