### PR TITLE
Test fix: Make addChannelsToPrincipal test helper set nil channels

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1655,11 +1655,7 @@ func GetRolePayload(t *testing.T, roleName, password string, collection *db.Data
 // add channels to principal depending if running with collections or not. then marshal the principal config
 func addChannelsToPrincipal(config auth.PrincipalConfig, collection *db.DatabaseCollection, chans []string) ([]byte, error) {
 	if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
-		if len(chans) == 0 {
-			config.ExplicitChannels = base.SetOf("[]")
-		} else {
-			config.ExplicitChannels = base.SetFromArray(chans)
-		}
+		config.ExplicitChannels = base.SetFromArray(chans)
 	} else {
 		config.SetExplicitChannels(collection.ScopeName, collection.Name, chans...)
 	}


### PR DESCRIPTION
Fixes a test where `nil` != `[]` from #6691 

This test helper was being _too helpful_, and turning `nil` into `[]`. The REST API can take `null` fields.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2313/
- [x] `default collection,GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2314/
