### PR TITLE
CBG-3762: [3.1.4 backport] Respond to _blipsync with BLIP context ID

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -76,6 +76,8 @@ func newBlipHandler(ctx context.Context, bc *BlipSyncContext, db *Database, seri
 type BLIPSyncContextClientType string
 
 const (
+	BLIPCorrelationIDResponseHeader = "X-Correlation-ID"
+
 	BLIPSyncClientTypeQueryParam = "client"
 
 	BLIPClientTypeCBL2 BLIPSyncContextClientType = "cbl2"

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -48,6 +48,7 @@ func (h *handler) handleBLIPSync() error {
 
 	// Overwrite the existing logging context with the blip context ID
 	h.rqCtx = base.CorrelationIDLogCtx(h.ctx(), base.FormatBlipContextID(blipContext.ID))
+	h.response.Header().Set(db.BLIPCorrelationIDResponseHeader, blipContext.ID)
 
 	// Create a new BlipSyncContext attached to the given blipContext.
 	ctx := db.NewBlipSyncContext(h.rqCtx, blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))


### PR DESCRIPTION

CBG-3762

backport of CBG-3747: Respond to _blipsync with BLIP context ID


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
