### PR TITLE
CBG-3723: [3.1.4 backport] allow tcp_nodelay to be set to false for tls connections

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1657,15 +1657,24 @@ func GetHttpClientForWebSocket(insecureSkipVerify bool) *http.Client {
 // Turns off TCP NODELAY on a TCP connection.
 // On success returns true; on failure logs a warning and returns false.
 // (There's really no reason for a caller to take note of the return value.)
-func turnOffNoDelay(ctx context.Context, conn net.Conn) bool {
-	if tcpConn, ok := conn.(*net.TCPConn); !ok {
-		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: it's not a TCPConn", conn)
-	} else if err := tcpConn.SetNoDelay(false); err != nil {
-		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %v", conn, err)
-	} else {
-		return true
+func turnOffNoDelay(ctx context.Context, conn net.Conn) {
+	netConnection := conn
+	var tcpConn *net.TCPConn
+
+	if tlsConn, ok := netConnection.(*tls.Conn); ok {
+		netConnection = tlsConn.NetConn()
 	}
-	return false
+
+	if netTCPConn, isTCPConn := netConnection.(*net.TCPConn); isTCPConn {
+		tcpConn = netTCPConn
+	} else {
+		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %T is not type *net.TCPConn", conn, conn)
+		return
+	}
+
+	if err := tcpConn.SetNoDelay(false); err != nil {
+		WarnfCtx(ctx, "Couldn't turn off NODELAY for %v: %v", conn, err)
+	}
 }
 
 // IsConnectionRefusedError returns true if the given error is due to a connection being actively refused.


### PR DESCRIPTION

CBG-3723

backport of CBG-2993: allow tcp_nodelay to be set to false for tls connections

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
