### PR TITLE
Use rt.Run so testing.T doesn't panic

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -123,7 +123,7 @@ func TestCheckPermissions(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, testCase := range testCases {
-		t.Run(testCase.Name, func(t *testing.T) {
+		rt.Run(testCase.Name, func(t *testing.T) {
 			if testCase.CreateUser != "" {
 				MakeUser(t, httpClient, eps[0], testCase.CreateUser, testCase.CreatePassword, testCase.CreateRoles)
 				defer DeleteUser(t, httpClient, eps[0], testCase.CreateUser)
@@ -415,7 +415,7 @@ func TestAdminAuth(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		t.Run(testCase.Name, func(t *testing.T) {
+		rt.Run(testCase.Name, func(t *testing.T) {
 			if testCase.CreateUser != "" {
 				MakeUser(t, httpClient, managementEndpoints[0], testCase.CreateUser, testCase.CreatePassword, testCase.CreateRoles)
 				defer DeleteUser(t, httpClient, managementEndpoints[0], testCase.CreateUser)
@@ -875,7 +875,7 @@ func TestAdminAPIAuth(t *testing.T) {
 			body = endPoint.body
 		}
 
-		t.Run(endPoint.Method+endPoint.Endpoint, func(t *testing.T) {
+		rt.Run(endPoint.Method+endPoint.Endpoint, func(t *testing.T) {
 			resp := rt.SendAdminRequest(endPoint.Method, endPoint.Endpoint, body)
 			RequireStatus(t, resp, http.StatusUnauthorized)
 			require.Contains(t, resp.Body.String(), ErrLoginRequired.Message)
@@ -968,7 +968,7 @@ func TestDisablePermissionCheck(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		t.Run(testCase.Name, func(t *testing.T) {
+		rt.Run(testCase.Name, func(t *testing.T) {
 			if testCase.EEOnly && serverIsCE {
 				t.Skip("This test case only works against Couchbase Server EE")
 			}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -82,7 +82,7 @@ func TestCollectionsPutDocInKeyspace(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		rt.Run(test.name, func(t *testing.T) {
 			if test.requireCollections {
 				base.TestRequiresCollections(t)
 			}

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -257,7 +257,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
+		rt.Run(testCase.name, func(t *testing.T) {
 
 			version := rt.CreateTestDoc(testCase.docID)
 
@@ -484,7 +484,7 @@ func TestAddingAttachment(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		t.Run(testCase.name, func(tt *testing.T) {
+		rt.Run(testCase.name, func(tt *testing.T) {
 			version := rt.CreateTestDoc(testCase.docName)
 
 			attachmentBody := base64.StdEncoding.EncodeToString(make([]byte, testCase.byteSize))

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -121,7 +121,7 @@ func TestBlipGetCollections(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
+			rt.Run(testCase.name, func(t *testing.T) {
 				getCollectionsRequest, err := db.NewGetCollectionsMessage(testCase.requestBody)
 				require.NoError(t, err)
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2402,7 +2402,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 		changes.Last_Seq = "0"
 
 		for i, test := range testCases {
-			t.Run(test.name, func(t *testing.T) {
+			rt.Run(test.name, func(t *testing.T) {
 				docID := fmt.Sprintf("test%d", i)
 				rawBody, err := json.Marshal(test.inputBody)
 				require.NoError(t, err)
@@ -2928,7 +2928,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 			},
 		}
 		for i, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
+			rt.Run(testCase.name, func(t *testing.T) {
 				docID := fmt.Sprintf("doc%d,", i)
 				markerDoc := fmt.Sprintf("markerDoc%d", i)
 				validBody := `{"foo":"bar"}`

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -938,7 +938,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}]}`,
 	}
 
-	t.Run("grant via existing channel", func(t *testing.T) {
+	rt.Run("grant via existing channel", func(t *testing.T) {
 		changes, err = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "alice", false)
 		require.NoError(t, err, "Error retrieving changes results for alice")
 		for index, result := range changes.Results {
@@ -948,7 +948,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		}
 	})
 
-	t.Run("grant via new channel", func(t *testing.T) {
+	rt.Run("grant via new channel", func(t *testing.T) {
 		changes, err = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "bernard", false)
 		require.NoError(t, err, "Error retrieving changes results for bernard")
 		for index, result := range changes.Results {
@@ -2838,7 +2838,7 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 
 	for _, test := range changesLimitTests {
 
-		t.Run(test.name, func(t *testing.T) {
+		rt.Run(test.name, func(t *testing.T) {
 			testDb.Options.CacheOptions.ChannelQueryLimit = test.queryLimit
 
 			// Create user

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -271,7 +271,7 @@ func TestCORSUserNoAccess(t *testing.T) {
 	RequireStatus(t, response, http.StatusCreated)
 
 	for _, endpoint := range []string{"/{{.db}}/", "/notadb/"} {
-		t.Run(endpoint, func(t *testing.T) {
+		rt.Run(endpoint, func(t *testing.T) {
 			reqHeaders := map[string]string{
 				"Origin": "http://couchbase.com",
 			}
@@ -369,7 +369,7 @@ func TestCORSOriginPerDatabase(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
+		rt.Run(test.name, func(t *testing.T) {
 			reqHeaders := map[string]string{
 				"Origin": test.origin,
 			}
@@ -452,7 +452,7 @@ func TestCORSBlipSync(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
+		rt.Run(test.name, func(t *testing.T) {
 
 			spec := getDefaultBlipTesterSpec()
 			spec.origin = test.origin
@@ -484,7 +484,7 @@ func TestCORSBlipSyncStar(t *testing.T) {
 	require.NoError(t, rt.SetAdminParty(true))
 	urls := []string{"http://example.com", "http://example2.com", "https://example.com"}
 	for _, url := range urls {
-		t.Run(url, func(t *testing.T) {
+		rt.Run(url, func(t *testing.T) {
 			spec := getDefaultBlipTesterSpec()
 			spec.origin = &url
 			_, err := createBlipTesterWithSpec(t, spec, rt)
@@ -514,7 +514,7 @@ func TestCORSBlipNoConfig(t *testing.T) {
 
 	urls := []string{"http://example.com", "http://example2.com", "https://example.com"}
 	for _, url := range urls {
-		t.Run(url, func(t *testing.T) {
+		rt.Run(url, func(t *testing.T) {
 			spec := getDefaultBlipTesterSpec()
 			spec.origin = &url
 			_, err := createBlipTesterWithSpec(t, spec, rt)

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -106,7 +106,7 @@ func TestDocumentNumbers(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	for _, test := range tests {
-		t.Run(test.name, func(ts *testing.T) {
+		rt.Run(test.name, func(ts *testing.T) {
 			// Create document
 			response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+test.name, test.body)
 			RequireStatus(ts, response, 201)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -169,7 +169,7 @@ func TestValidateReplicationAPI(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		rt.Run(test.name, func(t *testing.T) {
 			test.config.CollectionsEnabled = !rt.GetDatabase().OnlyDefaultCollection()
 			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.db}}/_replication/%s", test.ID), rest.MarshalConfig(t, test.config))
 			rest.RequireStatus(t, response, test.expectedResponseCode)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2295,7 +2295,7 @@ func TestRevocationMessage(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			t.Run(testCase.Name, func(t *testing.T) {
+			rt.Run(testCase.Name, func(t *testing.T) {
 				// Verify the deleted property in the changes message is "2" this indicated a revocation
 				for _, msg := range messages {
 					if msg.Properties[db.BlipProfile] == db.MessageChanges {

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -240,7 +240,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
+		rt.Run(testCase.name, func(t *testing.T) {
 			response = rt.SendAdminRequest("GET", "/db/_user/?"+paramNameOnly+"=false&"+paramLimit+"="+testCase.limit, "")
 			RequireStatus(t, response, 200)
 			err = json.Unmarshal(response.Body.Bytes(), &responseUsers)

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -189,7 +189,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		t.Run(test.input, func(t *testing.T) {
+		rt.Run(test.input, func(t *testing.T) {
 			output, err := rt.templateResource(test.input)
 			if test.errString == "" {
 				require.NoError(t, err)
@@ -243,7 +243,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		t.Run("dbone_"+test.input, func(t *testing.T) {
+		rt.Run("dbone_"+test.input, func(t *testing.T) {
 			output, err := rt.templateResource(test.input)
 			if test.errString == "" {
 				require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		t.Run("twodb_"+test.input, func(t *testing.T) {
+		rt.Run("twodb_"+test.input, func(t *testing.T) {
 			output, err := rt.templateResource(test.input)
 			if test.errString == "" {
 				require.NoError(t, err)


### PR DESCRIPTION
Fixes an issue of  

```
testing.go:1490: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```

in a few places.