### PR TITLE
Jenkinsfile: Add discoverGitReferenceBuild to infer base branch for PR coverage diffing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -376,6 +376,7 @@ pipeline {
             // Publish the cobertura formatted test coverage reports into Jenkins
             cobertura autoUpdateHealth: false, onlyStable: false, autoUpdateStability: false, coberturaReportFile: 'reports/coverage-*.xml', conditionalCoverageTargets: '70, 0, 0', failNoReports: false, failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', sourceEncoding: 'ASCII', zoomCoverageChart: false
             // record with general Coverage plugin and push coverage back out to GitHub
+            discoverGitReferenceBuild() // required before recordCoverage to infer base branch/commit for PR
             recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'reports/coverage-*.xml']])
 
             // Publish the junit test reports


### PR DESCRIPTION
Described here:
https://plugins.jenkins.io/coverage/#plugin-content-selecting-a-baseline-in-the-target-job 