### PR TITLE
implement body.Close checker

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -13,7 +13,7 @@ run:
 
 linters:
   enable:
-    #- bodyclose # checks whether HTTP response body is closed successfully
+    - bodyclose # checks whether HTTP response body is closed successfully
     #- dupl # Tool for code clone detection
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     #- goconst # Finds repeated strings that could be replaced by a constant
@@ -59,7 +59,6 @@ linters:
     - whitespace # Tool for detection of leading and trailing whitespace
     - wsl # Whitespace Linter - Forces you to use empty lines!
     # Once fixed, should enable
-    - bodyclose # checks whether HTTP response body is closed successfully
     - deadcode # Finds unused code
     - dupl # Tool for code clone detection
     - goconst # Finds repeated strings that could be replaced by a constant

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -555,13 +555,6 @@ func retrievePurgeInterval(ctx context.Context, bucket CouchbaseBucketStore, uri
 	return time.Duration(purgeIntervalHours) * time.Hour, nil
 }
 
-func ensureBodyClosed(ctx context.Context, body io.ReadCloser) {
-	err := body.Close()
-	if err != nil {
-		DebugfCtx(ctx, KeyBucket, "Failed to close socket: %v", err)
-	}
-}
-
 // AsViewStore returns a ViewStore if the underlying dataStore implements ViewStore.
 func AsViewStore(ds DataStore) (sgbucket.ViewStore, bool) {
 	viewStore, ok := ds.(sgbucket.ViewStore)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -83,7 +83,12 @@ func putDDocForTombstones(ctx context.Context, name string, payload []byte, capi
 		return err
 	}
 
-	defer ensureBodyClosed(ctx, resp.Body)
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			DebugfCtx(ctx, KeyBucket, "Failed to close socket: %v", err)
+		}
+	}()
 	if resp.StatusCode != 201 {
 		data, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3865,6 +3865,7 @@ func setServerPurgeInterval(t *testing.T, rt *rest.RestTester, newPurgeInterval 
 
 	resp, err := httpClient.Do(req)
 	require.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
 
 	require.Equal(t, resp.StatusCode, http.StatusOK)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -112,6 +112,7 @@ func TestPublicRESTStatCount(t *testing.T) {
 	// test metrics endpoint
 	response, err := http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	// assert the stat doesn't increment
 	base.RequireWaitForStat(t, func() int64 {

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -71,6 +71,7 @@ func TestBytesReadDocOperations(t *testing.T) {
 	response, err := http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, response.StatusCode)
+	require.NoError(t, response.Body.Close())
 
 	base.RequireWaitForStat(t, func() int64 {
 		return rt.GetDatabase().DbStats.DatabaseStats.PublicRestBytesRead.Value()

--- a/rest/functionsapitest/graphql_queries_test.go
+++ b/rest/functionsapitest/graphql_queries_test.go
@@ -11,6 +11,7 @@ package functionsapitest
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -37,8 +38,8 @@ func TestGraphQLQueryAdminOnly(t *testing.T) {
 	t.Run("AsAdmin - getUser", func(t *testing.T) {
 		t.Run("POST request", func(t *testing.T) {
 			response := rt.SendAdminRequest("POST", "/db/_graphql", `{"query": "query($id:ID!){ getUser(id:$id) { id , name } }" , "variables": {"id": 1}}`)
-			assert.Equal(t, 200, response.Result().StatusCode)
-			assert.Equal(t, `{"data":{"getUser":{"id":"1","name":"user1"}}}`, string(response.BodyBytes()))
+			rest.AssertStatus(t, response, http.StatusOK)
+			assert.Equal(t, response.BodyString(), `{"data":{"getUser":{"id":"1","name":"user1"}}}`)
 		})
 
 		t.Run("GET request", func(t *testing.T) {
@@ -46,8 +47,8 @@ func TestGraphQLQueryAdminOnly(t *testing.T) {
 			variableParam := `{"id": 1}`
 			getRequestUrl := fmt.Sprintf("/db/_graphql?query=%s&variables=%s", queryParam, variableParam)
 			response := rt.SendAdminRequest("GET", getRequestUrl, "")
-			assert.Equal(t, 200, response.Result().StatusCode)
-			assert.Equal(t, `{"data":{"getUser":{"id":"1","name":"user1"}}}`, string(response.BodyBytes()))
+			rest.AssertStatus(t, response, http.StatusOK)
+			assert.Equal(t, response.BodyString(), `{"data":{"getUser":{"id":"1","name":"user1"}}}`)
 		})
 
 		t.Run("POST request with Headers", func(t *testing.T) {
@@ -55,15 +56,15 @@ func TestGraphQLQueryAdminOnly(t *testing.T) {
 				"Content-type": "application/graphql",
 			}
 			response := rt.SendAdminRequestWithHeaders("POST", "/db/_graphql", `query{getUser(id:1){id,name}}`, headerMap)
-			assert.Equal(t, 200, response.Result().StatusCode)
-			assert.Equal(t, `{"data":{"getUser":{"id":"1","name":"user1"}}}`, string(response.BodyBytes()))
+			rest.AssertStatus(t, response, http.StatusOK)
+			assert.Equal(t, response.BodyString(), `{"data":{"getUser":{"id":"1","name":"user1"}}}`)
 		})
 	})
 
 	t.Run("AsAdmin - getAllUsers", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_graphql", `{"query": "query{getAllUsers{name}}"}`)
-		assert.Equal(t, 200, response.Result().StatusCode)
-		assert.Equal(t, `{"data":{"getAllUsers":[{"name":"user1"},{"name":"user2"},{"name":"user3"}]}}`, string(response.BodyBytes()))
+		rest.AssertStatus(t, response, http.StatusOK)
+		assert.Equal(t, response.BodyString(), `{"data":{"getAllUsers":[{"name":"user1"},{"name":"user2"},{"name":"user3"}]}}`)
 	})
 
 	// Test multiple query operations in a single request
@@ -80,7 +81,7 @@ func TestGraphQLQueryAdminOnly(t *testing.T) {
 				"operationName": "%s"
 			}`, queryParam, variableParam, operationParam)
 			response := rt.SendAdminRequest("POST", "/db/_graphql", requestBody)
-			assert.Equal(t, 200, response.Result().StatusCode)
+			rest.RequireStatus(t, response, http.StatusOK)
 			assert.Equal(t, expectedResponse, string(response.BodyBytes()))
 		})
 
@@ -105,26 +106,26 @@ func TestGraphQLQueryCustomUser(t *testing.T) {
 
 	t.Run("AsUser - getUser", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_user/", `{"name":"janhavi", "password":"password"}`)
-		assert.Equal(t, 201, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusCreated)
 
 		response = rt.SendUserRequestWithHeaders("POST", "/db/_graphql", `{"query": "query($id:ID!){ getUser(id:$id) { id , name } }" , "variables": {"id": 3}}`, nil, "janhavi", "password")
-		assert.Equal(t, 200, response.Result().StatusCode)
-		assert.Equal(t, `{"data":{"getUser":{"id":"3","name":"user3"}}}`, string(response.BodyBytes()))
+		rest.RequireStatus(t, response, http.StatusOK)
+		assert.Equal(t, `{"data":{"getUser":{"id":"3","name":"user3"}}}`, response.BodyString())
 
 		response = rt.SendAdminRequest("DELETE", "/db/_user/janhavi", "")
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 	})
 
 	t.Run("AsUser - getAllUsers", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_user/", `{"name":"janhavi", "password":"password"}`)
-		assert.Equal(t, 201, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusCreated)
 
 		response = rt.SendUserRequestWithHeaders("POST", "/db/_graphql", `{"query": "query{getAllUsers{name}}"}`, nil, "janhavi", "password")
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, `{"data":{"getAllUsers":[{"name":"user1"},{"name":"user2"},{"name":"user3"}]}}`, string(response.BodyBytes()))
 
 		response = rt.SendAdminRequest("DELETE", "/db/_user/janhavi", "")
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 	})
 
 }
@@ -145,12 +146,12 @@ func TestGraphQLQueriesGuest(t *testing.T) {
 
 	t.Run("AsGuest - getUser", func(t *testing.T) {
 		response := rt.SendRequest("POST", "/db/_graphql", `{"query": "query($id:ID!){ getUser(id:$id) { id , name } }" , "variables": {"id": 1}}`)
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, `{"data":{"getUser":{"id":"1","name":"user1"}}}`, string(response.BodyBytes()))
 	})
 	t.Run("AsGuest - getAllUsers", func(t *testing.T) {
 		response := rt.SendRequest("POST", "/db/_graphql", `{"query": "query{getAllUsers{name}}"}`)
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, `{"data":{"getAllUsers":[{"name":"user1"},{"name":"user2"},{"name":"user3"}]}}`, string(response.BodyBytes()))
 
 	})
@@ -169,13 +170,13 @@ func TestGraphQLMutationsAdminOnly(t *testing.T) {
 
 	t.Run("AsAdmin - updateName", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_graphql", `{"query":"mutation($id: ID!, $name:String!){ updateName(id:$id,name:$name) {id,name} }", "variables" : {"id":1,"name":"newUser"}}`)
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, `{"data":{"updateName":{"id":"1","name":"newUser"}}}`, string(response.BodyBytes()))
 	})
 
 	t.Run("AsAdmin - addEmail", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_graphql", `{"query": "mutation($id:ID!, $email: String!){ addEmail(id:$id, email:$email) {id,name,Emails} }" , "variables": {"id": 2, "email":"pqr@gmail.com"}}`)
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, `{"data":{"addEmail":{"Emails":["xyz@gmail.com","def@gmail.com","pqr@gmail.com"],"id":"2","name":"user2"}}}`, string(response.BodyBytes()))
 	})
 
@@ -193,7 +194,7 @@ func TestGraphQLMutationsAdminOnly(t *testing.T) {
 		}`, queryParam, variableParam, operationParam)
 
 		response := rt.SendAdminRequest("POST", "/db/_graphql", requestBody)
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, expectedResponse, string(response.BodyBytes()))
 	})
 }
@@ -211,26 +212,26 @@ func TestGraphQLMutationsCustomUser(t *testing.T) {
 
 	t.Run("AsUser - updateName", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_user/", `{"name":"jinesh", "password":"password"}`)
-		assert.Equal(t, 201, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusCreated)
 
 		response = rt.SendUserRequestWithHeaders("POST", "/db/_graphql", `{"query":"mutation($id: ID!, $name:String!){ updateName(id:$id,name:$name) {id,name} }", "variables" : {"id":1,"name":"newUser"}}`, nil, "jinesh", "password")
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, `{"data":{"updateName":{"id":"1","name":"newUser"}}}`, string(response.BodyBytes()))
 
 		response = rt.SendAdminRequest("DELETE", "/db/_user/jinesh", "")
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 	})
 
 	t.Run("AsUser - addEmail", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_user/", `{"name":"jinesh", "password":"password"}`)
-		assert.Equal(t, 201, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusCreated)
 
 		response = rt.SendUserRequestWithHeaders("POST", "/db/_graphql", `{"query": "mutation($id:ID!, $email: String!){ addEmail(id:$id, email:$email) {id,name,Emails} }" , "variables": {"id": 2, "email":"pqr@gmail.com"}}`, nil, "jinesh", "password")
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		testErrorMessage(t, response, "403 you are not allowed to call GraphQL resolver")
 
 		response = rt.SendAdminRequest("DELETE", "/db/_user/jinesh", "")
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 	})
 }
 
