### PR TITLE
Put UserXattrStore into DataStore to avoid need to typecast

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1035,9 +1035,7 @@ func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 
 	userXattrVal := map[string]interface{}{"val": "val"}
 
-	userXattrStore, ok := AsUserXattrStore(dataStore)
-	require.True(t, ok)
-	_, err = userXattrStore.WriteUserXattr(key, userXattrKey, userXattrVal)
+	_, err = dataStore.WriteUserXattr(key, userXattrKey, userXattrVal)
 	assert.NoError(t, err)
 
 	_, err = dataStore.WriteUpdateWithXattr(ctx, key, xattrKey, userXattrKey, 0, nil, nil, writeUpdateFunc)
@@ -2205,9 +2203,6 @@ func TestUserXattrGetWithXattr(t *testing.T) {
 	defer bucket.Close(ctx)
 	dataStore := bucket.GetSingleDataStore()
 
-	userXattrStore, ok := AsUserXattrStore(dataStore)
-	require.True(t, ok)
-
 	docKey := t.Name()
 
 	docVal := map[string]interface{}{"val": "docVal"}
@@ -2217,10 +2212,10 @@ func TestUserXattrGetWithXattr(t *testing.T) {
 	err := dataStore.Set(docKey, 0, nil, docVal)
 	assert.NoError(t, err)
 
-	_, err = userXattrStore.WriteUserXattr(docKey, "_sync", syncXattrVal)
+	_, err = dataStore.WriteUserXattr(docKey, "_sync", syncXattrVal)
 	assert.NoError(t, err)
 
-	_, err = userXattrStore.WriteUserXattr(docKey, "test", userXattrVal)
+	_, err = dataStore.WriteUserXattr(docKey, "test", userXattrVal)
 	assert.NoError(t, err)
 
 	var docValRet, syncXattrValRet, userXattrValRet map[string]interface{}
@@ -2248,9 +2243,7 @@ func TestUserXattrGetWithXattrNil(t *testing.T) {
 	err := dataStore.Set(docKey, 0, nil, docVal)
 	assert.NoError(t, err)
 
-	userXattrStore, ok := AsUserXattrStore(dataStore)
-	require.True(t, ok)
-	_, err = userXattrStore.WriteUserXattr(docKey, "_sync", syncXattrVal)
+	_, err = dataStore.WriteUserXattr(docKey, "_sync", syncXattrVal)
 	assert.NoError(t, err)
 
 	var docValRet, syncXattrValRet, userXattrValRet map[string]interface{}

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -32,7 +32,7 @@ func (c *Collection) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 }
 
 var _ sgbucket.XattrStore = &Collection{}
-var _ UserXattrStore = &Collection{}
+var _ sgbucket.UserXattrStore = &Collection{}
 
 func init() {
 	LookupOptsAccessDeleted = &gocb.LookupInOptions{}

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -22,14 +22,6 @@ const (
 	xattrMacroValueCrc32c = "value_crc32c"
 )
 
-// Utilities for creating/deleting user xattr.  For test use
-type UserXattrStore = sgbucket.UserXattrStore
-
-// KvXattrStore is used for xattr_common functions that perform subdoc and standard kv operations
-type KvXattrStore interface {
-	sgbucket.KVStore
-}
-
 // CAS-safe write of a document and it's associated named xattr
 func WriteCasWithXattr(ctx context.Context, store *Collection, k string, xattrKey string, exp uint32, cas uint64, opts *sgbucket.MutateInOptions, v interface{}, xv interface{}) (casOut uint64, err error) {
 
@@ -402,19 +394,6 @@ func deleteDocXattrOnly(ctx context.Context, store *Collection, k string, xattrK
 	}
 	return nil
 
-}
-
-func AsUserXattrStore(dataStore DataStore) (UserXattrStore, bool) {
-
-	switch typedDataStore := dataStore.(type) {
-	case UserXattrStore:
-		return typedDataStore, true
-	case *LeakyDataStore:
-		return AsUserXattrStore(typedDataStore.dataStore)
-	default:
-		// bail out for unrecognised/unsupported buckets
-		return nil, false
-	}
 }
 
 func xattrCasPath(xattrKey string) string {

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -292,6 +292,14 @@ func (lds *LeakyDataStore) DeleteWithXattr(ctx context.Context, k string, xattr 
 	return lds.dataStore.DeleteWithXattr(ctx, k, xattr)
 }
 
+func (lds *LeakyDataStore) WriteUserXattr(docKey string, xattrKey string, xattrVal interface{}) (uint64, error) {
+	return lds.dataStore.WriteUserXattr(docKey, xattrKey, xattrVal)
+}
+
+func (lds *LeakyDataStore) DeleteUserXattr(docKey string, xattrKey string) (uint64, error) {
+	return lds.dataStore.DeleteUserXattr(docKey, xattrKey)
+}
+
 func (lds *LeakyDataStore) GetXattr(ctx context.Context, k string, xattr string, xv interface{}) (cas uint64, err error) {
 	return lds.dataStore.GetXattr(ctx, k, xattr, xv)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.2.10
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483
+	github.com/couchbase/sg-bucket v0.0.0-20240205145213-1381da0bbd5d
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20231220172938-669667777223

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.2.10
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20240205145213-1381da0bbd5d
+	github.com/couchbase/sg-bucket v0.0.0-20240206113827-752ae6de6855
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20231220172938-669667777223

--- a/go.sum
+++ b/go.sum
@@ -42,10 +42,8 @@ github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUl
 github.com/couchbase/gomemcached v0.2.1/go.mod h1:mxliKQxOv84gQ0bJWbI+w9Wxdpt9HjDvgW9MjCym5Vo=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483 h1:K6y82On0A3coA+GwW+HGKIwpCpca6ZSvTAJwwTmzCrg=
-github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
-github.com/couchbase/sg-bucket v0.0.0-20240205145213-1381da0bbd5d h1:02+S3drhliTpQtOHnHchw+xQSFgmk0qMzqi8XpFtFfQ=
-github.com/couchbase/sg-bucket v0.0.0-20240205145213-1381da0bbd5d/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
+github.com/couchbase/sg-bucket v0.0.0-20240206113827-752ae6de6855 h1:mATYI89sJnZUL+99NLlgYcjZAo8hsOdUUYfean04IFQ=
+github.com/couchbase/sg-bucket v0.0.0-20240206113827-752ae6de6855/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9B
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
 github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483 h1:K6y82On0A3coA+GwW+HGKIwpCpca6ZSvTAJwwTmzCrg=
 github.com/couchbase/sg-bucket v0.0.0-20231116231254-16c1ad8b2483/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
+github.com/couchbase/sg-bucket v0.0.0-20240205145213-1381da0bbd5d h1:02+S3drhliTpQtOHnHchw+xQSFgmk0qMzqi8XpFtFfQ=
+github.com/couchbase/sg-bucket v0.0.0-20240205145213-1381da0bbd5d/go.mod h1:hy6J0RXx/Ry+5EiI8VVMetsVfBXQq5/djQLbvfRau0k=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=

--- a/rest/importuserxattrtest/rawdoc_test.go
+++ b/rest/importuserxattrtest/rawdoc_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,14 +32,11 @@ func TestUserXattrsRawGet(t *testing.T) {
 	})
 	defer rt.Close()
 
-	userXattrStore, ok := base.AsUserXattrStore(rt.GetSingleDataStore())
-	require.True(t, ok)
-
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, "{}")
 	rest.RequireStatus(t, resp, http.StatusCreated)
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	_, err := userXattrStore.WriteUserXattr(docKey, xattrKey, "val")
+	_, err := rt.GetSingleDataStore().WriteUserXattr(docKey, xattrKey, "val")
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {

--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -60,8 +60,6 @@ func TestUserXattrRevCache(t *testing.T) {
 	defer rt2.Close()
 
 	dataStore := rt2.GetSingleDataStore()
-	userXattrStore, ok := base.AsUserXattrStore(dataStore)
-	require.True(t, ok)
 
 	ctx = rt2.Context()
 	a := rt2.ServerContext().Database(ctx, "db").Authenticator(ctx)
@@ -76,7 +74,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 	require.NoError(t, rt.WaitForPendingChanges())
-	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "DEF")
+	_, err = dataStore.WriteUserXattr(docKey, xattrKey, "DEF")
 	assert.NoError(t, err)
 
 	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
@@ -86,7 +84,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// Add channel ABC to the userXattr
-	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = dataStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// wait for import of the xattr change on both nodes
@@ -143,8 +141,6 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	defer rt2.Close()
 
 	dataStore := rt2.GetSingleDataStore()
-	userXattrStore, ok := base.AsUserXattrStore(dataStore)
-	require.True(t, ok)
 
 	ctx = rt2.Context()
 	a := rt2.ServerContext().Database(ctx, "db").Authenticator(ctx)
@@ -158,7 +154,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Write DEF to the userXattrStore to give userDEF access
-	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "DEF")
+	_, err = dataStore.WriteUserXattr(docKey, xattrKey, "DEF")
 	assert.NoError(t, err)
 
 	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
@@ -168,7 +164,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// Delete DEF from the userXattr, removing the doc from channel DEF
-	_, err = userXattrStore.DeleteUserXattr(docKey, xattrKey)
+	_, err = dataStore.DeleteUserXattr(docKey, xattrKey)
 	assert.NoError(t, err)
 
 	// wait for import of the xattr change on both nodes

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -45,8 +45,6 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	defer rt.Close()
 
 	dataStore := rt.GetSingleDataStore()
-	userXattrStore, ok := base.AsUserXattrStore(dataStore)
-	require.True(t, ok)
 
 	// Initial PUT
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
@@ -65,7 +63,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
 
 	// Write xattr to trigger import of user xattr
-	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = dataStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Wait for import

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1496,13 +1496,10 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 
 	data := collection.GetCollectionDatastore()
 
-	userXattrStore, ok := base.AsUserXattrStore(data)
-	require.True(t, ok)
-
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/accessDoc", `{}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	_, err := userXattrStore.WriteUserXattr("accessDoc", xattrKey, map[string]interface{}{"userChannels": map[string]interface{}{"user": "a"}})
+	_, err := data.WriteUserXattr("accessDoc", xattrKey, map[string]interface{}{"userChannels": map[string]interface{}{"user": "a"}})
 	assert.NoError(t, err)
 
 	_ = rt.PutDoc("doc", `{"channels": "a"}`)
@@ -1510,7 +1507,7 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 	changes := revocationTester.getChanges(0, 2)
 	assert.Len(t, changes.Results, 2)
 
-	_, err = userXattrStore.WriteUserXattr("accessDoc", xattrKey, map[string]interface{}{})
+	_, err = data.WriteUserXattr("accessDoc", xattrKey, map[string]interface{}{})
 	assert.NoError(t, err)
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)


### PR DESCRIPTION
https://github.com/couchbase/sg-bucket/pull/111

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2282
