### PR TITLE
CBG-3611: Fix regression on `PUT /_user/...` endpoint when sending `null` `admin_channels` / `admin_roles`

### DIFF
--- a/db/users.go
+++ b/db/users.go
@@ -113,7 +113,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		if updatedExplicitChannels == nil {
 			updatedExplicitChannels = ch.TimedSet{}
 		}
-		if updates.ExplicitChannels != nil && !updatedExplicitChannels.Equals(updates.ExplicitChannels) {
+		if !updatedExplicitChannels.Equals(updates.ExplicitChannels) {
 			changed = true
 		}
 		collectionAccessChanged, err := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
@@ -149,7 +149,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			if updatedExplicitRoles == nil {
 				updatedExplicitRoles = ch.TimedSet{}
 			}
-			if updates.ExplicitRoleNames != nil && !updatedExplicitRoles.Equals(updates.ExplicitRoleNames) {
+			if !updatedExplicitRoles.Equals(updates.ExplicitRoleNames) {
 				changed = true
 			}
 
@@ -190,7 +190,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		princ.SetSequence(nextSeq)
 
 		// Now update the Principal object from the properties in the request, first the channels:
-		if updates.ExplicitChannels != nil && updatedExplicitChannels.UpdateAtSequence(updates.ExplicitChannels, nextSeq) {
+		if updatedExplicitChannels.UpdateAtSequence(updates.ExplicitChannels, nextSeq) {
 			princ.SetExplicitChannels(updatedExplicitChannels, nextSeq)
 		}
 
@@ -199,7 +199,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		}
 
 		if isUser {
-			if updates.ExplicitRoleNames != nil && updatedExplicitRoles.UpdateAtSequence(updates.ExplicitRoleNames, nextSeq) {
+			if updatedExplicitRoles.UpdateAtSequence(updates.ExplicitRoleNames, nextSeq) {
 				user.SetExplicitRoles(updatedExplicitRoles, nextSeq)
 			}
 			var hasJWTUpdates bool

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -531,7 +531,9 @@ func TestSessionPasswordInvalidation(t *testing.T) {
 			RequireStatus(t, response, http.StatusOK)
 
 			altPassword := "someotherpassword"
-			response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, fmt.Sprintf(`{"password": "%s"}`, altPassword))
+			// TODO CBG-3790: Add POST (upsert) support on User API, and specify only password here.
+			// This test was relying on a bug (CBG-3610) which allowed only the password to be specified without wiping channels.
+			response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(t, username, altPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"*"}, nil))
 			RequireStatus(t, response, http.StatusOK)
 
 			// make sure session is invalid

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1637,11 +1637,7 @@ func GetRolePayload(t *testing.T, roleName, password string, collection *db.Data
 // add channels to principal depending if running with collections or not. then marshal the principal config
 func addChannelsToPrincipal(config auth.PrincipalConfig, collection *db.DatabaseCollection, chans []string) ([]byte, error) {
 	if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
-		if len(chans) == 0 {
-			config.ExplicitChannels = base.SetOf("[]")
-		} else {
-			config.ExplicitChannels = base.SetFromArray(chans)
-		}
+		config.ExplicitChannels = base.SetFromArray(chans)
 	} else {
 		config.SetExplicitChannels(collection.ScopeName, collection.Name, chans...)
 	}


### PR DESCRIPTION
Backports #6691 (and follow-up #6694) to 3.1.4

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2315/