@@ -250,13 +251,13 @@ func TestGraphQLMutationsGuest(t *testing.T) {
 
 	t.Run("AsGuest - updateName", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_graphql", `{"query":"mutation($id: ID!, $name:String!){ updateName(id:$id,name:$name) {id,name} }", "variables" : {"id":1,"name":"newUser"}}`)
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, `{"data":{"updateName":{"id":"1","name":"newUser"}}}`, string(response.BodyBytes()))
 	})
 
 	t.Run("AsGuest - addEmail", func(t *testing.T) {
 		response := rt.SendAdminRequest("POST", "/db/_graphql", `{"query": "mutation($id:ID!, $email: String!){ addEmail(id:$id, email:$email) {id,name,Emails} }" , "variables": {"id": 2, "email":"pqr@gmail.com"}}`)
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		assert.Equal(t, `{"data":{"addEmail":{"Emails":["xyz@gmail.com","def@gmail.com","pqr@gmail.com"],"id":"2","name":"user2"}}}`, string(response.BodyBytes()))
 	})
 }
@@ -289,14 +290,13 @@ func TestContextDeadline(t *testing.T) {
 	t.Run("AsAdmin - exceedContextDeadline", func(t *testing.T) {
 		requestQuery := fmt.Sprintf(`{"query": "query{ checkContextDeadline(Timeout:%d) }"}`, timeout.Milliseconds()*2)
 		response := rt.SendAdminRequest("POST", "/db/_graphql", requestQuery)
-
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 		testErrorMessage(t, response, "context deadline exceeded")
 	})
 	t.Run("AsAdmin - doNotExceedContextDeadline", func(t *testing.T) {
 		requestQuery := `{"query": "query{ checkContextDeadline(Timeout:1) }"}`
 		response := rt.SendAdminRequest("POST", "/db/_graphql", requestQuery)
-		assert.Equal(t, 200, response.Result().StatusCode)
+		rest.RequireStatus(t, response, http.StatusOK)
 
 		assert.Equal(t, `{"data":{"checkContextDeadline":0}}`, string(response.BodyBytes()))
 	})

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1958,7 +1958,6 @@ func TestDcpBackfill(t *testing.T) {
 	newRt := rest.NewRestTester(t, &newRtConfig)
 	defer newRt.Close()
 	log.Printf("Poke the rest tester so it starts DCP processing:")
-	dataStore = newRt.GetSingleDataStore()
 
 	backfillComplete := false
 	var expectedBackfill, completedBackfill int

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2287,6 +2287,7 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 			request := createOIDCRequest(t, sessionEndpoint, token)
 			response, err := http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			assert.Equal(t, http.StatusUnauthorized, response.StatusCode) // Status code when unreachable
 
 			// Now reachable - success

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -860,6 +860,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			client := &http.Client{Jar: jar}
 			response, err := client.Do(request)
 			require.NoError(t, err, "Error sending request")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			if (forceError{}) != tc.forceAuthError {
 				assertHttpResponse(t, response, tc.forceAuthError)
 				return
@@ -868,7 +869,6 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			require.Equal(t, http.StatusOK, response.StatusCode)
 			var authResponseActual OIDCTokenResponse
 			require.NoError(t, err, json.NewDecoder(response.Body).Decode(&authResponseActual))
-			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.NotEmpty(t, authResponseActual.SessionID, "session_id doesn't exist")
 			assert.Equal(t, "foo_noah", authResponseActual.Username, "name mismatch")
 
@@ -889,9 +889,9 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			request.Header.Add("Authorization", BearerToken+" "+authResponseActual.IDToken)
 			response, err = client.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			require.Equal(t, http.StatusOK, response.StatusCode)
 			require.NoError(t, json.NewDecoder(response.Body).Decode(&responseBody))
-			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.Equal(t, restTester.DatabaseConfig.Name, responseBody["db_name"])
 
 			// Refresh auth token using the refresh token received from OP.
@@ -902,6 +902,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			require.NoError(t, err, "Error creating new request")
 			response, err = client.Do(request)
 			require.NoError(t, err, "Error sending request")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			if (forceError{}) != tc.forceRefreshError {
 				assertHttpResponse(t, response, tc.forceRefreshError)
 				return
@@ -911,7 +912,6 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			// Validate received token refresh response.
 			var refreshResponseActual OIDCTokenResponse
 			require.NoError(t, err, json.NewDecoder(response.Body).Decode(&refreshResponseActual))
-			require.NoError(t, response.Body.Close(), "Error closing response body")
 			refreshResponseExpected := mockAuthServer.options.tokenResponse
 			assert.NotEmpty(t, refreshResponseActual.SessionID, "session_id doesn't exist")
 			assert.Equal(t, "foo_noah", refreshResponseActual.Username, "name mismatch")
@@ -927,9 +927,9 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			request.Header.Add("Authorization", BearerToken+" "+refreshResponseActual.IDToken)
 			response, err = client.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			require.Equal(t, http.StatusOK, response.StatusCode)
 			require.NoError(t, json.NewDecoder(response.Body).Decode(&responseBody))
-			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.Equal(t, restTester.DatabaseConfig.Name, responseBody["db_name"])
 
 			// Make a keyspace-scoped request
@@ -938,8 +938,8 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			request.Header.Add("Authorization", BearerToken+" "+refreshResponseActual.IDToken)
 			response, err = client.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			require.Equal(t, http.StatusCreated, response.StatusCode)
-			require.NoError(t, response.Body.Close(), "Error closing response body")
 		})
 	}
 }
