### PR TITLE
CBG-3741 test fix: Cherry-pick 3.1.4-fix to slow down Walrus tests

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1205,7 +1205,14 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 		maxConcurrentRevs    = 10
 		concurrentSendRevNum = 50
 	)
-	rt := NewRestTester(t, &RestTesterConfig{maxConcurrentRevs: base.IntPtr(maxConcurrentRevs)})
+	rt := NewRestTester(t, &RestTesterConfig{
+		leakyBucketConfig: &base.LeakyBucketConfig{
+			UpdateCallback: func(_ string) {
+				time.Sleep(time.Millisecond * 5) // slow down Walrus - it's too quick to be throttled
+			},
+		},
+		maxConcurrentRevs: base.IntPtr(maxConcurrentRevs),
+	})
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1208,7 +1208,7 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		leakyBucketConfig: &base.LeakyBucketConfig{
 			UpdateCallback: func(_ string) {
-				time.Sleep(time.Millisecond * 5) // slow down Walrus - it's too quick to be throttled
+				time.Sleep(time.Millisecond * 5) // slow down rosmar - it's too quick to be throttled
 			},
 		},
 		maxConcurrentRevs: base.IntPtr(maxConcurrentRevs),


### PR DESCRIPTION
CBG-3741

Cherry-picked commit from 3.1.4 PR to improve reliability of test by slowing down writes making revs throttling easier to hit reliably under fast Walrus/Rosmar conditions.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a