### PR TITLE
CBG-3742: Allow registry rollbacks based on db config doc rollbacks

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -187,6 +187,10 @@ func (g *GlobalStat) initConfigStats() error {
 	if err != nil {
 		return err
 	}
+	configStat.DatabaseCollectionCollisions, err = NewIntStat(ConfigSubsystem, "database_config_collection_conflicts", StatUnitBytes, DatabaseCollectionConflictDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	g.ConfigStat = configStat
 	return nil
 }
@@ -354,6 +358,8 @@ type ResourceUtilization struct {
 type ConfigStat struct {
 	// The number of times the bucket specified in a database config doesn't match the bucket it's found in.
 	DatabaseBucketMismatches *SgwIntStat `json:"database_config_bucket_mismatches"`
+	// The number of times the config was rolled back to an invalid state (conflicting collections)
+	DatabaseCollectionCollisions *SgwIntStat `json:"database_config_collection_collisions"`
 }
 
 type DbStats struct {

--- a/base/stats.go
+++ b/base/stats.go
@@ -187,7 +187,7 @@ func (g *GlobalStat) initConfigStats() error {
 	if err != nil {
 		return err
 	}
-	configStat.DatabaseCollectionCollisions, err = NewIntStat(ConfigSubsystem, "database_config_collection_conflicts", StatUnitBytes, DatabaseCollectionConflictDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	configStat.DatabaseRollbackCollectionCollisions, err = NewIntStat(ConfigSubsystem, "database_config_collection_conflicts", StatUnitBytes, DatabaseCollectionConflictDesc, StatAddedVersion3dot1dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -359,7 +359,7 @@ type ConfigStat struct {
 	// The number of times the bucket specified in a database config doesn't match the bucket it's found in.
 	DatabaseBucketMismatches *SgwIntStat `json:"database_config_bucket_mismatches"`
 	// The number of times the config was rolled back to an invalid state (conflicting collections)
-	DatabaseCollectionCollisions *SgwIntStat `json:"database_config_collection_collisions"`
+	DatabaseRollbackCollectionCollisions *SgwIntStat `json:"database_config_rollback_collection_collisions"`
 }
 
 type DbStats struct {

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -71,7 +71,8 @@ const (
 
 // error stat
 const (
-	DatabaseBucketMismatchesDesc = "The total number of times a database config is polled from a bucket that doesn't match the bucket specified in the database config."
+	DatabaseBucketMismatchesDesc   = "The total number of times a database config is polled from a bucket that doesn't match the bucket specified in the database config."
+	DatabaseCollectionConflictDesc = "The total number of times a database config is rolled back to an invalid state (collection conflicts)."
 )
 
 // cache stats descriptions

--- a/rest/config.go
+++ b/rest/config.go
@@ -293,6 +293,7 @@ type invalidConfigInfo struct {
 	logged              bool
 	configBucketName    string
 	persistedBucketName string
+	collectionConflicts bool
 }
 
 type invalidDatabaseConfigs struct {
@@ -303,27 +304,39 @@ type invalidDatabaseConfigs struct {
 // addInvalidDatabase adds a db to invalid dbconfig map if it doesn't exist in there yet and will log for it at warning level
 // if the db already exists there we will calculate if we need to log again according to the config update interval
 func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname string, cnf DatabaseConfig, bucket string) {
-	configInfo := invalidConfigInfo{
-		configBucketName:    *cnf.Bucket,
-		persistedBucketName: bucket,
-	}
 	d.m.Lock()
 	defer d.m.Unlock()
 	if d.dbNames[dbname] == nil {
 		// db hasn't been tracked as invalid config yet so add it
-		d.dbNames[dbname] = &configInfo
+		d.dbNames[dbname] = &invalidConfigInfo{
+			configBucketName:    *cnf.Bucket,
+			persistedBucketName: bucket,
+			collectionConflicts: cnf.Version == invalidDatabaseConflictingCollectionsVersion,
+		}
 	}
-	logMessage := fmt.Sprintf("Mismatch in database config for database %q bucket name: %q and backend bucket: %q You must update database config immediately", base.MD(dbname), base.MD(d.dbNames[dbname].configBucketName), base.MD(d.dbNames[dbname].persistedBucketName))
+
+	logMessage := "Must repair invalid database config for %q for it to be usable!"
+	logArgs := []interface{}{base.MD(dbname)}
+
+	// build log message
+	if isBucketMismatch := *cnf.Bucket != bucket; isBucketMismatch {
+		base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Add(1)
+		logMessage += " Mismatched buckets (config bucket: %q, actual bucket: %q)"
+		logArgs = append(logArgs, base.MD(d.dbNames[dbname].configBucketName), base.MD(d.dbNames[dbname].persistedBucketName))
+	} else if isRegistryDbConfigVersionInvalid(cnf.Version) {
+		base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseCollectionCollisions.Add(1)
+		logMessage += " Conflicting collections detected"
+	}
+
 	// if we get here we already have the db logged as an invalid config, so now we need to work out iof we should log for it now
 	if !d.dbNames[dbname].logged {
 		// we need to log at warning if we haven't already logged for this particular corrupt db config
-		base.WarnfCtx(ctx, logMessage)
+		base.WarnfCtx(ctx, logMessage, logArgs...)
 		d.dbNames[dbname].logged = true
 	} else {
 		// already logged this entry at warning so need to log at info now
-		base.InfofCtx(ctx, base.KeyConfig, logMessage)
+		base.InfofCtx(ctx, base.KeyConfig, logMessage, logArgs...)
 	}
-	base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Add(1)
 }
 
 func (d *invalidDatabaseConfigs) exists(dbname string) (*invalidConfigInfo, bool) {
@@ -1749,7 +1762,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 			// Handle invalid database registry entries. Either:
 			// - CBG-3292: Bucket in config doesn't match the actual bucket
 			// - CBG-3742: Registry entry marked invalid (due to rollback causing collection conflict)
-			if cnf.Version == invalidDatabaseVersion || bucket != cnf.GetBucketName() {
+			if isRegistryDbConfigVersionInvalid(cnf.Version) || bucket != cnf.GetBucketName() {
 				sc.handleInvalidDatabaseConfig(ctx, bucket, *cnf)
 				continue
 			}

--- a/rest/config.go
+++ b/rest/config.go
@@ -323,9 +323,12 @@ func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname 
 		base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Add(1)
 		logMessage += " Mismatched buckets (config bucket: %q, actual bucket: %q)"
 		logArgs = append(logArgs, base.MD(d.dbNames[dbname].configBucketName), base.MD(d.dbNames[dbname].persistedBucketName))
-	} else if isRegistryDbConfigVersionInvalid(cnf.Version) {
+	} else if cnf.Version == invalidDatabaseConflictingCollectionsVersion {
 		base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseCollectionCollisions.Add(1)
 		logMessage += " Conflicting collections detected"
+	} else {
+		// Nothing is expected to hit this case, but we might add more invalid sentinel values and forget to update this code.
+		logMessage += "Invalid config with no known cause."
 	}
 
 	// if we get here we already have the db logged as an invalid config, so now we need to work out iof we should log for it now

--- a/rest/config.go
+++ b/rest/config.go
@@ -328,7 +328,7 @@ func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname 
 		logMessage += " Conflicting collections detected"
 	} else {
 		// Nothing is expected to hit this case, but we might add more invalid sentinel values and forget to update this code.
-		logMessage += " Invalid config with no known cause."
+		logMessage += " Database was marked invalid. See logs for details."
 	}
 
 	// if we get here we already have the db logged as an invalid config, so now we need to work out iof we should log for it now

--- a/rest/config.go
+++ b/rest/config.go
@@ -328,7 +328,7 @@ func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname 
 		logMessage += " Conflicting collections detected"
 	} else {
 		// Nothing is expected to hit this case, but we might add more invalid sentinel values and forget to update this code.
-		logMessage += "Invalid config with no known cause."
+		logMessage += " Invalid config with no known cause."
 	}
 
 	// if we get here we already have the db logged as an invalid config, so now we need to work out iof we should log for it now

--- a/rest/config.go
+++ b/rest/config.go
@@ -324,7 +324,7 @@ func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname 
 		logMessage += " Mismatched buckets (config bucket: %q, actual bucket: %q)"
 		logArgs = append(logArgs, base.MD(d.dbNames[dbname].configBucketName), base.MD(d.dbNames[dbname].persistedBucketName))
 	} else if cnf.Version == invalidDatabaseConflictingCollectionsVersion {
-		base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseCollectionCollisions.Add(1)
+		base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseRollbackCollectionCollisions.Add(1)
 		logMessage += " Conflicting collections detected"
 	} else {
 		// Nothing is expected to hit this case, but we might add more invalid sentinel values and forget to update this code.

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -417,10 +417,10 @@ func (b *bootstrapContext) getConfigVersionWithRetry(ctx context.Context, bucket
 			// If the config has a newer version than requested, return the config but alert caller that they have
 			// requested a stale version.
 			return false, base.ErrConfigVersionMismatch, config
-		} else {
-			base.InfofCtx(ctx, base.KeyConfig, "getConfigVersionWithRetry for key %s found version mismatch, retrying.  Requested: %s, Found: %s", metadataKey, version, config.Version)
-			return true, base.ErrConfigRegistryRollback, config
 		}
+
+		base.InfofCtx(ctx, base.KeyConfig, "getConfigVersionWithRetry for key %s found version mismatch, retrying.  Requested: %s, Found: %s", metadataKey, version, config.Version)
+		return true, base.ErrConfigRegistryRollback, config
 	}
 
 	// Kick off the retry loop
@@ -558,7 +558,7 @@ func (b *bootstrapContext) rollbackRegistry(ctx context.Context, bucketName, gro
 
 		// non-nil config indicates database version in registry should be updated to match config
 		base.InfofCtx(ctx, base.KeyConfig, "Rolling back config registry to align with db config version %s for db: %s, bucket:%s configGroup:%s", config.Version, base.MD(dbName), base.MD(bucketName), base.MD(groupID))
-		registryErr := registry.rollbackDatabaseConfig(ctx, groupID, dbName)
+		registryErr := registry.rollbackDatabaseConfig(ctx, groupID, dbName, config)
 		if registryErr != nil {
 			// There shouldn't be a case where rollback introduces a collection conflict - it
 			// shouldn't be possible to add a conflicting collection to the registry while a previous

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -405,6 +405,13 @@ func (b *bootstrapContext) getConfigVersionWithRetry(ctx context.Context, bucket
 		}
 
 		config.cfgCas = cas
+
+		if version == invalidDatabaseVersion {
+			// special case - return the invalid config to use in updates (repairs). Configs with this version will not be loaded by SG.
+			config.Version = invalidDatabaseVersion
+			return false, nil, config
+		}
+
 		// If version matches, success!
 		if config.Version == version {
 			return false, nil, config

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -560,9 +560,9 @@ func (b *bootstrapContext) rollbackRegistry(ctx context.Context, bucketName, gro
 		base.InfofCtx(ctx, base.KeyConfig, "Rolling back config registry to align with db config version %s for db: %s, bucket:%s configGroup:%s", config.Version, base.MD(dbName), base.MD(bucketName), base.MD(groupID))
 		registryErr := registry.rollbackDatabaseConfig(ctx, groupID, dbName, config)
 		if registryErr != nil {
-			// There shouldn't be a case where rollback introduces a collection conflict - it
-			// shouldn't be possible to add a conflicting collection to the registry while a previous
-			// config persistence is in-flight
+			// There is one case where the registry rollback can introduce a collection conflict.
+			// If there's no PreviousVersion present (i.e. we're handling a db config doc rollback, not a registry update)
+			// then it's possible for the db config to contain a collection that is now present on another database in the registry.
 			return fmt.Errorf("Unable to roll back registry to match existing config for database %s(%s): %w", base.MD(dbName), base.MD(groupID), registryErr)
 		}
 	}

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -51,6 +51,8 @@ type GatewayRegistry struct {
 
 const GatewayRegistryVersion = "1.0"
 
+// A set of special sentinel values to store as database versions.
+// NOTE: Update addInvalidDatabase and isRegistryDbConfigVersionInvalid if you add more.
 const (
 	// deletedDatabaseVersion represents an entry for an in-progress delete
 	deletedDatabaseVersion = "0-0"

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -230,10 +230,10 @@ func (r *GatewayRegistry) rollbackDatabaseConfig(ctx context.Context, configGrou
 
 	// handle dbconfig doc rollback without PreviousVersion
 	if registryDatabase.PreviousVersion == nil {
-		base.InfofCtx(ctx, base.KeyConfig, "Rollback requested but registry did not include previous version for db %s - using config doc as previous version", base.UD(dbName))
+		base.InfofCtx(ctx, base.KeyConfig, "Rollback requested but registry did not include previous version for db %s - using config doc as previous version", base.MD(dbName))
 		setRegistryDatabaseFromConfig(registryDatabase, config)
 		if conflicts := r.getCollectionConflicts(ctx, dbName, config.Scopes); len(conflicts) > 0 {
-			base.WarnfCtx(ctx, "db %s config rollback would cause collection conflicts (%v) - marking database as invalid to allow for manual repair", base.UD(dbName), base.UD(conflicts))
+			base.WarnfCtx(ctx, "db %s config rollback would cause collection conflicts (%v) - marking database as invalid to allow for manual repair", base.MD(dbName), base.MD(conflicts))
 			registryDatabase.Version = invalidDatabaseConflictingCollectionsVersion
 		}
 		return nil

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -483,7 +483,7 @@ func TestPersistentConfigRegistryRollbackAfterDbConfigRollback(t *testing.T) {
 	bc := sc.BootstrapContext
 
 	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Second
+	bc.configRetryTimeout = 1 * time.Millisecond
 
 	// set up ScopesConfigs used by tests
 	collection1Name := dataStoreNames[0].CollectionName()
@@ -560,7 +560,7 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 	bc := sc.BootstrapContext
 
 	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Second
+	bc.configRetryTimeout = 1 * time.Millisecond
 
 	// set up ScopesConfigs used by tests
 	collection1Name := dataStoreNames[0].CollectionName()
@@ -650,7 +650,7 @@ func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
 	bc := sc.BootstrapContext
 
 	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Second
+	bc.configRetryTimeout = 1 * time.Millisecond
 
 	// SimulateCreateFailure updates the registry with a new config, but doesn't create the associated config file
 	simulateCreateFailure := func(t *testing.T, config *DatabaseConfig) {
@@ -781,7 +781,7 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 
 	bc := sc.BootstrapContext
 	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Second
+	bc.configRetryTimeout = 1 * time.Millisecond
 
 	// Create database with collection 1
 	collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")
@@ -912,7 +912,7 @@ func TestPersistentConfigRegistryRollbackAfterDeleteFailure(t *testing.T) {
 	bc := sc.BootstrapContext
 
 	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Second
+	bc.configRetryTimeout = 1 * time.Millisecond
 
 	// Create database with collection 1
 	collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")
@@ -999,7 +999,7 @@ func TestPersistentConfigSlowCreateFailure(t *testing.T) {
 	bc := sc.BootstrapContext
 
 	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Second
+	bc.configRetryTimeout = 1 * time.Millisecond
 
 	// simulateSlowCreate updates the registry with a new config, but doesn't create the associated config file
 	simulateSlowCreate := func(t *testing.T, config *DatabaseConfig) {

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1218,7 +1218,6 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 func startBootstrapServerWithoutConfigPolling(t *testing.T) (*ServerContext, func()) {
 	config := BootstrapStartupConfigForTest(t)
 	// "disable" config polling for this test, to avoid non-deterministic test output based on polling times
-	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Minute * 10)
+	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Hour * 24)
 	return StartServerWithConfig(t, &config)
-
 }

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -601,6 +601,11 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 	require.NoError(t, err)
 	sc.RequireInvalidDatabaseConfigNames(t, []string{dbName1})
 
+	// try to read database config to allow manual inspection before a repair
+	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(configs))
+
 	// at this point the config and registry are still not aligned, let's write a correcting update to make sure it's in a repairable state
 	_, err = bc.UpdateConfig(ctx, bucketName, groupID, dbName1, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 		bucketDbConfig.Version = "3-c"
@@ -608,9 +613,6 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 		return bucketDbConfig, nil
 	})
 	require.NoError(t, err)
-
-	// FIXME: Can't repair?
-	//        "Unable to roll back registry to match existing config for database c1_db1(default): 409 Cannot rollback config for database c1_db1 - collections are in use by another database: map[sg_test_0.sg_test_1:c1_db2]"
 }
 
 // TestPersistentConfigRegistryRollbackAfterCreateFailure simulates node failure during an insertConfig operation, leaving

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -542,6 +542,7 @@ func TestPersistentConfigRegistryRollbackAfterDbConfigRollback(t *testing.T) {
 // leaving the registry version ahead of the config - but also with a collection conflict occurring in the subsequent rollback.
 func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback(t *testing.T) {
 	base.TestRequiresCollections(t)
+	base.RequireNumTestDataStores(t, 3)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig)
 
 	sc, closeFn := startBootstrapServerWithoutConfigPolling(t)
@@ -614,7 +615,7 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 	// database config and registry should now be aligned and we should have no invalid databses stored
 	count, err = sc.fetchAndLoadConfigs(ctx, false)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, count) // both databases valid butq already loaded
+	assert.Equal(t, 0, count) // both databases valid but already loaded
 	_, err = sc.GetActiveDatabase(dbName1)
 	require.NoError(t, err)
 	_, err = sc.GetActiveDatabase(dbName2)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -611,7 +611,7 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 			updatedDb2Config := *collection1db2Config
 			updatedDb2Config.Version = "1-a"
 			updatedDb2Config.Scopes = ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}, collection2Name: {}}}}
-			db2CAS, err = bc.Connection.WriteMetadataDocument(ctx, bucketName, docID, db2CAS, &updatedDb2Config)
+			_, err = bc.Connection.WriteMetadataDocument(ctx, bucketName, docID, db2CAS, &updatedDb2Config)
 			require.NoError(t, err)
 
 			// also roll back db3 to the same collection as db1 if multiDatabaseRollback
@@ -620,7 +620,7 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 				updatedDb3Config := *collection1db3Config
 				updatedDb3Config.Version = "1-a"
 				updatedDb3Config.Scopes = ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}, collection3Name: {}}}}
-				db3CAS, err = bc.Connection.WriteMetadataDocument(ctx, bucketName, docID, db3CAS, &updatedDb3Config)
+				_, err = bc.Connection.WriteMetadataDocument(ctx, bucketName, docID, db3CAS, &updatedDb3Config)
 				require.NoError(t, err)
 			}
 

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -496,7 +496,7 @@ func TestPersistentConfigRegistryRollbackAfterDbConfigRollback(t *testing.T) {
 	require.NoError(t, err)
 	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
+	require.Len(t, configs, 1)
 
 	db, err := sc.GetDatabase(ctx, dbName)
 	require.NoError(t, err)
@@ -580,7 +580,7 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 
 	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(configs))
+	require.Len(t, configs, 2)
 
 	// simulate a rollback (not exactly - CAS increments, but lowering the config version is enough)
 	// this time we'll "roll back" to a version of dbconfig that contains a collection now in use by db2

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2609,7 +2609,7 @@ func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, expecte
 	for name := range sc.invalidDatabaseConfigTracking.dbNames {
 		dbNames = append(dbNames, name)
 	}
-	require.EqualValues(t, expectedDbNames, dbNames)
+	require.ElementsMatch(t, expectedDbNames, dbNames)
 }
 
 // ForceDbConfigsReload forces the reload db config from bucket process (like the ConfigUpdate background process)

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -63,8 +63,17 @@ type boostrapResponse struct {
 	StatusCode int
 }
 
+func (r *boostrapResponse) AssertStatus(status int) {
+	assert.Equal(r.t, status, r.StatusCode, "unexpected status code - body: %s", r.Body)
+}
+
 func (r *boostrapResponse) RequireStatus(status int) {
 	require.Equal(r.t, status, r.StatusCode, "unexpected status code - body: %s", r.Body)
+}
+
+func (r *boostrapResponse) AssertResponse(status int, body string) {
+	assert.Equal(r.t, status, r.StatusCode, "unexpected status code - body: %s", r.Body)
+	assert.Equal(r.t, body, r.Body, "unexpected body")
 }
 
 func (r *boostrapResponse) RequireResponse(status int, body string) {


### PR DESCRIPTION
CBG-3742: Allow registry rollbacks based on db config doc rollbacks.
- Registry will roll back to state of an older db config when possible (allows for vbucket rollbacks, db config doc backup/restore).
- If a rollback like this causes a collection conflict, the database is marked as invalid and the registry rolls back with this information. The database will not be loaded, but can be repaired with a normal db config update.

Example log output for a rollback causing conflicting collections:

```
2024-02-29T15:39:54.284Z [INF] Config: db:c1_db1 Registry rollback required for bucket: sg_int_rosmar_0ce23081d42ca93d4beda50d123d681d, groupID: default, dbName:c1_db1
2024-02-29T15:39:54.284Z [INF] Config: db:c1_db1 Rolling back config registry to align with db config version 1-a for db: c1_db1, bucket:sg_int_rosmar_0ce23081d42ca93d4beda50d123d681d configGroup:default
2024-02-29T15:39:54.284Z [INF] Config: db:c1_db1 Rollback requested but registry did not include previous version for db <ud>c1_db1</ud> - using config doc as previous version
2024-02-29T15:39:54.284Z [WRN] db:c1_db1 db <ud>c1_db1</ud> config rollback would cause collection conflicts (<ud>map[sg_test_0.sg_test_1:c1_db2]</ud>) - marking database as invalid to allow for manual repair -- rest.(*GatewayRegistry).rollbackDatabaseConfig() at config_registry.go:234
2024-02-29T15:39:54.284Z [INF] Config: db:c1_db1 Successful config registry rollback for bucket: sg_int_rosmar_0ce23081d42ca93d4beda50d123d681d, configGroup: default, db: c1_db1
2024-02-29T15:39:54.285Z [WRN] Must repair invalid database config for "c1_db1" for it to be usable! Conflicting collections detected -- rest.(*invalidDatabaseConfigs).addInvalidDatabase() at config.go:334
```

## TODO
- [x] REST API level testing of db config (avoid direct usage of `sc.BootstrapContext` in `TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback`)
  - Want to make sure that it's not possible to load an invalid db config accidentally (e.g. an on-demand db config load)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2336/
