### PR TITLE
Add new targets for generating internal apis

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -11,10 +11,22 @@
 apis:
   admin:
     root: "./docs/api/admin.yaml"
+    decorators:
+      remove-x-internal: on
+  admin-internal:
+    root: "./docs/api/admin.yaml"
   public:
+    root: "./docs/api/public.yaml"
+    decorators:
+      remove-x-internal: on
+  public-internal:
     root: "./docs/api/public.yaml"
   metric:
     root: "./docs/api/metric.yaml"
+    decorators:
+      remove-x-internal: on
+  metric-internal:
+    root: "./docs/api/public.yaml"
 
 extends:
   - minimal

--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -65,13 +65,16 @@ keyspace:
   schema:
     type: string
   examples:
-    Default scope and collection:
+    default:
+      summary: Default scope and collection
       value: db1
       description: Default scope and collection
-    Named collection within the default scope:
+    namedInDefault:
+      summary: Named collection within the default scope
       value: db1.collection1
       description: Named collection within the default scope
-    Fully-qualified scope and collection:
+    fullyQualified:
+      summary: Fully-qualified scope and collection
       value: db1.scope1.collection1
       description: Fully-qualified scope and collection
   description: |-

--- a/docs/api/paths/admin/keyspace-_bulk_docs.yaml
+++ b/docs/api/paths/admin/keyspace-_bulk_docs.yaml
@@ -88,7 +88,8 @@ post:
                   rev: 6-b3e8dcf825b71ccee112f3572ec4323c
                 - id: BobSettings
                   rev: 2-5145e1086bb8d1d71a531e9f6b543c58
-            Partial success:
+            PartialSuccess:
+              summary: PartialSuccess
               value:
                 - error: conflict
                   id: FooBar

--- a/docs/api/paths/admin/keyspace-_purge.yaml
+++ b/docs/api/paths/admin/keyspace-_purge.yaml
@@ -41,11 +41,13 @@ post:
               enum:
                 - '*'
         examples:
-          Example:
+          single:
+            summary: 'Single document'
             value:
               doc_id:
                 - '*'
-          Multiple purges example:
+          multiple:
+            summary: 'Multiple documents'
             value:
               doc_id_1:
                 - '*'
@@ -70,12 +72,14 @@ post:
             required:
               - purged
           examples:
-            Example:
+            single:
+              summary: 'Single document'
               value:
                 purged:
                   doc_id:
                     - '*'
-            Multiple purges example:
+            multiple:
+              summary: 'Multiple documents'
               value:
                 purged:
                   doc_id_1:

--- a/docs/api/paths/public/keyspace-_bulk_docs.yaml
+++ b/docs/api/paths/public/keyspace-_bulk_docs.yaml
@@ -84,7 +84,8 @@ post:
                   rev: 6-b3e8dcf825b71ccee112f3572ec4323c
                 - id: BobSettings
                   rev: 2-5145e1086bb8d1d71a531e9f6b543c58
-            Partial success:
+            PartialSuccess:
+              summary: "Partial success"
               value:
                 - error: conflict
                   id: FooBar


### PR DESCRIPTION
With https://github.com/couchbase/docs-sync-gateway/pull/782 we can add `x-internal` to mark internal APIs.

The docs-sync-gateway change is backward compatible with 3.1 branches and is a no-op.
