### PR TITLE
CI: Add redoc.ly OpenAPI PR preview links

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -50,3 +50,26 @@ jobs:
       - uses: karancode/yamllint-github-action@master
         with:
           yamllint_file_or_dir: 'docs/api'
+
+  redocly_preview_links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Redocly previews
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Redocly previews
+            - [Admin API](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/couchbase/sync_gateway/${{ github.event.pull_request.head.sha }}/docs/api/admin.yaml)
+            - [Public API](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/couchbase/sync_gateway/${{ github.event.pull_request.head.sha }}/docs/api/public.yaml)
+            - [Metric API](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/couchbase/sync_gateway/${{ github.event.pull_request.head.sha }}/docs/api/metric.yaml)
+            - [Diagnostic API](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/couchbase/sync_gateway/${{ github.event.pull_request.head.sha }}/docs/api/diagnostic.yaml)
+          edit-mode: replace

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.1.0
+  version: 3.2.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -141,7 +141,7 @@ ExpVars:
                 process_cpu_percent_utilization:
                   type: number
                   format: float
-                  description: "The CPU's utilization as percentage value * 10. The extra 10 multiplier is a mistake left for backwards compability. Please consider using node_cpu_percent_utilization as of version 3.2. The CPU usage calculation is performed based on user and system CPU time, but it does not include components such as iowait. The derivation means that the values of process_cpu_percent_utilization and %Cpu, returned when running the top command, will differ."
+                  description: "The CPU utilization as percentage value * 10. The extra 10 multiplier is a mistake left for backwards compatibility. Please consider using node_cpu_percent_utilization as of version 3.2. The CPU usage calculation is performed based on user and system CPU time, but it does not include components such as iowait. The derivation means that the values of process_cpu_percent_utilization and %Cpu, returned when running the top command, will differ."
                 node_cpu_percent_utilization:
                   type: number
                   format: float
@@ -478,7 +478,7 @@ Document:
       type: string
     _exp:
       description: |-
-        Expiry time after which the document will be purged. The expiration time is set and managed on the Couchbase Server document. The value can be specified in two ways; in ISO-8601 format, for example the 6th of July 2022 at 17:00 in the BST timezone would be `2016-07-06T17:00:00+01:00`; it can also be specified as a numeric Couchbase Server expiry value. Couchbase Server expiries are specified as Unix time, and if the desired TTL is below 30 days then it can also represent an interval in seconds from the current time (for example, a value of 5 will remove the document 5 seconds after it is written to Couchbase Server). The document expiration time is returned in the response of `GET /{db}/{doc} ` when `show_exp=true` is included in the query.
+        Expiry time after which the document will be purged. The expiration time is set and managed on the Couchbase Server document. The value can be specified in two ways; in ISO-8601 format, for example the 6th of July 2022 at 17:00 in the BST timezone would be `2016-07-06T17:00:00+01:00`; it can also be specified as a numeric Couchbase Server expiry value. Couchbase Server expiry values are specified as Unix time, and if the desired TTL is below 30 days then it can also represent an interval in seconds from the current time (for example, a value of 5 will remove the document 5 seconds after it is written to Couchbase Server). The document expiration time is returned in the response of `GET /{db}/{doc} ` when `show_exp=true` is included in the query.
 
         As with the existing explicit purge mechanism, this applies only to the local database; it has nothing to do with replication. This expiration time is not propagated when the document is replicated. The purge of the document does not cause it to be deleted on any other database.
       type: string
@@ -677,7 +677,7 @@ Retrieved-replication:
 
         **Behaviour**
         * *default* - In priority order, this will cause
-          - Deletes to always win (the delete with the logest revision history wins if both revisions are deletes)
+          - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
           - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
         * *localWins* - This will result in local revisions always being the winner in any conflict.
         * *remoteWins* - This will result in remote revisions always being the winner in any conflict.
@@ -905,7 +905,7 @@ Replication:
 
         **Behaviour**
         * *default* - In priority order, this will cause
-          - Deletes to always win (the delete with the logest revision history wins if both revisions are deletes)
+          - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
           - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
         * *localWins* - This will result in local revisions always being the winner in any conflict.
         * *remoteWins* - This will result in remote revisions always being the winner in any conflict.
@@ -1702,7 +1702,7 @@ Database:
       description: Force the use of views instead of GSI.
       type: boolean
       default: false
-    send_www_authentice_header:
+    send_www_authenticate_header:
       description: Controls whether to send a `WWW-Authenticate` header in `401 Unauthorized` HTTP responses.
       type: boolean
       default: true

--- a/docs/api/diagnostic.yaml
+++ b/docs/api/diagnostic.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.1.0
+  version: 3.2.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.1.0
+  version: 3.2.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.1.0
+  version: 3.2.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'


### PR DESCRIPTION
For PRs that change OpenAPI specs, a bot leaves a comment with links to preview the rendered versions of the OpenAPI docs.

- Fix some typos (to test the bot)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a