### PR TITLE
CBG-3682: [3.1.4 backport] sgcollect loads entire file into mmap for upload, can run out of memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-github-actions-annotate-failures
+          pip install pytest pytest-github-actions-annotate-failures pytest-httpserver trustme
       - name: Run test
         run: |
           pytest

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -1072,29 +1072,26 @@ def do_upload(path, url, proxy):
 
     with open(path, 'rb') as f:
 
-        # mmap the file to reduce the amount of memory required (see bit.ly/2aNENXC)
-        with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as filedata:
+        # Get proxies from environment/system
+        proxy_handler = urllib.request.ProxyHandler(urllib.request.getproxies())
+        if proxy != "":
+            # unless a proxy is explicitly passed, then use that instead
+            proxy_handler = urllib.request.ProxyHandler({'https': proxy, 'http': proxy})
 
-            # Get proxies from environment/system
-            proxy_handler = urllib.request.ProxyHandler(urllib.request.getproxies())
-            if proxy != "":
-                # unless a proxy is explicitly passed, then use that instead
-                proxy_handler = urllib.request.ProxyHandler({'https': proxy, 'http': proxy})
+        opener = urllib.request.build_opener(proxy_handler)
+        request = urllib.request.Request(url, data=f, method='PUT')
+        request.add_header(str('Content-Type'), str('application/zip'))
 
-            opener = urllib.request.build_opener(proxy_handler)
-            request = urllib.request.Request(url, data=filedata.read(), method='PUT')
-            request.add_header(str('Content-Type'), str('application/zip'))
-
-            exit_code = 0
-            try:
-                url = opener.open(request)
-                if url.getcode() == 200:
-                    log('Done uploading')
-                else:
-                    raise Exception('Error uploading, expected status code 200, got status code: {0}'.format(url.getcode()))
-            except Exception as e:
-                log(traceback.format_exc())
-                return 1
+        exit_code = 0
+        try:
+            url = opener.open(request)
+            if url.getcode() == 200:
+                log('Done uploading')
+            else:
+                raise Exception('Error uploading, expected status code 200, got status code: {0}'.format(url.getcode()))
+        except Exception as e:
+            log(traceback.format_exc())
+            return 1
 
     return 0
 


### PR DESCRIPTION

CBG-3682

backport of CBG-3591: sgcollect loads entire file into mmap for upload, can run out of memory

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
