### PR TITLE
CBG-3704 add basic Couchbase Server stats for XDCR

### DIFF
--- a/xdcr/cbs_xdcr_test.go
+++ b/xdcr/cbs_xdcr_test.go
@@ -59,7 +59,18 @@ func TestCBSXDCR(t *testing.T) {
 			assert.Equal(c, body, value)
 		}, time.Second*5, time.Millisecond*100)
 	}
-	var value string
+
+	var value any
 	_, err = bucket2.DefaultDataStore().Get(syncDoc, &value)
 	require.True(t, base.IsKeyNotFoundError(bucket2.DefaultDataStore(), err))
+
+	// stats are not updated in real time, so we need to wait a bit
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		stats, err := xdcr.Stats(ctx)
+		assert.NoError(t, err)
+		assert.Equal(c, uint64(1), stats.DocsFiltered)
+		assert.Equal(c, uint64(2), stats.DocsWritten)
+
+	}, time.Second*5, time.Millisecond*100)
+
 }

--- a/xdcr/replication.go
+++ b/xdcr/replication.go
@@ -17,6 +17,8 @@ type Replication interface {
 	Start(context.Context) error
 	// Stop terminates the replication.
 	Stop(context.Context) error
+	// Stats returns the stats for the replication.
+	Stats(context.Context) (*Stats, error)
 }
 
 var _ Replication = &CouchbaseServerXDCR{}

--- a/xdcr/stats.go
+++ b/xdcr/stats.go
@@ -1,0 +1,17 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package xdcr
+
+// Stats represents the stats of a replication.
+type Stats struct {
+	// DocsFiltered is the number of documents that have been filtered out and have not been replicated to the target cluster.
+	DocsFiltered uint64
+	// DocsWritten is the number of documents written to the destination cluster, since the start or resumption of the current replication.
+	DocsWritten uint64 // json:"docs_written"`
+}


### PR DESCRIPTION
- Wrote a server metrics method on a bucket level to get `:8091/metrics`. It isn't inherently a bucket operation, but we have a bucket and we need the Bucket Spec to make the correct HTTP auth.
- Discovered that the output is not parseable by the standard prometheus libraries due to MB-43772. None of the duplicates are on data that we care about.
- Get some metrics for XDCR of `DocsWritten` and `DocsFiltered`.

The following metrics are available, but none of them seemed immediately useful:

- xdcr_add_docs_written_total
- xdcr_binary_filtered_total
- xdcr_changes_left_total
- xdcr_data_merged_bytes
- xdcr_data_replicated_bytes
- xdcr_datapool_failed_gets_total
- xdcr_dcp_datach_length_total
- xdcr_dcp_dispatch_time_seconds
- xdcr_deletion_cloned_total
- xdcr_deletion_docs_written_total
- xdcr_deletion_failed_cr_source_total
- xdcr_deletion_filtered_total
- xdcr_deletion_received_from_dcp_total
- xdcr_docs_checked_total
- xdcr_docs_cloned_total
- xdcr_docs_failed_cr_source_total
- xdcr_docs_failed_cr_target_total
- xdcr_docs_filtered_total
- xdcr_docs_merged_total
- xdcr_docs_opt_repd_total
- xdcr_docs_processed_total
- xdcr_docs_received_from_dcp_total
- xdcr_docs_unable_to_filter_total
- xdcr_docs_written_total
- xdcr_expiry_docs_merged_total
- xdcr_expiry_docs_written_total
- xdcr_expiry_failed_cr_source_total
- xdcr_expiry_filtered_total
- xdcr_expiry_received_from_dcp_total
- xdcr_expiry_stripped_total
- xdcr_num_checkpoints_total
- xdcr_num_failedckpts_total
- xdcr_pipeline_errors
- xdcr_pipeline_status
- xdcr_resp_wait_time_seconds
- xdcr_set_docs_written_total
- xdcr_set_failed_cr_source_total
- xdcr_set_filtered_total
- xdcr_set_received_from_dcp_total
- xdcr_size_rep_queue_bytes
- xdcr_target_docs_skipped_total
- xdcr_target_eaccess_total
- xdcr_target_tmpfail_total
- xdcr_throttle_latency_seconds
- xdcr_throughput_throttle_latency_seconds
- xdcr_time_committing_seconds
- xdcr_wtavg_docs_latency_seconds
- xdcr_wtavg_get_doc_latency_seconds
- xdcr_wtavg_merge_latency_seconds
- xdcr_wtavg_meta_latency_seconds


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2261/