### PR TITLE
Run CI like master for long running beryllium branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,14 @@ on:
     branches:
       - 'master'
       - 'release/*'
+      - 'beryllium'
       - 'CBG*'
       - 'ci-*'
   pull_request:
     branches:
       - 'master'
       - 'release/*'
+      - 'beryllium'
 
 jobs:
   build:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -16,6 +16,7 @@ on:
     branches:
       - 'master'
       - 'release/*'
+      - 'beryllium'
       - 'CBG*'
       - 'ci-*'
       - 'api-ci-*'
@@ -26,6 +27,7 @@ on:
     branches:
       - 'master'
       - 'release/*'
+      - 'beryllium'
 
 jobs:
   api_validation:


### PR DESCRIPTION
This would have allowed us to see a failure in GH with a recent beryllium rebase in `TestOnDemandImportBlipFailure`.