### PR TITLE
CBG-3761: [3.1.4 Backport] Ignore read-only fields if values unchanged in User API

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1349,12 +1349,18 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 		}
 	}
 
-	// NB: other read-only properties are ignored but no error is returned for backwards-compatibility
-	if newInfo.JWTIssuer != nil || len(newInfo.JWTRoles) > 0 || len(newInfo.JWTChannels) > 0 {
-		return base.HTTPErrorf(http.StatusBadRequest, "Can't change read-only properties")
+	// Check read only fields in request against existing read only fields on the user, if the request attempts to
+	// change them, return error.
+	internalName := internalUserName(*newInfo.Name)
+	var unchanged bool
+	user, _ := h.db.Authenticator(h.ctx()).GetUser(internalName)
+	if user != nil {
+		newInfo, unchanged = checkUserAPIReadOnlyFields(newInfo, user)
+		if !unchanged {
+			return base.HTTPErrorf(http.StatusBadRequest, "Can't change read-only properties")
+		}
 	}
 
-	internalName := internalUserName(*newInfo.Name)
 	if err = auth.ValidatePrincipalName(internalName); err != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 	}
@@ -1755,4 +1761,30 @@ func (h *handler) handleGetClusterInfo() error {
 	}
 	h.writeJSON(clusterInfo)
 	return nil
+}
+
+// checkUserAPIReadOnlyFields will return true if read only user fields are unchanged, else false. If a read only field
+// is unchanged it will nil the field so the update to principle ignores it.
+func checkUserAPIReadOnlyFields(newInfo auth.PrincipalConfig, user auth.User) (auth.PrincipalConfig, bool) {
+	if newInfo.JWTIssuer != nil {
+		if *newInfo.JWTIssuer != user.JWTIssuer() {
+			return newInfo, false
+		}
+		newInfo.JWTIssuer = nil
+	}
+	if len(newInfo.JWTRoles) > 0 {
+		userJWTRoles := user.JWTRoles().AsSet()
+		if !newInfo.JWTRoles.Equals(userJWTRoles) {
+			return newInfo, false
+		}
+		newInfo.JWTRoles = nil
+	}
+	if len(newInfo.JWTChannels) > 0 {
+		userJWTChan := user.JWTChannels().AsSet()
+		if !newInfo.JWTChannels.Equals(userJWTChan) {
+			return newInfo, false
+		}
+		newInfo.JWTChannels = nil
+	}
+	return newInfo, true
 }


### PR DESCRIPTION
CBG-3761

Backport of CBG-3641: Ignore read-only fields if values unchanged in User API

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
