### PR TITLE
CBG-3686 add idle kv ops stat

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -333,8 +333,9 @@ func (cc *CouchbaseCluster) GetMetadataDocument(ctx context.Context, location, d
 
 	defer teardown()
 
+	cas, err = cc.configPersistence.loadConfig(ctx, b.DefaultCollection(), docID, valuePtr)
 	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
-	return cc.configPersistence.loadConfig(ctx, b.DefaultCollection(), docID, valuePtr)
+	return cas, err
 }
 
 func (cc *CouchbaseCluster) InsertMetadataDocument(ctx context.Context, location, key string, value interface{}) (newCAS uint64, err error) {

--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -333,6 +333,7 @@ func (cc *CouchbaseCluster) GetMetadataDocument(ctx context.Context, location, d
 
 	defer teardown()
 
+	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	return cc.configPersistence.loadConfig(ctx, b.DefaultCollection(), docID, valuePtr)
 }
 

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -280,9 +280,9 @@ func (h *couchbaseHeartBeater) checkStaleHeartbeats(ctx context.Context) error {
 			continue
 		}
 
-		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 		timeoutDocID := heartbeatTimeoutDocID(heartbeatNodeUUID, h.keyPrefix)
 		_, _, err := h.datastore.GetRaw(timeoutDocID)
+		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 		if err != nil {
 			if !IsKeyNotFoundError(h.datastore, err) {
 				// unexpected error
@@ -308,8 +308,8 @@ func (h *couchbaseHeartBeater) sendHeartbeat() error {
 
 	docID := heartbeatTimeoutDocID(h.nodeUUID, h.keyPrefix)
 
-	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	_, touchErr := h.datastore.Touch(docID, h.heartbeatExpirySeconds)
+	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	if touchErr == nil {
 		h.sendCount++
 		return nil
@@ -317,9 +317,9 @@ func (h *couchbaseHeartBeater) sendHeartbeat() error {
 
 	// On KeyNotFound, recreate heartbeat timeout doc
 	if IsKeyNotFoundError(h.datastore, touchErr) {
-		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 		heartbeatDocBody := []byte(h.nodeUUID)
 		setErr := h.datastore.SetRaw(docID, h.heartbeatExpirySeconds, nil, heartbeatDocBody)
+		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 		if setErr != nil {
 			return setErr
 		}
@@ -468,8 +468,8 @@ func (dh *documentBackedListener) updateNodeList(ctx context.Context, nodeID str
 
 func (dh *documentBackedListener) loadNodeIDs() error {
 
-	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	docBytes, cas, err := dh.datastore.GetRaw(dh.nodeListKey)
+	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	if err != nil {
 		dh.cas = 0
 		dh.nodeIDs = []string{}

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -280,6 +280,7 @@ func (h *couchbaseHeartBeater) checkStaleHeartbeats(ctx context.Context) error {
 			continue
 		}
 
+		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 		timeoutDocID := heartbeatTimeoutDocID(heartbeatNodeUUID, h.keyPrefix)
 		_, _, err := h.datastore.GetRaw(timeoutDocID)
 		if err != nil {
@@ -307,6 +308,7 @@ func (h *couchbaseHeartBeater) sendHeartbeat() error {
 
 	docID := heartbeatTimeoutDocID(h.nodeUUID, h.keyPrefix)
 
+	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	_, touchErr := h.datastore.Touch(docID, h.heartbeatExpirySeconds)
 	if touchErr == nil {
 		h.sendCount++
@@ -315,6 +317,7 @@ func (h *couchbaseHeartBeater) sendHeartbeat() error {
 
 	// On KeyNotFound, recreate heartbeat timeout doc
 	if IsKeyNotFoundError(h.datastore, touchErr) {
+		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 		heartbeatDocBody := []byte(h.nodeUUID)
 		setErr := h.datastore.SetRaw(docID, h.heartbeatExpirySeconds, nil, heartbeatDocBody)
 		if setErr != nil {
@@ -465,6 +468,7 @@ func (dh *documentBackedListener) updateNodeList(ctx context.Context, nodeID str
 
 func (dh *documentBackedListener) loadNodeIDs() error {
 
+	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	docBytes, cas, err := dh.datastore.GetRaw(dh.nodeListKey)
 	if err != nil {
 		dh.cas = 0

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -95,7 +95,6 @@ func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 		return 0, fmt.Errorf("cfg_sg: key cannot start with a colon")
 	}
 
-	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	bucketKey := c.sgCfgBucketKey(cfgKey)
 	casOut, err := c.datastore.WriteCas(bucketKey, 0, 0, cas, val, 0)
 

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -95,8 +95,8 @@ func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 		return 0, fmt.Errorf("cfg_sg: key cannot start with a colon")
 	}
 
+	SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 	bucketKey := c.sgCfgBucketKey(cfgKey)
-
 	casOut, err := c.datastore.WriteCas(bucketKey, 0, 0, cas, val, 0)
 
 	if IsCasMismatch(err) {

--- a/base/stats.go
+++ b/base/stats.go
@@ -79,10 +79,11 @@ const (
 	StatFormatDuration = "duration"
 	StatFormatBool     = "bool"
 
-	StatAddedVersion3dot0dot0 = "3.0.0"
-	StatAddedVersion3dot1dot0 = "3.1.0"
-	StatAddedVersion3dot1dot2 = "3.1.2"
-	StatAddedVersion3dot2dot0 = "3.2.0"
+	StatAddedVersion3dot0dot0     = "3.0.0"
+	StatAddedVersion3dot1dot0     = "3.1.0"
+	StatAddedVersion3dot1dot2     = "3.1.2"
+	StatAddedVersion3dot1dot3dot1 = "3.1.3.1"
+	StatAddedVersion3dot2dot0     = "3.2.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
 	StatDeprecatedVersion3dot2dot0     = "3.2.0"
@@ -274,6 +275,10 @@ func (g *GlobalStat) initResourceUtilizationStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.NumIdleKvOps, err = NewIntStat(SubsystemDatabaseKey, "num_idle_kv_ops", StatUnitNoUnits, NumIdleKvOpsDesc, StatAddedVersion3dot1dot3dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 
 	resUtil.Uptime, err = NewDurStat(ResourceUtilizationSubsystem, "uptime", StatUnitNanoseconds, UptimeDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, time.Now())
 	if err != nil {
@@ -327,6 +332,9 @@ type ResourceUtilization struct {
 
 	// The node CPU usage calculation based values from /proc of user + system since the last time this function was called.
 	NodeCpuPercentUtil *SgwFloatStat `json:"node_cpu_percent_utilization"`
+
+	// The number of background kv operations.
+	NumIdleKvOps *SgwIntStat `json:"idle_kv_ops"`
 
 	// The memory utilization (Resident Set Size) for the process, in bytes.
 	ProcessMemoryResident *SgwIntStat `json:"process_memory_resident"`

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -291,6 +291,8 @@ const (
 	PublicRestBytesReadDesc = "The total amount of bytes read over the public REST api"
 
 	SyncProcessComputeDesc = "The compute unit for syncing with clients measured through cpu time and memory used for sync"
+
+	NumIdleKvOpsDesc = "The total number of idle kv operations."
 )
 
 // Delta Sync stats descriptions

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -135,6 +135,9 @@ ExpVars:
                 num_goroutines:
                   type: integer
                   description: "The total number of goroutines."
+                num_idle_kv_ops:
+                  type: integer
+                  description: "The total number of idle kv operations."
                 process_cpu_percent_utilization:
                   type: number
                   format: float


### PR DESCRIPTION
Setup up two SG nodes in two modes and compared stat on server for idle ops:

- ISGR between two nodes with different couchbase servers
- two nodes serving same database (to shard DCP)

`CfgSg` operations will only show up if there's multiple SGs.

I had uncertainty about what level to put the calls, especially `GetMetadataDocument`. In this case, some idle operations are going to get called. I could move this to the bootstrap polling when we call `GetDatabaseConfigs`. On the other hand, I could move this into `config_persistentence.go` and cover xattr and non xattr case.

For heartbeater, I put the Get cases, but not the updating the node lists, which presumably happens on a rebalance. I think this is most correct.

For `CfgSg`, I added for Get operations, since again `Set` will happen for ISGR or cbgt DCP rebalance.

The concerns I have are as follows:

- It is really easy to regress on this behavior because I did manual testing only and if we change pathways of code, this will break.
- I think overcounting is OK when we are doing other operations (like updating a configuration file), because then it won't register as idle anyway, there will be more CRUD operations.
- We are going to call this stat function a few times a second - is this updating the stat too frequently? I think it's fine because it is an atomic.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
