### PR TITLE
CBG-3610: Fix regression on `PUT /_user/...` endpoint when sending `null` `admin_channels` / `admin_roles`

### DIFF
--- a/db/users.go
+++ b/db/users.go
@@ -113,7 +113,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		if updatedExplicitChannels == nil {
 			updatedExplicitChannels = ch.TimedSet{}
 		}
-		if updates.ExplicitChannels != nil && !updatedExplicitChannels.Equals(updates.ExplicitChannels) {
+		if !updatedExplicitChannels.Equals(updates.ExplicitChannels) {
 			changed = true
 		}
 		collectionAccessChanged, err := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
@@ -149,7 +149,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			if updatedExplicitRoles == nil {
 				updatedExplicitRoles = ch.TimedSet{}
 			}
-			if updates.ExplicitRoleNames != nil && !updatedExplicitRoles.Equals(updates.ExplicitRoleNames) {
+			if !updatedExplicitRoles.Equals(updates.ExplicitRoleNames) {
 				changed = true
 			}
 
@@ -190,7 +190,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		princ.SetSequence(nextSeq)
 
 		// Now update the Principal object from the properties in the request, first the channels:
-		if updates.ExplicitChannels != nil && updatedExplicitChannels.UpdateAtSequence(updates.ExplicitChannels, nextSeq) {
+		if updatedExplicitChannels.UpdateAtSequence(updates.ExplicitChannels, nextSeq) {
 			princ.SetExplicitChannels(updatedExplicitChannels, nextSeq)
 		}
 
@@ -199,7 +199,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		}
 
 		if isUser {
-			if updates.ExplicitRoleNames != nil && updatedExplicitRoles.UpdateAtSequence(updates.ExplicitRoleNames, nextSeq) {
+			if updatedExplicitRoles.UpdateAtSequence(updates.ExplicitRoleNames, nextSeq) {
 				user.SetExplicitRoles(updatedExplicitRoles, nextSeq)
 			}
 			var hasJWTUpdates bool

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -534,7 +534,9 @@ func TestSessionPasswordInvalidation(t *testing.T) {
 			RequireStatus(t, response, http.StatusOK)
 
 			altPassword := "someotherpassword"
-			response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, fmt.Sprintf(`{"password": "%s"}`, altPassword))
+			// TODO CBG-3790: Add POST (upsert) support on User API, and specify only password here.
+			// This test was relying on a bug (CBG-3610) which allowed only the password to be specified without wiping channels.
+			response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(t, username, altPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"*"}, nil))
 			RequireStatus(t, response, http.StatusOK)
 
 			// make sure session is invalid


### PR DESCRIPTION
CBG-3610

- Test to repro issue (default collection passing on 3.0.x, failing on 3.1.x without this fix)
- Fix regression on `PUT /_user/...` endpoint when setting `null` `admin_channels` / `admin_roles`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2310/
- [ ] `default collection,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2311/
