### PR TITLE
CBG_3645 Prereq: don't override http.DefaultClient

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1538,7 +1538,7 @@ func GetHttpClient(insecureSkipVerify bool) *http.Client {
 		transport.TLSClientConfig.InsecureSkipVerify = true
 		return &http.Client{Transport: transport}
 	}
-	return http.DefaultClient
+	return &http.Client{}
 }
 
 // Like GetHttpClient, and also turns off the NODELAY option on the underlying TCP socket.

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -108,10 +108,9 @@ func TestPublicRESTStatCount(t *testing.T) {
 
 	srv := httptest.NewServer(rt.TestMetricsHandler())
 	defer srv.Close()
-	httpClient := http.DefaultClient
 
 	// test metrics endpoint
-	response, err := httpClient.Get(srv.URL + "/_metrics")
+	response, err := http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	// assert the stat doesn't increment
@@ -2674,10 +2673,8 @@ func TestMetricsHandler(t *testing.T) {
 	srv := httptest.NewServer(rt.TestMetricsHandler())
 	defer srv.Close()
 
-	httpClient := http.DefaultClient
-
 	// Ensure metrics endpoint is accessible and that db database has entries
-	resp, err := httpClient.Get(srv.URL + "/_metrics")
+	resp, err := http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	bodyString, err := io.ReadAll(resp.Body)
@@ -2693,7 +2690,7 @@ func TestMetricsHandler(t *testing.T) {
 	defer context.Close(context.AddDatabaseLogContext(ctx))
 
 	// Validate that metrics still works with both db and db2 databases and that they have entries
-	resp, err = httpClient.Get(srv.URL + "/_metrics")
+	resp, err = http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	bodyString, err = io.ReadAll(resp.Body)
@@ -2704,7 +2701,7 @@ func TestMetricsHandler(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Ensure metrics endpoint is not serving any other routes
-	resp, err = httpClient.Get(srv.URL + "/" + rt.GetSingleKeyspace() + "/")
+	resp, err = http.Get(srv.URL + "/" + rt.GetSingleKeyspace() + "/")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	err = resp.Body.Close()

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -66,10 +66,9 @@ func TestBytesReadDocOperations(t *testing.T) {
 
 	srv := httptest.NewServer(rt.TestMetricsHandler())
 	defer srv.Close()
-	httpClient := http.DefaultClient
 
 	// test metrics endpoint, assert the stat doesn't increment
-	response, err := httpClient.Get(srv.URL + "/_metrics")
+	response, err := http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -328,7 +328,7 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 			require.NoError(t, err, "Error creating new request")
 			jar, err := cookiejar.New(nil)
 			require.NoError(t, err, "Error creating new cookie jar")
-			client := http.DefaultClient
+			client := &http.Client{}
 			client.Jar = jar
 			response, err := client.Do(request)
 			require.NoError(t, err, "Error sending request")
@@ -431,7 +431,7 @@ func TestOIDCWithBasicAuthDisabled(t *testing.T) {
 	require.NoError(t, err, "Error creating new request")
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err, "Error creating new cookie jar")
-	client := http.DefaultClient
+	client := http.Client{}
 	client.Jar = jar
 	response, err := client.Do(request)
 	require.NoError(t, err, "Error sending request")

--- a/rest/stats_context_test.go
+++ b/rest/stats_context_test.go
@@ -49,10 +49,8 @@ func TestDescriptionPopulation(t *testing.T) {
 	srv := httptest.NewServer(rt.TestMetricsHandler())
 	defer srv.Close()
 
-	httpClient := http.DefaultClient
-
 	// Ensure metrics endpoint is accessible and that db database has entries
-	resp, err := httpClient.Get(srv.URL + "/_metrics")
+	resp, err := http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 


### PR DESCRIPTION
Setting http.DefaultClient.Jar would cause anything that ran after it
to authenticate with this session token. In practice, this happens for
blip tests becuase they use guest access and the flow is:

- check basic auth
- check session
- check guest access

To be safe, I switched places that use http.DefaultClient as a global in
anything other than read-only to use http.Client{} explicitly.

At initial look, this allows {{go test -shuffle on}} to work.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2247/
