### PR TITLE
CBG-3797 Attachment handling for HLV push replication

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -799,7 +799,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 		}
 		var status ProposedRevStatus
 		var currentRev string
-		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+		if bh.useHLV() {
 			status, currentRev = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, rev, parentRevID)
 		} else {
 			status, currentRev = bh.collection.CheckProposedRev(bh.loggingCtx, docID, rev, parentRevID)
@@ -943,7 +943,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 	}()
 
-	if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 && bh.conflictResolver != nil {
+	if bh.useHLV() && bh.conflictResolver != nil {
 		return base.HTTPErrorf(http.StatusNotImplemented, "conflict resolver handling (ISGR) not yet implemented for v4 protocol")
 	}
 
@@ -1001,17 +1001,18 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	}
 
 	var history []string
+	historyStr := rq.Properties[RevMessageHistory]
 	var incomingHLV HybridLogicalVector
 	// Build history/HLV
-	if bh.activeCBMobileSubprotocol < CBMobileReplicationV4 {
+	if !bh.useHLV() {
 		newDoc.RevID = rev
 		history = []string{rev}
-		if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" {
+		if historyStr != "" {
 			history = append(history, strings.Split(historyStr, ",")...)
 		}
 	} else {
 		versionVectorStr := rev
-		if historyStr := rq.Properties[RevMessageHistory]; historyStr != "" {
+		if historyStr != "" {
 			versionVectorStr += ";" + historyStr
 		}
 		incomingHLV, err = extractHLVFromBlipMessage(versionVectorStr)
@@ -1041,7 +1042,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		//       due to no-conflict write restriction, but we still need to enforce security here to prevent leaking data about previous
 		//       revisions to malicious actors (in the scenario where that user has write but not read access).
 		var deltaSrcRev DocumentRevision
-		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+		if bh.useHLV() {
 			cv := Version{}
 			cv.SourceID, cv.Value = incomingHLV.GetCurrentVersion()
 			deltaSrcRev, err = bh.collection.GetCV(bh.loggingCtx, docID, &cv, RevCacheOmitBody)
@@ -1113,31 +1114,32 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 
 	var rawBucketDoc *sgbucket.BucketDocument
 
-	// Pull out attachments
+	// Attachment processing
 	if injectedAttachmentsForDelta || bytes.Contains(bodyBytes, []byte(BodyAttachments)) {
-		// temporarily error here if V4
-		if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
-			return base.HTTPErrorf(http.StatusNotImplemented, "attachment handling not yet supported for v4 protocol")
-		}
+
 		body := newDoc.Body(bh.loggingCtx)
 
 		var currentBucketDoc *Document
 
-		// Look at attachments with revpos > the last common ancestor's
-		minRevpos := 1
-		if len(history) > 0 {
-			currentDoc, rawDoc, err := bh.collection.GetDocumentWithRaw(bh.loggingCtx, docID, DocUnmarshalSync)
-			// If we're able to obtain current doc data then we should use the common ancestor generation++ for min revpos
-			// as we will already have any attachments on the common ancestor so don't need to ask for them.
-			// Otherwise we'll have to go as far back as we can in the doc history and choose the last entry in there.
-			if err == nil {
-				commonAncestor := currentDoc.History.findAncestorFromSet(currentDoc.CurrentRev, history)
-				minRevpos, _ = ParseRevID(bh.loggingCtx, commonAncestor)
-				minRevpos++
-				rawBucketDoc = rawDoc
-				currentBucketDoc = currentDoc
-			} else {
-				minRevpos, _ = ParseRevID(bh.loggingCtx, history[len(history)-1])
+		minRevpos := 0
+		if historyStr != "" {
+			// fetch current bucket doc.  Treats error as not found
+			currentBucketDoc, rawBucketDoc, _ = bh.collection.GetDocumentWithRaw(bh.loggingCtx, docID, DocUnmarshalSync)
+
+			// For revtree clients, can use revPos as an optimization.  HLV always compares incoming
+			// attachments with current attachments on the document
+			if !bh.useHLV() {
+				// Look at attachments with revpos > the last common ancestor's
+				// If we're able to obtain current doc data then we should use the common ancestor generation++ for min revpos
+				// as we will already have any attachments on the common ancestor so don't need to ask for them.
+				// Otherwise we'll have to go as far back as we can in the doc history and choose the last entry in there.
+				if currentBucketDoc != nil {
+					commonAncestor := currentBucketDoc.History.findAncestorFromSet(currentBucketDoc.CurrentRev, history)
+					minRevpos, _ = ParseRevID(bh.loggingCtx, commonAncestor)
+					minRevpos++
+				} else {
+					minRevpos, _ = ParseRevID(bh.loggingCtx, history[len(history)-1])
+				}
 			}
 		}
 
@@ -1155,7 +1157,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 				if !ok {
 					// If we don't have this attachment already, ensure incoming revpos is greater than minRevPos, otherwise
 					// update to ensure it's fetched and uploaded
-					bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, rev)
+					if minRevpos > 0 {
+						bodyAtts[name].(map[string]interface{})["revpos"], _ = ParseRevID(bh.loggingCtx, rev)
+					}
 					continue
 				}
 
@@ -1226,7 +1230,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// If the doc is a tombstone we want to allow conflicts when running SGR2
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
-	if bh.activeCBMobileSubprotocol >= CBMobileReplicationV4 {
+	if bh.useHLV() {
 		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc)
 	} else if bh.conflictResolver != nil {
 		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
@@ -1567,4 +1571,8 @@ func allowedAttachmentKey(docID, digest string, activeCBMobileSubprotocol CBMobi
 
 func (bh *blipHandler) logEndpointEntry(profile, endpoint string) {
 	base.InfofCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Type:%s %s", bh.serialNumber, profile, endpoint)
+}
+
+func (bh *blipHandler) useHLV() bool {
+	return bh.activeCBMobileSubprotocol >= CBMobileReplicationV4
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -332,7 +332,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getCurrentVersion(ctx, doc); err != nil {
 		// TODO: CBG-3814 - pending support of channel removal for CV
-		base.ErrorfCtx(ctx, "pending CBG-3213 support of channel removal for CV: %v", err)
+		base.ErrorfCtx(ctx, "pending CBG-3814 support of channel removal for CV: %v", err)
 	}
 
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -694,7 +694,7 @@ func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, sou
 }
 
 // GetDocumentCurrentVersion fetches the document by key and returns the current version
-func (c *DatabaseCollection) GetDocumentCurrentVersion(t *testing.T, key string) (source string, version string) {
+func (c *DatabaseCollection) GetDocumentCurrentVersion(t testing.TB, key string) (source string, version string) {
 	ctx := base.TestCtx(t)
 	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2265,7 +2265,6 @@ func TestUpdateExistingAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
@@ -2279,8 +2278,8 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 
-		doc1Version := rt.PutDoc(doc1ID, `{}`)
-		doc2Version := rt.PutDoc(doc2ID, `{}`)
+		doc1Version := btc.PutDoc(doc1ID, `{}`)
+		doc2Version := btc.PutDoc(doc2ID, `{}`)
 
 		require.NoError(t, rt.WaitForPendingChanges())
 
@@ -2330,7 +2329,6 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 	}
 	const doc1ID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -2340,7 +2338,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
 		defer btc.Close()
 		// Add doc1 and doc2
-		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
+		doc1Version := btc.PutDoc(doc1ID, `{}`)
 
 		require.NoError(t, btc.rt.WaitForPendingChanges())
 
@@ -2381,7 +2379,6 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const docID = "doc"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -2392,7 +2389,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
 		defer btc.Close()
 		// Push an initial rev with attachment data
-		initialVersion := btc.rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		initialVersion := btc.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
 		err := btc.rt.WaitForPendingChanges()
 		assert.NoError(t, err)
 
@@ -2405,7 +2402,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		// Push a revision with a bunch of history simulating doc updated on mobile device
 		// Note this references revpos 1 and therefore SGW has it - Shouldn't need proveAttachment
 		proveAttachmentBefore := btc.pushReplication.replicationStats.ProveAttachment.Value()
-		revid, err := btcRunner.PushRevWithHistory(btc.id, docID, initialVersion.RevTreeID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
+		revid, err := btcRunner.PushRevWithHistory(btc.id, docID, initialVersion.GetRev(btc.UseHLV()), []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`), 25, 5)
 		assert.NoError(t, err)
 		proveAttachmentAfter := btc.pushReplication.replicationStats.ProveAttachment.Value()
 		assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
@@ -2424,7 +2421,6 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
@@ -2435,7 +2431,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		defer btc.Close()
 		// Create rev 1 with the hello.txt attachment
 		const docID = "doc"
-		version := btc.rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		version := btc.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
 		err := btc.rt.WaitForPendingChanges()
 		assert.NoError(t, err)
 
@@ -2451,7 +2447,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		btcRunner.AttachmentsLock(btc.id).Unlock()
 
 		// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
-		_, err = btcRunner.PushRevWithHistory(btc.id, docID, version.RevTreeID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
+		_, err = btcRunner.PushRevWithHistory(btc.id, docID, version.GetRev(btc.UseHLV()), []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
 		require.NoError(t, err)
 
 		// Ensure message and attachment is pushed up
@@ -2608,7 +2604,6 @@ func TestCBLRevposHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol (CBG-3797)
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
@@ -2622,8 +2617,8 @@ func TestCBLRevposHandling(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
 		defer btc.Close()
 
-		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
-		doc2Version := btc.rt.PutDoc(doc2ID, `{}`)
+		doc1Version := btc.PutDoc(doc1ID, `{}`)
+		doc2Version := btc.PutDoc(doc2ID, `{}`)
 		require.NoError(t, btc.rt.WaitForPendingChanges())
 
 		err := btcRunner.StartOneshotPull(btc.id)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2546,7 +2546,6 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires HLV revpos handling (CBG-3797) for _attachments subtest
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		// Setup

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2348,6 +2348,17 @@ func (v DocVersion) Equal(o DocVersion) bool {
 	return true
 }
 
+func (v DocVersion) GetRev(useHLV bool) string {
+	if useHLV {
+		if v.CV.SourceID == "" {
+			return ""
+		}
+		return v.CV.String()
+	} else {
+		return v.RevTreeID
+	}
+}
+
 // Digest returns the digest for the current version
 func (v DocVersion) Digest() string {
 	return strings.Split(v.RevTreeID, "-")[1]


### PR DESCRIPTION
CBG-3797

HLV clients don't consider revpos, and evaluate whether they need to request an attachment based on the existing set of attachments on the document.

SGW still needs to persist revpos into _attachments to support revtree clients.  For new attachments added by HLV client, revpos is set to the generation of SGW's computed revTreeID for the incoming revision.


## Dependencies (if applicable)
- [ ] After CBG-3255 is merged, rebase on beryllium before merging

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2320/
