### PR TITLE
CBG-3255  Replication protocol support for HLV - push replication

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1004,6 +1004,10 @@ func HexCasToUint64(cas string) uint64 {
 	return binary.LittleEndian.Uint64(casBytes[0:8])
 }
 
+func CasToString(cas uint64) string {
+	return string(Uint64CASToLittleEndianHex(cas))
+}
+
 func Uint64CASToLittleEndianHex(cas uint64) []byte {
 	littleEndian := make([]byte, 8)
 	binary.LittleEndian.PutUint64(littleEndian, cas)
@@ -1012,6 +1016,17 @@ func Uint64CASToLittleEndianHex(cas uint64) []byte {
 	encodedArray[0] = '0'
 	encodedArray[1] = 'x'
 	return encodedArray
+}
+
+// Converts a string decimal representation ("100") to little endian hex string ("0x64")
+func StringDecimalToLittleEndianHex(value string) (string, error) {
+	intValue, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return "", err
+	}
+	hexValue := Uint64CASToLittleEndianHex(intValue)
+	return string(hexValue), nil
+
 }
 
 func Crc32cHash(input []byte) uint32 {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -792,12 +792,18 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 
 	for i, change := range changeList {
 		docID := change[0].(string)
-		revID := change[1].(string)
+		rev := change[1].(string) // rev can represent a RevTree ID or HLV current version
 		parentRevID := ""
 		if len(change) > 2 {
 			parentRevID = change[2].(string)
 		}
-		status, currentRev := bh.collection.CheckProposedRev(bh.loggingCtx, docID, revID, parentRevID)
+		var status ProposedRevStatus
+		var currentRev string
+		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+			status, currentRev = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, rev, parentRevID)
+		} else {
+			status, currentRev = bh.collection.CheckProposedRev(bh.loggingCtx, docID, rev, parentRevID)
+		}
 		if status == ProposedRev_OK_IsNew {
 			// Remember that the doc doesn't exist locally, in order to optimize the upcoming Put:
 			bh.collectionCtx.notePendingInsertion(docID)
@@ -937,18 +943,21 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 	}()
 
-	// addRevisionParams := newAddRevisionParams(rq)
+	if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 && bh.conflictResolver != nil {
+		return base.HTTPErrorf(http.StatusNotImplemented, "conflict resolver handling (ISGR) not yet implemented for v4 protocol")
+	}
+
 	revMessage := RevMessage{Message: rq}
 
 	// Doc metadata comes from the BLIP message metadata, not magic document properties:
 	docID, found := revMessage.ID()
-	revID, rfound := revMessage.Rev()
+	rev, rfound := revMessage.Rev()
 	if !found || !rfound {
-		return base.HTTPErrorf(http.StatusBadRequest, "Missing docID or revID")
+		return base.HTTPErrorf(http.StatusBadRequest, "Missing docID or rrevIDev")
 	}
 
 	if bh.readOnly {
-		return base.HTTPErrorf(http.StatusForbidden, "Replication context is read-only, docID: %s, revID:%s", docID, revID)
+		return base.HTTPErrorf(http.StatusForbidden, "Replication context is read-only, docID: %s, rev:%s", docID, rev)
 	}
 
 	base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Type:%s %s", bh.serialNumber, rq.Profile(), revMessage.String())
@@ -968,7 +977,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 			return err
 		}
 		if removed, ok := body[BodyRemoved].(bool); ok && removed {
-			base.InfofCtx(bh.loggingCtx, base.KeySync, "Purging doc %v - removed at rev %v", base.UD(docID), revID)
+			base.InfofCtx(bh.loggingCtx, base.KeySync, "Purging doc %v - removed at rev %v", base.UD(docID), rev)
 			if err := bh.collection.Purge(bh.loggingCtx, docID); err != nil {
 				return err
 			}
@@ -980,7 +989,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				if err != nil {
 					base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %v - not tracking for checkpointing", seqStr, err)
 				} else {
-					bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+					bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: rev})
 				}
 			}
 			return nil
@@ -988,9 +997,30 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	}
 
 	newDoc := &Document{
-		ID:    docID,
-		RevID: revID,
+		ID: docID,
 	}
+
+	var history []string
+	var incomingHLV HybridLogicalVector
+	// Build history/HLV
+	if bh.activeCBMobileSubprotocol < CBMobileReplicationV4 {
+		newDoc.RevID = rev
+		history = []string{rev}
+		if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" {
+			history = append(history, strings.Split(historyStr, ",")...)
+		}
+	} else {
+		versionVectorStr := rev
+		if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" {
+			versionVectorStr += ";" + historyStr
+		}
+		incomingHLV, err = extractHLVFromBlipMessage(versionVectorStr)
+		if err != nil {
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "error extracting hlv from blip message")
+		}
+		newDoc.HLV = &incomingHLV
+	}
+
 	newDoc.UpdateBodyBytes(bodyBytes)
 
 	injectedAttachmentsForDelta := false
@@ -1009,7 +1039,15 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		//       while retrieving deltaSrcRevID.  Couchbase Lite replication guarantees client has access to deltaSrcRevID,
 		//       due to no-conflict write restriction, but we still need to enforce security here to prevent leaking data about previous
 		//       revisions to malicious actors (in the scenario where that user has write but not read access).
