### PR TITLE
OpenAPI: Update redocly.yaml config to remove deprecated `lint` section.

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -16,13 +16,13 @@ apis:
   metric:
     root: "./docs/api/metric.yaml"
 
-lint:
-  extends:
-    - minimal
-  rules:
-    # disable unnecessary/invalid warnings
-    operation-2xx-response: off # _blipsync 101 Upgrade ...
-    operation-summary: off      # Optional field
-    no-ambiguous-paths: off     # /{db}/{doc} != /_debug/expvar
-    no-identical-paths: off     # /{db} != /{targetdb}
-    no-path-trailing-slash: off # Some endpoints require a trailing slash
+extends:
+  - minimal
+rules:
+  # disable unnecessary/invalid warnings
+  operation-2xx-response: off # _blipsync 101 Upgrade ...
+  operation-summary: off      # Optional field
+  no-ambiguous-paths: off     # /{db}/{doc} != /_debug/expvar
+  no-identical-paths: off     # /{db} != /{targetdb}
+  no-path-trailing-slash: off # Some endpoints require a trailing slash
+  security-defined: off       # TODO: Denote public and authenticated API endpoints with https://redocly.com/docs/cli/rules/security-defined

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,17 @@
+# Sync Gateway OpenAPI Specs
+
+This directory contains the OpenAPI specs for the Sync Gateway REST API.
+
+The recommended tool to work with these specs is [Redocly](https://redoc.ly/).
+
+## Preview
+
+```sh
+$ redocly preview-docs
+```
+
+## Linting
+
+```sh
+$ redocly lint
+```


### PR DESCRIPTION
# Fix deprecated `lint` config.

Fixes:

```
[1] .redocly.yaml:21:1 at #/lint

Property `lint` is not expected here.

Did you mean: env ?

19 |     root: "./docs/api/diagnostic.yaml"
20 |
21 | lint:
22 |   extends:
23 |     - minimal

Warning was generated by the configuration spec rule.


⚠️ Your config has 1 warning.
The 'lint' field is deprecated. Read more about this change: https://redocly.com/docs/api-registry/guides/migration-guide-config-file/#changed-properties
```

# Disable [`security-defined` linter](https://redocly.com/docs/cli/rules/security-defined/)

Until we document what endpoints are public, this avoids the following lint warnings on all endpoints:

```
[4] docs/api/paths/admin/db-_session-sessionid.yaml:11:1 at #/get

Every operation should have security defined on it or on the root level.

 9 |   - $ref: ../../components/parameters.yaml#/db
10 |   - $ref: ../../components/parameters.yaml#/sessionid
11 | get:
12 |   summary: Get session information
13 |   description: |-

Warning was generated by the security-defined rule.
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a