### PR TITLE
CBG-3788 Support HLV operations in BlipTesterClient

### DIFF
--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -614,7 +614,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, rev string,
 		docRev, err = handleChangesResponseCollection.GetRev(bsc.loggingCtx, docID, rev, true, nil)
 	} else {
 		// extract CV string rev representation
-		version, vrsErr := CreateVersionFromString(rev)
+		version, vrsErr := ParseVersion(rev)
 		if vrsErr != nil {
 			return vrsErr
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -2249,7 +2249,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(ctx),
-			hlvHistory:       doc.HLV.toHistoryForHLV(),
+			hlvHistory:       doc.HLV.ToHistoryForHLV(),
 			CV:               &Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version},
 		}
 

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -332,7 +332,7 @@ func TestHLVMapToCBLString(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			hlv := createHLVForTest(t, test.inputHLV)
-			historyStr := hlv.toHistoryForHLV()
+			historyStr := hlv.ToHistoryForHLV()
 
 			if test.both {
 				initial := strings.Split(historyStr, ";")

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -52,7 +52,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.toHistoryForHLV()
+		docRev.hlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)
@@ -80,7 +80,7 @@ func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.toHistoryForHLV()
+		docRev.hlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)
@@ -111,7 +111,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, incl
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.toHistoryForHLV()
+		docRev.hlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -544,7 +544,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
 			value.revID = revid
 			if hlv != nil {
-				value.hlvHistory = hlv.toHistoryForHLV()
+				value.hlvHistory = hlv.ToHistoryForHLV()
 			}
 		} else {
 			revKey := IDAndRev{DocID: value.id, RevID: value.revID}
@@ -552,7 +552,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 			// based off the revision load we need to populate the hlv key with what has been fetched from the bucket (for use of populating the opposite lookup map)
 			if hlv != nil {
 				value.cv = *hlv.ExtractCurrentVersionFromHLV()
-				value.hlvHistory = hlv.toHistoryForHLV()
+				value.hlvHistory = hlv.ToHistoryForHLV()
 			}
 		}
 	}
@@ -655,12 +655,12 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 		if value.revID == "" {
 			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, hlv, value.err = revCacheLoaderForDocumentCV(ctx, backingStore, doc, value.cv)
 			value.revID = revid
-			value.hlvHistory = hlv.toHistoryForHLV()
+			value.hlvHistory = hlv.ToHistoryForHLV()
 		} else {
 			value.bodyBytes, value.body, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, hlv, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.revID)
 			if hlv != nil {
 				value.cv = *hlv.ExtractCurrentVersionFromHLV()
-				value.hlvHistory = hlv.toHistoryForHLV()
+				value.hlvHistory = hlv.ToHistoryForHLV()
 			}
 		}
 	}

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -414,11 +414,11 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// User has no permissions to access rev
-			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc?rev="+version.RevID, "", nil, "NoPerms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc?rev="+version.RevTreeID, "", nil, "NoPerms", "password")
 			assertRespStatus(resp, http.StatusOK)
 
 			// Guest has no permissions to access rev
-			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc?rev="+version.RevID, "", nil, "", "")
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc?rev="+version.RevTreeID, "", nil, "", "")
 			assertRespStatus(resp, http.StatusOK)
 
 			// Attachments should be forbidden as well
@@ -426,7 +426,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// Attachment revs should be forbidden as well
-			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc/attach?rev="+version.RevID, "", nil, "NoPerms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc/attach?rev="+version.RevTreeID, "", nil, "NoPerms", "password")
 			assertRespStatus(resp, http.StatusNotFound)
 
 			// Attachments should be forbidden for guests as well
@@ -434,7 +434,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// Attachment revs should be forbidden for guests as well
-			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc/attach?rev="+version.RevID, "", nil, "", "")
+			resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/doc/attach?rev="+version.RevTreeID, "", nil, "", "")
 			assertRespStatus(resp, http.StatusNotFound)
 
 			// Document does not exist should cause 403
