### PR TITLE
Add MustJSONMarshal helper function

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -152,8 +152,8 @@ func TestSerializeUser(t *testing.T) {
 	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 	user, _ := auth.NewUser("me", "letmein", ch.BaseSetOf(t, "me", "public"))
 	require.NoError(t, user.SetEmail("foo@example.com"))
-	encoded, _ := base.JSONMarshal(user)
-	assert.True(t, encoded != nil)
+	encoded := base.MustJSONMarshal(t, user)
+	require.NotNil(t, encoded)
 	log.Printf("Marshaled User as: %s", encoded)
 
 	resu := &userImpl{auth: auth}
@@ -174,8 +174,8 @@ func TestSerializeRole(t *testing.T) {
 	dataStore := bucket.GetSingleDataStore()
 	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 	role, _ := auth.NewRole("froods", ch.BaseSetOf(t, "hoopy", "public"))
-	encoded, _ := base.JSONMarshal(role)
-	assert.True(t, encoded != nil)
+	encoded := base.MustJSONMarshal(t, role)
+	require.NotNil(t, encoded)
 	log.Printf("Marshaled Role as: %s", encoded)
 	elor := &roleImpl{}
 	err := base.JSONUnmarshal(encoded, elor)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -908,3 +908,10 @@ func FastRandBytes(t testing.TB, size int) []byte {
 	require.NoError(t, err)
 	return b
 }
+
+// MustJSONMarshal marshals the given value to JSON, and errors the test if it can not be turned into json.
+func MustJSONMarshal(t testing.TB, v interface{}) []byte {
+	b, err := JSONMarshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/channels/sync_runner_test.go
+++ b/channels/sync_runner_test.go
@@ -25,11 +25,11 @@ func TestRequireUser(t *testing.T) {
 	runner, err := NewSyncRunner(ctx, funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_names": "alpha"}`), emptyMetaMap(), parse(`{"name": "alpha"}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_names": "alpha"}`), emptyMetaMap(), parse(t, `{"name": "alpha"}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_names": ["beta", "gamma"]}`), emptyMetaMap(), parse(`{"name": "beta"}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_names": ["beta", "gamma"]}`), emptyMetaMap(), parse(t, `{"name": "beta"}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_names": ["delta"]}`), emptyMetaMap(), parse(`{"name": "beta"}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_names": ["delta"]}`), emptyMetaMap(), parse(t, `{"name": "beta"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorWrongUser))
 }
 
@@ -39,11 +39,11 @@ func TestRequireRole(t *testing.T) {
 	runner, err := NewSyncRunner(ctx, funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_roles": ["alpha"]}`), emptyMetaMap(), parse(`{"name": "", "roles": {"alpha":""}}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_roles": ["alpha"]}`), emptyMetaMap(), parse(t, `{"name": "", "roles": {"alpha":""}}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_roles": ["beta", "gamma"]}`), emptyMetaMap(), parse(`{"name": "", "roles": {"beta": ""}}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_roles": ["beta", "gamma"]}`), emptyMetaMap(), parse(t, `{"name": "", "roles": {"beta": ""}}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_roles": ["delta"]}`), emptyMetaMap(), parse(`{"name": "", "roles": {"beta":""}}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_roles": ["delta"]}`), emptyMetaMap(), parse(t, `{"name": "", "roles": {"beta":""}}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorMissingRole))
 }
 
@@ -53,11 +53,11 @@ func TestRequireAccess(t *testing.T) {
 	runner, err := NewSyncRunner(ctx, funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_access": ["alpha"]}`), emptyMetaMap(), parse(`{"name": "", "channels": ["alpha"]}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_access": ["alpha"]}`), emptyMetaMap(), parse(t, `{"name": "", "channels": ["alpha"]}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_access": ["beta", "gamma"]}`), emptyMetaMap(), parse(`{"name": "", "channels": ["beta"]}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_access": ["beta", "gamma"]}`), emptyMetaMap(), parse(t, `{"name": "", "channels": ["beta"]}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{"_access": ["delta"]}`), emptyMetaMap(), parse(`{"name": "", "channels": ["beta"]}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{"_access": ["delta"]}`), emptyMetaMap(), parse(t, `{"name": "", "channels": ["beta"]}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorMissingChannelAccess))
 }
 
