### PR TITLE
CBG-3736: cv only delta sync

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -136,6 +136,7 @@ const (
 	SyncPropertyName = "_sync"
 	// SyncXattrName is used when storing sync data in a document's xattrs.
 	SyncXattrName = "_sync"
+	VvXattrName   = "_vv"
 
 	// Intended to be used in Meta Map and related tests
 	MetaMapXattrsKey = "xattrs"

--- a/base/stats.go
+++ b/base/stats.go
@@ -86,6 +86,7 @@ const (
 	StatAddedVersion3dot1dot4     = "3.1.4"
 	StatAddedVersion3dot2dot0     = "3.2.0"
 	StatAddedVersion3dot3dot0     = "3.3.0"
+	StatAddedVersion4dot0dot0     = "4.0.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
 	StatDeprecatedVersion3dot2dot0     = "3.2.0"

--- a/base/util.go
+++ b/base/util.go
@@ -1004,6 +1004,10 @@ func HexCasToUint64(cas string) uint64 {
 	return binary.LittleEndian.Uint64(casBytes[0:8])
 }
 
+func CasToString(cas uint64) string {
+	return string(Uint64CASToLittleEndianHex(cas))
+}
+
 func Uint64CASToLittleEndianHex(cas uint64) []byte {
 	littleEndian := make([]byte, 8)
 	binary.LittleEndian.PutUint64(littleEndian, cas)
@@ -1012,6 +1016,17 @@ func Uint64CASToLittleEndianHex(cas uint64) []byte {
 	encodedArray[0] = '0'
 	encodedArray[1] = 'x'
 	return encodedArray
+}
+
+// Converts a string decimal representation ("100") to little endian hex string ("0x64")
+func StringDecimalToLittleEndianHex(value string) (string, error) {
+	intValue, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return "", err
+	}
+	hexValue := Uint64CASToLittleEndianHex(intValue)
+	return string(hexValue), nil
+
 }
 
 func Crc32cHash(input []byte) uint32 {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -209,6 +209,9 @@ func TestUseXattrs() bool {
 	if err != nil {
 		panic(fmt.Sprintf("unable to parse %q value %q: %v", TestEnvSyncGatewayUseXattrs, useXattrs, err))
 	}
+	if !val {
+		panic("sync gateway requires xattrs to be enabled")
+	}
 
 	return val
 }

--- a/base/version.go
+++ b/base/version.go
@@ -19,8 +19,8 @@ import (
 const (
 	ProductName = "Couchbase Sync Gateway"
 
-	ProductAPIVersionMajor = "3"
-	ProductAPIVersionMinor = "2"
+	ProductAPIVersionMajor = "4"
+	ProductAPIVersionMinor = "0"
 	ProductAPIVersion      = ProductAPIVersionMajor + "." + ProductAPIVersionMinor
 )
 

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -109,7 +109,7 @@ func (channelMap ChannelMap) KeySet() []string {
 type RevAndVersion struct {
 	RevTreeID      string `json:"rev,omitempty"`
 	CurrentSource  string `json:"src,omitempty"`
-	CurrentVersion string `json:"vrs,omitempty"` // String representation of version
+	CurrentVersion string `json:"ver,omitempty"` // String representation of version
 }
 
 // RevAndVersionJSON aliases RevAndVersion to support conditional unmarshalling from either string (revTreeID) or

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -60,13 +60,15 @@ type LogEntry struct {
 
 func (l LogEntry) String() string {
 	return fmt.Sprintf(
-		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d",
+		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d source: %s version: %d",
 		l.Sequence,
 		l.DocID,
 		l.RevID,
 		l.VbNo,
 		l.Type,
 		l.CollectionID,
+		l.SourceID,
+		l.Version,
 	)
 }
 

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -54,6 +54,8 @@ type LogEntry struct {
 	PrevSequence uint64       // Sequence of previous active revision
 	IsPrincipal  bool         // Whether the log-entry is a tracking entry for a principal doc
 	CollectionID uint32       // Collection ID
+	SourceID     string       // SourceID allocated to the doc's Current Version on the HLV
+	Version      uint64       // Version allocated to the doc's Current Version on the HLV
 }
 
 func (l LogEntry) String() string {

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -57,12 +57,12 @@ type LogEntry struct {
 	IsPrincipal  bool         // Whether the log-entry is a tracking entry for a principal doc
 	CollectionID uint32       // Collection ID
 	SourceID     string       // SourceID allocated to the doc's Current Version on the HLV
-	Version      uint64       // Version allocated to the doc's Current Version on the HLV
+	Version      string       // Version allocated to the doc's Current Version on the HLV
 }
 
 func (l LogEntry) String() string {
 	return fmt.Sprintf(
-		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d source: %s version: %d",
+		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d source: %s version: %s",
 		l.Sequence,
 		l.DocID,
 		l.RevID,

--- a/db/access_test.go
+++ b/db/access_test.go
@@ -44,7 +44,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Create a document in channel chan1
 	doc1Body := Body{"channel": "chan1", "greeting": "hello"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc1", doc1Body, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc1", doc1Body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify user cannot access document
@@ -54,7 +54,7 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Write access granting document
 	grantingBody := Body{"type": "setaccess", "owner": "user1", "channel": "chan1"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant1", grantingBody, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant1", grantingBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify reloaded user can access document
@@ -66,12 +66,12 @@ func TestDynamicChannelGrant(t *testing.T) {
 
 	// Create a document in channel chan2
 	doc2Body := Body{"channel": "chan2", "greeting": "hello"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc2", doc2Body, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "doc2", doc2Body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Write access granting document for chan2 (tests invalidation when channels/inval_seq exists)
 	grantingBody = Body{"type": "setaccess", "owner": "user1", "channel": "chan2"}
-	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant2", grantingBody, []string{"1-a"}, false)
+	_, _, err = dbCollection.PutExistingRevWithBody(ctx, "grant2", grantingBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// Verify user can now access both documents

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -208,7 +208,11 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	arc.replicationStats.NumConnectAttempts.Add(1)
 
 	var originPatterns []string // no origin headers for ISGR
-	blipContext, err := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix, originPatterns)
+	// TODO: CBG-3661 ActiveReplicator subprotocol versions
+	// - make this configurable for testing mixed-version replications
+	// - if unspecified, default to v2 and v3 until VV is supported with ISGR, then also include v4
+	protocols := []string{CBMobileReplicationV3.SubprotocolString(), CBMobileReplicationV2.SubprotocolString()}
+	blipContext, err := NewSGBlipContextWithProtocols(arc.ctx, arc.config.ID+idSuffix, originPatterns, protocols)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -50,11 +50,12 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	rev1ID, _, err := collection.Put(ctx, docID, rev1Body)
+	rev1ID, docRev1, err := collection.Put(ctx, docID, rev1Body)
 	require.NoError(t, err)
 	assert.Equal(t, "1-12ff9ce1dd501524378fe092ce9aee8f", rev1ID)
 
-	rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, rev1ID)
+	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility)
+	rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
@@ -68,17 +69,18 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	var rev2Body Body
 	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
+	docRev2, _, err := collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
-	rev2ID := "2-abc"
 
 	// now in any case - we'll have rev 1 backed up
-	rev1OldBody, err = collection.getOldRevisionJSON(ctx, docID, rev1ID)
+	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility)
+	rev1OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	require.NoError(t, err)
 	assert.Contains(t, string(rev1OldBody), "hello.txt")
 
 	// and rev 2 should be present only for the xattrs and deltas case
-	rev2OldBody, err := collection.getOldRevisionJSON(ctx, docID, rev2ID)
+	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility)
+	rev2OldBody, err := collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
@@ -103,7 +105,7 @@ func TestAttachments(t *testing.T) {
 
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-	revid, _, err := collection.Put(ctx, "doc1", body)
+	revid, docRev1, err := collection.Put(ctx, "doc1", body)
 	rev1id := revid
 	assert.NoError(t, err, "Couldn't create document")
 
@@ -191,7 +193,8 @@ func TestAttachments(t *testing.T) {
 	assert.Equal(t, float64(2), bye["revpos"])
 
 	log.Printf("Expire body of rev 1, then add a child...") // test fix of #498
-	err = collection.dataStore.Delete(oldRevisionKey("doc1", rev1id))
+	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility)
+	err = collection.dataStore.Delete(oldRevisionKey("doc1", base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString()))))
 	assert.NoError(t, err, "Couldn't compact old revision")
 	rev2Bstr := `{"_attachments": {"bye.txt": {"stub":true,"revpos":1,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}, "_rev": "2-f000"}`
 	var body2B Body

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -68,7 +68,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	var rev2Body Body
 	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 	rev2ID := "2-abc"
 
@@ -196,7 +196,7 @@ func TestAttachments(t *testing.T) {
 	rev2Bstr := `{"_attachments": {"bye.txt": {"stub":true,"revpos":1,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}, "_rev": "2-f000"}`
 	var body2B Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev2Bstr), &body2B))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body2B, []string{"2-f000", rev1id}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body2B, []string{"2-f000", rev1id}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't update document")
 }
 
@@ -280,7 +280,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 			rev2Data := `{"prop1":"value2", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 			require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 			require.NoError(t, err)
 
 			log.Printf("Done creating rev 2 for key %s", key)
@@ -311,7 +311,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 	var rev3Body Body
 	rev3Data := `{"prop1":"value3", "_attachments": {"hello.txt": {"revpos":2,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev3Data), &rev3Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	log.Printf("rev 3 done")
@@ -343,7 +343,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 			rev2Data := `{"prop1":"value2"}`
 			require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 			require.NoError(t, err)
 
 			log.Printf("Done creating rev 2 for key %s", key)
@@ -374,7 +374,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 	var rev3Body Body
 	rev3Data := `{"prop1":"value3", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev3Data), &rev3Body))
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	log.Printf("rev 3 done")
@@ -563,7 +563,7 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 	// Create document (rev 1)
 	text := `{"key": "value", "version": "1a"}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
-	doc, revID, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
+	doc, revID, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
@@ -571,49 +571,49 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 	text = `{"key": "value", "version": "2a", "_attachments": {"att1.txt": {"data": "YXR0MS50eHQ="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-a", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "4a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-a", "3-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "5a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"5-a", "4-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"5-a", "4-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "6a", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"6-a", "5-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"6-a", "5-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3b", "type": "pruned"}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 
 	text = `{"key": "value", "version": "3b", "_attachments": {"att1.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(text), &body))
 	body[BodyRev] = revID
-	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false)
+	doc, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"3-b", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	log.Printf("doc: %v", doc)
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -800,12 +800,18 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 
 	for i, change := range changeList {
 		docID := change[0].(string)
-		revID := change[1].(string)
+		rev := change[1].(string) // rev can represent a RevTree ID or HLV current version
 		parentRevID := ""
 		if len(change) > 2 {
 			parentRevID = change[2].(string)
 		}
-		status, currentRev := bh.collection.CheckProposedRev(bh.loggingCtx, docID, revID, parentRevID)
+		var status ProposedRevStatus
+		var currentRev string
+		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+			status, currentRev = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, rev, parentRevID)
+		} else {
+			status, currentRev = bh.collection.CheckProposedRev(bh.loggingCtx, docID, rev, parentRevID)
+		}
 		if status == ProposedRev_OK_IsNew {
 			// Remember that the doc doesn't exist locally, in order to optimize the upcoming Put:
 			bh.collectionCtx.notePendingInsertion(docID)
@@ -947,6 +953,10 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 	}()
 
+	if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 && bh.conflictResolver != nil {
+		return base.HTTPErrorf(http.StatusNotImplemented, "conflict resolver handling (ISGR) not yet implemented for v4 protocol")
+	}
+
 	// throttle concurrent revs
 	if cap(bh.inFlightRevsThrottle) > 0 {
 		select {
@@ -965,13 +975,13 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 
 	// Doc metadata comes from the BLIP message metadata, not magic document properties:
 	docID, found := revMessage.ID()
-	revID, rfound := revMessage.Rev()
+	rev, rfound := revMessage.Rev()
 	if !found || !rfound {
-		return base.HTTPErrorf(http.StatusBadRequest, "Missing docID or revID")
+		return base.HTTPErrorf(http.StatusBadRequest, "Missing docID or rev")
 	}
 
 	if bh.readOnly {
-		return base.HTTPErrorf(http.StatusForbidden, "Replication context is read-only, docID: %s, revID:%s", docID, revID)
+		return base.HTTPErrorf(http.StatusForbidden, "Replication context is read-only, docID: %s, rev:%s", docID, rev)
 	}
 
 	base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Type:%s %s", bh.serialNumber, rq.Profile(), revMessage.String())
@@ -991,7 +1001,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 			return err
 		}
 		if removed, ok := body[BodyRemoved].(bool); ok && removed {
-			base.InfofCtx(bh.loggingCtx, base.KeySync, "Purging doc %v - removed at rev %v", base.UD(docID), revID)
+			base.InfofCtx(bh.loggingCtx, base.KeySync, "Purging doc %v - removed at rev %v", base.UD(docID), rev)
 			if err := bh.collection.Purge(bh.loggingCtx, docID); err != nil {
 				return err
 			}
@@ -1003,7 +1013,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				if err != nil {
 					base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %v - not tracking for checkpointing", seqStr, err)
 				} else {
-					bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+					bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: rev})
 				}
 			}
 			return nil
@@ -1011,9 +1021,31 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	}
 
 	newDoc := &Document{
-		ID:    docID,
-		RevID: revID,
+		ID: docID,
 	}
+
+	var history []string
+	var incomingHLV HybridLogicalVector
+	// Build history/HLV
+	if bh.activeCBMobileSubprotocol < CBMobileReplicationV4 {
+		newDoc.RevID = rev
+		history = []string{rev}
+		if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" {
+			history = append(history, strings.Split(historyStr, ",")...)
+		}
+	} else {
+		versionVectorStr := rev
+		if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" {
+			versionVectorStr += ";" + historyStr
+		}
+		incomingHLV, err = extractHLVFromBlipMessage(versionVectorStr)
+		if err != nil {
+			base.InfofCtx(bh.loggingCtx, base.KeySync, "Error parsing hlv while processing rev for doc %v.  HLV:%v Error: %v", base.UD(docID), versionVectorStr, err)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "error extracting hlv from blip message")
+		}
+		newDoc.HLV = &incomingHLV
+	}
+
 	newDoc.UpdateBodyBytes(bodyBytes)
 
 	injectedAttachmentsForDelta := false
@@ -1032,7 +1064,14 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		//       while retrieving deltaSrcRevID.  Couchbase Lite replication guarantees client has access to deltaSrcRevID,
 		//       due to no-conflict write restriction, but we still need to enforce security here to prevent leaking data about previous
 		//       revisions to malicious actors (in the scenario where that user has write but not read access).
-		deltaSrcRev, err := bh.collection.GetRev(bh.loggingCtx, docID, deltaSrcRevID, false, nil)
+		var deltaSrcRev DocumentRevision
+		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+			cv := Version{}
+			cv.SourceID, cv.Value = incomingHLV.GetCurrentVersion()
+			deltaSrcRev, err = bh.collection.GetCV(bh.loggingCtx, docID, &cv, RevCacheOmitBody)
+		} else {
+			deltaSrcRev, err = bh.collection.GetRev(bh.loggingCtx, docID, deltaSrcRevID, false, nil)
+		}
 		if err != nil {
 			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't fetch doc %s for deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
 		}
@@ -1058,7 +1097,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		// err should only ever be a FleeceDeltaError here - but to be defensive, handle other errors too (e.g. somehow reaching this code in a CE build)
 		if err != nil {
 			// Something went wrong in the diffing library. We want to know about this!
-			base.WarnfCtx(bh.loggingCtx, "Error patching deltaSrc %s with %s for doc %s with delta - err: %v", deltaSrcRevID, revID, base.UD(docID), err)
+			base.WarnfCtx(bh.loggingCtx, "Error patching deltaSrc %s with %s for doc %s with delta - err: %v", deltaSrcRevID, rev, base.UD(docID), err)
 			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Error patching deltaSrc with delta: %s", err)
 		}
 
@@ -1096,15 +1135,14 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 	}
 
-	history := []string{revID}
-	if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" {
-		history = append(history, strings.Split(historyStr, ",")...)
-	}
-
 	var rawBucketDoc *sgbucket.BucketDocument
 
 	// Pull out attachments
 	if injectedAttachmentsForDelta || bytes.Contains(bodyBytes, []byte(BodyAttachments)) {
+		// temporarily error here if V4
+		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+			return base.HTTPErrorf(http.StatusNotImplemented, "attachment handling not yet supported for v4 protocol")
+		}
 		body := newDoc.Body(bh.loggingCtx)
 
 		var currentBucketDoc *Document
@@ -1141,7 +1179,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				if !ok {
 					// If we don't have this attachment already, ensure incoming revpos is greater than minRevPos, otherwise
 					// update to ensure it's fetched and uploaded
-					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, revID)
+					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, rev)
 					continue
 				}
 
@@ -1181,7 +1219,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				// digest is different we need to override the revpos and set it to the current revision to ensure
 				// the attachment is requested and stored
 				if int(incomingAttachmentRevpos) <= minRevpos && currentAttachmentDigest != incomingAttachmentDigest {
-					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, revID)
+					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, rev)
 				}
 			}
 
@@ -1189,7 +1227,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 
 		if err := bh.downloadOrVerifyAttachments(rq.Sender, body, minRevpos, docID, currentDigests); err != nil {
-			base.ErrorfCtx(bh.loggingCtx, "Error during downloadOrVerifyAttachments for doc %s/%s: %v", base.UD(docID), revID, err)
+			base.ErrorfCtx(bh.loggingCtx, "Error during downloadOrVerifyAttachments for doc %s/%s: %v", base.UD(docID), rev, err)
 			return err
 		}
 
@@ -1199,7 +1237,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	}
 
 	if rawBucketDoc == nil && bh.collectionCtx.checkPendingInsertion(docID) {
-		// At the time we handled the `propseChanges` request, there was no doc with this docID
+		// At the time we handled the `proposeChanges` request, there was no doc with this docID
 		// in the bucket. As an optimization, tell PutExistingRev to assume the doc still doesn't
 		// exist and bypass getting it from the bucket during the save. If we're wrong, the save
 		// will fail with a CAS mismatch and the retry will fetch the existing doc.
@@ -1212,7 +1250,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// If the doc is a tombstone we want to allow conflicts when running SGR2
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
-	if bh.conflictResolver != nil {
+	if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc)
+	} else if bh.conflictResolver != nil {
 		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	} else {
 		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
@@ -1227,7 +1267,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		if err != nil {
 			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %v - not tracking for checkpointing", seqProperty, err)
 		} else {
-			bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+			bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: rev})
 		}
 	}
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -484,12 +484,19 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 					}
 
 				}
-				for _, item := range change.Changes {
-					changeRow := bh.buildChangesRow(change, item["rev"])
-					pendingChanges = append(pendingChanges, changeRow)
-					if err := sendPendingChangesAt(opts.batchSize); err != nil {
-						return err
+				// if V3 and below populate change row with rev id
+				if bh.activeCBMobileSubprotocol <= CBMobileReplicationV3 {
+					for _, item := range change.Changes {
+						changeRow := bh.buildChangesRow(change, item["rev"])
+						pendingChanges = append(pendingChanges, changeRow)
 					}
+				} else {
+					changeRow := bh.buildChangesRow(change, change.CurrentVersion.String())
+					pendingChanges = append(pendingChanges, changeRow)
+				}
+
+				if err := sendPendingChangesAt(opts.batchSize); err != nil {
+					return err
 				}
 			}
 		}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1206,9 +1206,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
 	if bh.conflictResolver != nil {
-		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc)
+		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	} else {
-		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc)
+		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	}
 	if err != nil {
 		return err

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1077,8 +1077,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		//       due to no-conflict write restriction, but we still need to enforce security here to prevent leaking data about previous
 		//       revisions to malicious actors (in the scenario where that user has write but not read access).
 		var deltaSrcRev DocumentRevision
+		var deltaSrcVersion Version
 		if bh.useHLV() {
-			deltaSrcVersion, err := ParseVersion(deltaSrcRevID)
+			deltaSrcVersion, err = ParseVersion(deltaSrcRevID)
 			if err != nil {
 				return base.HTTPErrorf(http.StatusUnprocessableEntity, "Unable to parse version for delta source for doc %s, error: %v", base.UD(docID), err)
 			}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1063,7 +1063,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		if !bh.sgCanUseDeltas {
 			return base.HTTPErrorf(http.StatusBadRequest, "Deltas are disabled for this peer")
 		} else if bh.activeCBMobileSubprotocol < CBMobileReplicationV4 {
-			return base.HTTPErrorf(http.StatusBadRequest, "backwards compatability for deltas not yet implemented")
+			return base.HTTPErrorf(http.StatusBadRequest, "backwards compatibility for deltas not yet implemented")
 		}
 
 		//  TODO: Doing a GetRevCopy here duplicates some rev cache retrieval effort, since deltaRevSrc is always

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -341,7 +341,7 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 	for i, knownRevsArrayInterface := range answer {
 		seq := changeArray[i][0].(SequenceID)
 		docID := changeArray[i][1].(string)
-		revID := changeArray[i][2].(string)
+		rev := changeArray[i][2].(string)
 
 		if knownRevsArray, ok := knownRevsArrayInterface.([]interface{}); ok {
 			deltaSrcRevID := ""
@@ -368,10 +368,11 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 			}
 
 			var err error
-			if deltaSrcRevID != "" {
-				err = bsc.sendRevAsDelta(sender, docID, revID, deltaSrcRevID, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx)
+			// fall back to sending full revision v4 protocol, delta sync not yet implemented for v4
+			if deltaSrcRevID != "" && bsc.activeCBMobileSubprotocol <= CBMobileReplicationV3 {
+				err = bsc.sendRevAsDelta(sender, docID, rev, deltaSrcRevID, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx)
 			} else {
-				err = bsc.sendRevision(sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx)
+				err = bsc.sendRevision(sender, docID, rev, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx)
 			}
 			if err != nil {
 				return err
@@ -384,7 +385,7 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 				sentSeqs = append(sentSeqs, seq)
 			}
 		} else {
-			base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Peer didn't want revision %s / %s (seq:%v)", base.UD(docID), revID, seq)
+			base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Peer didn't want revision %s / %s (seq:%v)", base.UD(docID), rev, seq)
 			if collectionCtx.sgr2PushAlreadyKnownSeqsCallback != nil {
 				alreadyKnownSeqs = append(alreadyKnownSeqs, seq)
 			}
@@ -615,52 +616,68 @@ func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, 
 }
 
 // Pushes a revision body to the client
-func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseCollection *DatabaseCollectionWithUser, collectionIdx *int) error {
-	rev, err := handleChangesResponseCollection.GetRev(bsc.loggingCtx, docID, revID, true, nil)
+func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, rev string, seq SequenceID, knownRevs map[string]bool, maxHistory int, handleChangesResponseCollection *DatabaseCollectionWithUser, collectionIdx *int) error {
+	var err error
+	var docRev DocumentRevision
+	if bsc.activeCBMobileSubprotocol <= CBMobileReplicationV3 {
+		docRev, err = handleChangesResponseCollection.GetRev(bsc.loggingCtx, docID, rev, true, nil)
+	} else {
+		// extract CV string rev representation
+		version, vrsErr := CreateVersionFromString(rev)
+		if vrsErr != nil {
+			return vrsErr
+		}
+		// replace with GetCV pending merge of CBG-3212
+		docRev, err = handleChangesResponseCollection.revisionCache.GetWithCV(bsc.loggingCtx, docID, &version, RevCacheOmitBody, RevCacheOmitDelta)
+	}
 	if base.IsDocNotFoundError(err) {
-		return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
+		return bsc.sendNoRev(sender, docID, rev, collectionIdx, seq, err)
 	} else if err != nil {
-		return fmt.Errorf("failed to GetRev for doc %s with rev %s: %w", base.UD(docID).Redact(), base.MD(revID).Redact(), err)
+		return fmt.Errorf("failed to GetRev for doc %s with rev %s: %w", base.UD(docID).Redact(), base.MD(rev).Redact(), err)
 	}
 
-	base.TracefCtx(bsc.loggingCtx, base.KeySync, "sendRevision, rev attachments for %s/%s are %v", base.UD(docID), revID, base.UD(rev.Attachments))
-	attachmentStorageMeta := ToAttachmentStorageMeta(rev.Attachments)
+	base.TracefCtx(bsc.loggingCtx, base.KeySync, "sendRevision, rev attachments for %s/%s are %v", base.UD(docID), rev, base.UD(docRev.Attachments))
+	attachmentStorageMeta := ToAttachmentStorageMeta(docRev.Attachments)
 	var bodyBytes []byte
 	if base.IsEnterpriseEdition() {
 		// Still need to stamp _attachments into BLIP messages
-		if len(rev.Attachments) > 0 {
-			DeleteAttachmentVersion(rev.Attachments)
-			bodyBytes, err = base.InjectJSONProperties(rev.BodyBytes, base.KVPair{Key: BodyAttachments, Val: rev.Attachments})
+		if len(docRev.Attachments) > 0 {
+			DeleteAttachmentVersion(docRev.Attachments)
+			bodyBytes, err = base.InjectJSONProperties(docRev.BodyBytes, base.KVPair{Key: BodyAttachments, Val: docRev.Attachments})
 			if err != nil {
 				return err
 			}
 		} else {
-			bodyBytes = rev.BodyBytes
+			bodyBytes = docRev.BodyBytes
 		}
 	} else {
-		body, err := rev.Body()
+		body, err := docRev.Body()
 		if err != nil {
-			return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
+			return bsc.sendNoRev(sender, docID, rev, collectionIdx, seq, err)
 		}
 
 		// Still need to stamp _attachments into BLIP messages
-		if len(rev.Attachments) > 0 {
-			DeleteAttachmentVersion(rev.Attachments)
-			body[BodyAttachments] = rev.Attachments
+		if len(docRev.Attachments) > 0 {
+			DeleteAttachmentVersion(docRev.Attachments)
+			body[BodyAttachments] = docRev.Attachments
 		}
 
 		bodyBytes, err = base.JSONMarshalCanonical(body)
 		if err != nil {
-			return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, err)
+			return bsc.sendNoRev(sender, docID, rev, collectionIdx, seq, err)
 		}
 	}
-
-	history := toHistory(rev.History, knownRevs, maxHistory)
-	properties := blipRevMessageProperties(history, rev.Deleted, seq)
-	if base.LogDebugEnabled(bsc.loggingCtx, base.KeySync) {
-		base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Sending rev %q %s based on %d known, digests: %v", base.UD(docID), revID, len(knownRevs), digests(attachmentStorageMeta))
+	var history []string
+	if bsc.activeCBMobileSubprotocol <= CBMobileReplicationV3 {
+		history = toHistory(docRev.History, knownRevs, maxHistory)
+	} else {
+		history = append(history, docRev.hlvHistory)
 	}
-	return bsc.sendRevisionWithProperties(sender, docID, revID, collectionIdx, bodyBytes, attachmentStorageMeta, properties, seq, nil)
+	properties := blipRevMessageProperties(history, docRev.Deleted, seq)
+	if base.LogDebugEnabled(bsc.loggingCtx, base.KeySync) {
+		base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Sending rev %q %s based on %d known, digests: %v", base.UD(docID), rev, len(knownRevs), digests(attachmentStorageMeta))
+	}
+	return bsc.sendRevisionWithProperties(sender, docID, rev, collectionIdx, bodyBytes, attachmentStorageMeta, properties, seq, nil)
 }
 
 // digests returns a slice of digest extracted from the given attachment meta.

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -623,7 +623,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, rev string,
 		docRev, err = handleChangesResponseCollection.GetRev(bsc.loggingCtx, docID, rev, true, nil)
 	} else {
 		// extract CV string rev representation
-		version, vrsErr := CreateVersionFromString(rev)
+		version, vrsErr := ParseVersion(rev)
 		if vrsErr != nil {
 			return vrsErr
 		}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -627,8 +627,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, rev string,
 		if vrsErr != nil {
 			return vrsErr
 		}
-		// replace with GetCV pending merge of CBG-3212
-		docRev, err = handleChangesResponseCollection.revisionCache.GetWithCV(bsc.loggingCtx, docID, &version, RevCacheOmitBody, RevCacheOmitDelta)
+		docRev, err = handleChangesResponseCollection.GetCV(bsc.loggingCtx, docID, &version, RevCacheOmitBody)
 	}
 	if base.IsDocNotFoundError(err) {
 		return bsc.sendNoRev(sender, docID, rev, collectionIdx, seq, err)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -129,7 +129,7 @@ func (entry *LogEntry) SetRevAndVersion(rv channels.RevAndVersion) {
 	entry.RevID = rv.RevTreeID
 	if rv.CurrentSource != "" {
 		entry.SourceID = rv.CurrentSource
-		entry.Version = base.HexCasToUint64(rv.CurrentVersion)
+		entry.Version = rv.CurrentVersion
 	}
 }
 
@@ -492,7 +492,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 					change.DocID = docID
 					change.RevID = atRev.RevTreeID
 					change.SourceID = atRev.CurrentSource
-					change.Version = base.HexCasToUint64(atRev.CurrentVersion)
+					change.Version = atRev.CurrentVersion
 					change.Channels = channelRemovals
 				}
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -396,7 +396,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// First unmarshal the doc (just its metadata, to save time/memory):
-	syncData, rawBody, _, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
+	syncData, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
@@ -409,6 +409,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// If using xattrs and this isn't an SG write, we shouldn't attempt to cache.
+	rawUserXattr := rawXattrs[collection.userXattrKey()]
 	if collection.UseXattrs() {
 		if syncData == nil {
 			return

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -496,6 +496,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	if len(rawUserXattr) > 0 {
 		collection.revisionCache.RemoveWithRev(docID, syncData.CurrentRev)
 	}
+
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,
 		DocID:        docID,
@@ -505,6 +506,10 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		TimeSaved:    syncData.TimeSaved,
 		Channels:     syncData.Channels,
 		CollectionID: event.CollectionID,
+	}
+	if syncData.HLV != nil {
+		change.SourceID = syncData.HLV.SourceID
+		change.Version = syncData.HLV.Version
 	}
 
 	millisecondLatency := int(feedLatency / time.Millisecond)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -125,7 +125,7 @@ func (entry *LogEntry) SetDeleted() {
 	entry.Flags |= channels.Deleted
 }
 
-func (entry *LogEntry) SetRevAndVersion(rv RevAndVersion) {
+func (entry *LogEntry) SetRevAndVersion(rv channels.RevAndVersion) {
 	entry.RevID = rv.RevTreeID
 	if rv.CurrentSource != "" {
 		entry.SourceID = rv.CurrentSource
@@ -488,9 +488,11 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 				// if the doc was removed from one or more channels at this sequence
 				// Set the removed flag and removed channel set on the LogEntry
-				if channelRemovals, atRevId := syncData.Channels.ChannelsRemovedAtSequence(seq); len(channelRemovals) > 0 {
+				if channelRemovals, atRev := syncData.Channels.ChannelsRemovedAtSequence(seq); len(channelRemovals) > 0 {
 					change.DocID = docID
-					change.RevID = atRevId
+					change.RevID = atRev.RevTreeID
+					change.SourceID = atRev.CurrentSource
+					change.Version = base.HexCasToUint64(atRev.CurrentVersion)
 					change.Channels = channelRemovals
 				}
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -494,7 +494,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.Remove(docID, syncData.CurrentRev)
+		collection.revisionCache.RemoveWithRev(docID, syncData.CurrentRev)
 	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -125,6 +125,14 @@ func (entry *LogEntry) SetDeleted() {
 	entry.Flags |= channels.Deleted
 }
 
+func (entry *LogEntry) SetRevAndVersion(rv RevAndVersion) {
+	entry.RevID = rv.RevTreeID
+	if rv.CurrentSource != "" {
+		entry.SourceID = rv.CurrentSource
+		entry.Version = base.HexCasToUint64(rv.CurrentVersion)
+	}
+}
+
 type LogEntries []*LogEntry
 
 // A priority-queue of LogEntries, kept ordered by increasing sequence #.

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -81,7 +81,7 @@ func testLogEntryWithCV(seq uint64, docid string, revid string, channelNames []s
 		TimeReceived: time.Now(),
 		CollectionID: collectionID,
 		SourceID:     sourceID,
-		Version:      version,
+		Version:      string(base.Uint64CASToLittleEndianHex(version)),
 	}
 	channelMap := make(channels.ChannelMap)
 	for _, channelName := range channelNames {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -73,6 +73,24 @@ func logEntry(seq uint64, docid string, revid string, channelNames []string, col
 	return entry
 }
 
+func testLogEntryWithCV(seq uint64, docid string, revid string, channelNames []string, collectionID uint32, sourceID string, version uint64) *LogEntry {
+	entry := &LogEntry{
+		Sequence:     seq,
+		DocID:        docid,
+		RevID:        revid,
+		TimeReceived: time.Now(),
+		CollectionID: collectionID,
+		SourceID:     sourceID,
+		Version:      version,
+	}
+	channelMap := make(channels.ChannelMap)
+	for _, channelName := range channelNames {
+		channelMap[channelName] = nil
+	}
+	entry.Channels = channelMap
+	return entry
+}
+
 func TestLateSequenceHandling(t *testing.T) {
 
 	context, ctx := setupTestDBWithCacheOptions(t, DefaultCacheOptions())

--- a/db/changes.go
+++ b/db/changes.go
@@ -57,7 +57,7 @@ type ChangeEntry struct {
 	principalDoc   bool         // Used to indicate _user/_role docs
 	Revoked        bool         `json:"revoked,omitempty"`
 	collectionID   uint32
-	CurrentVersion *Version `json:"current_version,omitempty"` // the current version of the change entry
+	CurrentVersion *Version `json:"-"` // the current version of the change entry.  (Not marshalled, pending REST support for cv)
 }
 
 const (

--- a/db/changes.go
+++ b/db/changes.go
@@ -485,7 +485,7 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channel channels.ID) 
 	// populate CurrentVersion entry if log entry has sourceID and Version populated
 	// This allows current version to be nil in event of CV not being populated on log entry
 	// allowing omitempty to work as expected
-	if logEntry.SourceID != "" && logEntry.Version != 0 {
+	if logEntry.SourceID != "" && logEntry.Version != "" {
 		change.CurrentVersion = &Version{SourceID: logEntry.SourceID, Value: logEntry.Version}
 	}
 	if logEntry.Flags&channels.Removed != 0 {

--- a/db/changes.go
+++ b/db/changes.go
@@ -57,7 +57,7 @@ type ChangeEntry struct {
 	principalDoc   bool         // Used to indicate _user/_role docs
 	Revoked        bool         `json:"revoked,omitempty"`
 	collectionID   uint32
-	CurrentVersion *SourceAndVersion `json:"current_version,omitempty"` // the current version of the change entry
+	CurrentVersion *Version `json:"current_version,omitempty"` // the current version of the change entry
 }
 
 const (
@@ -486,7 +486,7 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channel channels.ID) 
 	// This allows current version to be nil in event of CV not being populated on log entry
 	// allowing omitempty to work as expected
 	if logEntry.SourceID != "" && logEntry.Version != 0 {
-		change.CurrentVersion = &SourceAndVersion{SourceID: logEntry.SourceID, Version: logEntry.Version}
+		change.CurrentVersion = &Version{SourceID: logEntry.SourceID, Value: logEntry.Version}
 	}
 	if logEntry.Flags&channels.Removed != 0 {
 		change.Removed = base.SetOf(channel.Name)
@@ -1289,8 +1289,8 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 	row.SetBranched((populatedDoc.Flags & channels.Branched) != 0)
 
 	if populatedDoc.HLV != nil {
-		cv := SourceAndVersion{}
-		cv.SourceID, cv.Version = populatedDoc.HLV.GetCurrentVersion()
+		cv := Version{}
+		cv.SourceID, cv.Value = populatedDoc.HLV.GetCurrentVersion()
 		row.CurrentVersion = &cv
 	}
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -320,7 +320,7 @@ func TestCVPopulationOnChangeEntry(t *testing.T) {
 
 	assert.Equal(t, doc.ID, changes[0].ID)
 	assert.Equal(t, bucketUUID, changes[0].CurrentVersion.SourceID)
-	assert.Equal(t, doc.Cas, changes[0].CurrentVersion.Version)
+	assert.Equal(t, doc.Cas, changes[0].CurrentVersion.Value)
 }
 
 func TestDocDeletionFromChannelCoalesced(t *testing.T) {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -478,14 +478,14 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 		// Create child rev 1
 		docBody["child"] = "A"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-A", revId}, false)
+		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-A", revId}, false, ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			b.Fatalf("Error creating child1 rev: %v", err)
 		}
 
 		// Create child rev 2
 		docBody["child"] = "B"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-B", revId}, false)
+		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-B", revId}, false, ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			b.Fatalf("Error creating child2 rev: %v", err)
 		}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -290,6 +290,39 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	printChanges(changes)
 }
 
+func TestCVPopulationOnChangeEntry(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	collectionID := collection.GetCollectionID()
+	bucketUUID := db.BucketUUID
+
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	authenticator := db.Authenticator(base.TestCtx(t))
+	user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+	require.NoError(t, err)
+	require.NoError(t, authenticator.Save(user))
+
+	collection.user, _ = authenticator.GetUser("alice")
+
+	// Make channel active
+	_, err = db.channelCache.GetChanges(ctx, channels.NewID("A", collectionID), getChangesOptionsWithZeroSeq(t))
+	require.NoError(t, err)
+
+	_, doc, err := collection.Put(ctx, "doc1", Body{"channels": []string{"A"}})
+	require.NoError(t, err)
+
+	require.NoError(t, collection.WaitForPendingChanges(base.TestCtx(t)))
+
+	changes, err := collection.GetChanges(ctx, base.SetOf("A"), getChangesOptionsWithZeroSeq(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, doc.ID, changes[0].ID)
+	assert.Equal(t, bucketUUID, changes[0].CurrentVersion.SourceID)
+	assert.Equal(t, doc.Cas, changes[0].CurrentVersion.Version)
+}
+
 func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	if base.TestUseXattrs() {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Same error as TestDocDeletionFromChannelCoalescedRemoved")

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -295,7 +295,7 @@ func TestCVPopulationOnChangeEntry(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 	collectionID := collection.GetCollectionID()
-	bucketUUID := db.BucketUUID
+	bucketUUID := db.EncodedBucketUUID
 
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
@@ -318,9 +318,10 @@ func TestCVPopulationOnChangeEntry(t *testing.T) {
 	changes, err := collection.GetChanges(ctx, base.SetOf("A"), getChangesOptionsWithZeroSeq(t))
 	require.NoError(t, err)
 
+	encodedCAS := string(base.Uint64CASToLittleEndianHex(doc.Cas))
 	assert.Equal(t, doc.ID, changes[0].ID)
 	assert.Equal(t, bucketUUID, changes[0].CurrentVersion.SourceID)
-	assert.Equal(t, doc.Cas, changes[0].CurrentVersion.Value)
+	assert.Equal(t, encodedCAS, changes[0].CurrentVersion.Value)
 }
 
 func TestDocDeletionFromChannelCoalesced(t *testing.T) {
@@ -567,7 +568,7 @@ func TestCurrentVersionPopulationOnChannelCache(t *testing.T) {
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 	collectionID := collection.GetCollectionID()
-	bucketUUID := db.BucketUUID
+	bucketUUID := db.EncodedBucketUUID
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Make channel active
@@ -582,7 +583,6 @@ func TestCurrentVersionPopulationOnChannelCache(t *testing.T) {
 
 	syncData, err := collection.GetDocSyncData(ctx, "doc1")
 	require.NoError(t, err)
-	uintCAS := base.HexCasToUint64(syncData.Cas)
 
 	// get entry of above doc from channel cache
 	entries, err := db.channelCache.GetChanges(ctx, channels.NewID("ABC", collectionID), getChangesOptionsWithZeroSeq(t))
@@ -591,7 +591,7 @@ func TestCurrentVersionPopulationOnChannelCache(t *testing.T) {
 
 	// assert that the source and version has been populated with the channel cache entry for the doc
 	assert.Equal(t, "doc1", entries[0].DocID)
-	assert.Equal(t, uintCAS, entries[0].Version)
+	assert.Equal(t, syncData.Cas, entries[0].Version)
 	assert.Equal(t, bucketUUID, entries[0].SourceID)
 	assert.Equal(t, syncData.HLV.SourceID, entries[0].SourceID)
 	assert.Equal(t, syncData.HLV.Version, entries[0].Version)

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -256,7 +256,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	sync["recent_sequences"] = []uint64{1, 2, 3}
 
 	cm := make(channels.ChannelMap)
-	cm["A"] = &channels.ChannelRemoval{Seq: 2, RevID: "2-e99405a23fa102238fa8c3fd499b15bc"}
+	cm["A"] = &channels.ChannelRemoval{Seq: 2, Rev: channels.RevAndVersion{RevTreeID: "2-e99405a23fa102238fa8c3fd499b15bc"}}
 	sync["channels"] = cm
 
 	history := sync["history"].(map[string]interface{})

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -425,7 +425,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	// Tombstone 5 documents
 	for i := 2; i <= 6; i++ {
 		key := fmt.Sprintf("%s_%d", t.Name(), i)
-		_, err = collection.DeleteDoc(ctx, key, revId)
+		_, _, err = collection.DeleteDoc(ctx, key, revId)
 		require.NoError(t, err, "Couldn't delete document")
 	}
 

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -18,6 +18,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 )
 
 // One "changes" row in a channelsViewResult
@@ -25,7 +26,7 @@ type channelsViewRow struct {
 	ID    string
 	Key   []interface{} // Actually [channelName, sequence]
 	Value struct {
-		Rev   RevAndVersion
+		Rev   channels.RevAndVersion
 		Flags uint8
 	}
 }
@@ -66,8 +67,10 @@ func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIter
 	}
 	entry.SetRevAndVersion(queryRow.Rev)
 
-	if queryRow.RemovalRev != "" {
-		entry.RevID = queryRow.RemovalRev
+	if queryRow.RemovalRev != nil {
+		entry.RevID = queryRow.RemovalRev.RevTreeID
+		entry.Version = base.HexCasToUint64(queryRow.RemovalRev.CurrentVersion)
+		entry.SourceID = queryRow.RemovalRev.CurrentSource
 		if queryRow.RemovalDel {
 			entry.SetDeleted()
 		}

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -25,7 +25,7 @@ type channelsViewRow struct {
 	ID    string
 	Key   []interface{} // Actually [channelName, sequence]
 	Value struct {
-		Rev   string
+		Rev   RevAndVersion
 		Flags uint8
 	}
 }
@@ -42,13 +42,12 @@ func nextChannelViewEntry(ctx context.Context, results sgbucket.QueryResultItera
 	entry := &LogEntry{
 		Sequence:     uint64(viewRow.Key[1].(float64)),
 		DocID:        viewRow.ID,
-		RevID:        viewRow.Value.Rev,
 		Flags:        viewRow.Value.Flags,
 		TimeReceived: time.Now(),
 		CollectionID: collectionID,
 	}
+	entry.SetRevAndVersion(viewRow.Value.Rev)
 	return entry, true
-
 }
 
 func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIterator, collectionID uint32) (*LogEntry, bool) {
@@ -61,11 +60,11 @@ func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIter
 	entry := &LogEntry{
 		Sequence:     queryRow.Sequence,
 		DocID:        queryRow.Id,
-		RevID:        queryRow.Rev,
 		Flags:        queryRow.Flags,
 		TimeReceived: time.Now(),
 		CollectionID: collectionID,
 	}
+	entry.SetRevAndVersion(queryRow.Rev)
 
 	if queryRow.RemovalRev != "" {
 		entry.RevID = queryRow.RemovalRev

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -69,7 +69,7 @@ func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIter
 
 	if queryRow.RemovalRev != nil {
 		entry.RevID = queryRow.RemovalRev.RevTreeID
-		entry.Version = base.HexCasToUint64(queryRow.RemovalRev.CurrentVersion)
+		entry.Version = queryRow.RemovalRev.CurrentVersion
 		entry.SourceID = queryRow.RemovalRev.CurrentSource
 		if queryRow.RemovalDel {
 			entry.SetDeleted()

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -961,7 +961,8 @@ func verifyCVEntries(entries []*LogEntry, cvs []cvValues) bool {
 		if entries[index].SourceID != cv.source {
 			return false
 		}
-		if entries[index].Version != cv.version {
+		encdedVrs := string(base.Uint64CASToLittleEndianHex(cv.version))
+		if entries[index].Version != encdedVrs {
 			return false
 		}
 	}

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -951,6 +951,23 @@ func verifyChannelDocIDs(entries []*LogEntry, docIDs []string) bool {
 	return true
 }
 
+type cvValues struct {
+	source  string
+	version uint64
+}
+
+func verifyCVEntries(entries []*LogEntry, cvs []cvValues) bool {
+	for index, cv := range cvs {
+		if entries[index].SourceID != cv.source {
+			return false
+		}
+		if entries[index].Version != cv.version {
+			return false
+		}
+	}
+	return true
+}
+
 func writeEntries(entries []*LogEntry) {
 	for index, entry := range entries {
 		log.Printf("%d:seq=%d, docID=%s, revID=%s", index, entry.Sequence, entry.DocID, entry.RevID)

--- a/db/crud.go
+++ b/db/crud.go
@@ -865,9 +865,9 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 			d.HLV.ImportCAS = d.Cas
 		} else {
 			// Otherwise this is an SDK mutation made by the local cluster that should be added to HLV.
-			newVVEntry := SourceAndVersion{}
+			newVVEntry := Version{}
 			newVVEntry.SourceID = db.dbCtx.BucketUUID
-			newVVEntry.Version = hlvExpandMacroCASValue
+			newVVEntry.Value = hlvExpandMacroCASValue
 			err := d.SyncData.HLV.AddVersion(newVVEntry)
 			if err != nil {
 				return nil, err
@@ -878,9 +878,9 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
-		newVVEntry := SourceAndVersion{}
+		newVVEntry := Version{}
 		newVVEntry.SourceID = db.dbCtx.BucketUUID
-		newVVEntry.Version = hlvExpandMacroCASValue
+		newVVEntry.Value = hlvExpandMacroCASValue
 		err := d.SyncData.HLV.AddVersion(newVVEntry)
 		if err != nil {
 			return nil, err
@@ -1042,7 +1042,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	return newRevID, doc, err
 }
 
-func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, docHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *SourceAndVersion, newRevID string, err error) {
+func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, docHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *Version, newRevID string, err error) {
 	var matchRev string
 	if existingDoc != nil {
 		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattr, existingDoc.UserXattr, existingDoc.Cas, DocUnmarshalRev)
@@ -1129,11 +1129,11 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 
 	if doc != nil && doc.HLV != nil {
 		if cv == nil {
-			cv = &SourceAndVersion{}
+			cv = &Version{}
 		}
 		source, version := doc.HLV.GetCurrentVersion()
 		cv.SourceID = source
-		cv.Version = version
+		cv.Value = version
 	}
 
 	return doc, cv, newRevID, err
@@ -2272,7 +2272,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
-			CV:               &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+			CV:               &Version{Value: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 		}
 
 		if createNewRevIDSkipped {

--- a/db/crud.go
+++ b/db/crud.go
@@ -399,13 +399,27 @@ func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, c
 
 // GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
 // returns nil.
-func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromRevID, toRevID string) (delta *RevisionDelta, redactedRev *DocumentRevision, err error) {
+func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromRevID, toRevID string, versionVectorEnabled bool) (delta *RevisionDelta, redactedRev *DocumentRevision, err error) {
 
 	if docID == "" || fromRevID == "" || toRevID == "" {
 		return nil, nil, nil
 	}
+	var fromRevision DocumentRevision
+	var fromRev Version
+	if versionVectorEnabled {
+		fromRev, err = ParseVersion(fromRevID)
+		if err != nil {
+			return nil, nil, err
+		}
 
-	fromRevision, err := db.revisionCache.GetWithRev(ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		fromRevision, err = db.revisionCache.GetWithCV(ctx, docID, &fromRev, RevCacheOmitBody, RevCacheIncludeDelta)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		//fromRevision, err := db.revisionCache.GetWithRev(ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		return nil, nil, fmt.Errorf("delta sync for rev tree not implemented")
+	}
 
 	// If the fromRevision is a removal cache entry (no body), but the user has access to that removal, then just
 	// return 404 missing to indicate that the body of the revision is no longer available.
@@ -426,7 +440,8 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 	// If delta is found, check whether it is a delta for the toRevID we want
 	if fromRevision.Delta != nil {
-		if fromRevision.Delta.ToRevID == toRevID {
+		//if fromRevision.Delta.ToRevID == toRevID {
+		if fromRevision.Delta.ToCV == toRevID {
 
 			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, nil, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(ctx, docID, fromRevision.Delta.RevisionHistory))
 			if !isAuthorized {
@@ -445,7 +460,12 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		// db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheMisses, 1)
 		db.dbStats().DeltaSync().DeltaCacheMiss.Add(1)
-		toRevision, err := db.revisionCache.GetWithRev(ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		cv, err := ParseVersion(toRevID)
+		if err != nil {
+			return nil, nil, err
+		}
+		//toRevision, err := db.revisionCache.GetWithRev(ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		toRevision, err := db.revisionCache.GetWithCV(ctx, docID, &cv, RevCacheOmitBody, RevCacheIncludeDelta)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -463,7 +483,11 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		// If the revision we're generating a delta to is a tombstone, mark it as such and don't bother generating a delta
 		if deleted {
 			revCacheDelta := newRevCacheDelta([]byte(base.EmptyDocument), fromRevID, toRevision, deleted, nil)
-			db.revisionCache.UpdateDelta(ctx, docID, fromRevID, revCacheDelta)
+			if versionVectorEnabled {
+				db.revisionCache.UpdateDeltaCV(ctx, docID, &fromRev, revCacheDelta)
+			} else {
+				db.revisionCache.UpdateDelta(ctx, docID, fromRevID, revCacheDelta)
+			}
 			return &revCacheDelta, nil, nil
 		}
 
@@ -501,9 +525,12 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 			return nil, nil, err
 		}
 		revCacheDelta := newRevCacheDelta(deltaBytes, fromRevID, toRevision, deleted, toRevAttStorageMeta)
-
 		// Write the newly calculated delta back into the cache before returning
-		db.revisionCache.UpdateDelta(ctx, docID, fromRevID, revCacheDelta)
+		if versionVectorEnabled {
+			db.revisionCache.UpdateDeltaCV(ctx, docID, &fromRev, revCacheDelta)
+		} else {
+			db.revisionCache.UpdateDelta(ctx, docID, fromRevID, revCacheDelta)
+		}
 		return &revCacheDelta, nil, nil
 	}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -2331,7 +2331,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
-			hlvHistory:       doc.HLV.toHistoryForHLV(),
+			hlvHistory:       doc.HLV.ToHistoryForHLV(),
 			CV:               &Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version},
 		}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -2941,7 +2941,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 		localDocCV.SourceID, localDocCV.Value = doc.HLV.GetCurrentVersion()
 	}
 	if err != nil {
-		if !base.IsDocNotFoundError(err) && err != base.ErrXattrNotFound {
+		if !base.IsDocNotFoundError(err) && !errors.Is(err, base.ErrXattrNotFound) {
 			base.WarnfCtx(ctx, "CheckProposedRev(%q) --> %T %v", base.UD(docid), err, err)
 			return ProposedRev_Error, ""
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1090,7 +1090,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 
 	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, false, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool

--- a/db/crud.go
+++ b/db/crud.go
@@ -2967,8 +2967,8 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 const (
 	xattrMacroCas               = "cas"          // SyncData.Cas
 	xattrMacroValueCrc32c       = "value_crc32c" // SyncData.Crc32c
-	xattrMacroCurrentRevVersion = "rev.vrs"      // SyncDataJSON.RevAndVersion.CurrentVersion
-	versionVectorVrsMacro       = "_vv.vrs"      // PersistedHybridLogicalVector.Version
+	xattrMacroCurrentRevVersion = "rev.ver"      // SyncDataJSON.RevAndVersion.CurrentVersion
+	versionVectorVrsMacro       = "_vv.ver"      // PersistedHybridLogicalVector.Version
 	versionVectorCVCASMacro     = "_vv.cvCas"    // PersistedHybridLogicalVector.CurrentVersionCAS
 )
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1073,7 +1073,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	return newRevID, doc, err
 }
 
-func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, docHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *Version, newRevID string, err error) {
+func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, newDocHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *Version, newRevID string, err error) {
 	var matchRev string
 	if existingDoc != nil {
 		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattrs[base.SyncXattrName], existingDoc.Xattrs[db.userXattrKey()], existingDoc.Cas, DocUnmarshalRev)
@@ -1112,20 +1112,28 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 			}
 		}
 
+		// set up revTreeID for backward compatibility
+		previousRevTreeID := doc.CurrentRev
+		prevGeneration, _ := ParseRevID(ctx, previousRevTreeID)
+		newGeneration := prevGeneration + 1
+
 		// Conflict check here
 		// if doc has no HLV defined this is a new doc we haven't seen before, skip conflict check
 		if doc.HLV == nil {
-			doc.HLV = &HybridLogicalVector{}
-			addNewerVersionsErr := doc.HLV.AddNewerVersions(docHLV)
+			newHLV := NewHybridLogicalVector()
+			doc.HLV = &newHLV
+			addNewerVersionsErr := doc.HLV.AddNewerVersions(newDocHLV)
 			if addNewerVersionsErr != nil {
 				return nil, nil, false, nil, addNewerVersionsErr
 			}
 		} else {
-			incomingDecodedHLV := docHLV.ToDecodedHybridLogicalVector()
-			localDecodedHLV := doc.HLV.ToDecodedHybridLogicalVector()
-			if !incomingDecodedHLV.IsInConflict(localDecodedHLV) {
+			if doc.HLV.isDominating(newDocHLV) {
+				base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add", base.UD(newDoc.ID))
+				return nil, nil, false, nil, base.ErrUpdateCancel // No new revisions to add
+			}
+			if newDocHLV.isDominating(*doc.HLV) {
 				// update hlv for all newer incoming source version pairs
-				addNewerVersionsErr := doc.HLV.AddNewerVersions(docHLV)
+				addNewerVersionsErr := doc.HLV.AddNewerVersions(newDocHLV)
 				if addNewerVersionsErr != nil {
 					return nil, nil, false, nil, addNewerVersionsErr
 				}
@@ -1135,9 +1143,13 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				return nil, nil, false, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 			}
 		}
+		// populate merge versions
+		if newDocHLV.MergeVersions != nil {
+			doc.HLV.MergeVersions = newDocHLV.MergeVersions
+		}
 
 		// Process the attachments, replacing bodies with digests.
-		newAttachments, err := db.storeAttachments(ctx, doc, newDoc.DocAttachments, generation, matchRev, nil)
+		newAttachments, err := db.storeAttachments(ctx, doc, newDoc.DocAttachments, newGeneration, previousRevTreeID, nil)
 		if err != nil {
 			return nil, nil, false, nil, err
 		}
@@ -1148,9 +1160,9 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 		if err != nil {
 			return nil, nil, false, nil, err
 		}
-		newRev := CreateRevIDWithBytes(generation, matchRev, encoding)
+		newRev := CreateRevIDWithBytes(newGeneration, previousRevTreeID, encoding)
 
-		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: newDoc.Deleted}); err != nil {
+		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: previousRevTreeID, Deleted: newDoc.Deleted}); err != nil {
 			base.InfofCtx(ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(newDoc.ID), err)
 			return nil, nil, false, nil, base.ErrRevTreeAddRevFailure
 		}
@@ -2292,6 +2304,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		}
 	}
 
+	// ErrUpdateCancel is returned when the incoming revision is already known
 	if err == base.ErrUpdateCancel {
 		return nil, "", nil
 	} else if err != nil {
@@ -2900,6 +2913,54 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 	} else {
 		// Parent revision mismatch, so this is a conflict:
 		return ProposedRev_Conflict, doc.CurrentRev
+	}
+}
+
+// CheckProposedVersion - given DocID and a version in string form, check whether it can be added without conflict.
+func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, docid, proposedVersionStr string, previousVersionStr string) (status ProposedRevStatus, currentVersion string) {
+
+	proposedVersion, err := ParseVersion(proposedVersionStr)
+	if err != nil {
+		base.WarnfCtx(ctx, "Couldn't parse proposed version for doc %q / %q: %v", base.UD(docid), proposedVersionStr, err)
+		return ProposedRev_Error, ""
+	}
+
+	var previousVersion Version
+	if previousVersionStr != "" {
+		var err error
+		previousVersion, err = ParseVersion(previousVersionStr)
+		if err != nil {
+			base.WarnfCtx(ctx, "Couldn't parse previous version for doc %q / %q: %v", base.UD(docid), previousVersionStr, err)
+			return ProposedRev_Error, ""
+		}
+	}
+
+	localDocCV := Version{}
+	doc, err := db.GetDocSyncDataNoImport(ctx, docid, DocUnmarshalNoHistory)
+	if doc.HLV != nil {
+		localDocCV.SourceID, localDocCV.Value = doc.HLV.GetCurrentVersion()
+	}
+	if err != nil {
+		if !base.IsDocNotFoundError(err) && err != base.ErrXattrNotFound {
+			base.WarnfCtx(ctx, "CheckProposedRev(%q) --> %T %v", base.UD(docid), err, err)
+			return ProposedRev_Error, ""
+		}
+		// New document not found on server
+		return ProposedRev_OK_IsNew, ""
+	} else if localDocCV == previousVersion {
+		// Non-conflicting update, client's previous version is server's CV
+		return ProposedRev_OK, ""
+	} else if doc.HLV.DominatesSource(proposedVersion) {
+		// SGW already has this version
+		return ProposedRev_Exists, ""
+	} else if localDocCV.SourceID == proposedVersion.SourceID && localDocCV.Value < proposedVersion.Value {
+		// previousVersion didn't match, but proposed version and server CV have matching source, and proposed version is newer
+		return ProposedRev_OK, ""
+	} else {
+		// Conflict, return the current cv.  This may be a false positive conflict if the client has replicated
+		// the server cv via a different peer.  Client is responsible for performing this check based on the
+		// returned localDocCV
+		return ProposedRev_Conflict, localDocCV.String()
 	}
 }
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -857,19 +857,37 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 	case ExistingVersion:
 		// preserve any other logic on the HLV that has been done by the client, only update to cvCAS will be needed
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+		d.HLV.ImportCAS = 0 // remove importCAS for non-imports to save space
 	case Import:
-		// work to be done to decide if the VV needs updating here, pending CBG-3503
+		if d.HLV.CurrentVersionCAS == d.Cas {
+			// if cvCAS = document CAS, the HLV has already been updated for this mutation by another HLV-aware peer.
+			// Set ImportCAS to the previous document CAS, but don't otherwise modify HLV
+			d.HLV.ImportCAS = d.Cas
+		} else {
+			// Otherwise this is an SDK mutation made by the local cluster that should be added to HLV.
+			newVVEntry := SourceAndVersion{}
+			newVVEntry.SourceID = db.dbCtx.BucketUUID
+			newVVEntry.Version = hlvExpandMacroCASValue
+			err := d.SyncData.HLV.AddVersion(newVVEntry)
+			if err != nil {
+				return nil, err
+			}
+			d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+			d.HLV.ImportCAS = d.Cas
+		}
+
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
-		newVVEntry := CurrentVersionVector{}
+		newVVEntry := SourceAndVersion{}
 		newVVEntry.SourceID = db.dbCtx.BucketUUID
-		newVVEntry.VersionCAS = hlvExpandMacroCASValue
+		newVVEntry.Version = hlvExpandMacroCASValue
 		err := d.SyncData.HLV.AddVersion(newVVEntry)
 		if err != nil {
 			return nil, err
 		}
 		// update the cvCAS on the SGWrite event too
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+		d.HLV.ImportCAS = 0 // remove importCAS for non-imports to save space
 	}
 	return d, nil
 }
@@ -2157,7 +2175,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
-			CV:               &CurrentVersionVector{VersionCAS: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+			CV:               &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 		}
 
 		if createNewRevIDSkipped {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1042,6 +1042,103 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 	return newRevID, doc, err
 }
 
+func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, docHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *SourceAndVersion, newRevID string, err error) {
+	var matchRev string
+	if existingDoc != nil {
+		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattr, existingDoc.UserXattr, existingDoc.Cas, DocUnmarshalRev)
+		if unmarshalErr != nil {
+			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling exsiting doc")
+		}
+		matchRev = doc.CurrentRev
+	}
+	generation, _ := ParseRevID(ctx, matchRev)
+	if generation < 0 {
+		return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
+	}
+	generation++
+
+	docUpdateEvent := ExistingVersion
+	allowImport := db.UseXattrs()
+	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+		// (Be careful: this block can be invoked multiple times if there are races!)
+
+		var isSgWrite bool
+		var crc32Match bool
+
+		// Is this doc an sgWrite?
+		if doc != nil {
+			isSgWrite, crc32Match, _ = doc.IsSGWrite(ctx, nil)
+			if crc32Match {
+				db.dbStats().Database().Crc32MatchCount.Add(1)
+			}
+		}
+
+		// If the existing doc isn't an SG write, import prior to updating
+		if doc != nil && !isSgWrite && db.UseXattrs() {
+			err := db.OnDemandImportForWrite(ctx, newDoc.ID, doc, newDoc.Deleted)
+			if err != nil {
+				return nil, nil, false, nil, err
+			}
+		}
+
+		// Conflict check here
+		// if doc has no HLV defined this is a new doc we haven't seen before, skip conflict check
+		if doc.HLV == nil {
+			doc.HLV = &HybridLogicalVector{}
+			addNewerVersionsErr := doc.HLV.AddNewerVersions(docHLV)
+			if addNewerVersionsErr != nil {
+				return nil, nil, false, nil, addNewerVersionsErr
+			}
+		} else {
+			if !docHLV.IsInConflict(*doc.HLV) {
+				// update hlv for all newer incoming source version pairs
+				addNewerVersionsErr := doc.HLV.AddNewerVersions(docHLV)
+				if addNewerVersionsErr != nil {
+					return nil, nil, false, nil, addNewerVersionsErr
+				}
+			} else {
+				base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s", base.UD(doc.ID))
+				// cancel rest of update, HLV needs to be sent back to client with merge versions populated
+				return nil, nil, false, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
+			}
+		}
+
+		// Process the attachments, replacing bodies with digests.
+		newAttachments, err := db.storeAttachments(ctx, doc, newDoc.DocAttachments, generation, matchRev, nil)
+		if err != nil {
+			return nil, nil, false, nil, err
+		}
+
+		// generate rev id for new arriving doc
+		strippedBody, _ := stripInternalProperties(newDoc._body)
+		encoding, err := base.JSONMarshalCanonical(strippedBody)
+		if err != nil {
+			return nil, nil, false, nil, err
+		}
+		newRev := CreateRevIDWithBytes(generation, matchRev, encoding)
+
+		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: newDoc.Deleted}); err != nil {
+			base.InfofCtx(ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(newDoc.ID), err)
+			return nil, nil, false, nil, base.ErrRevTreeAddRevFailure
+		}
+
+		newDoc.RevID = newRev
+
+		return newDoc, newAttachments, false, nil, nil
+	})
+
+	if doc != nil && doc.HLV != nil {
+		if cv == nil {
+			cv = &SourceAndVersion{}
+		}
+		source, version := doc.HLV.GetCurrentVersion()
+		cv.SourceID = source
+		cv.Version = version
+	}
+
+	return doc, cv, newRevID, err
+}
+
 // Adds an existing revision to a document along with its history (list of rev IDs.)
 func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument, docUpdateEvent DocUpdateType) (doc *Document, newRevID string, err error) {
 	return db.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc, docUpdateEvent)

--- a/db/crud.go
+++ b/db/crud.go
@@ -1086,7 +1086,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 	if generation < 0 {
 		return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
-	generation++
+	generation++ //nolint
 
 	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()

--- a/db/crud.go
+++ b/db/crud.go
@@ -1045,7 +1045,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, docHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *Version, newRevID string, err error) {
 	var matchRev string
 	if existingDoc != nil {
-		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattr, existingDoc.UserXattr, existingDoc.Cas, DocUnmarshalRev)
+		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattrs[base.SyncXattrName], existingDoc.Xattrs[db.userXattrKey()], existingDoc.Cas, DocUnmarshalRev)
 		if unmarshalErr != nil {
 			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling exsiting doc")
 		}
@@ -2843,10 +2843,11 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 }
 
 const (
-	xattrMacroCas           = "cas"
-	xattrMacroValueCrc32c   = "value_crc32c"
-	versionVectorVrsMacro   = "_vv.vrs"
-	versionVectorCVCASMacro = "_vv.cvCas"
+	xattrMacroCas               = "cas"          // SyncData.Cas
+	xattrMacroValueCrc32c       = "value_crc32c" // SyncData.Crc32c
+	xattrMacroCurrentRevVersion = "rev.vrs"      // SyncDataJSON.RevAndVersion.CurrentVersion
+	versionVectorVrsMacro       = "_vv.vrs"      // PersistedHybridLogicalVector.Version
+	versionVectorCVCASMacro     = "_vv.cvCas"    // PersistedHybridLogicalVector.CurrentVersionCAS
 )
 
 func macroExpandSpec(xattrName string) []sgbucket.MacroExpansionSpec {
@@ -2864,6 +2865,10 @@ func xattrCasPath(xattrKey string) string {
 
 func xattrCrc32cPath(xattrKey string) string {
 	return xattrKey + "." + xattrMacroValueCrc32c
+}
+
+func xattrCurrentRevVersionPath(xattrKey string) string {
+	return xattrKey + "." + xattrMacroCurrentRevVersion
 }
 
 func xattrCurrentVersionPath(xattrKey string) string {

--- a/db/crud.go
+++ b/db/crud.go
@@ -2302,7 +2302,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
-			CV:               &Version{Value: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+			hlvHistory:       doc.HLV.toHistoryForHLV(),
+			CV:               &Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version},
 		}
 
 		if createNewRevIDSkipped {
@@ -2531,10 +2532,10 @@ func (db *DatabaseCollectionWithUser) Post(ctx context.Context, body Body) (doci
 }
 
 // Deletes a document, by adding a new revision whose _deleted property is true.
-func (db *DatabaseCollectionWithUser) DeleteDoc(ctx context.Context, docid string, revid string) (string, error) {
+func (db *DatabaseCollectionWithUser) DeleteDoc(ctx context.Context, docid string, revid string) (string, *Document, error) {
 	body := Body{BodyDeleted: true, BodyRev: revid}
-	newRevID, _, err := db.Put(ctx, docid, body)
-	return newRevID, err
+	newRevID, doc, err := db.Put(ctx, docid, body)
+	return newRevID, doc, err
 }
 
 // Purges a document from the bucket (no tombstone)

--- a/db/crud.go
+++ b/db/crud.go
@@ -887,29 +887,30 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 	case ExistingVersion:
 		// preserve any other logic on the HLV that has been done by the client, only update to cvCAS will be needed
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
-		d.HLV.ImportCAS = 0 // remove importCAS for non-imports to save space
+		d.HLV.ImportCAS = "" // remove importCAS for non-imports to save space
 	case Import:
-		if d.HLV.CurrentVersionCAS == d.Cas {
+		encodedCAS := string(base.Uint64CASToLittleEndianHex(d.Cas))
+		if d.HLV.CurrentVersionCAS == encodedCAS {
 			// if cvCAS = document CAS, the HLV has already been updated for this mutation by another HLV-aware peer.
 			// Set ImportCAS to the previous document CAS, but don't otherwise modify HLV
-			d.HLV.ImportCAS = d.Cas
+			d.HLV.ImportCAS = encodedCAS
 		} else {
 			// Otherwise this is an SDK mutation made by the local cluster that should be added to HLV.
 			newVVEntry := Version{}
-			newVVEntry.SourceID = db.dbCtx.BucketUUID
+			newVVEntry.SourceID = db.dbCtx.EncodedBucketUUID
 			newVVEntry.Value = hlvExpandMacroCASValue
 			err := d.SyncData.HLV.AddVersion(newVVEntry)
 			if err != nil {
 				return nil, err
 			}
 			d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
-			d.HLV.ImportCAS = d.Cas
+			d.HLV.ImportCAS = encodedCAS
 		}
 
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
 		newVVEntry := Version{}
-		newVVEntry.SourceID = db.dbCtx.BucketUUID
+		newVVEntry.SourceID = db.dbCtx.EncodedBucketUUID
 		newVVEntry.Value = hlvExpandMacroCASValue
 		err := d.SyncData.HLV.AddVersion(newVVEntry)
 		if err != nil {
@@ -917,7 +918,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 		}
 		// update the cvCAS on the SGWrite event too
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
-		d.HLV.ImportCAS = 0 // remove importCAS for non-imports to save space
+		d.HLV.ImportCAS = "" // remove importCAS for non-imports to save space
 	}
 	return d, nil
 }
@@ -1120,7 +1121,9 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				return nil, nil, false, nil, addNewerVersionsErr
 			}
 		} else {
-			if !docHLV.IsInConflict(*doc.HLV) {
+			incomingDecodedHLV := docHLV.ToDecodedHybridLogicalVector()
+			localDecodedHLV := doc.HLV.ToDecodedHybridLogicalVector()
+			if !incomingDecodedHLV.IsInConflict(localDecodedHLV) {
 				// update hlv for all newer incoming source version pairs
 				addNewerVersionsErr := doc.HLV.AddNewerVersions(docHLV)
 				if addNewerVersionsErr != nil {
@@ -2396,11 +2399,12 @@ func postWriteUpdateHLV(doc *Document, casOut uint64) *Document {
 	if doc.HLV == nil {
 		return doc
 	}
+	encodedCAS := string(base.Uint64CASToLittleEndianHex(casOut))
 	if doc.HLV.Version == hlvExpandMacroCASValue {
-		doc.HLV.Version = casOut
+		doc.HLV.Version = encodedCAS
 	}
 	if doc.HLV.CurrentVersionCAS == hlvExpandMacroCASValue {
-		doc.HLV.CurrentVersionCAS = casOut
+		doc.HLV.CurrentVersionCAS = encodedCAS
 	}
 	return doc
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1987,7 +1987,27 @@ func (db *DatabaseCollectionWithUser) IsIllegalConflict(ctx context.Context, doc
 	return true
 }
 
-func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry *uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, createNewRevIDSkipped bool, err error) {
+func (col *DatabaseCollectionWithUser) documentUpdateFunc(
+	ctx context.Context,
+	docExists bool,
+	doc *Document,
+	allowImport bool,
+	previousDocSequenceIn uint64,
+	unusedSequences []uint64,
+	callback updateAndReturnDocCallback,
+	expiry *uint32,
+	docUpdateEvent DocUpdateType,
+) (
+	retSyncFuncExpiry *uint32,
+	retNewRevID string,
+	retStoredDoc *Document,
+	retOldBodyJSON string,
+	retUnusedSequences []uint64,
+	changedAccessPrincipals []string,
+	changedRoleAccessUsers []string,
+	createNewRevIDSkipped bool,
+	revokedChannelsRequiringExpansion []string,
+	err error) {
 
 	err = validateExistingDoc(doc, allowImport, docExists)
 	if err != nil {
@@ -2036,6 +2056,14 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, d
 		return
 	}
 
+	// The callback has updated the HLV for mutations coming from CBL.  Update the HLV so that the current version is set before
+	// we call updateChannels, which needs to set the current version for removals
+	// update the HLV values
+	doc, err = col.updateHLV(doc, docUpdateEvent)
+	if err != nil {
+		return
+	}
+
 	if doc.CurrentRev != prevCurrentRev || createNewRevIDSkipped {
 		// Most of the time this update will change the doc's current rev. (The exception is
 		// if the new rev is a conflict that doesn't win the revid comparison.) If so, we
@@ -2047,7 +2075,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, d
 				return
 			}
 		}
-		_, err = doc.updateChannels(ctx, channelSet)
+		_, revokedChannelsRequiringExpansion, err = doc.updateChannels(ctx, channelSet)
 		if err != nil {
 			return
 		}
@@ -2072,7 +2100,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, d
 
 	doc.ClusterUUID = col.serverUUID()
 	doc.TimeSaved = time.Now()
-	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err
+	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, revokedChannelsRequiringExpansion, err
 }
 
 // Function type for the callback passed into updateAndReturnDoc
@@ -2124,7 +2152,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 			prevCurrentRev = doc.CurrentRev
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(ctx, docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, _, err = db.documentUpdateFunc(ctx, docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry, docUpdateEvent)
 			if err != nil {
 				return
 			}
@@ -2180,7 +2208,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			docExists := currentValue != nil
-			updatedDoc.Expiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(ctx, docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			var revokedChannelsRequiringExpansion []string
+			updatedDoc.Expiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, revokedChannelsRequiringExpansion, err = db.documentUpdateFunc(ctx, docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry, docUpdateEvent)
 			if err != nil {
 				return
 			}
@@ -2196,13 +2225,10 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				return
 			}
 
-			// update the HLV values
-			doc, err = db.updateHLV(doc, docUpdateEvent)
-			if err != nil {
-				return
-			}
 			// update the mutate in options based on the above logic
 			updatedDoc.Spec = doc.SyncData.HLV.computeMacroExpansions()
+
+			updatedDoc.Spec = appendRevocationMacroExpansions(updatedDoc.Spec, revokedChannelsRequiringExpansion)
 
 			updatedDoc.IsTombstone = currentRevFromHistory.Deleted
 
@@ -2908,4 +2934,8 @@ func xattrCurrentVersionPath(xattrKey string) string {
 
 func xattrCurrentVersionCASPath(xattrKey string) string {
 	return xattrKey + "." + versionVectorCVCASMacro
+}
+
+func xattrRevokedChannelVersionPath(xattrKey string, channelName string) string {
+	return xattrKey + ".channels." + channelName + "." + xattrMacroCurrentRevVersion
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -314,14 +314,29 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 		// No rev ID given, so load active revision
 		revision, err = db.revisionCache.GetActive(ctx, docid, includeBody)
 	}
-
 	if err != nil {
 		return DocumentRevision{}, err
 	}
 
+	return db.documentRevisionForRequest(ctx, docid, revision, &revid, nil, maxHistory, historyFrom)
+}
+
+// documentRevisionForRequest processes the given DocumentRevision and returns a version of it for a given client request, depending on access, deleted, etc.
+func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Context, docID string, revision DocumentRevision, revID *string, cv *Version, maxHistory int, historyFrom []string) (DocumentRevision, error) {
+	// ensure only one of cv or revID is specified
+	if cv != nil && revID != nil {
+		return DocumentRevision{}, fmt.Errorf("must have one of cv or revID in documentRevisionForRequest (had cv=%v revID=%v)", cv, revID)
+	}
+	var requestedVersion string
+	if revID != nil {
+		requestedVersion = *revID
+	} else if cv != nil {
+		requestedVersion = cv.String()
+	}
+
 	if revision.BodyBytes == nil {
 		if db.ForceAPIForbiddenErrors() {
-			base.InfofCtx(ctx, base.KeyCRUD, "Doc: %s %s is missing", base.UD(docid), base.MD(revid))
+			base.InfofCtx(ctx, base.KeyCRUD, "Doc: %s %s is missing", base.UD(docID), base.MD(requestedVersion))
 			return DocumentRevision{}, ErrForbidden
 		}
 		return DocumentRevision{}, ErrMissing
@@ -340,16 +355,17 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 		_, requestedHistory = trimEncodedRevisionsToAncestor(ctx, requestedHistory, historyFrom, maxHistory)
 	}
 
-	isAuthorized, redactedRev := db.authorizeUserForChannels(docid, revision.RevID, revision.Channels, revision.Deleted, requestedHistory)
+	isAuthorized, redactedRevision := db.authorizeUserForChannels(docID, revision.RevID, cv, revision.Channels, revision.Deleted, requestedHistory)
 	if !isAuthorized {
-		if revid == "" {
+		// client just wanted active revision, not a specific one
+		if requestedVersion == "" {
 			return DocumentRevision{}, ErrForbidden
 		}
 		if db.ForceAPIForbiddenErrors() {
-			base.InfofCtx(ctx, base.KeyCRUD, "Not authorized to view doc: %s %s", base.UD(docid), base.MD(revid))
+			base.InfofCtx(ctx, base.KeyCRUD, "Not authorized to view doc: %s %s", base.UD(docID), base.MD(requestedVersion))
 			return DocumentRevision{}, ErrForbidden
 		}
-		return redactedRev, nil
+		return redactedRevision, nil
 	}
 
 	// If the revision is a removal cache entry (no body), but the user has access to that removal, then just
@@ -358,11 +374,24 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 		return DocumentRevision{}, ErrMissing
 	}
 
-	if revision.Deleted && revid == "" {
+	if revision.Deleted && requestedVersion == "" {
 		return DocumentRevision{}, ErrDeleted
 	}
 
 	return revision, nil
+}
+
+func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *Version, includeBody bool) (revision DocumentRevision, err error) {
+	if cv != nil {
+		revision, err = db.revisionCache.GetWithCV(ctx, docid, cv, includeBody, RevCacheOmitDelta)
+	} else {
+		revision, err = db.revisionCache.GetActive(ctx, docid, includeBody)
+	}
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	return db.documentRevisionForRequest(ctx, docid, revision, nil, cv, 0, nil)
 }
 
 // GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
@@ -396,7 +425,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 	if fromRevision.Delta != nil {
 		if fromRevision.Delta.ToRevID == toRevID {
 
-			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(ctx, docID, fromRevision.Delta.RevisionHistory))
+			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, nil, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(ctx, docID, fromRevision.Delta.RevisionHistory))
 			if !isAuthorized {
 				return nil, &redactedBody, nil
 			}
@@ -419,7 +448,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		}
 
 		deleted := toRevision.Deleted
-		isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, toRevision.Channels, deleted, toRevision.History)
+		isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRevID, nil, toRevision.Channels, deleted, toRevision.History)
 		if !isAuthorized {
 			return nil, &redactedBody, nil
 		}
@@ -478,7 +507,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 	return nil, nil, nil
 }
 
-func (col *DatabaseCollectionWithUser) authorizeUserForChannels(docID, revID string, channels base.Set, isDeleted bool, history Revisions) (isAuthorized bool, redactedRev DocumentRevision) {
+func (col *DatabaseCollectionWithUser) authorizeUserForChannels(docID, revID string, cv *Version, channels base.Set, isDeleted bool, history Revisions) (isAuthorized bool, redactedRev DocumentRevision) {
 
 	if col.user != nil {
 		if err := col.user.AuthorizeAnyCollectionChannel(col.ScopeName, col.Name, channels); err != nil {
@@ -490,6 +519,7 @@ func (col *DatabaseCollectionWithUser) authorizeUserForChannels(docID, revID str
 				RevID:   revID,
 				History: history,
 				Deleted: isDeleted,
+				CV:      cv,
 			}
 			if isDeleted {
 				// Deletions are denoted by the deleted message property during 2.x replication
@@ -1047,7 +1077,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 	if existingDoc != nil {
 		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattrs[base.SyncXattrName], existingDoc.Xattrs[db.userXattrKey()], existingDoc.Cas, DocUnmarshalRev)
 		if unmarshalErr != nil {
-			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling exsiting doc")
+			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling existing doc")
 		}
 		matchRev = doc.CurrentRev
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -309,7 +309,7 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid s
 	if revid != "" {
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
-		revision, err = db.revisionCache.Get(ctx, docid, revid, includeBody, RevCacheOmitDelta)
+		revision, err = db.revisionCache.GetWithRev(ctx, docid, revid, includeBody, RevCacheOmitDelta)
 	} else {
 		// No rev ID given, so load active revision
 		revision, err = db.revisionCache.GetActive(ctx, docid, includeBody)
@@ -373,7 +373,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		return nil, nil, nil
 	}
 
-	fromRevision, err := db.revisionCache.Get(ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+	fromRevision, err := db.revisionCache.GetWithRev(ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 
 	// If the fromRevision is a removal cache entry (no body), but the user has access to that removal, then just
 	// return 404 missing to indicate that the body of the revision is no longer available.
@@ -413,7 +413,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		// db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheMisses, 1)
 		db.dbStats().DeltaSync().DeltaCacheMiss.Add(1)
-		toRevision, err := db.revisionCache.Get(ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		toRevision, err := db.revisionCache.GetWithRev(ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -859,7 +859,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
 	case Import:
 		// work to be done to decide if the VV needs updating here, pending CBG-3503
-	case NewVersion:
+	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
 		newVVEntry := CurrentVersionVector{}
 		newVVEntry.SourceID = db.dbCtx.BucketUUID
@@ -1025,8 +1025,8 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 }
 
 // Adds an existing revision to a document along with its history (list of rev IDs.)
-func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
-	return db.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc)
+func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument, docUpdateEvent DocUpdateType) (doc *Document, newRevID string, err error) {
+	return db.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc, docUpdateEvent)
 }
 
 // PutExistingRevWithConflictResolution Adds an existing revision to a document along with its history (list of rev IDs.)
@@ -1034,14 +1034,13 @@ func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc
 //  1. If noConflicts == false, the revision will be added to the rev tree as a conflict
 //  2. If noConflicts == true and a conflictResolverFunc is not provided, a 409 conflict error will be returned
 //  3. If noConflicts == true and a conflictResolverFunc is provided, conflicts will be resolved and the result added to the document.
-func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, conflictResolver *ConflictResolver, forceAllowConflictingTombstone bool, existingDoc *sgbucket.BucketDocument) (doc *Document, newRevID string, err error) {
+func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, conflictResolver *ConflictResolver, forceAllowConflictingTombstone bool, existingDoc *sgbucket.BucketDocument, docUpdateEvent DocUpdateType) (doc *Document, newRevID string, err error) {
 	newRev := docHistory[0]
 	generation, _ := ParseRevID(ctx, newRev)
 	if generation < 0 {
 		return nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 
-	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()
 	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, false, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 
@@ -1143,7 +1142,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 	return doc, newRev, err
 }
 
-func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context, docid string, body Body, docHistory []string, noConflicts bool) (doc *Document, newRev string, err error) {
+func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context, docid string, body Body, docHistory []string, noConflicts bool, docUpdateEvent DocUpdateType) (doc *Document, newRev string, err error) {
 	err = validateAPIDocUpdate(body)
 	if err != nil {
 		return nil, "", err
@@ -1168,7 +1167,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context
 
 	newDoc.UpdateBody(body)
 
-	doc, newRevID, putExistingRevErr := db.PutExistingRev(ctx, newDoc, docHistory, noConflicts, false, nil)
+	doc, newRevID, putExistingRevErr := db.PutExistingRev(ctx, newDoc, docHistory, noConflicts, false, nil, docUpdateEvent)
 
 	if putExistingRevErr != nil {
 		return nil, "", putExistingRevErr
@@ -2085,7 +2084,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Remove(doc.ID, doc.CurrentRev)
+				db.revisionCache.RemoveWithRev(doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
@@ -2099,6 +2098,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 		} else if doc != nil {
 			doc.Cas = casOut
+			// update the doc's HLV defined post macro expansion
+			doc = postWriteUpdateHLV(doc, casOut)
 		}
 	}
 
@@ -2156,6 +2157,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
+			CV:               &CurrentVersionVector{VersionCAS: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 		}
 
 		if createNewRevIDSkipped {
@@ -2216,6 +2218,19 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 	// Mark affected users/roles as needing to recompute their channel access:
 	db.MarkPrincipalsChanged(ctx, docid, newRevID, changedAccessPrincipals, changedRoleAccessUsers, doc.Sequence)
 	return doc, newRevID, nil
+}
+
+func postWriteUpdateHLV(doc *Document, casOut uint64) *Document {
+	if doc.HLV == nil {
+		return doc
+	}
+	if doc.HLV.Version == hlvExpandMacroCASValue {
+		doc.HLV.Version = casOut
+	}
+	if doc.HLV.CurrentVersionCAS == hlvExpandMacroCASValue {
+		doc.HLV.CurrentVersionCAS = casOut
+	}
+	return doc
 }
 
 func getAttachmentIDsForLeafRevisions(ctx context.Context, db *DatabaseCollectionWithUser, doc *Document, newRevID string) (map[string]struct{}, error) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -441,7 +441,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 	if fromRevision.Delta != nil {
 		if fromRevision.Delta.ToCV == toRev {
 
-			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRev, nil, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(ctx, docID, fromRevision.Delta.RevisionHistory))
+			isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRev, fromRevision.CV, fromRevision.Delta.ToChannels, fromRevision.Delta.ToDeleted, encodeRevisions(ctx, docID, fromRevision.Delta.RevisionHistory))
 			if !isAuthorized {
 				return nil, &redactedBody, nil
 			}
@@ -469,7 +469,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		}
 
 		deleted := toRevision.Deleted
-		isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRev, nil, toRevision.Channels, deleted, toRevision.History)
+		isAuthorized, redactedBody := db.authorizeUserForChannels(docID, toRev, toRevision.CV, toRevision.Channels, deleted, toRevision.History)
 		if !isAuthorized {
 			return nil, &redactedBody, nil
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -847,6 +847,33 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 	return nil
 }
 
+// updateHLV updates the HLV in the sync data appropriately based on what type of document update event we are encountering
+func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocUpdateType) (*Document, error) {
+
+	if d.HLV == nil {
+		d.HLV = &HybridLogicalVector{}
+	}
+	switch docUpdateEvent {
+	case ExistingVersion:
+		// preserve any other logic on the HLV that has been done by the client, only update to cvCAS will be needed
+		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+	case Import:
+		// work to be done to decide if the VV needs updating here, pending CBG-3503
+	case NewVersion:
+		// add a new entry to the version vector
+		newVVEntry := CurrentVersionVector{}
+		newVVEntry.SourceID = db.dbCtx.BucketUUID
+		newVVEntry.VersionCAS = hlvExpandMacroCASValue
+		err := d.SyncData.HLV.AddVersion(newVVEntry)
+		if err != nil {
+			return nil, err
+		}
+		// update the cvCAS on the SGWrite event too
+		d.HLV.CurrentVersionCAS = hlvExpandMacroCASValue
+	}
+	return d, nil
+}
+
 // Updates or creates a document.
 // The new body's BodyRev property must match the current revision's, if any.
 func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, body Body) (newRevID string, doc *Document, err error) {
@@ -886,8 +913,11 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 		return "", nil, err
 	}
 
+	docUpdateEvent := NewVersion
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &expiry, nil, nil, false, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+
+	doc, newRevID, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &expiry, nil, docUpdateEvent, nil, false, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+
 		var isSgWrite bool
 		var crc32Match bool
 
@@ -1011,8 +1041,10 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 		return nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 
+	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()
-	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, existingDoc, false, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, false, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -1907,7 +1939,8 @@ type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAtta
 //  2. Specify the existing document body/xattr/cas, to avoid initial retrieval of the doc in cases that the current contents are already known (e.g. import).
 //     On cas failure, the document will still be reloaded from the bucket as usual.
 //  3. If isImport=true, document body will not be updated - only metadata xattr(s)
-func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry *uint32, opts *sgbucket.MutateInOptions, existingDoc *sgbucket.BucketDocument, isImport bool, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
+
+func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, docid string, allowImport bool, expiry *uint32, opts *sgbucket.MutateInOptions, docUpdateEvent DocUpdateType, existingDoc *sgbucket.BucketDocument, isImport bool, callback updateAndReturnDocCallback) (doc *Document, newRevID string, err error) {
 	key := realDocID(docid)
 	if key == "" {
 		return nil, "", base.HTTPErrorf(400, "Invalid doc ID")
@@ -2018,6 +2051,14 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				err = base.RedactErrorf("WriteUpdateWithXattr() not able to find revision (%v) in history of doc: %+v.  Cannot update doc.", doc.CurrentRev, base.UD(doc))
 				return
 			}
+
+			// update the HLV values
+			doc, err = db.updateHLV(doc, docUpdateEvent)
+			if err != nil {
+				return
+			}
+			// update the mutate in options based on the above logic
+			updatedDoc.Spec = doc.SyncData.HLV.computeMacroExpansions()
 
 			updatedDoc.IsTombstone = currentRevFromHistory.Deleted
 
@@ -2672,8 +2713,10 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 }
 
 const (
-	xattrMacroCas         = "cas"
-	xattrMacroValueCrc32c = "value_crc32c"
+	xattrMacroCas           = "cas"
+	xattrMacroValueCrc32c   = "value_crc32c"
+	versionVectorVrsMacro   = "_vv.vrs"
+	versionVectorCVCASMacro = "_vv.cvCas"
 )
 
 func macroExpandSpec(xattrName string) []sgbucket.MacroExpansionSpec {
@@ -2691,4 +2734,12 @@ func xattrCasPath(xattrKey string) string {
 
 func xattrCrc32cPath(xattrKey string) string {
 	return xattrKey + "." + xattrMacroValueCrc32c
+}
+
+func xattrCurrentVersionPath(xattrKey string) string {
+	return xattrKey + "." + versionVectorVrsMacro
+}
+
+func xattrCurrentVersionCASPath(xattrKey string) string {
+	return xattrKey + "." + versionVectorCVCASMacro
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1196,10 +1196,11 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 }
 
 func TestGetAvailableRevAttachments(t *testing.T) {
+	t.Skip("pending backwards compatibility on backed up revs between revid and cv CBG-3748")
+
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
-	t.Skip("pending backwards compatability on backed up revs between revid and cv")
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -245,7 +245,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get the existing bucket doc
-		_, existingBucketDoc, err := collection.GetDocWithXattr(ctx, docID, DocUnmarshalAll)
+		_, existingBucketDoc, err := collection.GetDocWithXattrs(ctx, docID, DocUnmarshalAll)
 		require.NoError(t, err)
 
 		// Migrate document metadata from document body to system xattr.

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1272,7 +1272,7 @@ func TestGet1xRevAndChannels(t *testing.T) {
 	assert.Equal(t, []interface{}{"a"}, revisions[RevisionsIds])
 
 	// Delete the document, creating tombstone revision rev3
-	rev3, err := collection.DeleteDoc(ctx, docId, rev2)
+	rev3, _, err := collection.DeleteDoc(ctx, docId, rev2)
 	require.NoError(t, err)
 	bodyBytes, removed, err = collection.get1xRevFromDoc(ctx, doc2, rev3, true)
 	assert.False(t, removed)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1679,4 +1680,195 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 	expectedReleasedSequenceCount := otherClusterSequenceOffset
 	releasedSequenceCount := db.DbStats.Database().SequenceReleasedCount.Value() - startReleasedSequenceCount
 	assert.Equal(t, int64(expectedReleasedSequenceCount), releasedSequenceCount)
+}
+
+// TestPutExistingCurrentVersion:
+//   - Put a document in a db
+//   - Assert on the update to HLV after that PUT
+//   - Construct a HLV to represent the doc created locally being updated on a client
+//   - Call PutExistingCurrentVersion simulating doc update arriving over replicator
+//   - Assert that the doc's HLV in the bucket has been updated correctly with the CV, PV and cvCAS
+func TestPutExistingCurrentVersion(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	bucketUUID := db.BucketUUID
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	// create a new doc
+	key := "doc1"
+	body := Body{"key1": "value1"}
+
+	rev, _, err := collection.Put(ctx, key, body)
+	require.NoError(t, err)
+
+	// assert on HLV on that above PUT
+	syncData, err := collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// store the cas version allocated to the above doc creation for creation of incoming HLV later in test
+	originalDocVersion := syncData.HLV.Version
+
+	// PUT an update to the above doc
+	body = Body{"key1": "value11"}
+	body[BodyRev] = rev
+	_, _, err = collection.Put(ctx, key, body)
+	require.NoError(t, err)
+
+	// grab the new version for the above update to assert against later in test
+	syncData, err = collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	docUpdateVersion := syncData.HLV.Version
+
+	// construct a mock doc update coming over a replicator
+	body = Body{"key1": "value2"}
+	newDoc := createTestDocument(key, "", body, false, 0)
+
+	// construct a HLV that simulates a doc update happening on a client
+	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV
+	pv := make(map[string]uint64)
+	pv[bucketUUID] = originalDocVersion
+	// create a version larger than the allocated version above
+	incomingVersion := docUpdateVersion + 10
+	incomingHLV := HybridLogicalVector{
+		SourceID:         "test",
+		Version:          incomingVersion,
+		PreviousVersions: pv,
+	}
+
+	// grab the raw doc from the bucket to pass into the PutExistingCurrentVersion function for the above simulation of
+	// doc update arriving over replicator
+	_, rawDoc, err := collection.GetDocumentWithRaw(ctx, key, DocUnmarshalSync)
+	require.NoError(t, err)
+
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, rawDoc)
+	require.NoError(t, err)
+	// assert on returned CV
+	assert.Equal(t, "test", cv.SourceID)
+	assert.Equal(t, incomingVersion, cv.Version)
+	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
+
+	// assert on the sync data from the above update to the doc
+	// CV should be equal to CV of update on client but the cvCAS should be updated with the new update and
+	// PV should contain the old CV pair
+	syncData, err = collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, "test", syncData.HLV.SourceID)
+	assert.Equal(t, incomingVersion, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	// update the pv map so we can assert we have correct pv map in HLV
+	pv[bucketUUID] = docUpdateVersion
+	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
+	assert.Equal(t, "3-60b024c44c283b369116c2c2570e8088", syncData.CurrentRev)
+}
+
+// TestPutExistingCurrentVersionWithConflict:
+//   - Put a document in a db
+//   - Assert on the update to HLV after that PUT
+//   - Construct a HLV to represent the doc created locally being updated on a client
+//   - Call PutExistingCurrentVersion simulating doc update arriving over replicator
+//   - Assert conflict between the local HLV for the doc and the incoming mutation is correctly identified
+//   - Assert that the doc's HLV in the bucket hasn't been updated
+func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	bucketUUID := db.BucketUUID
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	// create a new doc
+	key := "doc1"
+	body := Body{"key1": "value1"}
+
+	_, _, err := collection.Put(ctx, key, body)
+	require.NoError(t, err)
+
+	// assert on the HLV values after the above creation of the doc
+	syncData, err := collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// create a new doc update to simulate a doc update arriving over replicator from, client
+	body = Body{"key1": "value2"}
+	newDoc := createTestDocument(key, "", body, false, 0)
+	incomingHLV := HybridLogicalVector{
+		SourceID: "test",
+		Version:  1234,
+	}
+
+	// grab the raw doc from the bucket to pass into the PutExistingCurrentVersion function
+	_, rawDoc, err := collection.GetDocumentWithRaw(ctx, key, DocUnmarshalSync)
+	require.NoError(t, err)
+
+	// assert that a conflict is correctly identified and the resulting doc and cv are nil
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, rawDoc)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Document revision conflict")
+	assert.Nil(t, cv)
+	assert.Nil(t, doc)
+
+	// assert persisted doc hlv hasn't been updated
+	syncData, err = collection.GetDocSyncData(ctx, "doc1")
+	assert.NoError(t, err)
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}
+
+// TestPutExistingCurrentVersionWithNoExistingDoc:
+//   - Purpose of this test is to test PutExistingRevWithBody code pathway where an
+//     existing doc is not provided from the bucket into the function simulating a new, not seen
+//     before doc entering this code path
+func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	bucketUUID := db.BucketUUID
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	// construct a mock doc update coming over a replicator
+	body := Body{"key1": "value2"}
+	newDoc := createTestDocument("doc2", "", body, false, 0)
+
+	// construct a HLV that simulates a doc update happening on a client
+	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV
+	pv := make(map[string]uint64)
+	pv[bucketUUID] = 2
+	// create a version larger than the allocated version above
+	incomingVersion := uint64(2 + 10)
+	incomingHLV := HybridLogicalVector{
+		SourceID:         "test",
+		Version:          incomingVersion,
+		PreviousVersions: pv,
+	}
+	// call PutExistingCurrentVersion with empty existing doc
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{})
+	require.NoError(t, err)
+	assert.NotNil(t, doc)
+	// assert on returned CV value
+	assert.Equal(t, "test", cv.SourceID)
+	assert.Equal(t, incomingVersion, cv.Version)
+	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
+
+	// assert on the sync data from the above update to the doc
+	// CV should be equal to CV of update on client but the cvCAS should be updated with the new update and
+	// PV should contain the old CV pair
+	syncData, err := collection.GetDocSyncData(ctx, "doc2")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+	assert.Equal(t, "test", syncData.HLV.SourceID)
+	assert.Equal(t, incomingVersion, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	// update the pv map so we can assert we have correct pv map in HLV
+	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
+	assert.Equal(t, "1-3a208ea66e84121b528f05b5457d1134", syncData.CurrentRev)
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1693,7 +1693,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	bucketUUID := db.BucketUUID
+	bucketUUID := db.EncodedBucketUUID
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// create a new doc
@@ -1706,10 +1706,9 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	// assert on HLV on that above PUT
 	syncData, err := collection.GetDocSyncData(ctx, "doc1")
 	assert.NoError(t, err)
-	uintCAS := base.HexCasToUint64(syncData.Cas)
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 
 	// store the cas version allocated to the above doc creation for creation of incoming HLV later in test
 	originalDocVersion := syncData.HLV.Version
@@ -1724,6 +1723,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	syncData, err = collection.GetDocSyncData(ctx, "doc1")
 	assert.NoError(t, err)
 	docUpdateVersion := syncData.HLV.Version
+	docUpdateVersionInt := base.HexCasToUint64(docUpdateVersion)
 
 	// construct a mock doc update coming over a replicator
 	body = Body{"key1": "value2"}
@@ -1731,10 +1731,10 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 
 	// construct a HLV that simulates a doc update happening on a client
 	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV
-	pv := make(map[string]uint64)
+	pv := make(map[string]string)
 	pv[bucketUUID] = originalDocVersion
 	// create a version larger than the allocated version above
-	incomingVersion := docUpdateVersion + 10
+	incomingVersion := string(base.Uint64CASToLittleEndianHex(docUpdateVersionInt + 10))
 	incomingHLV := HybridLogicalVector{
 		SourceID:         "test",
 		Version:          incomingVersion,
@@ -1758,11 +1758,10 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	// PV should contain the old CV pair
 	syncData, err = collection.GetDocSyncData(ctx, "doc1")
 	assert.NoError(t, err)
-	uintCAS = base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, "test", syncData.HLV.SourceID)
 	assert.Equal(t, incomingVersion, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 	// update the pv map so we can assert we have correct pv map in HLV
 	pv[bucketUUID] = docUpdateVersion
 	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
@@ -1780,7 +1779,7 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	bucketUUID := db.BucketUUID
+	bucketUUID := db.EncodedBucketUUID
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	// create a new doc
@@ -1793,17 +1792,16 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	// assert on the HLV values after the above creation of the doc
 	syncData, err := collection.GetDocSyncData(ctx, "doc1")
 	assert.NoError(t, err)
-	uintCAS := base.HexCasToUint64(syncData.Cas)
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 
 	// create a new doc update to simulate a doc update arriving over replicator from, client
 	body = Body{"key1": "value2"}
 	newDoc := createTestDocument(key, "", body, false, 0)
 	incomingHLV := HybridLogicalVector{
 		SourceID: "test",
-		Version:  1234,
+		Version:  string(base.Uint64CASToLittleEndianHex(1234)),
 	}
 
 	// grab the raw doc from the bucket to pass into the PutExistingCurrentVersion function
@@ -1821,8 +1819,8 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	syncData, err = collection.GetDocSyncData(ctx, "doc1")
 	assert.NoError(t, err)
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 }
 
 // TestPutExistingCurrentVersionWithNoExistingDoc:
@@ -1842,10 +1840,10 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 
 	// construct a HLV that simulates a doc update happening on a client
 	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV
-	pv := make(map[string]uint64)
-	pv[bucketUUID] = 2
+	pv := make(map[string]string)
+	pv[bucketUUID] = string(base.Uint64CASToLittleEndianHex(uint64(2)))
 	// create a version larger than the allocated version above
-	incomingVersion := uint64(2 + 10)
+	incomingVersion := string(base.Uint64CASToLittleEndianHex(uint64(2 + 10)))
 	incomingHLV := HybridLogicalVector{
 		SourceID:         "test",
 		Version:          incomingVersion,
@@ -1865,10 +1863,9 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	// PV should contain the old CV pair
 	syncData, err := collection.GetDocSyncData(ctx, "doc2")
 	assert.NoError(t, err)
-	uintCAS := base.HexCasToUint64(syncData.Cas)
 	assert.Equal(t, "test", syncData.HLV.SourceID)
 	assert.Equal(t, incomingVersion, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 	// update the pv map so we can assert we have correct pv map in HLV
 	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
 	assert.Equal(t, "1-3a208ea66e84121b528f05b5457d1134", syncData.CurrentRev)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1199,6 +1199,7 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	t.Skip("pending backwards compatability on backed up revs between revid and cv")
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -20,6 +20,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1871,4 +1872,182 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	// update the pv map so we can assert we have correct pv map in HLV
 	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
 	assert.Equal(t, "1-3a208ea66e84121b528f05b5457d1134", syncData.CurrentRev)
+}
+
+// TestGetCVWithDocResidentInCache:
+//   - Two test cases, one with doc a user will have access to, one without
+//   - Purpose is to have a doc that is resident in rev cache and use the GetCV function to retrieve these docs
+//   - Assert that the doc the user has access to is corrected fetched
+//   - Assert the doc the user doesn't have access to is fetched but correctly redacted
+func TestGetCVWithDocResidentInCache(t *testing.T) {
+	const docID = "doc1"
+
+	testCases := []struct {
+		name        string
+		docChannels []string
+		access      bool
+	}{
+		{
+			name:        "getCVWithUserAccess",
+			docChannels: []string{"A"},
+			access:      true,
+		},
+		{
+			name:        "getCVWithoutUserAccess",
+			docChannels: []string{"B"},
+			access:      false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db, ctx := setupTestDB(t)
+			defer db.Close(ctx)
+			collection := GetSingleDatabaseCollectionWithUser(t, db)
+			collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+			// Create a user with access to channel A
+			authenticator := db.Authenticator(base.TestCtx(t))
+			user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+			require.NoError(t, err)
+			require.NoError(t, authenticator.Save(user))
+			collection.user, err = authenticator.GetUser("alice")
+			require.NoError(t, err)
+
+			// create doc with the channels for the test case
+			docBody := Body{"channels": testCase.docChannels}
+			rev, doc, err := collection.Put(ctx, docID, docBody)
+			require.NoError(t, err)
+
+			vrs := doc.HLV.Version
+			src := doc.HLV.SourceID
+			sv := &Version{Value: vrs, SourceID: src}
+			revision, err := collection.GetCV(ctx, docID, sv, true)
+			require.NoError(t, err)
+			if testCase.access {
+				assert.Equal(t, rev, revision.RevID)
+				assert.Equal(t, sv, revision.CV)
+				assert.Equal(t, docID, revision.DocID)
+				assert.Equal(t, []byte(`{"channels":["A"]}`), revision.BodyBytes)
+			} else {
+				assert.Equal(t, rev, revision.RevID)
+				assert.Equal(t, sv, revision.CV)
+				assert.Equal(t, docID, revision.DocID)
+				assert.Equal(t, []byte(RemovedRedactedDocument), revision.BodyBytes)
+			}
+		})
+	}
+}
+
+// TestGetByCVForDocNotResidentInCache:
+//   - Setup db with rev cache size of 1
+//   - Put two docs forcing eviction of the first doc
+//   - Use GetCV function to fetch the first doc, forcing the rev cache to load the doc from bucket
+//   - Assert the doc revision fetched is correct to the first doc we created
+func TestGetByCVForDocNotResidentInCache(t *testing.T) {
+	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			Size: 1,
+		},
+	})
+	defer db.Close(ctx)
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+	// Create a user with access to channel A
+	authenticator := db.Authenticator(base.TestCtx(t))
+	user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+	require.NoError(t, err)
+	require.NoError(t, authenticator.Save(user))
+	collection.user, err = authenticator.GetUser("alice")
+	require.NoError(t, err)
+
+	const (
+		doc1ID = "doc1"
+		doc2ID = "doc2"
+	)
+
+	revBody := Body{"channels": []string{"A"}}
+	rev, doc, err := collection.Put(ctx, doc1ID, revBody)
+	require.NoError(t, err)
+
+	// put another doc that should evict first doc from cache
+	_, _, err = collection.Put(ctx, doc2ID, revBody)
+	require.NoError(t, err)
+
+	// get by CV should force a load from bucket and have a cache miss
+	vrs := doc.HLV.Version
+	src := doc.HLV.SourceID
+	sv := &Version{Value: vrs, SourceID: src}
+	revision, err := collection.GetCV(ctx, doc1ID, sv, true)
+	require.NoError(t, err)
+
+	// assert the fetched doc is the first doc we added and assert that we did in fact get cache miss
+	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
+	assert.Equal(t, rev, revision.RevID)
+	assert.Equal(t, sv, revision.CV)
+	assert.Equal(t, doc1ID, revision.DocID)
+	assert.Equal(t, []byte(`{"channels":["A"]}`), revision.BodyBytes)
+}
+
+// TestGetCVActivePathway:
+//   - Two test cases, one with doc a user will have access to, one without
+//   - Purpose is top specify nil CV to the GetCV function to force the GetActive code pathway
+//   - Assert doc that is created is fetched correctly when user has access to doc
+//   - Assert that correct error is returned when user has no access to the doc
+func TestGetCVActivePathway(t *testing.T) {
+	const docID = "doc1"
+
+	testCases := []struct {
+		name        string
+		docChannels []string
+		access      bool
+	}{
+		{
+			name:        "activeFetchWithUserAccess",
+			docChannels: []string{"A"},
+			access:      true,
+		},
+		{
+			name:        "activeFetchWithoutUserAccess",
+			docChannels: []string{"B"},
+			access:      false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			db, ctx := setupTestDB(t)
+			defer db.Close(ctx)
+			collection := GetSingleDatabaseCollectionWithUser(t, db)
+			collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
+
+			// Create a user with access to channel A
+			authenticator := db.Authenticator(base.TestCtx(t))
+			user, err := authenticator.NewUser("alice", "letmein", channels.BaseSetOf(t, "A"))
+			require.NoError(t, err)
+			require.NoError(t, authenticator.Save(user))
+			collection.user, err = authenticator.GetUser("alice")
+			require.NoError(t, err)
+
+			// test get active path by specifying nil cv
+			revBody := Body{"channels": testCase.docChannels}
+			rev, doc, err := collection.Put(ctx, docID, revBody)
+			require.NoError(t, err)
+			revision, err := collection.GetCV(ctx, docID, nil, true)
+
+			if testCase.access == true {
+				require.NoError(t, err)
+				vrs := doc.HLV.Version
+				src := doc.HLV.SourceID
+				sv := &Version{Value: vrs, SourceID: src}
+				assert.Equal(t, rev, revision.RevID)
+				assert.Equal(t, sv, revision.CV)
+				assert.Equal(t, docID, revision.DocID)
+				assert.Equal(t, []byte(`{"channels":["A"]}`), revision.BodyBytes)
+			} else {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, ErrForbidden.Error())
+				assert.Equal(t, DocumentRevision{}, revision)
+			}
+		})
+	}
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -78,7 +78,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Flush the cache
@@ -119,7 +119,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -130,7 +130,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	rev2a_body := unmarshalBody(t, `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -156,7 +156,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	rev2b_body := unmarshalBody(t, `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -254,7 +254,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a with legacy attachment.
@@ -283,7 +283,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -318,7 +318,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -329,7 +329,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -348,7 +348,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -391,7 +391,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
 	rev3b_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 	rev3b_body[BodyId] = doc.ID
 	rev3b_body[BodyRev] = newRev
 	rev3b_body[BodyDeleted] = true
@@ -428,7 +428,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2c_body := Body{}
 	rev2c_body["key1"] = prop_1000_bytes
 	rev2c_body["version"] = "2c"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"2-c", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"2-c", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2c_body[BodyId] = doc.ID
 	rev2c_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-c")
@@ -450,7 +450,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3c_body["version"] = "3c"
 	rev3c_body["key1"] = prop_1000_bytes
 	rev3c_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-c"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-c"}, false, ExistingVersionWithUpdateToHLV)
 	rev3c_body[BodyId] = doc.ID
 	rev3c_body[BodyRev] = newRev
 	rev3c_body[BodyDeleted] = true
@@ -479,7 +479,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3a_body := Body{}
 	rev3a_body["key1"] = prop_1000_bytes
 	rev3a_body["version"] = "3a"
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"3-a", "2-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2c_body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a")
 
 	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
@@ -502,7 +502,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -513,7 +513,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -532,7 +532,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -577,7 +577,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev3b_body["version"] = "3b"
 	rev3b_body["key1"] = prop_1000_bytes
 	rev3b_body[BodyDeleted] = true
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 	rev3b_body[BodyId] = doc.ID
 	rev3b_body[BodyRev] = newRev
 	rev3b_body[BodyDeleted] = true
@@ -612,17 +612,17 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	activeRevBody := Body{}
 	activeRevBody["version"] = "...a"
 	activeRevBody["key1"] = prop_1000_bytes
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"3-a", "2-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"4-a", "3-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 4-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"5-a", "4-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"5-a", "4-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 5-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"6-a", "5-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"6-a", "5-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 6-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"7-a", "6-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"7-a", "6-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 7-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"8-a", "7-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"8-a", "7-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 8-a")
 
 	// Verify that 3-b is still present at this point
@@ -631,7 +631,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	assert.NoError(t, err, "Rev 3-b should still exist")
 
 	// Add one more rev that triggers pruning since gen(9-3) > revsLimit
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"9-a", "8-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", activeRevBody, []string{"9-a", "8-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 9-a")
 
 	// Verify that 3-b has been pruned
@@ -660,7 +660,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a", "large": prop_1000_bytes}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -669,7 +669,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "version": "2a", "large": prop_1000_bytes}
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
@@ -689,7 +689,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "version": "3a", "large": prop_1000_bytes}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-a")
 	rev3a_body[BodyId] = doc.ID
 	rev3a_body[BodyRev] = newRev
@@ -708,7 +708,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "version": "2b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
@@ -731,7 +731,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "version": "6a", "large": prop_1000_bytes}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 6-a")
 	rev6a_body[BodyId] = doc.ID
 	rev6a_body[BodyRev] = newRev
@@ -756,7 +756,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "version": "3b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-b")
 
 	// Same again and again
@@ -775,12 +775,12 @@ func TestOldRevisionStorage(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "version": "3c", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-c")
 
 	log.Printf("Create rev 3-d")
 	rev3d_body := Body{"key1": "value2", "version": "3d", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 3-d")
 
 	// Create new winning revision on 'b' branch.  Triggers movement of 6-a to inline storage.  Force cas retry, check document contents
@@ -799,7 +799,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	//     7-b
 	log.Printf("Create rev 7-b")
 	rev7b_body := Body{"key1": "value2", "version": "7b", "large": prop_1000_bytes}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err, "add 7-b")
 
 }
@@ -820,7 +820,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "v": "1a"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
@@ -829,7 +829,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "v": "2a"}
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2a_body[BodyId] = doc.ID
 	rev2a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-a")
@@ -848,7 +848,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "v": "3a"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev3a_body[BodyId] = doc.ID
 	rev3a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 3-a")
@@ -861,7 +861,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "v": "2b"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev2b_body[BodyId] = doc.ID
 	rev2b_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 2-b")
@@ -886,7 +886,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "v": "6a"}
-	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	rev6a_body[BodyId] = doc.ID
 	rev6a_body[BodyRev] = newRev
 	assert.NoError(t, err, "add 6-a")
@@ -912,7 +912,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "v": "3b"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-b")
 
 	// Same again
@@ -932,7 +932,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-c")
 
 }
@@ -949,7 +949,7 @@ func TestLargeSequence(t *testing.T) {
 
 	// Write a doc via SG
 	body := Body{"key1": "largeSeqTest"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "largeSeqDoc", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "largeSeqDoc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add largeSeqDoc")
 
 	syncData, err := collection.GetDocSyncData(ctx, "largeSeqDoc")
@@ -1024,7 +1024,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	// 6-a
 	log.Printf("Attempt to create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-c")
 }
 
@@ -1036,16 +1036,16 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
 	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1064,9 +1064,9 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1093,16 +1093,16 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", longBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
 	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1121,9 +1121,9 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false)
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc2", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc3", updateBody, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -1151,7 +1151,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	collection := GetSingleDatabaseCollectionWithUser(b, db)
 
 	body := Body{"foo": "bar"}
-	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, _ = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 
 	getDelta := func(newDoc *Document) {
 		deltaSrcRev, _ := collection.GetRev(ctx, "doc1", "1-a", false, nil)
@@ -1200,18 +1200,18 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	_, rev, err := collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"1-a"}, false)
+	_, rev, err := collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	ancestor := rev // Ancestor revision
 
 	// Create the second revision of the document with attachment reference;
 	payload = `{"sku":"6213101","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	_, rev, err = collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"2-a", "1-a"}, false)
+	_, rev, err = collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	parent := rev // Immediate ancestor or parent revision
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213102","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	doc, _, err := collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"3-a", "2-a"}, false)
+	doc, _, err := collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get available attachments by immediate ancestor revision or parent revision
@@ -1238,11 +1238,11 @@ func TestGet1xRevAndChannels(t *testing.T) {
 
 	docId := "dd6d2dcc679d12b9430a9787bab45b33"
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc1, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"1-a"}, false)
+	doc1, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213101","_attachments":{"lens.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc2, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"2-a", "1-a"}, false)
+	doc2, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get the 1x revision from document with list revision enabled
@@ -1301,7 +1301,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	// Create the first revision of the document
 	docId := "356779a9a1696714480f57fa3fb66d4c"
 	payload := `{"city":"Los Angeles"}`
-	doc, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"1-a"}, false)
+	doc, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "1-a", rev1, "Provided input revision ID should be returned")
@@ -1324,7 +1324,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 
 	// Create the second revision of the document
 	payload = `{"city":"Hollywood"}`
-	doc, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"2-a", "1-a"}, false)
+	doc, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "2-a", rev2, "Provided input revision ID should be returned")

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1749,7 +1749,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	require.NoError(t, err)
 	// assert on returned CV
 	assert.Equal(t, "test", cv.SourceID)
-	assert.Equal(t, incomingVersion, cv.Version)
+	assert.Equal(t, incomingVersion, cv.Value)
 	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
 
 	// assert on the sync data from the above update to the doc
@@ -1856,7 +1856,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	assert.NotNil(t, doc)
 	// assert on returned CV value
 	assert.Equal(t, "test", cv.SourceID)
-	assert.Equal(t, incomingVersion, cv.Version)
+	assert.Equal(t, incomingVersion, cv.Value)
 	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
 
 	// assert on the sync data from the above update to the doc

--- a/db/database.go
+++ b/db/database.go
@@ -959,7 +959,7 @@ func (c *DatabaseCollection) processForEachDocIDResults(ctx context.Context, cal
 			found = results.Next(ctx, &viewRow)
 			if found {
 				docid = viewRow.Key
-				revid = viewRow.Value.RevID
+				revid = viewRow.Value.RevID.RevTreeID
 				seq = viewRow.Value.Sequence
 				channels = viewRow.Value.Channels
 			}
@@ -967,7 +967,7 @@ func (c *DatabaseCollection) processForEachDocIDResults(ctx context.Context, cal
 			found = results.Next(ctx, &queryRow)
 			if found {
 				docid = queryRow.Id
-				revid = queryRow.RevID
+				revid = queryRow.RevID.RevTreeID
 				seq = queryRow.Sequence
 				channels = make([]string, 0)
 				// Query returns all channels, but we only want to return active channels

--- a/db/database.go
+++ b/db/database.go
@@ -49,6 +49,14 @@ const (
 )
 
 const (
+	Import DocUpdateType = iota
+	NewVersion
+	ExistingVersion
+)
+
+type DocUpdateType uint32
+
+const (
 	DefaultRevsLimitNoConflicts = 50
 	DefaultRevsLimitConflicts   = 100
 
@@ -88,6 +96,7 @@ type DatabaseContext struct {
 	MetadataStore               base.DataStore     // Storage for database metadata (anything that isn't an end-user's/customer's documents)
 	Bucket                      base.Bucket        // Storage
 	BucketSpec                  base.BucketSpec    // The BucketSpec
+	BucketUUID                  string             // The bucket UUID for the bucket the database is created against
 	BucketLock                  sync.RWMutex       // Control Access to the underlying bucket object
 	mutationListener            changeListener     // Caching feed listener
 	ImportListener              *importListener    // Import feed listener
@@ -397,6 +406,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		metadataStore = bucket.DefaultDataStore()
 	}
 
+	bucketUUID, err := bucket.UUID()
+	if err != nil {
+		return nil, err
+	}
+
 	// Register the cbgt pindex type for the configGroup
 	RegisterImportPindexImpl(ctx, options.GroupID)
 
@@ -405,6 +419,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		UUID:                cbgt.NewUUID(),
 		MetadataStore:       metadataStore,
 		Bucket:              bucket,
+		BucketUUID:          bucketUUID,
 		StartTime:           time.Now(),
 		autoImport:          autoImport,
 		Options:             options,

--- a/db/database.go
+++ b/db/database.go
@@ -1792,7 +1792,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 			if currentValue == nil || len(currentValue) == 0 {
 				return sgbucket.UpdatedDoc{}, base.ErrUpdateCancel
 			}
-			doc, err := unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattrs[base.SyncXattrName], currentXattrs[db.userXattrKey()], cas, DocUnmarshalAll)
+			doc, err := db.unmarshalDocumentWithXattrs(ctx, docid, currentValue, currentXattrs, cas, DocUnmarshalAll)
 			if err != nil {
 				return sgbucket.UpdatedDoc{}, err
 			}
@@ -1808,11 +1808,12 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 				updatedDoc.UpdateExpiry(*updatedExpiry)
 			}
 			doc.SetCrc32cUserXattrHash()
-			_, rawXattr, err := updatedDoc.MarshalWithXattr()
+			_, rawSyncXattr, rawVvXattr, err := updatedDoc.MarshalWithXattrs()
 			return sgbucket.UpdatedDoc{
 				Doc: nil, // Resync does not require document body update
 				Xattrs: map[string][]byte{
-					base.SyncXattrName: rawXattr,
+					base.SyncXattrName: rawSyncXattr,
+					base.VvXattrName:   rawVvXattr,
 				},
 				Expiry: updatedExpiry,
 			}, err

--- a/db/database.go
+++ b/db/database.go
@@ -1760,7 +1760,7 @@ func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, d
 				forceUpdate = true
 			}
 
-			changedChannels, err := doc.updateChannels(ctx, channels)
+			changedChannels, _, err := doc.updateChannels(ctx, channels)
 			changed = len(doc.Access.updateAccess(ctx, doc, access)) +
 				len(doc.RoleAccess.updateAccess(ctx, doc, roles)) +
 				len(changedChannels)

--- a/db/database.go
+++ b/db/database.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -98,6 +99,7 @@ type DatabaseContext struct {
 	Bucket                      base.Bucket        // Storage
 	BucketSpec                  base.BucketSpec    // The BucketSpec
 	BucketUUID                  string             // The bucket UUID for the bucket the database is created against
+	EncodedBucketUUID           string             // The bucket UUID for the bucket the database is created against but encoded in base64
 	BucketLock                  sync.RWMutex       // Control Access to the underlying bucket object
 	mutationListener            changeListener     // Caching feed listener
 	ImportListener              *importListener    // Import feed listener
@@ -421,6 +423,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		MetadataStore:       metadataStore,
 		Bucket:              bucket,
 		BucketUUID:          bucketUUID,
+		EncodedBucketUUID:   base64.StdEncoding.EncodeToString([]byte(bucketUUID)),
 		StartTime:           time.Now(),
 		autoImport:          autoImport,
 		Options:             options,

--- a/db/database.go
+++ b/db/database.go
@@ -52,6 +52,7 @@ const (
 	Import DocUpdateType = iota
 	NewVersion
 	ExistingVersion
+	ExistingVersionWithUpdateToHLV
 )
 
 type DocUpdateType uint32

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -253,7 +253,7 @@ func (c *DatabaseCollection) unsupportedOptions() *UnsupportedOptions {
 
 // syncAndUserXattrKeys returns the xattr keys for the user and sync xattrs.
 func (c *DatabaseCollection) syncAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName}
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -294,7 +294,7 @@ func TestDatabase(t *testing.T) {
 	body["key2"] = int64(4444)
 	history := []string{"4-four", "3-three", "2-488724414d0ed6b398d6d2aeb228d797",
 		"1-cb0c9a22be0e5a1b01084ec019defa81"}
-	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", body, history, false)
+	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", body, history, false, ExistingVersionWithUpdateToHLV)
 	body[BodyId] = doc.ID
 	body[BodyRev] = newRev
 	assert.NoError(t, err, "PutExistingRev failed")
@@ -1020,18 +1020,18 @@ func TestRepeatedConflict(t *testing.T) {
 
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create two conflicting changes:
 	body["n"] = 2
 	body["channels"] = []string{"all", "2b"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-b")
 
 	body["n"] = 3
 	body["channels"] = []string{"all", "2a"}
-	_, newRev, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false)
+	_, newRev, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
 
 	// Get the _rev that was set in the body by PutExistingRevWithBody() and make assertions on it
@@ -1040,7 +1040,7 @@ func TestRepeatedConflict(t *testing.T) {
 
 	// Remove the _rev key from the body, and call PutExistingRevWithBody() again, which should re-add it
 	delete(body, BodyRev)
-	_, newRev, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false)
+	_, newRev, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err)
 
 	// The _rev should pass the same assertions as before, since PutExistingRevWithBody() should re-add it
@@ -1068,7 +1068,7 @@ func TestConflicts(t *testing.T) {
 
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Wait for rev to be cached
@@ -1081,11 +1081,11 @@ func TestConflicts(t *testing.T) {
 	// Create two conflicting changes:
 	body["n"] = 2
 	body["channels"] = []string{"all", "2b"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-b")
 	body["n"] = 3
 	body["channels"] = []string{"all", "2a"}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
 
 	cacheWaiter.Add(2)
@@ -1213,55 +1213,55 @@ func TestNoConflictsMode(t *testing.T) {
 
 	// Create revs 1 and 2 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 	body["n"] = 2
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
 
 	// Try to create a conflict branching from rev 1:
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assertHTTPError(t, err, 409)
 
 	// Try to create a conflict with no common ancestor:
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-c", "1-c"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-c", "1-c"}, false, ExistingVersionWithUpdateToHLV)
 	assertHTTPError(t, err, 409)
 
 	// Try to create a conflict with a longer history:
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-d", "3-d", "2-d", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-d", "3-d", "2-d", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assertHTTPError(t, err, 409)
 
 	// Try to create a conflict with no history:
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-e"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-e"}, false, ExistingVersionWithUpdateToHLV)
 	assertHTTPError(t, err, 409)
 
 	// Create a non-conflict with a longer history, ending in a deletion:
 	body[BodyDeleted] = true
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-a", "3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 4-a")
 	delete(body, BodyDeleted)
 
 	// Try to resurrect the document with a conflicting branch
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-f", "3-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"4-f", "3-a"}, false, ExistingVersionWithUpdateToHLV)
 	assertHTTPError(t, err, 409)
 
 	// Resurrect the tombstoned document with a disconnected branch):
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-f"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"1-f"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-f")
 
 	// Tombstone the resurrected branch
 	body[BodyDeleted] = true
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-f", "1-f"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"2-f", "1-f"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-f")
 	delete(body, BodyDeleted)
 
 	// Resurrect the tombstoned document with a valid history (descendents of leaf)
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"5-f", "4-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc", body, []string{"5-f", "4-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 5-f")
 	delete(body, BodyDeleted)
 
 	// Create a new document with a longer history:
-	_, _, err = collection.PutExistingRevWithBody(ctx, "COD", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "COD", body, []string{"4-a", "3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add COD")
 	delete(body, BodyDeleted)
 
@@ -1289,34 +1289,34 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	// Create documents with multiple non-deleted branches
 	log.Printf("Creating docs")
 	body := Body{"n": 1}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create two conflicting changes:
 	body["n"] = 2
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-b")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-b")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-b")
 	body["n"] = 3
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
 
 	// Set AllowConflicts to false
 	db.Options.AllowConflicts = base.BoolPtr(false)
 
 	// Attempt to tombstone a non-leaf node of a conflicted document
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-c", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-c", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.True(t, err != nil, "expected error tombstoning non-leaf")
 
 	// Tombstone the non-winning branch of a conflicted document
@@ -1366,27 +1366,27 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 	// Create documents with multiple non-deleted branches
 	log.Printf("Creating docs")
 	body := Body{"n": 1}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 1-a")
 
 	// Create two conflicting changes:
 	body["n"] = 2
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-b")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-b")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-b")
 	body["n"] = 3
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 2-a")
 
 	// Set AllowConflicts to false
@@ -1395,12 +1395,12 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 
 	// Attempt to tombstone a non-leaf node of a conflicted document
 	body[BodyDeleted] = true
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-c", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-c", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.True(t, err != nil, "expected error tombstoning non-leaf")
 
 	// Tombstone the non-winning branch of a conflicted document
 	body[BodyDeleted] = true
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-a", "2-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a (tombstone)")
 	doc, err := collection.GetDocument(ctx, "doc1", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
@@ -1408,7 +1408,7 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 
 	// Tombstone the winning branch of a conflicted document
 	body[BodyDeleted] = true
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"3-b", "2-b"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc2", body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-b (tombstone)")
 	doc, err = collection.GetDocument(ctx, "doc2", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
@@ -1417,7 +1417,7 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 	// Set revs_limit=1, then tombstone non-winning branch of a conflicted document.  Validate retrieval still works.
 	body[BodyDeleted] = true
 	db.RevsLimit = uint32(1)
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"3-a", "2-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc3", body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "add 3-a (tombstone)")
 	doc, err = collection.GetDocument(ctx, "doc3", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
@@ -1453,7 +1453,7 @@ func TestSyncFnOnPush(t *testing.T) {
 	body["channels"] = "clibup"
 	history := []string{"4-four", "3-three", "2-488724414d0ed6b398d6d2aeb228d797",
 		rev1id}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, history, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, history, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "PutExistingRev failed")
 
 	// Check that the doc has the correct channel (test for issue #300)
@@ -2145,7 +2145,7 @@ func TestConcurrentPushSameNewNonWinningRevision(t *testing.T) {
 			enableCallback = false
 			body := Body{"name": "Emily", "age": 20}
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b", "2-b", "1-a"}, false)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 			assert.NoError(t, err, "Adding revision 3-b")
 		}
 	}
@@ -2160,29 +2160,29 @@ func TestConcurrentPushSameNewNonWinningRevision(t *testing.T) {
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	body := Body{"name": "Olivia", "age": 80}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 1-a")
 
 	body = Body{"name": "Harry", "age": 40}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 2-a")
 
 	body = Body{"name": "Amelia", "age": 20}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-a", "2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 3-a")
 
 	body = Body{"name": "Charlie", "age": 10}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 4-a")
 
 	body = Body{"name": "Noah", "age": 40}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 2-b")
 
 	enableCallback = true
 
 	body = Body{"name": "Emily", "age": 20}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 3-b")
 
 	doc, err := collection.GetDocument(ctx, "doc1", DocUnmarshalAll)
@@ -2203,7 +2203,7 @@ func TestConcurrentPushSameTombstoneWinningRevision(t *testing.T) {
 			enableCallback = false
 			body := Body{"name": "Charlie", "age": 10, BodyDeleted: true}
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 			assert.NoError(t, err, "Couldn't add revision 4-a (tombstone)")
 		}
 	}
@@ -2218,19 +2218,19 @@ func TestConcurrentPushSameTombstoneWinningRevision(t *testing.T) {
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	body := Body{"name": "Olivia", "age": 80}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 1-a")
 
 	body = Body{"name": "Harry", "age": 40}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 2-a")
 
 	body = Body{"name": "Amelia", "age": 20}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-a", "2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 3-a")
 
 	body = Body{"name": "Noah", "age": 40}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 2-b")
 
 	doc, err := collection.GetDocument(ctx, "doc1", DocUnmarshalAll)
@@ -2240,7 +2240,7 @@ func TestConcurrentPushSameTombstoneWinningRevision(t *testing.T) {
 	enableCallback = true
 
 	body = Body{"name": "Charlie", "age": 10, BodyDeleted: true}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't add revision 4-a (tombstone)")
 
 	doc, err = collection.GetDocument(ctx, "doc1", DocUnmarshalAll)
@@ -2261,7 +2261,7 @@ func TestConcurrentPushDifferentUpdateNonWinningRevision(t *testing.T) {
 			enableCallback = false
 			body := Body{"name": "Joshua", "age": 11}
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b1", "2-b", "1-a"}, false)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b1", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 			assert.NoError(t, err, "Couldn't add revision 3-b1")
 		}
 	}
@@ -2276,29 +2276,29 @@ func TestConcurrentPushDifferentUpdateNonWinningRevision(t *testing.T) {
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
 	body := Body{"name": "Olivia", "age": 80}
-	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false)
+	_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 1-a")
 
 	body = Body{"name": "Harry", "age": 40}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 2-a")
 
 	body = Body{"name": "Amelia", "age": 20}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-a", "2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 3-a")
 
 	body = Body{"name": "Charlie", "age": 10}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 4-a")
 
 	body = Body{"name": "Noah", "age": 40}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Adding revision 2-b")
 
 	enableCallback = true
 
 	body = Body{"name": "Liam", "age": 12}
-	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b2", "2-b", "1-a"}, false)
+	_, _, err = collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b2", "2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err, "Couldn't add revision 3-b2")
 
 	doc, err := collection.GetDocument(ctx, "doc1", DocUnmarshalAll)
@@ -2332,7 +2332,7 @@ func TestIncreasingRecentSequences(t *testing.T) {
 			enableCallback = false
 			// Write a doc
 			collection := GetSingleDatabaseCollectionWithUser(t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-abc", revid}, true)
+			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"2-abc", revid}, true, ExistingVersionWithUpdateToHLV)
 			assert.NoError(t, err)
 		}
 	}
@@ -2349,7 +2349,7 @@ func TestIncreasingRecentSequences(t *testing.T) {
 	assert.NoError(t, err)
 
 	enableCallback = true
-	doc, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-abc", "2-abc", revid}, true)
+	doc, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-abc", "2-abc", revid}, true, ExistingVersionWithUpdateToHLV)
 	assert.NoError(t, err)
 
 	assert.True(t, sort.IsSorted(base.SortedUint64Slice(doc.SyncData.RecentSequences)))
@@ -2799,72 +2799,62 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 }
 
 func Test_resyncDocument(t *testing.T) {
-	testCases := []struct {
-		useXattr bool
-	}{
-		{useXattr: true},
-		{useXattr: false},
+	if !base.TestUseXattrs() {
+		t.Skip("Walrus doesn't support xattr")
 	}
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
 
-	for _, testCase := range testCases {
-		t.Run(fmt.Sprintf("Test_resyncDocument with useXattr: %t", testCase.useXattr), func(t *testing.T) {
-			if !base.TestUseXattrs() && testCase.useXattr {
-				t.Skip("Don't run xattr tests on non xattr tests")
-			}
-			db, ctx := setupTestDB(t)
-			defer db.Close(ctx)
+	db.Options.EnableXattr = true
+	db.Options.QueryPaginationLimit = 100
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
 
-			db.Options.EnableXattr = testCase.useXattr
-			db.Options.QueryPaginationLimit = 100
-			collection := GetSingleDatabaseCollectionWithUser(t, db)
-
-			syncFn := `
+	syncFn := `
 	function sync(doc, oldDoc){
 		channel("channel." + "ABC");
 	}
 `
-			_, err := collection.UpdateSyncFun(ctx, syncFn)
-			require.NoError(t, err)
+	_, err := collection.UpdateSyncFun(ctx, syncFn)
+	require.NoError(t, err)
 
-			docID := uuid.NewString()
+	docID := uuid.NewString()
 
-			updateBody := make(map[string]interface{})
-			updateBody["val"] = "value"
-			_, doc, err := collection.Put(ctx, docID, updateBody)
-			require.NoError(t, err)
-			assert.NotNil(t, doc)
+	updateBody := make(map[string]interface{})
+	updateBody["val"] = "value"
+	_, doc, err := collection.Put(ctx, docID, updateBody)
+	require.NoError(t, err)
+	assert.NotNil(t, doc)
 
-			syncFn = `
+	syncFn = `
 		function sync(doc, oldDoc){
 			channel("channel." + "ABC12332423234");
 		}
 	`
-			_, err = collection.UpdateSyncFun(ctx, syncFn)
-			require.NoError(t, err)
+	_, err = collection.UpdateSyncFun(ctx, syncFn)
+	require.NoError(t, err)
 
-			_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10})
-			require.NoError(t, err)
-			err = collection.WaitForPendingChanges(ctx)
-			require.NoError(t, err)
+	_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10})
+	require.NoError(t, err)
+	err = collection.WaitForPendingChanges(ctx)
+	require.NoError(t, err)
 
-			syncData, err := collection.GetDocSyncData(ctx, docID)
-			assert.NoError(t, err)
+	syncData, err := collection.GetDocSyncData(ctx, docID)
+	assert.NoError(t, err)
 
-			assert.Len(t, syncData.ChannelSet, 2)
-			assert.Len(t, syncData.Channels, 2)
-			found := false
+	assert.Len(t, syncData.ChannelSet, 2)
+	assert.Len(t, syncData.Channels, 2)
+	found := false
 
-			for _, chSet := range syncData.ChannelSet {
-				if chSet.Name == "channel.ABC12332423234" {
-					found = true
-					break
-				}
-			}
-
-			assert.True(t, found)
-			assert.Equal(t, 2, int(db.DbStats.Database().SyncFunctionCount.Value()))
-		})
+	for _, chSet := range syncData.ChannelSet {
+		if chSet.Name == "channel.ABC12332423234" {
+			found = true
+			break
+		}
 	}
+
+	assert.True(t, found)
+	assert.Equal(t, 2, int(db.DbStats.Database().SyncFunctionCount.Value()))
+
 }
 
 func Test_getUpdatedDocument(t *testing.T) {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1138,7 +1138,7 @@ func TestConflicts(t *testing.T) {
 		Changes:        []ChangeRev{{"rev": "2-b"}, {"rev": "2-a"}},
 		branched:       true,
 		collectionID:   collectionID,
-		CurrentVersion: &SourceAndVersion{SourceID: bucketUUID, Version: fetchedDoc.Cas},
+		CurrentVersion: &Version{SourceID: bucketUUID, Value: fetchedDoc.Cas},
 	}, changes[0],
 	)
 
@@ -1174,7 +1174,7 @@ func TestConflicts(t *testing.T) {
 		Changes:        []ChangeRev{{"rev": "2-a"}, {"rev": rev3}},
 		branched:       true,
 		collectionID:   collectionID,
-		CurrentVersion: &SourceAndVersion{SourceID: bucketUUID, Version: doc.Cas},
+		CurrentVersion: &Version{SourceID: bucketUUID, Value: doc.Cas},
 	}, changes[0])
 
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -307,6 +307,140 @@ func TestDatabase(t *testing.T) {
 
 }
 
+// TestCheckProposedVersion ensures that a given CV will return the appropriate status based on the information present in the HLV.
+func TestCheckProposedVersion(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	// create a doc
+	body := Body{"key1": "value1", "key2": 1234}
+	_, doc, err := collection.Put(ctx, "doc1", body)
+	require.NoError(t, err)
+	cvSource, cvValue := doc.HLV.GetCurrentVersion()
+	currentVersion := Version{cvSource, cvValue}
+
+	testCases := []struct {
+		name            string
+		newVersion      Version
+		previousVersion *Version
+		expectedStatus  ProposedRevStatus
+		expectedRev     string
+	}{
+		{
+			// proposed version matches the current server version
+			//  Already known
+			name:            "version exists",
+			newVersion:      currentVersion,
+			previousVersion: nil,
+			expectedStatus:  ProposedRev_Exists,
+			expectedRev:     "",
+		},
+		{
+			// proposed version is newer than server cv (same source), and previousVersion matches server cv
+			//  Not a conflict
+			name:            "new version,same source,prev matches",
+			newVersion:      Version{cvSource, incrementStringCas(cvValue, 100)},
+			previousVersion: &currentVersion,
+			expectedStatus:  ProposedRev_OK,
+			expectedRev:     "",
+		},
+		{
+			// proposed version is newer than server cv (same source), and previousVersion is not specified.
+			//  Not a conflict, even without previousVersion, because of source match
+			name:            "new version,same source,prev not specified",
+			newVersion:      Version{cvSource, incrementStringCas(cvValue, 100)},
+			previousVersion: nil,
+			expectedStatus:  ProposedRev_OK,
+			expectedRev:     "",
+		},
+		{
+			// proposed version is from a source not present in server HLV, and previousVersion matches server cv
+			//  Not a conflict, due to previousVersion match
+			name:            "new version,new source,prev matches",
+			newVersion:      Version{"other", incrementStringCas(cvValue, 100)},
+			previousVersion: &currentVersion,
+			expectedStatus:  ProposedRev_OK,
+			expectedRev:     "",
+		},
+		{
+			// proposed version is newer than server cv (same source), but previousVersion does not match server cv.
+			//  Not a conflict, regardless of previousVersion mismatch, because of source match between proposed
+			//  version and cv
+			name:            "new version,prev mismatch,new matches cv",
+			newVersion:      Version{cvSource, incrementStringCas(cvValue, 100)},
+			previousVersion: &Version{"other", incrementStringCas(cvValue, 50)},
+			expectedStatus:  ProposedRev_OK,
+			expectedRev:     "",
+		},
+		{
+			// proposed version is already known, source matches cv
+			name:           "proposed version already known, no prev version",
+			newVersion:     Version{cvSource, incrementStringCas(cvValue, -100)},
+			expectedStatus: ProposedRev_Exists,
+			expectedRev:    "",
+		},
+		{
+			// conflict - previous version is older than CV
+			name:            "conflict,same source,server updated",
+			newVersion:      Version{"other", incrementStringCas(cvValue, -100)},
+			previousVersion: &Version{cvSource, incrementStringCas(cvValue, -50)},
+			expectedStatus:  ProposedRev_Conflict,
+			expectedRev:     Version{cvSource, cvValue}.String(),
+		},
+		{
+			// conflict - previous version is older than CV
+			name:            "conflict,new source,server updated",
+			newVersion:      Version{"other", incrementStringCas(cvValue, 100)},
+			previousVersion: &Version{"other", incrementStringCas(cvValue, -50)},
+			expectedStatus:  ProposedRev_Conflict,
+			expectedRev:     Version{cvSource, cvValue}.String(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			previousVersionStr := ""
+			if tc.previousVersion != nil {
+				previousVersionStr = tc.previousVersion.String()
+			}
+			status, rev := collection.CheckProposedVersion(ctx, "doc1", tc.newVersion.String(), previousVersionStr)
+			assert.Equal(t, tc.expectedStatus, status)
+			assert.Equal(t, tc.expectedRev, rev)
+		})
+	}
+
+	t.Run("invalid hlv", func(t *testing.T) {
+		hlvString := ""
+		status, _ := collection.CheckProposedVersion(ctx, "doc1", hlvString, "")
+		assert.Equal(t, ProposedRev_Error, status)
+	})
+
+	// New doc cases - standard insert
+	t.Run("new doc", func(t *testing.T) {
+		newVersion := Version{"other", base.CasToString(100)}.String()
+		status, _ := collection.CheckProposedVersion(ctx, "doc2", newVersion, "")
+		assert.Equal(t, ProposedRev_OK_IsNew, status)
+	})
+
+	// New doc cases - insert with prev version (previous version purged from SGW)
+	t.Run("new doc with prev version", func(t *testing.T) {
+		newVersion := Version{"other", base.CasToString(100)}.String()
+		prevVersion := Version{"another other", base.CasToString(50)}.String()
+		status, _ := collection.CheckProposedVersion(ctx, "doc2", newVersion, prevVersion)
+		assert.Equal(t, ProposedRev_OK_IsNew, status)
+	})
+
+}
+
+func incrementStringCas(cas string, delta int) (casOut string) {
+	casValue := base.HexCasToUint64(cas)
+	casValue = casValue + uint64(delta)
+	return base.CasToString(casValue)
+}
+
 func TestGetDeleted(t *testing.T) {
 
 	db, ctx := setupTestDB(t)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1054,6 +1054,7 @@ func TestConflicts(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	bucketUUID := db.BucketUUID
 
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
@@ -1125,15 +1126,19 @@ func TestConflicts(t *testing.T) {
 		Conflicts:  true,
 		ChangesCtx: base.TestCtx(t),
 	}
+	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, "doc", DocUnmarshalCAS)
+	require.NoError(t, err)
+
 	changes, err := collection.GetChanges(ctx, channels.BaseSetOf(t, "all"), options)
 	assert.NoError(t, err, "Couldn't GetChanges")
 	assert.Len(t, changes, 1)
 	assert.Equal(t, &ChangeEntry{
-		Seq:          SequenceID{Seq: 3},
-		ID:           "doc",
-		Changes:      []ChangeRev{{"rev": "2-b"}, {"rev": "2-a"}},
-		branched:     true,
-		collectionID: collectionID,
+		Seq:            SequenceID{Seq: 3},
+		ID:             "doc",
+		Changes:        []ChangeRev{{"rev": "2-b"}, {"rev": "2-a"}},
+		branched:       true,
+		collectionID:   collectionID,
+		CurrentVersion: &SourceAndVersion{SourceID: bucketUUID, Version: fetchedDoc.Cas},
 	}, changes[0],
 	)
 
@@ -1164,11 +1169,12 @@ func TestConflicts(t *testing.T) {
 	assert.NoError(t, err, "Couldn't GetChanges")
 	assert.Len(t, changes, 1)
 	assert.Equal(t, &ChangeEntry{
-		Seq:          SequenceID{Seq: 4},
-		ID:           "doc",
-		Changes:      []ChangeRev{{"rev": "2-a"}, {"rev": rev3}},
-		branched:     true,
-		collectionID: collectionID,
+		Seq:            SequenceID{Seq: 4},
+		ID:             "doc",
+		Changes:        []ChangeRev{{"rev": "2-a"}, {"rev": rev3}},
+		branched:       true,
+		collectionID:   collectionID,
+		CurrentVersion: &SourceAndVersion{SourceID: bucketUUID, Version: doc.Cas},
 	}, changes[0])
 
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1828,6 +1828,84 @@ func TestChannelView(t *testing.T) {
 		log.Printf("View Query returned entry (%d): %v", i, entry)
 	}
 	assert.Len(t, entries, 1)
+	require.Equal(t, "doc1", entries[0].DocID)
+	collection.RequireCurrentVersion(t, "doc1", entries[0].SourceID, entries[0].Version)
+}
+
+func TestChannelQuery(t *testing.T) {
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	_, err := collection.UpdateSyncFun(ctx, `function(doc, oldDoc) {
+		channel(doc.channels);
+	}`)
+	require.NoError(t, err)
+
+	// Create doc
+	body := Body{"key1": "value1", "key2": 1234, "channels": "ABC"}
+	rev1ID, _, err := collection.Put(ctx, "doc1", body)
+	require.NoError(t, err, "Couldn't create doc1")
+
+	// Create a doc to test removal handling.  Needs three revisions so that the removal rev (2) isn't
+	// the current revision
+	removedDocID := "removed_doc"
+	removedDocRev1, _, err := collection.Put(ctx, removedDocID, body)
+	require.NoError(t, err, "Couldn't create removed_doc")
+	removalSource, removalVersion := collection.GetDocumentCurrentVersion(t, removedDocID)
+
+	updatedChannelBody := Body{"_rev": removedDocRev1, "key1": "value1", "key2": 1234, "channels": "DEF"}
+	removalRev, _, err := collection.Put(ctx, removedDocID, updatedChannelBody)
+	require.NoError(t, err, "Couldn't update removed_doc")
+
+	updatedChannelBody = Body{"_rev": removalRev, "key1": "value1", "key2": 2345, "channels": "DEF"}
+	removedDocRev3, _, err := collection.Put(ctx, removedDocID, updatedChannelBody)
+	require.NoError(t, err, "Couldn't update removed_doc")
+
+	var entries LogEntries
+
+	// Test query retrieval via star channel and named channel (queries use different indexes)
+	testCases := []struct {
+		testName    string
+		channelName string
+	}{
+		{
+			testName:    "star channel",
+			channelName: "*",
+		},
+		{
+			testName:    "named channel",
+			channelName: "ABC",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			entries, err = collection.getChangesInChannelFromQuery(ctx, testCase.channelName, 0, 100, 0, false)
+			require.NoError(t, err)
+
+			for i, entry := range entries {
+				log.Printf("Channel Query returned entry (%d): %v", i, entry)
+			}
+			require.Len(t, entries, 2)
+			require.Equal(t, "doc1", entries[0].DocID)
+			require.Equal(t, rev1ID, entries[0].RevID)
+			collection.RequireCurrentVersion(t, "doc1", entries[0].SourceID, entries[0].Version)
+
+			removedDocEntry := entries[1]
+			require.Equal(t, removedDocID, removedDocEntry.DocID)
+			if testCase.channelName == "*" {
+				require.Equal(t, removedDocRev3, removedDocEntry.RevID)
+				collection.RequireCurrentVersion(t, removedDocID, removedDocEntry.SourceID, removedDocEntry.Version)
+			} else {
+				require.Equal(t, removalRev, removedDocEntry.RevID)
+				// TODO: Pending channel removal rev handling, CBG-3213
+				log.Printf("removal rev check of removal cv %s@%d is pending CBG-3213", removalSource, removalVersion)
+				//require.Equal(t, removalSource, removedDocEntry.SourceID)
+				//require.Equal(t, removalVersion, removedDocEntry.Version)
+			}
+		})
+	}
 
 }
 
@@ -2450,7 +2528,7 @@ func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
 	assert.NoError(t, err)
 
 	var doc Body
-	var xattr Body
+	var xattr SyncData
 
 	var xattrs map[string][]byte
 	// Ensure document has been added
@@ -2464,8 +2542,8 @@ func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
 	assert.Equal(t, int64(1), db.DbStats.SharedBucketImport().ImportCount.Value())
 
 	assert.Nil(t, doc)
-	assert.Equal(t, "1-2cac91faf7b3f5e5fd56ff377bdb5466", xattr["rev"])
-	assert.Equal(t, float64(2), xattr["sequence"])
+	assert.Equal(t, "1-2cac91faf7b3f5e5fd56ff377bdb5466", xattr.CurrentRev)
+	assert.Equal(t, uint64(2), xattr.Sequence)
 }
 
 func TestResyncUpdateAllDocChannels(t *testing.T) {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -317,7 +317,7 @@ func TestGetDeleted(t *testing.T) {
 	rev1id, _, err := collection.Put(ctx, "doc1", body)
 	assert.NoError(t, err, "Put")
 
-	rev2id, err := collection.DeleteDoc(ctx, "doc1", rev1id)
+	rev2id, _, err := collection.DeleteDoc(ctx, "doc1", rev1id)
 	assert.NoError(t, err, "DeleteDoc")
 
 	// Get the deleted doc with its history; equivalent to GET with ?revs=true
@@ -898,7 +898,7 @@ func TestAllDocsOnly(t *testing.T) {
 	}
 
 	// Now delete one document and try again:
-	_, err = collection.DeleteDoc(ctx, ids[23].DocID, ids[23].RevID)
+	_, _, err = collection.DeleteDoc(ctx, ids[23].DocID, ids[23].RevID)
 	assert.NoError(t, err, "Couldn't delete doc 23")
 
 	alldocs, err = allDocIDs(ctx, collection.DatabaseCollection)
@@ -1143,7 +1143,7 @@ func TestConflicts(t *testing.T) {
 	)
 
 	// Delete 2-b; verify this makes 2-a current:
-	rev3, err := collection.DeleteDoc(ctx, "doc", "2-b")
+	rev3, _, err := collection.DeleteDoc(ctx, "doc", "2-b")
 	assert.NoError(t, err, "delete 2-b")
 
 	rawBody, _, _ = collection.dataStore.GetRaw("doc")
@@ -2603,7 +2603,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 		docID := fmt.Sprintf("doc%d", i)
 		rev, _, err := collection.Put(ctx, docID, Body{})
 		assert.NoError(t, err)
-		_, err = collection.DeleteDoc(ctx, docID, rev)
+		_, _, err = collection.DeleteDoc(ctx, docID, rev)
 		assert.NoError(t, err)
 	}
 
@@ -3026,7 +3026,7 @@ func TestImportCompactPanic(t *testing.T) {
 	// Create a document, then delete it, to create a tombstone
 	rev, doc, err := collection.Put(ctx, "test", Body{})
 	require.NoError(t, err)
-	_, err = collection.DeleteDoc(ctx, doc.ID, rev)
+	_, _, err = collection.DeleteDoc(ctx, doc.ID, rev)
 	require.NoError(t, err)
 	require.NoError(t, collection.WaitForPendingChanges(ctx))
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -706,7 +706,7 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 		name          string
 		versionVector bool
 	}{
-		// Disabled pending work on backwards compatability for revtree in delta sync
+		// Disabled pending work on backwards compatibility for revtree in delta sync CBG-3748
 		//{
 		//	name:          "revTree test",
 		//	versionVector: false,
@@ -814,6 +814,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 		name          string
 		versionVector bool
 	}{
+		// Disabled pending work on backwards compatibility for revtree in delta sync CBG-3748
 		//{
 		//	name:          "revTree test",
 		//	versionVector: false,

--- a/db/document.go
+++ b/db/document.go
@@ -1170,14 +1170,14 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
-func (d *Document) HasCurrentVersion(cv CurrentVersionVector) error {
+func (d *Document) HasCurrentVersion(cv SourceAndVersion) error {
 	if d.HLV == nil {
 		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
 	}
 
 	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
 	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
-	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.VersionCAS {
+	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Version {
 		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
 	}
 	return nil

--- a/db/document.go
+++ b/db/document.go
@@ -177,11 +177,12 @@ type Document struct {
 	Cas          uint64 // Document cas
 	rawUserXattr []byte // Raw user xattr as retrieved from the bucket
 
-	Deleted        bool
-	DocExpiry      uint32
-	RevID          string
-	DocAttachments AttachmentsMeta
-	inlineSyncData bool
+	Deleted            bool
+	DocExpiry          uint32
+	RevID              string
+	DocAttachments     AttachmentsMeta
+	inlineSyncData     bool
+	currentRevChannels base.Set // A base.Set of the current revision's channels (determined by SyncData.Channels at UnmarshalJSON time)
 }
 
 type historyOnlySyncData struct {
@@ -900,6 +901,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 			doc.updateChannelHistory(channel, doc.Sequence, true)
 		}
 	}
+	doc.currentRevChannels = newChannels
 	if changed != nil {
 		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)
@@ -1007,6 +1009,17 @@ func (doc *Document) UnmarshalJSON(data []byte) error {
 	}
 	if syncData.SyncData != nil {
 		doc.SyncData = *syncData.SyncData
+	}
+
+	// determine current revision's channels and store in-memory (avoids doc.Channels iteration at access-check time)
+	if len(doc.Channels) > 0 {
+		ch := base.SetOf()
+		for channelName, channelRemoval := range doc.Channels {
+			if channelRemoval == nil || channelRemoval.Seq == 0 {
+				ch.Add(channelName)
+			}
+		}
+		doc.currentRevChannels = ch
 	}
 
 	// Unmarshal the rest of the doc body as map[string]interface{}
@@ -1154,4 +1167,18 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 	}
 
 	return data, xdata, nil
+}
+
+// HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
+func (d *Document) HasCurrentVersion(cv CurrentVersionVector) error {
+	if d.HLV == nil {
+		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
+	}
+
+	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
+	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
+	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.VersionCAS {
+		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
+	}
+	return nil
 }

--- a/db/document.go
+++ b/db/document.go
@@ -1210,8 +1210,10 @@ func (s *SyncData) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	*s = SyncData(*sdj.SyncDataAlias)
-	s.CurrentRev = sdj.RevAndVersion.RevTreeID
+	if sdj.SyncDataAlias != nil {
+		*s = SyncData(*sdj.SyncDataAlias)
+		s.CurrentRev = sdj.RevAndVersion.RevTreeID
+	}
 	return nil
 }
 

--- a/db/document.go
+++ b/db/document.go
@@ -1170,14 +1170,14 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
-func (d *Document) HasCurrentVersion(cv SourceAndVersion) error {
+func (d *Document) HasCurrentVersion(cv Version) error {
 	if d.HLV == nil {
 		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
 	}
 
 	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
 	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
-	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Version {
+	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Value {
 		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
 	}
 	return nil

--- a/db/document.go
+++ b/db/document.go
@@ -34,11 +34,11 @@ const DocumentHistoryMaxEntriesPerChannel = 5
 type DocumentUnmarshalLevel uint8
 
 const (
-	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals sync metadata and body
-	DocUnmarshalSync                                     // Unmarshals all sync metadata
-	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding revtree history
+	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals metadata and body
+	DocUnmarshalSync                                     // Unmarshals metadata
+	DocUnmarshalNoHistory                                // Unmarshals metadata excluding revtree history
 	DocUnmarshalHistory                                  // Unmarshals revtree history + rev + CAS only
-	DocUnmarshalRev                                      // Unmarshals rev + CAS only
+	DocUnmarshalRev                                      // Unmarshals revTreeID + CAS only (no HLV)
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )
@@ -81,7 +81,7 @@ type SyncData struct {
 	Attachments       AttachmentsMeta      `json:"attachments,omitempty"`
 	ChannelSet        []ChannelSetEntry    `json:"channel_set"`
 	ChannelSetHistory []ChannelSetEntry    `json:"channel_set_history"`
-	HLV               *HybridLogicalVector `json:"_vv,omitempty"`
+	HLV               *HybridLogicalVector `json:"-"` // Marshalled/Unmarshalled separately from SyncData for storage in _vv, see MarshalWithXattrs/UnmarshalWithXattrs
 
 	// Only used for performance metrics:
 	TimeSaved time.Time `json:"time_saved,omitempty"` // Timestamp of save.
@@ -401,14 +401,14 @@ func unmarshalDocument(docid string, data []byte) (*Document, error) {
 	return doc, nil
 }
 
-func unmarshalDocumentWithXattr(ctx context.Context, docid string, data []byte, xattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+func unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, syncXattrData []byte, hlvXattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 
-	if xattrData == nil || len(xattrData) == 0 {
+	if len(syncXattrData) == 0 && len(hlvXattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
 	} else {
 		doc = NewDocument(docid)
-		err = doc.UnmarshalWithXattr(ctx, data, xattrData, unmarshalLevel)
+		err = doc.UnmarshalWithXattrs(ctx, data, syncXattrData, hlvXattrData, unmarshalLevel)
 	}
 	if err != nil {
 		return nil, err
@@ -444,37 +444,47 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*SyncData, error)
 // Returns the raw body, in case it's needed for import.
 
 // TODO: Using a pool of unmarshal workers may help prevent memory spikes under load
-func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawSyncXattr []byte, rawUserXattr []byte, err error) {
 
+func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawXattrs map[string][]byte, err error) {
 	var body []byte
 
 	// If xattr datatype flag is set, data includes both xattrs and document body.  Check for presence of sync xattr.
 	// Note that there could be a non-sync xattr present
+	var xattrValues map[string][]byte
+	var hlv *HybridLogicalVector
 	if dataType&base.MemcachedDataTypeXattr != 0 {
-		var xattrs map[string][]byte
-		xattrKeys := []string{base.SyncXattrName}
-		if userXattrKey != "" {
-			xattrKeys = append(xattrKeys, userXattrKey)
-		}
-		body, xattrs, err = sgbucket.DecodeValueWithXattrs(xattrKeys, data)
+		xattrKeys := []string{base.SyncXattrName, base.VvXattrName, userXattrKey}
+		body, xattrValues, err = sgbucket.DecodeValueWithXattrs(xattrKeys, data)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, err
 		}
-		rawSyncXattr = xattrs[base.SyncXattrName]
-		rawUserXattr = xattrs[userXattrKey]
 
 		// If the sync xattr is present, use that to build SyncData
-		if len(rawSyncXattr) > 0 {
+		syncXattr, ok := xattrValues[base.SyncXattrName]
+
+		if vvXattr, ok := xattrValues[base.VvXattrName]; ok {
+			err = base.JSONUnmarshal(vvXattr, &hlv)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("error unmarshalling HLV: %w", err)
+			}
+		}
+
+		if ok && len(syncXattr) > 0 {
 			result = &SyncData{}
 			if needHistory {
 				result.History = make(RevTree)
 			}
-			err = base.JSONUnmarshal(rawSyncXattr, result)
+			err = base.JSONUnmarshal(syncXattr, result)
 			if err != nil {
-				return nil, nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", syncXattr, err)
+				return nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", string(syncXattr), err)
 			}
-			return result, body, rawSyncXattr, rawUserXattr, nil
+
+			if hlv != nil {
+				result.HLV = hlv
+			}
+			return result, body, xattrValues, nil
 		}
+
 	} else {
 		// Xattr flag not set - data is just the document body
 		body = data
@@ -482,22 +492,16 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 
 	// Non-xattr data, or sync xattr not present.  Attempt to retrieve sync metadata from document body
 	result, err = UnmarshalDocumentSyncData(body, needHistory)
-	return result, body, nil, rawUserXattr, err
-}
 
-func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {
-	if dataType&base.MemcachedDataTypeXattr == 0 {
-		return unmarshalDocument(docid, data)
+	// If no sync data was found but HLV was present, initialize empty sync data
+	if result == nil && hlv != nil {
+		result = &SyncData{}
 	}
-	xattrKeys := []string{base.SyncXattrName}
-	if userXattrKey != "" {
-		xattrKeys = append(xattrKeys, userXattrKey)
+	// If HLV was found, add to sync data
+	if hlv != nil {
+		result.HLV = hlv
 	}
-	body, xattrs, err := sgbucket.DecodeValueWithXattrs(xattrKeys, data)
-	if err != nil {
-		return nil, err
-	}
-	return unmarshalDocumentWithXattr(ctx, docid, body, xattrs[base.SyncXattrName], xattrs[userXattrKey], cas, DocUnmarshalAll)
+	return result, body, xattrValues, err
 }
 
 func (doc *SyncData) HasValidSyncData() bool {
@@ -1055,11 +1059,12 @@ func (doc *Document) MarshalJSON() (data []byte, err error) {
 	return data, err
 }
 
-// UnmarshalWithXattr unmarshals the provided raw document and xattr bytes.  The provided DocumentUnmarshalLevel
+// UnmarshalWithXattrs unmarshals the provided raw document and xattr bytes when present.  The provided DocumentUnmarshalLevel
 // (unmarshalLevel) specifies how much of the provided document/xattr needs to be initially unmarshalled.  If
 // unmarshalLevel is anything less than the full document + metadata, the raw data is retained for subsequent
 // lazy unmarshalling as needed.
-func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata []byte, unmarshalLevel DocumentUnmarshalLevel) error {
+// Must handle cases where document body and hlvXattrData are present without syncXattrData for all DocumentUnmarshalLevel
+func (doc *Document) UnmarshalWithXattrs(ctx context.Context, data, syncXattrData, hlvXattrData []byte, unmarshalLevel DocumentUnmarshalLevel) error {
 	if doc.ID == "" {
 		base.WarnfCtx(ctx, "Attempted to unmarshal document without ID set")
 		return errors.New("Document was unmarshalled without ID set")
@@ -1067,11 +1072,19 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 
 	switch unmarshalLevel {
 	case DocUnmarshalAll, DocUnmarshalSync:
-		// Unmarshal full document and/or sync metadata
+		// Unmarshal full document and/or sync metadata. Documents written by XDCR may have HLV but no sync data
 		doc.SyncData = SyncData{History: make(RevTree)}
-		unmarshalErr := base.JSONUnmarshal(xdata, &doc.SyncData)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), unmarshalErr))
+		if syncXattrData != nil {
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &doc.SyncData)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+		}
+		if hlvXattrData != nil {
+			err := base.JSONUnmarshal(hlvXattrData, &doc.SyncData.HLV)
+			if err != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal HLV during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), err))
+			}
 		}
 		doc._rawBody = data
 		// Unmarshal body if requested and present
@@ -1081,50 +1094,70 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 	case DocUnmarshalNoHistory:
 		// Unmarshal sync metadata only, excluding history
 		doc.SyncData = SyncData{}
-		unmarshalErr := base.JSONUnmarshal(xdata, &doc.SyncData)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+		if syncXattrData != nil {
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &doc.SyncData)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+		}
+		if hlvXattrData != nil {
+			err := base.JSONUnmarshal(hlvXattrData, &doc.SyncData.HLV)
+			if err != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal HLV during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), err))
+			}
 		}
 		doc._rawBody = data
 	case DocUnmarshalHistory:
-		historyOnlyMeta := historyOnlySyncData{History: make(RevTree)}
-		unmarshalErr := base.JSONUnmarshal(xdata, &historyOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			CurrentRev: historyOnlyMeta.CurrentRev.RevTreeID,
-			History:    historyOnlyMeta.History,
-			Cas:        historyOnlyMeta.Cas,
+		if syncXattrData != nil {
+			historyOnlyMeta := historyOnlySyncData{History: make(RevTree)}
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &historyOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				CurrentRev: historyOnlyMeta.CurrentRev.RevTreeID,
+				History:    historyOnlyMeta.History,
+				Cas:        historyOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	case DocUnmarshalRev:
 		// Unmarshal only rev and cas from sync metadata
-		var revOnlyMeta revOnlySyncData
-		unmarshalErr := base.JSONUnmarshal(xdata, &revOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			CurrentRev: revOnlyMeta.CurrentRev.RevTreeID,
-			Cas:        revOnlyMeta.Cas,
+		if syncXattrData != nil {
+			var revOnlyMeta revOnlySyncData
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &revOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				CurrentRev: revOnlyMeta.CurrentRev.RevTreeID,
+				Cas:        revOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	case DocUnmarshalCAS:
 		// Unmarshal only cas from sync metadata
-		var casOnlyMeta casOnlySyncData
-		unmarshalErr := base.JSONUnmarshal(xdata, &casOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalCAS).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			Cas: casOnlyMeta.Cas,
+		if syncXattrData != nil {
+			var casOnlyMeta casOnlySyncData
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &casOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalCAS).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				Cas: casOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	}
 
 	// If there's no body, but there is an xattr, set deleted flag and initialize an empty body
-	if len(data) == 0 && len(xdata) > 0 {
+	if len(data) == 0 && len(syncXattrData) > 0 {
 		doc._body = Body{}
 		doc._rawBody = []byte(base.EmptyDocument)
 		doc.Deleted = true
@@ -1132,7 +1165,8 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 	return nil
 }
 
-func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
+// MarshalWithXattrs marshals the Document into body, and sync and vv xattrs for persistence.
+func (doc *Document) MarshalWithXattrs() (data []byte, syncXattr []byte, vvXattr []byte, err error) {
 	// Grab the rawBody if it's already marshalled, otherwise unmarshal the body
 	if doc._rawBody != nil {
 		if !doc.IsDeleted() {
@@ -1149,18 +1183,25 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 			if !deleted {
 				data, err = base.JSONMarshal(body)
 				if err != nil {
-					return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc body with id: %s.  Error: %v", base.UD(doc.ID), err))
+					return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc body with id: %s.  Error: %v", base.UD(doc.ID), err))
 				}
 			}
 		}
 	}
 
-	xdata, err = base.JSONMarshal(&doc.SyncData)
-	if err != nil {
-		return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
+	if doc.SyncData.HLV != nil {
+		vvXattr, err = base.JSONMarshal(&doc.SyncData.HLV)
+		if err != nil {
+			return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc vv with id: %s.  Error: %v", base.UD(doc.ID), err))
+		}
 	}
 
-	return data, xdata, nil
+	syncXattr, err = base.JSONMarshal(&doc.SyncData)
+	if err != nil {
+		return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
+	}
+
+	return data, syncXattr, vvXattr, nil
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two

--- a/db/document.go
+++ b/db/document.go
@@ -65,7 +65,7 @@ type ChannelSetEntry struct {
 
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
 type SyncData struct {
-	CurrentRev        string               `json:"rev"`
+	CurrentRev        string               `json:"-"`                 // CurrentRev.  Persisted as RevAndVersion in SyncDataJSON
 	NewestRev         string               `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
 	Flags             uint8                `json:"flags,omitempty"`
 	Sequence          uint64               `json:"sequence,omitempty"`
@@ -192,7 +192,7 @@ type historyOnlySyncData struct {
 
 type revOnlySyncData struct {
 	casOnlySyncData
-	CurrentRev string `json:"rev"`
+	CurrentRev RevAndVersion `json:"rev"`
 }
 
 type casOnlySyncData struct {
@@ -1091,7 +1091,7 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
 		doc.SyncData = SyncData{
-			CurrentRev: historyOnlyMeta.CurrentRev,
+			CurrentRev: historyOnlyMeta.CurrentRev.RevTreeID,
 			History:    historyOnlyMeta.History,
 			Cas:        historyOnlyMeta.Cas,
 		}
@@ -1104,7 +1104,7 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
 		doc.SyncData = SyncData{
-			CurrentRev: revOnlyMeta.CurrentRev,
+			CurrentRev: revOnlyMeta.CurrentRev.RevTreeID,
 			Cas:        revOnlyMeta.Cas,
 		}
 		doc._rawBody = data
@@ -1161,7 +1161,7 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 		}
 	}
 
-	xdata, err = base.JSONMarshal(doc.SyncData)
+	xdata, err = base.JSONMarshal(&doc.SyncData)
 	if err != nil {
 		return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
 	}
@@ -1181,4 +1181,83 @@ func (d *Document) HasCurrentVersion(cv Version) error {
 		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
 	}
 	return nil
+}
+
+// SyncDataAlias is an alias for SyncData that doesn't define custom MarshalJSON/UnmarshalJSON
+type SyncDataAlias SyncData
+
+// SyncDataJSON is the persisted form of SyncData, with RevAndVersion populated at marshal time
+type SyncDataJSON struct {
+	*SyncDataAlias
+	RevAndVersion RevAndVersion `json:"rev"`
+}
+
+// MarshalJSON populates RevAndVersion using CurrentRev and the HLV (current) source and version.
+// Marshals using SyncDataAlias to avoid recursion, and SyncDataJSON to add the combined RevAndVersion.
+func (s SyncData) MarshalJSON() (data []byte, err error) {
+
+	var sdj SyncDataJSON
+	var sd SyncDataAlias
+	sd = (SyncDataAlias)(s)
+	sdj.SyncDataAlias = &sd
+	sdj.RevAndVersion.RevTreeID = s.CurrentRev
+	if s.HLV != nil {
+		sdj.RevAndVersion.CurrentSource = s.HLV.SourceID
+		sdj.RevAndVersion.CurrentVersion = string(base.Uint64CASToLittleEndianHex(s.HLV.Version))
+	}
+	return base.JSONMarshal(sdj)
+}
+
+// UnmarshalJSON unmarshals using SyncDataJSON, then sets currentRev on SyncData based on the value in RevAndVersion.
+// The HLV's current version stored in RevAndVersion is ignored at unmarshal time - the value in the HLV is the source
+// of truth.
+func (s *SyncData) UnmarshalJSON(data []byte) error {
+
+	var sdj *SyncDataJSON
+	err := base.JSONUnmarshal(data, &sdj)
+	if err != nil {
+		return err
+	}
+	*s = SyncData(*sdj.SyncDataAlias)
+	s.CurrentRev = sdj.RevAndVersion.RevTreeID
+	return nil
+}
+
+// RevAndVersion is used to store both revTreeID and currentVersion in a single property, for backwards compatibility
+// with existing indexes using rev.  When only RevTreeID is specified, is marshalled/unmarshalled as a string.  Otherwise
+// marshalled normally.
+type RevAndVersion struct {
+	RevTreeID      string `json:"rev,omitempty"`
+	CurrentSource  string `json:"src,omitempty"`
+	CurrentVersion string `json:"vrs,omitempty"` // String representation of version
+}
+
+// RevAndVersionJSON aliases RevAndVersion to support conditional unmarshalling from either string (revTreeID) or
+// map (RevAndVersion) representations
+type RevAndVersionJSON RevAndVersion
+
+// Marshals RevAndVersion as simple string when only RevTreeID is specified - otherwise performs standard
+// marshalling
+func (rv RevAndVersion) MarshalJSON() (data []byte, err error) {
+
+	if rv.CurrentSource == "" {
+		return base.JSONMarshal(rv.RevTreeID)
+	}
+	return base.JSONMarshal(RevAndVersionJSON(rv))
+}
+
+// Unmarshals either from string (legacy, revID only) or standard RevAndVersion unmarshalling.
+func (rv *RevAndVersion) UnmarshalJSON(data []byte) error {
+
+	if len(data) == 0 {
+		return nil
+	}
+	switch data[0] {
+	case '"':
+		return base.JSONUnmarshal(data, &rv.RevTreeID)
+	case '{':
+		return base.JSONUnmarshal(data, (*RevAndVersionJSON)(rv))
+	default:
+		return fmt.Errorf("unrecognized JSON format for RevAndVersion: %s", data)
+	}
 }

--- a/db/document.go
+++ b/db/document.go
@@ -40,6 +40,7 @@ const (
 	DocUnmarshalHistory                                  // Unmarshals history + rev + CAS only
 	DocUnmarshalRev                                      // Unmarshals rev + CAS only
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
+	DocUnmarshalVV                                       // Unmarshals Version Vector only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )
 
@@ -64,23 +65,24 @@ type ChannelSetEntry struct {
 
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
 type SyncData struct {
-	CurrentRev        string              `json:"rev"`
-	NewestRev         string              `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
-	Flags             uint8               `json:"flags,omitempty"`
-	Sequence          uint64              `json:"sequence,omitempty"`
-	UnusedSequences   []uint64            `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
-	RecentSequences   []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
-	Channels          channels.ChannelMap `json:"channels,omitempty"`
-	Access            UserAccessMap       `json:"access,omitempty"`
-	RoleAccess        UserAccessMap       `json:"role_access,omitempty"`
-	Expiry            *time.Time          `json:"exp,omitempty"`                     // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
-	Cas               string              `json:"cas"`                               // String representation of a cas value, populated via macro expansion
-	Crc32c            string              `json:"value_crc32c"`                      // String representation of crc32c hash of doc body, populated via macro expansion
-	Crc32cUserXattr   string              `json:"user_xattr_value_crc32c,omitempty"` // String representation of crc32c hash of user xattr
-	TombstonedAt      int64               `json:"tombstoned_at,omitempty"`           // Time the document was tombstoned.  Used for view compaction
-	Attachments       AttachmentsMeta     `json:"attachments,omitempty"`
-	ChannelSet        []ChannelSetEntry   `json:"channel_set"`
-	ChannelSetHistory []ChannelSetEntry   `json:"channel_set_history"`
+	CurrentRev        string               `json:"rev"`
+	NewestRev         string               `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
+	Flags             uint8                `json:"flags,omitempty"`
+	Sequence          uint64               `json:"sequence,omitempty"`
+	UnusedSequences   []uint64             `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
+	RecentSequences   []uint64             `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
+	Channels          channels.ChannelMap  `json:"channels,omitempty"`
+	Access            UserAccessMap        `json:"access,omitempty"`
+	RoleAccess        UserAccessMap        `json:"role_access,omitempty"`
+	Expiry            *time.Time           `json:"exp,omitempty"`                     // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
+	Cas               string               `json:"cas"`                               // String representation of a cas value, populated via macro expansion
+	Crc32c            string               `json:"value_crc32c"`                      // String representation of crc32c hash of doc body, populated via macro expansion
+	Crc32cUserXattr   string               `json:"user_xattr_value_crc32c,omitempty"` // String representation of crc32c hash of user xattr
+	TombstonedAt      int64                `json:"tombstoned_at,omitempty"`           // Time the document was tombstoned.  Used for view compaction
+	Attachments       AttachmentsMeta      `json:"attachments,omitempty"`
+	ChannelSet        []ChannelSetEntry    `json:"channel_set"`
+	ChannelSetHistory []ChannelSetEntry    `json:"channel_set_history"`
+	HLV               *HybridLogicalVector `json:"_vv,omitempty"`
 
 	// Only used for performance metrics:
 	TimeSaved time.Time `json:"time_saved,omitempty"` // Timestamp of save.
@@ -1061,7 +1063,6 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		if unmarshalLevel == DocUnmarshalAll && len(data) > 0 {
 			return doc._body.Unmarshal(data)
 		}
-
 	case DocUnmarshalNoHistory:
 		// Unmarshal sync metadata only, excluding history
 		doc.SyncData = SyncData{}
@@ -1104,6 +1105,14 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		doc.SyncData = SyncData{
 			Cas: casOnlyMeta.Cas,
 		}
+		doc._rawBody = data
+	case DocUnmarshalVV:
+		tmpData := SyncData{}
+		unmarshalErr := base.JSONUnmarshal(xdata, &tmpData)
+		if unmarshalErr != nil {
+			return base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalVV).  Error: %w", base.UD(doc.ID), unmarshalErr)
+		}
+		doc.SyncData.HLV = tmpData.HLV
 		doc._rawBody = data
 	}
 

--- a/db/document.go
+++ b/db/document.go
@@ -1168,7 +1168,7 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two
-func (d *Document) HasCurrentVersion(cv Version) error {
+func (d *Document) HasCurrentVersion(ctx context.Context, cv Version) error {
 	if d.HLV == nil {
 		return base.RedactErrorf("no HLV present in fetched doc %s", base.UD(d.ID))
 	}
@@ -1176,7 +1176,9 @@ func (d *Document) HasCurrentVersion(cv Version) error {
 	// fetch the current version for the loaded doc and compare against the CV specified in the IDandCV key
 	fetchedDocSource, fetchedDocVersion := d.HLV.GetCurrentVersion()
 	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Value {
-		return base.RedactErrorf("mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
+		base.DebugfCtx(ctx, base.KeyCRUD, "mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
+		// return not found as specified cv does not match fetched doc cv
+		return base.ErrNotFound
 	}
 	return nil
 }

--- a/db/document.go
+++ b/db/document.go
@@ -979,7 +979,7 @@ func (doc *Document) IsChannelRemovalForCV(ctx context.Context, cv Version) (bod
 	var removalCV Version
 	for channel, removal := range doc.Channels {
 		if removal != nil {
-			removalCV = CreateVersion(removal.Rev.CurrentSource, base.HexCasToUint64(removal.Rev.CurrentVersion))
+			removalCV = CreateVersion(removal.Rev.CurrentSource, removal.Rev.CurrentVersion)
 			if removalCV == cv {
 				removedChannels[channel] = struct{}{}
 				if removal.Deleted {

--- a/db/document.go
+++ b/db/document.go
@@ -1215,7 +1215,7 @@ func (d *Document) HasCurrentVersion(ctx context.Context, cv Version) error {
 	if fetchedDocSource != cv.SourceID || fetchedDocVersion != cv.Value {
 		base.DebugfCtx(ctx, base.KeyCRUD, "mismatch between specified current version and fetched document current version for doc %s", base.UD(d.ID))
 		// return not found as specified cv does not match fetched doc cv
-		return base.ErrNotFound
+		return ErrMissing
 	}
 	return nil
 }

--- a/db/document.go
+++ b/db/document.go
@@ -98,6 +98,17 @@ type SyncData struct {
 	removedRevisionBodyKeys map[string]string // keys of non-winning revisions that have been removed (and so may require deletion), indexed by revID
 }
 
+// determine set of current channels based on removal entries.
+func (sd *SyncData) getCurrentChannels() base.Set {
+	ch := base.SetOf()
+	for channelName, channelRemoval := range sd.Channels {
+		if channelRemoval == nil || channelRemoval.Seq == 0 {
+			ch.Add(channelName)
+		}
+	}
+	return ch
+}
+
 func (sd *SyncData) HashRedact(salt string) SyncData {
 
 	// Creating a new SyncData with the redacted info. We copy all the information which stays the same and create new
@@ -177,12 +188,11 @@ type Document struct {
 	Cas          uint64 // Document cas
 	rawUserXattr []byte // Raw user xattr as retrieved from the bucket
 
-	Deleted            bool
-	DocExpiry          uint32
-	RevID              string
-	DocAttachments     AttachmentsMeta
-	inlineSyncData     bool
-	currentRevChannels base.Set // A base.Set of the current revision's channels (determined by SyncData.Channels at UnmarshalJSON time)
+	Deleted        bool
+	DocExpiry      uint32
+	RevID          string
+	DocAttachments AttachmentsMeta
+	inlineSyncData bool
 }
 
 type historyOnlySyncData struct {
@@ -901,7 +911,6 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 			doc.updateChannelHistory(channel, doc.Sequence, true)
 		}
 	}
-	doc.currentRevChannels = newChannels
 	if changed != nil {
 		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)
@@ -1009,17 +1018,6 @@ func (doc *Document) UnmarshalJSON(data []byte) error {
 	}
 	if syncData.SyncData != nil {
 		doc.SyncData = *syncData.SyncData
-	}
-
-	// determine current revision's channels and store in-memory (avoids doc.Channels iteration at access-check time)
-	if len(doc.Channels) > 0 {
-		ch := base.SetOf()
-		for channelName, channelRemoval := range doc.Channels {
-			if channelRemoval == nil || channelRemoval.Seq == 0 {
-				ch.Add(channelName)
-			}
-		}
-		doc.currentRevChannels = ch
 	}
 
 	// Unmarshal the rest of the doc body as map[string]interface{}

--- a/db/document.go
+++ b/db/document.go
@@ -36,11 +36,10 @@ type DocumentUnmarshalLevel uint8
 const (
 	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals sync metadata and body
 	DocUnmarshalSync                                     // Unmarshals all sync metadata
-	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding history
-	DocUnmarshalHistory                                  // Unmarshals history + rev + CAS only
+	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding revtree history
+	DocUnmarshalHistory                                  // Unmarshals revtree history + rev + CAS only
 	DocUnmarshalRev                                      // Unmarshals rev + CAS only
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
-	DocUnmarshalVV                                       // Unmarshals Version Vector only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )
 
@@ -1121,14 +1120,6 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		doc.SyncData = SyncData{
 			Cas: casOnlyMeta.Cas,
 		}
-		doc._rawBody = data
-	case DocUnmarshalVV:
-		tmpData := SyncData{}
-		unmarshalErr := base.JSONUnmarshal(xdata, &tmpData)
-		if unmarshalErr != nil {
-			return base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalVV).  Error: %w", base.UD(doc.ID), unmarshalErr)
-		}
-		doc.SyncData.HLV = tmpData.HLV
 		doc._rawBody = data
 	}
 

--- a/db/document.go
+++ b/db/document.go
@@ -1228,7 +1228,7 @@ func (s *SyncData) GetRevAndVersion() (rav channels.RevAndVersion) {
 	rav.RevTreeID = s.CurrentRev
 	if s.HLV != nil {
 		rav.CurrentSource = s.HLV.SourceID
-		rav.CurrentVersion = string(base.Uint64CASToLittleEndianHex(s.HLV.Version))
+		rav.CurrentVersion = s.HLV.Version
 	}
 	return rav
 }

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"log"
+	"reflect"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -187,6 +188,196 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 				}
 
 			}
+		})
+	}
+}
+
+const doc_meta_with_vv = `{
+    "rev": "3-89758294abc63157354c2b08547c2d21",
+    "sequence": 7,
+    "recent_sequences": [
+      5,
+      6,
+      7
+    ],
+    "history": {
+      "revs": [
+        "1-fc591a068c153d6c3d26023d0d93dcc1",
+        "2-0eab03571bc55510c8fc4bfac9fe4412",
+        "3-89758294abc63157354c2b08547c2d21"
+      ],
+      "parents": [
+        -1,
+        0,
+        1
+      ],
+      "channels": [
+        [
+          "ABC",
+          "DEF"
+        ],
+        [
+          "ABC",
+          "DEF",
+          "GHI"
+        ],
+        [
+          "ABC",
+          "GHI"
+        ]
+      ]
+    },
+    "channels": {
+      "ABC": null,
+      "DEF": {
+        "seq": 7,
+        "rev": "3-89758294abc63157354c2b08547c2d21"
+      },
+      "GHI": null
+    },
+	"_vv":{
+   		"cvCas":"0x40e2010000000000",
+   		"src":"cb06dc003846116d9b66d2ab23887a96",
+   		"vrs":"0x40e2010000000000",
+   		"mv":{
+      		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
+      		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
+		},
+		"pv":{
+      		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
+   		}
+	},
+    "cas": "",
+    "time_saved": "2017-10-25T12:45:29.622450174-07:00"
+  }`
+
+func TestParseVersionVectorSyncData(t *testing.T) {
+	mv := make(map[string]uint64)
+	pv := make(map[string]uint64)
+	mv["s_LhRPsa7CpjEvP5zeXTXEBA"] = 1628620455147864000
+	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = 1628620455139868700
+	pv["s_YZvBpEaztom9z5V/hDoeIw"] = 1628620455135215600
+
+	ctx := base.TestCtx(t)
+
+	doc_meta := []byte(doc_meta_with_vv)
+	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalVV)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
+
+	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalAll)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
+
+	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	require.NoError(t, err)
+
+	// assert on doc version vector values
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
+	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
+	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
+}
+
+// TestRevAndVersion tests marshalling and unmarshalling rev and current version
+func TestRevAndVersion(t *testing.T) {
+
+	ctx := base.TestCtx(t)
+	testCases := []struct {
+		testName  string
+		revTreeID string
+		source    string
+		version   uint64
+	}{
+		{
+			testName:  "rev_and_version",
+			revTreeID: "1-abc",
+			source:    "source1",
+			version:   1,
+		},
+		{
+			testName:  "both_empty",
+			revTreeID: "",
+			source:    "",
+			version:   0,
+		},
+		{
+			testName:  "revTreeID_only",
+			revTreeID: "1-abc",
+			source:    "",
+			version:   0,
+		},
+		{
+			testName:  "currentVersion_only",
+			revTreeID: "",
+			source:    "source1",
+			version:   1,
+		},
+	}
+
+	var expectedSequence = uint64(100)
+	for _, test := range testCases {
+		t.Run(test.testName, func(t *testing.T) {
+			syncData := &SyncData{
+				CurrentRev: test.revTreeID,
+				Sequence:   expectedSequence,
+			}
+			if test.source != "" {
+				syncData.HLV = &HybridLogicalVector{
+					SourceID: test.source,
+					Version:  test.version,
+				}
+			}
+			// SyncData test
+			marshalledSyncData, err := base.JSONMarshal(syncData)
+			require.NoError(t, err)
+			log.Printf("marshalled:%s", marshalledSyncData)
+
+			var newSyncData SyncData
+			err = base.JSONUnmarshal(marshalledSyncData, &newSyncData)
+			require.NoError(t, err)
+			require.Equal(t, test.revTreeID, newSyncData.CurrentRev)
+			require.Equal(t, expectedSequence, newSyncData.Sequence)
+			if test.source != "" {
+				require.NotNil(t, newSyncData.HLV)
+				require.Equal(t, test.source, newSyncData.HLV.SourceID)
+				require.Equal(t, test.version, newSyncData.HLV.Version)
+			}
+
+			// Document test
+			document := NewDocument("docID")
+			document.SyncData.CurrentRev = test.revTreeID
+			document.SyncData.HLV = &HybridLogicalVector{
+				SourceID: test.source,
+				Version:  test.version,
+			}
+			marshalledDoc, marshalledXattr, err := document.MarshalWithXattr()
+			require.NoError(t, err)
+
+			newDocument := NewDocument("docID")
+			err = newDocument.UnmarshalWithXattr(ctx, marshalledDoc, marshalledXattr, DocUnmarshalAll)
+			require.NoError(t, err)
+			require.Equal(t, test.revTreeID, newDocument.CurrentRev)
+			require.Equal(t, expectedSequence, newSyncData.Sequence)
+			if test.source != "" {
+				require.NotNil(t, newDocument.HLV)
+				require.Equal(t, test.source, newDocument.HLV.SourceID)
+				require.Equal(t, test.version, newDocument.HLV.Version)
+			}
+			//require.Equal(t, test.expectedCombinedVersion, newDocument.RevAndVersion)
 		})
 	}
 }

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -261,7 +261,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	ctx := base.TestCtx(t)
 
 	doc_meta := []byte(doc_meta_with_vv)
-	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalVV)
+	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	strCAS := string(base.Uint64CASToLittleEndianHex(123456))

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -137,7 +137,7 @@ func BenchmarkDocUnmarshal(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			ctx := base.TestCtx(b)
 			for i := 0; i < b.N; i++ {
-				_, _ = unmarshalDocumentWithXattr(ctx, "doc_1k", doc1k_body, doc1k_meta, nil, 1, bm.unmarshalLevel)
+				_, _ = unmarshalDocumentWithXattrs(ctx, "doc_1k", doc1k_body, doc1k_meta, nil, nil, 1, bm.unmarshalLevel)
 			}
 		})
 	}
@@ -192,7 +192,7 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 	}
 }
 
-const doc_meta_with_vv = `{
+const doc_meta_no_vv = `{
     "rev": "3-89758294abc63157354c2b08547c2d21",
     "sequence": 7,
     "recent_sequences": [
@@ -235,20 +235,21 @@ const doc_meta_with_vv = `{
       },
       "GHI": null
     },
-	"_vv":{
-   		"cvCas":"0x40e2010000000000",
-   		"src":"cb06dc003846116d9b66d2ab23887a96",
-   		"ver":"0x40e2010000000000",
-   		"mv":{
-      		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
-      		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
-		},
-		"pv":{
-      		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
-   		}
-	},
     "cas": "",
     "time_saved": "2017-10-25T12:45:29.622450174-07:00"
+  }`
+
+const doc_meta_vv = `{
+	"cvCas":"0x40e2010000000000",
+	"src":"cb06dc003846116d9b66d2ab23887a96",
+	"ver":"0x40e2010000000000",
+	"mv":{
+		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
+		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
+	},
+	"pv":{
+		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
+	}
   }`
 
 func TestParseVersionVectorSyncData(t *testing.T) {
@@ -260,8 +261,9 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 
-	doc_meta := []byte(doc_meta_with_vv)
-	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	sync_meta := []byte(doc_meta_no_vv)
+	vv_meta := []byte(doc_meta_vv)
+	doc, err := unmarshalDocumentWithXattrs(ctx, "doc_1k", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	strCAS := string(base.Uint64CASToLittleEndianHex(123456))
@@ -272,7 +274,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 
-	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalAll)
+	doc, err = unmarshalDocumentWithXattrs(ctx, "doc1", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalAll)
 	require.NoError(t, err)
 
 	// assert on doc version vector values
@@ -282,7 +284,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 
-	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	doc, err = unmarshalDocumentWithXattrs(ctx, "doc1", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	// assert on doc version vector values
@@ -347,32 +349,22 @@ func TestRevAndVersion(t *testing.T) {
 			require.NoError(t, err)
 			log.Printf("marshalled:%s", marshalledSyncData)
 
-			var newSyncData SyncData
-			err = base.JSONUnmarshal(marshalledSyncData, &newSyncData)
-			require.NoError(t, err)
-			require.Equal(t, test.revTreeID, newSyncData.CurrentRev)
-			require.Equal(t, expectedSequence, newSyncData.Sequence)
-			if test.source != "" {
-				require.NotNil(t, newSyncData.HLV)
-				require.Equal(t, test.source, newSyncData.HLV.SourceID)
-				require.Equal(t, test.version, newSyncData.HLV.Version)
-			}
-
 			// Document test
 			document := NewDocument("docID")
 			document.SyncData.CurrentRev = test.revTreeID
+			document.SyncData.Sequence = expectedSequence
 			document.SyncData.HLV = &HybridLogicalVector{
 				SourceID: test.source,
 				Version:  test.version,
 			}
-			marshalledDoc, marshalledXattr, err := document.MarshalWithXattr()
+			marshalledDoc, marshalledXattr, marshalledVvXattr, err := document.MarshalWithXattrs()
 			require.NoError(t, err)
 
 			newDocument := NewDocument("docID")
-			err = newDocument.UnmarshalWithXattr(ctx, marshalledDoc, marshalledXattr, DocUnmarshalAll)
+			err = newDocument.UnmarshalWithXattrs(ctx, marshalledDoc, marshalledXattr, marshalledVvXattr, DocUnmarshalAll)
 			require.NoError(t, err)
 			require.Equal(t, test.revTreeID, newDocument.CurrentRev)
-			require.Equal(t, expectedSequence, newSyncData.Sequence)
+			require.Equal(t, expectedSequence, newDocument.Sequence)
 			if test.source != "" {
 				require.NotNil(t, newDocument.HLV)
 				require.Equal(t, test.source, newDocument.HLV.SourceID)
@@ -493,17 +485,15 @@ func TestDCPDecodeValue(t *testing.T) {
 				require.Nil(t, xattrs)
 			}
 			// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
-			result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
+			result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
 			require.ErrorIs(t, err, test.expectedErr)
 			if test.expectedSyncXattr != nil {
 				require.NotNil(t, result)
+				require.Equal(t, test.expectedSyncXattr, rawXattrs[base.SyncXattrName])
 			} else {
 				require.Nil(t, result)
 			}
 			require.Equal(t, test.expectedBody, rawBody)
-			require.Equal(t, test.expectedSyncXattr, rawXattr)
-			require.Nil(t, rawUserXattr)
-
 		})
 	}
 }
@@ -514,19 +504,17 @@ func TestInvalidXattrStreamEmptyBody(t *testing.T) {
 	emptyBody := []byte{}
 
 	// DecodeValueWithXattrs is the underlying function
-	body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{"_sync"}, inputStream)
+	body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{base.SyncXattrName}, inputStream)
 	require.NoError(t, err)
 	require.Equal(t, emptyBody, body)
 	require.Empty(t, xattrs)
 
 	// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
-	result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
+	result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
 	require.Error(t, err) // unexpected end of JSON input
 	require.Nil(t, result)
 	require.Equal(t, emptyBody, rawBody)
-	require.Nil(t, rawXattr)
-	require.Nil(t, rawUserXattr)
-
+	require.Nil(t, rawXattrs[base.SyncXattrName])
 }
 
 // getSingleXattrDCPBytes returns a DCP body with a single xattr pair and body

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -252,11 +252,11 @@ const doc_meta_with_vv = `{
   }`
 
 func TestParseVersionVectorSyncData(t *testing.T) {
-	mv := make(map[string]uint64)
-	pv := make(map[string]uint64)
-	mv["s_LhRPsa7CpjEvP5zeXTXEBA"] = 1628620455147864000
-	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = 1628620455139868700
-	pv["s_YZvBpEaztom9z5V/hDoeIw"] = 1628620455135215600
+	mv := make(map[string]string)
+	pv := make(map[string]string)
+	mv["s_LhRPsa7CpjEvP5zeXTXEBA"] = "c0ff05d7ac059a16"
+	mv["s_NqiIe0LekFPLeX4JvTO6Iw"] = "1c008cd6ac059a16"
+	pv["s_YZvBpEaztom9z5V/hDoeIw"] = "f0ff44d6ac059a16"
 
 	ctx := base.TestCtx(t)
 
@@ -264,9 +264,10 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalVV)
 	require.NoError(t, err)
 
+	strCAS := string(base.Uint64CASToLittleEndianHex(123456))
 	// assert on doc version vector values
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.Version)
 	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
@@ -275,8 +276,8 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert on doc version vector values
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.Version)
 	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
@@ -285,8 +286,8 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert on doc version vector values
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.CurrentVersionCAS)
-	assert.Equal(t, uint64(123456), doc.SyncData.HLV.Version)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, strCAS, doc.SyncData.HLV.Version)
 	assert.Equal(t, "cb06dc003846116d9b66d2ab23887a96", doc.SyncData.HLV.SourceID)
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
@@ -300,31 +301,31 @@ func TestRevAndVersion(t *testing.T) {
 		testName  string
 		revTreeID string
 		source    string
-		version   uint64
+		version   string
 	}{
 		{
 			testName:  "rev_and_version",
 			revTreeID: "1-abc",
 			source:    "source1",
-			version:   1,
+			version:   "1",
 		},
 		{
 			testName:  "both_empty",
 			revTreeID: "",
 			source:    "",
-			version:   0,
+			version:   "0",
 		},
 		{
 			testName:  "revTreeID_only",
 			revTreeID: "1-abc",
 			source:    "",
-			version:   0,
+			version:   "0",
 		},
 		{
 			testName:  "currentVersion_only",
 			revTreeID: "",
 			source:    "source1",
-			version:   1,
+			version:   "1",
 		},
 	}
 

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -238,7 +238,7 @@ const doc_meta_with_vv = `{
 	"_vv":{
    		"cvCas":"0x40e2010000000000",
    		"src":"cb06dc003846116d9b66d2ab23887a96",
-   		"vrs":"0x40e2010000000000",
+   		"ver":"0x40e2010000000000",
    		"mv":{
       		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
       		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -11,7 +11,6 @@ package db
 import (
 	"encoding/base64"
 	"fmt"
-	"math"
 	"strings"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -19,14 +18,22 @@ import (
 )
 
 // hlvExpandMacroCASValue causes the field to be populated by CAS value by macro expansion
-const hlvExpandMacroCASValue = math.MaxUint64
+const hlvExpandMacroCASValue = "expand"
 
-// HybridLogicalVector (HLV) is a type that represents a vector of Hybrid Logical Clocks.
-type HybridLogicalVector struct {
-	CurrentVersionCAS uint64            // current version cas (or cvCAS) stores the current CAS at the time of replication
+// HybridLogicalVectorInterface is an interface to contain methods that will operate on both a decoded HLV and encoded HLV
+type HybridLogicalVectorInterface interface {
+	GetVersion(sourceID string) (uint64, bool)
+}
+
+var _ HybridLogicalVectorInterface = &HybridLogicalVector{}
+var _ HybridLogicalVectorInterface = &DecodedHybridLogicalVector{}
+
+// DecodedHybridLogicalVector (HLV) is a type that represents a decoded vector of Hybrid Logical Clocks.
+type DecodedHybridLogicalVector struct {
+	CurrentVersionCAS uint64            // current version cas (or cvCAS) stores the current CAS in uint64 type at the time of replication
 	ImportCAS         uint64            // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
-	SourceID          string            // source bucket uuid of where this entry originated from
-	Version           uint64            // current cas of the current version on the version vector
+	SourceID          string            // source bucket uuid in (base64 encoded format) of where this entry originated from
+	Version           uint64            // current cas in uint64 format of the current version on the version vector
 	MergeVersions     map[string]uint64 // map of merge versions for fast efficient lookup
 	PreviousVersions  map[string]uint64 // map of previous versions for fast efficient lookup
 }
@@ -36,10 +43,27 @@ type Version struct {
 	// SourceID is an ID representing the source of the value (e.g. Couchbase Lite ID)
 	SourceID string `json:"source_id"`
 	// Value is a Hybrid Logical Clock value (In Couchbase Server, CAS is a HLC)
+	Value string `json:"version"`
+}
+
+// DecodedVersion is a sourceID and version pair in string/uint64 format for use in conflict detection
+type DecodedVersion struct {
+	// SourceID is an ID representing the source of the value (e.g. Couchbase Lite ID)
+	SourceID string `json:"source_id"`
+	// Value is a Hybrid Logical Clock value (In Couchbase Server, CAS is a HLC)
 	Value uint64 `json:"version"`
 }
 
-func CreateVersion(source string, version uint64) Version {
+// CreateDecodedVersion creates a sourceID and version pair in string/uint64 format
+func CreateDecodedVersion(source string, version uint64) DecodedVersion {
+	return DecodedVersion{
+		SourceID: source,
+		Value:    version,
+	}
+}
+
+// CreateVersion creates an encoded sourceID and version pair
+func CreateVersion(source, version string) Version {
 	return Version{
 		SourceID: source,
 		Value:    version,
@@ -51,20 +75,21 @@ func CreateVersionFromString(versionString string) (version Version, err error) 
 	if !found {
 		return version, fmt.Errorf("Malformed version string %s, delimiter not found", versionString)
 	}
-	sourceBytes, err := base64.StdEncoding.DecodeString(sourceBase64)
-	if err != nil {
-		return version, fmt.Errorf("Unable to decode sourceID for version %s: %w", versionString, err)
-	}
-	version.SourceID = string(sourceBytes)
-	version.Value = base.HexCasToUint64(timestampString)
+	version.SourceID = sourceBase64
+	version.Value = timestampString
 	return version, nil
 }
 
 // String returns a Couchbase Lite-compatible string representation of the version.
-func (v Version) String() string {
+func (v DecodedVersion) String() string {
 	timestamp := string(base.Uint64CASToLittleEndianHex(v.Value))
 	source := base64.StdEncoding.EncodeToString([]byte(v.SourceID))
 	return timestamp + "@" + source
+}
+
+// String returns a version/sourceID pair in CBL string format
+func (v Version) String() string {
+	return v.Value + "@" + v.SourceID
 }
 
 // ExtractCurrentVersionFromHLV will take the current version form the HLV struct and return it in the Version struct
@@ -76,25 +101,25 @@ func (hlv *HybridLogicalVector) ExtractCurrentVersionFromHLV() *Version {
 
 // PersistedHybridLogicalVector is the marshalled format of HybridLogicalVector.
 // This representation needs to be kept in sync with XDCR.
-type PersistedHybridLogicalVector struct {
-	CurrentVersionCAS string            `json:"cvCas,omitempty"`
-	ImportCAS         string            `json:"importCAS,omitempty"`
-	SourceID          string            `json:"src"`
-	Version           string            `json:"vrs"`
-	MergeVersions     map[string]string `json:"mv,omitempty"`
-	PreviousVersions  map[string]string `json:"pv,omitempty"`
+type HybridLogicalVector struct {
+	CurrentVersionCAS string            `json:"cvCas,omitempty"`     // current version cas (or cvCAS) stores the current CAS in little endian hex format at the time of replication
+	ImportCAS         string            `json:"importCAS,omitempty"` // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
+	SourceID          string            `json:"src"`                 // source bucket uuid in (base64 encoded format) of where this entry originated from
+	Version           string            `json:"vrs"`                 // current cas in little endian hex format of the current version on the version vector
+	MergeVersions     map[string]string `json:"mv,omitempty"`        // map of merge versions for fast efficient lookup
+	PreviousVersions  map[string]string `json:"pv,omitempty"`        // map of previous versions for fast efficient lookup
 }
 
 // NewHybridLogicalVector returns an initialised HybridLogicalVector.
 func NewHybridLogicalVector() HybridLogicalVector {
 	return HybridLogicalVector{
-		PreviousVersions: make(map[string]uint64),
-		MergeVersions:    make(map[string]uint64),
+		PreviousVersions: make(map[string]string),
+		MergeVersions:    make(map[string]string),
 	}
 }
 
 // GetCurrentVersion returns the current version from the HLV in memory.
-func (hlv *HybridLogicalVector) GetCurrentVersion() (string, uint64) {
+func (hlv *HybridLogicalVector) GetCurrentVersion() (string, string) {
 	return hlv.SourceID, hlv.Version
 }
 
@@ -111,7 +136,7 @@ func (hlv *HybridLogicalVector) GetCurrentVersionString() string {
 }
 
 // IsInConflict tests to see if in memory HLV is conflicting with another HLV
-func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) IsInConflict(otherVector DecodedHybridLogicalVector) bool {
 	// test if either HLV(A) or HLV(B) are dominating over each other. If so they are not in conflict
 	if hlv.isDominating(otherVector) || otherVector.isDominating(*hlv) {
 		return false
@@ -122,8 +147,13 @@ func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bo
 
 // AddVersion adds newVersion to the in memory representation of the HLV.
 func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
-	if newVersion.Value < hlv.Version {
-		return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %d new cas %d", hlv.Version, newVersion.Value)
+	var newVersionCAS uint64
+	hlvVersionCAS := base.HexCasToUint64(hlv.Version)
+	if newVersion.Value != hlvExpandMacroCASValue {
+		newVersionCAS = base.HexCasToUint64(newVersion.Value)
+		if newVersionCAS < hlvVersionCAS {
+			return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %s new cas %s", hlv.Version, newVersion.Value)
+		}
 	}
 	// check if this is the first time we're adding a source - version pair
 	if hlv.SourceID == "" {
@@ -138,16 +168,17 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	}
 	// if we get here this is a new version from a different sourceID thus need to move current sourceID to previous versions and update current version
 	if hlv.PreviousVersions == nil {
-		hlv.PreviousVersions = make(map[string]uint64)
+		hlv.PreviousVersions = make(map[string]string)
 	}
 	// we need to check if source ID already exists in PV, if so we need to ensure we are only updating with the
 	// sourceID-version pair if incoming version is greater than version already there
 	if currPVVersion, ok := hlv.PreviousVersions[hlv.SourceID]; ok {
 		// if we get here source ID exists in PV, only replace version if it is less than the incoming version
-		if currPVVersion < hlv.Version {
+		currPVVersionCAS := base.HexCasToUint64(currPVVersion)
+		if currPVVersionCAS < hlvVersionCAS {
 			hlv.PreviousVersions[hlv.SourceID] = hlv.Version
 		} else {
-			return fmt.Errorf("local hlv has current source in previous versiosn with version greater than current version. Current CAS: %d, PV CAS %d", hlv.Version, currPVVersion)
+			return fmt.Errorf("local hlv has current source in previous versiosn with version greater than current version. Current CAS: %s, PV CAS %s", hlv.Version, currPVVersion)
 		}
 	} else {
 		// source doesn't exist in PV so add
@@ -162,7 +193,7 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 // TODO: Does this need to remove source from current version as well? Merge Versions?
 func (hlv *HybridLogicalVector) Remove(source string) error {
 	// if entry is not found in previous versions we return error
-	if hlv.PreviousVersions[source] == 0 {
+	if hlv.PreviousVersions[source] == "" {
 		return base.ErrNotFound
 	}
 	delete(hlv.PreviousVersions, source)
@@ -170,7 +201,7 @@ func (hlv *HybridLogicalVector) Remove(source string) error {
 }
 
 // isDominating tests if in memory HLV is dominating over another
-func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) isDominating(otherVector DecodedHybridLogicalVector) bool {
 	// Dominating Criteria:
 	// HLV A dominates HLV B if source(A) == source(B) and version(A) > version(B)
 	// If there is an entry in pv(B) for A's current source and version(A) > B's version for that pv entry then A is dominating
@@ -186,7 +217,7 @@ func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bo
 }
 
 // isEqual tests if in memory HLV is equal to another
-func (hlv *HybridLogicalVector) isEqual(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) isEqual(otherVector DecodedHybridLogicalVector) bool {
 	// if in HLV(A) sourceID the same as HLV(B) sourceID and HLV(A) CAS is equal to HLV(B) CAS then the two HLV's are equal
 	if hlv.SourceID == otherVector.SourceID && hlv.Version == otherVector.Version {
 		return true
@@ -208,7 +239,7 @@ func (hlv *HybridLogicalVector) isEqual(otherVector HybridLogicalVector) bool {
 }
 
 // equalMergeVectors tests if two merge vectors between HLV's are equal or not
-func (hlv *HybridLogicalVector) equalMergeVectors(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) equalMergeVectors(otherVector DecodedHybridLogicalVector) bool {
 	if len(hlv.MergeVersions) != len(otherVector.MergeVersions) {
 		return false
 	}
@@ -221,7 +252,7 @@ func (hlv *HybridLogicalVector) equalMergeVectors(otherVector HybridLogicalVecto
 }
 
 // equalPreviousVectors tests if two previous versions vectors between two HLV's are equal or not
-func (hlv *HybridLogicalVector) equalPreviousVectors(otherVector HybridLogicalVector) bool {
+func (hlv *DecodedHybridLogicalVector) equalPreviousVectors(otherVector DecodedHybridLogicalVector) bool {
 	if len(hlv.PreviousVersions) != len(otherVector.PreviousVersions) {
 		return false
 	}
@@ -235,7 +266,7 @@ func (hlv *HybridLogicalVector) equalPreviousVectors(otherVector HybridLogicalVe
 
 // GetVersion returns the latest CAS value in the HLV for a given sourceID along with boolean value to
 // indicate if sourceID is found in the HLV, if the sourceID is not present in the HLV it will return 0 CAS value and false
-func (hlv *HybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
+func (hlv *DecodedHybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
 	if sourceID == "" {
 		return 0, false
 	}
@@ -248,6 +279,34 @@ func (hlv *HybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
 	}
 	if mvEntry := hlv.MergeVersions[sourceID]; mvEntry > latestVersion {
 		latestVersion = mvEntry
+	}
+	// if we have 0 cas value, there is no entry for this source ID in the HLV
+	if latestVersion == 0 {
+		return latestVersion, false
+	}
+	return latestVersion, true
+}
+
+// GetVersion returns the latest decoded CAS value in the HLV for a given sourceID
+func (hlv *HybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
+	if sourceID == "" {
+		return 0, false
+	}
+	var latestVersion uint64
+	if sourceID == hlv.SourceID {
+		latestVersion = base.HexCasToUint64(hlv.Version)
+	}
+	if pvEntry, ok := hlv.PreviousVersions[sourceID]; ok {
+		entry := base.HexCasToUint64(pvEntry)
+		if entry > latestVersion {
+			latestVersion = entry
+		}
+	}
+	if mvEntry, ok := hlv.MergeVersions[sourceID]; ok {
+		entry := base.HexCasToUint64(mvEntry)
+		if entry > latestVersion {
+			latestVersion = entry
+		}
 	}
 	// if we have 0 cas value, there is no entry for this source ID in the HLV
 	if latestVersion == 0 {
@@ -272,8 +331,15 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 		// Iterate through incoming vector previous versions, update with the version from other vector
 		// for source if the local version for that source is lower
 		for i, v := range otherVector.PreviousVersions {
-			if hlv.PreviousVersions[i] == 0 || hlv.PreviousVersions[i] < v {
+			if hlv.PreviousVersions[i] == "" {
 				hlv.setPreviousVersion(i, v)
+			} else {
+				// if we get here then there is entry for this source in PV so we must check if its newer or not
+				otherHLVPVValue := base.HexCasToUint64(v)
+				localHLVPVValue := base.HexCasToUint64(hlv.PreviousVersions[i])
+				if localHLVPVValue < otherHLVPVValue {
+					hlv.setPreviousVersion(i, v)
+				}
 			}
 		}
 	}
@@ -282,104 +348,6 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 		delete(hlv.PreviousVersions, hlv.SourceID)
 	}
 	return nil
-}
-
-func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
-
-	persistedHLV, err := hlv.convertHLVToPersistedFormat()
-	if err != nil {
-		return nil, err
-	}
-
-	return base.JSONMarshal(*persistedHLV)
-}
-
-func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
-	persistedJSON := PersistedHybridLogicalVector{}
-	err := base.JSONUnmarshal(inputjson, &persistedJSON)
-	if err != nil {
-		return err
-	}
-	// convert the data to in memory format
-	hlv.convertPersistedHLVToInMemoryHLV(persistedJSON)
-	return nil
-}
-
-func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridLogicalVector, error) {
-	persistedHLV := PersistedHybridLogicalVector{}
-	var cvCasByteArray []byte
-	var importCASBytes []byte
-	var vrsCasByteArray []byte
-	if hlv.CurrentVersionCAS != 0 {
-		cvCasByteArray = base.Uint64CASToLittleEndianHex(hlv.CurrentVersionCAS)
-	}
-	if hlv.ImportCAS != 0 {
-		importCASBytes = base.Uint64CASToLittleEndianHex(hlv.ImportCAS)
-	}
-	if hlv.Version != 0 {
-		vrsCasByteArray = base.Uint64CASToLittleEndianHex(hlv.Version)
-	}
-
-	pvPersistedFormat, err := convertMapToPersistedFormat(hlv.PreviousVersions)
-	if err != nil {
-		return nil, err
-	}
-	mvPersistedFormat, err := convertMapToPersistedFormat(hlv.MergeVersions)
-	if err != nil {
-		return nil, err
-	}
-
-	persistedHLV.CurrentVersionCAS = string(cvCasByteArray)
-	persistedHLV.ImportCAS = string(importCASBytes)
-	persistedHLV.SourceID = hlv.SourceID
-	persistedHLV.Version = string(vrsCasByteArray)
-	persistedHLV.PreviousVersions = pvPersistedFormat
-	persistedHLV.MergeVersions = mvPersistedFormat
-	return &persistedHLV, nil
-}
-
-func (hlv *HybridLogicalVector) convertPersistedHLVToInMemoryHLV(persistedJSON PersistedHybridLogicalVector) {
-	hlv.CurrentVersionCAS = base.HexCasToUint64(persistedJSON.CurrentVersionCAS)
-	if persistedJSON.ImportCAS != "" {
-		hlv.ImportCAS = base.HexCasToUint64(persistedJSON.ImportCAS)
-	}
-	hlv.SourceID = persistedJSON.SourceID
-	// convert the hex cas to uint64 cas
-	hlv.Version = base.HexCasToUint64(persistedJSON.Version)
-	// convert the maps form persisted format to the in memory format
-	hlv.PreviousVersions = convertMapToInMemoryFormat(persistedJSON.PreviousVersions)
-	hlv.MergeVersions = convertMapToInMemoryFormat(persistedJSON.MergeVersions)
-}
-
-// convertMapToPersistedFormat will convert in memory map of previous versions or merge versions into the persisted format map
-func convertMapToPersistedFormat(memoryMap map[string]uint64) (map[string]string, error) {
-	if memoryMap == nil {
-		return nil, nil
-	}
-	returnedMap := make(map[string]string)
-	var persistedCAS string
-	for source, cas := range memoryMap {
-		casByteArray := base.Uint64CASToLittleEndianHex(cas)
-		persistedCAS = string(casByteArray)
-		// remove the leading '0x' from the CAS value
-		persistedCAS = persistedCAS[2:]
-		returnedMap[source] = persistedCAS
-	}
-	return returnedMap, nil
-}
-
-// convertMapToInMemoryFormat will convert the persisted format map to an in memory format of that map.
-// Used for previous versions and merge versions maps on HLV
-func convertMapToInMemoryFormat(persistedMap map[string]string) map[string]uint64 {
-	if persistedMap == nil {
-		return nil
-	}
-	returnedMap := make(map[string]uint64)
-	// convert each CAS entry from little endian hex to Uint64
-	for key, value := range persistedMap {
-		returnedMap[key] = base.HexCasToUint64(value)
-	}
-	return returnedMap
 }
 
 // computeMacroExpansions returns the mutate in spec needed for the document update based off the outcome in updateHLV
@@ -400,9 +368,9 @@ func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansi
 }
 
 // setPreviousVersion will take a source/version pair and add it to the HLV previous versions map
-func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64) {
+func (hlv *HybridLogicalVector) setPreviousVersion(source string, version string) {
 	if hlv.PreviousVersions == nil {
-		hlv.PreviousVersions = make(map[string]uint64)
+		hlv.PreviousVersions = make(map[string]string)
 	}
 	hlv.PreviousVersions[source] = version
 }
@@ -441,6 +409,36 @@ func (hlv *HybridLogicalVector) toHistoryForHLV() string {
 		}
 	}
 	return s.String()
+}
+
+// ToDecodedHybridLogicalVector converts the little endian hex values of a HLV to uint64 values
+func (hlv *HybridLogicalVector) ToDecodedHybridLogicalVector() DecodedHybridLogicalVector {
+	var decodedVersion, decodedCVCAS, decodedImportCAS uint64
+	if hlv.Version != "" {
+		decodedVersion = base.HexCasToUint64(hlv.Version)
+	}
+	if hlv.ImportCAS != "" {
+		decodedImportCAS = base.HexCasToUint64(hlv.ImportCAS)
+	}
+	if hlv.CurrentVersionCAS != "" {
+		decodedCVCAS = base.HexCasToUint64(hlv.CurrentVersionCAS)
+	}
+	decodedHLV := DecodedHybridLogicalVector{
+		CurrentVersionCAS: decodedCVCAS,
+		Version:           decodedVersion,
+		ImportCAS:         decodedImportCAS,
+		SourceID:          hlv.SourceID,
+		PreviousVersions:  make(map[string]uint64, len(hlv.PreviousVersions)),
+		MergeVersions:     make(map[string]uint64, len(hlv.MergeVersions)),
+	}
+
+	for i, v := range hlv.PreviousVersions {
+		decodedHLV.PreviousVersions[i] = base.HexCasToUint64(v)
+	}
+	for i, v := range hlv.MergeVersions {
+		decodedHLV.MergeVersions[i] = base.HexCasToUint64(v)
+	}
+	return decodedHLV
 }
 
 // appendRevocationMacroExpansions adds macro expansions for the channel map.  Not strictly an HLV operation

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -115,7 +115,7 @@ type HybridLogicalVector struct {
 	CurrentVersionCAS string            `json:"cvCas,omitempty"`     // current version cas (or cvCAS) stores the current CAS in little endian hex format at the time of replication
 	ImportCAS         string            `json:"importCAS,omitempty"` // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
 	SourceID          string            `json:"src"`                 // source bucket uuid in (base64 encoded format) of where this entry originated from
-	Version           string            `json:"vrs"`                 // current cas in little endian hex format of the current version on the version vector
+	Version           string            `json:"ver"`                 // current cas in little endian hex format of the current version on the version vector
 	MergeVersions     map[string]string `json:"mv,omitempty"`        // map of merge versions for fast efficient lookup
 	PreviousVersions  map[string]string `json:"pv,omitempty"`        // map of previous versions for fast efficient lookup
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -377,14 +377,14 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansionSpec {
 	var outputSpec []sgbucket.MacroExpansionSpec
 	if hlv.Version == hlvExpandMacroCASValue {
-		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionPath(base.SyncXattrName), sgbucket.MacroCas)
+		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionPath(base.VvXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, spec)
 		// If version is being expanded, we need to also specify the macro expansion for the expanded rev property
 		currentRevSpec := sgbucket.NewMacroExpansionSpec(xattrCurrentRevVersionPath(base.SyncXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, currentRevSpec)
 	}
 	if hlv.CurrentVersionCAS == hlvExpandMacroCASValue {
-		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.SyncXattrName), sgbucket.MacroCas)
+		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.VvXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, spec)
 	}
 	return outputSpec

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -94,7 +94,19 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion SourceAndVersion) error {
 	if hlv.PreviousVersions == nil {
 		hlv.PreviousVersions = make(map[string]uint64)
 	}
-	hlv.PreviousVersions[hlv.SourceID] = hlv.Version
+	// we need to check if source ID already exists in PV, if so we need to ensure we are only updating with the
+	// sourceID-version pair if incoming version is greater than version already there
+	if currPVVersion, ok := hlv.PreviousVersions[hlv.SourceID]; ok {
+		// if we get here source ID exists in PV, only replace version if it is less than the incoming version
+		if currPVVersion < hlv.Version {
+			hlv.PreviousVersions[hlv.SourceID] = hlv.Version
+		} else {
+			return fmt.Errorf("local hlv has current source in previous versiosn with version greater than current version. Current CAS: %d, PV CAS %d", hlv.Version, currPVVersion)
+		}
+	} else {
+		// source doesn't exist in PV so add
+		hlv.PreviousVersions[hlv.SourceID] = hlv.Version
+	}
 	hlv.Version = newVersion.Version
 	hlv.SourceID = newVersion.SourceID
 	return nil
@@ -119,7 +131,7 @@ func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bo
 
 	// Grab the latest CAS version for HLV(A)'s sourceID in HLV(B), if HLV(A) version CAS is > HLV(B)'s then it is dominating
 	// If 0 CAS is returned then the sourceID does not exist on HLV(B)
-	if latestCAS := otherVector.GetVersion(hlv.SourceID); latestCAS != 0 && hlv.Version > latestCAS {
+	if latestCAS, found := otherVector.GetVersion(hlv.SourceID); found && hlv.Version > latestCAS {
 		return true
 	}
 	// HLV A is not dominating over HLV B
@@ -174,8 +186,12 @@ func (hlv *HybridLogicalVector) equalPreviousVectors(otherVector HybridLogicalVe
 	return true
 }
 
-// GetVersion returns the latest CAS value in the HLV for a given sourceID, if the sourceID is not present in the HLV it will return 0 CAS value
-func (hlv *HybridLogicalVector) GetVersion(sourceID string) uint64 {
+// GetVersion returns the latest CAS value in the HLV for a given sourceID along with boolean value to
+// indicate if sourceID is found in the HLV, if the sourceID is not present in the HLV it will return 0 CAS value and false
+func (hlv *HybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
+	if sourceID == "" {
+		return 0, false
+	}
 	var latestVersion uint64
 	if sourceID == hlv.SourceID {
 		latestVersion = hlv.Version
@@ -186,7 +202,39 @@ func (hlv *HybridLogicalVector) GetVersion(sourceID string) uint64 {
 	if mvEntry := hlv.MergeVersions[sourceID]; mvEntry > latestVersion {
 		latestVersion = mvEntry
 	}
-	return latestVersion
+	// if we have 0 cas value, there is no entry for this source ID in the HLV
+	if latestVersion == 0 {
+		return latestVersion, false
+	}
+	return latestVersion, true
+}
+
+// AddNewerVersions will take a hlv and add any newer source/version pairs found across CV and PV found in the other HLV taken as parameter
+// when both HLV
+func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector) error {
+
+	// create current version for incoming vector and attempt to add it to the local HLV, AddVersion will handle if attempting to add older
+	// version than local HLVs CV pair
+	otherVectorCV := SourceAndVersion{SourceID: otherVector.SourceID, Version: otherVector.Version}
+	err := hlv.AddVersion(otherVectorCV)
+	if err != nil {
+		return err
+	}
+
+	if otherVector.PreviousVersions != nil || len(otherVector.PreviousVersions) != 0 {
+		// Iterate through incoming vector previous versions, update with the version from other vector
+		// for source if the local version for that source is lower
+		for i, v := range otherVector.PreviousVersions {
+			if hlv.PreviousVersions[i] == 0 || hlv.PreviousVersions[i] < v {
+				hlv.setPreviousVersion(i, v)
+			}
+		}
+	}
+	// if current source exists in PV, delete it.
+	if _, ok := hlv.PreviousVersions[hlv.SourceID]; ok {
+		delete(hlv.PreviousVersions, hlv.SourceID)
+	}
+	return nil
 }
 
 func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
@@ -299,4 +347,12 @@ func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansi
 		outputSpec = append(outputSpec, spec)
 	}
 	return outputSpec
+}
+
+// setPreviousVersion will take a source/version pair and add it to the HLV previous versions map
+func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64) {
+	if hlv.PreviousVersions == nil {
+		hlv.PreviousVersions = make(map[string]uint64)
+	}
+	hlv.PreviousVersions[source] = version
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -442,3 +442,13 @@ func (hlv *HybridLogicalVector) toHistoryForHLV() string {
 	}
 	return s.String()
 }
+
+// appendRevocationMacroExpansions adds macro expansions for the channel map.  Not strictly an HLV operation
+// but putting the function here as it's required when the HLV's current version is being macro expanded
+func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, channelNames []string) (updatedSpec []sgbucket.MacroExpansionSpec) {
+	for _, channelName := range channelNames {
+		spec := sgbucket.NewMacroExpansionSpec(xattrRevokedChannelVersionPath(base.SyncXattrName, channelName), sgbucket.MacroCas)
+		currentSpec = append(currentSpec, spec)
+	}
+	return currentSpec
+}

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -30,8 +30,8 @@ type HybridLogicalVector struct {
 
 // SourceAndVersion is a structure used to add a new entry to a HLV
 type SourceAndVersion struct {
-	SourceID string
-	Version  uint64
+	SourceID string `json:"source_id"`
+	Version  uint64 `json:"version"`
 }
 
 func CreateVersion(source string, version uint64) SourceAndVersion {

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -21,22 +21,31 @@ const hlvExpandMacroCASValue = math.MaxUint64
 
 type HybridLogicalVector struct {
 	CurrentVersionCAS uint64            // current version cas (or cvCAS) stores the current CAS at the time of replication
+	ImportCAS         uint64            // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
 	SourceID          string            // source bucket uuid of where this entry originated from
 	Version           uint64            // current cas of the current version on the version vector
 	MergeVersions     map[string]uint64 // map of merge versions for fast efficient lookup
 	PreviousVersions  map[string]uint64 // map of previous versions for fast efficient lookup
 }
 
-// CurrentVersionVector is a structure used to add a new sourceID:CAS entry to a HLV
-type CurrentVersionVector struct {
-	VersionCAS uint64
-	SourceID   string
+// SourceAndVersion is a structure used to add a new entry to a HLV
+type SourceAndVersion struct {
+	SourceID string
+	Version  uint64
+}
+
+func CreateVersion(source string, version uint64) SourceAndVersion {
+	return SourceAndVersion{
+		SourceID: source,
+		Version:  version,
+	}
 }
 
 type PersistedHybridLogicalVector struct {
 	CurrentVersionCAS string            `json:"cvCas,omitempty"`
-	SourceID          string            `json:"src,omitempty"`
-	Version           string            `json:"vrs,omitempty"`
+	ImportCAS         string            `json:"importCAS,omitempty"`
+	SourceID          string            `json:"src"`
+	Version           string            `json:"vrs"`
 	MergeVersions     map[string]string `json:"mv,omitempty"`
 	PreviousVersions  map[string]string `json:"pv,omitempty"`
 }
@@ -66,19 +75,19 @@ func (hlv *HybridLogicalVector) IsInConflict(otherVector HybridLogicalVector) bo
 
 // AddVersion adds a version vector to the in memory representation of a HLV and moves current version vector to
 // previous versions on the HLV if needed
-func (hlv *HybridLogicalVector) AddVersion(newVersion CurrentVersionVector) error {
-	if newVersion.VersionCAS < hlv.Version {
-		return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %d new cas %d", hlv.Version, newVersion.VersionCAS)
+func (hlv *HybridLogicalVector) AddVersion(newVersion SourceAndVersion) error {
+	if newVersion.Version < hlv.Version {
+		return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %d new cas %d", hlv.Version, newVersion.Version)
 	}
 	// check if this is the first time we're adding a source - version pair
 	if hlv.SourceID == "" {
-		hlv.Version = newVersion.VersionCAS
+		hlv.Version = newVersion.Version
 		hlv.SourceID = newVersion.SourceID
 		return nil
 	}
 	// if new entry has the same source we simple just update the version
 	if newVersion.SourceID == hlv.SourceID {
-		hlv.Version = newVersion.VersionCAS
+		hlv.Version = newVersion.Version
 		return nil
 	}
 	// if we get here this is a new version from a different sourceID thus need to move current sourceID to previous versions and update current version
@@ -86,7 +95,7 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion CurrentVersionVector) erro
 		hlv.PreviousVersions = make(map[string]uint64)
 	}
 	hlv.PreviousVersions[hlv.SourceID] = hlv.Version
-	hlv.Version = newVersion.VersionCAS
+	hlv.Version = newVersion.Version
 	hlv.SourceID = newVersion.SourceID
 	return nil
 }
@@ -204,9 +213,13 @@ func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
 func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridLogicalVector, error) {
 	persistedHLV := PersistedHybridLogicalVector{}
 	var cvCasByteArray []byte
+	var importCASBytes []byte
 	var vrsCasByteArray []byte
 	if hlv.CurrentVersionCAS != 0 {
 		cvCasByteArray = base.Uint64CASToLittleEndianHex(hlv.CurrentVersionCAS)
+	}
+	if hlv.ImportCAS != 0 {
+		importCASBytes = base.Uint64CASToLittleEndianHex(hlv.ImportCAS)
 	}
 	if hlv.Version != 0 {
 		vrsCasByteArray = base.Uint64CASToLittleEndianHex(hlv.Version)
@@ -222,6 +235,7 @@ func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridL
 	}
 
 	persistedHLV.CurrentVersionCAS = string(cvCasByteArray)
+	persistedHLV.ImportCAS = string(importCASBytes)
 	persistedHLV.SourceID = hlv.SourceID
 	persistedHLV.Version = string(vrsCasByteArray)
 	persistedHLV.PreviousVersions = pvPersistedFormat
@@ -231,6 +245,9 @@ func (hlv *HybridLogicalVector) convertHLVToPersistedFormat() (*PersistedHybridL
 
 func (hlv *HybridLogicalVector) convertPersistedHLVToInMemoryHLV(persistedJSON PersistedHybridLogicalVector) {
 	hlv.CurrentVersionCAS = base.HexCasToUint64(persistedJSON.CurrentVersionCAS)
+	if persistedJSON.ImportCAS != "" {
+		hlv.ImportCAS = base.HexCasToUint64(persistedJSON.ImportCAS)
+	}
 	hlv.SourceID = persistedJSON.SourceID
 	// convert the hex cas to uint64 cas
 	hlv.Version = base.HexCasToUint64(persistedJSON.Version)

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -9,7 +9,6 @@
 package db
 
 import (
-	"context"
 	"reflect"
 	"strconv"
 	"strings"
@@ -300,7 +299,7 @@ func TestHLVImport(t *testing.T) {
 	otherSource := "otherSource"
 	hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_sync")
 	existingHLVKey := "existingHLV_" + t.Name()
-	_ = hlvHelper.insertWithHLV(ctx, existingHLVKey)
+	_ = hlvHelper.InsertWithHLV(ctx, existingHLVKey)
 
 	existingBody, existingXattrs, cas, err := collection.dataStore.GetWithXattrs(ctx, existingHLVKey, []string{base.SyncXattrName})
 	require.NoError(t, err)
@@ -319,47 +318,52 @@ func TestHLVImport(t *testing.T) {
 	require.Equal(t, otherSource, importedHLV.SourceID)
 }
 
-// HLVAgent performs HLV updates directly (not via SG) for simulating/testing interaction with non-SG HLV agents
-type HLVAgent struct {
-	t         *testing.T
-	datastore base.DataStore
-	source    string // All writes by the HLVHelper are done as this source
-	xattrName string // xattr name to store the HLV
-}
+// TestHLVMapToCBLString:
+//   - Purpose is to test the ability to extract from HLV maps in CBL replication format
+//   - Three test cases, both MV and PV defined, only PV defined and only MV defined
+//   - To protect against flake added some splitting of the result string in test case 1 as we cannot guarantee the
+//     order the string will be made in given map iteration is random
+func TestHLVMapToCBLString(t *testing.T) {
 
-var defaultHelperBody = map[string]interface{}{"version": 1}
-
-func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrName string) *HLVAgent {
-	return &HLVAgent{
-		t:         t,
-		datastore: datastore,
-		source:    source, // all writes by the HLVHelper are done as this source
-		xattrName: xattrName,
+	testCases := []struct {
+		name        string
+		inputHLV    []string
+		expectedStr string
+		both        bool
+	}{
+		{
+			name: "Both PV and mv",
+			inputHLV: []string{"cb06dc003846116d9b66d2ab23887a96@123456", "YZvBpEaztom9z5V/hDoeIw@1628620455135215600", "m_NqiIe0LekFPLeX4JvTO6Iw@1628620455139868700",
+				"m_LhRPsa7CpjEvP5zeXTXEBA@1628620455147864000"},
+			expectedStr: "0x1c008cd6ac059a16@TnFpSWUwTGVrRlBMZVg0SnZUTzZJdw==,0xc0ff05d7ac059a16@TGhSUHNhN0NwakV2UDV6ZVhUWEVCQQ==;0xf0ff44d6ac059a16@WVp2QnBFYXp0b205ejVWL2hEb2VJdw==",
+			both:        true,
+		},
+		{
+			name:        "Just PV",
+			inputHLV:    []string{"cb06dc003846116d9b66d2ab23887a96@123456", "YZvBpEaztom9z5V/hDoeIw@1628620455135215600"},
+			expectedStr: "0xf0ff44d6ac059a16@WVp2QnBFYXp0b205ejVWL2hEb2VJdw==",
+		},
+		{
+			name:        "Just MV",
+			inputHLV:    []string{"cb06dc003846116d9b66d2ab23887a96@123456", "m_NqiIe0LekFPLeX4JvTO6Iw@1628620455139868700"},
+			expectedStr: "0x1c008cd6ac059a16@TnFpSWUwTGVrRlBMZVg0SnZUTzZJdw==",
+		},
 	}
-}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			hlv := createHLVForTest(t, test.inputHLV)
+			historyStr := hlv.toHistoryForHLV()
 
-// insertWithHLV inserts a new document into the bucket with a populated HLV (matching a write from
-// a different HLV-aware peer)
-func (h *HLVAgent) insertWithHLV(ctx context.Context, key string) (casOut uint64) {
-	hlv := &HybridLogicalVector{}
-	err := hlv.AddVersion(CreateVersion(h.source, hlvExpandMacroCASValue))
-	require.NoError(h.t, err)
-	hlv.CurrentVersionCAS = hlvExpandMacroCASValue
-
-	syncData := &SyncData{HLV: hlv}
-	syncDataBytes, err := base.JSONMarshal(syncData)
-	require.NoError(h.t, err)
-
-	mutateInOpts := &sgbucket.MutateInOptions{
-		MacroExpansion: hlv.computeMacroExpansions(),
+			if test.both {
+				initial := strings.Split(historyStr, ";")
+				mvSide := strings.Split(initial[0], ",")
+				assert.Contains(t, test.expectedStr, initial[1])
+				for _, v := range mvSide {
+					assert.Contains(t, test.expectedStr, v)
+				}
+			} else {
+				assert.Equal(t, test.expectedStr, historyStr)
+			}
+		})
 	}
-
-	docBody := base.MustJSONMarshal(h.t, defaultHelperBody)
-	xattrData := map[string][]byte{
-		h.xattrName: syncDataBytes,
-	}
-
-	cas, err := h.datastore.WriteWithXattrs(ctx, key, 0, 0, docBody, xattrData, mutateInOpts)
-	require.NoError(h.t, err)
-	return cas
 }

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -332,7 +332,7 @@ func TestHLVMapToCBLString(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			hlv := createHLVForTest(t, test.inputHLV)
-			historyStr := hlv.toHistoryForHLV()
+			historyStr := hlv.ToHistoryForHLV()
 
 			if test.both {
 				initial := strings.Split(historyStr, ";")

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -26,19 +26,19 @@ import (
 //   - Tests methods GetCurrentVersion, AddVersion and Remove
 func TestInternalHLVFunctions(t *testing.T) {
 	pv := make(map[string]string)
-	currSourceId := base64.StdEncoding.EncodeToString([]byte("5pRi8Piv1yLcLJ1iVNJIsA"))
-	currVersion := string(base.Uint64CASToLittleEndianHex(12345678))
-	pv[base64.StdEncoding.EncodeToString([]byte("YZvBpEaztom9z5V/hDoeIw"))] = string(base.Uint64CASToLittleEndianHex(64463204720))
+	currSourceId := EncodeSource("5pRi8Piv1yLcLJ1iVNJIsA")
+	currVersion := EncodeValue(12345678)
+	pv[EncodeSource("YZvBpEaztom9z5V/hDoeIw")] = EncodeValue(64463204720)
 
 	inputHLV := []string{"5pRi8Piv1yLcLJ1iVNJIsA@12345678", "YZvBpEaztom9z5V/hDoeIw@64463204720", "m_NqiIe0LekFPLeX4JvTO6Iw@345454"}
 	hlv := createHLVForTest(t, inputHLV)
 
-	newCAS := string(base.Uint64CASToLittleEndianHex(123456789))
+	newCAS := EncodeValue(123456789)
 	const newSource = "s_testsource"
 
 	// create a new version vector entry that will error method AddVersion
 	badNewVector := Version{
-		Value:    string(base.Uint64CASToLittleEndianHex(123345)),
+		Value:    EncodeValue(123345),
 		SourceID: currSourceId,
 	}
 	// create a new version vector entry that should be added to HLV successfully
@@ -78,7 +78,7 @@ func TestInternalHLVFunctions(t *testing.T) {
 }
 
 // TestConflictDetectionDominating:
-//   - Tests two cases where one HLV's is said to be 'dominating' over another and thus not in conflict
+//   - Tests cases where one HLV's is said to be 'dominating' over another
 //   - Test case 1: where sourceID is the same between HLV's but HLV(A) has higher version CAS than HLV(B) thus A dominates
 //   - Test case 2: where sourceID is different and HLV(A) sourceID is present in HLV(B) PV and HLV(A) has dominating version
 //   - Test case 3: where sourceID is different and HLV(A) sourceID is present in HLV(B) MV and HLV(A) has dominating version
@@ -86,39 +86,71 @@ func TestInternalHLVFunctions(t *testing.T) {
 //   - Assert that all scenarios returns false from IsInConflict method, as we have a HLV that is dominating in each case
 func TestConflictDetectionDominating(t *testing.T) {
 	testCases := []struct {
-		name          string
-		inputListHLVA []string
-		inputListHLVB []string
+		name           string
+		inputListHLVA  []string
+		inputListHLVB  []string
+		expectedResult bool
 	}{
 		{
-			name:          "Test case 1",
-			inputListHLVA: []string{"cluster1@20", "cluster2@2"},
-			inputListHLVB: []string{"cluster1@10", "cluster2@1"},
+			name:           "Matching current source, newer version",
+			inputListHLVA:  []string{"cluster1@20", "cluster2@2"},
+			inputListHLVB:  []string{"cluster1@10", "cluster2@1"},
+			expectedResult: true,
+		}, {
+			name:           "Matching current source and version",
+			inputListHLVA:  []string{"cluster1@20", "cluster2@2"},
+			inputListHLVB:  []string{"cluster1@20", "cluster2@1"},
+			expectedResult: true,
 		},
 		{
-			name:          "Test case 2",
-			inputListHLVA: []string{"cluster1@20", "cluster3@3"},
-			inputListHLVB: []string{"cluster2@10", "cluster1@15"},
+			name:           "B CV found in A's PV",
+			inputListHLVA:  []string{"cluster1@20", "cluster2@10"},
+			inputListHLVB:  []string{"cluster2@10", "cluster1@15"},
+			expectedResult: true,
 		},
 		{
-			name:          "Test case 3",
-			inputListHLVA: []string{"cluster1@20", "cluster3@3"},
-			inputListHLVB: []string{"cluster2@10", "m_cluster1@12", "m_cluster2@11"},
+			name:           "B CV older than A's PV for same source",
+			inputListHLVA:  []string{"cluster1@20", "cluster2@10"},
+			inputListHLVB:  []string{"cluster2@10", "cluster1@15"},
+			expectedResult: true,
 		},
 		{
-			name:          "Test case 4",
-			inputListHLVA: []string{"cluster2@10", "cluster1@15"},
-
-			inputListHLVB: []string{"cluster1@20", "cluster3@3"},
+			name:           "Unique sources in A",
+			inputListHLVA:  []string{"cluster1@20", "cluster2@15", "cluster3@3"},
+			inputListHLVB:  []string{"cluster2@10", "cluster1@10"},
+			expectedResult: true,
+		},
+		{
+			name:           "Unique sources in B",
+			inputListHLVA:  []string{"cluster1@20"},
+			inputListHLVB:  []string{"cluster1@15", "cluster3@3"},
+			expectedResult: true,
+		},
+		{
+			name:           "B has newer cv",
+			inputListHLVA:  []string{"cluster1@10"},
+			inputListHLVB:  []string{"cluster1@15"},
+			expectedResult: false,
+		},
+		{
+			name:           "B has newer cv than A pv",
+			inputListHLVA:  []string{"cluster2@20", "cluster1@10"},
+			inputListHLVB:  []string{"cluster1@15", "cluster2@20"},
+			expectedResult: false,
+		},
+		{
+			name:           "B's cv not found in A",
+			inputListHLVA:  []string{"cluster2@20", "cluster1@10"},
+			inputListHLVB:  []string{"cluster3@5"},
+			expectedResult: false,
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			hlvA := createHLVForTest(t, testCase.inputListHLVA)
 			hlvB := createHLVForTest(t, testCase.inputListHLVB)
-			decHLVA := hlvA.ToDecodedHybridLogicalVector()
-			decHLVB := hlvB.ToDecodedHybridLogicalVector()
-			require.False(t, decHLVA.IsInConflict(decHLVB))
+			require.True(t, hlvA.isDominating(hlvB) == testCase.expectedResult)
+
 		})
 	}
 }
@@ -163,21 +195,6 @@ func TestConflictEqualHLV(t *testing.T) {
 	require.False(t, decHLVA.isEqual(decHLVB))
 }
 
-// TestConflictExample:
-//   - Takes example conflict scenario from PRD to see if we correctly identify conflict in that scenario
-//   - Creates two HLV's similar to ones in example and calls IsInConflict to assert it returns true
-func TestConflictExample(t *testing.T) {
-	input := []string{"cluster1@11", "cluster3@2", "cluster2@4"}
-	inMemoryHLV := createHLVForTest(t, input)
-
-	input = []string{"cluster2@2", "cluster3@3"}
-	otherVector := createHLVForTest(t, input)
-
-	inMemoryHLVDec := inMemoryHLV.ToDecodedHybridLogicalVector()
-	otherVectorDec := otherVector.ToDecodedHybridLogicalVector()
-	require.True(t, inMemoryHLVDec.IsInConflict(otherVectorDec))
-}
-
 // createHLVForTest is a helper function to create a HLV for use in a test. Takes a list of strings in the format of <sourceID@version> and assumes
 // first entry is current version. For merge version entries you must specify 'm_' as a prefix to sourceID NOTE: it also sets cvCAS to the current version
 func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
@@ -186,25 +203,25 @@ func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
 	// first element will be current version and source pair
 	currentVersionPair := strings.Split(inputList[0], "@")
 	hlvOutput.SourceID = base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0]))
-	version, err := strconv.ParseUint(currentVersionPair[1], 10, 64)
+	value, err := strconv.ParseUint(currentVersionPair[1], 10, 64)
 	require.NoError(tb, err)
-	vrsEncoded := string(base.Uint64CASToLittleEndianHex(version))
+	vrsEncoded := EncodeValue(value)
 	hlvOutput.Version = vrsEncoded
 	hlvOutput.CurrentVersionCAS = vrsEncoded
 
 	// remove current version entry in list now we have parsed it into the HLV
 	inputList = inputList[1:]
 
-	for _, value := range inputList {
-		currentVersionPair = strings.Split(value, "@")
-		version, err = strconv.ParseUint(currentVersionPair[1], 10, 64)
+	for _, version := range inputList {
+		currentVersionPair = strings.Split(version, "@")
+		value, err = strconv.ParseUint(currentVersionPair[1], 10, 64)
 		require.NoError(tb, err)
 		if strings.HasPrefix(currentVersionPair[0], "m_") {
 			// add entry to merge version removing the leading prefix for sourceID
-			hlvOutput.MergeVersions[base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0][2:]))] = string(base.Uint64CASToLittleEndianHex(version))
+			hlvOutput.MergeVersions[EncodeSource(currentVersionPair[0][2:])] = EncodeValue(value)
 		} else {
 			// if it's not got the prefix we assume it's a previous version entry
-			hlvOutput.PreviousVersions[base64.StdEncoding.EncodeToString([]byte(currentVersionPair[0]))] = string(base.Uint64CASToLittleEndianHex(version))
+			hlvOutput.PreviousVersions[EncodeSource(currentVersionPair[0])] = EncodeValue(value)
 		}
 	}
 	return hlvOutput
@@ -283,7 +300,7 @@ func TestHLVImport(t *testing.T) {
 	existingBody, existingXattrs, cas, err := collection.dataStore.GetWithXattrs(ctx, existingHLVKey, []string{base.SyncXattrName})
 	require.NoError(t, err)
 	existingXattr := existingXattrs[base.SyncXattrName]
-	encodedCAS = string(base.Uint64CASToLittleEndianHex(cas))
+	encodedCAS = EncodeValue(cas)
 
 	_, err = collection.ImportDocRaw(ctx, existingHLVKey, existingBody, existingXattr, nil, false, cas, nil, ImportFromFeed)
 	require.NoError(t, err, "import error")
@@ -346,4 +363,143 @@ func TestHLVMapToCBLString(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestInvalidHLVOverChangesMessage:
+//   - Test hlv string that has too many sections to it (parts delimited by ;)
+//   - Test hlv string that is empty
+//   - Assert that extractHLVFromBlipMessage will return error in both cases
+func TestInvalidHLVInBlipMessageForm(t *testing.T) {
+	hlvStr := "25@def; 22@def,21@eff; 20@abc,18@hij; 222@hiowdwdew, 5555@dhsajidfgd"
+
+	hlv, err := extractHLVFromBlipMessage(hlvStr)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid hlv in changes message received")
+	assert.Equal(t, HybridLogicalVector{}, hlv)
+
+	hlvStr = ""
+	hlv, err = extractHLVFromBlipMessage(hlvStr)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid hlv in changes message received")
+	assert.Equal(t, HybridLogicalVector{}, hlv)
+}
+
+var extractHLVFromBlipMsgBMarkCases = []struct {
+	name             string
+	hlvString        string
+	expectedHLV      []string
+	mergeVersions    bool
+	previousVersions bool
+}{
+	{
+		name:             "mv and pv, leading spaces",                                                                                                                                                         // with spaces
+		hlvString:        "25@def; 22@def, 21@eff, 500@x, 501@xx, 4000@xxx, 700@y, 701@yy, 702@yyy; 20@abc, 18@hij, 3@x, 4@xx, 5@xxx, 6@xxxx, 7@xxxxx, 3@y, 4@yy, 5@yyy, 6@yyyy, 7@yyyyy, 2@xy, 3@xyy, 4@xxy", // 15 pv 8 mv
+		expectedHLV:      []string{"def@25", "abc@20", "hij@18", "x@3", "xx@4", "xxx@5", "xxxx@6", "xxxxx@7", "y@3", "yy@4", "yyy@5", "yyyy@6", "yyyyy@7", "xy@2", "xyy@3", "xxy@4", "m_def@22", "m_eff@21", "m_x@500", "m_xx@501", "m_xxx@4000", "m_y@700", "m_yy@701", "m_yyy@702"},
+		previousVersions: true,
+		mergeVersions:    true,
+	},
+	{
+		name:             "mv and pv, no spaces",                                                                                                                                       // without spaces
+		hlvString:        "25@def;22@def,21@eff,500@x,501@xx,4000@xxx,700@y,701@yy,702@yyy;20@abc,18@hij,3@x,4@xx,5@xxx,6@xxxx,7@xxxxx,3@y,4@yy,5@yyy,6@yyyy,7@yyyyy,2@xy,3@xyy,4@xxy", // 15 pv 8 mv
+		expectedHLV:      []string{"def@25", "abc@20", "hij@18", "x@3", "xx@4", "xxx@5", "xxxx@6", "xxxxx@7", "y@3", "yy@4", "yyy@5", "yyyy@6", "yyyyy@7", "xy@2", "xyy@3", "xxy@4", "m_def@22", "m_eff@21", "m_x@500", "m_xx@501", "m_xxx@4000", "m_y@700", "m_yy@701", "m_yyy@702"},
+		previousVersions: true,
+		mergeVersions:    true,
+	},
+	{
+		name:             "pv only",
+		hlvString:        "25@def; 20@abc,18@hij",
+		expectedHLV:      []string{"def@25", "abc@20", "hij@18"},
+		previousVersions: true,
+	},
+	{
+		name:             "mv and pv, mixed spacing",
+		hlvString:        "25@def; 22@def,21@eff; 20@abc,18@hij,3@x,4@xx,5@xxx,6@xxxx,7@xxxxx,3@y,4@yy,5@yyy,6@yyyy,7@yyyyy,2@xy,3@xyy,4@xxy", // 15
+		expectedHLV:      []string{"def@25", "abc@20", "hij@18", "x@3", "xx@4", "xxx@5", "xxxx@6", "xxxxx@7", "y@3", "yy@4", "yyy@5", "yyyy@6", "yyyyy@7", "xy@2", "xyy@3", "xxy@4", "m_def@22", "m_eff@21"},
+		mergeVersions:    true,
+		previousVersions: true,
+	},
+	{
+		name:        "cv only",
+		hlvString:   "24@def",
+		expectedHLV: []string{"def@24"},
+	},
+	{
+		name:             "cv and mv,base64 encoded",
+		hlvString:        "1@Hell0CA; 1@1Hr0k43xS662TToxODDAxQ",
+		expectedHLV:      []string{"Hell0CA@1", "1Hr0k43xS662TToxODDAxQ@1"},
+		previousVersions: true,
+	},
+	{
+		name:             "cv and mv - small",
+		hlvString:        "25@def; 22@def,21@eff; 20@abc,18@hij",
+		expectedHLV:      []string{"def@25", "abc@20", "hij@18", "m_def@22", "m_eff@21"},
+		mergeVersions:    true,
+		previousVersions: true,
+	},
+}
+
+// TestExtractHLVFromChangesMessage:
+//   - Test case 1: CV entry and 1 PV entry
+//   - Test case 2: CV entry and 2 PV entries
+//   - Test case 3: CV entry, 2 MV entries and 2 PV entries
+//   - Test case 4: just CV entry
+//   - Each test case gets run through extractHLVFromBlipMessage and assert that the resulting HLV
+//     is correct to what is expected
+func TestExtractHLVFromChangesMessage(t *testing.T) {
+	for _, test := range extractHLVFromBlipMsgBMarkCases {
+		t.Run(test.name, func(t *testing.T) {
+			expectedVector := createHLVForTest(t, test.expectedHLV)
+
+			// TODO: When CBG-3662 is done, should be able to simplify base64 handling to treat source as a string
+			//       that may represent a base64 encoding
+			base64EncodedHlvString := cblEncodeTestSources(test.hlvString)
+			hlv, err := extractHLVFromBlipMessage(base64EncodedHlvString)
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedVector.SourceID, hlv.SourceID)
+			assert.Equal(t, expectedVector.Version, hlv.Version)
+			if test.previousVersions {
+				assert.True(t, reflect.DeepEqual(expectedVector.PreviousVersions, hlv.PreviousVersions))
+			}
+			if test.mergeVersions {
+				assert.True(t, reflect.DeepEqual(expectedVector.MergeVersions, hlv.MergeVersions))
+			}
+		})
+	}
+}
+
+func BenchmarkExtractHLVFromBlipMessage(b *testing.B) {
+	for _, bm := range extractHLVFromBlipMsgBMarkCases {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = extractHLVFromBlipMessage(bm.hlvString)
+			}
+		})
+	}
+}
+
+// cblEncodeTestSources converts the simplified versions in test data to CBL-style encoding
+func cblEncodeTestSources(hlvString string) (base64HLVString string) {
+
+	vectorFields := strings.Split(hlvString, ";")
+	vectorLength := len(vectorFields)
+	if vectorLength == 0 {
+		return hlvString
+	}
+
+	// first vector field is single vector, cv
+	base64HLVString += EncodeTestVersion(vectorFields[0])
+	for _, field := range vectorFields[1:] {
+		base64HLVString += ";"
+		versions := strings.Split(field, ",")
+		if len(versions) == 0 {
+			continue
+		}
+		base64HLVString += EncodeTestVersion(versions[0])
+		for _, version := range versions[1:] {
+			base64HLVString += ","
+			base64HLVString += EncodeTestVersion(version)
+		}
+	}
+	return base64HLVString
 }

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -37,13 +37,13 @@ func TestInternalHLVFunctions(t *testing.T) {
 	const newSource = "s_testsource"
 
 	// create a new version vector entry that will error method AddVersion
-	badNewVector := SourceAndVersion{
-		Version:  123345,
+	badNewVector := Version{
+		Value:    123345,
 		SourceID: currSourceId,
 	}
 	// create a new version vector entry that should be added to HLV successfully
-	newVersionVector := SourceAndVersion{
-		Version:  newCAS,
+	newVersionVector := Version{
+		Value:    newCAS,
 		SourceID: currSourceId,
 	}
 

--- a/db/import.go
+++ b/db/import.go
@@ -148,7 +148,8 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		existingDoc.Expiry = *expiry
 	}
 
-	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, mutationOptions, existingDoc, true, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	docUpdateEvent := Import
+	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, mutationOptions, docUpdateEvent, existingDoc, true, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.
 		if doc.Cas != existingDoc.Cas {

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -426,14 +426,13 @@ func TestImportNullDocRaw(t *testing.T) {
 
 func assertXattrSyncMetaRevGeneration(t *testing.T, dataStore base.DataStore, key string, expectedRevGeneration int) {
 	_, xattrs, _, err := dataStore.GetWithXattrs(base.TestCtx(t), key, []string{base.SyncXattrName})
-	assert.NoError(t, err, "Error Getting Xattr")
+	require.NoError(t, err, "Error Getting Xattr")
 	require.Contains(t, xattrs, base.SyncXattrName)
-	var xattr map[string]any
-	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &xattr))
-	revision, ok := xattr["rev"]
-	assert.True(t, ok)
-	generation, _ := ParseRevID(base.TestCtx(t), revision.(string))
-	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, revision)
+	var syncData SyncData
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
+	require.True(t, syncData.CurrentRev != "")
+	generation, _ := ParseRevID(base.TestCtx(t), syncData.CurrentRev)
+	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, syncData.CurrentRev)
 	assert.True(t, generation == expectedRevGeneration)
 }
 

--- a/db/query.go
+++ b/db/query.go
@@ -154,12 +154,12 @@ var QuerySequences = SGQuery{
 }
 
 type QueryChannelsRow struct {
-	Id         string        `json:"id,omitempty"`
-	Rev        RevAndVersion `json:"rev,omitempty"`
-	Sequence   uint64        `json:"seq,omitempty"`
-	Flags      uint8         `json:"flags,omitempty"`
-	RemovalRev string        `json:"rRev,omitempty"`
-	RemovalDel bool          `json:"rDel,omitempty"`
+	Id         string                  `json:"id,omitempty"`
+	Rev        channels.RevAndVersion  `json:"rev,omitempty"`
+	Sequence   uint64                  `json:"seq,omitempty"`
+	Flags      uint8                   `json:"flags,omitempty"`
+	RemovalRev *channels.RevAndVersion `json:"rRev,omitempty"`
+	RemovalDel bool                    `json:"rDel,omitempty"`
 }
 
 var QueryPrincipals = SGQuery{
@@ -688,17 +688,17 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 type AllDocsViewQueryRow struct {
 	Key   string
 	Value struct {
-		RevID    RevAndVersion `json:"r"`
-		Sequence uint64        `json:"s"`
-		Channels []string      `json:"c"`
+		RevID    channels.RevAndVersion `json:"r"`
+		Sequence uint64                 `json:"s"`
+		Channels []string               `json:"c"`
 	}
 }
 
 type AllDocsIndexQueryRow struct {
 	Id       string
-	RevID    RevAndVersion       `json:"r"`
-	Sequence uint64              `json:"s"`
-	Channels channels.ChannelMap `json:"c"`
+	RevID    channels.RevAndVersion `json:"r"`
+	Sequence uint64                 `json:"s"`
+	Channels channels.ChannelMap    `json:"c"`
 }
 
 // AllDocs returns all non-deleted documents in the bucket between startKey and endKey

--- a/db/query.go
+++ b/db/query.go
@@ -154,12 +154,12 @@ var QuerySequences = SGQuery{
 }
 
 type QueryChannelsRow struct {
-	Id         string `json:"id,omitempty"`
-	Rev        string `json:"rev,omitempty"`
-	Sequence   uint64 `json:"seq,omitempty"`
-	Flags      uint8  `json:"flags,omitempty"`
-	RemovalRev string `json:"rRev,omitempty"`
-	RemovalDel bool   `json:"rDel,omitempty"`
+	Id         string        `json:"id,omitempty"`
+	Rev        RevAndVersion `json:"rev,omitempty"`
+	Sequence   uint64        `json:"seq,omitempty"`
+	Flags      uint8         `json:"flags,omitempty"`
+	RemovalRev string        `json:"rRev,omitempty"`
+	RemovalDel bool          `json:"rDel,omitempty"`
 }
 
 var QueryPrincipals = SGQuery{
@@ -688,15 +688,15 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 type AllDocsViewQueryRow struct {
 	Key   string
 	Value struct {
-		RevID    string   `json:"r"`
-		Sequence uint64   `json:"s"`
-		Channels []string `json:"c"`
+		RevID    RevAndVersion `json:"r"`
+		Sequence uint64        `json:"s"`
+		Channels []string      `json:"c"`
 	}
 }
 
 type AllDocsIndexQueryRow struct {
 	Id       string
-	RevID    string              `json:"r"`
+	RevID    RevAndVersion       `json:"r"`
 	Sequence uint64              `json:"s"`
 	Channels channels.ChannelMap `json:"c"`
 }

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -372,7 +372,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create 10 added documents
 	for i := 1; i <= 10; i++ {
 		id := "created" + strconv.Itoa(i)
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "1-a", revId)
 		docIdFlagMap[doc.ID] = uint8(0x0)
@@ -385,12 +385,12 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create 10 deleted documents
 	for i := 1; i <= 10; i++ {
 		id := "deleted" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "1-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "2-a", revId, "Couldn't create tombstone revision")
 
@@ -402,22 +402,22 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
@@ -429,27 +429,27 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched|deleted" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
 		body[BodyDeleted] = true
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"3-a", "2-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
 		body[BodyDeleted] = true
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-b", "2-b"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"3-b", "2-b"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-b", revId, "Couldn't create tombstone revision")
 
@@ -461,17 +461,17 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		body["sound"] = "meow"
 		id := "branched|conflict" + strconv.Itoa(i)
-		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false)
+		_, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create document revision 1-a")
 		require.Equal(t, "1-a", revId)
 
 		body["sound"] = "bark"
-		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false)
+		_, revId, err = collection.PutExistingRevWithBody(ctx, id, body, []string{"2-b", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-b")
 		require.Equal(t, "2-b", revId)
 
 		body["sound"] = "bleat"
-		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false)
+		doc, revId, err := collection.PutExistingRevWithBody(ctx, id, body, []string{"2-a", "1-a"}, false, ExistingVersionWithUpdateToHLV)
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -30,8 +30,8 @@ func NewBypassRevisionCache(backingStore RevisionCacheBackingStore, bypassStat *
 	}
 }
 
-// Get fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (docRev DocumentRevision, err error) {
+// GetWithRev fetches the revision for the given docID and revID immediately from the bucket.
+func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
@@ -45,7 +45,33 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, inc
 	docRev = DocumentRevision{
 		RevID: revID,
 	}
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, revID)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.CV, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, revID)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	rc.bypassStat.Add(1)
+
+	return docRev, nil
+}
+
+// GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+
+	unmarshalLevel := DocUnmarshalSync
+	if includeBody {
+		unmarshalLevel = DocUnmarshalAll
+	}
+	docRev = DocumentRevision{
+		CV: cv,
+	}
+
+	doc, err := rc.backingStore.GetDocument(ctx, docID, unmarshalLevel)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, err = revCacheLoaderForDocumentCV(ctx, rc.backingStore, doc, *cv)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -71,7 +97,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, incl
 		RevID: doc.CurrentRev,
 	}
 
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, doc.SyncData.CurrentRev)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.CV, err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -96,7 +122,11 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Remove(docID, revID string) {
+func (rc *BypassRevisionCache) RemoveWithRev(docID, revID string) {
+	// nop
+}
+
+func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
 	// nop
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -146,3 +146,8 @@ func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *Version) {
 func (rc *BypassRevisionCache) UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta) {
 	// no-op
 }
+
+// UpdateDeltaCV is a no-op for a BypassRevisionCache
+func (rc *BypassRevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, toDelta RevisionDelta) {
+	// no-op
+}

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -52,7 +52,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.toHistoryForHLV()
+		docRev.hlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)
@@ -80,7 +80,7 @@ func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.toHistoryForHLV()
+		docRev.hlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)
@@ -111,7 +111,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, incl
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.toHistoryForHLV()
+		docRev.hlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -56,7 +56,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 }
 
 // GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
@@ -126,7 +126,7 @@ func (rc *BypassRevisionCache) RemoveWithRev(docID, revID string) {
 	// nop
 }
 
-func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	// nop
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -56,7 +56,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 }
 
 // GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 
 	unmarshalLevel := DocUnmarshalSync
 	if includeBody {
@@ -126,7 +126,7 @@ func (rc *BypassRevisionCache) RemoveWithRev(docID, revID string) {
 	// nop
 }
 
-func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
+func (rc *BypassRevisionCache) RemoveWithCV(docID string, cv *Version) {
 	// nop
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -244,14 +244,14 @@ type IDandCV struct {
 
 // RevisionDelta stores data about a delta between a revision and ToRevID.
 type RevisionDelta struct {
-	ToRevID               string // Target revID for the delta
-	ToCV                  string
+	ToRevID               string                  // Target revID for the delta
+	ToCV                  string                  // Target CV for the delta
 	DeltaBytes            []byte                  // The actual delta
 	AttachmentStorageMeta []AttachmentStorageMeta // Storage metadata of all attachments present on ToRevID
 	ToChannels            base.Set                // Full list of channels for the to revision
 	RevisionHistory       []string                // Revision history from parent of ToRevID to source revID, in descending order
-	HlvHistory            string
-	ToDeleted             bool // Flag if ToRevID is a tombstone
+	HlvHistory            string                  // HLV History in CBL format
+	ToDeleted             bool                    // Flag if ToRevID is a tombstone
 }
 
 func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -332,7 +332,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
 		// TODO: CBG-3814 - pending support of channel removal for CV
-		base.ErrorfCtx(ctx, "pending CBG-3213 support of channel removal for CV: %v", err)
+		base.ErrorfCtx(ctx, "pending CBG-3814 support of channel removal for CV: %v", err)
 	}
 
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -28,10 +28,15 @@ const (
 
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
-	// Get returns the given revision, and stores if not already cached.
+	// GetWithRev returns the given revision, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (DocumentRevision, error)
+	GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (DocumentRevision, error)
+
+	// GetWithCV returns the given revision by CV, and stores if not already cached.
+	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
+	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
+	GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
@@ -46,8 +51,11 @@ type RevisionCache interface {
 	// Update will remove existing value and re-create new one
 	Upsert(ctx context.Context, docRev DocumentRevision)
 
-	// Remove eliminates a revision in the cache.
-	Remove(docID, revID string)
+	// RemoveWithRev evicts a revision from the cache using its revID.
+	RemoveWithRev(docID, revID string)
+
+	// RemoveWithCV evicts a revision from the cache using its current version.
+	RemoveWithCV(docID string, cv *CurrentVersionVector)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)
@@ -104,6 +112,7 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 type RevisionCacheBackingStore interface {
 	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
 	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error)
+	getCurrentVersion(ctx context.Context, doc *Document) ([]byte, Body, AttachmentsMeta, error)
 }
 
 // DocumentRevision stored and returned by the rev cache
@@ -119,6 +128,7 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
+	CV          *CurrentVersionVector
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
@@ -223,6 +233,12 @@ type IDAndRev struct {
 	RevID string
 }
 
+type IDandCV struct {
+	DocID   string
+	Version uint64
+	Source  string
+}
+
 // RevisionDelta stores data about a delta between a revision and ToRevID.
 type RevisionDelta struct {
 	ToRevID               string                  // Target revID for the delta
@@ -246,44 +262,104 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *CurrentVersionVector, err error) {
 	var doc *Document
 	unmarshalLevel := DocUnmarshalSync
 	if unmarshalBody {
 		unmarshalLevel = DocUnmarshalAll
 	}
 	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
-		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, err
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, fetchedCV, err
 	}
 
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
+// revCacheLoaderForCv will load a document from the bucket using the CV, comapre the fetched doc and the CV specified in the function,
+// and will still return revid for purpose of populating the Rev ID lookup map on the cache
+func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+	cv := CurrentVersionVector{
+		VersionCAS: id.Version,
+		SourceID:   id.Source,
+	}
+	var doc *Document
+	unmarshalLevel := DocUnmarshalSync
+	if unmarshalBody {
+		unmarshalLevel = DocUnmarshalAll
+	}
+	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, revid, err
+	}
+
+	return revCacheLoaderForDocumentCV(ctx, backingStore, doc, cv)
+}
+
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *CurrentVersionVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
 		if isRemovalErr != nil {
-			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
+			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, fetchedCV, isRemovalErr
 		}
 
 		if isRemoval {
-			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
+			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, fetchedCV, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
-			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, err
+			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, fetchedCV, err
 		}
 	}
 	deleted = doc.History[revid].Deleted
 
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
-		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
+		return bodyBytes, body, history, channels, removed, nil, deleted, nil, fetchedCV, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
+	if doc.HLV != nil {
+		fetchedCV = &CurrentVersionVector{SourceID: doc.HLV.SourceID, VersionCAS: doc.HLV.Version}
+	}
 
-	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, fetchedCV, err
+}
+
+// revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
+func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv CurrentVersionVector) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
+		// we need implementation of IsChannelRemoval for CV here.
+		// pending CBG-3213 support of channel removal for CV
+	}
+
+	if err = doc.HasCurrentVersion(cv); err != nil {
+		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+	}
+	channels = doc.currentRevChannels
+	revid = doc.CurrentRev
+
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+}
+
+func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {
+	bodyBytes, err = doc.BodyBytes(ctx)
+	if err != nil {
+		base.WarnfCtx(ctx, "Marshal error when retrieving active current version body: %v", err)
+		return nil, nil, nil, err
+	}
+
+	body = doc._body
+	attachments = doc.Attachments
+
+	// handle backup revision inline attachments, or pre-2.5 meta
+	if inlineAtts, cleanBodyBytes, cleanBody, err := extractInlineAttachments(bodyBytes); err != nil {
+		return nil, nil, nil, err
+	} else if len(inlineAtts) > 0 {
+		// we found some inline attachments, so merge them with attachments, and update the bodies
+		attachments = mergeAttachments(inlineAtts, attachments)
+		bodyBytes = cleanBodyBytes
+		body = cleanBody
+	}
+	return bodyBytes, body, attachments, err
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -129,6 +129,7 @@ type DocumentRevision struct {
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
 	CV          *Version
+	hlvHistory  string
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
@@ -262,14 +263,14 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *Version, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, hlv *HybridLogicalVector, err error) {
 	var doc *Document
 	unmarshalLevel := DocUnmarshalSync
 	if unmarshalBody {
 		unmarshalLevel = DocUnmarshalAll
 	}
 	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
-		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, fetchedCV, err
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, hlv, err
 	}
 
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
@@ -277,7 +278,7 @@ func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore,
 
 // revCacheLoaderForCv will load a document from the bucket using the CV, compare the fetched doc and the CV specified in the function,
 // and will still return revid for purpose of populating the Rev ID lookup map on the cache
-func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
 	cv := Version{
 		Value:    id.Version,
 		SourceID: id.Source,
@@ -288,59 +289,60 @@ func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingS
 		unmarshalLevel = DocUnmarshalAll
 	}
 	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
-		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, revid, err
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, revid, hlv, err
 	}
 
 	return revCacheLoaderForDocumentCV(ctx, backingStore, doc, cv)
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *Version, err error) {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, hlv *HybridLogicalVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
 		if isRemovalErr != nil {
-			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, fetchedCV, isRemovalErr
+			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, hlv, isRemovalErr
 		}
 
 		if isRemoval {
-			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, fetchedCV, nil
+			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, hlv, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
-			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, fetchedCV, err
+			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, hlv, err
 		}
 	}
 	deleted = doc.History[revid].Deleted
 
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
-		return bodyBytes, body, history, channels, removed, nil, deleted, nil, fetchedCV, getHistoryErr
+		return bodyBytes, body, history, channels, removed, nil, deleted, nil, hlv, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
 	if doc.HLV != nil {
-		fetchedCV = &Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}
+		hlv = doc.HLV
 	}
 
-	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, fetchedCV, err
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, hlv, err
 }
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
 // nolint:staticcheck
-func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
 		// TODO: pending CBG-3213 support of channel removal for CV
 		// we need implementation of IsChannelRemoval for CV here.
 	}
 
-	if err = doc.HasCurrentVersion(cv); err != nil {
-		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+	if err = doc.HasCurrentVersion(ctx, cv); err != nil {
+		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, hlv, err
 	}
 	channels = doc.SyncData.getCurrentChannels()
 	revid = doc.CurrentRev
+	hlv = doc.HLV
 
-	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, hlv, err
 }
 
 func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -236,7 +236,7 @@ type IDAndRev struct {
 
 type IDandCV struct {
 	DocID   string
-	Version uint64
+	Version string
 	Source  string
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -59,6 +59,8 @@ type RevisionCache interface {
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)
+
+	UpdateDeltaCV(ctx context.Context, docID string, cv *Version, toDelta RevisionDelta)
 }
 
 const (
@@ -242,21 +244,25 @@ type IDandCV struct {
 
 // RevisionDelta stores data about a delta between a revision and ToRevID.
 type RevisionDelta struct {
-	ToRevID               string                  // Target revID for the delta
+	ToRevID               string // Target revID for the delta
+	ToCV                  string
 	DeltaBytes            []byte                  // The actual delta
 	AttachmentStorageMeta []AttachmentStorageMeta // Storage metadata of all attachments present on ToRevID
 	ToChannels            base.Set                // Full list of channels for the to revision
 	RevisionHistory       []string                // Revision history from parent of ToRevID to source revID, in descending order
-	ToDeleted             bool                    // Flag if ToRevID is a tombstone
+	HlvHistory            string
+	ToDeleted             bool // Flag if ToRevID is a tombstone
 }
 
 func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {
 	return RevisionDelta{
 		ToRevID:               toRevision.RevID,
+		ToCV:                  toRevision.CV.String(),
 		DeltaBytes:            deltaBytes,
 		AttachmentStorageMeta: toRevAttStorageMeta,
 		ToChannels:            toRevision.Channels,
 		RevisionHistory:       toRevision.History.parseAncestorRevisions(fromRevID),
+		HlvHistory:            toRevision.hlvHistory,
 		ToDeleted:             deleted,
 	}
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -36,7 +36,7 @@ type RevisionCache interface {
 	// GetWithCV returns the given revision by CV, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (DocumentRevision, error)
+	GetWithCV(ctx context.Context, docID string, cv *Version, includeBody, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
@@ -55,7 +55,7 @@ type RevisionCache interface {
 	RemoveWithRev(docID, revID string)
 
 	// RemoveWithCV evicts a revision from the cache using its current version.
-	RemoveWithCV(docID string, cv *SourceAndVersion)
+	RemoveWithCV(docID string, cv *Version)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta)
@@ -128,7 +128,7 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
-	CV          *SourceAndVersion
+	CV          *Version
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
@@ -262,7 +262,7 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *SourceAndVersion, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *Version, err error) {
 	var doc *Document
 	unmarshalLevel := DocUnmarshalSync
 	if unmarshalBody {
@@ -278,8 +278,8 @@ func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore,
 // revCacheLoaderForCv will load a document from the bucket using the CV, comapre the fetched doc and the CV specified in the function,
 // and will still return revid for purpose of populating the Rev ID lookup map on the cache
 func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
-	cv := SourceAndVersion{
-		Version:  id.Version,
+	cv := Version{
+		Value:    id.Version,
 		SourceID: id.Source,
 	}
 	var doc *Document
@@ -295,7 +295,7 @@ func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingS
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *SourceAndVersion, err error) {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, fetchedCV *Version, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
@@ -320,7 +320,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
 	if doc.HLV != nil {
-		fetchedCV = &SourceAndVersion{SourceID: doc.HLV.SourceID, Version: doc.HLV.Version}
+		fetchedCV = &Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}
 	}
 
 	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, fetchedCV, err
@@ -328,7 +328,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
 // nolint:staticcheck
-func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv SourceAndVersion) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
+func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
 		// TODO: pending CBG-3213 support of channel removal for CV
 		// we need implementation of IsChannelRemoval for CV here.

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -352,6 +352,7 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	channels = doc.SyncData.getCurrentChannels()
 	revid = doc.CurrentRev
 	hlv = doc.HLV
+	deleted = doc.Deleted
 
 	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, hlv, err
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -327,10 +327,11 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 }
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
+// nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv SourceAndVersion) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
+		// TODO: pending CBG-3213 support of channel removal for CV
 		// we need implementation of IsChannelRemoval for CV here.
-		// pending CBG-3213 support of channel removal for CV
 	}
 
 	if err = doc.HasCurrentVersion(cv); err != nil {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -275,7 +275,7 @@ func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore,
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
-// revCacheLoaderForCv will load a document from the bucket using the CV, comapre the fetched doc and the CV specified in the function,
+// revCacheLoaderForCv will load a document from the bucket using the CV, compare the fetched doc and the CV specified in the function,
 // and will still return revid for purpose of populating the Rev ID lookup map on the cache
 func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, err error) {
 	cv := Version{
@@ -337,7 +337,7 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	if err = doc.HasCurrentVersion(cv); err != nil {
 		return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err
 	}
-	channels = doc.currentRevChannels
+	channels = doc.SyncData.getCurrentChannels()
 	revid = doc.CurrentRev
 
 	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, revid, err

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -331,8 +331,8 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 // nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
-		// TODO: pending CBG-3213 support of channel removal for CV
-		// we need implementation of IsChannelRemoval for CV here.
+		// TODO: CBG-3814 - pending support of channel removal for CV
+		base.ErrorfCtx(ctx, "pending CBG-3213 support of channel removal for CV: %v", err)
 	}
 
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -61,6 +61,10 @@ func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, revID
 	sc.getShard(docID).UpdateDelta(ctx, docID, revID, toDelta)
 }
 
+func (sc *ShardedLRURevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, toDelta RevisionDelta) {
+	sc.getShard(docID).UpdateDeltaCV(ctx, docID, cv, toDelta)
+}
+
 func (sc *ShardedLRURevisionCache) GetActive(ctx context.Context, docID string, includeBody bool) (docRev DocumentRevision, err error) {
 	return sc.getShard(docID).GetActive(ctx, docID, includeBody)
 }
@@ -152,6 +156,13 @@ func (rc *LRURevisionCache) Peek(ctx context.Context, docID, revID string) (docR
 // fails silently
 func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta) {
 	value := rc.getValue(docID, revID, false)
+	if value != nil {
+		value.updateDelta(toDelta)
+	}
+}
+
+func (rc *LRURevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, toDelta RevisionDelta) {
+	value := rc.getValueByCV(docID, cv, false)
 	if value != nil {
 		value.updateDelta(toDelta)
 	}

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -45,8 +45,12 @@ func (sc *ShardedLRURevisionCache) getShard(docID string) *LRURevisionCache {
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 
-func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).Get(ctx, docID, revID, includeBody, includeDelta)
+func (sc *ShardedLRURevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetWithRev(ctx, docID, revID, includeBody, includeDelta)
+}
+
+func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetWithCV(ctx, docID, cv, includeBody, includeDelta)
 }
 
 func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID, revID string) (docRev DocumentRevision, found bool) {
@@ -69,14 +73,19 @@ func (sc *ShardedLRURevisionCache) Upsert(ctx context.Context, docRev DocumentRe
 	sc.getShard(docRev.DocID).Upsert(ctx, docRev)
 }
 
-func (sc *ShardedLRURevisionCache) Remove(docID, revID string) {
-	sc.getShard(docID).Remove(docID, revID)
+func (sc *ShardedLRURevisionCache) RemoveWithRev(docID, revID string) {
+	sc.getShard(docID).RemoveWithRev(docID, revID)
+}
+
+func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+	sc.getShard(docID).RemoveWithCV(docID, cv)
 }
 
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	backingStore RevisionCacheBackingStore
 	cache        map[IDAndRev]*list.Element
+	hlvCache     map[IDandCV]*list.Element
 	lruList      *list.List
 	cacheHits    *base.SgwIntStat
 	cacheMisses  *base.SgwIntStat
@@ -93,7 +102,9 @@ type revCacheValue struct {
 	attachments AttachmentsMeta
 	delta       *RevisionDelta
 	body        Body
-	key         IDAndRev
+	id          string
+	cv          CurrentVersionVector
+	revID       string
 	bodyBytes   []byte
 	lock        sync.RWMutex
 	deleted     bool
@@ -105,6 +116,7 @@ func NewLRURevisionCache(capacity uint32, backingStore RevisionCacheBackingStore
 
 	return &LRURevisionCache{
 		cache:        map[IDAndRev]*list.Element{},
+		hlvCache:     map[IDandCV]*list.Element{},
 		lruList:      list.New(),
 		capacity:     capacity,
 		backingStore: backingStore,
@@ -117,14 +129,18 @@ func NewLRURevisionCache(capacity uint32, backingStore RevisionCacheBackingStore
 // Returns the body of the revision, its history, and the set of channels it's in.
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
-func (rc *LRURevisionCache) Get(ctx context.Context, docID, revID string, includeBody bool, includeDelta bool) (DocumentRevision, error) {
-	return rc.getFromCache(ctx, docID, revID, true, includeBody, includeDelta)
+func (rc *LRURevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (DocumentRevision, error) {
+	return rc.getFromCacheByRev(ctx, docID, revID, true, includeBody, includeDelta)
+}
+
+func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error) {
+	return rc.getFromCacheByCV(ctx, docID, cv, true, includeBody, includeDelta)
 }
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
 // present in the cache.
 func (rc *LRURevisionCache) Peek(ctx context.Context, docID, revID string) (docRev DocumentRevision, found bool) {
-	docRev, err := rc.getFromCache(ctx, docID, revID, false, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err := rc.getFromCacheByRev(ctx, docID, revID, false, RevCacheOmitBody, RevCacheOmitDelta)
 	if err != nil {
 		return DocumentRevision{}, false
 	}
@@ -140,18 +156,42 @@ func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string
 	}
 }
 
-func (rc *LRURevisionCache) getFromCache(ctx context.Context, docID, revID string, loadOnCacheMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID string, loadOnCacheMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
 	value := rc.getValue(docID, revID, loadOnCacheMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
 	}
 
-	docRev, statEvent, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
-	rc.statsRecorderFunc(statEvent)
+	docRev, cacheHit, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
+	rc.statsRecorderFunc(cacheHit)
 
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
+	if !cacheHit {
+		rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV)
+	}
+
+	return docRev, err
+}
+
+func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *CurrentVersionVector, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+	value := rc.getValueByCV(docID, cv, loadCacheOnMiss)
+	if value == nil {
+		return DocumentRevision{}, nil
+	}
+
+	docRev, cacheHit, err := value.load(ctx, rc.backingStore, includeBody, includeDelta)
+	rc.statsRecorderFunc(cacheHit)
+
+	if err != nil {
+		rc.removeValue(value) // don't keep failed loads in the cache
+	}
+
+	if !cacheHit {
+		rc.addToRevMapPostLoad(docID, docRev.RevID, docRev.CV)
+	}
+
 	return docRev, err
 }
 
@@ -162,15 +202,16 @@ func (rc *LRURevisionCache) LoadInvalidRevFromBackingStore(ctx context.Context, 
 	var docRevBody Body
 
 	value := revCacheValue{
-		key: key,
+		id:    key.DocID,
+		revID: key.RevID,
 	}
 
 	// If doc has been passed in use this to grab values. Otherwise run revCacheLoader which will grab the Document
 	// first
 	if doc != nil {
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, key.RevID)
+		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, _, value.err = revCacheLoaderForDocument(ctx, rc.backingStore, doc, key.RevID)
 	} else {
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoader(ctx, rc.backingStore, key, includeBody)
+		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, _, value.err = revCacheLoader(ctx, rc.backingStore, key, includeBody)
 	}
 
 	if includeDelta {
@@ -210,12 +251,15 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, include
 	// Retrieve from or add to rev cache
 	value := rc.getValue(docID, bucketDoc.CurrentRev, true)
 
-	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStore, bucketDoc, includeBody)
-	rc.statsRecorderFunc(statEvent)
+	docRev, cacheHit, err := value.loadForDoc(ctx, rc.backingStore, bucketDoc, includeBody)
+	rc.statsRecorderFunc(cacheHit)
 
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
+	// add successfully fetched value to cv lookup map too
+	rc.addToHLVMapPostLoad(docID, docRev.RevID, docRev.CV)
+
 	return docRev, err
 }
 
@@ -234,30 +278,43 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision) {
 		// TODO: CBG-1948
 		panic("Missing history for RevisionCache.Put")
 	}
-	value := rc.getValue(docRev.DocID, docRev.RevID, true)
+	// doc should always have a cv present in a PUT operation on the cache (update HLV is called before hand in doc update process)
+	// thus we can call getValueByCV directly the update the rev lookup post this
+	value := rc.getValueByCV(docRev.DocID, docRev.CV, true)
+	// store the created value
 	value.store(docRev)
+
+	// add new doc version to the rev id lookup map
+	rc.addToRevMapPostLoad(docRev.DocID, docRev.RevID, docRev.CV)
 }
 
 // Upsert a revision in the cache.
 func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision) {
-	key := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
+	var value *revCacheValue
+	// similar to PUT operation we should have the CV defined by this point (updateHLV is called before calling this)
+	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.VersionCAS}
+	legacyKey := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
 
 	rc.lock.Lock()
-	// If element exists remove from lrulist
-	if elem := rc.cache[key]; elem != nil {
+	// lookup for element in hlv lookup map, if not found for some reason try rev lookup map
+	if elem := rc.hlvCache[key]; elem != nil {
+		rc.lruList.Remove(elem)
+	} else if elem = rc.cache[legacyKey]; elem != nil {
 		rc.lruList.Remove(elem)
 	}
 
 	// Add new value and overwrite existing cache key, pushing to front to maintain order
-	value := &revCacheValue{key: key}
-	rc.cache[key] = rc.lruList.PushFront(value)
+	// also ensure we add to rev id lookup map too
+	value = &revCacheValue{id: docRev.DocID, cv: *docRev.CV}
+	elem := rc.lruList.PushFront(value)
+	rc.hlvCache[key] = elem
+	rc.cache[legacyKey] = elem
 
-	// Purge oldest item if required
-	for len(rc.cache) > int(rc.capacity) {
+	for rc.lruList.Len() > int(rc.capacity) {
 		rc.purgeOldest_()
 	}
 	rc.lock.Unlock()
-
+	// store upsert value
 	value.store(docRev)
 }
 
@@ -272,9 +329,9 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 		rc.lruList.MoveToFront(elem)
 		value = elem.Value.(*revCacheValue)
 	} else if create {
-		value = &revCacheValue{key: key}
+		value = &revCacheValue{id: docID, revID: revID}
 		rc.cache[key] = rc.lruList.PushFront(value)
-		for len(rc.cache) > int(rc.capacity) {
+		for rc.lruList.Len() > int(rc.capacity) {
 			rc.purgeOldest_()
 		}
 	}
@@ -282,8 +339,116 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 	return
 }
 
+// getValueByCV gets a value from rev cache by CV, if not found and create is true, will add the value to cache and both lookup maps
+func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector, create bool) (value *revCacheValue) {
+	if docID == "" || cv == nil {
+		return nil
+	}
+
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	rc.lock.Lock()
+	if elem := rc.hlvCache[key]; elem != nil {
+		rc.lruList.MoveToFront(elem)
+		value = elem.Value.(*revCacheValue)
+	} else if create {
+		value = &revCacheValue{id: docID, cv: *cv}
+		newElem := rc.lruList.PushFront(value)
+		rc.hlvCache[key] = newElem
+		for rc.lruList.Len() > int(rc.capacity) {
+			rc.purgeOldest_()
+		}
+	}
+	rc.lock.Unlock()
+	return
+}
+
+// addToRevMapPostLoad will generate and entry in the Rev lookup map for a new document entering the cache
+func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+	legacyKey := IDAndRev{DocID: docID, RevID: revID}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// check for existing value in rev cache map (due to concurrent fetch by rev ID)
+	cvElem, cvFound := rc.hlvCache[key]
+	revElem, revFound := rc.cache[legacyKey]
+	if !cvFound {
+		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
+		// need to return doc revision to caller still but no need repopulate the cache
+		return
+	}
+	// Check if another goroutine has already updated the rev map
+	if revFound {
+		if cvElem == revElem {
+			// already match, return
+			return
+		}
+		// if CV map and rev map are targeting different list elements, update to have both use the cv map element
+		rc.cache[legacyKey] = cvElem
+		rc.lruList.Remove(revElem)
+	} else {
+		// if not found we need to add the element to the rev lookup (for PUT code path)
+		rc.cache[legacyKey] = cvElem
+	}
+}
+
+// addToHLVMapPostLoad will generate and entry in the CV lookup map for a new document entering the cache
+func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+	legacyKey := IDAndRev{DocID: docID, RevID: revID}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// check for existing value in rev cache map (due to concurrent fetch by rev ID)
+	cvElem, cvFound := rc.hlvCache[key]
+	revElem, revFound := rc.cache[legacyKey]
+	if !revFound {
+		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
+		// need to return doc revision to caller still but no need repopulate the cache
+		return
+	}
+	// Check if another goroutine has already updated the cv map
+	if cvFound {
+		if cvElem == revElem {
+			// already match, return
+			return
+		}
+		// if CV map and rev map are targeting different list elements, update to have both use the cv map element
+		rc.cache[legacyKey] = cvElem
+		rc.lruList.Remove(revElem)
+	}
+}
+
 // Remove removes a value from the revision cache, if present.
-func (rc *LRURevisionCache) Remove(docID, revID string) {
+func (rc *LRURevisionCache) RemoveWithRev(docID, revID string) {
+	rc.removeFromCacheByRev(docID, revID)
+}
+
+// RemoveWithCV removes a value from rev cache by CV reference if present
+func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+	rc.removeFromCacheByCV(docID, cv)
+}
+
+// removeFromCacheByCV removes an entry from rev cache by CV
+func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *CurrentVersionVector) {
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	element, ok := rc.hlvCache[key]
+	if !ok {
+		return
+	}
+	// grab the revid key from the value to enable us to remove the reference from the rev lookup map too
+	elem := element.Value.(*revCacheValue)
+	legacyKey := IDAndRev{DocID: docID, RevID: elem.revID}
+	rc.lruList.Remove(element)
+	delete(rc.hlvCache, key)
+	// remove from rev lookup map too
+	delete(rc.cache, legacyKey)
+}
+
+// removeFromCacheByRev removes an entry from rev cache by revID
+func (rc *LRURevisionCache) removeFromCacheByRev(docID, revID string) {
 	key := IDAndRev{DocID: docID, RevID: revID}
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -291,23 +456,38 @@ func (rc *LRURevisionCache) Remove(docID, revID string) {
 	if !ok {
 		return
 	}
+	// grab the cv key key from the value to enable us to remove the reference from the rev lookup map too
+	elem := element.Value.(*revCacheValue)
+	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.VersionCAS}
 	rc.lruList.Remove(element)
 	delete(rc.cache, key)
+	// remove from CV lookup map too
+	delete(rc.hlvCache, hlvKey)
 }
 
 // removeValue removes a value from the revision cache, if present and the value matches the the value. If there's an item in the revision cache with a matching docID and revID but the document is different, this item will not be removed from the rev cache.
 func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 	rc.lock.Lock()
-	if element := rc.cache[value.key]; element != nil && element.Value == value {
+	defer rc.lock.Unlock()
+	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+	if element := rc.cache[revKey]; element != nil && element.Value == value {
 		rc.lruList.Remove(element)
-		delete(rc.cache, value.key)
+		delete(rc.cache, revKey)
 	}
-	rc.lock.Unlock()
+	// need to also check hlv lookup cache map
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	if element := rc.hlvCache[hlvKey]; element != nil && element.Value == value {
+		rc.lruList.Remove(element)
+		delete(rc.hlvCache, hlvKey)
+	}
 }
 
 func (rc *LRURevisionCache) purgeOldest_() {
 	value := rc.lruList.Remove(rc.lruList.Back()).(*revCacheValue)
-	delete(rc.cache, value.key)
+	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	delete(rc.cache, revKey)
+	delete(rc.hlvCache, hlvKey)
 }
 
 // Gets the body etc. out of a revCacheValue. If they aren't present already, the loader func
@@ -319,6 +499,8 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	// to reduce locking when includeDelta=false
 	var delta *RevisionDelta
 	var docRevBody Body
+	var fetchedCV *CurrentVersionVector
+	var revid string
 
 	// Attempt to read cached value.
 	value.lock.RLock()
@@ -349,12 +531,24 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 		// If body is requested and not already present in cache, populate value.body from value.BodyBytes
 		if includeBody && value.body == nil && value.err == nil {
 			if err := value.body.Unmarshal(value.bodyBytes); err != nil {
-				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 			}
 		}
 	} else {
 		cacheHit = false
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoader(ctx, backingStore, value.key, includeBody)
+		if value.revID == "" {
+			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForCv(ctx, backingStore, hlvKey, includeBody)
+			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
+			value.revID = revid
+		} else {
+			revKey := IDAndRev{DocID: value.id, RevID: value.revID}
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, fetchedCV, value.err = revCacheLoader(ctx, backingStore, revKey, includeBody)
+			// based off the revision load we need to populate the hlv key with what has been fetched from the bucket (for use of populating the opposite lookup map)
+			if fetchedCV != nil {
+				value.cv = *fetchedCV
+			}
+		}
 	}
 
 	if includeDelta {
@@ -374,7 +568,7 @@ func (value *revCacheValue) updateBody(ctx context.Context) (err error) {
 	var body Body
 	if err := body.Unmarshal(value.bodyBytes); err != nil {
 		// On unmarshal error, warn return docRev without body
-		base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+		base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 		return err
 	}
 
@@ -391,8 +585,8 @@ func (value *revCacheValue) updateBody(ctx context.Context) (err error) {
 func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) (DocumentRevision, error) {
 
 	docRev := DocumentRevision{
-		DocID:       value.key.DocID,
-		RevID:       value.key.RevID,
+		DocID:       value.id,
+		RevID:       value.revID,
 		BodyBytes:   value.bodyBytes,
 		History:     value.history,
 		Channels:    value.channels,
@@ -400,6 +594,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 		Attachments: value.attachments.ShallowCopy(), // Avoid caller mutating the stored attachments
 		Deleted:     value.deleted,
 		Removed:     value.removed,
+		CV:          &CurrentVersionVector{VersionCAS: value.cv.VersionCAS, SourceID: value.cv.SourceID},
 	}
 	if body != nil {
 		docRev._shallowCopyBody = body.ShallowCopy()
@@ -414,6 +609,8 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, includeBody bool) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	var docRevBody Body
+	var fetchedCV *CurrentVersionVector
+	var revid string
 	value.lock.RLock()
 	if value.bodyBytes != nil || value.err != nil {
 		if includeBody {
@@ -443,13 +640,22 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 		// If body is requested and not already present in cache, attempt to generate from bytes and insert into cache
 		if includeBody && value.body == nil {
 			if err := value.body.Unmarshal(value.bodyBytes); err != nil {
-				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+				base.WarnfCtx(ctx, "Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.id), value.revID)
 			}
 		}
 	} else {
 		cacheHit = false
-		value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.key.RevID)
+		if value.revID == "" {
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForDocumentCV(ctx, backingStore, doc, value.cv)
+			value.revID = revid
+		} else {
+			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, fetchedCV, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.revID)
+			if fetchedCV != nil {
+				value.cv = *fetchedCV
+			}
+		}
 	}
+
 	if includeBody {
 		docRevBody = value.body
 	}
@@ -462,7 +668,7 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 func (value *revCacheValue) store(docRev DocumentRevision) {
 	value.lock.Lock()
 	if value.bodyBytes == nil {
-		// value already has doc id/rev id in key
+		value.revID = docRev.RevID
 		value.bodyBytes = docRev.BodyBytes
 		value.history = docRev.History
 		value.channels = docRev.Channels

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -544,7 +544,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
 			value.revID = revid
 			if hlv != nil {
-				value.hlvHistory = hlv.toHistoryForHLV()
+				value.hlvHistory = hlv.ToHistoryForHLV()
 			}
 		} else {
 			revKey := IDAndRev{DocID: value.id, RevID: value.revID}
@@ -552,7 +552,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 			// based off the revision load we need to populate the hlv key with what has been fetched from the bucket (for use of populating the opposite lookup map)
 			if hlv != nil {
 				value.cv = *hlv.ExtractCurrentVersionFromHLV()
-				value.hlvHistory = hlv.toHistoryForHLV()
+				value.hlvHistory = hlv.ToHistoryForHLV()
 			}
 		}
 	}
@@ -655,12 +655,12 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 		if value.revID == "" {
 			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, hlv, value.err = revCacheLoaderForDocumentCV(ctx, backingStore, doc, value.cv)
 			value.revID = revid
-			value.hlvHistory = hlv.toHistoryForHLV()
+			value.hlvHistory = hlv.ToHistoryForHLV()
 		} else {
 			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, hlv, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.revID)
 			if hlv != nil {
 				value.cv = *hlv.ExtractCurrentVersionFromHLV()
-				value.hlvHistory = hlv.toHistoryForHLV()
+				value.hlvHistory = hlv.ToHistoryForHLV()
 			}
 		}
 	}

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -49,7 +49,7 @@ func (sc *ShardedLRURevisionCache) GetWithRev(ctx context.Context, docID, revID 
 	return sc.getShard(docID).GetWithRev(ctx, docID, revID, includeBody, includeDelta)
 }
 
-func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
 	return sc.getShard(docID).GetWithCV(ctx, docID, cv, includeBody, includeDelta)
 }
 
@@ -77,7 +77,7 @@ func (sc *ShardedLRURevisionCache) RemoveWithRev(docID, revID string) {
 	sc.getShard(docID).RemoveWithRev(docID, revID)
 }
 
-func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (sc *ShardedLRURevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	sc.getShard(docID).RemoveWithCV(docID, cv)
 }
 
@@ -103,7 +103,7 @@ type revCacheValue struct {
 	delta       *RevisionDelta
 	body        Body
 	id          string
-	cv          CurrentVersionVector
+	cv          SourceAndVersion
 	revID       string
 	bodyBytes   []byte
 	lock        sync.RWMutex
@@ -133,7 +133,7 @@ func (rc *LRURevisionCache) GetWithRev(ctx context.Context, docID, revID string,
 	return rc.getFromCacheByRev(ctx, docID, revID, true, includeBody, includeDelta)
 }
 
-func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *CurrentVersionVector, includeBody, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *SourceAndVersion, includeBody, includeDelta bool) (DocumentRevision, error) {
 	return rc.getFromCacheByCV(ctx, docID, cv, true, includeBody, includeDelta)
 }
 
@@ -175,7 +175,7 @@ func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID 
 	return docRev, err
 }
 
-func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *CurrentVersionVector, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *SourceAndVersion, loadCacheOnMiss bool, includeBody bool, includeDelta bool) (DocumentRevision, error) {
 	value := rc.getValueByCV(docID, cv, loadCacheOnMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
@@ -292,7 +292,7 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision) {
 func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision) {
 	var value *revCacheValue
 	// similar to PUT operation we should have the CV defined by this point (updateHLV is called before calling this)
-	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.VersionCAS}
+	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.Version}
 	legacyKey := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
 
 	rc.lock.Lock()
@@ -340,12 +340,12 @@ func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *r
 }
 
 // getValueByCV gets a value from rev cache by CV, if not found and create is true, will add the value to cache and both lookup maps
-func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector, create bool) (value *revCacheValue) {
+func (rc *LRURevisionCache) getValueByCV(docID string, cv *SourceAndVersion, create bool) (value *revCacheValue) {
 	if docID == "" || cv == nil {
 		return nil
 	}
 
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 	rc.lock.Lock()
 	if elem := rc.hlvCache[key]; elem != nil {
 		rc.lruList.MoveToFront(elem)
@@ -363,9 +363,9 @@ func (rc *LRURevisionCache) getValueByCV(docID string, cv *CurrentVersionVector,
 }
 
 // addToRevMapPostLoad will generate and entry in the Rev lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *SourceAndVersion) {
 	legacyKey := IDAndRev{DocID: docID, RevID: revID}
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -393,9 +393,9 @@ func (rc *LRURevisionCache) addToRevMapPostLoad(docID, revID string, cv *Current
 }
 
 // addToHLVMapPostLoad will generate and entry in the CV lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) addToHLVMapPostLoad(docID, revID string, cv *SourceAndVersion) {
 	legacyKey := IDAndRev{DocID: docID, RevID: revID}
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
@@ -425,13 +425,13 @@ func (rc *LRURevisionCache) RemoveWithRev(docID, revID string) {
 }
 
 // RemoveWithCV removes a value from rev cache by CV reference if present
-func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *CurrentVersionVector) {
+func (rc *LRURevisionCache) RemoveWithCV(docID string, cv *SourceAndVersion) {
 	rc.removeFromCacheByCV(docID, cv)
 }
 
 // removeFromCacheByCV removes an entry from rev cache by CV
-func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *CurrentVersionVector) {
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.VersionCAS}
+func (rc *LRURevisionCache) removeFromCacheByCV(docID string, cv *SourceAndVersion) {
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Version}
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	element, ok := rc.hlvCache[key]
@@ -458,7 +458,7 @@ func (rc *LRURevisionCache) removeFromCacheByRev(docID, revID string) {
 	}
 	// grab the cv key key from the value to enable us to remove the reference from the rev lookup map too
 	elem := element.Value.(*revCacheValue)
-	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.Version}
 	rc.lruList.Remove(element)
 	delete(rc.cache, key)
 	// remove from CV lookup map too
@@ -475,7 +475,7 @@ func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 		delete(rc.cache, revKey)
 	}
 	// need to also check hlv lookup cache map
-	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 	if element := rc.hlvCache[hlvKey]; element != nil && element.Value == value {
 		rc.lruList.Remove(element)
 		delete(rc.hlvCache, hlvKey)
@@ -485,7 +485,7 @@ func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 func (rc *LRURevisionCache) purgeOldest_() {
 	value := rc.lruList.Remove(rc.lruList.Back()).(*revCacheValue)
 	revKey := IDAndRev{DocID: value.id, RevID: value.revID}
-	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 	delete(rc.cache, revKey)
 	delete(rc.hlvCache, hlvKey)
 }
@@ -499,7 +499,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	// to reduce locking when includeDelta=false
 	var delta *RevisionDelta
 	var docRevBody Body
-	var fetchedCV *CurrentVersionVector
+	var fetchedCV *SourceAndVersion
 	var revid string
 
 	// Attempt to read cached value.
@@ -537,7 +537,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	} else {
 		cacheHit = false
 		if value.revID == "" {
-			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.VersionCAS}
+			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Version}
 			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, value.err = revCacheLoaderForCv(ctx, backingStore, hlvKey, includeBody)
 			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
 			value.revID = revid
@@ -594,7 +594,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 		Attachments: value.attachments.ShallowCopy(), // Avoid caller mutating the stored attachments
 		Deleted:     value.deleted,
 		Removed:     value.removed,
-		CV:          &CurrentVersionVector{VersionCAS: value.cv.VersionCAS, SourceID: value.cv.SourceID},
+		CV:          &SourceAndVersion{Version: value.cv.Version, SourceID: value.cv.SourceID},
 	}
 	if body != nil {
 		docRev._shallowCopyBody = body.ShallowCopy()
@@ -609,7 +609,7 @@ func (value *revCacheValue) asDocumentRevision(body Body, delta *RevisionDelta) 
 func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, includeBody bool) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	var docRevBody Body
-	var fetchedCV *CurrentVersionVector
+	var fetchedCV *SourceAndVersion
 	var revid string
 	value.lock.RLock()
 	if value.bodyBytes != nil || value.err != nil {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -80,7 +80,7 @@ func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document)
 		"testing":         true,
 		BodyId:            doc.ID,
 		BodyRev:           doc.CurrentRev,
-		"current_version": &CurrentVersionVector{VersionCAS: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+		"current_version": &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 	}
 	bodyBytes, err := base.JSONMarshal(b)
 	return bodyBytes, b, nil, err
@@ -110,7 +110,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Get them back out
@@ -127,7 +127,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Add 3 more docs to the now full revcache
 	for i := 10; i < 13; i++ {
 		docID := strconv.Itoa(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Check that the first 3 docs were evicted
@@ -170,7 +170,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// assert that the list has 10 elements along with both lookup maps
@@ -181,7 +181,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Add 3 more docs to the now full rev cache to trigger eviction
 	for docID := 10; docID < 13; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
 	assert.Equal(t, 10, len(cache.hlvCache))
@@ -192,7 +192,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	prevCacheHitCount := cacheHitCounter.Value()
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		cv := CurrentVersionVector{VersionCAS: uint64(i + 3), SourceID: "test"}
+		cv := SourceAndVersion{Version: uint64(i + 3), SourceID: "test"}
 		docRev, err := cache.GetWithCV(ctx, id, &cv, RevCacheOmitBody, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -270,13 +270,13 @@ func TestBackingStoreCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"not_found"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
@@ -287,14 +287,14 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	cv = CurrentVersionVector{SourceID: "test11", VersionCAS: 100}
+	cv = SourceAndVersion{SourceID: "test11", Version: 100}
 	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -557,7 +557,7 @@ func TestSingleLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
 	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", true, false)
 	assert.NoError(t, err)
 }
@@ -567,7 +567,7 @@ func TestConcurrentLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &CurrentVersionVector{VersionCAS: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
 
 	// Trigger load into cache
 	var wg sync.WaitGroup
@@ -632,7 +632,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	documentRevision := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -648,7 +648,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
@@ -661,7 +661,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.VersionCAS)
+	assert.Equal(t, uint64(123), docRev.CV.Version)
 	assert.Equal(t, []byte(`{"test":"12345"}`), docRev.BodyBytes)
 	assert.Equal(t, int64(2), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
@@ -705,7 +705,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// create cv with incorrect version to the one stored in backing store
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 1234}
+	cv := SourceAndVersion{SourceID: "test", Version: 1234}
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	require.Error(t, err)
@@ -735,7 +735,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	go func() {
 		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", RevCacheOmitBody, RevCacheIncludeDelta)
 		require.NoError(t, err)
@@ -773,9 +773,9 @@ func TestGetActive(t *testing.T) {
 	rev1id, doc, err := collection.Put(ctx, "doc", Body{"val": 123})
 	require.NoError(t, err)
 
-	expectedCV := CurrentVersionVector{
-		SourceID:   db.BucketUUID,
-		VersionCAS: doc.Cas,
+	expectedCV := SourceAndVersion{
+		SourceID: db.BucketUUID,
+		Version:  doc.Cas,
 	}
 
 	// remove the entry form the rev cache to force teh cache to not have the active version in it
@@ -801,7 +801,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := CurrentVersionVector{SourceID: "test", VersionCAS: 123}
+	cv := SourceAndVersion{SourceID: "test", Version: 123}
 	docRev := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -571,7 +571,6 @@ func TestConcurrentLoad(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
-
 	// Trigger load into cache
 	var wg sync.WaitGroup
 	wg.Add(20)
@@ -712,7 +711,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "mismatch between specified current version and fetched document current version for doc")
+	require.Error(t, err, base.ErrNotFound)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, 0, cache.lruList.Len())

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -80,7 +80,7 @@ func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document)
 		"testing":         true,
 		BodyId:            doc.ID,
 		BodyRev:           doc.CurrentRev,
-		"current_version": &SourceAndVersion{Version: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+		"current_version": &Version{Value: doc.HLV.Version, SourceID: doc.HLV.SourceID},
 	}
 	bodyBytes, err := base.JSONMarshal(b)
 	return bodyBytes, b, nil, err
@@ -110,7 +110,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Get them back out
@@ -127,7 +127,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Add 3 more docs to the now full revcache
 	for i := 10; i < 13; i++ {
 		docID := strconv.Itoa(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Check that the first 3 docs were evicted
@@ -170,7 +170,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// assert that the list has 10 elements along with both lookup maps
@@ -181,7 +181,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Add 3 more docs to the now full rev cache to trigger eviction
 	for docID := 10; docID < 13; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
 	assert.Equal(t, 10, len(cache.hlvCache))
@@ -192,7 +192,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	prevCacheHitCount := cacheHitCounter.Value()
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		cv := SourceAndVersion{Version: uint64(i + 3), SourceID: "test"}
+		cv := Version{Value: uint64(i + 3), SourceID: "test"}
 		docRev, err := cache.GetWithCV(ctx, id, &cv, RevCacheOmitBody, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -270,13 +270,13 @@ func TestBackingStoreCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"not_found"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	cv := SourceAndVersion{SourceID: "test", Version: 123}
+	cv := Version{SourceID: "test", Value: 123}
 	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Version)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
@@ -287,14 +287,14 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Version)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	cv = SourceAndVersion{SourceID: "test11", Version: 100}
+	cv = Version{SourceID: "test11", Value: 100}
 	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -557,7 +557,7 @@ func TestSingleLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
 	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", true, false)
 	assert.NoError(t, err)
 }
@@ -567,7 +567,7 @@ func TestConcurrentLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &SourceAndVersion{Version: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
 
 	// Trigger load into cache
 	var wg sync.WaitGroup
@@ -632,7 +632,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cv := SourceAndVersion{SourceID: "test", Version: 123}
+	cv := Version{SourceID: "test", Value: 123}
 	documentRevision := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -648,7 +648,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Version)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
@@ -661,7 +661,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Version)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, []byte(`{"test":"12345"}`), docRev.BodyBytes)
 	assert.Equal(t, int64(2), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
@@ -705,7 +705,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// create cv with incorrect version to the one stored in backing store
-	cv := SourceAndVersion{SourceID: "test", Version: 1234}
+	cv := Version{SourceID: "test", Value: 1234}
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	require.Error(t, err)
@@ -735,7 +735,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := SourceAndVersion{SourceID: "test", Version: 123}
+	cv := Version{SourceID: "test", Value: 123}
 	go func() {
 		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", RevCacheOmitBody, RevCacheIncludeDelta)
 		require.NoError(t, err)
@@ -773,9 +773,9 @@ func TestGetActive(t *testing.T) {
 	rev1id, doc, err := collection.Put(ctx, "doc", Body{"val": 123})
 	require.NoError(t, err)
 
-	expectedCV := SourceAndVersion{
+	expectedCV := Version{
 		SourceID: db.BucketUUID,
-		Version:  doc.Cas,
+		Value:    doc.Cas,
 	}
 
 	// remove the entry form the rev cache to force teh cache to not have the active version in it
@@ -801,7 +801,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := SourceAndVersion{SourceID: "test", Version: 123}
+	cv := Version{SourceID: "test", Value: 123}
 	docRev := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -53,7 +53,7 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 
 	doc.HLV = &HybridLogicalVector{
 		SourceID: "test",
-		Version:  123,
+		Version:  "123",
 	}
 	_, _, err = doc.updateChannels(ctx, base.SetOf("*"))
 	if err != nil {
@@ -113,7 +113,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Get them back out
@@ -130,7 +130,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Add 3 more docs to the now full revcache
 	for i := 10; i < 13; i++ {
 		docID := strconv.Itoa(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: uint64(i), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: docID, SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// Check that the first 3 docs were evicted
@@ -173,7 +173,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 
 	// assert that the list has 10 elements along with both lookup maps
@@ -184,7 +184,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Add 3 more docs to the now full rev cache to trigger eviction
 	for docID := 10; docID < 13; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: uint64(docID), SourceID: "test"}, History: Revisions{"start": 1}})
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}})
 	}
 	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
 	assert.Equal(t, 10, len(cache.hlvCache))
@@ -195,7 +195,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	prevCacheHitCount := cacheHitCounter.Value()
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		cv := Version{Value: uint64(i + 3), SourceID: "test"}
+		cv := Version{Value: id, SourceID: "test"}
 		docRev, err := cache.GetWithCV(ctx, id, &cv, RevCacheOmitBody, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -273,13 +273,13 @@ func TestBackingStoreCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"not_found"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	cv := Version{SourceID: "test", Value: 123}
+	cv := Version{SourceID: "test", Value: "123"}
 	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Value)
+	assert.Equal(t, "123", docRev.CV.Value)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
@@ -290,14 +290,14 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Value)
+	assert.Equal(t, "123", docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	cv = Version{SourceID: "test11", Value: 100}
+	cv = Version{SourceID: "test11", Value: "100"}
 	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -560,7 +560,7 @@ func TestSingleLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: uint64(123), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: "123", SourceID: "test"}, History: Revisions{"start": 1}})
 	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", true, false)
 	assert.NoError(t, err)
 }
@@ -570,7 +570,8 @@ func TestConcurrentLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: uint64(1234), SourceID: "test"}, History: Revisions{"start": 1}})
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: "1234", SourceID: "test"}, History: Revisions{"start": 1}})
+
 	// Trigger load into cache
 	var wg sync.WaitGroup
 	wg.Add(20)
@@ -634,7 +635,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
-	cv := Version{SourceID: "test", Value: 123}
+	cv := Version{SourceID: "test", Value: "123"}
 	documentRevision := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -650,7 +651,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Value)
+	assert.Equal(t, "123", docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
@@ -663,7 +664,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, uint64(123), docRev.CV.Value)
+	assert.Equal(t, "123", docRev.CV.Value)
 	assert.Equal(t, []byte(`{"test":"12345"}`), docRev.BodyBytes)
 	assert.Equal(t, int64(2), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
@@ -707,7 +708,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, &testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)
 
 	// create cv with incorrect version to the one stored in backing store
-	cv := Version{SourceID: "test", Value: 1234}
+	cv := Version{SourceID: "test", Value: "1234"}
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, RevCacheOmitBody, RevCacheOmitDelta)
 	require.Error(t, err)
@@ -737,7 +738,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := Version{SourceID: "test", Value: 123}
+	cv := Version{SourceID: "test", Value: "123"}
 	go func() {
 		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", RevCacheOmitBody, RevCacheIncludeDelta)
 		require.NoError(t, err)
@@ -753,7 +754,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg.Wait()
 
 	revElement := cache.cache[IDAndRev{RevID: "1-abc", DocID: "doc1"}]
-	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123}]
+	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: "123"}]
 	assert.Equal(t, 1, cache.lruList.Len())
 	assert.Equal(t, 1, len(cache.cache))
 	assert.Equal(t, 1, len(cache.hlvCache))
@@ -774,10 +775,11 @@ func TestGetActive(t *testing.T) {
 
 	rev1id, doc, err := collection.Put(ctx, "doc", Body{"val": 123})
 	require.NoError(t, err)
+	syncCAS := string(base.Uint64CASToLittleEndianHex(doc.Cas))
 
 	expectedCV := Version{
-		SourceID: db.BucketUUID,
-		Value:    doc.Cas,
+		SourceID: db.EncodedBucketUUID,
+		Value:    syncCAS,
 	}
 
 	// remove the entry form the rev cache to force the cache to not have the active version in it
@@ -803,7 +805,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := Version{SourceID: "test", Value: 123}
+	cv := Version{SourceID: "test", Value: "123"}
 	docRev := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -827,7 +829,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg.Wait()
 
 	revElement := cache.cache[IDAndRev{RevID: "1-abc", DocID: "doc1"}]
-	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123}]
+	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: "123"}]
 
 	assert.Equal(t, 1, cache.lruList.Len())
 	assert.Equal(t, 1, len(cache.cache))

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -76,7 +76,7 @@ func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid
 	return bodyBytes, b, nil, err
 }
 
-func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document) ([]byte, Body, AttachmentsMeta, error) {
+func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, Body, AttachmentsMeta, error) {
 	t.getRevisionCounter.Add(1)
 
 	b := Body{
@@ -84,6 +84,10 @@ func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document)
 		BodyId:            doc.ID,
 		BodyRev:           doc.CurrentRev,
 		"current_version": &Version{Value: doc.HLV.Version, SourceID: doc.HLV.SourceID},
+	}
+
+	if err := doc.HasCurrentVersion(ctx, cv); err != nil {
+		return nil, b, nil, err
 	}
 	bodyBytes, err := base.JSONMarshal(b)
 	return bodyBytes, b, nil, err
@@ -99,7 +103,7 @@ func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid s
 	return nil, nil, nil, nil
 }
 
-func (*noopBackingStore) getCurrentVersion(ctx context.Context, doc *Document) ([]byte, Body, AttachmentsMeta, error) {
+func (*noopBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, Body, AttachmentsMeta, error) {
 	return nil, nil, nil, nil
 }
 
@@ -366,6 +370,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 }
 
 func TestBypassRevisionCache(t *testing.T) {
+	t.Skip("CBG-3748: backwards compatibility between cv and rev id for fetching backed up revs needed")
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,13 +50,14 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 			Channels: base.SetOf("*"),
 		},
 	}
-	doc.Channels = channels.ChannelMap{
-		"*": &channels.ChannelRemoval{RevID: doc.CurrentRev},
-	}
 
 	doc.HLV = &HybridLogicalVector{
 		SourceID: "test",
 		Version:  123,
+	}
+	_, _, err = doc.updateChannels(ctx, base.SetOf("*"))
+	if err != nil {
+		return nil, err
 	}
 
 	return doc, nil

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -131,7 +131,7 @@ func TestBackupOldRevision(t *testing.T) {
 
 	// create rev 2 and check backups for both revs
 	rev2ID := "2-abc"
-	_, _, err = collection.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true)
+	_, _, err = collection.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// now in all cases we'll have rev 1 backed up (for at least 5 minutes)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -778,7 +778,7 @@ func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, sou
 }
 
 // GetDocumentCurrentVersion fetches the document by key and returns the current version
-func (c *DatabaseCollection) GetDocumentCurrentVersion(t *testing.T, key string) (source string, version string) {
+func (c *DatabaseCollection) GetDocumentCurrentVersion(t testing.TB, key string) (source string, version string) {
 	ctx := base.TestCtx(t)
 	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -761,3 +761,29 @@ func createTestDocument(docID string, revID string, body Body, deleted bool, exp
 	}
 	return newDoc
 }
+
+// requireCurrentVersion fetches the document by key, and validates that cv matches.
+func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, source string, version uint64) {
+	ctx := base.TestCtx(t)
+	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
+	require.NoError(t, err)
+	if doc.HLV == nil {
+		require.Equal(t, "", source)
+		require.Equal(t, "", version)
+		return
+	}
+
+	require.Equal(t, doc.HLV.SourceID, source)
+	require.Equal(t, doc.HLV.Version, version)
+}
+
+// GetDocumentCurrentVersion fetches the document by key and returns the current version
+func (c *DatabaseCollection) GetDocumentCurrentVersion(t *testing.T, key string) (source string, version uint64) {
+	ctx := base.TestCtx(t)
+	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
+	require.NoError(t, err)
+	if doc.HLV == nil {
+		return "", 0
+	}
+	return doc.HLV.SourceID, doc.HLV.Version
+}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -746,3 +746,14 @@ func DefaultMutateInOpts() *sgbucket.MutateInOptions {
 		MacroExpansion: macroExpandSpec(base.SyncXattrName),
 	}
 }
+
+func createTestDocument(docID string, revID string, body Body, deleted bool, expiry uint32) (newDoc *Document) {
+	newDoc = &Document{
+		ID:        docID,
+		Deleted:   deleted,
+		DocExpiry: expiry,
+		RevID:     revID,
+		_body:     body,
+	}
+	return newDoc
+}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -561,6 +561,10 @@ func (dbc *DatabaseContext) CollectionChannelViewForTest(tb testing.TB, collecti
 	return collection.getChangesInChannelFromQuery(base.TestCtx(tb), channelName, startSeq, endSeq, 0, false)
 }
 
+func (db *DatabaseContext) GetChannelCache() ChannelCache {
+	return db.channelCache
+}
+
 // Test-only version of GetPrincipal that doesn't trigger channel/role recalculation
 func (dbc *DatabaseContext) GetPrincipalForTest(tb testing.TB, name string, isUser bool) (info *auth.PrincipalConfig, err error) {
 	ctx := base.TestCtx(tb)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -763,7 +763,7 @@ func createTestDocument(docID string, revID string, body Body, deleted bool, exp
 }
 
 // requireCurrentVersion fetches the document by key, and validates that cv matches.
-func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, source string, version uint64) {
+func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, source string, version string) {
 	ctx := base.TestCtx(t)
 	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)
@@ -778,12 +778,12 @@ func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, sou
 }
 
 // GetDocumentCurrentVersion fetches the document by key and returns the current version
-func (c *DatabaseCollection) GetDocumentCurrentVersion(t *testing.T, key string) (source string, version uint64) {
+func (c *DatabaseCollection) GetDocumentCurrentVersion(t *testing.T, key string) (source string, version string) {
 	ctx := base.TestCtx(t)
 	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)
 	if doc.HLV == nil {
-		return "", 0
+		return "", ""
 	}
 	return doc.HLV.SourceID, doc.HLV.Version
 }

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -23,7 +24,7 @@ import (
 type HLVAgent struct {
 	t         *testing.T
 	datastore base.DataStore
-	source    string // All writes by the HLVHelper are done as this source
+	Source    string // All writes by the HLVHelper are done as this source
 	xattrName string // xattr name to store the HLV
 }
 
@@ -33,7 +34,7 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 	return &HLVAgent{
 		t:         t,
 		datastore: datastore,
-		source:    source, // all writes by the HLVHelper are done as this source
+		Source:    base64.StdEncoding.EncodeToString([]byte(source)), // all writes by the HLVHelper are done as this source
 		xattrName: xattrName,
 	}
 }
@@ -42,7 +43,7 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 // a different HLV-aware peer)
 func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64) {
 	hlv := &HybridLogicalVector{}
-	err := hlv.AddVersion(CreateVersion(h.source, hlvExpandMacroCASValue))
+	err := hlv.AddVersion(CreateVersion(h.Source, hlvExpandMacroCASValue))
 	require.NoError(h.t, err)
 	hlv.CurrentVersionCAS = hlvExpandMacroCASValue
 

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -12,7 +12,8 @@ package db
 
 import (
 	"context"
-	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -34,7 +35,7 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 	return &HLVAgent{
 		t:         t,
 		datastore: datastore,
-		Source:    base64.StdEncoding.EncodeToString([]byte(source)), // all writes by the HLVHelper are done as this source
+		Source:    EncodeSource(source), // all writes by the HLVHelper are done as this source
 		xattrName: xattrName,
 	}
 }
@@ -63,4 +64,96 @@ func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64
 	cas, err := h.datastore.WriteWithXattrs(ctx, key, 0, 0, docBody, xattrData, mutateInOpts)
 	require.NoError(h.t, err)
 	return cas
+}
+
+// EncodeTestVersion converts a simplified string version of the form 1@abc to a hex-encoded version and base64 encoded
+// source, like 0x0100000000000000@YWJj.  Allows use of simplified versions in tests for readability, ease of use.
+func EncodeTestVersion(versionString string) (encodedString string) {
+	timestampString, source, found := strings.Cut(versionString, "@")
+	if !found {
+		return versionString
+	}
+	hexTimestamp, err := EncodeValueStr(timestampString)
+	if err != nil {
+		panic(fmt.Sprintf("unable to encode timestampString %v", timestampString))
+	}
+	base64Source := EncodeSource(source)
+	return hexTimestamp + "@" + base64Source
+}
+
+// encodeTestHistory converts a simplified version history of the form "1@abc,2@def;3@ghi" to use hex-encoded versions and
+// base64 encoded sources
+func EncodeTestHistory(historyString string) (encodedString string) {
+	// possible versionSets are pv;mv
+	// possible versionSets are pv;mv
+	versionSets := strings.Split(historyString, ";")
+	if len(versionSets) == 0 {
+		return ""
+	}
+	for index, versionSet := range versionSets {
+		// versionSet delimiter
+		if index > 0 {
+			encodedString += ";"
+		}
+		versions := strings.Split(versionSet, ",")
+		for index, version := range versions {
+			// version delimiter
+			if index > 0 {
+				encodedString += ","
+			}
+			encodedString += EncodeTestVersion(version)
+		}
+	}
+	return encodedString
+}
+
+// ParseTestHistory takes a string test history in the form 1@abc,2@def;3@ghi,4@jkl and formats this
+// as pv and mv maps keyed by encoded source, with encoded values
+func ParseTestHistory(t *testing.T, historyString string) (pv map[string]string, mv map[string]string) {
+	versionSets := strings.Split(historyString, ";")
+
+	pv = make(map[string]string)
+	mv = make(map[string]string)
+
+	var pvString, mvString string
+	switch len(versionSets) {
+	case 1:
+		pvString = versionSets[0]
+	case 2:
+		mvString = versionSets[0]
+		pvString = versionSets[1]
+	default:
+		return pv, mv
+	}
+
+	// pv
+	for _, versionStr := range strings.Split(pvString, ",") {
+		version, err := ParseVersion(versionStr)
+		require.NoError(t, err)
+		encodedValue, err := EncodeValueStr(version.Value)
+		require.NoError(t, err)
+		pv[EncodeSource(version.SourceID)] = encodedValue
+	}
+
+	// mv
+	if mvString != "" {
+		for _, versionStr := range strings.Split(mvString, ",") {
+			version, err := ParseVersion(versionStr)
+			require.NoError(t, err)
+			encodedValue, err := EncodeValueStr(version.Value)
+			require.NoError(t, err)
+			mv[EncodeSource(version.SourceID)] = encodedValue
+		}
+	}
+	return pv, mv
+}
+
+// Requires that the CV for the provided HLV matches the expected CV (sent in simplified test format)
+func RequireCVEqual(t *testing.T, hlv *HybridLogicalVector, expectedCV string) {
+	testVersion, err := ParseVersion(expectedCV)
+	require.NoError(t, err)
+	require.Equal(t, EncodeSource(testVersion.SourceID), hlv.SourceID)
+	encodedValue, err := EncodeValueStr(testVersion.Value)
+	require.NoError(t, err)
+	require.Equal(t, encodedValue, hlv.Version)
 }

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/require"
+)
+
+// HLVAgent performs HLV updates directly (not via SG) for simulating/testing interaction with non-SG HLV agents
+type HLVAgent struct {
+	t         *testing.T
+	datastore base.DataStore
+	source    string // All writes by the HLVHelper are done as this source
+	xattrName string // xattr name to store the HLV
+}
+
+var defaultHelperBody = map[string]interface{}{"version": 1}
+
+func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrName string) *HLVAgent {
+	return &HLVAgent{
+		t:         t,
+		datastore: datastore,
+		source:    source, // all writes by the HLVHelper are done as this source
+		xattrName: xattrName,
+	}
+}
+
+// InsertWithHLV inserts a new document into the bucket with a populated HLV (matching a write from
+// a different HLV-aware peer)
+func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64) {
+	hlv := &HybridLogicalVector{}
+	err := hlv.AddVersion(CreateVersion(h.source, hlvExpandMacroCASValue))
+	require.NoError(h.t, err)
+	hlv.CurrentVersionCAS = hlvExpandMacroCASValue
+
+	syncData := &SyncData{HLV: hlv}
+	syncDataBytes, err := base.JSONMarshal(syncData)
+	require.NoError(h.t, err)
+
+	mutateInOpts := &sgbucket.MutateInOptions{
+		MacroExpansion: hlv.computeMacroExpansions(),
+	}
+
+	docBody := base.MustJSONMarshal(h.t, defaultHelperBody)
+	xattrData := map[string][]byte{
+		h.xattrName: syncDataBytes,
+	}
+
+	cas, err := h.datastore.WriteWithXattrs(ctx, key, 0, 0, docBody, xattrData, mutateInOpts)
+	require.NoError(h.t, err)
+	return cas
+}

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.4.1
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c
+	github.com/couchbase/sg-bucket v0.0.0-20240514232448-927889ef9624
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389
+	github.com/couchbaselabs/rosmar v0.0.0-20240424002439-5fd321c3b01b
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.4
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/couchbase/goprotostellar v1.0.2 h1:yoPbAL9sCtcyZ5e/DcU5PRMOEFaJrF9awX
 github.com/couchbase/goprotostellar v1.0.2/go.mod h1:5/yqVnZlW2/NSbAWu1hPJCFBEwjxgpe0PFFOlRixnp4=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c h1:ftZeu97TaEWxBAINW2AaGNk3Icyg+/6XHs7OHnR23qQ=
-github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
+github.com/couchbase/sg-bucket v0.0.0-20240514232448-927889ef9624 h1:0vkmiPDRCNiJIv570e9DW1v0tqCQ4RHs3KiqGCB0X/4=
+github.com/couchbase/sg-bucket v0.0.0-20240514232448-927889ef9624/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=
@@ -74,8 +74,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131 h1:2EAfFswAfgYn3a05DVcegiw6DgMgn1Mv5eGz6IHt1Cw=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389 h1:feX52yzl6wrIXt6gqmcOKzpHOdigwnzJ5TP15M9i3Ow=
-github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
+github.com/couchbaselabs/rosmar v0.0.0-20240424002439-5fd321c3b01b h1:aP8cbbI/CiRyL0mOGA4HJ9jjhcOgx1M9V78i2tAAdJ4=
+github.com/couchbaselabs/rosmar v0.0.0-20240424002439-5fd321c3b01b/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -414,11 +414,11 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// User has no permissions to access rev
-			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc?rev="+version.RevID, "", nil, "NoPerms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc?rev="+version.RevTreeID, "", nil, "NoPerms", "password")
 			assertRespStatus(resp, http.StatusOK)
 
 			// Guest has no permissions to access rev
-			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc?rev="+version.RevID, "", nil, "", "")
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc?rev="+version.RevTreeID, "", nil, "", "")
 			assertRespStatus(resp, http.StatusOK)
 
 			// Attachments should be forbidden as well
@@ -426,7 +426,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// Attachment revs should be forbidden as well
-			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc/attach?rev="+version.RevID, "", nil, "NoPerms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc/attach?rev="+version.RevTreeID, "", nil, "NoPerms", "password")
 			assertRespStatus(resp, http.StatusNotFound)
 
 			// Attachments should be forbidden for guests as well
@@ -434,7 +434,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// Attachment revs should be forbidden for guests as well
-			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc/attach?rev="+version.RevID, "", nil, "", "")
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc/attach?rev="+version.RevTreeID, "", nil, "", "")
 			assertRespStatus(resp, http.StatusNotFound)
 
 			// Document does not exist should cause 403
@@ -451,7 +451,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusConflict)
 
 			// PUT with rev
-			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevID, `{}`, nil, "NoPerms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevTreeID, `{}`, nil, "NoPerms", "password")
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// PUT with incorrect rev
@@ -463,7 +463,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusConflict)
 
 			// PUT with rev as Guest
-			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevID, `{}`, nil, "", "")
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevTreeID, `{}`, nil, "", "")
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// PUT with incorrect rev as Guest
@@ -495,7 +495,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assert.NotContains(t, user.GetChannels(s, c).ToArray(), "chan2")
 
 			// Successful PUT which will grant access grants
-			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevID, `{"channels": "chan"}`, nil, "Perms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevTreeID, `{"channels": "chan"}`, nil, "Perms", "password")
 			AssertStatus(t, resp, http.StatusCreated)
 
 			// Make sure channel access grant was successful
@@ -512,7 +512,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusConflict)
 
 			// Attempt to delete document rev with no permissions
-			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/{{.keyspace}}/doc?rev="+version.RevID, "", nil, "NoPerms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/{{.keyspace}}/doc?rev="+version.RevTreeID, "", nil, "NoPerms", "password")
 			assertRespStatus(resp, http.StatusConflict)
 
 			// Attempt to delete document with wrong rev
@@ -528,7 +528,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusConflict)
 
 			// Attempt to delete document rev with no write perms as guest
-			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/{{.keyspace}}/doc?rev="+version.RevID, "", nil, "", "")
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/{{.keyspace}}/doc?rev="+version.RevTreeID, "", nil, "", "")
 			assertRespStatus(resp, http.StatusConflict)
 
 			// Attempt to delete document with wrong rev as guest
@@ -1184,7 +1184,7 @@ func TestRoleChannelGrantInheritance(t *testing.T) {
 	RequireStatus(t, response, 200)
 
 	// Revoke access to chan2 (dynamic)
-	response = rt.SendUserRequest("PUT", "/{{.keyspace}}/grant1?rev="+grant1Version.RevID, `{"type":"setaccess", "owner":"none", "channel":"chan2"}`, "user1")
+	response = rt.SendUserRequest("PUT", "/{{.keyspace}}/grant1?rev="+grant1Version.RevTreeID, `{"type":"setaccess", "owner":"none", "channel":"chan2"}`, "user1")
 	RequireStatus(t, response, 201)
 
 	// Verify user cannot access doc in revoked channel, but can successfully access remaining documents

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2296,7 +2296,7 @@ func TestHandlePutDbConfigWithBackticksCollections(t *testing.T) {
 	reqBodyWithBackticks := `{
         "server": "walrus:",
         "bucket": "backticks",
-		"enable_shared_bucket_access":false,
+		"enable_shared_bucket_access":true,
 		"scopes": {
 			"scope1": {
 			  "collections" : {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2144,7 +2144,7 @@ func TestRawTombstone(t *testing.T) {
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	assert.NotContains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
-	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+version.RevID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+version.RevTreeID+`"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"_deleted":true`)
 
@@ -2154,7 +2154,7 @@ func TestRawTombstone(t *testing.T) {
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	assert.NotContains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
-	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+deletedVersion.RevID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+deletedVersion.RevTreeID+`"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"_deleted":true`)
 }
@@ -3880,9 +3880,9 @@ func TestPutIDRevMatchBody(t *testing.T) {
 			docRev := test.rev
 			docBody := test.docBody
 			if test.docID == "" {
-				docID = "doc"                                                 // Used for the rev tests to branch off of
-				docBody = strings.ReplaceAll(docBody, "[REV]", version.RevID) // FIX for HLV?
-				docRev = strings.ReplaceAll(docRev, "[REV]", version.RevID)
+				docID = "doc"                                                     // Used for the rev tests to branch off of
+				docBody = strings.ReplaceAll(docBody, "[REV]", version.RevTreeID) // FIX for HLV?
+				docRev = strings.ReplaceAll(docRev, "[REV]", version.RevTreeID)
 			}
 
 			resp := rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, docRev), docBody)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2746,6 +2746,79 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "null doc body for doc")
 }
 
+// TestDatabaseXattrConfigHandlingForDBConfigUpdate:
+//   - Create database with xattrs enabled
+//   - Test updating the config to disable the use of xattrs in this database through replacing + upserting the config
+//   - Assert error code is returned and response contains error string
+func TestDatabaseXattrConfigHandlingForDBConfigUpdate(t *testing.T) {
+	base.LongRunningTest(t)
+	const (
+		dbName  = "db1"
+		errResp = "sync gateway requires enable_shared_bucket_access=true"
+	)
+
+	testCases := []struct {
+		name         string
+		upsertConfig bool
+	}{
+		{
+			name:         "POST update",
+			upsertConfig: true,
+		},
+		{
+			name:         "PUT update",
+			upsertConfig: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rt := NewRestTester(t, &RestTesterConfig{
+				PersistentConfig: true,
+			})
+			defer rt.Close()
+
+			dbConfig := rt.NewDbConfig()
+
+			resp := rt.CreateDatabase(dbName, dbConfig)
+			RequireStatus(t, resp, http.StatusCreated)
+			assert.NoError(t, rt.WaitForDBOnline())
+
+			dbConfig.EnableXattrs = base.BoolPtr(false)
+
+			if testCase.upsertConfig {
+				resp = rt.UpsertDbConfig(dbName, dbConfig)
+				RequireStatus(t, resp, http.StatusInternalServerError)
+				assert.Contains(t, resp.Body.String(), errResp)
+			} else {
+				resp = rt.ReplaceDbConfig(dbName, dbConfig)
+				RequireStatus(t, resp, http.StatusInternalServerError)
+				assert.Contains(t, resp.Body.String(), errResp)
+			}
+		})
+	}
+}
+
+// TestCreateDBWithXattrsDisbaled:
+//   - Test that you cannot create a database with xattrs disabled
+//   - Assert error code is returned and response contains error string
+func TestCreateDBWithXattrsDisbaled(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+	const (
+		dbName  = "db1"
+		errResp = "sync gateway requires enable_shared_bucket_access=true"
+	)
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.EnableXattrs = base.BoolPtr(false)
+
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusInternalServerError)
+	assert.Contains(t, resp.Body.String(), errResp)
+}
+
 // TestPutDocUpdateVersionVector:
 //   - Put a doc and assert that the versions and the source for the hlv is correctly updated
 //   - Update that doc and assert HLV has also been updated

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2746,6 +2746,97 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "null doc body for doc")
 }
 
+// TestPutDocUpdateVersionVector:
+//   - Put a doc and assert that the versions and the source for the hlv is correctly updated
+//   - Update that doc and assert HLV has also been updated
+//   - Delete the doc and assert that the HLV has been updated in deletion event
+func TestPutDocUpdateVersionVector(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"key": "value"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Put a new revision of this doc and assert that the version vector SourceID and Version is updated
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, `{"key1": "value1"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Delete doc and assert that the version vector SourceID and Version is updated
+	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}
+
+// TestHLVOnPutWithImportRejection:
+//   - Put a doc successfully and assert the HLV is updated correctly
+//   - Put a doc that will be rejected by the custom import filter
+//   - Assert that the HLV values on the sync data are still correctly updated/preserved
+func TestHLVOnPutWithImportRejection(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
+	importFilter := `function (doc) { return doc.type == "mobile"}`
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport:   false,
+			ImportFilter: &importFilter,
+		}},
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"type": "mobile"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// Put a doc that will be rejected by the import filter on the attempt to perform on demand import for write
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"type": "not-mobile"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// assert that the hlv is correctly updated and in tact after the import was cancelled on the doc
+	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc2")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}
+
 func TestTombstoneCompactionAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -211,9 +211,9 @@ func TestDocLifecycle(t *testing.T) {
 	defer rt.Close()
 
 	version := rt.CreateTestDoc("doc")
-	assert.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", version.RevID)
+	assert.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", version.RevTreeID)
 
-	response := rt.SendAdminRequest("DELETE", "/{{.keyspace}}/doc?rev="+version.RevID, "")
+	response := rt.SendAdminRequest("DELETE", "/{{.keyspace}}/doc?rev="+version.RevTreeID, "")
 	RequireStatus(t, response, 200)
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1655,10 +1655,9 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 	xattrs, _, err := rt.GetSingleDataStore().GetXattrs(rt.Context(), "-21SK00U-ujxUO9fU2HezxL", []string{base.SyncXattrName})
 	require.NoError(t, err)
 	require.Contains(t, xattrs, base.SyncXattrName)
-	var retrievedXattr map[string]any
-	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &retrievedXattr))
-	assert.NoError(t, err, "Unexpected Error")
-	assert.Equal(t, "2-466a1fab90a810dc0a63565b70680e4e", retrievedXattr["rev"])
+	var retrievedSyncData db.SyncData
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &retrievedSyncData))
+	assert.Equal(t, "2-466a1fab90a810dc0a63565b70680e4e", retrievedSyncData.CurrentRev)
 
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2826,19 +2826,17 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
-	require.NoError(t, err)
+	bucketUUID := rt.GetDatabase().EncodedBucketUUID
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"key": "value"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
-	uintCAS := base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 
 	// Put a new revision of this doc and assert that the version vector SourceID and Version is updated
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, `{"key1": "value1"}`)
@@ -2846,11 +2844,10 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 
 	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
-	uintCAS = base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 
 	// Delete doc and assert that the version vector SourceID and Version is updated
 	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, "")
@@ -2858,11 +2855,10 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 
 	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
-	uintCAS = base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 }
 
 // TestHLVOnPutWithImportRejection:
@@ -2881,19 +2877,17 @@ func TestHLVOnPutWithImportRejection(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	bucketUUID, err := rt.GetDatabase().Bucket.UUID()
-	require.NoError(t, err)
+	bucketUUID := rt.GetDatabase().EncodedBucketUUID
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"type": "mobile"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
 	assert.NoError(t, err)
-	uintCAS := base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 
 	// Put a doc that will be rejected by the import filter on the attempt to perform on demand import for write
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"type": "not-mobile"}`)
@@ -2902,11 +2896,10 @@ func TestHLVOnPutWithImportRejection(t *testing.T) {
 	// assert that the hlv is correctly updated and in tact after the import was cancelled on the doc
 	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc2")
 	assert.NoError(t, err)
-	uintCAS = base.HexCasToUint64(syncData.Cas)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, uintCAS, syncData.HLV.Version)
-	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
 }
 
 func TestTombstoneCompactionAPI(t *testing.T) {

--- a/rest/api_test_helpers.go
+++ b/rest/api_test_helpers.go
@@ -50,13 +50,13 @@ func (rt *RestTester) PutNewEditsFalse(docID string, newVersion DocVersion, pare
 	require.NoError(rt.TB, marshalErr)
 
 	requestBody := body.ShallowCopy()
-	newRevGeneration, newRevDigest := db.ParseRevID(base.TestCtx(rt.TB), newVersion.RevID)
+	newRevGeneration, newRevDigest := db.ParseRevID(base.TestCtx(rt.TB), newVersion.RevTreeID)
 
 	revisions := make(map[string]interface{})
 	revisions["start"] = newRevGeneration
 	ids := []string{newRevDigest}
-	if parentVersion.RevID != "" {
-		_, parentDigest := db.ParseRevID(base.TestCtx(rt.TB), parentVersion.RevID)
+	if parentVersion.RevTreeID != "" {
+		_, parentDigest := db.ParseRevID(base.TestCtx(rt.TB), parentVersion.RevTreeID)
 		ids = append(ids, parentDigest)
 	}
 	revisions["ids"] = ids

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -1060,7 +1060,6 @@ func TestAttachmentContentType(t *testing.T) {
 }
 
 func TestBasicAttachmentRemoval(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
@@ -2224,7 +2223,6 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 }
 
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -1060,6 +1060,7 @@ func TestAttachmentContentType(t *testing.T) {
 }
 
 func TestBasicAttachmentRemoval(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
 	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
 
@@ -2223,6 +2224,7 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 }
 
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -684,6 +684,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 }
 
 func TestConflictWithInvalidAttachment(t *testing.T) {
+	t.Skip("CBG-3748: backwards compatibility between cv and rev id for fetching backed up revs needed")
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2265,6 +2265,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
@@ -2327,6 +2328,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 	}
 	const doc1ID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -2376,6 +2378,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
 	const docID = "doc"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -2417,6 +2420,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -2598,6 +2602,7 @@ func TestCBLRevposHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2265,7 +2265,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
@@ -2328,7 +2328,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 	}
 	const doc1ID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -2378,7 +2378,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const docID = "doc"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -2420,7 +2420,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -2602,7 +2602,7 @@ func TestCBLRevposHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -43,25 +43,25 @@ func TestDocEtag(t *testing.T) {
 	version := DocVersionFromPutResponse(t, response)
 
 	// Validate Etag returned on doc creation
-	assert.Equal(t, strconv.Quote(version.RevID), response.Header().Get("Etag"))
+	assert.Equal(t, strconv.Quote(version.RevTreeID), response.Header().Get("Etag"))
 
 	response = rt.SendRequest("GET", "/{{.keyspace}}/doc", "")
 	RequireStatus(t, response, 200)
 
 	// Validate Etag returned when retrieving doc
-	assert.Equal(t, strconv.Quote(version.RevID), response.Header().Get("Etag"))
+	assert.Equal(t, strconv.Quote(version.RevTreeID), response.Header().Get("Etag"))
 
 	// Validate Etag returned when updating doc
-	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc?rev="+version.RevID, `{"prop":false}`)
+	response = rt.SendRequest("PUT", "/{{.keyspace}}/doc?rev="+version.RevTreeID, `{"prop":false}`)
 	version = DocVersionFromPutResponse(t, response)
-	assert.Equal(t, strconv.Quote(version.RevID), response.Header().Get("Etag"))
+	assert.Equal(t, strconv.Quote(version.RevTreeID), response.Header().Get("Etag"))
 
 	// Test Attachments
 	attachmentBody := "this is the body of attachment"
 	attachmentContentType := "content/type"
 
 	// attach to existing document with correct rev (should succeed), manual request to change etag
-	resource := fmt.Sprintf("/{{.keyspace}}/%s/%s?rev=%s", "doc", "attach1", version.RevID)
+	resource := fmt.Sprintf("/{{.keyspace}}/%s/%s?rev=%s", "doc", "attach1", version.RevTreeID)
 	response = rt.SendAdminRequestWithHeaders(http.MethodPut, resource, attachmentBody, attachmentHeaders())
 	RequireStatus(t, response, http.StatusCreated)
 	var body db.Body
@@ -71,7 +71,7 @@ func TestDocEtag(t *testing.T) {
 	RequireDocVersionNotEqual(t, version, afterAttachmentVersion)
 
 	// validate Etag returned from adding an attachment
-	assert.Equal(t, strconv.Quote(afterAttachmentVersion.RevID), response.Header().Get("Etag"))
+	assert.Equal(t, strconv.Quote(afterAttachmentVersion.RevTreeID), response.Header().Get("Etag"))
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/{{.keyspace}}/doc/attach1", "")
@@ -115,7 +115,7 @@ func TestDocAttachment(t *testing.T) {
 	assert.Equal(t, attachmentContentType, response.Header().Get("Content-Type"))
 
 	// attempt to delete an attachment that is not on the document
-	response = rt.SendRequest("DELETE", "/{{.keyspace}}/doc/attach2?rev="+version.RevID, "")
+	response = rt.SendRequest("DELETE", "/{{.keyspace}}/doc/attach2?rev="+version.RevTreeID, "")
 	RequireStatus(t, response, 404)
 
 	// attempt to delete attachment from non existing doc
@@ -127,7 +127,7 @@ func TestDocAttachment(t *testing.T) {
 	RequireStatus(t, response, 409)
 
 	// delete the attachment calling the delete attachment endpoint
-	response = rt.SendRequest("DELETE", "/{{.keyspace}}/doc/attach1?rev="+version.RevID, "")
+	response = rt.SendRequest("DELETE", "/{{.keyspace}}/doc/attach1?rev="+version.RevTreeID, "")
 	RequireStatus(t, response, 200)
 
 	// attempt to access deleted attachment (should return error)
@@ -221,7 +221,7 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 	}
 
 	// attach to existing document with correct rev (should fail)
-	response := rt.SendUserRequestWithHeaders("PUT", "/{{.keyspace}}/doc/attach1?rev="+version.RevID, attachmentBody, reqHeaders, "user1", "letmein")
+	response := rt.SendUserRequestWithHeaders("PUT", "/{{.keyspace}}/doc/attach1?rev="+version.RevTreeID, attachmentBody, reqHeaders, "user1", "letmein")
 	RequireStatus(t, response, 404)
 }
 
@@ -429,7 +429,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 		"Accept": "application/json",
 	}
 
-	response := rt.SendAdminRequestWithHeaders("GET", fmt.Sprintf("/{{.keyspace}}/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", afterAttachmentVersion.RevID, doc1Version.RevID), "", reqHeaders)
+	response := rt.SendAdminRequestWithHeaders("GET", fmt.Sprintf("/{{.keyspace}}/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", afterAttachmentVersion.RevTreeID, doc1Version.RevTreeID), "", reqHeaders)
 	assert.Equal(t, 200, response.Code)
 	// validate attachment has data property
 	body := db.Body{}
@@ -440,7 +440,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	data := attach1["data"]
 	assert.True(t, data != nil)
 
-	response = rt.SendAdminRequestWithHeaders("GET", fmt.Sprintf("/{{.keyspace}}/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", afterAttachmentVersion.RevID, afterAttachmentVersion.RevID), "", reqHeaders)
+	response = rt.SendAdminRequestWithHeaders("GET", fmt.Sprintf("/{{.keyspace}}/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", afterAttachmentVersion.RevTreeID, afterAttachmentVersion.RevTreeID), "", reqHeaders)
 	assert.Equal(t, 200, response.Code)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	log.Printf("response body revid1 = %s", body)
@@ -593,7 +593,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	version, _ := rt.GetDoc(doc1ID)
 
 	// Do a bulk_get to get the doc -- this was causing a panic prior to the fix for #2528
-	bulkGetDocs := fmt.Sprintf(`{"docs": [{"id": "%v", "rev": "%v"}, {"id": "%v", "rev": "%v"}]}`, doc1ID, version.RevID, doc2ID, doc2Version.RevID)
+	bulkGetDocs := fmt.Sprintf(`{"docs": [{"id": "%v", "rev": "%v"}, {"id": "%v", "rev": "%v"}]}`, doc1ID, version.RevTreeID, doc2ID, doc2Version.RevTreeID)
 	bulkGetResponse := rt.SendAdminRequest("POST", "/{{.keyspace}}/_bulk_get?revs=true&attachments=true&revs_limit=2", bulkGetDocs)
 	if bulkGetResponse.Code != 200 {
 		panic(fmt.Sprintf("Got unexpected response: %v", bulkGetResponse))
@@ -698,15 +698,15 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 
 	// Set attachment
 	attachmentBody := "aGVsbG8gd29ybGQ=" // hello.txt
-	response := rt.SendAdminRequestWithHeaders("PUT", "/{{.keyspace}}/doc1/attach1?rev="+version.RevID, attachmentBody, reqHeaders)
+	response := rt.SendAdminRequestWithHeaders("PUT", "/{{.keyspace}}/doc1/attach1?rev="+version.RevTreeID, attachmentBody, reqHeaders)
 	RequireStatus(t, response, http.StatusCreated)
-	docrevId2 := DocVersionFromPutResponse(t, response).RevID
+	docrevId2 := DocVersionFromPutResponse(t, response).RevTreeID
 
 	// Update Doc
 	rev3Input := `{"_attachments":{"attach1":{"content-type": "content/type", "digest":"sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 2, "stub": true}}, "_id": "doc1", "_rev": "` + docrevId2 + `", "prop":true}`
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", rev3Input)
 	RequireStatus(t, response, http.StatusCreated)
-	docrevId3 := DocVersionFromPutResponse(t, response).RevID
+	docrevId3 := DocVersionFromPutResponse(t, response).RevTreeID
 
 	// Get Existing Doc & Update rev
 	rev4Input := `{"_attachments":{"attach1":{"content-type": "content/type", "digest":"sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 2, "stub": true}}, "_id": "doc1", "_rev": "` + docrevId3 + `", "prop":true}`
@@ -796,7 +796,7 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", reqBodyRev2a)
 	RequireStatus(t, response, http.StatusCreated)
 	docVersion2a := DocVersionFromPutResponse(t, response)
-	assert.Equal(t, "2-twoa", docVersion2a.RevID)
+	assert.Equal(t, "2-twoa", docVersion2a.RevTreeID)
 
 	// Put attachment on doc1 rev 2
 	rev3Attachment := `aGVsbG8gd29ybGQ=` // hello.txt
@@ -815,8 +815,8 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	docVersion4a := rt.UpdateDoc("doc1", docVersion3a, rev4aBody)
 
 	// Ensure the two attachments are different
-	response1 := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?atts_since=[\""+version.RevID+"\"]&rev="+docVersion4.RevID, "")
-	response2 := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?rev="+docVersion4a.RevID, "")
+	response1 := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?atts_since=[\""+version.RevTreeID+"\"]&rev="+docVersion4.RevTreeID, "")
+	response2 := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?rev="+docVersion4a.RevTreeID, "")
 
 	var body1 db.Body
 	var body2 db.Body
@@ -865,14 +865,14 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 		`}`
 	_ = rt.UpdateDoc("doc1", docVersion5, rev6Body)
 
-	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?atts_since=[\""+version.RevID+"\"]", "")
+	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?atts_since=[\""+version.RevTreeID+"\"]", "")
 	log.Printf("Rev6 GET: %s", response.Body.Bytes())
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, attachmentsPresent := body["_attachments"]
 	assert.True(t, attachmentsPresent)
 
 	// Create conflicting rev 6 that doesn't have attachments
-	reqBodyRev6a := `{"_rev": "6-a", "_revisions": {"ids": ["a", "` + docVersion5.RevID + `"], "start": 6}}`
+	reqBodyRev6a := `{"_rev": "6-a", "_revisions": {"ids": ["a", "` + docVersion5.RevTreeID + `"], "start": 6}}`
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", reqBodyRev6a)
 	RequireStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -880,7 +880,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 	assert.Equal(t, "6-a", docRevId2a)
 
 	var rev6Response db.Body
-	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?atts_since=[\""+version.RevID+"\"]", "")
+	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?atts_since=[\""+version.RevTreeID+"\"]", "")
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &rev6Response))
 	_, attachmentsPresent = rev6Response["_attachments"]
 	assert.False(t, attachmentsPresent)
@@ -891,7 +891,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 
 	// Retrieve current winning rev with attachments
 	var rev7Response db.Body
-	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?atts_since=[\""+version.RevID+"\"]", "")
+	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?atts_since=[\""+version.RevTreeID+"\"]", "")
 	log.Printf("Rev6 GET: %s", response.Body.Bytes())
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &rev7Response))
 	_, attachmentsPresent = rev7Response["_attachments"]
@@ -2117,7 +2117,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 
 	var doc1 docResp
 	// Get losing rev and ensure attachment is still there and has not been deleted
-	resp := rt.SendAdminRequestWithHeaders("GET", "/{{.keyspace}}/doc?attachments=true&rev="+losingVersion3.RevID, "", map[string]string{"Accept": "application/json"})
+	resp := rt.SendAdminRequestWithHeaders("GET", "/{{.keyspace}}/doc?attachments=true&rev="+losingVersion3.RevTreeID, "", map[string]string{"Accept": "application/json"})
 	RequireStatus(t, resp, http.StatusOK)
 
 	err = base.JSONUnmarshal(resp.BodyBytes(), &doc1)
@@ -2134,7 +2134,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 
 	var doc2 docResp
 	// Get winning rev and ensure attachment is indeed removed from this rev
-	resp = rt.SendAdminRequestWithHeaders("GET", "/{{.keyspace}}/doc?attachments=true&rev="+finalVersion4.RevID, "", map[string]string{"Accept": "application/json"})
+	resp = rt.SendAdminRequestWithHeaders("GET", "/{{.keyspace}}/doc?attachments=true&rev="+finalVersion4.RevTreeID, "", map[string]string{"Accept": "application/json"})
 	RequireStatus(t, resp, http.StatusOK)
 
 	err = base.JSONUnmarshal(resp.BodyBytes(), &doc2)
@@ -2401,7 +2401,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		// Push a revision with a bunch of history simulating doc updated on mobile device
 		// Note this references revpos 1 and therefore SGW has it - Shouldn't need proveAttachment
 		proveAttachmentBefore := btc.pushReplication.replicationStats.ProveAttachment.Value()
-		revid, err := btcRunner.PushRevWithHistory(btc.id, docID, initialVersion.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
+		revid, err := btcRunner.PushRevWithHistory(btc.id, docID, initialVersion.RevTreeID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
 		assert.NoError(t, err)
 		proveAttachmentAfter := btc.pushReplication.replicationStats.ProveAttachment.Value()
 		assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
@@ -2446,7 +2446,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		btcRunner.AttachmentsLock(btc.id).Unlock()
 
 		// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
-		_, err = btcRunner.PushRevWithHistory(btc.id, docID, version.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
+		_, err = btcRunner.PushRevWithHistory(btc.id, docID, version.RevTreeID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
 		require.NoError(t, err)
 
 		// Ensure message and attachment is pushed up
@@ -2749,7 +2749,7 @@ func (rt *RestTester) storeAttachment(docID string, version DocVersion, attName,
 
 // storeAttachmentWithHeaders adds an attachment to a document version and returns the new version using rev= syntax.
 func (rt *RestTester) storeAttachmentWithHeaders(docID string, version DocVersion, attName, attBody string, reqHeaders map[string]string) DocVersion {
-	resource := fmt.Sprintf("/{{.keyspace}}/%s/%s?rev=%s", docID, attName, version.RevID)
+	resource := fmt.Sprintf("/{{.keyspace}}/%s/%s?rev=%s", docID, attName, version.RevTreeID)
 	response := rt.SendAdminRequestWithHeaders(http.MethodPut, resource, attBody, reqHeaders)
 	RequireStatus(rt.TB, response, http.StatusCreated)
 	var body db.Body
@@ -2761,7 +2761,7 @@ func (rt *RestTester) storeAttachmentWithHeaders(docID string, version DocVersio
 // storeAttachmentWithIfMatch adds an attachment to a document version and returns the new version, using If-Match.
 func (rt *RestTester) storeAttachmentWithIfMatch(docID string, version DocVersion, attName, attBody string) DocVersion {
 	reqHeaders := attachmentHeaders()
-	reqHeaders["If-Match"] = `"` + version.RevID + `"`
+	reqHeaders["If-Match"] = `"` + version.RevTreeID + `"`
 	resource := fmt.Sprintf("/{{.keyspace}}/%s/%s", docID, attName)
 	response := rt.SendRequestWithHeaders(http.MethodPut, resource, attBody, reqHeaders)
 	RequireStatus(rt.TB, response, http.StatusCreated)

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -291,6 +291,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -366,6 +367,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -530,6 +532,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -579,6 +582,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -601,7 +605,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 		docVersion, _ := client1.rt.GetDoc(docID)
 
 		// Store the document and attachment on the test client
-		err := btcRunner.StoreRevOnClient(client1.id, docID, docVersion.RevID, rawDoc)
+		err := btcRunner.StoreRevOnClient(client1.id, docID, docVersion.RevTreeID, rawDoc)
 
 		require.NoError(t, err)
 		btcRunner.AttachmentsLock(client1.id).Lock()
@@ -636,6 +640,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -658,7 +663,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 		version, _ := client1.rt.GetDoc(docID)
 
 		// Store the document and attachment on the test client
-		err := btcRunner.StoreRevOnClient(client1.id, docID, version.RevID, rawDoc)
+		err := btcRunner.StoreRevOnClient(client1.id, docID, version.RevTreeID, rawDoc)
 		require.NoError(t, err)
 		btcRunner.AttachmentsLock(client1.id).Lock()
 		btcRunner.Attachments(client1.id)[digest] = attBody

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -46,7 +46,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 
 	btcRunner := NewBlipTesterClientRunner(t)
 	// given this test is for v2 protocol, skip version vector test
-	btcRunner.SkipVersionVectorInitialization = true
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -120,6 +120,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -192,7 +193,7 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 	)
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipVersionVectorInitialization = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -250,7 +251,7 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 	)
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipVersionVectorInitialization = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -290,8 +290,8 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 	const docID = "doc1"
+	ctx := base.TestCtx(t)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -306,50 +306,58 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 
 		// CBL creates revisions 1-abc,2-abc on the client, with an attachment associated with rev 2.
 		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-		err = btcRunner.StoreRevOnClient(btc.id, docID, "2-abc", []byte(bodyText))
+		rev := "2-abc"
+		if btc.UseHLV() {
+			rev = db.EncodeTestVersion("2@abc")
+		}
+		err = btcRunner.StoreRevOnClient(btc.id, docID, rev, []byte(bodyText))
 		require.NoError(t, err)
 
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 		revId, err := btcRunner.PushRevWithHistory(btc.id, docID, "", []byte(bodyText), 2, 0)
 		require.NoError(t, err)
-		assert.Equal(t, "2-abc", revId)
+		assert.Equal(t, rev, revId)
 
 		// Wait for the documents to be replicated at SG
 		btc.pushReplication.WaitForMessage(2)
 
-		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-		assert.Equal(t, http.StatusOK, resp.Code)
+		collection := rt.GetSingleTestDatabaseCollection()
+		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalNoHistory)
+		require.NoError(t, err)
+
+		attachmentRevPos, _ := db.ParseRevID(ctx, doc.CurrentRev)
 
 		// CBL updates the doc w/ two more revisions, 3-abc, 4-abc,
 		// these are sent to SG as 4-abc, history:[4-abc,3-abc,2-abc], the attachment has revpos=2
 		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 		revId, err = btcRunner.PushRevWithHistory(btc.id, docID, revId, []byte(bodyText), 2, 0)
 		require.NoError(t, err)
-		assert.Equal(t, "4-abc", revId)
+		expectedRev := "4-abc"
+		if btc.UseHLV() {
+			expectedRev = db.EncodeTestVersion("4@abc")
+		}
+		assert.Equal(t, expectedRev, revId)
 
 		// Wait for the document to be replicated at SG
 		btc.pushReplication.WaitForMessage(4)
 
-		resp = btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-		assert.Equal(t, http.StatusOK, resp.Code)
+		doc, err = collection.GetDocument(ctx, docID, db.DocUnmarshalNoHistory)
+		require.NoError(t, err)
 
-		var respBody db.Body
-		assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
-
-		assert.Equal(t, docID, respBody[db.BodyId])
-		assert.Equal(t, "4-abc", respBody[db.BodyRev])
-		greetings := respBody["greetings"].([]interface{})
+		btc.RequireRev(t, expectedRev, doc)
+		body := doc.Body(ctx)
+		greetings := body["greetings"].([]interface{})
 		assert.Len(t, greetings, 1)
 		assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
 
-		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-		require.True(t, ok)
-		assert.Len(t, attachments, 1)
-		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		assert.Len(t, doc.Attachments, 1)
+		hello, ok := doc.Attachments["hello.txt"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
 		assert.Equal(t, float64(11), hello["length"])
-		assert.Equal(t, float64(2), hello["revpos"])
+
+		// revpos should mach the generation of the original revision
+		assert.Equal(t, float64(attachmentRevPos), hello["revpos"])
 		assert.True(t, hello["stub"].(bool))
 
 		// Check the number of sendProveAttachment/sendGetAttachment calls.
@@ -366,7 +374,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
+	ctx := base.TestCtx(t)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -382,37 +390,47 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		// rev tree pruning on the CBL side, so 1-abc no longer exists.
 		// CBL replicates, sends to client as 4-abc history:[4-abc, 3-abc, 2-abc], attachment has revpos=2
 		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-		err = btcRunner.StoreRevOnClient(btc.id, docID, "2-abc", []byte(bodyText))
+		rev := "2-abc"
+		if btc.UseHLV() {
+			rev = db.EncodeTestVersion("2@abc")
+		}
+		err = btcRunner.StoreRevOnClient(btc.id, docID, rev, []byte(bodyText))
 		require.NoError(t, err)
 
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-		revId, err := btcRunner.PushRevWithHistory(btc.id, docID, "2-abc", []byte(bodyText), 2, 0)
+		currentRev, err := btcRunner.PushRevWithHistory(btc.id, docID, rev, []byte(bodyText), 2, 0)
 		require.NoError(t, err)
-		assert.Equal(t, "4-abc", revId)
+		expectedRev := "4-abc"
+		if btc.UseHLV() {
+			expectedRev = db.EncodeTestVersion("4@abc")
+		}
+		assert.Equal(t, expectedRev, currentRev)
 
 		// Wait for the document to be replicated at SG
 		btc.pushReplication.WaitForMessage(2)
 
-		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
-		assert.Equal(t, http.StatusOK, resp.Code)
+		collection := rt.GetSingleTestDatabaseCollection()
+		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalNoHistory)
+		require.NoError(t, err)
 
-		var respBody db.Body
-		assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
+		btc.RequireRev(t, expectedRev, doc)
 
-		assert.Equal(t, docID, respBody[db.BodyId])
-		assert.Equal(t, "4-abc", respBody[db.BodyRev])
-		greetings := respBody["greetings"].([]interface{})
+		body := doc.Body(ctx)
+		greetings := body["greetings"].([]interface{})
 		assert.Len(t, greetings, 1)
 		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
 
-		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-		require.True(t, ok)
-		assert.Len(t, attachments, 1)
-		hello, ok := attachments["hello.txt"].(map[string]interface{})
+		assert.Len(t, doc.Attachments, 1)
+		hello, ok := doc.Attachments["hello.txt"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
 		assert.Equal(t, float64(11), hello["length"])
-		assert.Equal(t, float64(4), hello["revpos"])
+
+		// revpos should match the generation of the current revision, since it's new to SGW with that revision.
+		// The actual revTreeID will differ when running this test as HLV client (multiple updates to HLV on client
+		// don't result in multiple revTree revisions)
+		expectedRevPos, _ := db.ParseRevID(ctx, doc.CurrentRev)
+		assert.Equal(t, float64(expectedRevPos), hello["revpos"])
 		assert.True(t, hello["stub"].(bool))
 
 		// Check the number of sendProveAttachment/sendGetAttachment calls.
@@ -532,7 +550,6 @@ func TestBlipAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -582,7 +599,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires legacy attachment upgrade to HLV (CBG-3806)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -602,10 +619,10 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 		CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDoc, attKey, attBody)
 
 		// Get the document and grab the revID.
-		docVersion, _ := client1.rt.GetDoc(docID)
+		docVersion := client1.GetDocVersion(docID)
 
 		// Store the document and attachment on the test client
-		err := btcRunner.StoreRevOnClient(client1.id, docID, docVersion.RevTreeID, rawDoc)
+		err := btcRunner.StoreRevOnClient(client1.id, docID, docVersion.GetRev(client1.UseHLV()), rawDoc)
 
 		require.NoError(t, err)
 		btcRunner.AttachmentsLock(client1.id).Lock()
@@ -640,7 +657,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires legacy attachment upgrade to HLV (CBG-3806)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -45,8 +45,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	// given this test is for v2 protocol, skip version vector test
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -120,7 +119,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -193,7 +192,7 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 	)
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -251,7 +250,7 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 	)
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -291,7 +290,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -367,7 +366,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -527,12 +526,13 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 // TestBlipAttachNameChange tests CBL handling - attachments with changed names are sent as stubs, and not new attachments
 func TestBlipAttachNameChange(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
+
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -582,7 +582,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -640,7 +640,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1837,7 +1837,7 @@ func TestPutRevV4(t *testing.T) {
 // Actual:
 // - Same as Expected (this test is unable to repro SG #3281, but is being left in as a regression test)
 func TestGetRemovedDoc(t *testing.T) {
-
+	t.Skip("CBG-3748: backwards compatibility between cv and rev id for fetching backed up revs needed")
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1955,8 +1955,8 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 		version1 := DocVersion{
 			RevID: bucketDoc.CurrentRev,
 			CV: db.Version{
-				SourceID: otherSource,
-				Value:    cas,
+				SourceID: hlvHelper.Source,
+				Value:    string(base.Uint64CASToLittleEndianHex(cas)),
 			},
 		}
 
@@ -3008,7 +3008,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 			},
 			{
 				name:        "_revisions property",
-				invalidBody: []byte(`{"_revisions": {"start": 0, "ids": ["foo", "def]"}}`),
+				invalidBody: []byte(`{"_revisions": {"start": 0, "ids": ["foo", "def"]}}`),
 			},
 
 			{

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2580,7 +2580,6 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797) for _attachments subtest
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		// Setup

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -651,21 +651,21 @@ func TestProposedChangesIncludeConflictingRev(t *testing.T) {
 	// Write existing docs to server directly (not via blip)
 	rt := bt.restTester
 	resp := rt.PutDoc("conflictingInsert", `{"version":1}`)
-	conflictingInsertRev := resp.RevID
+	conflictingInsertRev := resp.RevTreeID
 
 	resp = rt.PutDoc("matchingInsert", `{"version":1}`)
-	matchingInsertRev := resp.RevID
+	matchingInsertRev := resp.RevTreeID
 
 	resp = rt.PutDoc("conflictingUpdate", `{"version":1}`)
-	conflictingUpdateRev1 := resp.RevID
-	conflictingUpdateRev2 := rt.UpdateDocRev("conflictingUpdate", resp.RevID, `{"version":2}`)
+	conflictingUpdateRev1 := resp.RevTreeID
+	conflictingUpdateRev2 := rt.UpdateDocRev("conflictingUpdate", resp.RevTreeID, `{"version":2}`)
 
 	resp = rt.PutDoc("matchingUpdate", `{"version":1}`)
-	matchingUpdateRev1 := resp.RevID
-	matchingUpdateRev2 := rt.UpdateDocRev("matchingUpdate", resp.RevID, `{"version":2}`)
+	matchingUpdateRev1 := resp.RevTreeID
+	matchingUpdateRev2 := rt.UpdateDocRev("matchingUpdate", resp.RevTreeID, `{"version":2}`)
 
 	resp = rt.PutDoc("newUpdate", `{"version":1}`)
-	newUpdateRev1 := resp.RevID
+	newUpdateRev1 := resp.RevTreeID
 
 	type proposeChangesCase struct {
 		key           string
@@ -1953,7 +1953,7 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 
 		// create doc version of the above doc write
 		version1 := DocVersion{
-			RevID: bucketDoc.CurrentRev,
+			RevTreeID: bucketDoc.CurrentRev,
 			CV: db.Version{
 				SourceID: hlvHelper.Source,
 				Value:    string(base.Uint64CASToLittleEndianHex(cas)),
@@ -2479,6 +2479,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		// Setup

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -24,7 +24,7 @@ import (
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.
 func TestBlipDeltaSyncPushAttachment(t *testing.T) {
-	t.Skip("attachments not yet implemented for HLV replication CBG-3797") // delta sync not implemented for Version Vectors replication attachment handling
+	//t.Skip("attachments not yet implemented for HLV replication CBG-3797") // delta sync not implemented for Version Vectors replication attachment handling
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.IsEnterpriseEdition() {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -199,7 +199,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		bodyText := `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`
-		body := jsonToMap(t, bodyText)
+		body := JsonToMap(t, bodyText)
 		version := rt.PutDocDirectly(doc1ID, body)
 
 		data := btcRunner.WaitForVersion(client.id, doc1ID, version)
@@ -207,7 +207,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 
 		// create doc1 rev 2-10000d5ec533b29b117e60274b1e3653 on SG with the first attachment
 		bodyText = `{"greetings": [{"hello": "world!"}, {"hi": "alice"}], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
-		body = jsonToMap(t, bodyText)
+		body = JsonToMap(t, bodyText)
 		version2 := rt.UpdateDocDirectly(doc1ID, version, body)
 
 		data = btcRunner.WaitForVersion(client.id, doc1ID, version2)
@@ -303,7 +303,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		bodyText := `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`
-		body := jsonToMap(t, bodyText)
+		body := JsonToMap(t, bodyText)
 		version := rt.PutDocDirectly(docID, body)
 
 		data := btcRunner.WaitForVersion(client.id, docID, version)
@@ -311,7 +311,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 
 		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
 		bodyText = `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 1234567890123}]}`
-		version2 := rt.UpdateDocDirectly(docID, version, jsonToMap(t, bodyText))
+		version2 := rt.UpdateDocDirectly(docID, version, JsonToMap(t, bodyText))
 
 		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":1234567890123}]}`, string(data))
@@ -372,7 +372,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		docID := "doc1"
 		// create doc1 rev 1
 		bodyText := `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`
-		docVersion1 := rt.PutDocDirectly(docID, jsonToMap(t, bodyText))
+		docVersion1 := rt.PutDocDirectly(docID, JsonToMap(t, bodyText))
 
 		deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 
@@ -397,7 +397,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 
 		// create doc1 rev 2
 		bodyText = `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 1234567890123}]}`
-		docVersion2 := rt.UpdateDocDirectly(docID, docVersion1, jsonToMap(t, bodyText))
+		docVersion2 := rt.UpdateDocDirectly(docID, docVersion1, JsonToMap(t, bodyText))
 
 		data = btcRunner.WaitForVersion(client.id, docID, docVersion2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":1234567890123}]}`, string(data))
@@ -539,7 +539,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		const docID = "doc1"
 		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
 		bodyText := `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`
-		version := rt.PutDocDirectly(docID, jsonToMap(t, bodyText))
+		version := rt.PutDocDirectly(docID, JsonToMap(t, bodyText))
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Contains(t, string(data), `"channels":["public"]`)
 		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
@@ -643,7 +643,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
 		bodyText := `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`
-		version := rt.PutDocDirectly(docID, jsonToMap(t, bodyText))
+		version := rt.PutDocDirectly(docID, JsonToMap(t, bodyText))
 
 		data := btcRunner.WaitForVersion(client1.id, docID, version)
 		assert.Contains(t, string(data), `"channels":["public"]`)
@@ -764,7 +764,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		bodyText := `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`
-		version1 := rt.PutDocDirectly(docID, jsonToMap(t, bodyText))
+		version1 := rt.PutDocDirectly(docID, JsonToMap(t, bodyText))
 
 		data := btcRunner.WaitForVersion(client.id, docID, version1)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
@@ -781,7 +781,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
 		bodyText = `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`
-		version2 := rt.UpdateDocDirectly(docID, version1, jsonToMap(t, bodyText))
+		version2 := rt.UpdateDocDirectly(docID, version1, JsonToMap(t, bodyText))
 
 		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -23,10 +23,8 @@ import (
 )
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.
-
 func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -42,7 +40,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	const docID = "pushAttachmentDoc"
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -113,7 +111,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
@@ -184,7 +182,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	const doc1ID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -282,7 +280,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	const docID = "doc1"
 	var deltaSentCount int64
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			rtConfig)
@@ -358,7 +356,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			&rtConfig)
@@ -428,7 +426,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // requires delta sync - CBG-3736
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -493,7 +491,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication"
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
@@ -589,7 +587,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -732,7 +730,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	}
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
@@ -817,7 +815,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -924,7 +922,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -185,7 +185,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatability
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatibility
 	const doc1ID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -287,7 +287,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	const docID = "doc1"
 	var deltaSentCount int64
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatability
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatibility
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			rtConfig)
@@ -366,7 +366,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatability
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatibility
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			&rtConfig)
@@ -509,7 +509,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatability
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatibility
 
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
@@ -606,7 +606,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatability
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatibility
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -750,7 +750,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	}
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatability
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for backwards compatibility
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -42,6 +42,8 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	const docID = "pushAttachmentDoc"
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
@@ -373,7 +375,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		defer client.Close()
 
 		// reject deltas built ontop of rev 1
-		client.rejectDeltasForSrcRev = docVersion1.RevID
+		client.rejectDeltasForSrcRev = docVersion1.RevTreeID
 
 		client.ClientDeltas = true
 		err := btcRunner.StartPull(client.id)
@@ -390,7 +392,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		msg := client.pullReplication.WaitForMessage(5)
 
 		// Check the request was initially sent with the correct deltaSrc property
-		assert.Equal(t, docVersion1.RevID, msg.Properties[db.RevMessageDeltaSrc])
+		assert.Equal(t, docVersion1.RevTreeID, msg.Properties[db.RevMessageDeltaSrc])
 		// Check the request body was the actual delta
 		msgBody, err := msg.Body()
 		assert.NoError(t, err)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -24,6 +24,8 @@ import (
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.
 func TestBlipDeltaSyncPushAttachment(t *testing.T) {
+	t.Skip("delta sync not implemented for Version Vectors replication push") // delta sync not implemented for Version Vectors replication 'push'
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
@@ -97,6 +99,8 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 // 5. Update doc in the test client by adding another attachment
 // 6. Have that update pushed using delta sync via the continuous replication started in step 2
 func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
+	t.Skip("delta sync not implemented for Version Vectors replication push") // delta sync not implemented for Version Vectors replication
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
@@ -111,7 +115,6 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
@@ -823,6 +826,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 // TestBlipDeltaSyncPush tests that a simple push replication handles deltas in EE,
 // and checks that full body replication is still supported in CE.
 func TestBlipDeltaSyncPush(t *testing.T) {
+	t.Skip("delta sync not implemented for Version Vectors replication push") // delta sync not implemented for Version Vectors replication 'push'
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	sgUseDeltas := base.IsEnterpriseEdition()
@@ -834,10 +838,9 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		}},
 		GuestEnabled: true,
 	}
-	btcRunner := NewBlipTesterClientRunner(t)
-	t.Skip("delta sync not implemented for Version Vectors replication push") // delta sync not implemented for Version Vectors replication 'push'
-	const docID = "doc1"
 
+	btcRunner := NewBlipTesterClientRunner(t)
+	const docID = "doc1"
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			&rtConfig)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -845,7 +845,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 			assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
+			docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -24,7 +24,7 @@ import (
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.
 func TestBlipDeltaSyncPushAttachment(t *testing.T) {
-	//t.Skip("attachments not yet implemented for HLV replication CBG-3797") // delta sync not implemented for Version Vectors replication attachment handling
+	t.Skip("attachments not yet implemented for HLV replication CBG-3797") // delta sync not implemented for Version Vectors replication attachment handling
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.IsEnterpriseEdition() {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -111,6 +111,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
@@ -181,6 +182,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
 	const doc1ID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -278,6 +280,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	const docID = "doc1"
 	var deltaSentCount int64
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			rtConfig)
@@ -353,6 +356,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			&rtConfig)
@@ -422,7 +426,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipVersionVectorInitialization = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -487,6 +491,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication"
 
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
@@ -582,6 +587,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -724,6 +730,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	}
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
@@ -808,6 +815,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -914,6 +922,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -1125,6 +1125,13 @@ func (btc *BlipTesterClient) UseHLV() bool {
 	return false
 }
 
+func (btc *BlipTesterClient) AssertDeltaSrcProperty(t *testing.T, msg *blip.Message, docVersion DocVersion) {
+	subProtocol, err := db.ParseSubprotocolString(btc.SupportedBLIPProtocols[0])
+	require.NoError(t, err)
+	rev := docVersion.GetRev(subProtocol >= db.CBMobileReplicationV4)
+	assert.Equal(t, rev, msg.Properties[db.RevMessageDeltaSrc])
+}
+
 func (btc *BlipTesterClient) AssertOnBlipHistory(t *testing.T, msg *blip.Message, docVersion DocVersion) {
 	subProtocol, err := db.ParseSubprotocolString(btc.SupportedBLIPProtocols[0])
 	require.NoError(t, err)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -65,18 +65,13 @@ type BlipTesterClient struct {
 }
 
 type BlipTesterCollectionClient struct {
-	parent *BlipTesterClient
-
-	collection    string
-	collectionIdx int
-
-	docs map[string]map[string]*BodyMessagePair // Client's local store of documents - Map of docID
-	// to rev ID to bytes
-	attachments           map[string][]byte // Client's local store of attachments - Map of digest to bytes
-	lastReplicatedRev     map[string]string // Latest known rev pulled or pushed
-	docsLock              sync.RWMutex      // lock for docs map
-	attachmentsLock       sync.RWMutex      // lock for attachments map
-	lastReplicatedRevLock sync.RWMutex      // lock for lastReplicatedRev map
+	parent          *BlipTesterClient
+	collection      string
+	collectionIdx   int
+	docs            map[string]*BlipTesterDoc // Client's local store of documents, indexed by DocID
+	attachments     map[string][]byte         // Client's local store of attachments - Map of digest to bytes
+	docsLock        sync.RWMutex              // lock for docs map
+	attachmentsLock sync.RWMutex              // lock for attachments map
 }
 
 // BlipTestClientRunner is for running the blip tester client and its associated methods in test framework
@@ -87,9 +82,94 @@ type BlipTestClientRunner struct {
 	SkipSubtest                 map[string]bool // map of sub tests on the blip tester runner to skip
 }
 
-type BodyMessagePair struct {
-	body    []byte
-	message *blip.Message
+type BlipTesterDoc struct {
+	revMode           blipTesterRevMode
+	body              []byte
+	revMessageHistory map[string]*blip.Message // History of rev messages received for this document, indexed by revID
+	revHistory        []string                 // ordered history of revTreeIDs (newest first), populated when mode = revtree
+	HLV               db.HybridLogicalVector   // HLV, populated when mode = HLV
+}
+
+const (
+	revModeRevTree blipTesterRevMode = iota
+	revModeHLV
+)
+
+type blipTesterRevMode uint32
+
+func (doc *BlipTesterDoc) isRevKnown(revID string) bool {
+	if doc.revMode == revModeHLV {
+		version := VersionFromRevID(revID)
+		return doc.HLV.IsVersionKnown(version)
+	} else {
+		for _, revTreeID := range doc.revHistory {
+			if revTreeID == revID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (doc *BlipTesterDoc) makeRevHistoryForChangesResponse() []string {
+	if doc.revMode == revModeHLV {
+		// For HLV, a changes response only needs to send cv, since rev message will always send full HLV
+		return []string{doc.HLV.GetCurrentVersionString()}
+	} else {
+		var revList []string
+		if len(doc.revHistory) < 20 {
+			revList = doc.revHistory
+		} else {
+			revList = doc.revHistory[0:19]
+		}
+		return revList
+	}
+}
+
+func (doc *BlipTesterDoc) getCurrentRevID() string {
+	if doc.revMode == revModeHLV {
+		return doc.HLV.GetCurrentVersionString()
+	} else {
+		if len(doc.revHistory) == 0 {
+			return ""
+		}
+		return doc.revHistory[0]
+	}
+}
+
+func (doc *BlipTesterDoc) addRevision(revID string, body []byte, message *blip.Message) {
+	doc.revMessageHistory[revID] = message
+	doc.body = body
+	if doc.revMode == revModeHLV {
+		_ = doc.HLV.AddVersion(VersionFromRevID(revID))
+	} else {
+		// prepend revID to revHistory
+		doc.revHistory = append([]string{revID}, doc.revHistory...)
+	}
+}
+
+func (btcr *BlipTesterCollectionClient) NewBlipTesterDoc(revID string, body []byte, message *blip.Message) *BlipTesterDoc {
+	doc := &BlipTesterDoc{
+		body:              body,
+		revMessageHistory: map[string]*blip.Message{revID: message},
+	}
+	if btcr.UseHLV() {
+		doc.revMode = revModeHLV
+		doc.HLV = db.NewHybridLogicalVector()
+		_ = doc.HLV.AddVersion(VersionFromRevID(revID))
+	} else {
+		doc.revMode = revModeRevTree
+		doc.revHistory = []string{revID}
+	}
+	return doc
+}
+
+func VersionFromRevID(revID string) db.Version {
+	version, err := db.ParseVersion(revID)
+	if err != nil {
+		panic(err)
+	}
+	return version
 }
 
 // BlipTesterReplicator is a BlipTester which stores a map of messages keyed by Serial Number
@@ -150,7 +230,6 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 	btr.bt.blipContext.HandlerForProfile[db.MessageChanges] = func(msg *blip.Message) {
 		btr.storeMessage(msg)
-
 		btcr := btc.getCollectionClientFromMessage(msg)
 
 		// Exit early when there's nothing to do
@@ -186,33 +265,16 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 				// Build up a list of revisions known to the client for each change
 				// The first element of each revision list must be the parent revision of the change
-				if revs, haveDoc := btcr.docs[docID]; haveDoc {
-					revList := make([]string, 0, len(revs))
-
-					// Insert the highest ancestor rev generation at the start of the revList
-					latest, ok := btcr.getLastReplicatedRev(docID)
-					if ok {
-						revList = append(revList, latest)
+				if doc, haveDoc := btcr.docs[docID]; haveDoc {
+					if deletedInt&2 == 2 {
+						continue
 					}
 
-					for knownRevID := range revs {
-						if deletedInt&2 == 2 {
-							continue
-						}
-
-						if revID == knownRevID {
-							knownRevs[i] = nil // Send back null to signal we don't need this change
-							continue outer
-						} else if latest == knownRevID {
-							// We inserted this rev as the first element above, so skip it here
-							continue
-						}
-
-						// TODO: Limit known revs to 20 to copy CBL behaviour
-						revList = append(revList, knownRevID)
+					if doc.isRevKnown(revID) {
+						knownRevs[i] = nil
+						continue outer
 					}
-
-					knownRevs[i] = revList
+					knownRevs[i] = doc.makeRevHistoryForChangesResponse()
 				} else {
 					knownRevs[i] = []interface{}{} // sending empty array means we've not seen the doc before, but still want it
 				}
@@ -252,14 +314,12 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		if msg.Properties[db.RevMessageDeleted] == "1" {
 			btcr.docsLock.Lock()
 			defer btcr.docsLock.Unlock()
-			if _, ok := btcr.docs[docID]; ok {
-				bodyMessagePair := &BodyMessagePair{body: body, message: msg}
-				btcr.docs[docID][revID] = bodyMessagePair
+
+			if doc, ok := btcr.docs[docID]; ok {
+				doc.addRevision(revID, body, msg)
 			} else {
-				bodyMessagePair := &BodyMessagePair{body: body, message: msg}
-				btcr.docs[docID] = map[string]*BodyMessagePair{revID: bodyMessagePair}
+				btcr.docs[docID] = btcr.NewBlipTesterDoc(revID, body, msg)
 			}
-			btcr.updateLastReplicatedRev(docID, revID)
 
 			if !msg.NoReply() {
 				response := msg.Response()
@@ -290,7 +350,12 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 			var old db.Body
 			btcr.docsLock.RLock()
-			oldBytes := btcr.docs[docID][deltaSrc].body
+			// deltaSrc must be the current rev
+			doc := btcr.docs[docID]
+			if doc.getCurrentRevID() != deltaSrc {
+				panic("current rev doesn't match deltaSrc")
+			}
+			oldBytes := doc.body
 			btcr.docsLock.RUnlock()
 			err = old.Unmarshal(oldBytes)
 			require.NoError(btc.TB(), err)
@@ -416,14 +481,11 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		btcr.docsLock.Lock()
 		defer btcr.docsLock.Unlock()
 
-		if _, ok := btcr.docs[docID]; ok {
-			bodyMessagePair := &BodyMessagePair{body: body, message: msg}
-			btcr.docs[docID][revID] = bodyMessagePair
+		if doc, ok := btcr.docs[docID]; ok {
+			doc.addRevision(revID, body, msg)
 		} else {
-			bodyMessagePair := &BodyMessagePair{body: body, message: msg}
-			btcr.docs[docID] = map[string]*BodyMessagePair{revID: bodyMessagePair}
+			btcr.docs[docID] = btcr.NewBlipTesterDoc(revID, body, msg)
 		}
-		btcr.updateLastReplicatedRev(docID, revID)
 
 		if !msg.NoReply() {
 			response := msg.Response()
@@ -472,6 +534,10 @@ func (btc *BlipTesterCollectionClient) TB() testing.TB {
 	return btc.parent.rt.TB
 }
 
+func (btcc *BlipTesterCollectionClient) UseHLV() bool {
+	return btcc.parent.UseHLV()
+}
+
 // saveAttachment takes a content-type, and base64 encoded data and stores the attachment on the client
 func (btc *BlipTesterCollectionClient) saveAttachment(_, base64data string) (dataLength int, digest string, err error) {
 	btc.attachmentsLock.Lock()
@@ -506,32 +572,6 @@ func (btc *BlipTesterCollectionClient) getAttachment(digest string) (attachment 
 	return attachment, nil
 }
 
-func (btc *BlipTesterCollectionClient) updateLastReplicatedRev(docID, revID string) {
-	btc.lastReplicatedRevLock.Lock()
-	defer btc.lastReplicatedRevLock.Unlock()
-
-	currentRevID, ok := btc.lastReplicatedRev[docID]
-	if !ok {
-		btc.lastReplicatedRev[docID] = revID
-		return
-	}
-
-	ctx := base.TestCtx(btc.parent.rt.TB)
-	currentGen, _ := db.ParseRevID(ctx, currentRevID)
-	incomingGen, _ := db.ParseRevID(ctx, revID)
-	if incomingGen > currentGen {
-		btc.lastReplicatedRev[docID] = revID
-	}
-}
-
-func (btc *BlipTesterCollectionClient) getLastReplicatedRev(docID string) (revID string, ok bool) {
-	btc.lastReplicatedRevLock.RLock()
-	defer btc.lastReplicatedRevLock.RUnlock()
-
-	revID, ok = btc.lastReplicatedRev[docID]
-	return revID, ok
-}
-
 func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, skipCollectionsInitialization bool) (*BlipTesterReplicator, error) {
 	bt, err := NewBlipTesterFromSpecWithRT(tb, &BlipTesterSpec{
 		connectingPassword:            "test",
@@ -558,9 +598,9 @@ func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, s
 
 // getCollectionsForBLIP returns collections configured by a single database instance on a restTester. If only default collection exists, it will skip returning it to test "legacy" blip mode.
 func getCollectionsForBLIP(_ testing.TB, rt *RestTester) []string {
-	db := rt.GetDatabase()
+	dbc := rt.GetDatabase()
 	var collections []string
-	for _, collection := range db.CollectionByID {
+	for _, collection := range dbc.CollectionByID {
 		if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
 			continue
 		}
@@ -659,10 +699,9 @@ func (btc *BlipTesterClient) createBlipTesterReplications() error {
 		}
 	} else {
 		btc.nonCollectionAwareClient = &BlipTesterCollectionClient{
-			docs:              make(map[string]map[string]*BodyMessagePair),
-			attachments:       make(map[string][]byte),
-			lastReplicatedRev: make(map[string]string),
-			parent:            btc,
+			docs:        make(map[string]*BlipTesterDoc),
+			attachments: make(map[string][]byte),
+			parent:      btc,
 		}
 	}
 
@@ -674,10 +713,9 @@ func (btc *BlipTesterClient) createBlipTesterReplications() error {
 
 func (btc *BlipTesterClient) initCollectionReplication(collection string, collectionIdx int) error {
 	btcReplicator := &BlipTesterCollectionClient{
-		docs:              make(map[string]map[string]*BodyMessagePair),
-		attachments:       make(map[string][]byte),
-		lastReplicatedRev: make(map[string]string),
-		parent:            btc,
+		docs:        make(map[string]*BlipTesterDoc),
+		attachments: make(map[string][]byte),
+		parent:      btc,
 	}
 
 	btcReplicator.collection = collection
@@ -790,12 +828,8 @@ func (btc *BlipTesterCollectionClient) UnsubPushChanges() (response []byte, err 
 // Close will empty the stored docs and close the underlying replications.
 func (btc *BlipTesterCollectionClient) Close() {
 	btc.docsLock.Lock()
-	btc.docs = make(map[string]map[string]*BodyMessagePair, 0)
+	btc.docs = make(map[string]*BlipTesterDoc, 0)
 	btc.docsLock.Unlock()
-
-	btc.lastReplicatedRevLock.Lock()
-	btc.lastReplicatedRev = make(map[string]string, 0)
-	btc.lastReplicatedRevLock.Unlock()
 
 	btc.attachmentsLock.Lock()
 	btc.attachments = make(map[string][]byte, 0)
@@ -814,20 +848,66 @@ func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) (err error) {
 // PushRev creates a revision on the client, and immediately sends a changes request for it.
 // The rev ID is always: "N-abc", where N is rev generation for predictability.
 func (btc *BlipTesterCollectionClient) PushRev(docID string, parentVersion DocVersion, body []byte) (DocVersion, error) {
-	revid, err := btc.PushRevWithHistory(docID, parentVersion.RevID, body, 1, 0)
-	return DocVersion{RevID: revid}, err
+	revid, err := btc.PushRevWithHistory(docID, parentVersion.RevTreeID, body, 1, 0)
+	if err != nil {
+		return DocVersion{}, err
+	}
+	docVersion := btc.GetDocVersion(docID)
+	require.Equal(btc.parent.rt.TB, docVersion.RevTreeID, revid)
+	return docVersion, nil
+}
+
+// GetDocVersion fetches revid and cv directly from the bucket.  Used to support REST-based verification in btc tests
+// even while REST only supports revTreeId
+func (btc *BlipTesterCollectionClient) GetDocVersion(docID string) DocVersion {
+
+	collection := btc.parent.rt.GetSingleTestDatabaseCollection()
+	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB), btc.parent.rt.GetDatabase().Name, nil)
+	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalSync)
+	require.NoError(btc.parent.rt.TB, err)
+	if doc.HLV == nil {
+		return DocVersion{RevTreeID: doc.CurrentRev}
+	}
+	return DocVersion{RevTreeID: doc.CurrentRev, CV: db.Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}}
 }
 
 // PushRevWithHistory creates a revision on the client with history, and immediately sends a changes request for it.
 func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev string, body []byte, revCount, prunedRevCount int) (revID string, err error) {
 	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB), btc.parent.rt.GetDatabase().Name, nil)
-	parentRevGen, _ := db.ParseRevID(ctx, parentRev)
-	revGen := parentRevGen + revCount + prunedRevCount
 
+	revGen := 0
+	newRevID := ""
 	var revisionHistory []string
-	for i := revGen - 1; i > parentRevGen; i-- {
-		rev := fmt.Sprintf("%d-%s", i, "abc")
-		revisionHistory = append(revisionHistory, rev)
+	if btc.UseHLV() {
+		// When using version vectors:
+		//  - source is "abc"
+		//  - version value is simple counter
+		//  - revisionHistory is just previous cv (parentRev) for changes response
+		startValue := uint64(0)
+		if parentRev != "" {
+			parentVersion, _ := db.ParseDecodedVersion(parentRev)
+			startValue = parentVersion.Value
+			revisionHistory = append(revisionHistory, parentRev)
+		}
+		newVersion := db.DecodedVersion{SourceID: "abc", Value: startValue + uint64(revCount) + 1}
+		newRevID = newVersion.String()
+
+	} else {
+		// When using revtrees:
+		//  - all revIDs are of the form [generation]-abc
+		//  - [revCount] history entries are generated between the parent and the new rev
+		parentRevGen, _ := db.ParseRevID(ctx, parentRev)
+		revGen = parentRevGen + revCount + prunedRevCount
+
+		for i := revGen - 1; i > parentRevGen; i-- {
+			rev := fmt.Sprintf("%d-%s", i, "abc")
+			revisionHistory = append(revisionHistory, rev)
+		}
+		if parentRev != "" {
+
+			revisionHistory = append(revisionHistory, parentRev)
+		}
+		newRevID = fmt.Sprintf("%d-%s", revGen, "abc")
 	}
 
 	// Inline attachment processing
@@ -837,19 +917,16 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev strin
 	}
 
 	var parentDocBody []byte
-	newRevID := fmt.Sprintf("%d-%s", revGen, "abc")
 	btc.docsLock.Lock()
 	if parentRev != "" {
-		revisionHistory = append(revisionHistory, parentRev)
-		if _, ok := btc.docs[docID]; ok {
-			// create new rev if doc and parent rev already exists
-			if parentDoc, okParent := btc.docs[docID][parentRev]; okParent {
-				parentDocBody = parentDoc.body
-				bodyMessagePair := &BodyMessagePair{body: body}
-				btc.docs[docID][newRevID] = bodyMessagePair
+		if doc, ok := btc.docs[docID]; ok {
+			// create new rev if doc exists and parent rev is current rev
+			if doc.getCurrentRevID() == parentRev {
+				parentDocBody = doc.body
+				doc.addRevision(newRevID, body, nil)
 			} else {
 				btc.docsLock.Unlock()
-				return "", fmt.Errorf("docID: %v with parent rev: %v was not found on the client", docID, parentRev)
+				return "", fmt.Errorf("docID: %v with current rev: %v was not found on the client", docID, parentRev)
 			}
 		} else {
 			btc.docsLock.Unlock()
@@ -858,8 +935,7 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev strin
 	} else {
 		// create new doc + rev
 		if _, ok := btc.docs[docID]; !ok {
-			bodyMessagePair := &BodyMessagePair{body: body}
-			btc.docs[docID] = map[string]*BodyMessagePair{newRevID: bodyMessagePair}
+			btc.docs[docID] = btc.NewBlipTesterDoc(newRevID, body, nil)
 		}
 	}
 	btc.docsLock.Unlock()
@@ -936,7 +1012,6 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev strin
 		return "", fmt.Errorf("error %s %s from revResponse: %s", revResponse.Properties["Error-Domain"], revResponse.Properties["Error-Code"], rspBody)
 	}
 
-	btc.updateLastReplicatedRev(docID, newRevID)
 	return newRevID, nil
 }
 
@@ -947,8 +1022,9 @@ func (btc *BlipTesterCollectionClient) StoreRevOnClient(docID, revID string, bod
 	if err != nil {
 		return err
 	}
-	bodyMessagePair := &BodyMessagePair{body: newBody}
-	btc.docs[docID] = map[string]*BodyMessagePair{revID: bodyMessagePair}
+	btc.docsLock.Lock()
+	defer btc.docsLock.Unlock()
+	btc.docs[docID] = btc.NewBlipTesterDoc(revID, newBody, nil)
 	return nil
 }
 
@@ -1004,22 +1080,27 @@ func (btc *BlipTesterCollectionClient) ProcessInlineAttachments(inputBody []byte
 	return inputBody, nil
 }
 
-// GetVersion returns the data stored in the Client under the given docID and version
-func (btc *BlipTesterCollectionClient) GetVersion(docID string, docVersion DocVersion) (data []byte, found bool) {
+// GetCurrentRevID gets the current revID for the specified docID
+func (btc *BlipTesterCollectionClient) GetCurrentRevID(docID string) (revID string, data []byte, found bool) {
 	btc.docsLock.RLock()
 	defer btc.docsLock.RUnlock()
 
-	if rev, ok := btc.docs[docID]; ok {
-		if data, ok := rev[docVersion.RevID]; ok && data != nil {
-			return data.body, true
-		}
-		// lookup by cv if not found using revid
-		if data, ok := rev[docVersion.CV.String()]; ok && data != nil {
-			return data.body, true
-		}
+	if doc, ok := btc.docs[docID]; ok {
+		return doc.getCurrentRevID(), doc.body, true
 	}
 
-	return nil, false
+	return "", nil, false
+}
+
+func (btc *BlipTesterClient) UseHLV() bool {
+	for _, protocol := range btc.SupportedBLIPProtocols {
+		subProtocol, err := db.ParseSubprotocolString(protocol)
+		require.NoError(btc.rt.TB, err)
+		if subProtocol >= db.CBMobileReplicationV4 {
+			return true
+		}
+	}
+	return false
 }
 
 func (btc *BlipTesterClient) AssertOnBlipHistory(t *testing.T, msg *blip.Message, docVersion DocVersion) {
@@ -1030,8 +1111,27 @@ func (btc *BlipTesterClient) AssertOnBlipHistory(t *testing.T, msg *blip.Message
 			assert.Equal(t, docVersion.CV.String(), msg.Properties[db.RevMessageHistory])
 		}
 	} else {
-		assert.Equal(t, docVersion.RevID, msg.Properties[db.RevMessageHistory])
+		assert.Equal(t, docVersion.RevTreeID, msg.Properties[db.RevMessageHistory])
 	}
+}
+
+// GetVersion returns the document body when the provided version matches the document's current revision
+func (btc *BlipTesterCollectionClient) GetVersion(docID string, docVersion DocVersion) (data []byte, found bool) {
+	btc.docsLock.RLock()
+	defer btc.docsLock.RUnlock()
+
+	if doc, ok := btc.docs[docID]; ok {
+		if doc.revMode == revModeHLV {
+			if doc.getCurrentRevID() == docVersion.CV.String() {
+				return doc.body, true
+			}
+		} else {
+			if doc.getCurrentRevID() == docVersion.RevTreeID {
+				return doc.body, true
+			}
+		}
+	}
+	return nil, false
 }
 
 // WaitForVersion blocks until the given document version has been stored by the client, and returns the data when found. The test will fail after 10 seocnds if a matching document is not found.
@@ -1047,15 +1147,13 @@ func (btc *BlipTesterCollectionClient) WaitForVersion(docID string, docVersion D
 	return data
 }
 
-// GetDoc returns a rev stored in the Client under the given docID.  (if multiple revs are present, rev body returned is non-deterministic)
+// GetDoc returns the current body stored in the Client for the given docID.
 func (btc *BlipTesterCollectionClient) GetDoc(docID string) (data []byte, found bool) {
 	btc.docsLock.RLock()
 	defer btc.docsLock.RUnlock()
 
-	if rev, ok := btc.docs[docID]; ok {
-		for _, data := range rev {
-			return data.body, true
-		}
+	if doc, ok := btc.docs[docID]; ok {
+		return doc.body, true
 	}
 
 	return nil, false
@@ -1119,28 +1217,29 @@ func (btr *BlipTesterReplicator) storeMessage(msg *blip.Message) {
 }
 
 // WaitForBlipRevMessage blocks until the given doc ID and rev ID has been stored by the client, and returns the message when found. If not found after 10 seconds, test will fail.
-func (btc *BlipTesterCollectionClient) WaitForBlipRevMessage(docID string, docVersion DocVersion) (msg *blip.Message) {
+func (btc *BlipTesterCollectionClient) WaitForBlipRevMessage(docID string, version DocVersion) (msg *blip.Message) {
+	var revID string
+	if btc.UseHLV() {
+		revID = version.CV.String()
+	} else {
+		revID = version.RevTreeID
+	}
+
 	require.EventuallyWithT(btc.TB(), func(c *assert.CollectT) {
 		var ok bool
-		msg, ok = btc.GetBlipRevMessage(docID, docVersion)
-		assert.True(c, ok, "Could not find docID:%+v, RevID: %+v", docID, docVersion.RevID)
-	}, 10*time.Second, 50*time.Millisecond, "BlipTesterReplicator timed out waiting for BLIP message")
+		msg, ok = btc.GetBlipRevMessage(docID, revID)
+		assert.True(c, ok, "Could not find docID:%+v, RevID: %+v", docID, revID)
+	}, 10*time.Second, 50*time.Millisecond, "BlipTesterClient timed out waiting for BLIP message docID: %v, revID: %v", docID, revID)
 	return msg
 }
 
-func (btc *BlipTesterCollectionClient) GetBlipRevMessage(docID string, version DocVersion) (msg *blip.Message, found bool) {
+func (btc *BlipTesterCollectionClient) GetBlipRevMessage(docID string, revID string) (msg *blip.Message, found bool) {
 	btc.docsLock.RLock()
 	defer btc.docsLock.RUnlock()
 
-	if rev, ok := btc.docs[docID]; ok {
-		if pair, found := rev[version.RevID]; found {
-			found = pair.message != nil
-			return pair.message, found
-		}
-		// lookup by cv if not found using revid
-		if pair, found := rev[version.CV.String()]; found {
-			found = pair.message != nil
-			return pair.message, found
+	if doc, ok := btc.docs[docID]; ok {
+		if message, found := doc.revMessageHistory[revID]; found {
+			return message, found
 		}
 	}
 
@@ -1162,8 +1261,8 @@ func (btcRunner *BlipTestClientRunner) WaitForDoc(clientID uint32, docID string)
 }
 
 // WaitForBlipRevMessage blocks until the given doc ID and rev ID has been stored by the client, and returns the message when found. If document is not found after 10 seconds, test will fail.
-func (btcRunner *BlipTestClientRunner) WaitForBlipRevMessage(clientID uint32, docID string, docVersion DocVersion) *blip.Message {
-	return btcRunner.SingleCollection(clientID).WaitForBlipRevMessage(docID, docVersion)
+func (btcRunner *BlipTestClientRunner) WaitForBlipRevMessage(clientID uint32, docID string, version DocVersion) *blip.Message {
+	return btcRunner.SingleCollection(clientID).WaitForBlipRevMessage(docID, version)
 }
 
 func (btcRunner *BlipTestClientRunner) StartOneshotPull(clientID uint32) error {
@@ -1190,8 +1289,8 @@ func (btcRunner *BlipTestClientRunner) StartFilteredPullSince(clientID uint32, c
 	return btcRunner.SingleCollection(clientID).StartPullSince(continuous, since, activeOnly, channels, "")
 }
 
-func (btcRunner *BlipTestClientRunner) GetVersion(clientID uint32, docID string, docVersion DocVersion) ([]byte, bool) {
-	return btcRunner.SingleCollection(clientID).GetVersion(docID, docVersion)
+func (btcRunner *BlipTestClientRunner) GetVersion(clientID uint32, docID string, version DocVersion) ([]byte, bool) {
+	return btcRunner.SingleCollection(clientID).GetVersion(docID, version)
 }
 
 func (btcRunner *BlipTestClientRunner) saveAttachment(clientID uint32, contentType string, attachmentData string) (int, string, error) {

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -848,7 +848,9 @@ func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) (err error) {
 // PushRev creates a revision on the client, and immediately sends a changes request for it.
 // The rev ID is always: "N-abc", where N is rev generation for predictability.
 func (btc *BlipTesterCollectionClient) PushRev(docID string, parentVersion DocVersion, body []byte) (DocVersion, error) {
-	revID, err := btc.PushRevWithHistory(docID, parentVersion.RevTreeID, body, 1, 0)
+
+	parentRev := parentVersion.GetRev(btc.UseHLV())
+	revID, err := btc.PushRevWithHistory(docID, parentRev, body, 1, 0)
 	if err != nil {
 		return DocVersion{}, err
 	}
@@ -867,13 +869,21 @@ func (btc *BlipTesterCollectionClient) requireRevID(expected DocVersion, revID s
 
 // GetDocVersion fetches revid and cv directly from the bucket.  Used to support REST-based verification in btc tests
 // even while REST only supports revTreeId
-func (btc *BlipTesterCollectionClient) GetDocVersion(docID string) DocVersion {
+// TODO: This doesn't support multi-collection testing, btc.GetDocVersion uses
+//
+//	GetSingleTestDatabaseCollection()
+func (btcc *BlipTesterCollectionClient) GetDocVersion(docID string) DocVersion {
+	return btcc.parent.GetDocVersion(docID)
+}
 
-	collection := btc.parent.rt.GetSingleTestDatabaseCollection()
-	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB), btc.parent.rt.GetDatabase().Name, nil)
+// GetDocVersion fetches revid and cv directly from the bucket.  Used to support REST-based verification in btc tests
+// even while REST only supports revTreeId
+func (btc *BlipTesterClient) GetDocVersion(docID string) DocVersion {
+	collection := btc.rt.GetSingleTestDatabaseCollection()
+	ctx := base.DatabaseLogCtx(base.TestCtx(btc.rt.TB), btc.rt.GetDatabase().Name, nil)
 	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalSync)
-	require.NoError(btc.parent.rt.TB, err)
-	if !btc.UseHLV() {
+	require.NoError(btc.rt.TB, err)
+	if !btc.UseHLV() || doc.HLV == nil {
 		return DocVersion{RevTreeID: doc.CurrentRev}
 	}
 	return DocVersion{RevTreeID: doc.CurrentRev, CV: db.Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}}
@@ -897,7 +907,7 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev strin
 			startValue = parentVersion.Value
 			revisionHistory = append(revisionHistory, parentRev)
 		}
-		newVersion := db.DecodedVersion{SourceID: "abc", Value: startValue + uint64(revCount) + 1}
+		newVersion := db.DecodedVersion{SourceID: "abc", Value: startValue + uint64(revCount)}
 		newRevID = newVersion.String()
 
 	} else {
@@ -1023,16 +1033,20 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev strin
 	return newRevID, nil
 }
 
-func (btc *BlipTesterCollectionClient) StoreRevOnClient(docID, revID string, body []byte) error {
+func (btc *BlipTesterCollectionClient) StoreRevOnClient(docID, rev string, body []byte) error {
 	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB), btc.parent.rt.GetDatabase().Name, nil)
-	revGen, _ := db.ParseRevID(ctx, revID)
+
+	revGen := 0
+	if !btc.UseHLV() {
+		revGen, _ = db.ParseRevID(ctx, rev)
+	}
 	newBody, err := btc.ProcessInlineAttachments(body, revGen)
 	if err != nil {
 		return err
 	}
 	btc.docsLock.Lock()
 	defer btc.docsLock.Unlock()
-	btc.docs[docID] = btc.NewBlipTesterDoc(revID, newBody, nil)
+	btc.docs[docID] = btc.NewBlipTesterDoc(rev, newBody, nil)
 	return nil
 }
 
@@ -1375,4 +1389,29 @@ func (btc *BlipTesterCollectionClient) sendPullMsg(msg *blip.Message) error {
 func (btc *BlipTesterCollectionClient) sendPushMsg(msg *blip.Message) error {
 	btc.addCollectionProperty(msg)
 	return btc.parent.pushReplication.sendMsg(msg)
+}
+
+// Wrappers for RT helpers that populate version information for use in HLV tests
+// PutDoc will upsert the document with a given contents.
+func (btc *BlipTesterClient) PutDoc(docID string, body string) DocVersion {
+	rt := btc.rt
+	version := rt.PutDoc(docID, body)
+	if btc.UseHLV() {
+		source, value := rt.GetSingleTestDatabaseCollection().GetDocumentCurrentVersion(rt.TB, docID)
+		version.CV = db.Version{
+			SourceID: source,
+			Value:    value,
+		}
+	}
+	return version
+}
+
+// RequireRev checks the current rev for the specified docID on the backend the BTC is replicating
+// with (NOT in the btc store)
+func (btc *BlipTesterClient) RequireRev(t *testing.T, expectedRev string, doc *db.Document) {
+	if btc.UseHLV() {
+		require.Equal(t, expectedRev, doc.HLV.GetCurrentVersionString())
+	} else {
+		require.Equal(t, expectedRev, doc.CurrentRev)
+	}
 }

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -848,13 +848,21 @@ func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) (err error) {
 // PushRev creates a revision on the client, and immediately sends a changes request for it.
 // The rev ID is always: "N-abc", where N is rev generation for predictability.
 func (btc *BlipTesterCollectionClient) PushRev(docID string, parentVersion DocVersion, body []byte) (DocVersion, error) {
-	revid, err := btc.PushRevWithHistory(docID, parentVersion.RevTreeID, body, 1, 0)
+	revID, err := btc.PushRevWithHistory(docID, parentVersion.RevTreeID, body, 1, 0)
 	if err != nil {
 		return DocVersion{}, err
 	}
 	docVersion := btc.GetDocVersion(docID)
-	require.Equal(btc.parent.rt.TB, docVersion.RevTreeID, revid)
+	btc.requireRevID(docVersion, revID)
 	return docVersion, nil
+}
+
+func (btc *BlipTesterCollectionClient) requireRevID(expected DocVersion, revID string) {
+	if btc.UseHLV() {
+		require.Equal(btc.parent.rt.TB, expected.CV.String(), revID)
+	} else {
+		require.Equal(btc.parent.rt.TB, expected.RevTreeID, revID)
+	}
 }
 
 // GetDocVersion fetches revid and cv directly from the bucket.  Used to support REST-based verification in btc tests
@@ -865,7 +873,7 @@ func (btc *BlipTesterCollectionClient) GetDocVersion(docID string) DocVersion {
 	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB), btc.parent.rt.GetDatabase().Name, nil)
 	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalSync)
 	require.NoError(btc.parent.rt.TB, err)
-	if doc.HLV == nil {
+	if !btc.UseHLV() {
 		return DocVersion{RevTreeID: doc.CurrentRev}
 	}
 	return DocVersion{RevTreeID: doc.CurrentRev, CV: db.Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -142,7 +142,7 @@ func (h *handler) handleAllDocs() error {
 					row.Status = http.StatusForbidden
 					return row
 				}
-				// handle the case where the incoming doc.RevID == ""
+				// handle the case where the incoming doc.RevTreeID == ""
 				// and Get1xRevAndChannels returns the current revision
 				doc.RevID = currentRevID
 			}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -511,7 +511,7 @@ func (h *handler) handleBulkDocs() error {
 				err = base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 			} else {
 				revid = revisions[0]
-				_, _, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, doc, revisions, false)
+				_, _, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, doc, revisions, false, db.ExistingVersionWithUpdateToHLV)
 			}
 		}
 

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -238,7 +238,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 
 	// push winning branch
 	wg.Add(2)
-	res := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+version1.RevID+`"]}}`)
+	res := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+version1.RevTreeID+`"]}}`)
 	RequireStatus(t, res, http.StatusCreated)
 	winningVersion := DocVersionFromPutResponse(t, res)
 
@@ -261,7 +261,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 
 	// push a separate winning branch
 	wg.Add(2)
-	res = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", `{"foo":"quux","_revisions":{"start":4,"ids":["quux", "buzz","bar","`+version1.RevID+`"]}}`)
+	res = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", `{"foo":"quux","_revisions":{"start":4,"ids":["quux", "buzz","bar","`+version1.RevTreeID+`"]}}`)
 	RequireStatus(t, res, http.StatusCreated)
 	newWinningVersion := DocVersionFromPutResponse(t, res)
 

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -273,3 +273,65 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 	assert.Equal(t, 5, int(atomic.LoadUint32(&WinningRevChangedCount)))
 	assert.Equal(t, 6, int(atomic.LoadUint32(&DocumentChangedCount)))
 }
+
+func TestCVPopulationOnChangesViaAPI(t *testing.T) {
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {channel(doc.channels)}`,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	collection := rt.GetSingleTestDatabaseCollection()
+	bucketUUID := rt.GetDatabase().BucketUUID
+	const DocID = "doc1"
+
+	// activate channel cache
+	_, err := rt.WaitForChanges(0, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+DocID, `{"channels": ["ABC"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	require.NoError(t, collection.WaitForPendingChanges(base.TestCtx(t)))
+
+	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	require.NoError(t, err)
+
+	assert.Equal(t, "doc1", changes.Results[0].ID)
+	assert.Equal(t, bucketUUID, changes.Results[0].CurrentVersion.SourceID)
+	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Version)
+}
+
+func TestCVPopulationOnDocIDChanges(t *testing.T) {
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {channel(doc.channels)}`,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	collection := rt.GetSingleTestDatabaseCollection()
+	bucketUUID := rt.GetDatabase().BucketUUID
+	const DocID = "doc1"
+
+	// activate channel cache
+	_, err := rt.WaitForChanges(0, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+DocID, `{"channels": ["ABC"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	require.NoError(t, collection.WaitForPendingChanges(base.TestCtx(t)))
+
+	changes, err := rt.WaitForChanges(1, fmt.Sprintf(`/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=%s`, DocID), "", true)
+	require.NoError(t, err)
+
+	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	require.NoError(t, err)
+
+	assert.Equal(t, "doc1", changes.Results[0].ID)
+	assert.Equal(t, bucketUUID, changes.Results[0].CurrentVersion.SourceID)
+	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Version)
+}

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -298,7 +298,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, DocID, db.DocUnmarshalCAS)
 	require.NoError(t, err)
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)
@@ -330,7 +330,7 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 	changes, err := rt.WaitForChanges(1, fmt.Sprintf(`/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=%s`, DocID), "", true)
 	require.NoError(t, err)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, DocID, db.DocUnmarshalCAS)
 	require.NoError(t, err)
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -302,7 +302,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)
 	assert.Equal(t, bucketUUID, changes.Results[0].CurrentVersion.SourceID)
-	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Version)
+	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Value)
 }
 
 func TestCVPopulationOnDocIDChanges(t *testing.T) {
@@ -333,5 +333,5 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)
 	assert.Equal(t, bucketUUID, changes.Results[0].CurrentVersion.SourceID)
-	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Version)
+	assert.Equal(t, fetchedDoc.Cas, changes.Results[0].CurrentVersion.Value)
 }

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -275,6 +275,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 }
 
 func TestCVPopulationOnChangesViaAPI(t *testing.T) {
+	t.Skip("Disabled until REST support for version is added")
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}
@@ -306,6 +307,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 }
 
 func TestCVPopulationOnDocIDChanges(t *testing.T) {
+	t.Skip("Disabled until REST support for version is added")
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channels)}`,
 	}

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -283,7 +283,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 	defer rt.Close()
 	ctx := base.TestCtx(t)
 	collection := rt.GetSingleTestDatabaseCollection()
-	bucketUUID := rt.GetDatabase().BucketUUID
+	bucketUUID := rt.GetDatabase().EncodedBucketUUID
 	const DocID = "doc1"
 
 	// activate channel cache
@@ -315,7 +315,7 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 	defer rt.Close()
 	ctx := base.TestCtx(t)
 	collection := rt.GetSingleTestDatabaseCollection()
-	bucketUUID := rt.GetDatabase().BucketUUID
+	bucketUUID := rt.GetDatabase().EncodedBucketUUID
 	const DocID = "doc1"
 
 	// activate channel cache

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -935,7 +935,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	expectedResults = []string{
 		`{"seq":"8:2","id":"hbo-1","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":8,"id":"grant-1","changes":[{"rev":"1-c5098bb14d12d647c901850ff6a6292a"}]}`,
-		fmt.Sprintf(`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}], "current_version":{"source_id": "%s", "version": %d}}`, mixSource, mixVersion),
+		fmt.Sprintf(`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}], "current_version":{"source_id": "%s", "version": "%s"}}`, mixSource, mixVersion),
 	}
 
 	rt.Run("grant via existing channel", func(t *testing.T) {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -861,6 +861,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	}
 }`})
 	defer rt.Close()
+	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create user with access to channel NBC:
 	ctx := rt.Context()
@@ -928,6 +929,10 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	// Write another doc
 	_ = rt.PutDoc("mix-1", `{"channel":["ABC", "PBS", "HBO"]}`)
 
+	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, "mix-1", db.DocUnmarshalSync)
+	require.NoError(t, err)
+	mixSource, mixVersion := fetchedDoc.HLV.GetCurrentVersion()
+
 	cacheWaiter.AddAndWait(1)
 
 	// Issue a changes request with a compound since value from the last changes response
@@ -935,7 +940,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	expectedResults = []string{
 		`{"seq":"8:2","id":"hbo-1","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":8,"id":"grant-1","changes":[{"rev":"1-c5098bb14d12d647c901850ff6a6292a"}]}`,
-		`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}]}`,
+		fmt.Sprintf(`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}], "current_version":{"source_id": "%s", "version": %d}}`, mixSource, mixVersion),
 	}
 
 	rt.Run("grant via existing channel", func(t *testing.T) {

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -924,7 +924,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	// Write another doc
 	_ = rt.PutDoc("mix-1", `{"channel":["ABC", "PBS", "HBO"]}`)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, "mix-1", db.DocUnmarshalSync)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, "mix-1", db.DocUnmarshalSync)
 	require.NoError(t, err)
 	mixSource, mixVersion := fetchedDoc.HLV.GetCurrentVersion()
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -807,10 +807,10 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(4)
 
 	// Mark the first four PBS docs as removals
-	_ = rt.PutDoc("pbs-1", fmt.Sprintf(`{"_rev":%q}`, pbs1.RevID))
-	_ = rt.PutDoc("pbs-2", fmt.Sprintf(`{"_rev":%q}`, pbs2.RevID))
-	_ = rt.PutDoc("pbs-3", fmt.Sprintf(`{"_rev":%q}`, pbs3.RevID))
-	_ = rt.PutDoc("pbs-4", fmt.Sprintf(`{"_rev":%q}`, pbs4.RevID))
+	_ = rt.PutDoc("pbs-1", fmt.Sprintf(`{"_rev":%q}`, pbs1.RevTreeID))
+	_ = rt.PutDoc("pbs-2", fmt.Sprintf(`{"_rev":%q}`, pbs2.RevTreeID))
+	_ = rt.PutDoc("pbs-3", fmt.Sprintf(`{"_rev":%q}`, pbs3.RevTreeID))
+	_ = rt.PutDoc("pbs-4", fmt.Sprintf(`{"_rev":%q}`, pbs4.RevTreeID))
 
 	cacheWaiter.AddAndWait(4)
 
@@ -886,7 +886,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	cacheWaiter.AddAndWait(4)
 
 	// remove channels/tombstone a couple of docs to ensure they're not backfilled after a dynamic grant
-	_ = rt.PutDoc("hbo-2", fmt.Sprintf(`{"_rev":%q}`, hbo2.RevID))
+	_ = rt.PutDoc("hbo-2", fmt.Sprintf(`{"_rev":%q}`, hbo2.RevTreeID))
 	rt.DeleteDoc(pbs2ID, pbs2Version)
 	cacheWaiter.AddAndWait(2)
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -2011,6 +2011,7 @@ func updateTestDoc(rt *rest.RestTester, docid string, revid string, body string)
 
 // Validate retrieval of various document body types using include_docs.
 func TestChangesIncludeDocs(t *testing.T) {
+	t.Skip("CBG-3748: backwards compatibility between cv and rev id for fetching backed up revs needed")
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -9,7 +9,6 @@
 package changestest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -901,9 +900,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	changes, err := rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes", "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 	for index, result := range changes.Results {
-		var expectedChange db.ChangeEntry
-		require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-		assert.Equal(t, expectedChange, result)
+		assertChangeEntryMatches(t, expectedResults[index], result)
 	}
 
 	// create doc that dynamically grants both users access to PBS and HBO
@@ -921,9 +918,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "bernard", false)
 	require.NoError(t, err, "Error retrieving changes results")
 	for index, result := range changes.Results {
-		var expectedChange db.ChangeEntry
-		require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-		assert.Equal(t, expectedChange, result)
+		assertChangeEntryMatches(t, expectedResults[index], result)
 	}
 
 	// Write another doc
@@ -947,9 +942,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		changes, err = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "alice", false)
 		require.NoError(t, err, "Error retrieving changes results for alice")
 		for index, result := range changes.Results {
-			var expectedChange db.ChangeEntry
-			require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-			assert.Equal(t, expectedChange, result)
+			assertChangeEntryMatches(t, expectedResults[index], result)
 		}
 	})
 
@@ -957,11 +950,31 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		changes, err = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "bernard", false)
 		require.NoError(t, err, "Error retrieving changes results for bernard")
 		for index, result := range changes.Results {
-			var expectedChange db.ChangeEntry
-			require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-			assert.Equal(t, expectedChange, result)
+			assertChangeEntryMatches(t, expectedResults[index], result)
 		}
 	})
+}
+
+// TODO: enhance to compare source/version when expectedChanges are updated to include
+func assertChangeEntryMatches(t *testing.T, expectedChangeEntryString string, result db.ChangeEntry) {
+	var expectedChange db.ChangeEntry
+	require.NoError(t, base.JSONUnmarshal([]byte(expectedChangeEntryString), &expectedChange))
+	assert.Equal(t, expectedChange.Seq, result.Seq)
+	assert.Equal(t, expectedChange.ID, result.ID)
+	assert.Equal(t, expectedChange.Changes, result.Changes)
+	assert.Equal(t, expectedChange.Deleted, result.Deleted)
+	assert.Equal(t, expectedChange.Removed, result.Removed)
+
+	if expectedChange.Doc != nil {
+		// result.Doc is json.RawMessage, and properties may not be in the same order for a direct comparison
+		var expectedBody db.Body
+		var resultBody db.Body
+		assert.NoError(t, expectedBody.Unmarshal(expectedChange.Doc))
+		assert.NoError(t, resultBody.Unmarshal(result.Doc))
+		db.AssertEqualBodies(t, expectedBody, resultBody)
+	} else {
+		assert.Equal(t, expectedChange.Doc, result.Doc)
+	}
 }
 
 // Ensures that changes feed goroutines blocked on a ChangeWaiter are closed when the changes feed is terminated.
@@ -2115,26 +2128,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.Equal(t, len(expectedResults), len(changes.Results))
 
 	for index, result := range changes.Results {
-		var expectedChange db.ChangeEntry
-		assert.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-
-		assert.Equal(t, expectedChange.ID, result.ID)
-		assert.Equal(t, expectedChange.Seq, result.Seq)
-		assert.Equal(t, expectedChange.Deleted, result.Deleted)
-		assert.Equal(t, expectedChange.Changes, result.Changes)
-		assert.Equal(t, expectedChange.Err, result.Err)
-		assert.Equal(t, expectedChange.Removed, result.Removed)
-
-		if expectedChange.Doc != nil {
-			// result.Doc is json.RawMessage, and properties may not be in the same order for a direct comparison
-			var expectedBody db.Body
-			var resultBody db.Body
-			assert.NoError(t, expectedBody.Unmarshal(expectedChange.Doc))
-			assert.NoError(t, resultBody.Unmarshal(result.Doc))
-			db.AssertEqualBodies(t, expectedBody, resultBody)
-		} else {
-			assert.Equal(t, expectedChange.Doc, result.Doc)
-		}
+		assertChangeEntryMatches(t, expectedResults[index], result)
 	}
 
 	// Flush the rev cache, and issue changes again to ensure successful handling for rev cache misses
@@ -2150,16 +2144,10 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.Equal(t, len(expectedResults), len(postFlushChanges.Results))
 
 	for index, result := range postFlushChanges.Results {
+
+		assertChangeEntryMatches(t, expectedResults[index], result)
 		var expectedChange db.ChangeEntry
 		assert.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-
-		assert.Equal(t, expectedChange.ID, result.ID)
-		assert.Equal(t, expectedChange.Seq, result.Seq)
-		assert.Equal(t, expectedChange.Deleted, result.Deleted)
-		assert.Equal(t, expectedChange.Changes, result.Changes)
-		assert.Equal(t, expectedChange.Err, result.Err)
-		assert.Equal(t, expectedChange.Removed, result.Removed)
-
 		if expectedChange.Doc != nil {
 			// result.Doc is json.RawMessage, and properties may not be in the same order for a direct comparison
 			var expectedBody db.Body
@@ -2186,14 +2174,12 @@ func TestChangesIncludeDocs(t *testing.T) {
 	expectedStyleAllDocs[9] = `{"seq":26,"id":"doc_resolved_conflict","changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"},{"rev":"3-f25ad98ef169791adec6c1d385717b84"}]}`
 
 	styleAllDocsChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs", "", "user1")
-	var allDocsChanges struct {
-		Results []*json.RawMessage
-	}
+	var allDocsChanges rest.ChangesResults
 	err = base.JSONUnmarshal(styleAllDocsChangesResponse.Body.Bytes(), &allDocsChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, len(expectedStyleAllDocs), len(allDocsChanges.Results))
 	for index, result := range allDocsChanges.Results {
-		assert.Equal(t, expectedStyleAllDocs[index], fmt.Sprintf("%s", *result))
+		assertChangeEntryMatches(t, expectedStyleAllDocs[index], result)
 	}
 
 	// Validate style=all_docs, include_docs=true permutations.  Only modified doc from include_docs test is doc_conflict (adds open revisions)
@@ -2206,26 +2192,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.Equal(t, len(expectedResults), len(combinedChanges.Results))
 
 	for index, result := range combinedChanges.Results {
-		var expectedChange db.ChangeEntry
-		assert.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
-
-		assert.Equal(t, expectedChange.ID, result.ID)
-		assert.Equal(t, expectedChange.Seq, result.Seq)
-		assert.Equal(t, expectedChange.Deleted, result.Deleted)
-		assert.Equal(t, expectedChange.Changes, result.Changes)
-		assert.Equal(t, expectedChange.Err, result.Err)
-		assert.Equal(t, expectedChange.Removed, result.Removed)
-
-		if expectedChange.Doc != nil {
-			// result.Doc is json.RawMessage, and properties may not be in the same order for a direct comparison
-			var expectedBody db.Body
-			var resultBody db.Body
-			assert.NoError(t, expectedBody.Unmarshal(expectedChange.Doc))
-			assert.NoError(t, resultBody.Unmarshal(result.Doc))
-			db.AssertEqualBodies(t, expectedBody, resultBody)
-		} else {
-			assert.Equal(t, expectedChange.Doc, result.Doc)
-		}
+		assertChangeEntryMatches(t, expectedResults[index], result)
 	}
 }
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -605,7 +605,7 @@ func (h *handler) handleDeleteDoc() error {
 			return err
 		}
 	}
-	newRev, err := h.collection.DeleteDoc(h.ctx(), docid, revid)
+	newRev, _, err := h.collection.DeleteDoc(h.ctx(), docid, revid)
 	if err == nil {
 		h.writeRawJSONStatus(http.StatusOK, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
 	}

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -471,7 +471,7 @@ func (h *handler) handlePutDoc() error {
 		if revisions == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 		}
-		doc, newRev, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false)
+		doc, newRev, err = h.collection.PutExistingRevWithBody(h.ctx(), docid, body, revisions, false, db.ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			return err
 		}
@@ -548,7 +548,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		newDoc.UpdateBody(body)
 	}
 
-	doc, rev, err := h.collection.PutExistingRev(h.ctx(), newDoc, history, true, false, nil)
+	doc, rev, err := h.collection.PutExistingRev(h.ctx(), newDoc, history, true, false, nil, db.ExistingVersionWithUpdateToHLV)
 
 	if err != nil {
 		return err

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -461,6 +461,9 @@ func TestXattrDoubleDelete(t *testing.T) {
 }
 
 func TestViewQueryTombstoneRetrieval(t *testing.T) {
+	t.Skip("Disabled pending CBG-3503")
+	base.SkipImportTestsIfNotEnabled(t)
+
 	if !base.TestsDisableGSI() {
 		t.Skip("views tests are not applicable under GSI")
 	}

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1651,7 +1651,7 @@ func TestImportRevisionCopy(t *testing.T) {
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
-	rev1id := rawInsertResponse.Sync.Rev
+	rev1id := rawInsertResponse.Sync.Rev.RevTreeID
 
 	// 3. Update via SDK
 	updatedBody := make(map[string]interface{})
@@ -1712,7 +1712,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
-	rev1id := rawInsertResponse.Sync.Rev
+	rev1id := rawInsertResponse.Sync.Rev.RevTreeID
 
 	// 3. Flush the rev cache (simulates attempted retrieval by a different SG node, since testing framework isn't great
 	//    at simulating multiple SG instances)
@@ -1770,7 +1770,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
-	rev1id := rawInsertResponse.Sync.Rev
+	rev1id := rawInsertResponse.Sync.Rev.RevTreeID
 
 	// 3. Update via SDK
 	updatedBody := make(map[string]interface{})
@@ -1945,15 +1945,14 @@ func rawDocWithSyncMeta() string {
 
 func assertXattrSyncMetaRevGeneration(t *testing.T, dataStore base.DataStore, key string, expectedRevGeneration int) {
 	xattrs, _, err := dataStore.GetXattrs(base.TestCtx(t), key, []string{base.SyncXattrName})
-	assert.NoError(t, err, "Error Getting Xattr")
-	xattr := map[string]interface{}{}
+	require.NoError(t, err, "Error Getting Xattr")
 	require.Contains(t, xattrs, base.SyncXattrName)
-	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &xattr))
-	revision, ok := xattr["rev"]
-	assert.True(t, ok)
-	generation, _ := db.ParseRevID(base.TestCtx(t), revision.(string))
-	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, revision)
-	assert.True(t, generation == expectedRevGeneration)
+	var syncData db.SyncData
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
+	assert.True(t, syncData.CurrentRev != "")
+	generation, _ := db.ParseRevID(base.TestCtx(t), syncData.CurrentRev)
+	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, syncData.CurrentRev)
+	assert.Equal(t, expectedRevGeneration, generation)
 }
 
 func TestDeletedEmptyDocumentImport(t *testing.T) {
@@ -1977,13 +1976,12 @@ func TestDeletedEmptyDocumentImport(t *testing.T) {
 	// Get the doc and check deleted revision is getting imported
 	response = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docId, "")
 	assert.Equal(t, http.StatusOK, response.Code)
-	rawResponse := make(map[string]interface{})
+	var rawResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawResponse)
 	require.NoError(t, err, "Unable to unmarshal raw response")
 
-	assert.True(t, rawResponse[db.BodyDeleted].(bool))
-	syncMeta := rawResponse["_sync"].(map[string]interface{})
-	assert.Equal(t, "2-5d3308aae9930225ed7f6614cf115366", syncMeta["rev"])
+	assert.True(t, rawResponse.Deleted)
+	assert.Equal(t, "2-5d3308aae9930225ed7f6614cf115366", rawResponse.Sync.Rev.RevTreeID)
 }
 
 // Check deleted document via SDK is getting imported if it is included in through ImportFilter function.
@@ -2017,10 +2015,9 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	endpoint := fmt.Sprintf("/{{.keyspace}}/_raw/%s?redact=false", key)
 	response := rt.SendAdminRequest(http.MethodGet, endpoint, "")
 	assert.Equal(t, http.StatusOK, response.Code)
-	var respBody db.Body
+	var respBody rest.RawResponse
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
-	syncMeta := respBody[base.SyncPropertyName].(map[string]interface{})
-	assert.NotEmpty(t, syncMeta["rev"].(string))
+	assert.NotEmpty(t, respBody.Sync.Rev.RevTreeID)
 
 	// Delete the document via SDK
 	err = dataStore.Delete(key)
@@ -2030,9 +2027,8 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, endpoint, "")
 	assert.Equal(t, http.StatusOK, response.Code)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
-	assert.True(t, respBody[db.BodyDeleted].(bool))
-	syncMeta = respBody[base.SyncPropertyName].(map[string]interface{})
-	assert.NotEmpty(t, syncMeta["rev"].(string))
+	assert.True(t, respBody.Deleted)
+	assert.NotEmpty(t, respBody.Sync.Rev.RevTreeID)
 }
 
 // CBG-1995: Test the support for using an underscore prefix in the top-level body of a document
@@ -2201,7 +2197,7 @@ func TestImportTouch(t *testing.T) {
 	var rawInsertResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	require.NoError(t, err, "Unable to unmarshal raw response")
-	initialRev := rawInsertResponse.Sync.Rev
+	initialRev := rawInsertResponse.Sync.Rev.RevTreeID
 
 	// 2. Test import behaviour after SDK touch
 	_, err = dataStore.Touch(key, 1000000)
@@ -2213,7 +2209,7 @@ func TestImportTouch(t *testing.T) {
 	var rawUpdateResponse rest.RawResponse
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawUpdateResponse)
 	require.NoError(t, err, "Unable to unmarshal raw response")
-	require.Equal(t, initialRev, rawUpdateResponse.Sync.Rev)
+	require.Equal(t, initialRev, rawUpdateResponse.Sync.Rev.RevTreeID)
 }
 func TestImportingPurgedDocument(t *testing.T) {
 	if !base.TestUseXattrs() {

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -461,7 +461,6 @@ func TestXattrDoubleDelete(t *testing.T) {
 }
 
 func TestViewQueryTombstoneRetrieval(t *testing.T) {
-	t.Skip("Disabled pending CBG-3503")
 	base.SkipImportTestsIfNotEnabled(t)
 
 	if !base.TestsDisableGSI() {

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -178,7 +178,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 	// 1. Create revision with history
 	docID := t.Name()
 	version := rt.PutDoc(docID, `{"val":-1}`)
-	revID := version.RevID
+	revID := version.RevTreeID
 	collection := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	ctx := rt.Context()
@@ -187,7 +187,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 		// Purge old revision JSON to simulate expiry, and to verify import doesn't attempt multiple retrievals
 		purgeErr := collection.PurgeOldRevisionJSON(ctx, docID, revID)
 		require.NoError(t, purgeErr)
-		revID = version.RevID
+		revID = version.RevTreeID
 	}
 
 	// 2. Modify doc via SDK

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -410,11 +410,11 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	}
 	value := sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
-	assert.Equal(t, syncXattr, string(rawXattr))
+	assert.Equal(t, syncXattr, string(rawXattrs[base.SyncXattrName]))
 	assert.Equal(t, uint64(200), syncData.Sequence)
-	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Equal(t, channelName, string(rawXattrs[userXattrKey]))
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with just user xattr defined
@@ -423,21 +423,21 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	}
 	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Nil(t, syncData)
-	assert.Nil(t, rawXattr)
-	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Nil(t, rawXattrs[base.SyncXattrName])
+	assert.Equal(t, channelName, string(rawXattrs[userXattrKey]))
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with no xattr defined
 	xattrs = []sgbucket.Xattr{}
 	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Nil(t, syncData)
-	assert.Nil(t, rawXattr)
-	assert.Nil(t, rawUserXattr)
+	assert.Nil(t, rawXattrs[base.SyncXattrName])
+	assert.Nil(t, rawXattrs[userXattrKey])
 	assert.Equal(t, body, rawBody)
 }

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -59,7 +59,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
 
-	docRev, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
+	docRev, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Len(t, docRev.Channels.ToArray(), 0)
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
@@ -81,7 +81,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData2))
 
-	docRev2, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
+	docRev2, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().GetWithRev(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.CurrentRev, docRev2.RevID)
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8309,3 +8309,46 @@ func requireBodyEqual(t *testing.T, expected string, doc *db.Document) {
 	require.NoError(t, base.JSONUnmarshal([]byte(expected), &expectedBody))
 	require.Equal(t, expectedBody, doc.Body(base.TestCtx(t)))
 }
+
+// TestReplicatorUpdateHLVOnPut:
+//   - For purpose of testing the PutExistingRev code path
+//   - Put a doc on a active rest tester
+//   - Create replication and wait for the doc to be replicated to passive node
+//   - Assert on the HLV in the metadata of the replicated document
+func TestReplicatorUpdateHLVOnPut(t *testing.T) {
+
+	activeRT, passiveRT, remoteURL, teardown := rest.SetupSGRPeers(t)
+	defer teardown()
+
+	// Grab the bucket UUIDs for both rest testers
+	activeBucketUUID, err := activeRT.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
+
+	const rep = "replication"
+
+	// Put a doc and assert on the HLV update in the sync data
+	resp := activeRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"source": "activeRT"}`)
+	rest.RequireStatus(t, resp, http.StatusCreated)
+
+	syncData, err := activeRT.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS := base.HexCasToUint64(syncData.Cas)
+
+	assert.Equal(t, activeBucketUUID, syncData.HLV.SourceID)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+
+	// create the replication to push the doc to the passive node and wait for the doc to be replicated
+	activeRT.CreateReplication(rep, remoteURL, db.ActiveReplicatorTypePush, nil, false, db.ConflictResolverDefault)
+
+	_, err = passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+
+	// assert on the HLV update on the passive node
+	syncData, err = passiveRT.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	assert.NoError(t, err)
+	uintCAS = base.HexCasToUint64(syncData.Cas)
+
+	// TODO: assert that the SourceID and Verison pair are preserved correctly pending CBG-3211
+	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+}

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8349,6 +8349,6 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	assert.NoError(t, err)
 	uintCAS = base.HexCasToUint64(syncData.Cas)
 
-	// TODO: assert that the SourceID and Verison pair are preserved correctly pending CBG-3211
+	// TODO: assert that the SourceID and Version pair are preserved correctly pending CBG-3211
 	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8323,6 +8323,8 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	// Grab the bucket UUIDs for both rest testers
 	activeBucketUUID, err := activeRT.GetDatabase().Bucket.UUID()
 	require.NoError(t, err)
+	passiveBucketUUID, err := passiveRT.GetDatabase().Bucket.UUID()
+	require.NoError(t, err)
 
 	const rep = "replication"
 
@@ -8349,6 +8351,7 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	assert.NoError(t, err)
 	uintCAS = base.HexCasToUint64(syncData.Cas)
 
-	// TODO: assert that the SourceID and Version pair are preserved correctly pending CBG-3211
+	assert.Equal(t, passiveBucketUUID, syncData.HLV.SourceID)
 	assert.Equal(t, uintCAS, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, uintCAS, syncData.HLV.Version)
 }

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -71,7 +71,7 @@ func addActiveRT(t *testing.T, dbName string, testBucket *base.TestBucket) (acti
 
 // requireDocumentVersion asserts that the given ChangeRev has the expected version for a given entry returned by _changes feed
 func requireDocumentVersion(t testing.TB, expected rest.DocVersion, doc *db.Document) {
-	rest.RequireDocVersionEqual(t, expected, rest.DocVersion{RevID: doc.SyncData.CurrentRev})
+	rest.RequireDocVersionEqual(t, expected, rest.DocVersion{RevTreeID: doc.SyncData.CurrentRev})
 }
 
 // requireRevID asserts that the specified document version is written to the

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2248,7 +2248,7 @@ func TestRevocationMessage(t *testing.T) {
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
-		version := rt.PutDoc("doc", `{"channels": "A"}`)
+		version := rt.PutDocDirectly("doc", db.Body{"channels": "A"})
 
 		require.NoError(t, rt.WaitForPendingChanges())
 
@@ -2263,10 +2263,10 @@ func TestRevocationMessage(t *testing.T) {
 		revocationTester.removeRole("user", "foo")
 
 		const doc1ID = "doc1"
-		version = rt.PutDoc(doc1ID, `{"channels": "!"}`)
+		version = rt.PutDocDirectly(doc1ID, db.Body{"channels": "!"})
 
 		revocationTester.fillToSeq(10)
-		version = rt.UpdateDoc(doc1ID, version, "{}")
+		version = rt.UpdateDocDirectly(doc1ID, version, db.Body{})
 
 		require.NoError(t, rt.WaitForPendingChanges())
 
@@ -2363,7 +2363,7 @@ func TestRevocationNoRev(t *testing.T) {
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
-		version := rt.PutDoc(docID, `{"channels": "A"}`)
+		version := rt.PutDocDirectly(docID, db.Body{"channels": "A"})
 
 		require.NoError(t, rt.WaitForPendingChanges())
 		firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
@@ -2377,9 +2377,9 @@ func TestRevocationNoRev(t *testing.T) {
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
 
-		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
+		_ = rt.UpdateDocDirectly(docID, version, db.Body{"channels": "A", "val": "mutate"})
 
-		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
+		waitMarkerVersion := rt.PutDocDirectly(waitMarkerID, db.Body{"channels": "!"})
 		require.NoError(t, rt.WaitForPendingChanges())
 
 		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
@@ -2459,7 +2459,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
-		version := rt.PutDoc(docID, `{"channels": "A"}}`)
+		version := rt.PutDocDirectly(docID, db.Body{"channels": "A"})
 
 		require.NoError(t, rt.WaitForPendingChanges())
 		firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
@@ -2473,9 +2473,9 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
 
-		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
+		_ = rt.UpdateDocDirectly(docID, version, db.Body{"channels": "A", "val": "mutate"})
 
-		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
+		waitMarkerVersion := rt.PutDocDirectly(waitMarkerID, db.Body{"channels": "!"})
 		require.NoError(t, rt.WaitForPendingChanges())
 
 		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1014,10 +1014,10 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 2)
 	assert.Equal(t, doc1ID, changes.Results[0].ID)
-	assert.Equal(t, doc1Version.RevID, changes.Results[0].Changes[0]["rev"])
+	assert.Equal(t, doc1Version.RevTreeID, changes.Results[0].Changes[0]["rev"])
 	assert.True(t, changes.Results[0].Revoked)
 	assert.Equal(t, doc2ID, changes.Results[1].ID)
-	assert.Equal(t, doc2Version.RevID, changes.Results[1].Changes[0]["rev"])
+	assert.Equal(t, doc2Version.RevTreeID, changes.Results[1].Changes[0]["rev"])
 	assert.True(t, changes.Results[1].Revoked)
 
 	changes = revocationTester.getChanges("20:40", 1)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1099,6 +1099,11 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		}
 	}
 
+	// In sync gateway version 4.0+ we do not support the disabling of use of xattrs
+	if !config.UseXattrs() {
+		return db.DatabaseContextOptions{}, fmt.Errorf("sync gateway requires enable_shared_bucket_access=true")
+	}
+
 	// Create a callback function that will be invoked if the database goes offline and comes
 	// back online again
 	dbOnlineCallback := func(dbContext *db.DatabaseContext) {

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -317,6 +317,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	assert.NotNil(t, sc.dbConfigs["db"])
 
 	// Update config in bucket to see if unsuspending check for updates
+	sc.dbConfigs["db"].EnableXattrs = base.BoolPtr(true) // xattrs must be enabled
 	cas, err := sc.BootstrapContext.UpdateConfig(base.TestCtx(t), tb.GetName(), sc.Config.Bootstrap.ConfigGroupID, "db", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 		config := sc.dbConfigs["db"].ToDatabaseConfig()
 		config.cfgCas = bucketDbConfig.cfgCas

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2683,3 +2683,10 @@ func RequireGocbDCPResync(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server since rosmar has no support for DCP resync")
 	}
 }
+
+func jsonToMap(t *testing.T, jsonStr string) map[string]interface{} {
+	result := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonStr), &result)
+	require.NoError(t, err)
+	return result
+}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -780,7 +780,7 @@ func (cr ChangesResults) RequireDocIDs(t testing.TB, docIDs []string) {
 
 // RequireChangeRevVersion asserts that the given ChangeRev has the expected version for a given entry returned by _changes feed
 func RequireChangeRevVersion(t *testing.T, expected DocVersion, changeRev db.ChangeRev) {
-	RequireDocVersionEqual(t, expected, DocVersion{RevID: changeRev["rev"]})
+	RequireDocVersionEqual(t, expected, DocVersion{RevTreeID: changeRev["rev"]})
 }
 
 func (rt *RestTester) CreateWaitForChangesRetryWorker(numChangesExpected int, changesURL, username string, useAdminPort bool) (worker base.RetryWorker) {
@@ -2353,16 +2353,16 @@ func WaitAndAssertBackgroundManagerExpiredHeartbeat(t testing.TB, bm *db.Backgro
 
 // DocVersion represents a specific version of a document in an revID/HLV agnostic manner.
 type DocVersion struct {
-	RevID string
-	CV    db.Version
+	RevTreeID string
+	CV        db.Version
 }
 
 func (v *DocVersion) String() string {
-	return fmt.Sprintf("RevID: %s", v.RevID)
+	return fmt.Sprintf("RevTreeID: %s", v.RevTreeID)
 }
 
 func (v DocVersion) Equal(o DocVersion) bool {
-	if v.RevID != o.RevID {
+	if v.RevTreeID != o.RevTreeID {
 		return false
 	}
 	return true
@@ -2370,12 +2370,12 @@ func (v DocVersion) Equal(o DocVersion) bool {
 
 // Digest returns the digest for the current version
 func (v DocVersion) Digest() string {
-	return strings.Split(v.RevID, "-")[1]
+	return strings.Split(v.RevTreeID, "-")[1]
 }
 
 // RequireDocVersionNotNil calls t.Fail if two document version is not specified.
 func RequireDocVersionNotNil(t *testing.T, version DocVersion) {
-	require.NotEqual(t, "", version.RevID)
+	require.NotEqual(t, "", version.RevTreeID)
 }
 
 // RequireDocVersionEqual calls t.Fail if two document versions are not equal.
@@ -2390,12 +2390,12 @@ func RequireDocVersionNotEqual(t *testing.T, expected, actual DocVersion) {
 
 // EmptyDocVersion reprents an empty document version.
 func EmptyDocVersion() DocVersion {
-	return DocVersion{RevID: ""}
+	return DocVersion{RevTreeID: ""}
 }
 
 // NewDocVersionFromFakeRev returns a new DocVersion from the given fake rev ID, intended for use when we explicit create conflicts.
 func NewDocVersionFromFakeRev(fakeRev string) DocVersion {
-	return DocVersion{RevID: fakeRev}
+	return DocVersion{RevTreeID: fakeRev}
 }
 
 // DocVersionFromPutResponse returns a DocRevisionID from the given response to PUT /{, or fails the given test if a rev ID was not found.
@@ -2407,7 +2407,7 @@ func DocVersionFromPutResponse(t testing.TB, response *TestResponse) DocVersion 
 	require.NoError(t, json.Unmarshal(response.BodyBytes(), &r))
 	require.NotNil(t, r.RevID, "expecting non-nil rev ID from response: %s", string(response.BodyBytes()))
 	require.NotEqual(t, "", *r.RevID, "expecting non-empty rev ID from response: %s", string(response.BodyBytes()))
-	return DocVersion{RevID: *r.RevID}
+	return DocVersion{RevTreeID: *r.RevID}
 }
 
 func MarshalConfig(t *testing.T, config db.ReplicationConfig) string {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2354,6 +2354,7 @@ func WaitAndAssertBackgroundManagerExpiredHeartbeat(t testing.TB, bm *db.Backgro
 // DocVersion represents a specific version of a document in an revID/HLV agnostic manner.
 type DocVersion struct {
 	RevID string
+	CV    db.Version
 }
 
 func (v *DocVersion) String() string {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2368,6 +2368,17 @@ func (v DocVersion) Equal(o DocVersion) bool {
 	return true
 }
 
+func (v DocVersion) GetRev(useHLV bool) string {
+	if useHLV {
+		if v.CV.SourceID == "" {
+			return ""
+		}
+		return v.CV.String()
+	} else {
+		return v.RevTreeID
+	}
+}
+
 // Digest returns the digest for the current version
 func (v DocVersion) Digest() string {
 	return strings.Split(v.RevTreeID, "-")[1]

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1060,12 +1060,13 @@ func (rt *RestTester) SetAdminChannels(username string, keyspace string, channel
 
 type SimpleSync struct {
 	Channels map[string]interface{}
-	Rev      string
+	Rev      db.RevAndVersion
 	Sequence uint64
 }
 
 type RawResponse struct {
-	Sync SimpleSync `json:"_sync"`
+	Sync    SimpleSync `json:"_sync"`
+	Deleted bool       `json:"_deleted"`
 }
 
 // GetDocumentSequence looks up the sequence for a document using the _raw endpoint.

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1060,7 +1060,7 @@ func (rt *RestTester) SetAdminChannels(username string, keyspace string, channel
 
 type SimpleSync struct {
 	Channels map[string]interface{}
-	Rev      db.RevAndVersion
+	Rev      channels.RevAndVersion
 	Sequence uint64
 }
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2684,7 +2684,7 @@ func RequireGocbDCPResync(t *testing.T) {
 	}
 }
 
-func jsonToMap(t *testing.T, jsonStr string) map[string]interface{} {
+func JsonToMap(t *testing.T, jsonStr string) map[string]interface{} {
 	result := make(map[string]interface{})
 	err := json.Unmarshal([]byte(jsonStr), &result)
 	require.NoError(t, err)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -410,3 +410,36 @@ func (rt *RestTester) RequireDbOnline() {
 	require.NoError(rt.TB, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	require.Equal(rt.TB, "Online", body["state"].(string))
 }
+
+// TEMPORARY HELPER METHODS FOR BLIP TEST CLIENT RUNNER
+func (rt *RestTester) PutDocDirectly(docID string, body db.Body) DocVersion {
+	collection := rt.GetSingleTestDatabaseCollectionWithUser()
+	rev, doc, err := collection.Put(rt.Context(), docID, body)
+	require.NoError(rt.TB, err)
+	return DocVersion{RevID: rev, CV: db.Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}}
+}
+
+func (rt *RestTester) UpdateDocDirectly(docID string, version DocVersion, body db.Body) DocVersion {
+	collection := rt.GetSingleTestDatabaseCollectionWithUser()
+	body[db.BodyId] = docID
+	body[db.BodyRev] = version.RevID
+	rev, doc, err := collection.Put(rt.Context(), docID, body)
+	require.NoError(rt.TB, err)
+	return DocVersion{RevID: rev, CV: db.Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}}
+}
+
+func (rt *RestTester) DeleteDocDirectly(docID string, version DocVersion) DocVersion {
+	collection := rt.GetSingleTestDatabaseCollectionWithUser()
+	rev, doc, err := collection.DeleteDoc(rt.Context(), docID, version.RevID)
+	require.NoError(rt.TB, err)
+	return DocVersion{RevID: rev, CV: db.Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}}
+}
+
+func (rt *RestTester) PutDocDirectlyInCollection(collection *db.DatabaseCollection, docID string, body db.Body) DocVersion {
+	dbUser := &db.DatabaseCollectionWithUser{
+		DatabaseCollection: collection,
+	}
+	rev, doc, err := dbUser.Put(rt.Context(), docID, body)
+	require.NoError(rt.TB, err)
+	return DocVersion{RevID: rev, CV: db.Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}}
+}


### PR DESCRIPTION
CBG-3736


- Store CV (In CBL format) on the DocumentDelta (this needs to be stored alongside the ToRevID on the delta for future backwards compatibility reasons)
- DocumentDelta needs now also stores history in CBL string format 
- oldRevisionKey: changes to have cv instead of revID here, to adfdress isseus with key length I have made is to CV is hased befgore being persisted to the bucket
- When subprotocol version is below v4 and delta sync is requested, fall back to sending full revision
- GetDelta: fromRevision switch the fetch from rev cache for this revision from using revID to CV, If delta is found on fromRevision we now check if this delta correlates to the top the CV we want the delta for, toRevision: switch the fetch from rev cache to use CV rather than revID
- UpdateDelta: has a CV version entitled UpdateDeltaCV which uses the CV code path to update a delata on revcache
- newRevCacheDelta: grabs HLV history off documentRevision and store in onto RevisionDelta for ease of sending to CBL inside sendDelta function
- processRev: Switch to get by CV from revcache for deltaSrcRev
- backupRevisionJSON: had to move the handling for backing up sdk writes as it was using the new rev to do this. From where this code is called we haven't yet macro expanded the version thus cannot use the new CV to back up here. Solution was to move the code to where we update hlv post doc update. 
- Some test changes to fetch the backup revisions by the new format, some tets are just too difficult to work around in this sense till backwards compatibility is done, thus filed a ticket for this work and liked in the skip comments of these tests 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2397/