@@ -451,7 +451,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusConflict)
 
 			// PUT with rev
-			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevID, `{}`, nil, "NoPerms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevTreeID, `{}`, nil, "NoPerms", "password")
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// PUT with incorrect rev
@@ -463,7 +463,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusConflict)
 
 			// PUT with rev as Guest
-			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevID, `{}`, nil, "", "")
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevTreeID, `{}`, nil, "", "")
 			assertRespStatus(resp, http.StatusForbidden)
 
 			// PUT with incorrect rev as Guest
@@ -495,7 +495,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assert.NotContains(t, user.GetChannels(s, c).ToArray(), "chan2")
 
 			// Successful PUT which will grant access grants
-			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevID, `{"channels": "chan"}`, nil, "Perms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev="+version.RevTreeID, `{"channels": "chan"}`, nil, "Perms", "password")
 			AssertStatus(t, resp, http.StatusCreated)
 
 			// Make sure channel access grant was successful
@@ -512,7 +512,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusConflict)
 
 			// Attempt to delete document rev with no permissions
-			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/{{.keyspace}}/doc?rev="+version.RevID, "", nil, "NoPerms", "password")
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/{{.keyspace}}/doc?rev="+version.RevTreeID, "", nil, "NoPerms", "password")
 			assertRespStatus(resp, http.StatusConflict)
 
 			// Attempt to delete document with wrong rev
@@ -528,7 +528,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			assertRespStatus(resp, http.StatusConflict)
 
 			// Attempt to delete document rev with no write perms as guest
-			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/{{.keyspace}}/doc?rev="+version.RevID, "", nil, "", "")
+			resp = rt.SendUserRequestWithHeaders(http.MethodDelete, "/{{.keyspace}}/doc?rev="+version.RevTreeID, "", nil, "", "")
 			assertRespStatus(resp, http.StatusConflict)
 
 			// Attempt to delete document with wrong rev as guest
@@ -1184,7 +1184,7 @@ func TestRoleChannelGrantInheritance(t *testing.T) {
 	RequireStatus(t, response, 200)
 
 	// Revoke access to chan2 (dynamic)
-	response = rt.SendUserRequest("PUT", "/{{.keyspace}}/grant1?rev="+grant1Version.RevID, `{"type":"setaccess", "owner":"none", "channel":"chan2"}`, "user1")
+	response = rt.SendUserRequest("PUT", "/{{.keyspace}}/grant1?rev="+grant1Version.RevTreeID, `{"type":"setaccess", "owner":"none", "channel":"chan2"}`, "user1")
 	RequireStatus(t, response, 201)
 
 	// Verify user cannot access doc in revoked channel, but can successfully access remaining documents

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2093,7 +2093,7 @@ func TestRawTombstone(t *testing.T) {
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	assert.NotContains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
-	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+version.RevID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+version.RevTreeID+`"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"_deleted":true`)
 
@@ -2103,7 +2103,7 @@ func TestRawTombstone(t *testing.T) {
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
 	assert.NotContains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
-	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+deletedVersion.RevID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+deletedVersion.RevTreeID+`"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"_deleted":true`)
 }
@@ -3830,9 +3830,9 @@ func TestPutIDRevMatchBody(t *testing.T) {
 			docRev := test.rev
 			docBody := test.docBody
 			if test.docID == "" {
-				docID = "doc"                                                 // Used for the rev tests to branch off of
-				docBody = strings.ReplaceAll(docBody, "[REV]", version.RevID) // FIX for HLV?
-				docRev = strings.ReplaceAll(docRev, "[REV]", version.RevID)
+				docID = "doc"                                                     // Used for the rev tests to branch off of
+				docBody = strings.ReplaceAll(docBody, "[REV]", version.RevTreeID) // FIX for HLV?
+				docRev = strings.ReplaceAll(docRev, "[REV]", version.RevTreeID)
 			}
 
 			resp := rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, docRev), docBody)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -211,9 +211,9 @@ func TestDocLifecycle(t *testing.T) {
 	defer rt.Close()
 
 	version := rt.CreateTestDoc("doc")
-	assert.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", version.RevID)
+	assert.Equal(t, "1-45ca73d819d5b1c9b8eea95290e79004", version.RevTreeID)
 
-	response := rt.SendAdminRequest("DELETE", "/{{.keyspace}}/doc?rev="+version.RevID, "")
+	response := rt.SendAdminRequest("DELETE", "/{{.keyspace}}/doc?rev="+version.RevTreeID, "")
 	RequireStatus(t, response, 200)
 }
 

