### PR TITLE
CBG-3463: stop error logs filling up with db under maintenance messages. 

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1441,9 +1441,8 @@ func (h *handler) writeError(err error) {
 		status, message := base.ErrorAsHTTPStatus(err)
 		h.writeStatus(status, message)
 		if status >= 500 {
-			// Log additional context when the handler has a database reference
-			if h.db != nil {
-				base.ErrorfCtx(h.ctx(), "%s: %v", h.formatSerialNumber(), err)
+			if status == http.StatusServiceUnavailable {
+				base.InfofCtx(h.ctx(), base.KeyHTTP, "%s: %v", h.formatSerialNumber(), err)
 			} else {
 				base.ErrorfCtx(h.ctx(), "%s: %v", h.formatSerialNumber(), err)
 			}


### PR DESCRIPTION
CBG-3463

Log 503 errors at info level to stop logs filling error logs with db under maintenance messages. Did try to add extra check to see if db state != Online but panics when handler has no db reference in it. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a