@@ -67,13 +67,13 @@ func TestRequireAdmin(t *testing.T) {
 	runner, err := NewSyncRunner(ctx, funcSource, 0)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{}`), emptyMetaMap(), parse(t, `{}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{"name": ""}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{}`), emptyMetaMap(), parse(t, `{"name": ""}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{"name": "GUEST"}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{}`), emptyMetaMap(), parse(t, `{"name": "GUEST"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
-	result, _ = runner.Call(ctx, parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{"name": "beta"}`))
+	result, _ = runner.Call(ctx, parse(t, `{}`), parse(t, `{}`), emptyMetaMap(), parse(t, `{"name": "beta"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
 }
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -124,7 +124,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	//  |
 	// 2-a
 	log.Printf("Create rev 2-a with a large body")
-	rev2a_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
+	rev2a_body := unmarshalBody(t, `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
 	doc, newRev, err := collection.PutExistingRevWithBody(ctx, "doc1", rev2a_body, []string{"2-a", "1-a"}, false)
@@ -150,7 +150,7 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	//   /  \
 	// 2-a  2-b
 	log.Printf("Create rev 2-b with a large body")
-	rev2b_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
+	rev2b_body := unmarshalBody(t, `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
 	doc, newRev, err = collection.PutExistingRevWithBody(ctx, "doc1", rev2b_body, []string{"2-b", "1-a"}, false)
@@ -276,7 +276,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	//   /  \
 	// 2-a  2-b
 	log.Printf("Create rev 2-b with a large body")
-	// rev2b_body := unjson(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
+	// rev2b_body := unmarshalBody(`{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
@@ -1197,18 +1197,18 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	_, rev, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"1-a"}, false)
+	_, rev, err := collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 	ancestor := rev // Ancestor revision
 
 	// Create the second revision of the document with attachment reference;
 	payload = `{"sku":"6213101","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	_, rev, err = collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"2-a", "1-a"}, false)
+	_, rev, err = collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"2-a", "1-a"}, false)
 	parent := rev // Immediate ancestor or parent revision
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213102","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
-	doc, _, err := collection.PutExistingRevWithBody(ctx, "camera", unjson(payload), []string{"3-a", "2-a"}, false)
+	doc, _, err := collection.PutExistingRevWithBody(ctx, "camera", unmarshalBody(t, payload), []string{"3-a", "2-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get available attachments by immediate ancestor revision or parent revision
@@ -1235,11 +1235,11 @@ func TestGet1xRevAndChannels(t *testing.T) {
 
 	docId := "dd6d2dcc679d12b9430a9787bab45b33"
 	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc1, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false)
+	doc1, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
 	payload = `{"sku":"6213101","_attachments":{"lens.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
-	doc2, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	doc2, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"2-a", "1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Get the 1x revision from document with list revision enabled
@@ -1298,7 +1298,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	// Create the first revision of the document
 	docId := "356779a9a1696714480f57fa3fb66d4c"
 	payload := `{"city":"Los Angeles"}`
-	doc, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"1-a"}, false)
+	doc, rev1, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "1-a", rev1, "Provided input revision ID should be returned")
@@ -1321,7 +1321,7 @@ func TestGet1xRevFromDoc(t *testing.T) {
 
 	// Create the second revision of the document
 	payload = `{"city":"Hollywood"}`
-	doc, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	doc, rev2, err := collection.PutExistingRevWithBody(ctx, docId, unmarshalBody(t, payload), []string{"2-a", "1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "2-a", rev2, "Provided input revision ID should be returned")

--- a/db/event_handler_test.go
+++ b/db/event_handler_test.go
@@ -50,7 +50,7 @@ func TestCallValidateFunction(t *testing.T) {
 	// filter function which returns a bool value while calling CallValidateFunction.
 	channels := base.SetFromArray([]string{"Netflix"})
 	docId, body, oldBodyJSON := "doc1", Body{BodyId: "doc1", "key1": "value1"}, ""
-	bodyBytes, _ := base.JSONMarshal(body)
+	bodyBytes := base.MustJSONMarshal(t, body)
 	event := &DocumentChangeEvent{DocID: docId, DocBytes: bodyBytes, OldDoc: oldBodyJSON, Channels: channels}
 
 	ctx := base.TestCtx(t)

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const DefaultWaitForWebhook = time.Second * 5
@@ -113,7 +114,7 @@ func TestDocumentChangeEvent(t *testing.T) {
 	// Raise events
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -199,7 +200,7 @@ func TestSlowExecutionProcessing(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		body, docid, channels := eventForTest(i % 10)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -243,7 +244,7 @@ func TestCustomHandler(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -289,7 +290,7 @@ func TestUnhandledEvent(t *testing.T) {
 	// send DocumentChange events to handler
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -472,7 +473,7 @@ func TestWebhookBasic(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -496,7 +497,7 @@ func TestWebhookBasic(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -513,7 +514,8 @@ func TestWebhookBasic(t *testing.T) {
 	webhookHandler, _ = NewWebhook(ctx, fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	body, docId, channels := eventForTest(0)
-	bodyBytes, _ := base.JSONMarshalCanonical(body)
+	bodyBytes, err := base.JSONMarshalCanonical(body)
+	require.NoError(t, err)
 	err = em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, "", channels, false)
 	assert.NoError(t, err)
 	err = em.waitForProcessedTotal(ctx, 1, DefaultWaitForWebhook)
@@ -566,7 +568,7 @@ func TestWebhookOverflows(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -586,7 +588,7 @@ func TestWebhookOverflows(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, "", channels, false)
 		if err != nil {
 			errCount++
@@ -609,7 +611,7 @@ func TestWebhookOverflows(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -657,9 +659,9 @@ func TestWebhookOldDoc(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
 		oldBody[BodyId] = oldDocId
-		oldBodyBytes, _ := base.JSONMarshal(oldBody)
+		oldBodyBytes := base.MustJSONMarshal(t, oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 
@@ -686,9 +688,9 @@ func TestWebhookOldDoc(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
 		oldBody[BodyId] = oldDocId
-		oldBodyBytes, _ := base.JSONMarshal(oldBody)
+		oldBodyBytes := base.MustJSONMarshal(t, oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
@@ -714,9 +716,9 @@ func TestWebhookOldDoc(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
 		oldBody[BodyId] = oldDocId
-		oldBodyBytes, _ := base.JSONMarshal(oldBody)
+		oldBodyBytes := base.MustJSONMarshal(t, oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
@@ -741,16 +743,16 @@ func TestWebhookOldDoc(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	for i := 10; i < 20; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
 		oldBody[BodyId] = oldDocId
-		oldBodyBytes, _ := base.JSONMarshal(oldBody)
+		oldBodyBytes := base.MustJSONMarshal(t, oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
@@ -801,7 +803,7 @@ func TestWebhookTimeout(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
@@ -823,7 +825,7 @@ func TestWebhookTimeout(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
@@ -848,7 +850,7 @@ func TestWebhookTimeout(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
@@ -871,7 +873,7 @@ func TestWebhookTimeout(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
@@ -920,7 +922,7 @@ func TestUnavailableWebhook(t *testing.T) {
 	em.RegisterEventHandler(ctx, webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(-i), i)
-		bodyBytes, _ := base.JSONMarshal(body)
+		bodyBytes := base.MustJSONMarshal(t, body)
 		err := em.RaiseDocumentChangeEvent(ctx, bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -698,7 +698,7 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 	defer rt.Close()
 
 	// Create a DB configured with one scope
-	res := rt.SendAdminRequest(http.MethodPut, "/db/", string(mustMarshalJSON(t, map[string]any{
+	res := rt.SendAdminRequest(http.MethodPut, "/db/", string(base.MustJSONMarshal(t, map[string]any{
 		"bucket":                      tb.GetName(),
 		"num_index_replicas":          0,
 		"enable_shared_bucket_access": base.TestUseXattrs(),
@@ -714,7 +714,7 @@ func TestCollectionsChangeConfigScope(t *testing.T) {
 	RequireStatus(t, res, http.StatusCreated)
 
 	// Try updating its scopes
-	res = rt.SendAdminRequest(http.MethodPut, "/db/_config", string(mustMarshalJSON(t, map[string]any{
+	res = rt.SendAdminRequest(http.MethodPut, "/db/_config", string(base.MustJSONMarshal(t, map[string]any{
 		"bucket":                      tb.GetName(),
 		"num_index_replicas":          0,
 		"enable_shared_bucket_access": base.TestUseXattrs(),

--- a/rest/multipart_test.go
+++ b/rest/multipart_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteMultipartDocument(t *testing.T) {
@@ -170,7 +171,8 @@ func TestWriteJSONPart(t *testing.T) {
 	log.Printf("body: %v", body)
 	buffer := &bytes.Buffer{}
 	writer := multipart.NewWriter(buffer)
-	bytes, _ := base.JSONMarshalCanonical(body)
+	bytes, err := base.JSONMarshalCanonical(body)
+	require.NoError(t, err)
 	log.Printf("len(bytes): %v", len(bytes))
 	assert.NoError(t, writeJSONPart(writer, "application/json", body, true))
 	assert.NoError(t, writeJSONPart(writer, "application/json", body, false))

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2519,12 +2519,6 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 	}
 }
 
-func mustMarshalJSON(t testing.TB, val interface{}) []byte {
-	result, err := base.JSONMarshal(val)
-	require.NoError(t, err)
-	return result
-}
-
 // Checks that we correctly handle the removal of an OIDC provider while it's in use
 func TestOpenIDConnectProviderRemoval(t *testing.T) {
 
@@ -2584,7 +2578,7 @@ func TestOpenIDConnectProviderRemoval(t *testing.T) {
 	providers["INVALID"] = mockProviderWith("INVALID")
 	providers["INVALID"].Issuer = "INVALID"
 
-	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config?disable_oidc_validation=true", string(mustMarshalJSON(t, &dbConfig))), http.StatusCreated)
+	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config?disable_oidc_validation=true", string(base.MustJSONMarshal(t, &dbConfig))), http.StatusCreated)
 
 	// Check that the user is still present, but with no OIDC info
 	res = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_user/"+subject, "")

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -53,7 +53,7 @@ func (tester *ChannelRevocationTester) addRole(user, role string) {
 	}
 
 	tester.roles.Roles[user] = append(tester.roles.Roles[user], fmt.Sprintf("role:%s", role))
-	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roles)))
+	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.roles)))
 }
 
 func (tester *ChannelRevocationTester) removeRole(user, role string) {
@@ -66,7 +66,7 @@ func (tester *ChannelRevocationTester) removeRole(user, role string) {
 		}
 	}
 	tester.roles.Roles[revocationTestUser] = append(roles[:delIdx], roles[delIdx+1:]...)
-	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roles)))
+	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.roles)))
 }
 
 func (tester *ChannelRevocationTester) addRoleChannel(role, channel string) {
@@ -77,7 +77,7 @@ func (tester *ChannelRevocationTester) addRoleChannel(role, channel string) {
 	role = fmt.Sprintf("role:%s", role)
 
 	tester.roleChannels.Channels[role] = append(tester.roleChannels.Channels[role], channel)
-	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roleChannels)))
+	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.roleChannels)))
 }
 
 func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
@@ -91,7 +91,7 @@ func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
 		}
 	}
 	tester.roleChannels.Channels[role] = append(channelsSlice[:delIdx], channelsSlice[delIdx+1:]...)
-	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.roleChannels)))
+	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.roleChannels)))
 }
 
 func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
@@ -100,7 +100,7 @@ func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
 	}
 
 	tester.userChannels.Channels[user] = append(tester.userChannels.Channels[user], channel)
-	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.userChannels)))
+	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.userChannels)))
 }
 
 func (tester *ChannelRevocationTester) removeUserChannel(user string, channel string) {
@@ -113,7 +113,7 @@ func (tester *ChannelRevocationTester) removeUserChannel(user string, channel st
 		}
 	}
 	tester.userChannels.Channels[revocationTestUser] = append(channelsSlice[:delIdx], channelsSlice[delIdx+1:]...)
-	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(mustMarshalJSON(tester.restTester.TB, tester.userChannels)))
+	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.userChannels)))
 }
 
 func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {


### PR DESCRIPTION
- add checks for json marshaling everywhere except benchmark code

This will become more helpful for testing when passing xattrs in tests works as `map[string][]byte` for xattr name plus marshaled value.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