-		deltaSrcRev, err := bh.collection.GetRev(bh.loggingCtx, docID, deltaSrcRevID, false, nil)
+		var deltaSrcRev DocumentRevision
+		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+			cv := Version{}
+			cv.SourceID, cv.Value = incomingHLV.GetCurrentVersion()
+			// swap for GetCV once merged (CBG-3212)
+			deltaSrcRev, err = bh.collection.revisionCache.GetWithCV(bh.loggingCtx, docID, &cv, RevCacheOmitBody, RevCacheOmitDelta)
+		} else {
+			deltaSrcRev, err = bh.collection.GetRev(bh.loggingCtx, docID, deltaSrcRevID, false, nil)
+		}
 		if err != nil {
 			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't fetch doc %s for deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
 		}
@@ -1035,7 +1073,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		// err should only ever be a FleeceDeltaError here - but to be defensive, handle other errors too (e.g. somehow reaching this code in a CE build)
 		if err != nil {
 			// Something went wrong in the diffing library. We want to know about this!
-			base.WarnfCtx(bh.loggingCtx, "Error patching deltaSrc %s with %s for doc %s with delta - err: %v", deltaSrcRevID, revID, base.UD(docID), err)
+			base.WarnfCtx(bh.loggingCtx, "Error patching deltaSrc %s with %s for doc %s with delta - err: %v", deltaSrcRevID, rev, base.UD(docID), err)
 			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Error patching deltaSrc with delta: %s", err)
 		}
 
@@ -1073,15 +1111,14 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 	}
 
-	history := []string{revID}
-	if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" {
-		history = append(history, strings.Split(historyStr, ",")...)
-	}
-
 	var rawBucketDoc *sgbucket.BucketDocument
 
 	// Pull out attachments
 	if injectedAttachmentsForDelta || bytes.Contains(bodyBytes, []byte(BodyAttachments)) {
+		// temporarily error here if V4
+		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+			return base.HTTPErrorf(http.StatusNotImplemented, "attachment handling not yet supported for v4 protocol")
+		}
 		body := newDoc.Body(bh.loggingCtx)
 
 		var currentBucketDoc *Document
@@ -1118,7 +1155,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				if !ok {
 					// If we don't have this attachment already, ensure incoming revpos is greater than minRevPos, otherwise
 					// update to ensure it's fetched and uploaded
-					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, revID)
+					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, rev)
 					continue
 				}
 
@@ -1158,7 +1195,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				// digest is different we need to override the revpos and set it to the current revision to ensure
 				// the attachment is requested and stored
 				if int(incomingAttachmentRevpos) <= minRevpos && currentAttachmentDigest != incomingAttachmentDigest {
-					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, revID)
+					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, rev)
 				}
 			}
 
@@ -1166,7 +1203,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 
 		if err := bh.downloadOrVerifyAttachments(rq.Sender, body, minRevpos, docID, currentDigests); err != nil {
-			base.ErrorfCtx(bh.loggingCtx, "Error during downloadOrVerifyAttachments for doc %s/%s: %v", base.UD(docID), revID, err)
+			base.ErrorfCtx(bh.loggingCtx, "Error during downloadOrVerifyAttachments for doc %s/%s: %v", base.UD(docID), rev, err)
 			return err
 		}
 
@@ -1176,7 +1213,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	}
 
 	if rawBucketDoc == nil && bh.collectionCtx.checkPendingInsertion(docID) {
-		// At the time we handled the `propseChanges` request, there was no doc with this docID
+		// At the time we handled the `proposeChanges` request, there was no doc with this docID
 		// in the bucket. As an optimization, tell PutExistingRev to assume the doc still doesn't
 		// exist and bypass getting it from the bucket during the save. If we're wrong, the save
 		// will fail with a CAS mismatch and the retry will fetch the existing doc.
@@ -1189,7 +1226,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// If the doc is a tombstone we want to allow conflicts when running SGR2
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
-	if bh.conflictResolver != nil {
+	if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc)
+	} else if bh.conflictResolver != nil {
 		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	} else {
 		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
@@ -1204,7 +1243,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		if err != nil {
 			base.WarnfCtx(bh.loggingCtx, "Unable to parse sequence %q from rev message: %v - not tracking for checkpointing", seqProperty, err)
 		} else {
-			bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: revID})
+			bh.collectionCtx.sgr2PullProcessedSeqCallback(&seq, IDAndRev{DocID: docID, RevID: rev})
 		}
 	}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1131,7 +1131,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				return nil, nil, false, nil, addNewerVersionsErr
 			}
 		} else {
-			if (*doc.HLV).isDominating(newDocHLV) {
+			if doc.HLV.isDominating(newDocHLV) {
 				base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add", base.UD(newDoc.ID))
 				return nil, nil, false, nil, base.ErrUpdateCancel // No new revisions to add
 			}
@@ -2209,6 +2209,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		}
 	}
 