@@ -1072,6 +1072,7 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 			request := createOIDCRequest(t, sessionEndpoint, token)
 			response, err := http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 
 			if (forceError{}) != tc.expectedError {
 				assertHttpResponse(t, response, tc.expectedError)
@@ -1290,6 +1291,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 
 	runBadAuthTest := func(claimSet claimSet) {
 		response, err := sendAuthRequest(claimSet)
+		defer func() { assert.NoError(t, response.Body.Close()) }()
 		require.NoError(t, err, "Error sending request with bearer token")
 		expectedAuthError := forceError{
 			expectedErrorCode:    http.StatusUnauthorized,
@@ -1300,6 +1302,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 
 	runGoodAuthTest := func(claimSet claimSet, username string) {
 		response, err := sendAuthRequest(claimSet)
+		defer func() { assert.NoError(t, response.Body.Close()) }()
 		require.NoError(t, err, "Error sending request with bearer token")
 		checkGoodAuthResponse(t, restTester, response, username)
 	}
@@ -1930,6 +1933,7 @@ func TestCallbackStateClientCookies(t *testing.T) {
 	t.Run("unsuccessful auth when callback state enabled with no cookies support from client", func(t *testing.T) {
 		response, err := http.DefaultClient.Do(request)
 		require.NoError(t, err, "Error sending request")
+		defer func() { assert.NoError(t, response.Body.Close()) }()
 		expectedAuthError := forceError{
 			expectedErrorCode:    http.StatusBadRequest,
 			expectedErrorMessage: ErrNoStateCookie.Message,
@@ -1943,10 +1947,10 @@ func TestCallbackStateClientCookies(t *testing.T) {
 		client := &http.Client{Jar: jar}
 		response, err := client.Do(request)
 		require.NoError(t, err, "Error sending request")
+		defer func() { assert.NoError(t, response.Body.Close()) }()
 		require.Equal(t, http.StatusOK, response.StatusCode)
 		var authResponseActual OIDCTokenResponse
 		require.NoError(t, err, json.NewDecoder(response.Body).Decode(&authResponseActual))
-		require.NoError(t, response.Body.Close(), "Error closing response body")
 		assert.NotEmpty(t, authResponseActual.SessionID, "session_id doesn't exist")
 		assert.Equal(t, "foo_noah", authResponseActual.Username, "name mismatch")
 	})
@@ -1955,11 +1959,11 @@ func TestCallbackStateClientCookies(t *testing.T) {
 		restTester.DatabaseConfig.OIDCConfig.Providers.GetDefaultProvider().DisableCallbackState = true
 		response, err := http.DefaultClient.Do(request)
 		require.NoError(t, err, "Error sending request")
+		defer func() { assert.NoError(t, response.Body.Close()) }()
 		require.Equal(t, http.StatusOK, response.StatusCode)
 
 		var authResponseActual OIDCTokenResponse
 		require.NoError(t, err, json.NewDecoder(response.Body).Decode(&authResponseActual))
-		require.NoError(t, response.Body.Close(), "Error closing response body")
 		assert.NotEmpty(t, authResponseActual.SessionID, "session_id doesn't exist")
 		assert.Equal(t, "foo_noah", authResponseActual.Username, "name mismatch")
 	})
@@ -2187,6 +2191,7 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 			client := &http.Client{Jar: jar}
 			response, err := client.Do(request)
 			require.NoError(t, err, "Error sending request")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			if (forceError{}) != tc.authErrorExpected {
 				assertHttpResponse(t, response, tc.authErrorExpected)
 				return
@@ -2195,7 +2200,6 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 			require.Equal(t, http.StatusOK, response.StatusCode)
 			var authResponseActual OIDCTokenResponse
 			require.NoError(t, err, json.NewDecoder(response.Body).Decode(&authResponseActual))
-			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.NotEmpty(t, authResponseActual.SessionID, "session_id doesn't exist")
 			expectedUsername := tc.usernameExpected
 			if strings.Contains(expectedUsername, "$issuer") {
@@ -2215,9 +2219,9 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 			request.Header.Add("Authorization", BearerToken+" "+authResponseActual.IDToken)
 			response, err = client.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			require.Equal(t, http.StatusOK, response.StatusCode)
 			require.NoError(t, json.NewDecoder(response.Body).Decode(&responseBody))
-			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.Equal(t, restTester.DatabaseConfig.Name, responseBody["db_name"])
 		})
 	}
@@ -2295,6 +2299,7 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 			request = createOIDCRequest(t, sessionEndpoint, token)
 			response, err = http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			checkGoodAuthResponse(t, restTester, response, "foo_noah")
 
 			// Unreachable again after being reachable - still success
@@ -2302,6 +2307,7 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 			request = createOIDCRequest(t, sessionEndpoint, token)
 			response, err = http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			checkGoodAuthResponse(t, restTester, response, "foo_noah")
 		})
 	}
@@ -2416,11 +2422,11 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 			client := &http.Client{Jar: jar}
 			response, err := client.Do(request)
 			require.NoError(t, err, "Error sending request")
+			defer func() { assert.NoError(t, response.Body.Close()) }()
 			// Validate received token response
 			require.Equal(t, http.StatusOK, response.StatusCode)
 			var authResponseActual OIDCTokenResponse
 			require.NoError(t, err, json.NewDecoder(response.Body).Decode(&authResponseActual))
-			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.NotEmpty(t, authResponseActual.SessionID, "session_id doesn't exist")
 
 			authResponseExpected := mockAuthServer.options.tokenResponse

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1979,7 +1979,7 @@ func doHTTPAuthRequest(ctx context.Context, httpClient *http.Client, username, p
 
 		req.SetBasicAuth(username, password)
 
-		httpResponse, err = httpClient.Do(req)
+		httpResponse, err = httpClient.Do(req) // nolint:bodyclose // The body is closed outside of the worker loop
 		if err == nil {
 			return false, nil, httpResponse
 		}
@@ -1992,7 +1992,7 @@ func doHTTPAuthRequest(ctx context.Context, httpClient *http.Client, username, p
 		return false, err, nil
 	}
 
-	err, result := base.RetryLoop(ctx, "", worker, base.CreateSleeperFunc(10, 100))
+	err, result := base.RetryLoop(ctx, "doHTTPAuthRequest", worker, base.CreateSleeperFunc(10, 100))
 	if err != nil {
 		return 0, nil, err
 	}

--- a/rest/stats_context_test.go
+++ b/rest/stats_context_test.go
@@ -52,6 +52,9 @@ func TestDescriptionPopulation(t *testing.T) {
 	// Ensure metrics endpoint is accessible and that db database has entries
 	resp, err := http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, resp.Body.Close())
+	}()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	bodyString, err := io.ReadAll(resp.Body)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1093,11 +1093,18 @@ type TestResponse struct {
 // BodyBytes takes a copy of the bytes in the response buffer, and saves them for future callers.
 func (r TestResponse) BodyBytes() []byte {
 	if r.bodyCache == nil {
+		// since we are reading the underlying write buffer here, we do not need to close. If call r.Result().Body, then this needs to be closed.
 		r.bodyCache = r.ResponseRecorder.Body.Bytes()
 	}
 	return r.bodyCache
 }
 
+// BodyString returns the string of the response body. This is cached once the first time it is called.
+func (r TestResponse) BodyString() string {
+	return string(r.BodyBytes())
+}
+
+// DumpBody returns the byte array of the response body. This is cached once the first time it is called.
 func (r TestResponse) DumpBody() {
 	log.Printf("%v", r.Body.String())
 }

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -150,6 +150,7 @@ func TestCECheck(t *testing.T) {
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
 	require.Equal(t, resp.StatusCode, http.StatusBadRequest)
 }
 

--- a/rest/utilities_testing_user.go
+++ b/rest/utilities_testing_user.go
@@ -37,6 +37,7 @@ func MakeUser(t *testing.T, httpClient *http.Client, serverURL, username, passwo
 		if err != nil {
 			return true, err, resp
 		}
+		assert.NoError(t, resp.Body.Close())
 		return false, err, resp
 	}
 
@@ -64,6 +65,7 @@ func DeleteUser(t *testing.T, httpClient *http.Client, serverURL, username strin
 		if err != nil {
 			return true, err, resp
 		}
+		assert.NoError(t, resp.Body.Close())
 		return false, err, resp
 	}
 

--- a/rest/utilities_testing_user.go
+++ b/rest/utilities_testing_user.go
@@ -37,7 +37,7 @@ func MakeUser(t *testing.T, httpClient *http.Client, serverURL, username, passwo
 		if err != nil {
 			return true, err, nil
 		}
-		defer resp.Body.Close()
+		defer func() { assert.NoError(t, resp.Body.Close()) }()
 		if resp.StatusCode != http.StatusOK {
 			bodyResp, err := io.ReadAll(resp.Body)
 			assert.NoError(t, err, "Failed to create user: %s", bodyResp)


### PR DESCRIPTION
There were no production code that was missing body.Close() but there was a lot missing in tests. This is a small resource leak.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2263/
