### PR TITLE
beryllium: fix misspell typos

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1064,7 +1064,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 	if existingDoc != nil {
 		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattr, existingDoc.UserXattr, existingDoc.Cas, DocUnmarshalRev)
 		if unmarshalErr != nil {
-			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling exsiting doc")
+			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling existing doc")
 		}
 		matchRev = doc.CurrentRev
 	}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -275,7 +275,7 @@ func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore,
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
-// revCacheLoaderForCv will load a document from the bucket using the CV, comapre the fetched doc and the CV specified in the function,
+// revCacheLoaderForCv will load a document from the bucket using the CV, compare the fetched doc and the CV specified in the function,
 // and will still return revid for purpose of populating the Rev ID lookup map on the cache
 func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	cv := Version{

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -698,7 +698,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 
 // TestLoaderMismatchInCV:
 //   - Get doc that is not in cache by CV to trigger a load from bucket
-//   - Ensure the CV passed into teh GET operation won't match the doc in teh bucket
+//   - Ensure the CV passed into the GET operation won't match the doc in the bucket
 //   - Assert we get error and the value is not loaded into the cache
 func TestLoaderMismatchInCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
@@ -722,7 +722,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 //   - Now perform two concurrent Gets, one by CV and one by revid on a document that doesn't exist in the cache
 //   - This will trigger two concurrent loads from bucket in the CV code path and revid code path
 //   - In doing so we will have two processes trying to update lookup maps at the same time and a race condition will appear
-//   - In doing so will cause us to potentially have two of teh same elements the cache, one with nothing referencing it
+//   - In doing so will cause us to potentially have two of the same elements the cache, one with nothing referencing it
 //   - Assert after both gets are processed, that the cache only has one element in it and that both lookup maps have only one
 //     element
 //   - Grab the single element in the list and assert that both maps point to that element in the cache list
@@ -778,10 +778,10 @@ func TestGetActive(t *testing.T) {
 		Value:    doc.Cas,
 	}
 
-	// remove the entry form the rev cache to force teh cache to not have the active version in it
+	// remove the entry form the rev cache to force the cache to not have the active version in it
 	collection.revisionCache.RemoveWithCV("doc", &expectedCV)
 
-	// call get active to get teh active version from the bucket
+	// call get active to get the active version from the bucket
 	docRev, err := collection.revisionCache.GetActive(base.TestCtx(t), "doc", true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8325,6 +8325,8 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	// Grab the bucket UUIDs for both rest testers
 	activeBucketUUID, err := activeRT.GetDatabase().Bucket.UUID()
 	require.NoError(t, err)
+	passiveBucketUUID, err := passiveRT.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
 
 	const rep = "replication"
 
@@ -8351,6 +8353,7 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	assert.NoError(t, err)
 	uintCAS = base.HexCasToUint64(syncData.Cas)
 
-	// TODO: assert that the SourceID and Verison pair are preserved correctly pending CBG-3211
+	assert.Equal(t, passiveBucketUUID, syncData.HLV.SourceID)
 	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
 }


### PR DESCRIPTION
These existing beryllium-only typos started failing due to rebased `misspell` adoption.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `TestReplicatorUpdateHLVOnPut` `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2266/