+	// ErrUpdateCancel is returned when the incoming revision is already known
 	if err == base.ErrUpdateCancel {
 		return nil, "", nil
 	} else if err != nil {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1724,10 +1724,11 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	body = Body{"key1": "value2"}
 	newDoc := createTestDocument(key, "", body, false, 0)
 
-	// construct a HLV that simulates a doc update happening on a client
-	// this means moving the current source version pair to PV and adding new sourceID and version pair to CV
+	// Simulate a conflicting doc update happening from a client that
+	// has only replicated the initial version of the document
 	pv := make(map[string]string)
-	pv[bucketUUID] = originalDocVersion
+	pv[syncData.HLV.SourceID] = originalDocVersion
+
 	// create a version larger than the allocated version above
 	incomingVersion := string(base.Uint64CASToLittleEndianHex(docUpdateVersionInt + 10))
 	incomingHLV := HybridLogicalVector{
@@ -1736,14 +1737,18 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 		PreviousVersions: pv,
 	}
 
-	// grab the raw doc from the bucket to pass into the PutExistingCurrentVersion function for the above simulation of
-	// doc update arriving over replicator
-	_, rawDoc, err := collection.GetDocumentWithRaw(ctx, key, DocUnmarshalSync)
-	require.NoError(t, err)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil)
+	assertHTTPError(t, err, 409)
+	require.Nil(t, doc)
+	require.Nil(t, cv)
 
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, rawDoc)
+	// Update the client's HLV to include the latest SGW version.
+	incomingHLV.PreviousVersions[syncData.HLV.SourceID] = docUpdateVersion
+	// TODO: because currentRev isn't being updated, storeOldBodyInRevTreeAndUpdateCurrent isn't
+	//  updating the document body.   Need to review whether it makes sense to keep using
+	// storeOldBodyInRevTreeAndUpdateCurrent, or if this needs a larger overhaul to support VV
+	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil)
 	require.NoError(t, err)
-	// assert on returned CV
 	assert.Equal(t, "test", cv.SourceID)
 	assert.Equal(t, incomingVersion, cv.Value)
 	assert.Equal(t, []byte(`{"key1":"value2"}`), doc._rawBody)
@@ -1761,6 +1766,8 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	pv[bucketUUID] = docUpdateVersion
 	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
 	assert.Equal(t, "3-60b024c44c283b369116c2c2570e8088", syncData.CurrentRev)
+
+	// TODO: Test the case where server version dominates incoming
 }
 
 // TestPutExistingCurrentVersionWithConflict:
@@ -1799,16 +1806,11 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 		Version:  string(base.Uint64CASToLittleEndianHex(1234)),
 	}
 
-	// grab the raw doc from the bucket to pass into the PutExistingCurrentVersion function
-	_, rawDoc, err := collection.GetDocumentWithRaw(ctx, key, DocUnmarshalSync)
-	require.NoError(t, err)
-
-	// assert that a conflict is correctly identified and the resulting doc and cv are nil
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, rawDoc)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "Document revision conflict")
-	assert.Nil(t, cv)
-	assert.Nil(t, doc)
+	// assert that a conflict is correctly identified and the doc and cv are nil
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil)
+	assertHTTPError(t, err, 409)
+	require.Nil(t, doc)
+	require.Nil(t, cv)
 
 	// assert persisted doc hlv hasn't been updated
 	syncData, err = collection.GetDocSyncData(ctx, "doc1")

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1767,7 +1767,15 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(syncData.HLV.PreviousVersions, pv))
 	assert.Equal(t, "3-60b024c44c283b369116c2c2570e8088", syncData.CurrentRev)
 
-	// TODO: Test the case where server version dominates incoming
+	// Attempt to push the same client update, validate server rejects as an already known version and cancels the update.
+	// This case doesn't return error, verify that SyncData hasn't been changed.
+	_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil)
+	require.NoError(t, err)
+	syncData2, err := collection.GetDocSyncData(ctx, "doc1")
+	require.NoError(t, err)
+	require.Equal(t, syncData.TimeSaved, syncData2.TimeSaved)
+	require.Equal(t, syncData.CurrentRev, syncData2.CurrentRev)
+
 }
 
 // TestPutExistingCurrentVersionWithConflict:

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -433,23 +433,6 @@ func TestCheckProposedVersion(t *testing.T) {
 		assert.Equal(t, ProposedRev_OK_IsNew, status)
 	})
 
-	/*
-		t.Run("conflict - previous version source matches cv", func(t *testing.T) {
-
-			newVersion := Version{"other", 100}.String()
-			prevVersion := Version{cvSource, cvValue - 100}.String()
-			assert.NoError(t, base.DeepCopyInefficient(&hlv, doc.HLV))
-			err = hlv.AddVersion(Version{"cluster2", hlv.CurrentVersionCAS + 1})
-			require.NoError(t, err)
-			err = hlv.AddVersion(Version{"cluster2", hlv.CurrentVersionCAS + 4})
-			require.NoError(t, err)
-			// TODO: Get full BLIP formatted HLV
-			hlvString := hlv.GetCurrentVersionString()
-			status, _ := collection.CheckProposedVersion(ctx, "doc1", hlvString)
-			assert.Equal(t, ProposedRev_Conflict, status)
-		})
-	*/
-
 }
 
 func incrementStringCas(cas string, delta int) (casOut string) {

--- a/db/document.go
+++ b/db/document.go
@@ -37,11 +37,10 @@ type DocumentUnmarshalLevel uint8
 const (
 	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals sync metadata and body
 	DocUnmarshalSync                                     // Unmarshals all sync metadata
-	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding history
-	DocUnmarshalHistory                                  // Unmarshals history + rev + CAS only
+	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding revtree history
+	DocUnmarshalHistory                                  // Unmarshals revtree history + rev + CAS only
 	DocUnmarshalRev                                      // Unmarshals rev + CAS only
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
-	DocUnmarshalVV                                       // Unmarshals Version Vector only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )
 
@@ -1190,14 +1189,6 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 		doc.SyncData = SyncData{
 			Cas: casOnlyMeta.Cas,
 		}
-		doc._rawBody = data
-	case DocUnmarshalVV:
-		tmpData := SyncData{}
-		unmarshalErr := base.JSONUnmarshal(xdata, &tmpData)
-		if unmarshalErr != nil {
-			return base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalVV).  Error: %w", base.UD(doc.ID), unmarshalErr)
-		}
-		doc.SyncData.HLV = tmpData.HLV
 		doc._rawBody = data
 	}
 

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -260,7 +260,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	ctx := base.TestCtx(t)
 
 	doc_meta := []byte(doc_meta_with_vv)
