### PR TITLE
CBG-3701 lock on RegisterImportPindexImpl

### DIFF
--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -14,15 +14,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/couchbase/cbgt"
 	"github.com/couchbase/sync_gateway/base"
 )
 
+// registerImportPindexImplMutex locks access to cbgt.RegisterImportPindexImpl.
+var registerImportPindexImplMutex = sync.Mutex{}
+
 // RegisterImportPindexImpl registers the PIndex type definition.  This is invoked by cbgt when a Pindex (collection of
 // vbuckets) is assigned to this node.
-
 func RegisterImportPindexImpl(ctx context.Context, configGroup string) {
+	registerImportPindexImplMutex.Lock()
+	defer registerImportPindexImplMutex.Unlock()
 
 	// Since RegisterPIndexImplType is a global var without synchronization, index type needs to be
 	// config group scoped.  The associated importListener within the context is retrieved based on the


### PR DESCRIPTION
This causes a race condition in the instance that two databases with the same config group are created simultaneously. An example of how this can happen is:

- config polling to pick up a db config A
- GET /dbA/

The second will independently attempt to load the configuration while the first is running. In theory, this could happen for any different database in step 2, since all databases will be in the same group id.

Tested on `TestDbConfigPersistentSGVersions` by tweaking `config.Bootstrap.UpdateFrequency` to 10ms. This slows down tests, but does reproduce the data race locally.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
