### PR TITLE
CBG-3586: [3.1.4 backport] log bucket and groupID during config search

### DIFF
--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -206,14 +206,14 @@ func (a *AttachmentCompactionManager) handleAttachmentCompactionRollbackError(ct
 		// to rollback any phase for attachment compaction we need to purge all persisted dcp metadata
 		err = a.PurgeDCPMetadata(ctx, dataStore, database, keyPrefix)
 		if err != nil {
-			base.WarnfCtx(ctx, "error occurred during purging of dcp metadata: %w", err)
+			base.WarnfCtx(ctx, "error occurred during purging of dcp metadata: %s", err)
 			return false, err
 		}
 		if phase == MarkPhase {
 			// initialise new compaction run as we want to start the phase mark again in event of rollback
 			err = a.Init(ctx, options, nil)
 			if err != nil {
-				base.WarnfCtx(ctx, "error on initialization of new run after rollback has been indicated, %w", err)
+				base.WarnfCtx(ctx, "error on initialization of new run after rollback has been indicated: %s", err)
 				return false, err
 			}
 		} else {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1454,7 +1454,7 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 		if getErr == base.ErrNotFound {
 			continue
 		} else if getErr != nil {
-			base.InfofCtx(ctx, base.KeyConfig, "Unable to retrieve 3.0 config during config migration for bucket: %s, groupID: %s: %w", base.MD(bucketName), base.MD(groupID), getErr)
+			base.InfofCtx(ctx, base.KeyConfig, "Unable to retrieve 3.0 config during config migration for bucket: %s, groupID: %s: %s", base.MD(bucketName), base.MD(groupID), getErr)
 			continue
 		}
 
@@ -1464,7 +1464,7 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 			if insertErr == base.ErrAlreadyExists {
 				base.DebugfCtx(ctx, base.KeyConfig, "Found legacy config for database %s in bucket %s, groupID: %s, but already exists in registry.", base.MD(dbConfig.Name), base.MD(bucketName), base.MD(groupID))
 			} else {
-				base.InfofCtx(ctx, base.KeyConfig, "Unable to persist migrated v3.0 config for bucket %s groupID %s: %w", base.MD(bucketName), base.MD(groupID), insertErr)
+				base.InfofCtx(ctx, base.KeyConfig, "Unable to persist migrated v3.0 config for bucket %s groupID %s: %s", base.MD(bucketName), base.MD(groupID), insertErr)
 				continue
 			}
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2036,7 +2036,7 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 		}
 
 		if count > 0 {
-			base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs from buckets in cluster", count)
+			base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs for group %q from buckets in cluster", count, sc.Config.Bootstrap.ConfigGroupID)
 		} else {
 			base.WarnfCtx(ctx, "Config: No database configs for group %q. Continuing startup to allow REST API database creation", sc.Config.Bootstrap.ConfigGroupID)
 		}
@@ -2060,10 +2060,10 @@ func (sc *ServerContext) initializeCouchbaseServerConnections(ctx context.Contex
 						base.DebugfCtx(ctx, base.KeyConfig, "Fetching configs from buckets in cluster for group %q", sc.Config.Bootstrap.ConfigGroupID)
 						count, err := sc.fetchAndLoadConfigs(ctx, false)
 						if err != nil {
-							base.WarnfCtx(ctx, "Couldn't load configs from bucket when polled: %v", err)
+							base.WarnfCtx(ctx, "Couldn't load configs from bucket for group %q when polled: %v", sc.Config.Bootstrap.ConfigGroupID, err)
 						}
 						if count > 0 {
-							base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs from buckets in cluster", count)
+							base.InfofCtx(ctx, base.KeyConfig, "Successfully fetched %d database configs for group %d from buckets in cluster", count, sc.Config.Bootstrap.ConfigGroupID)
 						}
 					}
 				}


### PR DESCRIPTION
CBG-3586

Backport of CBG-3585 Inconsistent logging for config file reading 

Also includes https://github.com/couchbase/sync_gateway/pull/6494

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2283/
