### PR TITLE
CBG-3791: change getAuthScopeHandleCreateDB method to not expand environment variables

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -180,24 +180,13 @@ func getAuthScopeHandleCreateDB(ctx context.Context, h *handler) (bucketName str
 	var dbConfigBody struct {
 		Bucket string `json:"bucket"`
 	}
-	reader := bytes.NewReader(bodyJSON)
 
-	// read and decode json to pull bucket name from the config
-	b, err := io.ReadAll(reader)
+	bodyJSON, err = sanitiseConfig(ctx, bodyJSON, h.server.Config.Unsupported.AllowDbConfigEnvVars)
 	if err != nil {
 		return "", err
 	}
 
-	// Expand environment variables if needed
-	if base.BoolDefault(h.server.Config.Unsupported.AllowDbConfigEnvVars, true) {
-		b, err = expandEnv(h.ctx(), b)
-		if err != nil {
-			return "", err
-		}
-	}
-	b = base.ConvertBackQuotedStrings(b)
-
-	d := base.JSONDecoder(bytes.NewBuffer(b))
+	d := base.JSONDecoder(bytes.NewBuffer(bodyJSON))
 	err = d.Decode(&dbConfigBody)
 	if err != nil {
 		return "", err

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4052,7 +4052,7 @@ func TestDatabaseCreationWithEnvVariable(t *testing.T) {
 
 	// create db config with sync function that has env variable in it
 	bucketConfig := fmt.Sprintf(
-		`{"bucket": "%s",
+		`{"bucket": `+"`"+"%s"+"`"+`,
 		  "scopes": {
 			"%s": {
 				"collections": {
@@ -4070,6 +4070,57 @@ func TestDatabaseCreationWithEnvVariable(t *testing.T) {
 	)
 
 	// create db with config and assert it is successful
-	resp := rt.SendAdminRequestWithAuth("PUT", "/db/", bucketConfig, rest.MobileSyncGatewayRole.RoleName, "password")
+	resp := rt.SendAdminRequestWithAuth(http.MethodPut, "/db/", bucketConfig, rest.MobileSyncGatewayRole.RoleName, "password")
+	rest.RequireStatus(t, resp, http.StatusCreated)
+}
+
+func TestDatabaseCreationWithEnvVariableWithBackticks(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	tb := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer tb.Close(ctx)
+
+	// disable AllowDbConfigEnvVars to avoid attempting to expand variables + enable admin auth
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{PersistentConfig: true, MutateStartupConfig: func(config *rest.StartupConfig) {
+		config.Unsupported.AllowDbConfigEnvVars = base.BoolPtr(false)
+	},
+		AdminInterfaceAuthentication: true,
+	})
+	defer rt.Close()
+
+	// create a role to authenticate with in admin endpoint
+	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+	rest.MakeUser(t, httpClient, eps[0], rest.MobileSyncGatewayRole.RoleName, "password", []string{fmt.Sprintf("%s[%s]", rest.MobileSyncGatewayRole.RoleName, tb.GetName())})
+	defer rest.DeleteUser(t, httpClient, eps[0], rest.MobileSyncGatewayRole.RoleName)
+
+	dataStore1, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	dataStore1Name, ok := base.AsDataStoreName(dataStore1)
+	require.True(t, ok)
+	syncFunction := `function (doc) { console.log(\"${environment}\"); return true }`
+
+	bucketConfig := fmt.Sprintf(
+		`{"bucket": "%s",
+		  "scopes": {
+			"%s": {
+				"collections": {
+					"%s": {
+        					"sync": "%s"
+					}
+				}
+			}
+		  },
+		  "num_index_replicas": 0,
+		  "enable_shared_bucket_access": true,
+		  "use_views": false}`,
+		tb.GetName(), dataStore1Name.ScopeName(), dataStore1Name.CollectionName(),
+		syncFunction,
+	)
+	// create db with config and assert it is successful
+	resp := rt.SendAdminRequestWithAuth(http.MethodPut, "/backticks/", bucketConfig, rest.MobileSyncGatewayRole.RoleName, "password")
 	rest.RequireStatus(t, resp, http.StatusCreated)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1437,7 +1437,7 @@ func TestEventConfigValidationInvalid(t *testing.T) {
 
 	buf := bytes.NewBufferString(dbConfigJSON)
 	var dbConfig DbConfig
-	err := DecodeAndSanitiseConfig(base.TestCtx(t), buf, &dbConfig, true)
+	err := DecodeAndSanitiseStartupConfig(base.TestCtx(t), buf, &dbConfig, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "document_scribbled_on")
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -1134,8 +1134,8 @@ func (config *DbConfig) redactInPlace(ctx context.Context) error {
 	return nil
 }
 
-// DecodeAndSanitiseConfig will sanitise a config from an io.Reader and unmarshal it into the given config parameter.
-func DecodeAndSanitiseConfig(ctx context.Context, r io.Reader, config interface{}, disallowUnknownFields bool) (err error) {
+// DecodeAndSanitiseStartupConfig will sanitise a config from an io.Reader and unmarshal it into the given config parameter.
+func DecodeAndSanitiseStartupConfig(ctx context.Context, r io.Reader, config interface{}, disallowUnknownFields bool) (err error) {
 	b, err := io.ReadAll(r)
 	if err != nil {
 		return err

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -370,7 +370,7 @@ func LoadLegacyServerConfig(ctx context.Context, path string) (config *LegacySer
 
 // readLegacyServerConfig returns a validated LegacyServerConfig from an io.Reader
 func readLegacyServerConfig(ctx context.Context, r io.Reader) (config *LegacyServerConfig, err error) {
-	err = DecodeAndSanitiseConfig(ctx, r, &config, true)
+	err = DecodeAndSanitiseStartupConfig(ctx, r, &config, true)
 	if err != nil {
 		return config, err
 	}

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -217,7 +217,7 @@ func LoadStartupConfigFromPath(ctx context.Context, path string) (*StartupConfig
 	defer func() { _ = rc.Close() }()
 
 	var sc StartupConfig
-	err = DecodeAndSanitiseConfig(ctx, rc, &sc, true)
+	err = DecodeAndSanitiseStartupConfig(ctx, rc, &sc, true)
 	return &sc, err
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1090,17 +1090,10 @@ func (h *handler) readSanitizeJSON(val interface{}) error {
 		return err
 	}
 
-	// Expand environment variables.
-	if base.BoolDefault(h.server.Config.Unsupported.AllowDbConfigEnvVars, true) {
-		content, err = expandEnv(h.ctx(), content)
-		if err != nil {
-			return err
-		}
+	content, err = sanitiseConfig(h.ctx(), content, h.server.Config.Unsupported.AllowDbConfigEnvVars)
+	if err != nil {
+		return err
 	}
-
-	// Convert the back quotes into double-quotes, escapes literal
-	// backslashes, newlines or double-quotes with backslashes.
-	content = base.ConvertBackQuotedStrings(content)
 
 	// Decode the body bytes into target structure.
 	decoder := base.JSONDecoder(bytes.NewReader(content))


### PR DESCRIPTION
CBG-3791

- Removed the use of DecodeAndSanitiseConfig as it expands environment variables 
- As we only need bucket name from this function just kept much the functionality the same but with no expansion of environment variables.  
- Kept the use of Decode over Unmarshal as I feel it's more memory efficient and given we unmarshal the config later in readSanitizeDbConfigJSON I didn't want this done twice. 
- Evaluated the use of readSanitizeDbConfigJSON in place of what I have done in this PR but found it awkward putting the bytes back into a reader for use later. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2327/
