### PR TITLE
CBG-3213 Version support for channel removals

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -120,7 +120,7 @@ func (entry *LogEntry) SetDeleted() {
 	entry.Flags |= channels.Deleted
 }
 
-func (entry *LogEntry) SetRevAndVersion(rv RevAndVersion) {
+func (entry *LogEntry) SetRevAndVersion(rv channels.RevAndVersion) {
 	entry.RevID = rv.RevTreeID
 	if rv.CurrentSource != "" {
 		entry.SourceID = rv.CurrentSource
@@ -491,9 +491,11 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 				// if the doc was removed from one or more channels at this sequence
 				// Set the removed flag and removed channel set on the LogEntry
-				if channelRemovals, atRevId := syncData.Channels.ChannelsRemovedAtSequence(seq); len(channelRemovals) > 0 {
+				if channelRemovals, atRev := syncData.Channels.ChannelsRemovedAtSequence(seq); len(channelRemovals) > 0 {
 					change.DocID = docID
-					change.RevID = atRevId
+					change.RevID = atRev.RevTreeID
+					change.SourceID = atRev.CurrentSource
+					change.Version = base.HexCasToUint64(atRev.CurrentVersion)
 					change.Channels = channelRemovals
 				}
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -256,7 +256,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	sync["recent_sequences"] = []uint64{1, 2, 3}
 
 	cm := make(channels.ChannelMap)
-	cm["A"] = &channels.ChannelRemoval{Seq: 2, RevID: "2-e99405a23fa102238fa8c3fd499b15bc"}
+	cm["A"] = &channels.ChannelRemoval{Seq: 2, Rev: channels.RevAndVersion{RevTreeID: "2-e99405a23fa102238fa8c3fd499b15bc"}}
 	sync["channels"] = cm
 
 	history := sync["history"].(map[string]interface{})

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -18,6 +18,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 )
 
 // One "changes" row in a channelsViewResult
@@ -25,7 +26,7 @@ type channelsViewRow struct {
 	ID    string
 	Key   []interface{} // Actually [channelName, sequence]
 	Value struct {
-		Rev   RevAndVersion
+		Rev   channels.RevAndVersion
 		Flags uint8
 	}
 }
@@ -66,8 +67,10 @@ func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIter
 	}
 	entry.SetRevAndVersion(queryRow.Rev)
 
-	if queryRow.RemovalRev != "" {
-		entry.RevID = queryRow.RemovalRev
+	if queryRow.RemovalRev != nil {
+		entry.RevID = queryRow.RemovalRev.RevTreeID
+		entry.Version = base.HexCasToUint64(queryRow.RemovalRev.CurrentVersion)
+		entry.SourceID = queryRow.RemovalRev.CurrentSource
 		if queryRow.RemovalDel {
 			entry.SetDeleted()
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -1761,7 +1761,7 @@ func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, d
 				forceUpdate = true
 			}
 
-			changedChannels, err := doc.updateChannels(ctx, channels)
+			changedChannels, _, err := doc.updateChannels(ctx, channels)
 			changed = len(doc.Access.updateAccess(ctx, doc, access)) +
 				len(doc.RoleAccess.updateAccess(ctx, doc, roles)) +
 				len(changedChannels)

--- a/db/document.go
+++ b/db/document.go
@@ -202,7 +202,7 @@ type historyOnlySyncData struct {
 
 type revOnlySyncData struct {
 	casOnlySyncData
-	CurrentRev RevAndVersion `json:"rev"`
+	CurrentRev channels.RevAndVersion `json:"rev"`
 }
 
 type casOnlySyncData struct {
@@ -951,7 +951,7 @@ func (doc *Document) addToChannelSetHistory(channelName string, historyEntry Cha
 
 // Updates the Channels property of a document object with current & past channels.
 // Returns the set of channels that have changed (document joined or left in this revision)
-func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (changedChannels base.Set, err error) {
+func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (changedChannels base.Set, revokedChannelsRequiringExpansion []string, err error) {
 	var changed []string
 	oldChannels := doc.Channels
 	if oldChannels == nil {
@@ -960,14 +960,19 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 	} else {
 		// Mark every no-longer-current channel as unsubscribed:
 		curSequence := doc.Sequence
+		curRevAndVersion := doc.GetRevAndVersion()
 		for channel, removal := range oldChannels {
 			if removal == nil && !newChannels.Contains(channel) {
 				oldChannels[channel] = &channels.ChannelRemoval{
 					Seq:     curSequence,
-					RevID:   doc.CurrentRev,
+					Rev:     curRevAndVersion,
 					Deleted: doc.hasFlag(channels.Deleted)}
 				doc.updateChannelHistory(channel, curSequence, false)
 				changed = append(changed, channel)
+				// If the current version requires macro expansion, new removal in channel map will also require macro expansion
+				if doc.HLV.Version == hlvExpandMacroCASValue {
+					revokedChannelsRequiringExpansion = append(revokedChannelsRequiringExpansion, channel)
+				}
 			}
 		}
 	}
@@ -996,7 +1001,7 @@ func (doc *Document) IsChannelRemoval(ctx context.Context, revID string) (bodyBy
 
 	// Iterate over the document's channel history, looking for channels that were removed at revID.  If found, also identify whether the removal was a tombstone.
 	for channel, removal := range doc.Channels {
-		if removal != nil && removal.RevID == revID {
+		if removal != nil && removal.Rev.RevTreeID == revID {
 			removedChannels[channel] = struct{}{}
 			if removal.Deleted == true {
 				isDelete = true
@@ -1258,7 +1263,7 @@ type SyncDataAlias SyncData
 // SyncDataJSON is the persisted form of SyncData, with RevAndVersion populated at marshal time
 type SyncDataJSON struct {
 	*SyncDataAlias
-	RevAndVersion RevAndVersion `json:"rev"`
+	RevAndVersion channels.RevAndVersion `json:"rev"`
 }
 
 // MarshalJSON populates RevAndVersion using CurrentRev and the HLV (current) source and version.
@@ -1269,11 +1274,7 @@ func (s SyncData) MarshalJSON() (data []byte, err error) {
 	var sd SyncDataAlias
 	sd = (SyncDataAlias)(s)
 	sdj.SyncDataAlias = &sd
-	sdj.RevAndVersion.RevTreeID = s.CurrentRev
-	if s.HLV != nil {
-		sdj.RevAndVersion.CurrentSource = s.HLV.SourceID
-		sdj.RevAndVersion.CurrentVersion = string(base.Uint64CASToLittleEndianHex(s.HLV.Version))
-	}
+	sdj.RevAndVersion = s.GetRevAndVersion()
 	return base.JSONMarshal(sdj)
 }
 
@@ -1292,41 +1293,11 @@ func (s *SyncData) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// RevAndVersion is used to store both revTreeID and currentVersion in a single property, for backwards compatibility
-// with existing indexes using rev.  When only RevTreeID is specified, is marshalled/unmarshalled as a string.  Otherwise
-// marshalled normally.
-type RevAndVersion struct {
-	RevTreeID      string `json:"rev,omitempty"`
-	CurrentSource  string `json:"src,omitempty"`
-	CurrentVersion string `json:"vrs,omitempty"` // String representation of version
-}
-
-// RevAndVersionJSON aliases RevAndVersion to support conditional unmarshalling from either string (revTreeID) or
-// map (RevAndVersion) representations
-type RevAndVersionJSON RevAndVersion
-
-// Marshals RevAndVersion as simple string when only RevTreeID is specified - otherwise performs standard
-// marshalling
-func (rv RevAndVersion) MarshalJSON() (data []byte, err error) {
-
-	if rv.CurrentSource == "" {
-		return base.JSONMarshal(rv.RevTreeID)
+func (s *SyncData) GetRevAndVersion() (rav channels.RevAndVersion) {
+	rav.RevTreeID = s.CurrentRev
+	if s.HLV != nil {
+		rav.CurrentSource = s.HLV.SourceID
+		rav.CurrentVersion = string(base.Uint64CASToLittleEndianHex(s.HLV.Version))
 	}
-	return base.JSONMarshal(RevAndVersionJSON(rv))
-}
-
-// Unmarshals either from string (legacy, revID only) or standard RevAndVersion unmarshalling.
-func (rv *RevAndVersion) UnmarshalJSON(data []byte) error {
-
-	if len(data) == 0 {
-		return nil
-	}
-	switch data[0] {
-	case '"':
-		return base.JSONUnmarshal(data, &rv.RevTreeID)
-	case '{':
-		return base.JSONUnmarshal(data, (*RevAndVersionJSON)(rv))
-	default:
-		return fmt.Errorf("unrecognized JSON format for RevAndVersion: %s", data)
-	}
+	return rav
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -442,3 +442,13 @@ func (hlv *HybridLogicalVector) toHistoryForHLV() string {
 	}
 	return s.String()
 }
+
+// appendRevocationMacroExpansions adds macro expansions for the channel map.  Not strictly an HLV operation
+// but putting the function here as it's required when the HLV's current version is being macro expanded
+func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, channelNames []string) (updatedSpec []sgbucket.MacroExpansionSpec) {
+	for _, channelName := range channelNames {
+		spec := sgbucket.NewMacroExpansionSpec(xattrRevokedChannelVersionPath(base.SyncXattrName, channelName), sgbucket.MacroCas)
+		currentSpec = append(currentSpec, spec)
+	}
+	return currentSpec
+}

--- a/db/query.go
+++ b/db/query.go
@@ -154,12 +154,12 @@ var QuerySequences = SGQuery{
 }
 
 type QueryChannelsRow struct {
-	Id         string        `json:"id,omitempty"`
-	Rev        RevAndVersion `json:"rev,omitempty"`
-	Sequence   uint64        `json:"seq,omitempty"`
-	Flags      uint8         `json:"flags,omitempty"`
-	RemovalRev string        `json:"rRev,omitempty"`
-	RemovalDel bool          `json:"rDel,omitempty"`
+	Id         string                  `json:"id,omitempty"`
+	Rev        channels.RevAndVersion  `json:"rev,omitempty"`
+	Sequence   uint64                  `json:"seq,omitempty"`
+	Flags      uint8                   `json:"flags,omitempty"`
+	RemovalRev *channels.RevAndVersion `json:"rRev,omitempty"`
+	RemovalDel bool                    `json:"rDel,omitempty"`
 }
 
 var QueryPrincipals = SGQuery{
@@ -688,17 +688,17 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 type AllDocsViewQueryRow struct {
 	Key   string
 	Value struct {
-		RevID    RevAndVersion `json:"r"`
-		Sequence uint64        `json:"s"`
-		Channels []string      `json:"c"`
+		RevID    channels.RevAndVersion `json:"r"`
+		Sequence uint64                 `json:"s"`
+		Channels []string               `json:"c"`
 	}
 }
 
 type AllDocsIndexQueryRow struct {
 	Id       string
-	RevID    RevAndVersion       `json:"r"`
-	Sequence uint64              `json:"s"`
-	Channels channels.ChannelMap `json:"c"`
+	RevID    channels.RevAndVersion `json:"r"`
+	Sequence uint64                 `json:"s"`
+	Channels channels.ChannelMap    `json:"c"`
 }
 
 // AllDocs returns all non-deleted documents in the bucket between startKey and endKey

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,13 +50,14 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 			Channels: base.SetOf("*"),
 		},
 	}
-	doc.Channels = channels.ChannelMap{
-		"*": &channels.ChannelRemoval{RevID: doc.CurrentRev},
-	}
 
 	doc.HLV = &HybridLogicalVector{
 		SourceID: "test",
 		Version:  123,
+	}
+	_, _, err = doc.updateChannels(ctx, base.SetOf("*"))
+	if err != nil {
+		return nil, err
 	}
 
 	return doc, nil

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1036,7 +1036,7 @@ func (rt *RestTester) SetAdminChannels(username string, keyspace string, channel
 
 type SimpleSync struct {
 	Channels map[string]interface{}
-	Rev      db.RevAndVersion
+	Rev      channels.RevAndVersion
 	Sequence uint64
 }
 


### PR DESCRIPTION
CBG-3213

Adds cv (source and version) to removals in _sync.channels (ChannelMap).  Uses RevAndVersion to support query (the same approached used for _sync.rev).

Required moving RevAndVersion to channels package for usage within ChannelMap.

Changes in crud.go required to support the case where the removal version needs to be set via macro expansion.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2272/
