### PR TITLE
CBG-3645: Shuffle tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
@@ -99,7 +99,7 @@ jobs:
         with:
           go-version: 1.21.4
       - name: Run Tests
-        run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
@@ -141,5 +141,5 @@ jobs:
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests
-        run: go test -timeout=5m -count=1 -json -v "./tools/stats-definition-exporter" | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -shuffle=on -timeout=5m -count=1 -json -v "./tools/stats-definition-exporter" | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,7 +199,7 @@ pipeline {
                                     githubNotify(credentialsId: "${GH_ACCESS_TOKEN_CREDENTIAL}", context: 'sgw-pipeline-ce-unit-tests', description: 'CE Unit Tests Running', status: 'PENDING')
 
                                     // Build CE coverprofiles
-                                    sh '2>&1 go test -timeout=20m -coverpkg=./... -coverprofile=cover_ce.out -race -count=1 -v ./... > verbose_ce.out.raw || true'
+                                    sh '2>&1 go test -shuffle=on -timeout=20m -coverpkg=./... -coverprofile=cover_ce.out -race -count=1 -v ./... > verbose_ce.out.raw || true'
 
                                     // Print total coverage stats
                                     sh 'go tool cover -func=cover_ce.out | awk \'END{print "Total SG CE Coverage: " $3}\''
@@ -254,7 +254,7 @@ pipeline {
                                     githubNotify(credentialsId: "${GH_ACCESS_TOKEN_CREDENTIAL}", context: 'sgw-pipeline-ee-unit-tests', description: 'EE Unit Tests Running', status: 'PENDING')
 
                                     // Build EE coverprofiles
-                                    sh "2>&1 go test -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=./... -coverprofile=cover_ee.out -race -count=1 -v ./... > verbose_ee.out.raw || true"
+                                    sh "2>&1 go test -shuffle=on -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=./... -coverprofile=cover_ee.out -race -count=1 -v ./... > verbose_ee.out.raw || true"
 
                                     sh 'go tool cover -func=cover_ee.out | awk \'END{print "Total SG EE Coverage: " $3}\''
 

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -52,18 +52,21 @@ func TestRedactHelper(t *testing.T) {
 }
 
 func TestSetRedaction(t *testing.T) {
+	// reset
+	defer SetRedaction(-1)
+
+	SetRedaction(RedactNone)
+	assert.Equal(t, false, RedactUserData)
+
 	// Hits the default case
 	SetRedaction(-1)
-	assert.Equal(t, true, RedactUserData)
-
-	SetRedaction(RedactFull)
 	assert.Equal(t, true, RedactUserData)
 
 	SetRedaction(RedactPartial)
 	assert.Equal(t, true, RedactUserData)
 
-	SetRedaction(RedactNone)
-	assert.Equal(t, false, RedactUserData)
+	SetRedaction(RedactFull)
+	assert.Equal(t, true, RedactUserData)
 }
 
 func TestRedactionLevelMarshalText(t *testing.T) {

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -107,9 +107,9 @@ fi
 
 if [ "${RUN_WALRUS}" == "true" ]; then
     # EE
-    go test -shuffle=on -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
+    go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
     # CE
-    go test -shuffle=on -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ce.out.raw 2>&1 | true
+    go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ce.out.raw 2>&1 | true
 fi
 
 # Run CBS
@@ -135,7 +135,7 @@ if [ "${SG_EDITION}" == "EE" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_enterprise"
 fi
 
-go test -shuffle=on ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
+go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
 if [ "${PIPESTATUS[0]}" -ne "0" ]; then # If test exit code is not 0 (failed)
     echo "Go test failed! Parsing logs to find cause..."
     TEST_FAILED=true

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -107,9 +107,9 @@ fi
 
 if [ "${RUN_WALRUS}" == "true" ]; then
     # EE
-    go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
+    go test -shuffle=on -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
     # CE
-    go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ce.out.raw 2>&1 | true
+    go test -shuffle=on -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ce.out.raw 2>&1 | true
 fi
 
 # Run CBS
@@ -135,7 +135,7 @@ if [ "${SG_EDITION}" == "EE" ]; then
     GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_enterprise"
 fi
 
-go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
+go test -shuffle=on ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'
 if [ "${PIPESTATUS[0]}" -ne "0" ]; then # If test exit code is not 0 (failed)
     echo "Go test failed! Parsing logs to find cause..."
     TEST_FAILED=true

--- a/test.sh
+++ b/test.sh
@@ -55,10 +55,10 @@ doTest () {
     if [[ "$SG_TEST_PACKAGE" != "" ]]; then
         IFS=',' read -ra TEST <<< "$SG_TEST_PACKAGE"
         for i in "${TEST[@]}"; do
-            go test ${buildTags} "${@:2}" $EXTRA_FLAGS github.com/couchbase/sync_gateway/$i
+            go test -shuffle=on ${buildTags} "${@:2}" $EXTRA_FLAGS github.com/couchbase/sync_gateway/$i
         done
     else
-        go test ${buildTags} "${@:2}" $EXTRA_FLAGS github.com/couchbase/sync_gateway/...
+        go test -shuffle=on ${buildTags} "${@:2}" $EXTRA_FLAGS github.com/couchbase/sync_gateway/...
     fi
 
 }

--- a/test_with_coverage.sh
+++ b/test_with_coverage.sh
@@ -25,17 +25,17 @@ set -e
 set -x
 
 echo "Running Sync Gateway unit tests against Walrus"
-SG_TEST_USE_XATTRS="false" SG_TEST_BACKING_STORE=Walrus gocoverutil -coverprofile=cover_sg.out test -v "$@" -covermode=count ./...
+SG_TEST_USE_XATTRS="false" SG_TEST_BACKING_STORE=Walrus gocoverutil -coverprofile=cover_sg.out test -shuffle=on -v "$@" -covermode=count ./...
 go tool cover -html=cover_sg.out -o cover_sg.html
 
 echo "Running Sync Gateway integration unit tests (XATTRS=false)"
 echo "Integration mode: tests to run in serial across packages by default using gocoverutil"
-SG_TEST_USE_XATTRS="false" SG_TEST_BACKING_STORE=Couchbase gocoverutil -coverprofile=cover_sg_integration_xattrs_false.out test -v "$@" -covermode=count ./...
+SG_TEST_USE_XATTRS="false" SG_TEST_BACKING_STORE=Couchbase gocoverutil -coverprofile=cover_sg_integration_xattrs_false.out test -shuffle=on -v "$@" -covermode=count ./...
 go tool cover -html=cover_sg_integration_xattrs_false.out -o cover_sg_integration_xattrs_false.html
 
 echo "Running Sync Gateway integration unit tests (XATTRS=true)"
 echo "Integration mode: tests to run in serial across packages by default using gocoverutil"
-SG_TEST_USE_XATTRS="true" SG_TEST_BACKING_STORE=Couchbase gocoverutil -coverprofile=cover_sg_integration_xattrs_true.out test -v "$@" -covermode=count ./...
+SG_TEST_USE_XATTRS="true" SG_TEST_BACKING_STORE=Couchbase gocoverutil -coverprofile=cover_sg_integration_xattrs_true.out test -shuffle=on -v "$@" -covermode=count ./...
 go tool cover -html=cover_sg_integration_xattrs_true.out -o cover_sg_integration_xattrs_true.html
 
 


### PR DESCRIPTION
CBG-3645

- Randomises test order for CI (GitHub Actions and Dev Jenkins pipeline)
- Does not change order for Integration tests or mobile builds
- Fix `TestSetRedaction` not resetting redaction global after running

```
-shuffle off,on,N
        Randomize the execution order of tests and benchmarks.
        It is off by default. If -shuffle is set to on, then it will seed
        the randomizer using the system clock. If -shuffle is set to an
        integer N, then N will be used as the seed value. In both cases,
        the seed will be reported for reproducibility.
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a