### PR TITLE
CBG-2557: Include trace logs with sgcollect_info

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -249,6 +249,7 @@ def make_collect_logs_tasks(zip_dir, sg_url, sg_config_file_path, sg_username, s
         "sg_warn.log": "sg_warn.log",
         "sg_info.log": "sg_info.log",
         "sg_debug.log": "sg_debug.log",
+        "sg_trace.log": "sg_trace.log",
         "sg_stats.log": "sg_stats.log",
         "sync_gateway_access.log": "sync_gateway_access.log",
         "sync_gateway_error.log": "sync_gateway_error.log",


### PR DESCRIPTION
CBG-2557

When sgcollect_info runs, also include trace log files.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a