### PR TITLE
Speed up `auth` package tests by setting lower test-only bcrypt cost

### DIFF
--- a/auth/auth_time_sensitive_test.go
+++ b/auth/auth_time_sensitive_test.go
@@ -32,7 +32,7 @@ func TestAuthenticationSpeed(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 	user, _ := auth.NewUser("me", "goIsKewl", nil)
 	assert.True(t, user.Authenticate("goIsKewl"))
 

--- a/auth/collection_access_test.go
+++ b/auth/collection_access_test.go
@@ -40,7 +40,7 @@ func TestUserCollectionAccess(t *testing.T) {
 			"collection1": struct{}{},
 		},
 	}
-	auth := NewAuthenticator(bucket.GetSingleDataStore(), nil, options)
+	auth := NewTestAuthenticator(t, bucket.GetSingleDataStore(), nil, options)
 	user, _ := auth.NewUser("foo", "password", nil)
 	scope := "scope1"
 	collection := "collection1"
@@ -172,7 +172,7 @@ func TestSerializeUserWithCollections(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
-	auth := NewAuthenticator(bucket.GetSingleDataStore(), nil, DefaultAuthenticatorOptions(base.TestCtx(t)))
+	auth := NewTestAuthenticator(t, bucket.GetSingleDataStore(), nil, DefaultAuthenticatorOptions(base.TestCtx(t)))
 	user, _ := auth.NewUser("me", "letmein", ch.BaseSetOf(t, "me", "public"))
 	encoded, err := base.JSONMarshal(user)
 	require.NoError(t, err)

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1191,7 +1191,7 @@ func TestJWTRolesChannels(t *testing.T) {
 				roleChannels: map[string]ch.TimedSet{},
 			}
 
-			auth := NewAuthenticator(dataStore, &testMockComputer, DefaultAuthenticatorOptions(ctx))
+			auth := NewTestAuthenticator(t, dataStore, &testMockComputer, DefaultAuthenticatorOptions(ctx))
 
 			provider := &OIDCProvider{
 				Name: "foo",

--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -66,6 +66,8 @@ func TestSetBcryptCost(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
 	dataStore := bucket.GetSingleDataStore()
+
+	// Not NewTestAuthenticator, since we're testing BcryptCost and want the actual bcrypt default.
 	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	err := auth.SetBcryptCost(DefaultBcryptCost - 1) // below minimum allowed value

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -46,7 +46,7 @@ func TestAuthorizeChannelsRole(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	role, err := auth.NewRole("root", channels.BaseSetOf(t, "superuser"))
 	assert.NoError(t, err)
@@ -67,12 +67,12 @@ func TestRoleKeysHash(t *testing.T) {
 			defer testBucket.Close(ctx)
 			dataStore := testBucket.DefaultDataStore()
 
-			auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+			auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 			if !metadataDefault {
 				namedMetadataOptions := DefaultAuthenticatorOptions(ctx)
 				namedMetadataOptions.MetaKeys = base.NewMetadataKeys("foo")
 
-				auth = NewAuthenticator(dataStore, nil, namedMetadataOptions)
+				auth = NewTestAuthenticator(t, dataStore, nil, namedMetadataOptions)
 
 			}
 			shortRoleName := "shortRole"

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -30,7 +30,7 @@ func TestCreateSession(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	user, err := auth.NewUser(username, "password", base.Set{})
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestDeleteSession(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	id, err := base.GenerateRandomSecret()
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestMakeSessionCookie(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	sessionID, err := base.GenerateRandomSecret()
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestMakeSessionCookieProperties(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	sessionID, err := base.GenerateRandomSecret()
 	require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestDeleteSessionForCookie(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	sessionID, err := base.GenerateRandomSecret()
 	require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestCreateSessionChangePassword(t *testing.T) {
 			testBucket := base.GetTestBucket(t)
 			defer testBucket.Close(ctx)
 			dataStore := testBucket.GetSingleDataStore()
-			auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+			auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 			user, err := auth.NewUser(test.username, test.password, base.Set{})
 			require.NoError(t, err)
@@ -273,7 +273,7 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 	const username = "Alice"
 	user, err := auth.NewUser(username, "password", base.Set{})
 	require.NoError(t, err)

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -36,7 +36,7 @@ func TestUserAuthenticateDisabled(t *testing.T) {
 	defer bucket.Close(ctx)
 	dataStore := bucket.GetSingleDataStore()
 	// Create user
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 	u, err := auth.NewUser(username, oldPassword, base.Set{})
 	assert.NoError(t, err)
 	assert.NotNil(t, u)
@@ -70,8 +70,11 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
 	dataStore := bucket.GetSingleDataStore()
-	// Create user
+
+	// Not NewTestAuthenticator, since we're testing BcryptCost and want the actual bcrypt default.
 	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+
+	// Create user
 	u, err := auth.NewUser(username, oldPassword, base.Set{})
 	require.NoError(t, err)
 	require.NotNil(t, u)
@@ -254,7 +257,7 @@ func TestCanSeeChannelSince(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 	freeChannels := base.SetFromArray([]string{"ESPN", "HBO", "FX", "AMC"})
 	user, err := auth.NewUser("user", "password", freeChannels)
 	assert.Nil(t, err)
@@ -283,7 +286,7 @@ func TestGetAddedChannels(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	role, err := auth.NewRole("music", channels.BaseSetOf(t, "Spotify", "Youtube"))
 	assert.Nil(t, err)
@@ -327,7 +330,7 @@ func TestUserAuthenticateWithDisabledUserAccount(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -350,7 +353,7 @@ func TestUserAuthenticateWithOldPasswordHash(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -372,7 +375,7 @@ func TestUserAuthenticateWithBadPasswordHash(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -394,7 +397,7 @@ func TestUserAuthenticateWithNoHashAndBadPassword(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 	dataStore := testBucket.GetSingleDataStore()
-	auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -412,12 +415,12 @@ func TestUserKeysHash(t *testing.T) {
 			defer testBucket.Close(ctx)
 			dataStore := testBucket.GetSingleDataStore()
 
-			auth := NewAuthenticator(dataStore, nil, DefaultAuthenticatorOptions(ctx))
+			auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 			if !metadataDefault {
 				namedMetadataOptions := DefaultAuthenticatorOptions(ctx)
 				namedMetadataOptions.MetaKeys = base.NewMetadataKeys("foo")
 
-				auth = NewAuthenticator(testBucket.GetSingleDataStore(), nil, namedMetadataOptions)
+				auth = NewTestAuthenticator(t, testBucket.GetSingleDataStore(), nil, namedMetadataOptions)
 
 			}
 			bobUsername := "bob"


### PR DESCRIPTION
Initialize most `auth` tests with `NewTestAuthenticator`, which lowers the bcrypt cost.

## Comparison
```diff
- ok  	github.com/couchbase/sync_gateway/auth	8.656s
+ ok  	github.com/couchbase/sync_gateway/auth	2.361s
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a (unit test covered)