### PR TITLE
CBG-3719: convert in memory format of HLV to match XDCR/CBL format

### DIFF
--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -57,7 +57,7 @@ type LogEntry struct {
 	IsPrincipal  bool         // Whether the log-entry is a tracking entry for a principal doc
 	CollectionID uint32       // Collection ID
 	SourceID     string       // SourceID allocated to the doc's Current Version on the HLV
-	Version      uint64       // Version allocated to the doc's Current Version on the HLV
+	Version      string       // Version allocated to the doc's Current Version on the HLV
 }
 
 func (l LogEntry) String() string {

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -62,7 +62,7 @@ type LogEntry struct {
 
 func (l LogEntry) String() string {
 	return fmt.Sprintf(
-		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d source: %s version: %d",
+		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d source: %s version: %s",
 		l.Sequence,
 		l.DocID,
 		l.RevID,

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -618,8 +618,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, rev string,
 		if vrsErr != nil {
 			return vrsErr
 		}
-		// replace with GetCV pending merge of CBG-3212
-		docRev, err = handleChangesResponseCollection.revisionCache.GetWithCV(bsc.loggingCtx, docID, &version, RevCacheOmitBody, RevCacheOmitDelta)
+		docRev, err = handleChangesResponseCollection.GetCV(bsc.loggingCtx, docID, &version, RevCacheOmitBody)
 	}
 	if base.IsDocNotFoundError(err) {
 		return bsc.sendNoRev(sender, docID, rev, collectionIdx, seq, err)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -495,7 +495,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 					change.DocID = docID
 					change.RevID = atRev.RevTreeID
 					change.SourceID = atRev.CurrentSource
-					change.Version = base.HexCasToUint64(atRev.CurrentVersion)
+					change.Version = atRev.CurrentVersion
 					change.Channels = channelRemovals
 				}
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -124,7 +124,7 @@ func (entry *LogEntry) SetRevAndVersion(rv channels.RevAndVersion) {
 	entry.RevID = rv.RevTreeID
 	if rv.CurrentSource != "" {
 		entry.SourceID = rv.CurrentSource
-		entry.Version = base.HexCasToUint64(rv.CurrentVersion)
+		entry.Version = rv.CurrentVersion
 	}
 }
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -82,7 +82,7 @@ func testLogEntryWithCV(seq uint64, docid string, revid string, channelNames []s
 		TimeReceived: time.Now(),
 		CollectionID: collectionID,
 		SourceID:     sourceID,
-		Version:      version,
+		Version:      string(base.Uint64CASToLittleEndianHex(version)),
 	}
 	channelMap := make(channels.ChannelMap)
 	for _, channelName := range channelNames {

--- a/db/changes.go
+++ b/db/changes.go
@@ -485,7 +485,7 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channel channels.ID) 
 	// populate CurrentVersion entry if log entry has sourceID and Version populated
 	// This allows current version to be nil in event of CV not being populated on log entry
 	// allowing omitempty to work as expected
-	if logEntry.SourceID != "" && logEntry.Version != 0 {
+	if logEntry.SourceID != "" && logEntry.Version != "" {
 		change.CurrentVersion = &Version{SourceID: logEntry.SourceID, Value: logEntry.Version}
 	}
 	if logEntry.Flags&channels.Removed != 0 {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -11,7 +11,6 @@ package db
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"log"
 	"testing"
@@ -296,7 +295,7 @@ func TestCVPopulationOnChangeEntry(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 	collectionID := collection.GetCollectionID()
-	bucketUUID := base64.StdEncoding.EncodeToString([]byte(db.BucketUUID))
+	bucketUUID := db.EncodedBucketUUID
 
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
@@ -569,7 +568,7 @@ func TestCurrentVersionPopulationOnChannelCache(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 	collectionID := collection.GetCollectionID()
-	bucketUUID := base64.StdEncoding.EncodeToString([]byte(db.BucketUUID))
+	bucketUUID := db.EncodedBucketUUID
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Make channel active

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -69,7 +69,7 @@ func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIter
 
 	if queryRow.RemovalRev != nil {
 		entry.RevID = queryRow.RemovalRev.RevTreeID
-		entry.Version = base.HexCasToUint64(queryRow.RemovalRev.CurrentVersion)
+		entry.Version = queryRow.RemovalRev.CurrentVersion
 		entry.SourceID = queryRow.RemovalRev.CurrentSource
 		if queryRow.RemovalDel {
 			entry.SetDeleted()

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -961,7 +961,8 @@ func verifyCVEntries(entries []*LogEntry, cvs []cvValues) bool {
 		if entries[index].SourceID != cv.source {
 			return false
 		}
-		if entries[index].Version != cv.version {
+		encdedVrs := string(base.Uint64CASToLittleEndianHex(cv.version))
+		if entries[index].Version != encdedVrs {
 			return false
 		}
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -909,11 +909,11 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
 		d.HLV.ImportCAS = "" // remove importCAS for non-imports to save space
 	case Import:
-		encdedCAS := string(base.Uint64CASToLittleEndianHex(d.Cas))
-		if d.HLV.CurrentVersionCAS == encdedCAS {
+		encodedCAS := string(base.Uint64CASToLittleEndianHex(d.Cas))
+		if d.HLV.CurrentVersionCAS == encodedCAS {
 			// if cvCAS = document CAS, the HLV has already been updated for this mutation by another HLV-aware peer.
 			// Set ImportCAS to the previous document CAS, but don't otherwise modify HLV
-			d.HLV.ImportCAS = encdedCAS
+			d.HLV.ImportCAS = encodedCAS
 		} else {
 			// Otherwise this is an SDK mutation made by the local cluster that should be added to HLV.
 			newVVEntry := Version{}
@@ -924,7 +924,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 				return nil, err
 			}
 			d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
-			d.HLV.ImportCAS = encdedCAS
+			d.HLV.ImportCAS = encodedCAS
 		}
 
 	case NewVersion, ExistingVersionWithUpdateToHLV:
@@ -2319,11 +2319,12 @@ func postWriteUpdateHLV(doc *Document, casOut uint64) *Document {
 	if doc.HLV == nil {
 		return doc
 	}
+	encodedCAS := string(base.Uint64CASToLittleEndianHex(casOut))
 	if doc.HLV.Version == hlvExpandMacroCASValue {
-		doc.HLV.Version = string(base.Uint64CASToLittleEndianHex(casOut))
+		doc.HLV.Version = encodedCAS
 	}
 	if doc.HLV.CurrentVersionCAS == hlvExpandMacroCASValue {
-		doc.HLV.CurrentVersionCAS = string(base.Uint64CASToLittleEndianHex(casOut))
+		doc.HLV.CurrentVersionCAS = encodedCAS
 	}
 	return doc
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -11,7 +11,6 @@ package db
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"math"
 	"net/http"
@@ -917,7 +916,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 		} else {
 			// Otherwise this is an SDK mutation made by the local cluster that should be added to HLV.
 			newVVEntry := Version{}
-			newVVEntry.SourceID = base64.StdEncoding.EncodeToString([]byte(db.dbCtx.BucketUUID))
+			newVVEntry.SourceID = db.dbCtx.EncodedBucketUUID
 			newVVEntry.Value = hlvExpandMacroCASValue
 			err := d.SyncData.HLV.AddVersion(newVVEntry)
 			if err != nil {
@@ -930,7 +929,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
 		newVVEntry := Version{}
-		newVVEntry.SourceID = base64.StdEncoding.EncodeToString([]byte(db.dbCtx.BucketUUID))
+		newVVEntry.SourceID = db.dbCtx.EncodedBucketUUID
 		newVVEntry.Value = hlvExpandMacroCASValue
 		err := d.SyncData.HLV.AddVersion(newVVEntry)
 		if err != nil {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1139,7 +1139,6 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				return nil, nil, false, nil, addNewerVersionsErr
 			}
 		} else {
-			// TEMP
 			incomingDecodedHLV := docHLV.ToDecodedHybridLogicalVector()
 			localDecodedHLV := doc.HLV.ToDecodedHybridLogicalVector()
 			if !incomingDecodedHLV.IsInConflict(localDecodedHLV) {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1720,7 +1720,6 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	assert.NoError(t, err)
 	docUpdateVersion := syncData.HLV.Version
 	docUpdateVersionInt := base.HexCasToUint64(docUpdateVersion)
-	require.NoError(t, err)
 
 	// construct a mock doc update coming over a replicator
 	body = Body{"key1": "value2"}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"log"
 	"reflect"
@@ -1689,7 +1688,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	bucketUUID := base64.StdEncoding.EncodeToString([]byte(db.BucketUUID))
+	bucketUUID := db.EncodedBucketUUID
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// create a new doc
@@ -1775,7 +1774,7 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	bucketUUID := base64.StdEncoding.EncodeToString([]byte(db.BucketUUID))
+	bucketUUID := db.EncodedBucketUUID
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// create a new doc

--- a/db/database.go
+++ b/db/database.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -98,6 +99,7 @@ type DatabaseContext struct {
 	Bucket                      base.Bucket        // Storage
 	BucketSpec                  base.BucketSpec    // The BucketSpec
 	BucketUUID                  string             // The bucket UUID for the bucket the database is created against
+	EncodedBucketUUID           string             // The bucket UUID for the bucket the database is created against but encoded in base64
 	BucketLock                  sync.RWMutex       // Control Access to the underlying bucket object
 	mutationListener            changeListener     // Caching feed listener
 	ImportListener              *importListener    // Import feed listener
@@ -420,6 +422,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		MetadataStore:       metadataStore,
 		Bucket:              bucket,
 		BucketUUID:          bucketUUID,
+		EncodedBucketUUID:   base64.StdEncoding.EncodeToString([]byte(bucketUUID)),
 		StartTime:           time.Now(),
 		autoImport:          autoImport,
 		Options:             options,

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -10,7 +10,6 @@ package db
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -1055,7 +1054,7 @@ func TestConflicts(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	bucketUUID := base64.StdEncoding.EncodeToString([]byte(db.BucketUUID))
+	bucketUUID := db.EncodedBucketUUID
 
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1466,7 +1466,7 @@ func TestSyncFnOnPush(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, channels.ChannelMap{
 		"clibup": nil,
-		"public": &channels.ChannelRemoval{Seq: 2, Rev: channels.RevAndVersion{RevTreeID: "4-four", CurrentSource: newDoc.HLV.SourceID, CurrentVersion: string(base.Uint64CASToLittleEndianHex(newDoc.HLV.Version))}},
+		"public": &channels.ChannelRemoval{Seq: 2, Rev: channels.RevAndVersion{RevTreeID: "4-four", CurrentSource: newDoc.HLV.SourceID, CurrentVersion: newDoc.HLV.Version}},
 	}, doc.Channels)
 
 	assert.Equal(t, base.SetOf("clibup"), doc.History["4-four"].Channels)
@@ -1903,7 +1903,7 @@ func TestChannelQuery(t *testing.T) {
 			log.Printf("removedDocEntry Version: %v", removedDocEntry.Version)
 			require.Equal(t, testCase.expectedRev.RevTreeID, removedDocEntry.RevID)
 			require.Equal(t, testCase.expectedRev.CurrentSource, removedDocEntry.SourceID)
-			require.Equal(t, base.HexCasToUint64(testCase.expectedRev.CurrentVersion), removedDocEntry.Version)
+			require.Equal(t, testCase.expectedRev.CurrentVersion, removedDocEntry.Version)
 		})
 	}
 
@@ -1982,7 +1982,7 @@ func TestChannelQueryRevocation(t *testing.T) {
 			log.Printf("removedDocEntry Version: %v", removedDocEntry.Version)
 			require.Equal(t, testCase.expectedRev.RevTreeID, removedDocEntry.RevID)
 			require.Equal(t, testCase.expectedRev.CurrentSource, removedDocEntry.SourceID)
-			require.Equal(t, base.HexCasToUint64(testCase.expectedRev.CurrentVersion), removedDocEntry.Version)
+			require.Equal(t, testCase.expectedRev.CurrentVersion, removedDocEntry.Version)
 		})
 	}
 

--- a/db/document.go
+++ b/db/document.go
@@ -1297,7 +1297,7 @@ func (s *SyncData) GetRevAndVersion() (rav channels.RevAndVersion) {
 	rav.RevTreeID = s.CurrentRev
 	if s.HLV != nil {
 		rav.CurrentSource = s.HLV.SourceID
-		rav.CurrentVersion = string(base.Uint64CASToLittleEndianHex(s.HLV.Version))
+		rav.CurrentVersion = s.HLV.Version
 	}
 	return rav
 }

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -251,11 +251,11 @@ const doc_meta_with_vv = `{
   }`
 
 func TestParseVersionVectorSyncData(t *testing.T) {
-	mv := make(map[string]uint64)
-	pv := make(map[string]uint64)
-	mv["s_LhRPsa7CpjEvP5zeXTXEBA"] = 1628620455147864000
-	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = 1628620455139868700
-	pv["s_YZvBpEaztom9z5V/hDoeIw"] = 1628620455135215600
+	mv := make(map[string]string)
+	pv := make(map[string]string)
+	mv["s_LhRPsa7CpjEvP5zeXTXEBA"] = "c0ff05d7ac059a16"
+	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = "1c008cd6ac059a16"
+	pv["s_YZvBpEaztom9z5V/hDoeIw"] = "f0ff44d6ac059a16"
 
 	ctx := base.TestCtx(t)
 
@@ -263,9 +263,10 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalVV)
 	require.NoError(t, err)
 
+	strCAS := string(base.Uint64CASToLittleEndianHex(123456))
 	// assert on doc version vector values
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.Version)
 	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
@@ -274,8 +275,8 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert on doc version vector values
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.Version)
 	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
@@ -284,8 +285,8 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert on doc version vector values
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.Version)
 	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
@@ -299,31 +300,31 @@ func TestRevAndVersion(t *testing.T) {
 		testName  string
 		revTreeID string
 		source    string
-		version   uint64
+		version   string
 	}{
 		{
 			testName:  "rev_and_version",
 			revTreeID: "1-abc",
 			source:    "source1",
-			version:   1,
+			version:   "1",
 		},
 		{
 			testName:  "both_empty",
 			revTreeID: "",
 			source:    "",
-			version:   0,
+			version:   "0",
 		},
 		{
 			testName:  "revTreeID_only",
 			revTreeID: "1-abc",
 			source:    "",
-			version:   0,
+			version:   "0",
 		},
 		{
 			testName:  "currentVersion_only",
 			revTreeID: "",
 			source:    "source1",
-			version:   1,
+			version:   "1",
 		},
 	}
 

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -19,10 +19,10 @@ import (
 )
 
 // hlvExpandMacroCASValue causes the field to be populated by CAS value by macro expansion
-const hlvExpandMacroCASValue = math.MaxUint64
+const hlvExpandMacroCASValue = "expand"
 
-// HybridLogicalVector (HLV) is a type that represents a vector of Hybrid Logical Clocks.
-type HybridLogicalVector struct {
+// DecodedHybridLogicalVector (HLV) is a type that represents a decoded vector of Hybrid Logical Clocks.
+type DecodedHybridLogicalVector struct {
 	CurrentVersionCAS uint64            // current version cas (or cvCAS) stores the current CAS at the time of replication
 	ImportCAS         uint64            // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
 	SourceID          string            // source bucket uuid of where this entry originated from
@@ -36,10 +36,25 @@ type Version struct {
 	// SourceID is an ID representing the source of the value (e.g. Couchbase Lite ID)
 	SourceID string `json:"source_id"`
 	// Value is a Hybrid Logical Clock value (In Couchbase Server, CAS is a HLC)
+	Value string `json:"version"`
+}
+
+// ConflictFormatVersion is a sourceID and version pair in string/uint64 format for use in conflict detection
+type DecodedVersion struct {
+	// SourceID is an ID representing the source of the value (e.g. Couchbase Lite ID)
+	SourceID string `json:"source_id"`
+	// Value is a Hybrid Logical Clock value (In Couchbase Server, CAS is a HLC)
 	Value uint64 `json:"version"`
 }
 
-func CreateVersion(source string, version uint64) Version {
+func CreateDecodedVersion(source string, version uint64) DecodedVersion {
+	return DecodedVersion{
+		SourceID: source,
+		Value:    version,
+	}
+}
+
+func CreateVersion(source, version string) Version {
 	return Version{
 		SourceID: source,
 		Value:    version,
@@ -51,20 +66,20 @@ func CreateVersionFromString(versionString string) (version Version, err error) 
 	if !found {
 		return version, fmt.Errorf("Malformed version string %s, delimiter not found", versionString)
 	}
-	sourceBytes, err := base64.StdEncoding.DecodeString(sourceBase64)
-	if err != nil {
-		return version, fmt.Errorf("Unable to decode sourceID for version %s: %w", versionString, err)
-	}
-	version.SourceID = string(sourceBytes)
-	version.Value = base.HexCasToUint64(timestampString)
+	version.SourceID = sourceBase64
+	version.Value = timestampString
 	return version, nil
 }
 
 // String returns a Couchbase Lite-compatible string representation of the version.
-func (v Version) String() string {
+func (v DecodedVersion) String() string {
 	timestamp := string(base.Uint64CASToLittleEndianHex(v.Value))
 	source := base64.StdEncoding.EncodeToString([]byte(v.SourceID))
 	return timestamp + "@" + source
+}
+
+func (v Version) String() string {
+	return v.Value + "@" + v.SourceID
 }
 
 // ExtractCurrentVersionFromHLV will take the current version form the HLV struct and return it in the Version struct
@@ -76,7 +91,7 @@ func (hlv *HybridLogicalVector) ExtractCurrentVersionFromHLV() *Version {
 
 // PersistedHybridLogicalVector is the marshalled format of HybridLogicalVector.
 // This representation needs to be kept in sync with XDCR.
-type PersistedHybridLogicalVector struct {
+type HybridLogicalVector struct {
 	CurrentVersionCAS string            `json:"cvCas,omitempty"`
 	ImportCAS         string            `json:"importCAS,omitempty"`
 	SourceID          string            `json:"src"`
@@ -88,13 +103,13 @@ type PersistedHybridLogicalVector struct {
 // NewHybridLogicalVector returns an initialised HybridLogicalVector.
 func NewHybridLogicalVector() HybridLogicalVector {
 	return HybridLogicalVector{
-		PreviousVersions: make(map[string]uint64),
-		MergeVersions:    make(map[string]uint64),
+		PreviousVersions: make(map[string]string),
+		MergeVersions:    make(map[string]string),
 	}
 }
 
 // GetCurrentVersion returns the current version from the HLV in memory.
-func (hlv *HybridLogicalVector) GetCurrentVersion() (string, uint64) {
+func (hlv *HybridLogicalVector) GetCurrentVersion() (string, string) {
 	return hlv.SourceID, hlv.Version
 }
 
@@ -111,7 +126,7 @@ func (hlv *HybridLogicalVector) GetCurrentVersionString() string {
 }
 
 // IsInConflict tests to see if in memory HLV is conflicting with another HLV
-func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) IsInConflict(otherVector DecodedHybridLogicalVector) bool {
 	// test if either HLV(A) or HLV(B) are dominating over each other. If so they are not in conflict
 	if hlv.isDominating(otherVector) || otherVector.isDominating(*hlv) {
 		return false
@@ -122,8 +137,16 @@ func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bo
 
 // AddVersion adds newVersion to the in memory representation of the HLV.
 func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
-	if newVersion.Value < hlv.Version {
-		return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %d new cas %d", hlv.Version, newVersion.Value)
+	var newVersionCAS uint64
+	if newVersion.Value == hlvExpandMacroCASValue {
+		// if we have expand value than we need to add max uint64 here for below comparison
+		newVersionCAS = math.MaxUint64
+	} else {
+		newVersionCAS = base.HexCasToUint64(newVersion.Value)
+	}
+	hlvVersionCAS := base.HexCasToUint64(hlv.Version)
+	if newVersionCAS < hlvVersionCAS {
+		return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %s new cas %s", hlv.Version, newVersion.Value)
 	}
 	// check if this is the first time we're adding a source - version pair
 	if hlv.SourceID == "" {
@@ -138,16 +161,17 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	}
 	// if we get here this is a new version from a different sourceID thus need to move current sourceID to previous versions and update current version
 	if hlv.PreviousVersions == nil {
-		hlv.PreviousVersions = make(map[string]uint64)
+		hlv.PreviousVersions = make(map[string]string)
 	}
 	// we need to check if source ID already exists in PV, if so we need to ensure we are only updating with the
 	// sourceID-version pair if incoming version is greater than version already there
 	if currPVVersion, ok := hlv.PreviousVersions[hlv.SourceID]; ok {
 		// if we get here source ID exists in PV, only replace version if it is less than the incoming version
-		if currPVVersion < hlv.Version {
+		currPVVersionCAS := base.HexCasToUint64(currPVVersion)
+		if currPVVersionCAS < hlvVersionCAS {
 			hlv.PreviousVersions[hlv.SourceID] = hlv.Version
 		} else {
-			return fmt.Errorf("local hlv has current source in previous versiosn with version greater than current version. Current CAS: %d, PV CAS %d", hlv.Version, currPVVersion)
+			return fmt.Errorf("local hlv has current source in previous versiosn with version greater than current version. Current CAS: %s, PV CAS %s", hlv.Version, currPVVersion)
 		}
 	} else {
 		// source doesn't exist in PV so add
@@ -162,7 +186,7 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 // TODO: Does this need to remove source from current version as well? Merge Versions?
 func (hlv *HybridLogicalVector) Remove(source string) error {
 	// if entry is not found in previous versions we return error
-	if hlv.PreviousVersions[source] == 0 {
+	if hlv.PreviousVersions[source] == "" {
 		return base.ErrNotFound
 	}
 	delete(hlv.PreviousVersions, source)
@@ -170,7 +194,7 @@ func (hlv *HybridLogicalVector) Remove(source string) error {
 }
 
 // isDominating tests if in memory HLV is dominating over another
-func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) isDominating(otherVector DecodedHybridLogicalVector) bool {
 	// Dominating Criteria:
 	// HLV A dominates HLV B if source(A) == source(B) and version(A) > version(B)
 	// If there is an entry in pv(B) for A's current source and version(A) > B's version for that pv entry then A is dominating
@@ -186,7 +210,7 @@ func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bo
 }
 
 // isEqual tests if in memory HLV is equal to another
-func (hlv *HybridLogicalVector) isEqual(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) isEqual(otherVector DecodedHybridLogicalVector) bool {
 	// if in HLV(A) sourceID the same as HLV(B) sourceID and HLV(A) CAS is equal to HLV(B) CAS then the two HLV's are equal
 	if hlv.SourceID == otherVector.SourceID && hlv.Version == otherVector.Version {
 		return true
@@ -208,7 +232,7 @@ func (hlv *HybridLogicalVector) isEqual(otherVector HybridLogicalVector) bool {
 }
 
 // equalMergeVectors tests if two merge vectors between HLV's are equal or not
-func (hlv *HybridLogicalVector) equalMergeVectors(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) equalMergeVectors(otherVector DecodedHybridLogicalVector) bool {
 	if len(hlv.MergeVersions) != len(otherVector.MergeVersions) {
 		return false
 	}
@@ -221,7 +245,7 @@ func (hlv *HybridLogicalVector) equalMergeVectors(otherVector HybridLogicalVecto
 }
 
 // equalPreviousVectors tests if two previous versions vectors between two HLV's are equal or not
-func (hlv *HybridLogicalVector) equalPreviousVectors(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) equalPreviousVectors(otherVector DecodedHybridLogicalVector) bool {
 	if len(hlv.PreviousVersions) != len(otherVector.PreviousVersions) {
 		return false
 	}
@@ -235,7 +259,7 @@ func (hlv *HybridLogicalVector) equalPreviousVectors(otherVector HybridLogicalVe
 
 // GetVersion returns the latest CAS value in the HLV for a given sourceID along with boolean value to
 // indicate if sourceID is found in the HLV, if the sourceID is not present in the HLV it will return 0 CAS value and false
-func (hlv *HybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
+func (hlv *DecodedHybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
 	if sourceID == "" {
 		return 0, false
 	}
@@ -272,7 +296,13 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 		// Iterate through incoming vector previous versions, update with the version from other vector
 		// for source if the local version for that source is lower
 		for i, v := range otherVector.PreviousVersions {
-			if hlv.PreviousVersions[i] == 0 || hlv.PreviousVersions[i] < v {
+			if hlv.PreviousVersions[i] == "" {
+				hlv.setPreviousVersion(i, v)
+			}
+			// if we get here then there is entry for this source in PV dso we must check if its newer or not
+			otherHLVPVValue := base.HexCasToUint64(v)
+			localHLVPVValue := base.HexCasToUint64(hlv.PreviousVersions[i])
+			if localHLVPVValue < otherHLVPVValue {
 				hlv.setPreviousVersion(i, v)
 			}
 		}
@@ -282,104 +312,6 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 		delete(hlv.PreviousVersions, hlv.SourceID)
 	}
 	return nil
-}
-
-func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
-
-	persistedHLV, err := hlv.convertHLVToPersistedFormat()
-	if err != nil {
-		return nil, err
-	}
-
-	return base.JSONMarshal(*persistedHLV)
-}
-
-func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
-	persistedJSON := PersistedHybridLogicalVector{}
-	err := base.JSONUnmarshal(inputjson, &persistedJSON)
-	if err != nil {
-		return err
-	}
-	// convert the data to in memory format
-	hlv.convertPersistedHLVToInMemoryHLV(persistedJSON)
-	return nil
-}
-
-func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridLogicalVector, error) {
-	persistedHLV := PersistedHybridLogicalVector{}
-	var cvCasByteArray []byte
-	var importCASBytes []byte
-	var vrsCasByteArray []byte
-	if hlv.CurrentVersionCAS != 0 {
-		cvCasByteArray = base.Uint64CASToLittleEndianHex(hlv.CurrentVersionCAS)
-	}
-	if hlv.ImportCAS != 0 {
-		importCASBytes = base.Uint64CASToLittleEndianHex(hlv.ImportCAS)
-	}
-	if hlv.Version != 0 {
-		vrsCasByteArray = base.Uint64CASToLittleEndianHex(hlv.Version)
-	}
-
-	pvPersistedFormat, err := convertMapToPersistedFormat(hlv.PreviousVersions)
-	if err != nil {
-		return nil, err
-	}
-	mvPersistedFormat, err := convertMapToPersistedFormat(hlv.MergeVersions)
-	if err != nil {
-		return nil, err
-	}
-
-	persistedHLV.CurrentVersionCAS = string(cvCasByteArray)
-	persistedHLV.ImportCAS = string(importCASBytes)
-	persistedHLV.SourceID = hlv.SourceID
-	persistedHLV.Version = string(vrsCasByteArray)
-	persistedHLV.PreviousVersions = pvPersistedFormat
-	persistedHLV.MergeVersions = mvPersistedFormat
-	return &persistedHLV, nil
-}
-
-func (hlv *HybridLogicalVector) convertPersistedHLVToInMemoryHLV(persistedJSON PersistedHybridLogicalVector) {
-	hlv.CurrentVersionCAS = base.HexCasToUint64(persistedJSON.CurrentVersionCAS)
-	if persistedJSON.ImportCAS != "" {
-		hlv.ImportCAS = base.HexCasToUint64(persistedJSON.ImportCAS)
-	}
-	hlv.SourceID = persistedJSON.SourceID
-	// convert the hex cas to uint64 cas
-	hlv.Version = base.HexCasToUint64(persistedJSON.Version)
-	// convert the maps form persisted format to the in memory format
-	hlv.PreviousVersions = convertMapToInMemoryFormat(persistedJSON.PreviousVersions)
-	hlv.MergeVersions = convertMapToInMemoryFormat(persistedJSON.MergeVersions)
-}
-
-// convertMapToPersistedFormat will convert in memory map of previous versions or merge versions into the persisted format map
-func convertMapToPersistedFormat(memoryMap map[string]uint64) (map[string]string, error) {
-	if memoryMap == nil {
-		return nil, nil
-	}
-	returnedMap := make(map[string]string)
-	var persistedCAS string
-	for source, cas := range memoryMap {
-		casByteArray := base.Uint64CASToLittleEndianHex(cas)
-		persistedCAS = string(casByteArray)
-		// remove the leading '0x' from the CAS value
-		persistedCAS = persistedCAS[2:]
-		returnedMap[source] = persistedCAS
-	}
-	return returnedMap, nil
-}
-
-// convertMapToInMemoryFormat will convert the persisted format map to an in memory format of that map.
-// Used for previous versions and merge versions maps on HLV
-func convertMapToInMemoryFormat(persistedMap map[string]string) map[string]uint64 {
-	if persistedMap == nil {
-		return nil
-	}
-	returnedMap := make(map[string]uint64)
-	// convert each CAS entry from little endian hex to Uint64
-	for key, value := range persistedMap {
-		returnedMap[key] = base.HexCasToUint64(value)
-	}
-	return returnedMap
 }
 
 // computeMacroExpansions returns the mutate in spec needed for the document update based off the outcome in updateHLV
@@ -400,9 +332,9 @@ func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansi
 }
 
 // setPreviousVersion will take a source/version pair and add it to the HLV previous versions map
-func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64) {
+func (hlv *HybridLogicalVector) setPreviousVersion(source string, version string) {
 	if hlv.PreviousVersions == nil {
-		hlv.PreviousVersions = make(map[string]uint64)
+		hlv.PreviousVersions = make(map[string]string)
 	}
 	hlv.PreviousVersions[source] = version
 }
@@ -441,6 +373,36 @@ func (hlv *HybridLogicalVector) toHistoryForHLV() string {
 		}
 	}
 	return s.String()
+}
+
+// check if HexCasToUint64 handles empty string, if so remove checks for empty string
+func (hlv *HybridLogicalVector) ToDecodedHybridLogicalVector() DecodedHybridLogicalVector {
+	var decodedVersion, decodedCVCAS, decodedImportCAS uint64
+	if hlv.Version != "" {
+		decodedVersion = base.HexCasToUint64(hlv.Version)
+	}
+	if hlv.ImportCAS != "" {
+		decodedImportCAS = base.HexCasToUint64(hlv.ImportCAS)
+	}
+	if hlv.CurrentVersionCAS != "" {
+		decodedCVCAS = base.HexCasToUint64(hlv.CurrentVersionCAS)
+	}
+	decodedHLV := DecodedHybridLogicalVector{
+		CurrentVersionCAS: decodedCVCAS,
+		Version:           decodedVersion,
+		ImportCAS:         decodedImportCAS,
+		SourceID:          hlv.SourceID,
+		PreviousVersions:  make(map[string]uint64),
+		MergeVersions:     make(map[string]uint64),
+	}
+
+	for i, v := range hlv.PreviousVersions {
+		decodedHLV.PreviousVersions[i] = base.HexCasToUint64(v)
+	}
+	for i, v := range hlv.MergeVersions {
+		decodedHLV.MergeVersions[i] = base.HexCasToUint64(v)
+	}
+	return decodedHLV
 }
 
 // appendRevocationMacroExpansions adds macro expansions for the channel map.  Not strictly an HLV operation

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -47,7 +47,7 @@ type Version struct {
 	Value string `json:"version"`
 }
 
-// ConflictFormatVersion is a sourceID and version pair in string/uint64 format for use in conflict detection
+// DecodedVersion is a sourceID and version pair in string/uint64 format for use in conflict detection
 type DecodedVersion struct {
 	// SourceID is an ID representing the source of the value (e.g. Couchbase Lite ID)
 	SourceID string `json:"source_id"`
@@ -55,6 +55,7 @@ type DecodedVersion struct {
 	Value uint64 `json:"version"`
 }
 
+// CreateDecodedVersion creates a sourceID and version pair in string/uint64 format
 func CreateDecodedVersion(source string, version uint64) DecodedVersion {
 	return DecodedVersion{
 		SourceID: source,
@@ -62,6 +63,7 @@ func CreateDecodedVersion(source string, version uint64) DecodedVersion {
 	}
 }
 
+// CreateVersion creates an encoded sourceID and version pair
 func CreateVersion(source, version string) Version {
 	return Version{
 		SourceID: source,
@@ -86,6 +88,7 @@ func (v DecodedVersion) String() string {
 	return timestamp + "@" + source
 }
 
+// String returns a version/sourceID pair in CBL string format
 func (v Version) String() string {
 	return v.Value + "@" + v.SourceID
 }

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -255,7 +255,7 @@ func TestHLVImport(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	localSource := base64.StdEncoding.EncodeToString([]byte(collection.dbCtx.BucketUUID))
+	localSource := db.EncodedBucketUUID
 
 	// 1. Test standard import of an SDK write
 	standardImportKey := "standardImport_" + t.Name()

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -202,10 +202,9 @@ func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 		require.NoError(tb, err)
 		if strings.HasPrefix(currentVersionPair[0], "m_") {
 			// add entry to merge version removing the leading prefix for sourceID
-
 			hlvOutput.MergeVersions[base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0][2:]))] = string(base.Uint64CASToLittleEndianHex(version))
 		} else {
-			// if its not got the prefix we assume its a previous version entry
+			// if it's not got the prefix we assume it's a previous version entry
 			hlvOutput.PreviousVersions[base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0]))] = string(base.Uint64CASToLittleEndianHex(version))
 		}
 	}
@@ -278,7 +277,6 @@ func TestHLVImport(t *testing.T) {
 
 	// 2. Test import of write by HLV-aware peer (HLV is already updated, sync metadata is not).
 	otherSource := "otherSource"
-	encodedSource := base64.StdEncoding.EncodeToString([]byte(otherSource))
 	hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_sync")
 	existingHLVKey := "existingHLV_" + t.Name()
 	_ = hlvHelper.InsertWithHLV(ctx, existingHLVKey)
@@ -298,7 +296,7 @@ func TestHLVImport(t *testing.T) {
 	require.Equal(t, encodedCAS, importedHLV.ImportCAS)
 	require.Equal(t, encodedCAS, importedHLV.CurrentVersionCAS)
 	require.Equal(t, encodedCAS, importedHLV.Version)
-	require.Equal(t, encodedSource, importedHLV.SourceID)
+	require.Equal(t, hlvHelper.Source, importedHLV.SourceID)
 }
 
 func TestGreg(t *testing.T) {

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -10,7 +10,6 @@ package db
 
 import (
 	"encoding/base64"
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -189,8 +188,9 @@ func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 	hlvOutput.SourceID = base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0]))
 	version, err := strconv.ParseUint(currentVersionPair[1], 10, 64)
 	require.NoError(tb, err)
-	hlvOutput.Version = string(base.Uint64CASToLittleEndianHex(version))
-	hlvOutput.CurrentVersionCAS = string(base.Uint64CASToLittleEndianHex(version))
+	vrsEncoded := string(base.Uint64CASToLittleEndianHex(version))
+	hlvOutput.Version = vrsEncoded
+	hlvOutput.CurrentVersionCAS = vrsEncoded
 
 	// remove current version entry in list now we have parsed it into the HLV
 	inputList = inputList[1:]
@@ -198,7 +198,6 @@ func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 	for _, value := range inputList {
 		currentVersionPair = strings.Split(value, "@")
 		version, err = strconv.ParseUint(currentVersionPair[1], 10, 64)
-		//strconv.ParseUint(decData.UID, 16, 64)
 		require.NoError(tb, err)
 		if strings.HasPrefix(currentVersionPair[0], "m_") {
 			// add entry to merge version removing the leading prefix for sourceID
@@ -297,11 +296,6 @@ func TestHLVImport(t *testing.T) {
 	require.Equal(t, encodedCAS, importedHLV.CurrentVersionCAS)
 	require.Equal(t, encodedCAS, importedHLV.Version)
 	require.Equal(t, hlvHelper.Source, importedHLV.SourceID)
-}
-
-func TestGreg(t *testing.T) {
-	lol := base.HexCasToUint64("")
-	fmt.Println(lol)
 }
 
 // TestHLVMapToCBLString:

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -9,6 +9,8 @@
 package db
 
 import (
+	"encoding/base64"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -24,20 +26,20 @@ import (
 //   - Tests internal api methods on the HLV work as expected
 //   - Tests methods GetCurrentVersion, AddVersion and Remove
 func TestInternalHLVFunctions(t *testing.T) {
-	pv := make(map[string]uint64)
-	currSourceId := "s_5pRi8Piv1yLcLJ1iVNJIsA"
-	const currVersion = 12345678
-	pv["s_YZvBpEaztom9z5V/hDoeIw"] = 64463204720
+	pv := make(map[string]string)
+	currSourceId := base64.StdEncoding.EncodeToString([]byte("5pRi8Piv1yLcLJ1iVNJIsA"))
+	currVersion := string(base.Uint64CASToLittleEndianHex(12345678))
+	pv[base64.StdEncoding.EncodeToString([]byte("YZvBpEaztom9z5V/hDoeIw"))] = string(base.Uint64CASToLittleEndianHex(64463204720))
 
-	inputHLV := []string{"s_5pRi8Piv1yLcLJ1iVNJIsA@12345678", "s_YZvBpEaztom9z5V/hDoeIw@64463204720", "m_s_NqiIe0LekFPLeX4JvTO6Iw@345454"}
+	inputHLV := []string{"5pRi8Piv1yLcLJ1iVNJIsA@12345678", "YZvBpEaztom9z5V/hDoeIw@64463204720", "m_NqiIe0LekFPLeX4JvTO6Iw@345454"}
 	hlv := createHLVForTest(t, inputHLV)
 
-	const newCAS = 123456789
+	newCAS := string(base.Uint64CASToLittleEndianHex(123456789))
 	const newSource = "s_testsource"
 
 	// create a new version vector entry that will error method AddVersion
 	badNewVector := Version{
-		Value:    123345,
+		Value:    string(base.Uint64CASToLittleEndianHex(123345)),
 		SourceID: currSourceId,
 	}
 	// create a new version vector entry that should be added to HLV successfully
@@ -49,7 +51,7 @@ func TestInternalHLVFunctions(t *testing.T) {
 	// Get current version vector, sourceID and CAS pair
 	source, version := hlv.GetCurrentVersion()
 	assert.Equal(t, currSourceId, source)
-	assert.Equal(t, uint64(currVersion), version)
+	assert.Equal(t, currVersion, version)
 
 	// add new version vector with same sourceID as current sourceID and assert it doesn't add to previous versions then restore HLV to previous state
 	require.NoError(t, hlv.AddVersion(newVersionVector))
@@ -64,7 +66,7 @@ func TestInternalHLVFunctions(t *testing.T) {
 	// Add a new version vector pair to the HLV structure and assert that it moves the current version vector pair to the previous versions section
 	newVersionVector.SourceID = newSource
 	require.NoError(t, hlv.AddVersion(newVersionVector))
-	assert.Equal(t, uint64(newCAS), hlv.Version)
+	assert.Equal(t, newCAS, hlv.Version)
 	assert.Equal(t, newSource, hlv.SourceID)
 	assert.True(t, reflect.DeepEqual(hlv.PreviousVersions, pv))
 
@@ -115,7 +117,9 @@ func TestConflictDetectionDominating(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			hlvA := createHLVForTest(t, testCase.inputListHLVA)
 			hlvB := createHLVForTest(t, testCase.inputListHLVB)
-			require.False(t, hlvA.IsInConflict(hlvB))
+			decHLVA := hlvA.ToDecodedHybridLogicalVector()
+			decHLVB := hlvB.ToDecodedHybridLogicalVector()
+			require.False(t, decHLVA.IsInConflict(decHLVB))
 		})
 	}
 }
@@ -131,25 +135,33 @@ func TestConflictEqualHLV(t *testing.T) {
 	inputHLVB := []string{"cluster1@10", "cluster2@4"}
 	hlvA := createHLVForTest(t, inputHLVA)
 	hlvB := createHLVForTest(t, inputHLVB)
-	require.True(t, hlvA.isEqual(hlvB))
+	decHLVA := hlvA.ToDecodedHybridLogicalVector()
+	decHLVB := hlvB.ToDecodedHybridLogicalVector()
+	require.True(t, decHLVA.isEqual(decHLVB))
 
 	// test conflict detection with different version CAS but same merge versions
 	inputHLVA = []string{"cluster2@12", "cluster3@3", "cluster4@2"}
 	inputHLVB = []string{"cluster1@10", "cluster3@3", "cluster4@2"}
 	hlvA = createHLVForTest(t, inputHLVA)
 	hlvB = createHLVForTest(t, inputHLVB)
-	require.True(t, hlvA.isEqual(hlvB))
+	decHLVA = hlvA.ToDecodedHybridLogicalVector()
+	decHLVB = hlvB.ToDecodedHybridLogicalVector()
+	require.True(t, decHLVA.isEqual(decHLVB))
 
 	// test conflict detection with different version CAS but same previous version vectors
 	inputHLVA = []string{"cluster3@2", "cluster1@3", "cluster2@5"}
 	hlvA = createHLVForTest(t, inputHLVA)
 	inputHLVB = []string{"cluster4@7", "cluster1@3", "cluster2@5"}
 	hlvB = createHLVForTest(t, inputHLVB)
-	require.True(t, hlvA.isEqual(hlvB))
+	decHLVA = hlvA.ToDecodedHybridLogicalVector()
+	decHLVB = hlvB.ToDecodedHybridLogicalVector()
+	require.True(t, decHLVA.isEqual(decHLVB))
 
+	cluster1Encoded := base64.StdEncoding.EncodeToString([]byte("cluster1"))
 	// remove an entry from one of the HLV PVs to assert we get false returned from isEqual
-	require.NoError(t, hlvA.Remove("cluster1"))
-	require.False(t, hlvA.isEqual(hlvB))
+	require.NoError(t, hlvA.Remove(cluster1Encoded))
+	decHLVA = hlvA.ToDecodedHybridLogicalVector()
+	require.False(t, decHLVA.isEqual(decHLVB))
 }
 
 // TestConflictExample:
@@ -161,7 +173,10 @@ func TestConflictExample(t *testing.T) {
 
 	input = []string{"cluster2@2", "cluster3@3"}
 	otherVector := createHLVForTest(t, input)
-	require.True(t, inMemoryHLV.IsInConflict(otherVector))
+
+	inMemoryHLVDec := inMemoryHLV.ToDecodedHybridLogicalVector()
+	otherVectorDec := otherVector.ToDecodedHybridLogicalVector()
+	require.True(t, inMemoryHLVDec.IsInConflict(otherVectorDec))
 }
 
 // createHLVForTest is a helper function to create a HLV for use in a test. Takes a list of strings in the format of <sourceID@version> and assumes
@@ -171,65 +186,30 @@ func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 
 	// first element will be current version and source pair
 	currentVersionPair := strings.Split(inputList[0], "@")
-	hlvOutput.SourceID = currentVersionPair[0]
-	version, err := strconv.Atoi(currentVersionPair[1])
+	hlvOutput.SourceID = base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0]))
+	version, err := strconv.ParseUint(currentVersionPair[1], 10, 64)
 	require.NoError(tb, err)
-	hlvOutput.Version = uint64(version)
-	hlvOutput.CurrentVersionCAS = uint64(version)
+	hlvOutput.Version = string(base.Uint64CASToLittleEndianHex(version))
+	hlvOutput.CurrentVersionCAS = string(base.Uint64CASToLittleEndianHex(version))
 
 	// remove current version entry in list now we have parsed it into the HLV
 	inputList = inputList[1:]
 
 	for _, value := range inputList {
 		currentVersionPair = strings.Split(value, "@")
-		version, err = strconv.Atoi(currentVersionPair[1])
+		version, err = strconv.ParseUint(currentVersionPair[1], 10, 64)
+		//strconv.ParseUint(decData.UID, 16, 64)
 		require.NoError(tb, err)
 		if strings.HasPrefix(currentVersionPair[0], "m_") {
 			// add entry to merge version removing the leading prefix for sourceID
-			hlvOutput.MergeVersions[currentVersionPair[0][2:]] = uint64(version)
+
+			hlvOutput.MergeVersions[base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0][2:]))] = string(base.Uint64CASToLittleEndianHex(version))
 		} else {
 			// if its not got the prefix we assume its a previous version entry
-			hlvOutput.PreviousVersions[currentVersionPair[0]] = uint64(version)
+			hlvOutput.PreviousVersions[base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0]))] = string(base.Uint64CASToLittleEndianHex(version))
 		}
 	}
 	return hlvOutput
-}
-
-// TestHybridLogicalVectorPersistence:
-//   - Tests the process of constructing in memory HLV and marshaling it to persisted format
-//   - Asserts on the format
-//   - Unmarshal the HLV and assert that the process works as expected
-func TestHybridLogicalVectorPersistence(t *testing.T) {
-	// create HLV
-	inputHLV := []string{"cb06dc003846116d9b66d2ab23887a96@123456", "s_YZvBpEaztom9z5V/hDoeIw@1628620455135215600", "m_s_NqiIe0LekFPLeX4JvTO6Iw@1628620455139868700",
-		"m_s_LhRPsa7CpjEvP5zeXTXEBA@1628620455147864000"}
-	inMemoryHLV := createHLVForTest(t, inputHLV)
-
-	// marshal in memory hlv into persisted form
-	byteArray, err := inMemoryHLV.MarshalJSON()
-	require.NoError(t, err)
-
-	// convert to string and assert the in memory struct is converted to persisted form correctly
-	// no guarantee the order of the marshaling of the mv part so just assert on the values
-	strHLV := string(byteArray)
-	assert.Contains(t, strHLV, `"cvCas":"0x40e2010000000000`)
-	assert.Contains(t, strHLV, `"src":"cb06dc003846116d9b66d2ab23887a96"`)
-	assert.Contains(t, strHLV, `"vrs":"0x40e2010000000000"`)
-	assert.Contains(t, strHLV, `"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16"`)
-	assert.Contains(t, strHLV, `"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"`)
-	assert.Contains(t, strHLV, `"pv":{"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"}`)
-
-	// Unmarshal the in memory constructed HLV above
-	hlvFromPersistance := HybridLogicalVector{}
-	err = hlvFromPersistance.UnmarshalJSON(byteArray)
-	require.NoError(t, err)
-
-	// assertions on values of unmarshaled HLV
-	assert.Equal(t, inMemoryHLV.CurrentVersionCAS, hlvFromPersistance.CurrentVersionCAS)
-	assert.Equal(t, inMemoryHLV.SourceID, hlvFromPersistance.SourceID)
-	assert.Equal(t, inMemoryHLV.Version, hlvFromPersistance.Version)
-	assert.Equal(t, inMemoryHLV.PreviousVersions, hlvFromPersistance.PreviousVersions)
-	assert.Equal(t, inMemoryHLV.MergeVersions, hlvFromPersistance.MergeVersions)
 }
 
 func TestAddNewerVersionsBetweenTwoVectorsWhenNotInConflict(t *testing.T) {
@@ -277,7 +257,7 @@ func TestHLVImport(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	localSource := collection.dbCtx.BucketUUID
+	localSource := base64.StdEncoding.EncodeToString([]byte(collection.dbCtx.BucketUUID))
 
 	// 1. Test standard import of an SDK write
 	standardImportKey := "standardImport_" + t.Name()
@@ -290,13 +270,15 @@ func TestHLVImport(t *testing.T) {
 	importedDoc, _, err := collection.GetDocWithXattr(ctx, standardImportKey, DocUnmarshalAll)
 	require.NoError(t, err)
 	importedHLV := importedDoc.HLV
-	require.Equal(t, cas, importedHLV.ImportCAS)
-	require.Equal(t, importedDoc.Cas, importedHLV.CurrentVersionCAS)
-	require.Equal(t, importedDoc.Cas, importedHLV.Version)
+	encodedCAS := string(base.Uint64CASToLittleEndianHex(cas))
+	require.Equal(t, encodedCAS, importedHLV.ImportCAS)
+	require.Equal(t, importedDoc.SyncData.Cas, importedHLV.CurrentVersionCAS)
+	require.Equal(t, importedDoc.SyncData.Cas, importedHLV.Version)
 	require.Equal(t, localSource, importedHLV.SourceID)
 
 	// 2. Test import of write by HLV-aware peer (HLV is already updated, sync metadata is not).
 	otherSource := "otherSource"
+	encodedSource := base64.StdEncoding.EncodeToString([]byte(otherSource))
 	hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_sync")
 	existingHLVKey := "existingHLV_" + t.Name()
 	_ = hlvHelper.InsertWithHLV(ctx, existingHLVKey)
@@ -304,6 +286,7 @@ func TestHLVImport(t *testing.T) {
 	var existingBody, existingXattr []byte
 	cas, err = collection.dataStore.GetWithXattr(ctx, existingHLVKey, "_sync", "", &existingBody, &existingXattr, nil)
 	require.NoError(t, err)
+	encodedCAS = string(base.Uint64CASToLittleEndianHex(cas))
 
 	_, err = collection.ImportDocRaw(ctx, existingHLVKey, existingBody, existingXattr, nil, false, cas, nil, ImportFromFeed)
 	require.NoError(t, err, "import error")
@@ -312,10 +295,15 @@ func TestHLVImport(t *testing.T) {
 	require.NoError(t, err)
 	importedHLV = importedDoc.HLV
 	// cas in the HLV's current version and cvCAS should not have changed, and should match importCAS
-	require.Equal(t, cas, importedHLV.ImportCAS)
-	require.Equal(t, cas, importedHLV.CurrentVersionCAS)
-	require.Equal(t, cas, importedHLV.Version)
-	require.Equal(t, otherSource, importedHLV.SourceID)
+	require.Equal(t, encodedCAS, importedHLV.ImportCAS)
+	require.Equal(t, encodedCAS, importedHLV.CurrentVersionCAS)
+	require.Equal(t, encodedCAS, importedHLV.Version)
+	require.Equal(t, encodedSource, importedHLV.SourceID)
+}
+
+func TestGreg(t *testing.T) {
+	lol := base.HexCasToUint64("")
+	fmt.Println(lol)
 }
 
 // TestHLVMapToCBLString:

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -236,7 +236,7 @@ type IDAndRev struct {
 
 type IDandCV struct {
 	DocID   string
-	Version uint64
+	Version string
 	Source  string
 }
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -779,7 +778,7 @@ func TestGetActive(t *testing.T) {
 	syncCAS := string(base.Uint64CASToLittleEndianHex(doc.Cas))
 
 	expectedCV := Version{
-		SourceID: base64.StdEncoding.EncodeToString([]byte(db.BucketUUID)),
+		SourceID: db.EncodedBucketUUID,
 		Value:    syncCAS,
 	}
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -53,7 +54,7 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 
 	doc.HLV = &HybridLogicalVector{
 		SourceID: "test",
-		Version:  123,
+		Version:  "123",
 	}
 	_, _, err = doc.updateChannels(ctx, base.SetOf("*"))
 	if err != nil {
@@ -113,7 +114,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Get them back out
@@ -130,7 +131,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Add 3 more docs to the now full revcache
 	for i := 10; i < 13; i++ {
 		docID := strconv.Itoa(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: docID, SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Check that the first 3 docs were evicted
@@ -173,7 +174,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// assert that the list has 10 elements along with both lookup maps
@@ -184,7 +185,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Add 3 more docs to the now full rev cache to trigger eviction
 	for docID := 10; docID < 13; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
 	assert.Equal(t, 10, len(cache.hlvCache))
@@ -195,7 +196,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	prevCacheHitCount := cacheHitCounter.Value()
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		cv := Version{Value: uint64(i + 3), SourceID: "test"}
+		cv := Version{Value: id, SourceID: "test"}
 		docRev, err := cache.GetWithCV(ctx, id, &cv, RevCacheOmitBody, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -273,13 +274,13 @@ func TestBackingStoreCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"not_found"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	cv := Version{SourceID: "test", Value: 123}
+	cv := Version{SourceID: "test", Value: "123"}
 	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Value)
+	assert.Equal(t, "123", docRev.CV.Value)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
@@ -290,14 +291,14 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Value)
+	assert.Equal(t, "123", docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	cv = Version{SourceID: "test11", Value: 100}
+	cv = Version{SourceID: "test11", Value: "100"}
 	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -560,7 +561,7 @@ func TestSingleLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: "123", SourceID: "test"}, History: Revisions{"start": 1}})
 	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", true, false)
 	assert.NoError(t, err)
 }
@@ -570,7 +571,8 @@ func TestConcurrentLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: "1234", SourceID: "test"}, History: Revisions{"start": 1}})
+
 	// Trigger load into cache
 	var wg sync.WaitGroup
 	wg.Add(20)
@@ -634,7 +636,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cv := Version{SourceID: "test", Value: 123}
+	cv := Version{SourceID: "test", Value: "123"}
 	documentRevision := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -650,7 +652,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Value)
+	assert.Equal(t, "123", docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
@@ -663,7 +665,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Value)
+	assert.Equal(t, "123", docRev.CV.Value)
 	assert.Equal(t, []byte(`{"test":"12345"}`), docRev.BodyBytes)
 	assert.Equal(t, int64(2), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
@@ -707,7 +709,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// create cv with incorrect version to the one stored in backing store
-	cv := Version{SourceID: "test", Value: 1234}
+	cv := Version{SourceID: "test", Value: "1234"}
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	require.Error(t, err)
@@ -737,7 +739,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := Version{SourceID: "test", Value: 123}
+	cv := Version{SourceID: "test", Value: "123"}
 	go func() {
 		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", RevCacheOmitBody, RevCacheIncludeDelta)
 		require.NoError(t, err)
@@ -753,7 +755,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg.Wait()
 
 	revElement := cache.cache[IDAndRev{RevID: "1-abc", DocID: "doc1"}]
-	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123}]
+	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: "123"}]
 	assert.Equal(t, 1, cache.lruList.Len())
 	assert.Equal(t, 1, len(cache.cache))
 	assert.Equal(t, 1, len(cache.hlvCache))
@@ -774,10 +776,11 @@ func TestGetActive(t *testing.T) {
 
 	rev1id, doc, err := collection.Put(ctx, "doc", Body{"val": 123})
 	require.NoError(t, err)
+	syncCAS := string(base.Uint64CASToLittleEndianHex(doc.Cas))
 
 	expectedCV := Version{
-		SourceID: db.BucketUUID,
-		Value:    doc.Cas,
+		SourceID: base64.StdEncoding.EncodeToString([]byte(db.BucketUUID)),
+		Value:    syncCAS,
 	}
 
 	// remove the entry form the rev cache to force the cache to not have the active version in it
@@ -803,7 +806,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := Version{SourceID: "test", Value: 123}
+	cv := Version{SourceID: "test", Value: "123"}
 	docRev := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -827,7 +830,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg.Wait()
 
 	revElement := cache.cache[IDAndRev{RevID: "1-abc", DocID: "doc1"}]
-	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123}]
+	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: "123"}]
 
 	assert.Equal(t, 1, cache.lruList.Len())
 	assert.Equal(t, 1, len(cache.cache))

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -679,7 +679,7 @@ func createTestDocument(docID string, revID string, body Body, deleted bool, exp
 }
 
 // requireCurrentVersion fetches the document by key, and validates that cv matches.
-func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, source string, version uint64) {
+func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, source string, version string) {
 	ctx := base.TestCtx(t)
 	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)
@@ -694,12 +694,12 @@ func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, sou
 }
 
 // GetDocumentCurrentVersion fetches the document by key and returns the current version
-func (c *DatabaseCollection) GetDocumentCurrentVersion(t *testing.T, key string) (source string, version uint64) {
+func (c *DatabaseCollection) GetDocumentCurrentVersion(t *testing.T, key string) (source string, version string) {
 	ctx := base.TestCtx(t)
 	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)
 	if doc.HLV == nil {
-		return "", 0
+		return "", ""
 	}
 	return doc.HLV.SourceID, doc.HLV.Version
 }

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -23,7 +24,7 @@ import (
 type HLVAgent struct {
 	t         *testing.T
 	datastore base.DataStore
-	source    string // All writes by the HLVHelper are done as this source
+	Source    string // All writes by the HLVHelper are done as this source
 	xattrName string // xattr name to store the HLV
 }
 
@@ -33,7 +34,7 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 	return &HLVAgent{
 		t:         t,
 		datastore: datastore,
-		source:    source, // all writes by the HLVHelper are done as this source
+		Source:    base64.StdEncoding.EncodeToString([]byte(source)), // all writes by the HLVHelper are done as this source
 		xattrName: xattrName,
 	}
 }
@@ -42,7 +43,7 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 // a different HLV-aware peer)
 func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64) {
 	hlv := &HybridLogicalVector{}
-	err := hlv.AddVersion(CreateVersion(h.source, hlvExpandMacroCASValue))
+	err := hlv.AddVersion(CreateVersion(h.Source, hlvExpandMacroCASValue))
 	require.NoError(h.t, err)
 	hlv.CurrentVersionCAS = hlvExpandMacroCASValue
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2825,7 +2825,7 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	bucketUUID := base64.StdEncoding.EncodeToString([]byte(rt.GetDatabase().BucketUUID))
+	bucketUUID := rt.GetDatabase().EncodedBucketUUID
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"key": "value"}`)
 	RequireStatus(t, resp, http.StatusCreated)
@@ -2876,7 +2876,7 @@ func TestHLVOnPutWithImportRejection(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	bucketUUID := base64.StdEncoding.EncodeToString([]byte(rt.GetDatabase().BucketUUID))
+	bucketUUID := rt.GetDatabase().EncodedBucketUUID
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"type": "mobile"}`)
 	RequireStatus(t, resp, http.StatusCreated)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2825,19 +2825,17 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
-	require.NoError(t, err)
+	bucketUUID := base64.StdEncoding.EncodeToString([]byte(rt.GetDatabase().BucketUUID))
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"key": "value"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
-	uintCAS := base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 
 	// Put a new revision of this doc and assert that the version vector SourceID and Version is updated
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, `{"key1": "value1"}`)
@@ -2845,11 +2843,10 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 
 	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
-	uintCAS = base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 
 	// Delete doc and assert that the version vector SourceID and Version is updated
 	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, "")
@@ -2857,11 +2854,10 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 
 	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
-	uintCAS = base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 }
 
 // TestHLVOnPutWithImportRejection:
@@ -2880,19 +2876,17 @@ func TestHLVOnPutWithImportRejection(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
-	require.NoError(t, err)
+	bucketUUID := base64.StdEncoding.EncodeToString([]byte(rt.GetDatabase().BucketUUID))
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"type": "mobile"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
-	uintCAS := base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 
 	// Put a doc that will be rejected by the import filter on the attempt to perform on demand import for write
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"type": "not-mobile"}`)
@@ -2901,11 +2895,10 @@ func TestHLVOnPutWithImportRejection(t *testing.T) {
 	// assert that the hlv is correctly updated and in tact after the import was cancelled on the doc
 	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc2")
 	assert.NoError(t, err)
-	uintCAS = base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 }
 
 func TestTombstoneCompactionAPI(t *testing.T) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1911,8 +1911,8 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 		version1 := DocVersion{
 			RevID: bucketDoc.CurrentRev,
 			CV: db.Version{
-				SourceID: otherSource,
-				Value:    cas,
+				SourceID: hlvHelper.Source,
+				Value:    string(base.Uint64CASToLittleEndianHex(cas)),
 			},
 		}
 		_, ok := btcRunner.WaitForVersion(client.id, docID, version1)
@@ -2979,7 +2979,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 			},
 			{
 				name:        "_revisions property",
-				invalidBody: []byte(`{"_revisions": {"start": 0, "ids": ["foo", "def]"}}`),
+				invalidBody: []byte(`{"_revisions": {"start": 0, "ids": ["foo", "def"]}}`),
 			},
 
 			{

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -283,7 +283,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 	defer rt.Close()
 	ctx := base.TestCtx(t)
 	collection := rt.GetSingleTestDatabaseCollection()
-	bucketUUID := rt.GetDatabase().BucketUUID
+	bucketUUID := rt.GetDatabase().EncodedBucketUUID
 	const DocID = "doc1"
 
 	// activate channel cache
@@ -315,7 +315,7 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 	defer rt.Close()
 	ctx := base.TestCtx(t)
 	collection := rt.GetSingleTestDatabaseCollection()
-	bucketUUID := rt.GetDatabase().BucketUUID
+	bucketUUID := rt.GetDatabase().EncodedBucketUUID
 	const DocID = "doc1"
 
 	// activate channel cache

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -935,7 +935,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	expectedResults = []string{
 		`{"seq":"8:2","id":"hbo-1","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":8,"id":"grant-1","changes":[{"rev":"1-c5098bb14d12d647c901850ff6a6292a"}]}`,
-		fmt.Sprintf(`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}], "current_version":{"source_id": "%s", "version": %d}}`, mixSource, mixVersion),
+		fmt.Sprintf(`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}], "current_version":{"source_id": "%s", "version": "%s"}}`, mixSource, mixVersion),
 	}
 
 	rt.Run("grant via existing channel", func(t *testing.T) {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -9,7 +9,6 @@
 package replicatortest
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"expvar"
 	"fmt"
@@ -8324,8 +8323,8 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	defer teardown()
 
 	// Grab the bucket UUIDs for both rest testers
-	activeBucketUUID := base64.StdEncoding.EncodeToString([]byte(activeRT.GetDatabase().BucketUUID))
-	passiveBucketUUID := base64.StdEncoding.EncodeToString([]byte(passiveRT.GetDatabase().BucketUUID))
+	activeBucketUUID := activeRT.GetDatabase().EncodedBucketUUID
+	passiveBucketUUID := passiveRT.GetDatabase().EncodedBucketUUID
 
 	const rep = "replication"
 


### PR DESCRIPTION
CBG-3719

- Changed the in memory structs to have string representation of version instead of uint64 
- Changes to tests to correctly asert on the new version values 
- Removal of json marshal and unmarshal function in Hybridlogicalvector.go as they're no longer needed
- Added interface to hybridlogicalvector.go for ease of adding methods to act upon both HybridLogicalVector and DecodedHybridLogicalVector

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2275/
