### PR TITLE
lint: gocritic: Enable ruleguard for non-strict lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,44 @@ linters-settings:
     enable:
       - fieldalignment # detect Go structs that would take less memory if their fields were sorted
   gocritic:
+    enabled-checks:
+      # start defaults
+      - appendAssign
+      - argOrder
+      - assignOp
+      - badCall
+      - badCond
+      - captLocal
+      - caseOrder
+      - codegenComment
+      - commentFormatting
+      - defaultCaseOrder
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - elseif
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - ifElseChain
+      - mapKey
+      - newDeref
+      - offBy1
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - sloppyTypeAssert
+      - switchTrue
+      - typeSwitchVar
+      - underef
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      # end defaults
+      - ruleguard
     settings:
       ruleguard:
         rules: '${configDir}/ruleguard/*.go'

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -237,8 +237,9 @@ func TestIndexMeta(t *testing.T) {
 
 	// Check index state pre-creation
 	exists, meta, err := n1qlStore.GetIndexMeta(ctx, "testIndex_value")
+	require.NoError(t, err, "Error getting meta for non-existent index")
 	assert.False(t, exists)
-	assert.NoError(t, err, "Error getting meta for non-existent index")
+	assert.Nil(t, meta)
 
 	indexExpression := "val"
 	err = n1qlStore.CreateIndex(ctx, "testIndex_value", indexExpression, "", testN1qlOptions)
@@ -260,9 +261,9 @@ func TestIndexMeta(t *testing.T) {
 
 	// Check index state post-creation
 	exists, meta, err = n1qlStore.GetIndexMeta(ctx, "testIndex_value")
+	require.NoError(t, err, "Error retrieving index state")
 	assert.True(t, exists)
 	assert.Equal(t, "online", meta.State)
-	assert.NoError(t, err, "Error retrieving index state")
 }
 
 // Ensure that n1ql query errors are handled and returned (and don't result in panic etc)

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -26,9 +26,6 @@ var testN1qlOptions = &N1qlIndexOptions{
 
 func TestN1qlQuery(t *testing.T) {
 
-	// Disabled due to CBG-755:
-	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
-
 	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
@@ -138,9 +135,6 @@ func TestN1qlQuery(t *testing.T) {
 
 func TestN1qlFilterExpression(t *testing.T) {
 
-	// Disabled due to CBG-755:
-	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
-
 	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
@@ -216,9 +210,6 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 // Test index state retrieval
 func TestIndexMeta(t *testing.T) {
-
-	// Disabled due to CBG-755:
-	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
 
 	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -112,13 +112,14 @@ func TestN1qlQuery(t *testing.T) {
 		assert.True(t, queryResult.Val > 2, "Query returned unexpected result")
 		count++
 	}
+	assert.NoError(t, queryCloseErr, "Unexpected error closing query results")
 
 	// Requery the index, validate empty resultset behaviour
 	params = make(map[string]interface{})
 	params["minvalue"] = 10
 
 	queryResults, queryErr = n1qlStore.Query(ctx, queryExpression, params, RequestPlus, false)
-	assert.NoError(t, queryErr, "Error executing n1ql query")
+	require.NoError(t, queryErr, "Error executing n1ql query")
 
 	count = 0
 	for {


### PR DESCRIPTION
- Avoids this warning for the non-strict lint config, which didn't have ruleguard enabled by default:
```
$ golangci-lint run
WARN [linters_context] gocritic: settings were provided for not enabled check "ruleguard"
```
- Also have to explicitly list the set of default enabled checks.
- Fixed lint errors that have somehow only just started to appear

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a