--- a/rest/api_test_helpers.go
+++ b/rest/api_test_helpers.go
@@ -50,13 +50,13 @@ func (rt *RestTester) PutNewEditsFalse(docID string, newVersion DocVersion, pare
 	require.NoError(rt.TB, marshalErr)
 
 	requestBody := body.ShallowCopy()
-	newRevGeneration, newRevDigest := db.ParseRevID(base.TestCtx(rt.TB), newVersion.RevID)
+	newRevGeneration, newRevDigest := db.ParseRevID(base.TestCtx(rt.TB), newVersion.RevTreeID)
 
 	revisions := make(map[string]interface{})
 	revisions["start"] = newRevGeneration
 	ids := []string{newRevDigest}
-	if parentVersion.RevID != "" {
-		_, parentDigest := db.ParseRevID(base.TestCtx(rt.TB), parentVersion.RevID)
+	if parentVersion.RevTreeID != "" {
+		_, parentDigest := db.ParseRevID(base.TestCtx(rt.TB), parentVersion.RevTreeID)
 		ids = append(ids, parentDigest)
 	}
 	revisions["ids"] = ids

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -297,6 +297,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -374,6 +375,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -539,6 +541,7 @@ func TestBlipAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -588,6 +591,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -610,7 +614,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 		docVersion, _ := client1.rt.GetDoc(docID)
 
 		// Store the document and attachment on the test client
-		err := btcRunner.StoreRevOnClient(client1.id, docID, docVersion.RevID, rawDoc)
+		err := btcRunner.StoreRevOnClient(client1.id, docID, docVersion.RevTreeID, rawDoc)
 
 		require.NoError(t, err)
 		btcRunner.AttachmentsLock(client1.id).Lock()
@@ -645,6 +649,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -667,7 +672,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 		version, _ := client1.rt.GetDoc(docID)
 
 		// Store the document and attachment on the test client
-		err := btcRunner.StoreRevOnClient(client1.id, docID, version.RevID, rawDoc)
+		err := btcRunner.StoreRevOnClient(client1.id, docID, version.RevTreeID, rawDoc)
 		require.NoError(t, err)
 		btcRunner.AttachmentsLock(client1.id).Lock()
 		btcRunner.Attachments(client1.id)[digest] = attBody

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -651,21 +651,21 @@ func TestProposedChangesIncludeConflictingRev(t *testing.T) {
 	// Write existing docs to server directly (not via blip)
 	rt := bt.restTester
 	resp := rt.PutDoc("conflictingInsert", `{"version":1}`)
-	conflictingInsertRev := resp.RevID
+	conflictingInsertRev := resp.RevTreeID
 
 	resp = rt.PutDoc("matchingInsert", `{"version":1}`)
-	matchingInsertRev := resp.RevID
+	matchingInsertRev := resp.RevTreeID
 
 	resp = rt.PutDoc("conflictingUpdate", `{"version":1}`)
-	conflictingUpdateRev1 := resp.RevID
-	conflictingUpdateRev2 := rt.UpdateDocRev("conflictingUpdate", resp.RevID, `{"version":2}`)
+	conflictingUpdateRev1 := resp.RevTreeID
+	conflictingUpdateRev2 := rt.UpdateDocRev("conflictingUpdate", resp.RevTreeID, `{"version":2}`)
 
 	resp = rt.PutDoc("matchingUpdate", `{"version":1}`)
-	matchingUpdateRev1 := resp.RevID
-	matchingUpdateRev2 := rt.UpdateDocRev("matchingUpdate", resp.RevID, `{"version":2}`)
+	matchingUpdateRev1 := resp.RevTreeID
+	matchingUpdateRev2 := rt.UpdateDocRev("matchingUpdate", resp.RevTreeID, `{"version":2}`)
 
 	resp = rt.PutDoc("newUpdate", `{"version":1}`)
-	newUpdateRev1 := resp.RevID
+	newUpdateRev1 := resp.RevTreeID
 
 	type proposeChangesCase struct {
 		key           string
@@ -1909,7 +1909,7 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 
 		// create doc version of the above doc write
 		version1 := DocVersion{
-			RevID: bucketDoc.CurrentRev,
+			RevTreeID: bucketDoc.CurrentRev,
 			CV: db.Version{
 				SourceID: hlvHelper.Source,
 				Value:    string(base.Uint64CASToLittleEndianHex(cas)),
@@ -2445,6 +2445,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		// Setup

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -42,6 +42,8 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	const docID = "pushAttachmentDoc"
 
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
@@ -382,7 +384,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		defer client.Close()
 
 		// reject deltas built ontop of rev 1
-		client.rejectDeltasForSrcRev = docVersion1.RevID
+		client.rejectDeltasForSrcRev = docVersion1.RevTreeID
 
 		client.ClientDeltas = true
 		err := btcRunner.StartPull(client.id)
@@ -402,7 +404,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		assert.True(t, ok)
 
 		// Check the request was initially sent with the correct deltaSrc property
-		assert.Equal(t, docVersion1.RevID, msg.Properties[db.RevMessageDeltaSrc])
+		assert.Equal(t, docVersion1.RevTreeID, msg.Properties[db.RevMessageDeltaSrc])
 		// Check the request body was the actual delta
 		msgBody, err := msg.Body()
 		assert.NoError(t, err)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -142,12 +142,9 @@ func (doc *BlipTesterDoc) addRevision(revID string, body []byte, message *blip.M
 	doc.body = body
 	if doc.revMode == revModeHLV {
 		_ = doc.HLV.AddVersion(VersionFromRevID(revID))
-		doc.body = body
 	} else {
 		// prepend revID to revHistory
-		doc.revHistory = append(doc.revHistory, "")
-		copy(doc.revHistory[1:], doc.revHistory)
-		doc.revHistory[0] = revID
+		doc.revHistory = append([]string{revID}, doc.revHistory...)
 	}
 }
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -142,7 +142,7 @@ func (h *handler) handleAllDocs() error {
 					row.Status = http.StatusForbidden
 					return row
 				}
-				// handle the case where the incoming doc.RevID == ""
+				// handle the case where the incoming doc.RevTreeID == ""
 				// and Get1xRevAndChannels returns the current revision
 				doc.RevID = currentRevID
 			}

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -238,7 +238,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 
 	// push winning branch
 	wg.Add(2)
-	res := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+version1.RevID+`"]}}`)
+	res := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+version1.RevTreeID+`"]}}`)
 	RequireStatus(t, res, http.StatusCreated)
 	winningVersion := DocVersionFromPutResponse(t, res)
 
@@ -261,7 +261,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 
 	// push a separate winning branch
 	wg.Add(2)
-	res = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", `{"foo":"quux","_revisions":{"start":4,"ids":["quux", "buzz","bar","`+version1.RevID+`"]}}`)
+	res = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?new_edits=false", `{"foo":"quux","_revisions":{"start":4,"ids":["quux", "buzz","bar","`+version1.RevTreeID+`"]}}`)
 	RequireStatus(t, res, http.StatusCreated)
 	newWinningVersion := DocVersionFromPutResponse(t, res)
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -807,10 +807,10 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(4)
 
 	// Mark the first four PBS docs as removals
-	_ = rt.PutDoc("pbs-1", fmt.Sprintf(`{"_rev":%q}`, pbs1.RevID))
-	_ = rt.PutDoc("pbs-2", fmt.Sprintf(`{"_rev":%q}`, pbs2.RevID))
-	_ = rt.PutDoc("pbs-3", fmt.Sprintf(`{"_rev":%q}`, pbs3.RevID))
-	_ = rt.PutDoc("pbs-4", fmt.Sprintf(`{"_rev":%q}`, pbs4.RevID))
+	_ = rt.PutDoc("pbs-1", fmt.Sprintf(`{"_rev":%q}`, pbs1.RevTreeID))
+	_ = rt.PutDoc("pbs-2", fmt.Sprintf(`{"_rev":%q}`, pbs2.RevTreeID))
+	_ = rt.PutDoc("pbs-3", fmt.Sprintf(`{"_rev":%q}`, pbs3.RevTreeID))
+	_ = rt.PutDoc("pbs-4", fmt.Sprintf(`{"_rev":%q}`, pbs4.RevTreeID))
 
 	cacheWaiter.AddAndWait(4)
 
@@ -886,7 +886,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	cacheWaiter.AddAndWait(4)
 
 	// remove channels/tombstone a couple of docs to ensure they're not backfilled after a dynamic grant
-	_ = rt.PutDoc("hbo-2", fmt.Sprintf(`{"_rev":%q}`, hbo2.RevID))
+	_ = rt.PutDoc("hbo-2", fmt.Sprintf(`{"_rev":%q}`, hbo2.RevTreeID))
 	rt.DeleteDoc(pbs2ID, pbs2Version)
 	cacheWaiter.AddAndWait(2)
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -141,7 +141,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 	// 1. Create revision with history
 	docID := t.Name()
 	version := rt.PutDoc(docID, `{"val":-1}`)
-	revID := version.RevID
+	revID := version.RevTreeID
 	collection := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	ctx := rt.Context()
@@ -150,7 +150,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 		// Purge old revision JSON to simulate expiry, and to verify import doesn't attempt multiple retrievals
 		purgeErr := collection.PurgeOldRevisionJSON(ctx, docID, revID)
 		require.NoError(t, purgeErr)
-		revID = version.RevID
+		revID = version.RevTreeID
 	}
 
 	// 2. Modify doc via SDK

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -71,7 +71,7 @@ func addActiveRT(t *testing.T, dbName string, testBucket *base.TestBucket) (acti
 
 // requireDocumentVersion asserts that the given ChangeRev has the expected version for a given entry returned by _changes feed
 func requireDocumentVersion(t testing.TB, expected rest.DocVersion, doc *db.Document) {
-	rest.RequireDocVersionEqual(t, expected, rest.DocVersion{RevID: doc.SyncData.CurrentRev})
+	rest.RequireDocVersionEqual(t, expected, rest.DocVersion{RevTreeID: doc.SyncData.CurrentRev})
 }
 
 // requireRevID asserts that the specified document version is written to the

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1014,10 +1014,10 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 2)
 	assert.Equal(t, doc1ID, changes.Results[0].ID)
-	assert.Equal(t, doc1Version.RevID, changes.Results[0].Changes[0]["rev"])
+	assert.Equal(t, doc1Version.RevTreeID, changes.Results[0].Changes[0]["rev"])
 	assert.True(t, changes.Results[0].Revoked)
 	assert.Equal(t, doc2ID, changes.Results[1].ID)
-	assert.Equal(t, doc2Version.RevID, changes.Results[1].Changes[0]["rev"])
+	assert.Equal(t, doc2Version.RevTreeID, changes.Results[1].Changes[0]["rev"])
 	assert.True(t, changes.Results[1].Revoked)
 
 	changes = revocationTester.getChanges("20:40", 1)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -754,7 +754,7 @@ func (cr ChangesResults) RequireDocIDs(t testing.TB, docIDs []string) {
 
 // RequireChangeRevVersion asserts that the given ChangeRev has the expected version for a given entry returned by _changes feed
 func RequireChangeRevVersion(t *testing.T, expected DocVersion, changeRev db.ChangeRev) {
-	RequireDocVersionEqual(t, expected, DocVersion{RevID: changeRev["rev"]})
+	RequireDocVersionEqual(t, expected, DocVersion{RevTreeID: changeRev["rev"]})
 }
 
 func (rt *RestTester) CreateWaitForChangesRetryWorker(numChangesExpected int, changesURL, username string, useAdminPort bool) (worker base.RetryWorker) {
@@ -2333,16 +2333,16 @@ func WaitAndAssertBackgroundManagerExpiredHeartbeat(t testing.TB, bm *db.Backgro
 
 // DocVersion represents a specific version of a document in an revID/HLV agnostic manner.
 type DocVersion struct {
-	RevID string
-	CV    db.Version
+	RevTreeID string
+	CV        db.Version
 }
 
 func (v *DocVersion) String() string {
-	return fmt.Sprintf("RevID: %s", v.RevID)
+	return fmt.Sprintf("RevTreeID: %s", v.RevTreeID)
 }
 
 func (v DocVersion) Equal(o DocVersion) bool {
-	if v.RevID != o.RevID {
+	if v.RevTreeID != o.RevTreeID {
 		return false
 	}
 	return true
@@ -2350,12 +2350,12 @@ func (v DocVersion) Equal(o DocVersion) bool {
 
 // Digest returns the digest for the current version
 func (v DocVersion) Digest() string {
-	return strings.Split(v.RevID, "-")[1]
+	return strings.Split(v.RevTreeID, "-")[1]
 }
 
 // RequireDocVersionNotNil calls t.Fail if two document version is not specified.
 func RequireDocVersionNotNil(t *testing.T, version DocVersion) {
-	require.NotEqual(t, "", version.RevID)
+	require.NotEqual(t, "", version.RevTreeID)
 }
 
 // RequireDocVersionEqual calls t.Fail if two document versions are not equal.
@@ -2370,12 +2370,12 @@ func RequireDocVersionNotEqual(t *testing.T, expected, actual DocVersion) {
 
 // EmptyDocVersion reprents an empty document version.
 func EmptyDocVersion() DocVersion {
-	return DocVersion{RevID: ""}
+	return DocVersion{RevTreeID: ""}
 }
 
 // NewDocVersionFromFakeRev returns a new DocVersion from the given fake rev ID, intended for use when we explicit create conflicts.
 func NewDocVersionFromFakeRev(fakeRev string) DocVersion {
-	return DocVersion{RevID: fakeRev}
+	return DocVersion{RevTreeID: fakeRev}
 }
 
 // DocVersionFromPutResponse returns a DocRevisionID from the given response to PUT /{, or fails the given test if a rev ID was not found.
@@ -2387,7 +2387,7 @@ func DocVersionFromPutResponse(t testing.TB, response *TestResponse) DocVersion 
 	require.NoError(t, json.Unmarshal(response.BodyBytes(), &r))
 	require.NotNil(t, r.RevID, "expecting non-nil rev ID from response: %s", string(response.BodyBytes()))
 	require.NotEqual(t, "", *r.RevID, "expecting non-empty rev ID from response: %s", string(response.BodyBytes()))
-	return DocVersion{RevID: *r.RevID}
+	return DocVersion{RevTreeID: *r.RevID}
 }
 
 func MarshalConfig(t *testing.T, config db.ReplicationConfig) string {


### PR DESCRIPTION
CBG-3788

Switches the BlipTesterCollectionClient to maintain client HLV and (linear) revtree per document.  Switches the docs struct to a map of a new BlipTesterDoc struct, instead of a map of revs per document.

BlipTesterDoc still maintains a history of all rev messages received (revMessageHistory) to support test evaluation of received messages, but also defines a linear revTreeId history or an HLV (depending on protocol enabled for the test).

Includes a refactor of revID to revTreeID in RevAndVersion, as a step toward standardizing ‘revID’ as the generic property used during replication (which can be currentRev or cv), and revTreeID as a traditional revtree revision ID.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2304/
