### PR TITLE
CBG-3237: hook CompactionTombstoneStartTime up

### DIFF
--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -36,7 +36,7 @@ func NewTombstoneCompactionManager() *BackgroundManager {
 
 func (t *TombstoneCompactionManager) Init(ctx context.Context, options map[string]interface{}, clusterStatus []byte) error {
 	database := options["database"].(*Database)
-	database.DbStats.Database().CompactionAttachmentStartTime.Set(time.Now().UTC().Unix())
+	database.DbStats.Database().CompactionTombstoneStartTime.Set(time.Now().UTC().Unix())
 
 	return nil
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2767,7 +2767,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	assert.Equal(t, db.BackgroundProcessStateCompleted, tombstoneCompactionStatus.State)
 	assert.Empty(t, tombstoneCompactionStatus.LastErrorMessage)
 	assert.Equal(t, 0, int(tombstoneCompactionStatus.DocsPurged))
-	firstStartTimeStat := rt.GetDatabase().DbStats.Database().CompactionAttachmentStartTime.Value()
+	firstStartTimeStat := rt.GetDatabase().DbStats.Database().CompactionTombstoneStartTime.Value()
 	assert.NotEqual(t, 0, firstStartTimeStat)
 
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact", "")
@@ -2783,7 +2783,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 		return tombstoneCompactionStatus.State == db.BackgroundProcessStateCompleted
 	})
 	assert.NoError(t, err)
-	assert.True(t, rt.GetDatabase().DbStats.Database().CompactionAttachmentStartTime.Value() > firstStartTimeStat)
+	assert.True(t, rt.GetDatabase().DbStats.Database().CompactionTombstoneStartTime.Value() > firstStartTimeStat)
 
 	resp = rt.SendAdminRequest("GET", "/{{.db}}/_compact", "")
 	RequireStatus(t, resp, http.StatusOK)


### PR DESCRIPTION
CBG-3237

- Tombstone compaction was incorrectly using attachment compaction start time
- Change to the test using this incorrect metric too

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2325/
