### PR TITLE
CBG-3795: Deprecate enable_star_channel config option

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -255,7 +255,7 @@ type ChannelCacheConfig struct {
 	MaxWaitPending       *uint32 `json:"max_wait_pending,omitempty"`           // Max wait for pending sequence before skipping
 	MaxNumPending        *int    `json:"max_num_pending,omitempty"`            // Max number of pending sequences before skipping
 	MaxWaitSkipped       *uint32 `json:"max_wait_skipped,omitempty"`           // Max wait for skipped sequence before abandoning
-	EnableStarChannel    *bool   `json:"enable_star_channel,omitempty"`        // Enable star channel
+	EnableStarChannel    *bool   `json:"enable_star_channel,omitempty"`        // Deprecated: Enable star channel
 	MaxLength            *int    `json:"max_length,omitempty"`                 // Maximum number of entries maintained in cache per channel
 	MinLength            *int    `json:"min_length,omitempty"`                 // Minimum number of entries maintained in cache per channel
 	ExpirySeconds        *int    `json:"expiry_seconds,omitempty"`             // Time (seconds) to keep entries in cache beyond the minimum retained

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1062,6 +1062,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 			// set EnableStarChannelLog directly here (instead of via NewDatabaseContext), so that it's set when we create the channels view in ConnectToBucket
 			if config.CacheConfig.ChannelCacheConfig.EnableStarChannel != nil {
 				db.EnableStarChannelLog = *config.CacheConfig.ChannelCacheConfig.EnableStarChannel
+				base.WarnfCtx(ctx, `Deprecation notice: enable_star_channel config option is due to be removed, in future star channel will always be enabled`)
 			}
 			if config.CacheConfig.ChannelCacheConfig.MaxLength != nil {
 				cacheOptions.ChannelCacheMaxLength = *config.CacheConfig.ChannelCacheConfig.MaxLength


### PR DESCRIPTION

CBG-3795

Deprecate enable_star_channel on cache config. Print warning when the config option is set.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
