### PR TITLE
Include BLIP context ID in _blipsync response with X-Correlation-ID…

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -77,6 +77,8 @@ func newBlipHandler(ctx context.Context, bc *BlipSyncContext, db *Database, seri
 type BLIPSyncContextClientType string
 
 const (
+	BLIPCorrelationIDResponseHeader = "X-Correlation-ID"
+
 	BLIPSyncClientTypeQueryParam = "client"
 
 	BLIPClientTypeCBL2 BLIPSyncContextClientType = "cbl2"

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -59,6 +59,7 @@ func (h *handler) handleBLIPSync() error {
 
 	// Overwrite the existing logging context with the blip context ID
 	h.rqCtx = base.CorrelationIDLogCtx(h.ctx(), base.FormatBlipContextID(blipContext.ID))
+	h.response.Header().Set("X-Correlation-ID", blipContext.ID)
 
 	// Create a new BlipSyncContext attached to the given blipContext.
 	ctx := db.NewBlipSyncContext(h.rqCtx, blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -59,7 +59,7 @@ func (h *handler) handleBLIPSync() error {
 
 	// Overwrite the existing logging context with the blip context ID
 	h.rqCtx = base.CorrelationIDLogCtx(h.ctx(), base.FormatBlipContextID(blipContext.ID))
-	h.response.Header().Set("X-Correlation-ID", blipContext.ID)
+	h.response.Header().Set(db.BLIPCorrelationIDResponseHeader, blipContext.ID)
 
 	// Create a new BlipSyncContext attached to the given blipContext.
 	ctx := db.NewBlipSyncContext(h.rqCtx, blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))


### PR DESCRIPTION
CBG-3747

- Include BLIP context ID in _blipsync response with `X-Correlation-ID` header

![Screenshot 2024-02-02 at 09 17 29](https://github.com/couchbase/sync_gateway/assets/1525809/02d57df8-f152-4f50-8802-a50e2da81fd0)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a