### PR TITLE
CBG-3744: [3.1.4 backport] fetchAndLoadDatabase NewDatabaseContext race fix

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1425,6 +1425,8 @@ func (sc *ServerContext) fetchAndLoadDatabaseSince(ctx context.Context, dbName s
 }
 
 func (sc *ServerContext) fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string) (found bool, err error) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
 	return sc._fetchAndLoadDatabase(nonContextStruct, dbName)
 }
 


### PR DESCRIPTION
CBG-3744

backport of CBG-3743: fetchAndLoadDatabase NewDatabaseContext race fix

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2286/