-	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalVV)
+	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	strCAS := string(base.Uint64CASToLittleEndianHex(123456))

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -180,7 +180,7 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	}
 	// if new entry has the same source we simple just update the version
 	if newVersion.SourceID == hlv.SourceID {
-		if newVersionCAS < hlvVersionCAS {
+		if newVersion.Value != hlvExpandMacroCASValue && newVersionCAS < hlvVersionCAS {
 			return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value for the same source. Current cas: %s new cas %s", hlv.Version, newVersion.Value)
 		}
 		hlv.Version = newVersion.Value

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -22,7 +22,7 @@ const hlvExpandMacroCASValue = "expand"
 
 // HybridLogicalVectorInterface is an interface to contain methods that will operate on both a decoded HLV and encoded HLV
 type HybridLogicalVectorInterface interface {
-	GetVersion(sourceID string) (uint64, bool)
+	GetValue(sourceID string) (uint64, bool)
 }
 
 var _ HybridLogicalVectorInterface = &HybridLogicalVector{}
@@ -145,14 +145,24 @@ func (hlv *HybridLogicalVector) GetCurrentVersionString() string {
 	return version.String()
 }
 
-// IsInConflict tests to see if in memory HLV is conflicting with another HLV
-func (hlv *DecodedHybridLogicalVector) IsInConflict(otherVector DecodedHybridLogicalVector) bool {
-	// test if either HLV(A) or HLV(B) are dominating over each other. If so they are not in conflict
-	if hlv.isDominating(otherVector) || otherVector.isDominating(*hlv) {
+// IsVersionInConflict tests to see if a given version would be in conflict with the in memory HLV.
+func (hlv *HybridLogicalVector) IsVersionInConflict(version Version) bool {
+	v1 := Version{hlv.SourceID, hlv.Version}
+	if v1.isVersionDominating(version) || version.isVersionDominating(v1) {
 		return false
 	}
-	// if the version vectors aren't dominating over one another then conflict is present
 	return true
+}
+
+// IsVersionKnown checks to see whether the HLV already contains a Version for the provided
+// source with a matching or newer value
+func (hlv *HybridLogicalVector) DominatesSource(version Version) bool {
+	existingValueForSource, found := hlv.GetValue(version.SourceID)
+	if !found {
+		return false
+	}
+	return existingValueForSource >= base.HexCasToUint64(version.Value)
+
 }
 
 // AddVersion adds newVersion to the in memory representation of the HLV.
@@ -161,9 +171,6 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	hlvVersionCAS := base.HexCasToUint64(hlv.Version)
 	if newVersion.Value != hlvExpandMacroCASValue {
 		newVersionCAS = base.HexCasToUint64(newVersion.Value)
-		if newVersionCAS < hlvVersionCAS {
-			return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value. Current cas: %s new cas %s", hlv.Version, newVersion.Value)
-		}
 	}
 	// check if this is the first time we're adding a source - version pair
 	if hlv.SourceID == "" {
@@ -173,6 +180,9 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	}
 	// if new entry has the same source we simple just update the version
 	if newVersion.SourceID == hlv.SourceID {
+		if newVersionCAS < hlvVersionCAS {
+			return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value for the same source. Current cas: %s new cas %s", hlv.Version, newVersion.Value)
+		}
 		hlv.Version = newVersion.Value
 		return nil
 	}
@@ -210,19 +220,22 @@ func (hlv *HybridLogicalVector) Remove(source string) error {
 	return nil
 }
 
-// isDominating tests if in memory HLV is dominating over another
-func (hlv *DecodedHybridLogicalVector) isDominating(otherVector DecodedHybridLogicalVector) bool {
-	// Dominating Criteria:
-	// HLV A dominates HLV B if source(A) == source(B) and version(A) > version(B)
-	// If there is an entry in pv(B) for A's current source and version(A) > B's version for that pv entry then A is dominating
-	// if there is an entry in mv(B) for A's current source and version(A) > B's version for that pv entry then A is dominating
+// isDominating tests if in memory HLV is dominating over another.
+// If HLV A dominates CV of HLV B, it can be assumed to dominate the entire HLV, since
+// CV dominates PV for a given HLV.  Given this, it's sufficient to check whether HLV A
+// has a version for HLV B's current source that's greater than or equal to HLV B's current version.
+func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bool {
+	return hlv.DominatesSource(Version{otherVector.SourceID, otherVector.Version})
+}
 
-	// Grab the latest CAS version for HLV(A)'s sourceID in HLV(B), if HLV(A) version CAS is > HLV(B)'s then it is dominating
-	// If 0 CAS is returned then the sourceID does not exist on HLV(B)
-	if latestCAS, found := otherVector.GetVersion(hlv.SourceID); found && hlv.Version > latestCAS {
+// isVersionDominating tests if v2 is dominating v1
+func (v1 *Version) isVersionDominating(v2 Version) bool {
+	if v1.SourceID != v2.SourceID {
+		return false
+	}
+	if v1.Value > v2.Value {
 		return true
 	}
-	// HLV A is not dominating over HLV B
 	return false
 }
 
@@ -274,9 +287,9 @@ func (hlv *DecodedHybridLogicalVector) equalPreviousVectors(otherVector DecodedH
 	return true
 }
 
-// GetVersion returns the latest CAS value in the HLV for a given sourceID along with boolean value to
+// GetValue returns the latest CAS value in the HLV for a given sourceID along with boolean value to
 // indicate if sourceID is found in the HLV, if the sourceID is not present in the HLV it will return 0 CAS value and false
-func (hlv *DecodedHybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
+func (hlv *DecodedHybridLogicalVector) GetValue(sourceID string) (uint64, bool) {
 	if sourceID == "" {
 		return 0, false
 	}
@@ -298,7 +311,7 @@ func (hlv *DecodedHybridLogicalVector) GetVersion(sourceID string) (uint64, bool
 }
 
 // GetVersion returns the latest decoded CAS value in the HLV for a given sourceID
-func (hlv *HybridLogicalVector) GetVersion(sourceID string) (uint64, bool) {
+func (hlv *HybridLogicalVector) GetValue(sourceID string) (uint64, bool) {
 	if sourceID == "" {
 		return 0, false
 	}
@@ -386,7 +399,7 @@ func (hlv *HybridLogicalVector) setPreviousVersion(source string, version string
 }
 
 func (hlv *HybridLogicalVector) IsVersionKnown(otherVersion Version) bool {
-	value, found := hlv.GetVersion(otherVersion.SourceID)
+	value, found := hlv.GetValue(otherVersion.SourceID)
 	if !found {
 		return false
 	}
@@ -467,4 +480,109 @@ func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, 
 		currentSpec = append(currentSpec, spec)
 	}
 	return currentSpec
+
+}
+
+// extractHLVFromBlipMessage extracts the full HLV a string in the format seen over Blip
+// blip string may be the following formats
+//  1. cv only:    		cv
+//  2. cv and pv:  		cv;pv
+//  3. cv, pv, and mv: 	cv;mv;pv
+//
+// TODO: CBG-3662 - Optimise once we've settled on and tested the format with CBL
+func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, error) {
+	hlv := HybridLogicalVector{}
+
+	vectorFields := strings.Split(versionVectorStr, ";")
+	vectorLength := len(vectorFields)
+	if (vectorLength == 1 && vectorFields[0] == "") || vectorLength > 3 {
+		return HybridLogicalVector{}, fmt.Errorf("invalid hlv in changes message received")
+	}
+
+	// add current version (should always be present)
+	cvStr := vectorFields[0]
+	version := strings.Split(cvStr, "@")
+	if len(version) < 2 {
+		return HybridLogicalVector{}, fmt.Errorf("invalid version in changes message received")
+	}
+
+	err := hlv.AddVersion(Version{SourceID: version[1], Value: version[0]})
+	if err != nil {
+		return HybridLogicalVector{}, err
+	}
+
+	switch vectorLength {
+	case 1:
+		// cv only
+		return hlv, nil
+	case 2:
+		// only cv and pv present
+		sourceVersionListPV, err := parseVectorValues(vectorFields[1])
+		if err != nil {
+			return HybridLogicalVector{}, err
+		}
+		hlv.PreviousVersions = make(map[string]string)
+		for _, v := range sourceVersionListPV {
+			hlv.PreviousVersions[v.SourceID] = v.Value
+		}
+		return hlv, nil
+	case 3:
+		// cv, mv and pv present
+		sourceVersionListPV, err := parseVectorValues(vectorFields[2])
+		hlv.PreviousVersions = make(map[string]string)
+		if err != nil {
+			return HybridLogicalVector{}, err
+		}
+		for _, pv := range sourceVersionListPV {
+			hlv.PreviousVersions[pv.SourceID] = pv.Value
+		}
+
+		sourceVersionListMV, err := parseVectorValues(vectorFields[1])
+		hlv.MergeVersions = make(map[string]string)
+		if err != nil {
+			return HybridLogicalVector{}, err
+		}
+		for _, mv := range sourceVersionListMV {
+			hlv.MergeVersions[mv.SourceID] = mv.Value
+		}
+		return hlv, nil
+	default:
+		return HybridLogicalVector{}, fmt.Errorf("invalid hlv in changes message received")
+	}
+}
+
+// parseVectorValues takes an HLV section (cv, pv or mv) in string form and splits into
+// source and version pairs
+func parseVectorValues(vectorStr string) (versions []Version, err error) {
+	versionsStr := strings.Split(vectorStr, ",")
+	versions = make([]Version, 0, len(versionsStr))
+
+	for _, v := range versionsStr {
+		// remove any leading whitespace form the string value
+		// TODO: Can avoid by restricting spec
+		if len(v) > 0 && v[0] == ' ' {
+			v = v[1:]
+		}
+		version, err := ParseVersion(v)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, version)
+	}
+
+	return versions, nil
+}
+
+// Helper functions for version source and value encoding
+func EncodeSource(source string) string {
+	return base64.StdEncoding.EncodeToString([]byte(source))
+}
+
+func EncodeValue(value uint64) string {
+	return base.CasToString(value)
+}
+
+// EncodeValueStr converts a simplified number ("1") to a hex-encoded string
+func EncodeValueStr(value string) (string, error) {
+	return base.StringDecimalToLittleEndianHex(strings.TrimSpace(value))
 }

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -9,7 +9,6 @@
 package db
 
 import (
-	"context"
 	"encoding/base64"
 	"reflect"
 	"strconv"
@@ -364,27 +363,6 @@ func TestHLVMapToCBLString(t *testing.T) {
 			}
 		})
 	}
-}
-
-// insertWithHLV inserts a new document into the bucket with a populated HLV (matching a write from
-// a different HLV-aware peer)
-func (h *HLVAgent) insertWithHLV(ctx context.Context, key string) (casOut uint64) {
-	hlv := &HybridLogicalVector{}
-	err := hlv.AddVersion(CreateVersion(h.Source, hlvExpandMacroCASValue))
-	require.NoError(h.t, err)
-	hlv.CurrentVersionCAS = hlvExpandMacroCASValue
-
-	syncData := &SyncData{HLV: hlv}
-	syncDataBytes, err := base.JSONMarshal(syncData)
-	require.NoError(h.t, err)
-
-	mutateInOpts := &sgbucket.MutateInOptions{
-		MacroExpansion: hlv.computeMacroExpansions(),
-	}
-
-	cas, err := h.datastore.WriteCasWithXattr(ctx, key, h.xattrName, 0, 0, defaultHelperBody, syncDataBytes, mutateInOpts)
-	require.NoError(h.t, err)
-	return cas
 }
 
 // TestInvalidHLVOverChangesMessage:

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -331,8 +331,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 // nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
-		// need implementation of IsChannelRemoval for CV
-		// TODO: CBG-3213 - pending support of channel removal for CV
+		// TODO: CBG-3814 - pending support of channel removal for CV
 		base.ErrorfCtx(ctx, "pending CBG-3213 support of channel removal for CV: %v", err)
 	}
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -331,8 +331,9 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 // nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
-		// TODO: pending CBG-3213 support of channel removal for CV
-		// we need implementation of IsChannelRemoval for CV here.
+		// need implementation of IsChannelRemoval for CV
+		// TODO: CBG-3213 - pending support of channel removal for CV
+		base.ErrorfCtx(ctx, "pending CBG-3213 support of channel removal for CV: %v", err)
 	}
 
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -70,7 +70,7 @@ func EncodeTestVersion(versionString string) (encodedString string) {
 	}
 	hexTimestamp, err := EncodeValueStr(timestampString)
 	if err != nil {
-		panic(fmt.Sprintf("unable to encode timestampString", timestampString))
+		panic(fmt.Sprintf("unable to encode timestampString %v", timestampString))
 	}
 	base64Source := EncodeSource(source)
 	return hexTimestamp + "@" + base64Source

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -12,7 +12,8 @@ package db
 
 import (
 	"context"
-	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -34,7 +35,7 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 	return &HLVAgent{
 		t:         t,
 		datastore: datastore,
-		Source:    base64.StdEncoding.EncodeToString([]byte(source)), // all writes by the HLVHelper are done as this source
+		Source:    EncodeSource(source), // all writes by the HLVHelper are done as this source
 		xattrName: xattrName,
 	}
 }
@@ -58,4 +59,96 @@ func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64
 	cas, err := h.datastore.WriteCasWithXattr(ctx, key, h.xattrName, 0, 0, defaultHelperBody, syncDataBytes, mutateInOpts)
 	require.NoError(h.t, err)
 	return cas
+}
+
+// EncodeTestVersion converts a simplified string version of the form 1@abc to a hex-encoded version and base64 encoded
+// source, like 0x0100000000000000@YWJj.  Allows use of simplified versions in tests for readability, ease of use.
+func EncodeTestVersion(versionString string) (encodedString string) {
+	timestampString, source, found := strings.Cut(versionString, "@")
+	if !found {
+		return versionString
+	}
+	hexTimestamp, err := EncodeValueStr(timestampString)
+	if err != nil {
+		panic(fmt.Sprintf("unable to encode timestampString", timestampString))
+	}
+	base64Source := EncodeSource(source)
+	return hexTimestamp + "@" + base64Source
+}
+
+// encodeTestHistory converts a simplified version history of the form "1@abc,2@def;3@ghi" to use hex-encoded versions and
+// base64 encoded sources
+func EncodeTestHistory(historyString string) (encodedString string) {
+	// possible versionSets are pv;mv
+	// possible versionSets are pv;mv
+	versionSets := strings.Split(historyString, ";")
+	if len(versionSets) == 0 {
+		return ""
+	}
+	for index, versionSet := range versionSets {
+		// versionSet delimiter
+		if index > 0 {
+			encodedString += ";"
+		}
+		versions := strings.Split(versionSet, ",")
+		for index, version := range versions {
+			// version delimiter
+			if index > 0 {
+				encodedString += ","
+			}
+			encodedString += EncodeTestVersion(version)
+		}
+	}
+	return encodedString
+}
+
+// ParseTestHistory takes a string test history in the form 1@abc,2@def;3@ghi,4@jkl and formats this
+// as pv and mv maps keyed by encoded source, with encoded values
+func ParseTestHistory(t *testing.T, historyString string) (pv map[string]string, mv map[string]string) {
+	versionSets := strings.Split(historyString, ";")
+
+	pv = make(map[string]string)
+	mv = make(map[string]string)
+
+	var pvString, mvString string
+	switch len(versionSets) {
+	case 1:
+		pvString = versionSets[0]
+	case 2:
+		mvString = versionSets[0]
+		pvString = versionSets[1]
+	default:
+		return pv, mv
+	}
+
+	// pv
+	for _, versionStr := range strings.Split(pvString, ",") {
+		version, err := ParseVersion(versionStr)
+		require.NoError(t, err)
+		encodedValue, err := EncodeValueStr(version.Value)
+		require.NoError(t, err)
+		pv[EncodeSource(version.SourceID)] = encodedValue
+	}
+
+	// mv
+	if mvString != "" {
+		for _, versionStr := range strings.Split(mvString, ",") {
+			version, err := ParseVersion(versionStr)
+			require.NoError(t, err)
+			encodedValue, err := EncodeValueStr(version.Value)
+			require.NoError(t, err)
+			mv[EncodeSource(version.SourceID)] = encodedValue
+		}
+	}
+	return pv, mv
+}
+
+// Requires that the CV for the provided HLV matches the expected CV (sent in simplified test format)
+func RequireCVEqual(t *testing.T, hlv *HybridLogicalVector, expectedCV string) {
+	testVersion, err := ParseVersion(expectedCV)
+	require.NoError(t, err)
+	require.Equal(t, EncodeSource(testVersion.SourceID), hlv.SourceID)
+	encodedValue, err := EncodeValueStr(testVersion.Value)
+	require.NoError(t, err)
+	require.Equal(t, encodedValue, hlv.Version)
 }

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2265,7 +2265,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
@@ -2330,7 +2330,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 	}
 	const doc1ID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -2381,7 +2381,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const docID = "doc"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -2424,7 +2424,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -2608,7 +2608,7 @@ func TestCBLRevposHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -45,8 +45,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	// given this test is for v2 protocol, skip version vector test
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -122,7 +121,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -197,7 +196,7 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 	)
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -257,7 +256,7 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 	)
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -297,7 +296,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -375,7 +374,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
@@ -536,12 +535,13 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 // TestBlipAttachNameChange tests CBL handling - attachments with changed names are sent as stubs, and not new attachments
 func TestBlipAttachNameChange(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
+
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -591,7 +591,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -649,7 +649,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -727,7 +727,7 @@ func TestAttachmentComputeStat(t *testing.T) {
 	}
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1720,9 +1720,6 @@ func TestPutRevV4(t *testing.T) {
 	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
 	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
 
-	doc, _, err = collection.GetDocWithXattr(base.TestCtx(t), "foo", db.DocUnmarshalNoHistory)
-	require.NoError(t, err)
-
 	// 3. Update the document again with a non-conflicting revision from a different source (previous cv moved to pv)
 	updatedHistory := "1@def, 2@abc, 4@efg"
 	sent, _, resp, err = bt.SendRev("foo", db.EncodeTestVersion("1@jkl"), []byte(`{"key": "val"}`), blip.Properties{"history": db.EncodeTestHistory(updatedHistory)})
@@ -1759,7 +1756,7 @@ func TestPutRevV4(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, "409", resp.Properties["Error-Code"])
 
-	// 6. Test sending rev with merge versions included in history (for new key)
+	// 6. Test sending rev with merge versions included in history (note new key)
 	mvHistory := "3@def, 3@abc; 1@def, 2@abc"
 	sent, _, resp, err = bt.SendRev("boo", db.EncodeTestVersion("3@efg"), []byte(`{"key": "val"}`), blip.Properties{"history": db.EncodeTestHistory(mvHistory)})
 	assert.True(t, sent)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -1673,6 +1674,109 @@ func TestPutRevConflictsMode(t *testing.T) {
 
 }
 
+// TestPutRevV4:
+//   - Create blip tester to run with V4 protocol
+//   - Use send rev with CV defined in rev field and history field with PV/MV defined
+//   - Retrieve the doc from bucket and assert that the HLV is set to what has been sent over the blip tester
+func TestPutRevV4(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
+
+	// Create blip tester with v4 protocol
+	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		noConflictsMode:    true,
+		connectingUsername: "user1",
+		connectingPassword: "1234",
+		blipProtocols:      []string{db.CBMobileReplicationV4.SubprotocolString()},
+	})
+	require.NoError(t, err, "Unexpected error creating BlipTester")
+	defer bt.Close()
+	collection := bt.restTester.GetSingleTestDatabaseCollection()
+
+	// 1. Send rev with history
+	history := "1@def, 2@abc"
+	sent, _, resp, err := bt.SendRev("foo", db.EncodeTestVersion("3@efg"), []byte(`{"key": "val"}`), blip.Properties{"history": db.EncodeTestHistory(history)})
+	assert.True(t, sent)
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Properties["Error-Code"])
+
+	// Validate against the bucket doc's HLV
+	doc, _, err := collection.GetDocWithXattr(base.TestCtx(t), "foo", db.DocUnmarshalNoHistory)
+	require.NoError(t, err)
+	pv, _ := db.ParseTestHistory(t, history)
+	db.RequireCVEqual(t, doc.HLV, "3@efg")
+	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
+
+	// 2. Update the document with a non-conflicting revision, where only cv is updated
+	sent, _, resp, err = bt.SendRev("foo", db.EncodeTestVersion("4@efg"), []byte(`{"key": "val"}`), blip.Properties{"history": db.EncodeTestHistory(history)})
+	assert.True(t, sent)
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Properties["Error-Code"])
+
+	// Validate against the bucket doc's HLV
+	doc, _, err = collection.GetDocWithXattr(base.TestCtx(t), "foo", db.DocUnmarshalNoHistory)
+	require.NoError(t, err)
+	db.RequireCVEqual(t, doc.HLV, "4@efg")
+	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
+
+	doc, _, err = collection.GetDocWithXattr(base.TestCtx(t), "foo", db.DocUnmarshalNoHistory)
+	require.NoError(t, err)
+
+	// 3. Update the document again with a non-conflicting revision from a different source (previous cv moved to pv)
+	updatedHistory := "1@def, 2@abc, 4@efg"
+	sent, _, resp, err = bt.SendRev("foo", db.EncodeTestVersion("1@jkl"), []byte(`{"key": "val"}`), blip.Properties{"history": db.EncodeTestHistory(updatedHistory)})
+	assert.True(t, sent)
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Properties["Error-Code"])
+
+	// Validate against the bucket doc's HLV
+	doc, _, err = collection.GetDocWithXattr(base.TestCtx(t), "foo", db.DocUnmarshalNoHistory)
+	require.NoError(t, err)
+	pv, _ = db.ParseTestHistory(t, updatedHistory)
+	db.RequireCVEqual(t, doc.HLV, "1@jkl")
+	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
+
+	// 4. Update the document again with a non-conflicting revision from a different source, and additional sources in history (previous cv moved to pv, and pv expanded)
+	updatedHistory = "1@def, 2@abc, 4@efg, 1@jkl, 1@mmm"
+	sent, _, resp, err = bt.SendRev("foo", db.EncodeTestVersion("1@nnn"), []byte(`{"key": "val"}`), blip.Properties{"history": db.EncodeTestHistory(updatedHistory)})
+	assert.True(t, sent)
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Properties["Error-Code"])
+
+	// Validate against the bucket doc's HLV
+	doc, _, err = collection.GetDocWithXattr(base.TestCtx(t), "foo", db.DocUnmarshalNoHistory)
+	require.NoError(t, err)
+	pv, _ = db.ParseTestHistory(t, updatedHistory)
+	db.RequireCVEqual(t, doc.HLV, "1@nnn")
+	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
+
+	// 5. Attempt to update the document again with a conflicting revision from a different source (previous cv not in pv), expect conflict
+	sent, _, resp, err = bt.SendRev("foo", db.EncodeTestVersion("1@pqr"), []byte(`{"key": "val"}`), blip.Properties{"history": db.EncodeTestHistory(updatedHistory)})
+	assert.True(t, sent)
+	require.Error(t, err)
+	assert.Equal(t, "409", resp.Properties["Error-Code"])
+
+	// 6. Test sending rev with merge versions included in history (for new key)
+	mvHistory := "3@def, 3@abc; 1@def, 2@abc"
+	sent, _, resp, err = bt.SendRev("boo", db.EncodeTestVersion("3@efg"), []byte(`{"key": "val"}`), blip.Properties{"history": db.EncodeTestHistory(mvHistory)})
+	assert.True(t, sent)
+	require.NoError(t, err)
+	assert.Equal(t, "", resp.Properties["Error-Code"])
+
+	// assert on bucket doc
+	doc, _, err = collection.GetDocWithXattr(base.TestCtx(t), "boo", db.DocUnmarshalNoHistory)
+	require.NoError(t, err)
+
+	pv, mv := db.ParseTestHistory(t, mvHistory)
+	db.RequireCVEqual(t, doc.HLV, "3@efg")
+	assert.Equal(t, base.CasToString(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
+	assert.True(t, reflect.DeepEqual(mv, doc.HLV.MergeVersions))
+}
+
 // Repro attempt for SG #3281
 //
 // - Set up a user w/ access to channel A
@@ -2445,7 +2549,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797) for _attachments subtest
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		// Setup

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -23,10 +23,8 @@ import (
 )
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.
-
 func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -42,7 +40,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	const docID = "pushAttachmentDoc"
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires push replication (CBG-3255)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -113,7 +111,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
@@ -186,7 +184,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	const doc1ID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -288,7 +286,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	const docID = "doc1"
 	var deltaSentCount int64
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			rtConfig)
@@ -367,7 +365,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			&rtConfig)
@@ -441,7 +439,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // v2 protocol test
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // requires delta sync - CBG-3736
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -509,7 +507,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication"
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 
 	var deltaCacheHitsStart int64
 	var deltaCacheMissesStart int64
@@ -608,7 +606,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -757,7 +755,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	}
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
@@ -847,7 +845,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -957,7 +955,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // delta sync not implemented for Version Vectors replication (CBG-3736)
 	const docID = "doc1"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {


### PR DESCRIPTION
CBG-3255

Adds push replication support for HLV clients. Delta sync and attachments are not yet supported (pending CBG-3736, CBG-3797).

On proposeChanges, checks whether the incoming CV and parent version represent a new document, known version, valid update, or conflict. Uses the same handling as revTreeID (conflict if parent version isn’t the server’s current version), with the additional non-conflict case where the incoming CV and server CV share the same source and the incoming CV is a newer version.

For the incoming rev, detects conflict based on the incoming cv (based on the implicit hierarchy in an HLV, where cv > pv > mv).

Includes some test helpers to support writing tests with simplified versions (e.g. 1@abc) while still asserting for encoded source and version.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2317/
