### PR TITLE
CBG-3741: Throttle concurrent revs per-replication

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -483,6 +483,10 @@ type CBLReplicationPushStats struct {
 	ProposeChangeTime *SgwIntStat `json:"propose_change_time"`
 	// Total time spent processing writes. Measures complete request-to-response time for a write.
 	WriteProcessingTime *SgwIntStat `json:"write_processing_time"`
+	// WriteThrottledCount is the cumulative number of writes that were throttled.
+	WriteThrottledCount *SgwIntStat `json:"write_throttled_count"`
+	// WriteThrottledTime is the cumulative time spent throttling writes.
+	WriteThrottledTime *SgwIntStat `json:"write_throttled_time"`
 }
 
 // CollectionStats are stats that are tracked on a per-collection basis.
@@ -1497,6 +1501,14 @@ func (d *DbStats) initCBLReplicationPushStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.WriteThrottledCount, err = NewIntStat(SubsystemReplicationPush, "write_throttled_count", StatUnitNoUnits, WriteThrottledCountDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.WriteThrottledTime, err = NewIntStat(SubsystemReplicationPush, "write_throttled_time", StatUnitNanoseconds, WriteThrottledTimeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 
 	d.CBLReplicationPushStats = resUtil
 	return nil
@@ -1510,6 +1522,8 @@ func (d *DbStats) unregisterCBLReplicationPushStats() {
 	prometheus.Unregister(d.CBLReplicationPushStats.ProposeChangeCount)
 	prometheus.Unregister(d.CBLReplicationPushStats.ProposeChangeTime)
 	prometheus.Unregister(d.CBLReplicationPushStats.WriteProcessingTime)
+	prometheus.Unregister(d.CBLReplicationPushStats.WriteThrottledCount)
+	prometheus.Unregister(d.CBLReplicationPushStats.WriteThrottledTime)
 }
 
 func (d *DbStats) CBLReplicationPush() *CBLReplicationPushStats {

--- a/base/stats.go
+++ b/base/stats.go
@@ -83,6 +83,7 @@ const (
 	StatAddedVersion3dot1dot0     = "3.1.0"
 	StatAddedVersion3dot1dot2     = "3.1.2"
 	StatAddedVersion3dot1dot3dot1 = "3.1.3.1"
+	StatAddedVersion3dot1dot4     = "3.1.4"
 	StatAddedVersion3dot2dot0     = "3.2.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
@@ -456,8 +457,12 @@ type CBLReplicationPullStats struct {
 	// The total amount of time processing rev messages (revisions) during pull revision.
 	RevProcessingTime *SgwIntStat `json:"rev_processing_time"`
 	// The total number of rev messages processed during replication.
-	RevSendCount  *SgwIntStat `json:"rev_send_count"`
-	RevErrorCount *SgwIntStat `json:"rev_error_count"`
+	RevSendCount *SgwIntStat `json:"rev_send_count"`
+	// The total number of rev messages that were throttled.
+	ReadThrottledCount *SgwIntStat `json:"read_throttled_count"`
+	// The total time spent throttling rev messages.
+	ReadThrottledTime *SgwIntStat `json:"read_throttled_time"`
+	RevErrorCount     *SgwIntStat `json:"rev_error_count"`
 	// The total amount of time between Sync Gateway receiving a request for a revision and that revision being sent.
 	//
 	// In a pull replication, Sync Gateway sends a /_changes request to the client and the client responds with the list of revisions it wants to receive.
@@ -1426,6 +1431,14 @@ func (d *DbStats) initCBLReplicationPullStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.ReadThrottledCount, err = NewIntStat(SubsystemReplicationPull, "read_throttled_count", StatUnitNoUnits, ReadThrottledCountDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.ReadThrottledTime, err = NewIntStat(SubsystemReplicationPull, "read_throttled_count", StatUnitNanoseconds, ReadThrottledTimeDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.RevSendCount, err = NewIntStat(SubsystemReplicationPull, "rev_send_count", StatUnitNoUnits, RevSendCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1460,6 +1473,8 @@ func (d *DbStats) unregisterCBLReplicationPullStats() {
 	prometheus.Unregister(d.CBLReplicationPullStats.RevProcessingTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevErrorCount)
+	prometheus.Unregister(d.CBLReplicationPullStats.ReadThrottledCount)
+	prometheus.Unregister(d.CBLReplicationPullStats.ReadThrottledTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendLatency)
 }
 
@@ -1501,11 +1516,11 @@ func (d *DbStats) initCBLReplicationPushStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.WriteThrottledCount, err = NewIntStat(SubsystemReplicationPush, "write_throttled_count", StatUnitNoUnits, WriteThrottledCountDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.WriteThrottledCount, err = NewIntStat(SubsystemReplicationPush, "write_throttled_count", StatUnitNoUnits, WriteThrottledCountDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.WriteThrottledTime, err = NewIntStat(SubsystemReplicationPush, "write_throttled_time", StatUnitNanoseconds, WriteThrottledTimeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.WriteThrottledTime, err = NewIntStat(SubsystemReplicationPush, "write_throttled_time", StatUnitNanoseconds, WriteThrottledTimeDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -457,12 +457,8 @@ type CBLReplicationPullStats struct {
 	// The total amount of time processing rev messages (revisions) during pull revision.
 	RevProcessingTime *SgwIntStat `json:"rev_processing_time"`
 	// The total number of rev messages processed during replication.
-	RevSendCount *SgwIntStat `json:"rev_send_count"`
-	// The total number of rev messages that were throttled.
-	ReadThrottledCount *SgwIntStat `json:"read_throttled_count"`
-	// The total time spent throttling rev messages.
-	ReadThrottledTime *SgwIntStat `json:"read_throttled_time"`
-	RevErrorCount     *SgwIntStat `json:"rev_error_count"`
+	RevSendCount  *SgwIntStat `json:"rev_send_count"`
+	RevErrorCount *SgwIntStat `json:"rev_error_count"`
 	// The total amount of time between Sync Gateway receiving a request for a revision and that revision being sent.
 	//
 	// In a pull replication, Sync Gateway sends a /_changes request to the client and the client responds with the list of revisions it wants to receive.
@@ -1431,14 +1427,6 @@ func (d *DbStats) initCBLReplicationPullStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.ReadThrottledCount, err = NewIntStat(SubsystemReplicationPull, "read_throttled_count", StatUnitNoUnits, ReadThrottledCountDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.ReadThrottledTime, err = NewIntStat(SubsystemReplicationPull, "read_throttled_count", StatUnitNanoseconds, ReadThrottledTimeDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
-	if err != nil {
-		return err
-	}
 	resUtil.RevSendCount, err = NewIntStat(SubsystemReplicationPull, "rev_send_count", StatUnitNoUnits, RevSendCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1473,8 +1461,6 @@ func (d *DbStats) unregisterCBLReplicationPullStats() {
 	prometheus.Unregister(d.CBLReplicationPullStats.RevProcessingTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevErrorCount)
-	prometheus.Unregister(d.CBLReplicationPullStats.ReadThrottledCount)
-	prometheus.Unregister(d.CBLReplicationPullStats.ReadThrottledTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendLatency)
 }
 

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -205,8 +205,8 @@ const (
 	WriteProcessingTimeDesc = "Total time spent processing writes. Measures complete request-to-response time for a write. The write_processing_time stat can be useful when: (a). Determining the average time per write: average time per write = write_processing_time / num_doc_writes stat value " +
 		"(b). Assessing the benefit of adding additional Sync Gateway nodes, as it can point to Sync Gateway being a bottleneck (c). Troubleshooting slow push replication, in which case it ought to be considered in conjunction with sync_function_time"
 
-	WriteThrottledCountDesc = "TODO"
-	WriteThrottledTimeDesc  = "TODO"
+	WriteThrottledCountDesc = "The total number of times a revision was throttled during push replication from clients. The write_throttled_count stat can be useful to to determine an appropriate limit of concurrent revisions for each client. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
+	WriteThrottledTimeDesc  = "The total time waiting for an available slot to handle a pushed revision after being throttled. The write_throttled_time stat can be useful to determine whether clients are waiting too long for an available slot to push a revision. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
 
 	DocPushErrorCountDesc = "The total number of documents that failed to push."
 )

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -134,7 +134,6 @@ const (
 )
 
 // CBL Replication pull stats descriptions
-
 const (
 	AttachmentPullBytesDesc = "The total size of attachments pulled. This is the pre-compressed size."
 
@@ -171,6 +170,9 @@ const (
 		"Note: Measuring time from the /_changes response means that this stat will vary significantly depending on the changes batch size A larger batch size will result in a spike of this stat, even if the processing time per revision is unchanged. " +
 		"A more useful stat might be the average processing time per revision: average processing time per revision = rev_processing_time] / rev_send_count"
 
+	ReadThrottledCountDesc = "The total number of times a revision was throttled during pull replication to clients. The read_throttled_count stat can be useful to to determine an appropriate limit of concurrent revisions for each client. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
+	ReadThrottledTimeDesc  = "The total time (in nanoseconds) waiting for an available slot to handle a pulled revision after being throttled. The read_throttled_time stat can be useful to determine whether clients are waiting too long for an available slot to pull a revision. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
+
 	NumPullRepliTotalCaughtUpDesc = "The total number of pull replications which have caught up to the latest changes across all replications."
 
 	RevErrorCountDesc = "The total number of rev messages that were failed to be processed during replication."
@@ -206,7 +208,7 @@ const (
 		"(b). Assessing the benefit of adding additional Sync Gateway nodes, as it can point to Sync Gateway being a bottleneck (c). Troubleshooting slow push replication, in which case it ought to be considered in conjunction with sync_function_time"
 
 	WriteThrottledCountDesc = "The total number of times a revision was throttled during push replication from clients. The write_throttled_count stat can be useful to to determine an appropriate limit of concurrent revisions for each client. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
-	WriteThrottledTimeDesc  = "The total time waiting for an available slot to handle a pushed revision after being throttled. The write_throttled_time stat can be useful to determine whether clients are waiting too long for an available slot to push a revision. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
+	WriteThrottledTimeDesc  = "The total time (in nanoseconds) waiting for an available slot to handle a pushed revision after being throttled. The write_throttled_time stat can be useful to determine whether clients are waiting too long for an available slot to push a revision. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
 
 	DocPushErrorCountDesc = "The total number of documents that failed to push."
 )

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -205,6 +205,9 @@ const (
 	WriteProcessingTimeDesc = "Total time spent processing writes. Measures complete request-to-response time for a write. The write_processing_time stat can be useful when: (a). Determining the average time per write: average time per write = write_processing_time / num_doc_writes stat value " +
 		"(b). Assessing the benefit of adding additional Sync Gateway nodes, as it can point to Sync Gateway being a bottleneck (c). Troubleshooting slow push replication, in which case it ought to be considered in conjunction with sync_function_time"
 
+	WriteThrottledCountDesc = "TODO"
+	WriteThrottledTimeDesc  = "TODO"
+
 	DocPushErrorCountDesc = "The total number of documents that failed to push."
 )
 

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -170,9 +170,6 @@ const (
 		"Note: Measuring time from the /_changes response means that this stat will vary significantly depending on the changes batch size A larger batch size will result in a spike of this stat, even if the processing time per revision is unchanged. " +
 		"A more useful stat might be the average processing time per revision: average processing time per revision = rev_processing_time] / rev_send_count"
 
-	ReadThrottledCountDesc = "The total number of times a revision was throttled during pull replication to clients. The read_throttled_count stat can be useful to to determine an appropriate limit of concurrent revisions for each client. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
-	ReadThrottledTimeDesc  = "The total time (in nanoseconds) waiting for an available slot to handle a pulled revision after being throttled. The read_throttled_time stat can be useful to determine whether clients are waiting too long for an available slot to pull a revision. There's a direct tradeoff with memory and CPU usage for replicating clients and large amounts of concurrent revisions."
-
 	NumPullRepliTotalCaughtUpDesc = "The total number of pull replications which have caught up to the latest changes across all replications."
 
 	RevErrorCountDesc = "The total number of rev messages that were failed to be processed during replication."

--- a/db/blip_connected_client.go
+++ b/db/blip_connected_client.go
@@ -71,12 +71,14 @@ func (bh *blipHandler) handleGetRev(rq *blip.Message) error {
 // Handles a Connected-Client "putRev" request.
 func (bh *blipHandler) handlePutRev(rq *blip.Message) error {
 	stats := processRevStats{
-		count:           bh.replicationStats.HandlePutRevCount,
-		errorCount:      bh.replicationStats.HandlePutRevErrorCount,
-		deltaRecvCount:  bh.replicationStats.HandlePutRevDeltaRecvCount,
-		bytes:           bh.replicationStats.HandlePutRevBytes,
-		processingTime:  bh.replicationStats.HandlePutRevProcessingTime,
-		docsPurgedCount: bh.replicationStats.HandlePutRevDocsPurgedCount,
+		count:            bh.replicationStats.HandlePutRevCount,
+		errorCount:       bh.replicationStats.HandlePutRevErrorCount,
+		deltaRecvCount:   bh.replicationStats.HandlePutRevDeltaRecvCount,
+		bytes:            bh.replicationStats.HandlePutRevBytes,
+		processingTime:   bh.replicationStats.HandlePutRevProcessingTime,
+		docsPurgedCount:  bh.replicationStats.HandlePutRevDocsPurgedCount,
+		throttledRevs:    bh.replicationStats.HandlePutRevThrottledCount,
+		throttledRevTime: bh.replicationStats.HandlePutRevThrottledTime,
 	}
 	return bh.processRev(rq, &stats)
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -53,10 +53,10 @@ var kConnectedClientHandlersByProfile = map[string]blipHandlerFunc{
 
 // Replication throttling
 const (
-	// maxInFlightChangesBatches is the maximum number of in-flight changes batches a client is allowed to send without being throttled.
-	maxInFlightChangesBatches = 2
-	// maxInFlightRevs is the maximum number of in-flight revisions a client is allowed to send or receive without being throttled.
-	maxInFlightRevs = 5
+	// DefaultMaxConcurrentChangesBatches is the maximum number of in-flight changes batches a client is allowed to send concurrently without being throttled.
+	DefaultMaxConcurrentChangesBatches = 2
+	// DefaultMaxConcurrentRevs is the maximum number of in-flight revisions a client is allowed to send or receive concurrently without being throttled.
+	DefaultMaxConcurrentRevs = 5
 )
 
 type blipHandler struct {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -36,12 +36,12 @@ var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 
 func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, contextID string, replicationStats *BlipSyncStats) *BlipSyncContext {
 	maxInFlightChangesBatches := DefaultMaxConcurrentChangesBatches
-	if db.Options.MaxConcurrentChangesBatches != 0 {
-		maxInFlightChangesBatches = db.Options.MaxConcurrentChangesBatches
+	if db.Options.MaxConcurrentChangesBatches != nil {
+		maxInFlightChangesBatches = *db.Options.MaxConcurrentChangesBatches
 	}
 	maxInFlightRevs := DefaultMaxConcurrentRevs
-	if db.Options.MaxConcurrentRevs != 0 {
-		maxInFlightRevs = db.Options.MaxConcurrentRevs
+	if db.Options.MaxConcurrentRevs != nil {
+		maxInFlightRevs = *db.Options.MaxConcurrentRevs
 	}
 
 	bsc := &BlipSyncContext{

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -40,7 +40,7 @@ func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, con
 		maxInFlightChangesBatches = db.Options.MaxConcurrentChangesBatches
 	}
 	maxInFlightRevs := DefaultMaxConcurrentRevs
-	if db.Options.MaxConcurrentChangesBatches != 0 {
+	if db.Options.MaxConcurrentRevs != 0 {
 		maxInFlightRevs = db.Options.MaxConcurrentRevs
 	}
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -35,6 +35,15 @@ const (
 var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 
 func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, contextID string, replicationStats *BlipSyncStats) *BlipSyncContext {
+	maxInFlightChangesBatches := DefaultMaxConcurrentChangesBatches
+	if db.Options.MaxConcurrentChangesBatches > 0 {
+		maxInFlightChangesBatches = db.Options.MaxConcurrentChangesBatches
+	}
+	maxInFlightRevs := DefaultMaxConcurrentRevs
+	if db.Options.MaxConcurrentChangesBatches > 0 {
+		maxInFlightRevs = db.Options.MaxConcurrentRevs
+	}
+
 	bsc := &BlipSyncContext{
 		blipContext:             bc,
 		blipContextDb:           db,

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -36,11 +36,11 @@ var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 
 func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, contextID string, replicationStats *BlipSyncStats) *BlipSyncContext {
 	maxInFlightChangesBatches := DefaultMaxConcurrentChangesBatches
-	if db.Options.MaxConcurrentChangesBatches > 0 {
+	if db.Options.MaxConcurrentChangesBatches != 0 {
 		maxInFlightChangesBatches = db.Options.MaxConcurrentChangesBatches
 	}
 	maxInFlightRevs := DefaultMaxConcurrentRevs
-	if db.Options.MaxConcurrentChangesBatches > 0 {
+	if db.Options.MaxConcurrentChangesBatches != 0 {
 		maxInFlightRevs = db.Options.MaxConcurrentRevs
 	}
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -24,6 +24,8 @@ type BlipSyncStats struct {
 	HandleRevBytes                   *base.SgwIntStat
 	HandleRevProcessingTime          *base.SgwIntStat
 	HandleRevDocsPurgedCount         *base.SgwIntStat
+	HandleRevThrottledCount          *base.SgwIntStat
+	HandleRevThrottledTime           *base.SgwIntStat
 	HandleGetRevCount                *base.SgwIntStat // Connected Client API
 	HandlePutRevCount                *base.SgwIntStat // Connected Client API
 	HandlePutRevErrorCount           *base.SgwIntStat // Connected Client API
@@ -133,9 +135,10 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 
 	blipStats.HandleRevBytes = dbStats.Database().DocWritesBytesBlip
 	blipStats.HandleRevProcessingTime = dbStats.CBLReplicationPush().WriteProcessingTime
-
 	blipStats.HandleRevCount = dbStats.CBLReplicationPush().DocPushCount
 	blipStats.HandleRevErrorCount = dbStats.CBLReplicationPush().DocPushErrorCount
+	blipStats.HandleRevThrottledCount = dbStats.CBLReplicationPush().WriteThrottledCount
+	blipStats.HandleRevThrottledTime = dbStats.CBLReplicationPush().WriteThrottledTime
 
 	blipStats.HandleGetAttachment = dbStats.CBLReplicationPull().AttachmentPullCount
 	blipStats.HandleGetAttachmentBytes = dbStats.CBLReplicationPull().AttachmentPullBytes

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -17,104 +17,108 @@ import (
 // Note: To have any of these appear in expvars they must be connected to a stat inside of stats.go - This is done via
 // the BlipSyncStatsForCBL, BlipSyncStatsForSGRPush and BlipSyncStatsForSGRPull functions.
 type BlipSyncStats struct {
-	DeltaEnabledPullReplicationCount *base.SgwIntStat // global
-	HandleRevCount                   *base.SgwIntStat // handleRev
-	HandleRevErrorCount              *base.SgwIntStat
-	HandleRevDeltaRecvCount          *base.SgwIntStat
-	HandleRevBytes                   *base.SgwIntStat
-	HandleRevProcessingTime          *base.SgwIntStat
-	HandleRevDocsPurgedCount         *base.SgwIntStat
-	HandleRevThrottledCount          *base.SgwIntStat
-	HandleRevThrottledTime           *base.SgwIntStat
-	HandleGetRevCount                *base.SgwIntStat // Connected Client API
-	HandlePutRevCount                *base.SgwIntStat // Connected Client API
-	HandlePutRevErrorCount           *base.SgwIntStat // Connected Client API
-	HandlePutRevDeltaRecvCount       *base.SgwIntStat // Connected Client API
-	HandlePutRevBytes                *base.SgwIntStat // Connected Client API
-	HandlePutRevProcessingTime       *base.SgwIntStat // Connected Client API
-	HandlePutRevDocsPurgedCount      *base.SgwIntStat // Connected Client API
-	HandlePutRevThrottledCount       *base.SgwIntStat // Connected Client API
-	HandlePutRevThrottledTime        *base.SgwIntStat // Connected Client API
-	SendRevCount                     *base.SgwIntStat // sendRev
-	SendRevDeltaRequestedCount       *base.SgwIntStat
-	SendRevDeltaSentCount            *base.SgwIntStat
-	SendRevBytes                     *base.SgwIntStat
-	SendRevErrorTotal                *base.SgwIntStat
-	SendRevErrorConflictCount        *base.SgwIntStat
-	SendRevErrorRejectedCount        *base.SgwIntStat
-	SendRevErrorOtherCount           *base.SgwIntStat
-	HandleChangesCount               *base.SgwIntStat // handleChanges/handleProposeChanges
-	HandleChangesTime                *base.SgwIntStat
-	HandleChangesDeltaRequestedCount *base.SgwIntStat
-	HandleProveAttachment            *base.SgwIntStat // handleProveAttachment
-	HandleGetAttachment              *base.SgwIntStat // handleGetAttachment
-	HandleGetAttachmentBytes         *base.SgwIntStat
-	ProveAttachment                  *base.SgwIntStat // sendProveAttachment
-	GetAttachment                    *base.SgwIntStat // sendGetAttachment
-	GetAttachmentBytes               *base.SgwIntStat
-	HandleChangesResponseCount       *base.SgwIntStat // handleChangesResponse
-	HandleChangesResponseTime        *base.SgwIntStat
-	HandleChangesSendRevCount        *base.SgwIntStat //  - (duplicates SendRevCount, included for support of CBL expvars)
-	HandleChangesSendRevLatency      *base.SgwIntStat
-	HandleChangesSendRevTime         *base.SgwIntStat
-	SubChangesContinuousActive       *base.SgwIntStat // subChanges
-	SubChangesContinuousTotal        *base.SgwIntStat
-	SubChangesOneShotActive          *base.SgwIntStat
-	SubChangesOneShotTotal           *base.SgwIntStat
-	SendChangesCount                 *base.SgwIntStat // sendChanges
-	NumConnectAttempts               *base.SgwIntStat
-	NumReconnectsAborted             *base.SgwIntStat
-	NumHandlersPanicked              *base.SgwIntStat
+	DeltaEnabledPullReplicationCount  *base.SgwIntStat // global
+	HandleRevCount                    *base.SgwIntStat // handleRev
+	HandleRevErrorCount               *base.SgwIntStat
+	HandleRevDeltaRecvCount           *base.SgwIntStat
+	HandleRevBytes                    *base.SgwIntStat
+	HandleRevProcessingTime           *base.SgwIntStat
+	HandleRevDocsPurgedCount          *base.SgwIntStat
+	HandleRevThrottledCount           *base.SgwIntStat
+	HandleRevThrottledTime            *base.SgwIntStat
+	HandleGetRevCount                 *base.SgwIntStat // Connected Client API
+	HandlePutRevCount                 *base.SgwIntStat // Connected Client API
+	HandlePutRevErrorCount            *base.SgwIntStat // Connected Client API
+	HandlePutRevDeltaRecvCount        *base.SgwIntStat // Connected Client API
+	HandlePutRevBytes                 *base.SgwIntStat // Connected Client API
+	HandlePutRevProcessingTime        *base.SgwIntStat // Connected Client API
+	HandlePutRevDocsPurgedCount       *base.SgwIntStat // Connected Client API
+	HandlePutRevThrottledCount        *base.SgwIntStat // Connected Client API
+	HandlePutRevThrottledTime         *base.SgwIntStat // Connected Client API
+	SendRevCount                      *base.SgwIntStat // sendRev
+	SendRevDeltaRequestedCount        *base.SgwIntStat
+	SendRevDeltaSentCount             *base.SgwIntStat
+	SendRevBytes                      *base.SgwIntStat
+	SendRevErrorTotal                 *base.SgwIntStat
+	SendRevErrorConflictCount         *base.SgwIntStat
+	SendRevErrorRejectedCount         *base.SgwIntStat
+	SendRevErrorOtherCount            *base.SgwIntStat
+	HandleChangesCount                *base.SgwIntStat // handleChanges/handleProposeChanges
+	HandleChangesTime                 *base.SgwIntStat
+	HandleChangesDeltaRequestedCount  *base.SgwIntStat
+	HandleProveAttachment             *base.SgwIntStat // handleProveAttachment
+	HandleGetAttachment               *base.SgwIntStat // handleGetAttachment
+	HandleGetAttachmentBytes          *base.SgwIntStat
+	ProveAttachment                   *base.SgwIntStat // sendProveAttachment
+	GetAttachment                     *base.SgwIntStat // sendGetAttachment
+	GetAttachmentBytes                *base.SgwIntStat
+	HandleChangesResponseCount        *base.SgwIntStat // handleChangesResponse
+	HandleChangesResponseTime         *base.SgwIntStat
+	HandleChangesSendRevCount         *base.SgwIntStat //  - (duplicates SendRevCount, included for support of CBL expvars)
+	HandleChangesSendRevLatency       *base.SgwIntStat
+	HandleChangesSendRevTime          *base.SgwIntStat
+	HandleChangesSendRevThrottleCount *base.SgwIntStat
+	HandleChangesSendRevThrottleTime  *base.SgwIntStat
+	SubChangesContinuousActive        *base.SgwIntStat // subChanges
+	SubChangesContinuousTotal         *base.SgwIntStat
+	SubChangesOneShotActive           *base.SgwIntStat
+	SubChangesOneShotTotal            *base.SgwIntStat
+	SendChangesCount                  *base.SgwIntStat // sendChanges
+	NumConnectAttempts                *base.SgwIntStat
+	NumReconnectsAborted              *base.SgwIntStat
+	NumHandlersPanicked               *base.SgwIntStat
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
 	return &BlipSyncStats{
-		DeltaEnabledPullReplicationCount: &base.SgwIntStat{}, // global
-		HandleRevCount:                   &base.SgwIntStat{}, // handleRev
-		HandleRevErrorCount:              &base.SgwIntStat{},
-		HandleRevDeltaRecvCount:          &base.SgwIntStat{},
-		HandleRevBytes:                   &base.SgwIntStat{},
-		HandleRevProcessingTime:          &base.SgwIntStat{},
-		HandleRevDocsPurgedCount:         &base.SgwIntStat{},
-		HandleRevThrottledCount:          &base.SgwIntStat{},
-		HandleRevThrottledTime:           &base.SgwIntStat{},
-		HandleGetRevCount:                &base.SgwIntStat{},
-		HandlePutRevCount:                &base.SgwIntStat{},
-		HandlePutRevErrorCount:           &base.SgwIntStat{},
-		HandlePutRevDeltaRecvCount:       &base.SgwIntStat{},
-		HandlePutRevBytes:                &base.SgwIntStat{},
-		HandlePutRevProcessingTime:       &base.SgwIntStat{},
-		HandlePutRevDocsPurgedCount:      &base.SgwIntStat{},
-		SendRevCount:                     &base.SgwIntStat{}, // sendRev
-		SendRevDeltaRequestedCount:       &base.SgwIntStat{},
-		SendRevDeltaSentCount:            &base.SgwIntStat{},
-		SendRevBytes:                     &base.SgwIntStat{},
-		SendRevErrorTotal:                &base.SgwIntStat{},
-		SendRevErrorConflictCount:        &base.SgwIntStat{},
-		SendRevErrorRejectedCount:        &base.SgwIntStat{},
-		SendRevErrorOtherCount:           &base.SgwIntStat{},
-		HandleChangesCount:               &base.SgwIntStat{}, // handleChanges/handleProposeChanges
-		HandleChangesTime:                &base.SgwIntStat{},
-		HandleChangesDeltaRequestedCount: &base.SgwIntStat{},
-		HandleProveAttachment:            &base.SgwIntStat{}, // handleProveAttachment
-		HandleGetAttachment:              &base.SgwIntStat{}, // handleGetAttachment
-		HandleGetAttachmentBytes:         &base.SgwIntStat{},
-		ProveAttachment:                  &base.SgwIntStat{}, // sendProveAttachment
-		GetAttachment:                    &base.SgwIntStat{}, // sendGetAttachment
-		GetAttachmentBytes:               &base.SgwIntStat{},
-		HandleChangesResponseCount:       &base.SgwIntStat{}, // handleChangesResponse
-		HandleChangesResponseTime:        &base.SgwIntStat{},
-		HandleChangesSendRevCount:        &base.SgwIntStat{}, //  - (duplicates SendRevCount, included for support of CBL expvars)
-		HandleChangesSendRevLatency:      &base.SgwIntStat{},
-		HandleChangesSendRevTime:         &base.SgwIntStat{},
-		SubChangesContinuousActive:       &base.SgwIntStat{}, // subChanges
-		SubChangesContinuousTotal:        &base.SgwIntStat{},
-		SubChangesOneShotActive:          &base.SgwIntStat{},
-		SubChangesOneShotTotal:           &base.SgwIntStat{},
-		SendChangesCount:                 &base.SgwIntStat{},
-		NumConnectAttempts:               &base.SgwIntStat{},
-		NumReconnectsAborted:             &base.SgwIntStat{},
-		NumHandlersPanicked:              &base.SgwIntStat{},
+		DeltaEnabledPullReplicationCount:  &base.SgwIntStat{}, // global
+		HandleRevCount:                    &base.SgwIntStat{}, // handleRev
+		HandleRevErrorCount:               &base.SgwIntStat{},
+		HandleRevDeltaRecvCount:           &base.SgwIntStat{},
+		HandleRevBytes:                    &base.SgwIntStat{},
+		HandleRevProcessingTime:           &base.SgwIntStat{},
+		HandleRevDocsPurgedCount:          &base.SgwIntStat{},
+		HandleRevThrottledCount:           &base.SgwIntStat{},
+		HandleRevThrottledTime:            &base.SgwIntStat{},
+		HandleGetRevCount:                 &base.SgwIntStat{},
+		HandlePutRevCount:                 &base.SgwIntStat{},
+		HandlePutRevErrorCount:            &base.SgwIntStat{},
+		HandlePutRevDeltaRecvCount:        &base.SgwIntStat{},
+		HandlePutRevBytes:                 &base.SgwIntStat{},
+		HandlePutRevProcessingTime:        &base.SgwIntStat{},
+		HandlePutRevDocsPurgedCount:       &base.SgwIntStat{},
+		SendRevCount:                      &base.SgwIntStat{}, // sendRev
+		SendRevDeltaRequestedCount:        &base.SgwIntStat{},
+		SendRevDeltaSentCount:             &base.SgwIntStat{},
+		SendRevBytes:                      &base.SgwIntStat{},
+		SendRevErrorTotal:                 &base.SgwIntStat{},
+		SendRevErrorConflictCount:         &base.SgwIntStat{},
+		SendRevErrorRejectedCount:         &base.SgwIntStat{},
+		SendRevErrorOtherCount:            &base.SgwIntStat{},
+		HandleChangesCount:                &base.SgwIntStat{}, // handleChanges/handleProposeChanges
+		HandleChangesTime:                 &base.SgwIntStat{},
+		HandleChangesDeltaRequestedCount:  &base.SgwIntStat{},
+		HandleProveAttachment:             &base.SgwIntStat{}, // handleProveAttachment
+		HandleGetAttachment:               &base.SgwIntStat{}, // handleGetAttachment
+		HandleGetAttachmentBytes:          &base.SgwIntStat{},
+		ProveAttachment:                   &base.SgwIntStat{}, // sendProveAttachment
+		GetAttachment:                     &base.SgwIntStat{}, // sendGetAttachment
+		GetAttachmentBytes:                &base.SgwIntStat{},
+		HandleChangesResponseCount:        &base.SgwIntStat{}, // handleChangesResponse
+		HandleChangesResponseTime:         &base.SgwIntStat{},
+		HandleChangesSendRevCount:         &base.SgwIntStat{}, //  - (duplicates SendRevCount, included for support of CBL expvars)
+		HandleChangesSendRevLatency:       &base.SgwIntStat{},
+		HandleChangesSendRevTime:          &base.SgwIntStat{},
+		HandleChangesSendRevThrottleCount: &base.SgwIntStat{},
+		HandleChangesSendRevThrottleTime:  &base.SgwIntStat{},
+		SubChangesContinuousActive:        &base.SgwIntStat{}, // subChanges
+		SubChangesContinuousTotal:         &base.SgwIntStat{},
+		SubChangesOneShotActive:           &base.SgwIntStat{},
+		SubChangesOneShotTotal:            &base.SgwIntStat{},
+		SendChangesCount:                  &base.SgwIntStat{},
+		NumConnectAttempts:                &base.SgwIntStat{},
+		NumReconnectsAborted:              &base.SgwIntStat{},
+		NumHandlersPanicked:               &base.SgwIntStat{},
 	}
 }
 
@@ -152,6 +156,8 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	blipStats.HandleChangesSendRevCount = dbStats.CBLReplicationPull().RevSendCount
 	blipStats.HandleChangesSendRevLatency = dbStats.CBLReplicationPull().RevSendLatency
 	blipStats.HandleChangesSendRevTime = dbStats.CBLReplicationPull().RevProcessingTime
+	blipStats.HandleChangesSendRevThrottleCount = dbStats.CBLReplicationPull().ReadThrottledCount
+	blipStats.HandleChangesSendRevThrottleTime = dbStats.CBLReplicationPull().ReadThrottledTime
 
 	// TODO: these are strictly cross-replication stats, maybe do elsewhere?
 	blipStats.SubChangesContinuousActive = dbStats.CBLReplicationPull().NumPullReplActiveContinuous

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -17,108 +17,104 @@ import (
 // Note: To have any of these appear in expvars they must be connected to a stat inside of stats.go - This is done via
 // the BlipSyncStatsForCBL, BlipSyncStatsForSGRPush and BlipSyncStatsForSGRPull functions.
 type BlipSyncStats struct {
-	DeltaEnabledPullReplicationCount  *base.SgwIntStat // global
-	HandleRevCount                    *base.SgwIntStat // handleRev
-	HandleRevErrorCount               *base.SgwIntStat
-	HandleRevDeltaRecvCount           *base.SgwIntStat
-	HandleRevBytes                    *base.SgwIntStat
-	HandleRevProcessingTime           *base.SgwIntStat
-	HandleRevDocsPurgedCount          *base.SgwIntStat
-	HandleRevThrottledCount           *base.SgwIntStat
-	HandleRevThrottledTime            *base.SgwIntStat
-	HandleGetRevCount                 *base.SgwIntStat // Connected Client API
-	HandlePutRevCount                 *base.SgwIntStat // Connected Client API
-	HandlePutRevErrorCount            *base.SgwIntStat // Connected Client API
-	HandlePutRevDeltaRecvCount        *base.SgwIntStat // Connected Client API
-	HandlePutRevBytes                 *base.SgwIntStat // Connected Client API
-	HandlePutRevProcessingTime        *base.SgwIntStat // Connected Client API
-	HandlePutRevDocsPurgedCount       *base.SgwIntStat // Connected Client API
-	HandlePutRevThrottledCount        *base.SgwIntStat // Connected Client API
-	HandlePutRevThrottledTime         *base.SgwIntStat // Connected Client API
-	SendRevCount                      *base.SgwIntStat // sendRev
-	SendRevDeltaRequestedCount        *base.SgwIntStat
-	SendRevDeltaSentCount             *base.SgwIntStat
-	SendRevBytes                      *base.SgwIntStat
-	SendRevErrorTotal                 *base.SgwIntStat
-	SendRevErrorConflictCount         *base.SgwIntStat
-	SendRevErrorRejectedCount         *base.SgwIntStat
-	SendRevErrorOtherCount            *base.SgwIntStat
-	HandleChangesCount                *base.SgwIntStat // handleChanges/handleProposeChanges
-	HandleChangesTime                 *base.SgwIntStat
-	HandleChangesDeltaRequestedCount  *base.SgwIntStat
-	HandleProveAttachment             *base.SgwIntStat // handleProveAttachment
-	HandleGetAttachment               *base.SgwIntStat // handleGetAttachment
-	HandleGetAttachmentBytes          *base.SgwIntStat
-	ProveAttachment                   *base.SgwIntStat // sendProveAttachment
-	GetAttachment                     *base.SgwIntStat // sendGetAttachment
-	GetAttachmentBytes                *base.SgwIntStat
-	HandleChangesResponseCount        *base.SgwIntStat // handleChangesResponse
-	HandleChangesResponseTime         *base.SgwIntStat
-	HandleChangesSendRevCount         *base.SgwIntStat //  - (duplicates SendRevCount, included for support of CBL expvars)
-	HandleChangesSendRevLatency       *base.SgwIntStat
-	HandleChangesSendRevTime          *base.SgwIntStat
-	HandleChangesSendRevThrottleCount *base.SgwIntStat
-	HandleChangesSendRevThrottleTime  *base.SgwIntStat
-	SubChangesContinuousActive        *base.SgwIntStat // subChanges
-	SubChangesContinuousTotal         *base.SgwIntStat
-	SubChangesOneShotActive           *base.SgwIntStat
-	SubChangesOneShotTotal            *base.SgwIntStat
-	SendChangesCount                  *base.SgwIntStat // sendChanges
-	NumConnectAttempts                *base.SgwIntStat
-	NumReconnectsAborted              *base.SgwIntStat
-	NumHandlersPanicked               *base.SgwIntStat
+	DeltaEnabledPullReplicationCount *base.SgwIntStat // global
+	HandleRevCount                   *base.SgwIntStat // handleRev
+	HandleRevErrorCount              *base.SgwIntStat
+	HandleRevDeltaRecvCount          *base.SgwIntStat
+	HandleRevBytes                   *base.SgwIntStat
+	HandleRevProcessingTime          *base.SgwIntStat
+	HandleRevDocsPurgedCount         *base.SgwIntStat
+	HandleRevThrottledCount          *base.SgwIntStat
+	HandleRevThrottledTime           *base.SgwIntStat
+	HandleGetRevCount                *base.SgwIntStat // Connected Client API
+	HandlePutRevCount                *base.SgwIntStat // Connected Client API
+	HandlePutRevErrorCount           *base.SgwIntStat // Connected Client API
+	HandlePutRevDeltaRecvCount       *base.SgwIntStat // Connected Client API
+	HandlePutRevBytes                *base.SgwIntStat // Connected Client API
+	HandlePutRevProcessingTime       *base.SgwIntStat // Connected Client API
+	HandlePutRevDocsPurgedCount      *base.SgwIntStat // Connected Client API
+	HandlePutRevThrottledCount       *base.SgwIntStat // Connected Client API
+	HandlePutRevThrottledTime        *base.SgwIntStat // Connected Client API
+	SendRevCount                     *base.SgwIntStat // sendRev
+	SendRevDeltaRequestedCount       *base.SgwIntStat
+	SendRevDeltaSentCount            *base.SgwIntStat
+	SendRevBytes                     *base.SgwIntStat
+	SendRevErrorTotal                *base.SgwIntStat
+	SendRevErrorConflictCount        *base.SgwIntStat
+	SendRevErrorRejectedCount        *base.SgwIntStat
+	SendRevErrorOtherCount           *base.SgwIntStat
+	HandleChangesCount               *base.SgwIntStat // handleChanges/handleProposeChanges
+	HandleChangesTime                *base.SgwIntStat
+	HandleChangesDeltaRequestedCount *base.SgwIntStat
+	HandleProveAttachment            *base.SgwIntStat // handleProveAttachment
+	HandleGetAttachment              *base.SgwIntStat // handleGetAttachment
+	HandleGetAttachmentBytes         *base.SgwIntStat
+	ProveAttachment                  *base.SgwIntStat // sendProveAttachment
+	GetAttachment                    *base.SgwIntStat // sendGetAttachment
+	GetAttachmentBytes               *base.SgwIntStat
+	HandleChangesResponseCount       *base.SgwIntStat // handleChangesResponse
+	HandleChangesResponseTime        *base.SgwIntStat
+	HandleChangesSendRevCount        *base.SgwIntStat //  - (duplicates SendRevCount, included for support of CBL expvars)
+	HandleChangesSendRevLatency      *base.SgwIntStat
+	HandleChangesSendRevTime         *base.SgwIntStat
+	SubChangesContinuousActive       *base.SgwIntStat // subChanges
+	SubChangesContinuousTotal        *base.SgwIntStat
+	SubChangesOneShotActive          *base.SgwIntStat
+	SubChangesOneShotTotal           *base.SgwIntStat
+	SendChangesCount                 *base.SgwIntStat // sendChanges
+	NumConnectAttempts               *base.SgwIntStat
+	NumReconnectsAborted             *base.SgwIntStat
+	NumHandlersPanicked              *base.SgwIntStat
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
 	return &BlipSyncStats{
-		DeltaEnabledPullReplicationCount:  &base.SgwIntStat{}, // global
-		HandleRevCount:                    &base.SgwIntStat{}, // handleRev
-		HandleRevErrorCount:               &base.SgwIntStat{},
-		HandleRevDeltaRecvCount:           &base.SgwIntStat{},
-		HandleRevBytes:                    &base.SgwIntStat{},
-		HandleRevProcessingTime:           &base.SgwIntStat{},
-		HandleRevDocsPurgedCount:          &base.SgwIntStat{},
-		HandleRevThrottledCount:           &base.SgwIntStat{},
-		HandleRevThrottledTime:            &base.SgwIntStat{},
-		HandleGetRevCount:                 &base.SgwIntStat{},
-		HandlePutRevCount:                 &base.SgwIntStat{},
-		HandlePutRevErrorCount:            &base.SgwIntStat{},
-		HandlePutRevDeltaRecvCount:        &base.SgwIntStat{},
-		HandlePutRevBytes:                 &base.SgwIntStat{},
-		HandlePutRevProcessingTime:        &base.SgwIntStat{},
-		HandlePutRevDocsPurgedCount:       &base.SgwIntStat{},
-		SendRevCount:                      &base.SgwIntStat{}, // sendRev
-		SendRevDeltaRequestedCount:        &base.SgwIntStat{},
-		SendRevDeltaSentCount:             &base.SgwIntStat{},
-		SendRevBytes:                      &base.SgwIntStat{},
-		SendRevErrorTotal:                 &base.SgwIntStat{},
-		SendRevErrorConflictCount:         &base.SgwIntStat{},
-		SendRevErrorRejectedCount:         &base.SgwIntStat{},
-		SendRevErrorOtherCount:            &base.SgwIntStat{},
-		HandleChangesCount:                &base.SgwIntStat{}, // handleChanges/handleProposeChanges
-		HandleChangesTime:                 &base.SgwIntStat{},
-		HandleChangesDeltaRequestedCount:  &base.SgwIntStat{},
-		HandleProveAttachment:             &base.SgwIntStat{}, // handleProveAttachment
-		HandleGetAttachment:               &base.SgwIntStat{}, // handleGetAttachment
-		HandleGetAttachmentBytes:          &base.SgwIntStat{},
-		ProveAttachment:                   &base.SgwIntStat{}, // sendProveAttachment
-		GetAttachment:                     &base.SgwIntStat{}, // sendGetAttachment
-		GetAttachmentBytes:                &base.SgwIntStat{},
-		HandleChangesResponseCount:        &base.SgwIntStat{}, // handleChangesResponse
-		HandleChangesResponseTime:         &base.SgwIntStat{},
-		HandleChangesSendRevCount:         &base.SgwIntStat{}, //  - (duplicates SendRevCount, included for support of CBL expvars)
-		HandleChangesSendRevLatency:       &base.SgwIntStat{},
-		HandleChangesSendRevTime:          &base.SgwIntStat{},
-		HandleChangesSendRevThrottleCount: &base.SgwIntStat{},
-		HandleChangesSendRevThrottleTime:  &base.SgwIntStat{},
-		SubChangesContinuousActive:        &base.SgwIntStat{}, // subChanges
-		SubChangesContinuousTotal:         &base.SgwIntStat{},
-		SubChangesOneShotActive:           &base.SgwIntStat{},
-		SubChangesOneShotTotal:            &base.SgwIntStat{},
-		SendChangesCount:                  &base.SgwIntStat{},
-		NumConnectAttempts:                &base.SgwIntStat{},
-		NumReconnectsAborted:              &base.SgwIntStat{},
-		NumHandlersPanicked:               &base.SgwIntStat{},
+		DeltaEnabledPullReplicationCount: &base.SgwIntStat{}, // global
+		HandleRevCount:                   &base.SgwIntStat{}, // handleRev
+		HandleRevErrorCount:              &base.SgwIntStat{},
+		HandleRevDeltaRecvCount:          &base.SgwIntStat{},
+		HandleRevBytes:                   &base.SgwIntStat{},
+		HandleRevProcessingTime:          &base.SgwIntStat{},
+		HandleRevDocsPurgedCount:         &base.SgwIntStat{},
+		HandleRevThrottledCount:          &base.SgwIntStat{},
+		HandleRevThrottledTime:           &base.SgwIntStat{},
+		HandleGetRevCount:                &base.SgwIntStat{},
+		HandlePutRevCount:                &base.SgwIntStat{},
+		HandlePutRevErrorCount:           &base.SgwIntStat{},
+		HandlePutRevDeltaRecvCount:       &base.SgwIntStat{},
+		HandlePutRevBytes:                &base.SgwIntStat{},
+		HandlePutRevProcessingTime:       &base.SgwIntStat{},
+		HandlePutRevDocsPurgedCount:      &base.SgwIntStat{},
+		SendRevCount:                     &base.SgwIntStat{}, // sendRev
+		SendRevDeltaRequestedCount:       &base.SgwIntStat{},
+		SendRevDeltaSentCount:            &base.SgwIntStat{},
+		SendRevBytes:                     &base.SgwIntStat{},
+		SendRevErrorTotal:                &base.SgwIntStat{},
+		SendRevErrorConflictCount:        &base.SgwIntStat{},
+		SendRevErrorRejectedCount:        &base.SgwIntStat{},
+		SendRevErrorOtherCount:           &base.SgwIntStat{},
+		HandleChangesCount:               &base.SgwIntStat{}, // handleChanges/handleProposeChanges
+		HandleChangesTime:                &base.SgwIntStat{},
+		HandleChangesDeltaRequestedCount: &base.SgwIntStat{},
+		HandleProveAttachment:            &base.SgwIntStat{}, // handleProveAttachment
+		HandleGetAttachment:              &base.SgwIntStat{}, // handleGetAttachment
+		HandleGetAttachmentBytes:         &base.SgwIntStat{},
+		ProveAttachment:                  &base.SgwIntStat{}, // sendProveAttachment
+		GetAttachment:                    &base.SgwIntStat{}, // sendGetAttachment
+		GetAttachmentBytes:               &base.SgwIntStat{},
+		HandleChangesResponseCount:       &base.SgwIntStat{}, // handleChangesResponse
+		HandleChangesResponseTime:        &base.SgwIntStat{},
+		HandleChangesSendRevCount:        &base.SgwIntStat{}, //  - (duplicates SendRevCount, included for support of CBL expvars)
+		HandleChangesSendRevLatency:      &base.SgwIntStat{},
+		HandleChangesSendRevTime:         &base.SgwIntStat{},
+		SubChangesContinuousActive:       &base.SgwIntStat{}, // subChanges
+		SubChangesContinuousTotal:        &base.SgwIntStat{},
+		SubChangesOneShotActive:          &base.SgwIntStat{},
+		SubChangesOneShotTotal:           &base.SgwIntStat{},
+		SendChangesCount:                 &base.SgwIntStat{},
+		NumConnectAttempts:               &base.SgwIntStat{},
+		NumReconnectsAborted:             &base.SgwIntStat{},
+		NumHandlersPanicked:              &base.SgwIntStat{},
 	}
 }
 
@@ -156,8 +152,6 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	blipStats.HandleChangesSendRevCount = dbStats.CBLReplicationPull().RevSendCount
 	blipStats.HandleChangesSendRevLatency = dbStats.CBLReplicationPull().RevSendLatency
 	blipStats.HandleChangesSendRevTime = dbStats.CBLReplicationPull().RevProcessingTime
-	blipStats.HandleChangesSendRevThrottleCount = dbStats.CBLReplicationPull().ReadThrottledCount
-	blipStats.HandleChangesSendRevThrottleTime = dbStats.CBLReplicationPull().ReadThrottledTime
 
 	// TODO: these are strictly cross-replication stats, maybe do elsewhere?
 	blipStats.SubChangesContinuousActive = dbStats.CBLReplicationPull().NumPullReplActiveContinuous

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -33,6 +33,8 @@ type BlipSyncStats struct {
 	HandlePutRevBytes                *base.SgwIntStat // Connected Client API
 	HandlePutRevProcessingTime       *base.SgwIntStat // Connected Client API
 	HandlePutRevDocsPurgedCount      *base.SgwIntStat // Connected Client API
+	HandlePutRevThrottledCount       *base.SgwIntStat // Connected Client API
+	HandlePutRevThrottledTime        *base.SgwIntStat // Connected Client API
 	SendRevCount                     *base.SgwIntStat // sendRev
 	SendRevDeltaRequestedCount       *base.SgwIntStat
 	SendRevDeltaSentCount            *base.SgwIntStat
@@ -74,6 +76,8 @@ func NewBlipSyncStats() *BlipSyncStats {
 		HandleRevBytes:                   &base.SgwIntStat{},
 		HandleRevProcessingTime:          &base.SgwIntStat{},
 		HandleRevDocsPurgedCount:         &base.SgwIntStat{},
+		HandleRevThrottledCount:          &base.SgwIntStat{},
+		HandleRevThrottledTime:           &base.SgwIntStat{},
 		HandleGetRevCount:                &base.SgwIntStat{},
 		HandlePutRevCount:                &base.SgwIntStat{},
 		HandlePutRevErrorCount:           &base.SgwIntStat{},

--- a/db/database.go
+++ b/db/database.go
@@ -175,8 +175,8 @@ type DatabaseContextOptions struct {
 	ConfigPrincipals              *ConfigPrincipals
 	PurgeInterval                 *time.Duration // Add a custom purge interval, as a testing seam. If nil, this parameter is filled in by Couchbase Server, with a fallback to a default value SG has.
 	LoggingConfig                 DbLogConfig    // Per-database log configuration
-	MaxConcurrentChangesBatches   int            // Maximum number of changes batches to process concurrently per replication
-	MaxConcurrentRevs             int            // Maximum number of revs to process concurrently per replication
+	MaxConcurrentChangesBatches   *int           // Maximum number of changes batches to process concurrently per replication
+	MaxConcurrentRevs             *int           // Maximum number of revs to process concurrently per replication
 }
 
 // DbLogConfig can be used to customise the logging for logs associated with this database.

--- a/db/database.go
+++ b/db/database.go
@@ -175,6 +175,8 @@ type DatabaseContextOptions struct {
 	ConfigPrincipals              *ConfigPrincipals
 	PurgeInterval                 *time.Duration // Add a custom purge interval, as a testing seam. If nil, this parameter is filled in by Couchbase Server, with a fallback to a default value SG has.
 	LoggingConfig                 DbLogConfig    // Per-database log configuration
+	MaxConcurrentChangesBatches   int            // Maximum number of changes batches to process concurrently per replication
+	MaxConcurrentRevs             int            // Maximum number of revs to process concurrently per replication
 }
 
 // DbLogConfig can be used to customise the logging for logs associated with this database.

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1207,7 +1207,7 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 		maxConcurrentRevs    = 10
 		concurrentSendRevNum = 50
 	)
-	rt := NewRestTester(t, &RestTesterConfig{maxConcurrentRevs: maxConcurrentRevs})
+	rt := NewRestTester(t, &RestTesterConfig{maxConcurrentRevs: base.IntPtr(maxConcurrentRevs)})
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1201,8 +1201,6 @@ func TestBlipSendAndGetRev(t *testing.T) {
 // Sends many revisions concurrently and ensures that SG limits the processing on the server-side with MaxConcurrentRevs
 func TestBlipSendConcurrentRevs(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
-
 	const (
 		maxConcurrentRevs    = 10
 		concurrentSendRevNum = 50

--- a/rest/config.go
+++ b/rest/config.go
@@ -1346,6 +1346,23 @@ func (sc *StartupConfig) Validate(ctx context.Context, isEnterpriseEdition bool)
 		}
 	}
 
+	const (
+		minConcurrentChangesBatches = 1
+		maxConcurrentChangesBatches = 5
+		minConcurrentRevs           = 5
+		maxConcurrentRevs           = 200
+	)
+	if val := sc.Replicator.MaxConcurrentChangesBatches; val != nil {
+		if *val < minConcurrentChangesBatches || *val > maxConcurrentChangesBatches {
+			multiError = multiError.Append(fmt.Errorf("max_concurrent_changes_batches: %d outside allowed range: %d-%d", *val, minConcurrentChangesBatches, maxConcurrentChangesBatches))
+		}
+	}
+	if val := sc.Replicator.MaxConcurrentRevs; val != nil {
+		if *val < minConcurrentRevs || *val > maxConcurrentRevs {
+			multiError = multiError.Append(fmt.Errorf("max_concurrent_revs: %d outside allowed range: %d-%d", *val, minConcurrentRevs, maxConcurrentRevs))
+		}
+	}
+
 	return multiError.ErrorOrNil()
 }
 

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -122,9 +122,11 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 
 		"auth.bcrypt_cost": {&config.Auth.BcryptCost, fs.Int("auth.bcrypt_cost", 0, "Cost to use for bcrypt password hashes")},
 
-		"replicator.max_heartbeat":               {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
-		"replicator.blip_compression":            {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
-		"replicator.max_concurrent_replications": {&config.Replicator.MaxConcurrentReplications, fs.Int("replicator.max_concurrent_replications", 0, "Maximum number of replication connections to the node")},
+		"replicator.max_heartbeat":                  {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
+		"replicator.blip_compression":               {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
+		"replicator.max_concurrent_replications":    {&config.Replicator.MaxConcurrentReplications, fs.Int("replicator.max_concurrent_replications", 0, "Maximum number of replication connections to the node")},
+		"replicator.max_concurrent_changes_batches": {&config.Replicator.MaxConcurrentChangesBatches, fs.Int("replicator.max_concurrent_changes_batches", 0, "Maximum number of changes batches to process concurrently per replication")},
+		"replicator.max_concurrent_revs":            {&config.Replicator.MaxConcurrentRevs, fs.Int("replicator.max_concurrent_revs", 0, "Maximum number of revs to process concurrently per replication")},
 
 		"unsupported.diagnostic_interface":                 {&config.Unsupported.DiagnosticInterface, fs.String("unsupported.diagnostic_interface", "", "Network interface to bind diagnostic API to")},
 		"unsupported.stats_log_frequency":                  {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -59,8 +59,8 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			BcryptCost: auth.DefaultBcryptCost,
 		},
 		Replicator: ReplicatorConfig{
-			MaxConcurrentChangesBatches: db.DefaultMaxConcurrentChangesBatches,
-			MaxConcurrentRevs:           db.DefaultMaxConcurrentRevs,
+			MaxConcurrentChangesBatches: base.IntPtr(db.DefaultMaxConcurrentChangesBatches),
+			MaxConcurrentRevs:           base.IntPtr(db.DefaultMaxConcurrentRevs),
 		},
 		Unsupported: UnsupportedConfig{
 			StatsLogFrequency: base.NewConfigDuration(time.Minute),
@@ -146,8 +146,8 @@ type ReplicatorConfig struct {
 	MaxHeartbeat                *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
 	BLIPCompression             *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
 	MaxConcurrentReplications   int                  `json:"max_concurrent_replications,omitempty"    help:"Maximum number of replication connections to the node"`
-	MaxConcurrentChangesBatches int                  `json:"max_concurrent_changes_batches,omitempty" help:"Maximum number of changes batches to process concurrently per replication (1-5)"`
-	MaxConcurrentRevs           int                  `json:"max_concurrent_revs,omitempty"            help:"Maximum number of revs to process concurrently per replication (5-200)"`
+	MaxConcurrentChangesBatches *int                 `json:"max_concurrent_changes_batches,omitempty" help:"Maximum number of changes batches to process concurrently per replication (1-5)"`
+	MaxConcurrentRevs           *int                 `json:"max_concurrent_revs,omitempty"            help:"Maximum number of revs to process concurrently per replication (5-200)"`
 }
 
 type UnsupportedConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -146,8 +146,8 @@ type ReplicatorConfig struct {
 	MaxHeartbeat                *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
 	BLIPCompression             *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
 	MaxConcurrentReplications   int                  `json:"max_concurrent_replications,omitempty"    help:"Maximum number of replication connections to the node"`
-	MaxConcurrentChangesBatches int                  `json:"max_concurrent_changes_batches,omitempty" help:"Maximum number of changes batches to process concurrently per replication"`
-	MaxConcurrentRevs           int                  `json:"max_concurrent_revs,omitempty"            help:"Maximum number of revs to process concurrently per replication"`
+	MaxConcurrentChangesBatches int                  `json:"max_concurrent_changes_batches,omitempty" help:"Maximum number of changes batches to process concurrently per replication (1-5)"`
+	MaxConcurrentRevs           int                  `json:"max_concurrent_revs,omitempty"            help:"Maximum number of revs to process concurrently per replication (5-200)"`
 }
 
 type UnsupportedConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 )
 
 const (
@@ -56,6 +57,10 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 		},
 		Auth: AuthConfig{
 			BcryptCost: auth.DefaultBcryptCost,
+		},
+		Replicator: ReplicatorConfig{
+			MaxConcurrentChangesBatches: db.DefaultMaxConcurrentChangesBatches,
+			MaxConcurrentRevs:           db.DefaultMaxConcurrentRevs,
 		},
 		Unsupported: UnsupportedConfig{
 			StatsLogFrequency: base.NewConfigDuration(time.Minute),
@@ -138,9 +143,11 @@ type AuthConfig struct {
 }
 
 type ReplicatorConfig struct {
-	MaxHeartbeat              *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
-	BLIPCompression           *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
-	MaxConcurrentReplications int                  `json:"max_concurrent_replications,omitempty" help:"Maximum number of replication connections to the node"`
+	MaxHeartbeat                *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
+	BLIPCompression             *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
+	MaxConcurrentReplications   int                  `json:"max_concurrent_replications,omitempty"    help:"Maximum number of replication connections to the node"`
+	MaxConcurrentChangesBatches int                  `json:"max_concurrent_changes_batches,omitempty" help:"Maximum number of changes batches to process concurrently per replication"`
+	MaxConcurrentRevs           int                  `json:"max_concurrent_revs,omitempty"            help:"Maximum number of revs to process concurrently per replication"`
 }
 
 type UnsupportedConfig struct {
@@ -151,7 +158,7 @@ type UnsupportedConfig struct {
 	UserQueries          *bool                `json:"user_queries,omitempty"            help:"Feature flag for user N1QL/JS/GraphQL queries"`
 	UseXattrConfig       *bool                `json:"use_xattr_config,omitempty"        help:"Store database configurations in system xattrs"`
 	AllowDbConfigEnvVars *bool                `json:"allow_dbconfig_env_vars,omitempty" help:"Can be set to false to skip environment variable expansion in database configs"`
-	DiagnosticInterface  string               `json:"diagnostic_interface,omitempty" help:"Network interface to bind diagnostic API to"`
+	DiagnosticInterface  string               `json:"diagnostic_interface,omitempty"    help:"Network interface to bind diagnostic API to"`
 }
 
 type ServerlessConfig struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1225,6 +1225,23 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		sendWWWAuthenticate = base.BoolPtr(false)
 	}
 
+	const (
+		minConcurrentChangesBatches = 1
+		maxConcurrentChangesBatches = 5
+		minConcurrentRevs           = 5
+		maxConcurrentRevs           = 200
+	)
+	if size := sc.Config.Replicator.MaxConcurrentChangesBatches; size != 0 {
+		if size < minConcurrentChangesBatches || size > maxConcurrentChangesBatches {
+			return db.DatabaseContextOptions{}, fmt.Errorf("max_concurrent_changes_batches must be between %d and %d", minConcurrentChangesBatches, maxConcurrentChangesBatches)
+		}
+	}
+	if size := sc.Config.Replicator.MaxConcurrentRevs; size != 0 {
+		if size < minConcurrentRevs || size > maxConcurrentRevs {
+			return db.DatabaseContextOptions{}, fmt.Errorf("max_concurrent_revs must be between %d and %d", minConcurrentRevs, maxConcurrentRevs)
+		}
+	}
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:                  &cacheOptions,
 		RevisionCacheOptions:          revCacheOptions,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1261,6 +1261,8 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		// UserQueries:               config.UserQueries,   // behind feature flag (see below)
 		// UserFunctions:             config.UserFunctions, // behind feature flag (see below)
 		// GraphQL:                   config.GraphQL,       // behind feature flag (see below)
+		MaxConcurrentChangesBatches: sc.Config.Replicator.MaxConcurrentChangesBatches,
+		MaxConcurrentRevs:           sc.Config.Replicator.MaxConcurrentRevs,
 	}
 
 	// Per-database console logging config overrides

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1225,23 +1225,6 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		sendWWWAuthenticate = base.BoolPtr(false)
 	}
 
-	const (
-		minConcurrentChangesBatches = 1
-		maxConcurrentChangesBatches = 5
-		minConcurrentRevs           = 5
-		maxConcurrentRevs           = 200
-	)
-	if size := sc.Config.Replicator.MaxConcurrentChangesBatches; size != nil {
-		if *size < minConcurrentChangesBatches || *size > maxConcurrentChangesBatches {
-			return db.DatabaseContextOptions{}, fmt.Errorf("max_concurrent_changes_batches must be between %d and %d", minConcurrentChangesBatches, maxConcurrentChangesBatches)
-		}
-	}
-	if size := sc.Config.Replicator.MaxConcurrentRevs; size != nil {
-		if *size < minConcurrentRevs || *size > maxConcurrentRevs {
-			return db.DatabaseContextOptions{}, fmt.Errorf("max_concurrent_revs must be between %d and %d", minConcurrentRevs, maxConcurrentRevs)
-		}
-	}
-
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:                  &cacheOptions,
 		RevisionCacheOptions:          revCacheOptions,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1231,13 +1231,13 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		minConcurrentRevs           = 5
 		maxConcurrentRevs           = 200
 	)
-	if size := sc.Config.Replicator.MaxConcurrentChangesBatches; size != 0 {
-		if size < minConcurrentChangesBatches || size > maxConcurrentChangesBatches {
+	if size := sc.Config.Replicator.MaxConcurrentChangesBatches; size != nil {
+		if *size < minConcurrentChangesBatches || *size > maxConcurrentChangesBatches {
 			return db.DatabaseContextOptions{}, fmt.Errorf("max_concurrent_changes_batches must be between %d and %d", minConcurrentChangesBatches, maxConcurrentChangesBatches)
 		}
 	}
-	if size := sc.Config.Replicator.MaxConcurrentRevs; size != 0 {
-		if size < minConcurrentRevs || size > maxConcurrentRevs {
+	if size := sc.Config.Replicator.MaxConcurrentRevs; size != nil {
+		if *size < minConcurrentRevs || *size > maxConcurrentRevs {
 			return db.DatabaseContextOptions{}, fmt.Errorf("max_concurrent_revs must be between %d and %d", minConcurrentRevs, maxConcurrentRevs)
 		}
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -73,7 +73,7 @@ type RestTesterConfig struct {
 	numCollections                  int
 	syncGatewayVersion              *base.ComparableBuildVersion // alternate version of Sync Gateway to use on startup
 	allowDbConfigEnvVars            *bool
-	maxConcurrentRevs               int
+	maxConcurrentRevs               *int
 }
 
 type collectionConfiguration uint8

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -73,6 +73,7 @@ type RestTesterConfig struct {
 	numCollections                  int
 	syncGatewayVersion              *base.ComparableBuildVersion // alternate version of Sync Gateway to use on startup
 	allowDbConfigEnvVars            *bool
+	maxConcurrentRevs               int
 }
 
 type collectionConfiguration uint8
@@ -227,6 +228,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
 	sc.Unsupported.Serverless.Enabled = &rt.serverless
 	sc.Unsupported.AllowDbConfigEnvVars = rt.RestTesterConfig.allowDbConfigEnvVars
+	sc.Replicator.MaxConcurrentRevs = rt.RestTesterConfig.maxConcurrentRevs
 	if rt.serverless {
 		if !rt.PersistentConfig {
 			rt.TB.Fatalf("Persistent config must be used when running in serverless mode")


### PR DESCRIPTION
CBG-3741

- Throttles the maximum number of in-flight/parallel `rev` messages for a given client for push and pull.
  - Limits memory usage and other work associated with document retrieval, even if cached.
  - Should still allow clients to be fed a continous stream of revisions assuming replications were bandwidth bottlenecked.
  - Clients can send `revs` without being throttled, but the handling of messages, and any repsonses will be throttled.
  - Configurable. Default 5 (min 5, max 200) via startup config for tuning based on SG node sizing.
  - New stats to monitor rev throttling (`WriteThrottledCount` and `WriteThrottledTime`)
- Made changes batch throttle configurable in the same way.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2299/
