### PR TITLE
CBG-3279: Reduce compaction error logging volume 

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -1465,7 +1465,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 					_, addErr := collection.dataStore.Add(tombstonesRow.Id, 0, purgeBody)
 					if addErr != nil {
 						addErrorCount++
-						base.InfofCtx(ctx, base.KeyAll, "problem compacting key %s (add) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), addErr)
+						base.InfofCtx(ctx, base.KeyAll, "Couldn't compact key %s (add): %v", base.UD(tombstonesRow.Id), addErr)
 						continue
 					}
 
@@ -1475,11 +1475,11 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 
 					if delErr := collection.dataStore.Delete(tombstonesRow.Id); delErr != nil {
 						deleteErrorCount++
-						base.InfofCtx(ctx, base.KeyAll, "problem compacting key %s (delete) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), delErr)
+						base.InfofCtx(ctx, base.KeyAll, "Couldn't compact key %s (delete): %v", base.UD(tombstonesRow.Id), delErr)
 					}
 				} else {
 					purgeErrorCount++
-					base.InfofCtx(ctx, base.KeyAll, "problem compacting key %s (purge) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), purgeErr)
+					base.InfofCtx(ctx, base.KeyAll, "Couldn't compact key %s (purge): %v", base.UD(tombstonesRow.Id), purgeErr)
 				}
 			}
 
@@ -1507,7 +1507,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 	base.InfofCtx(ctx, base.KeyAll, "Finished compaction of purged tombstones for %s... Total Tombstones Compacted: %d", base.MD(db.Name), purgedDocCount)
 
 	if purgeErrorCount > 0 || deleteErrorCount > 0 || addErrorCount > 0 {
-		base.WarnfCtx(ctx, "compaction finished with %d add key errors, %d delete key errors and %d purge key errors", addErrorCount, deleteErrorCount, purgeErrorCount)
+		base.WarnfCtx(ctx, "Compaction finished with %d errors (add: %d, delete: %d, purge: %d)", addErrorCount+deleteErrorCount+purgeErrorCount, addErrorCount, deleteErrorCount, purgeErrorCount)
 	}
 
 	return purgedDocCount, nil

--- a/db/database.go
+++ b/db/database.go
@@ -1506,7 +1506,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 	}
 	base.InfofCtx(ctx, base.KeyAll, "Finished compaction of purged tombstones for %s... Total Tombstones Compacted: %d", base.MD(db.Name), purgedDocCount)
 
-	if purgedDocCount > 0 || deleteErrorCount > 0 || addErrorCount > 0 {
+	if purgeErrorCount > 0 || deleteErrorCount > 0 || addErrorCount > 0 {
 		base.ErrorfCtx(ctx, "compaction finished with %d add key errors, %d delete key errors and %d purge key errors", addErrorCount, deleteErrorCount, purgeErrorCount)
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -1465,7 +1465,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 					_, addErr := collection.dataStore.Add(tombstonesRow.Id, 0, purgeBody)
 					if addErr != nil {
 						addErrorCount++
-						base.InfofCtx(ctx, base.KeyAll, "Error compacting key %s (add) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), addErr)
+						base.InfofCtx(ctx, base.KeyAll, "problem compacting key %s (add) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), addErr)
 						continue
 					}
 
@@ -1475,11 +1475,11 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 
 					if delErr := collection.dataStore.Delete(tombstonesRow.Id); delErr != nil {
 						deleteErrorCount++
-						base.InfofCtx(ctx, base.KeyAll, "Error compacting key %s (delete) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), delErr)
+						base.InfofCtx(ctx, base.KeyAll, "problem compacting key %s (delete) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), delErr)
 					}
 				} else {
 					purgeErrorCount++
-					base.InfofCtx(ctx, base.KeyAll, "Error compacting key %s (purge) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), purgeErr)
+					base.InfofCtx(ctx, base.KeyAll, "problem compacting key %s (purge) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), purgeErr)
 				}
 			}
 
@@ -1507,7 +1507,7 @@ func (db *Database) Compact(ctx context.Context, skipRunningStateCheck bool, cal
 	base.InfofCtx(ctx, base.KeyAll, "Finished compaction of purged tombstones for %s... Total Tombstones Compacted: %d", base.MD(db.Name), purgedDocCount)
 
 	if purgeErrorCount > 0 || deleteErrorCount > 0 || addErrorCount > 0 {
-		base.ErrorfCtx(ctx, "compaction finished with %d add key errors, %d delete key errors and %d purge key errors", addErrorCount, deleteErrorCount, purgeErrorCount)
+		base.WarnfCtx(ctx, "compaction finished with %d add key errors, %d delete key errors and %d purge key errors", addErrorCount, deleteErrorCount, purgeErrorCount)
 	}
 
 	return purgedDocCount, nil


### PR DESCRIPTION

CBG-3279

Log at info level for each operation error (add, delete and purge) keeping track of how many errors each one has so we can log once at end of compaction showing amount of errors for each operation throughout compaction run has.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
