### PR TITLE
CBG-3641: Ignore read-only fields if values unchanged in User API

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1350,8 +1350,9 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 
 	// Check read only fields in request against existing read only fields on the user, if the request attempts to
 	// change them, return error.
+	internalName := internalUserName(*newInfo.Name)
 	var unchanged bool
-	user, _ := h.db.Authenticator(h.ctx()).GetUser(internalUserName(name))
+	user, _ := h.db.Authenticator(h.ctx()).GetUser(internalName)
 	if user != nil {
 		newInfo, unchanged = checkUserAPIReadOnlyFields(newInfo, user)
 		if !unchanged {
@@ -1359,7 +1360,6 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 		}
 	}
 
-	internalName := internalUserName(*newInfo.Name)
 	if err = auth.ValidatePrincipalName(internalName); err != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 	}


### PR DESCRIPTION
CBG-3641

- Added helper method checkUserAPIReadOnlyFields to check read only fields, if they exist in the request ensure they are unchanged. If they are unchanged then nil the value on the request so UpdatePrinciple ignores it. If change detected then error. 
- Add test perfoming a GET on a user that will have read only fields populated, the using that request response in a PUT on the user, ensuring there is no error

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2302/
