### PR TITLE
Update to non deprecated actions to avoid use of node16.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.21.4
       - name: go-build
@@ -37,8 +37,8 @@ jobs:
     name: addlicense
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.21.4
       - run: go install github.com/google/addlicense@latest
@@ -48,8 +48,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.21.4
           cache: false
@@ -76,8 +76,8 @@ jobs:
       MallocNanoZone: 0
     name: test (${{ matrix.name }})
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.21.4
       - name: Build
@@ -87,7 +87,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.7.0
         with:
           test-results: test.json
 
@@ -96,8 +96,8 @@ jobs:
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.21.4
       - name: Run Tests
@@ -116,9 +116,9 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -136,8 +136,8 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.21.4
       - name: Build

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     name: OpenAPI Validation
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r7kamura/redocly-problem-matchers@v1
       - uses: mhiew/redoc-lint-github-action@v3
         with:
@@ -46,7 +46,7 @@ jobs:
     name: 'yamllint'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: karancode/yamllint-github-action@master
         with:
           yamllint_file_or_dir: 'docs/api'


### PR DESCRIPTION
This prevents deprecated node version warning messages from showing up in actions. One will show up from https://github.com/golangci/golangci-lint-action/issues/953 which is better than 10 showing up.