### PR TITLE
CBG-3760: [3.1.4 backport] Include trace logs with sgcollect_info

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -249,6 +249,7 @@ def make_collect_logs_tasks(zip_dir, sg_url, sg_config_file_path, sg_username, s
         "sg_warn.log": "sg_warn.log",
         "sg_info.log": "sg_info.log",
         "sg_debug.log": "sg_debug.log",
+        "sg_trace.log": "sg_trace.log",
         "sg_stats.log": "sg_stats.log",
         "sync_gateway_access.log": "sync_gateway_access.log",
         "sync_gateway_error.log": "sync_gateway_error.log",


### PR DESCRIPTION
CBG-3760

Backport of CBG-2557: sgcollect_info not collecting trace logging

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


