### PR TITLE
CBG-3029 use matching regex replacement for go and python code

### DIFF
--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -1,0 +1,101 @@
+# Copyright 2024-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
+import json
+import pathlib
+
+import password_remover
+import tasks
+
+import pytest
+
+VERBOSE = 2
+
+INPUT_CONFIG = """\
+{
+    "password": "password",
+    "server": "http://localhost:4984/db",
+    "databases": {
+        "db" : {
+            "users" : {
+                "foo" : "bar"
+            }
+        }
+    }
+}"""
+
+REDACTED_OUTPUT = """\
+{
+    "password": "******",
+    "server": "http://localhost:4984/db",
+    "databases": {
+        "db": {
+            "users": {
+                "<ud>foo</ud>": "bar"
+            }
+        }
+    }
+}"""
+
+
+@pytest.mark.parametrize("tag_userdata", [True, False])
+def test_add_file_task(tmpdir, tag_userdata):
+    if tag_userdata:
+        expected = REDACTED_OUTPUT
+    else:
+        expected = REDACTED_OUTPUT.replace("<ud>foo</ud>", "foo")
+
+    filename = "config.json"
+    config_file = tmpdir.join(filename)
+    config_file.write(INPUT_CONFIG)
+    postprocessors = [password_remover.remove_passwords]
+    if tag_userdata:
+        postprocessors.append(password_remover.tag_userdata_in_server_config)
+    task = tasks.add_file_task(
+        config_file.strpath,
+        content_postprocessors=postprocessors,
+    )
+    output_dir = tmpdir.mkdir("output")
+    runner = tasks.TaskRunner(
+        verbosity=VERBOSE,
+        default_name="sg.log",
+        tmp_dir=output_dir,
+    )
+    runner.run(task)
+    runner.close_all_files()
+
+    with open(pathlib.Path(runner.tmpdir) / filename) as fh:
+        assert expected in fh.read()
+
+
+def test_make_curl_task(tmpdir, httpserver):
+    output = "curltask"
+    httpserver.expect_request("/").respond_with_json(json.loads(INPUT_CONFIG))
+    task = tasks.make_curl_task(
+        "curltask",
+        httpserver.url_for("/"),
+        content_postprocessors=[
+            password_remover.remove_passwords,
+            password_remover.tag_userdata_in_server_config,
+        ],
+        log_file=output,
+    )
+
+    output_dir = tmpdir.mkdir("output")
+    runner = tasks.TaskRunner(
+        verbosity=VERBOSE,
+        default_name="sg.log",
+        tmp_dir=output_dir,
+    )
+    runner.run(task)
+    runner.close_all_files()
+
+    with open(pathlib.Path(runner.tmpdir) / output) as fh:
+        assert REDACTED_OUTPUT in fh.read()
+
+    httpserver.check()


### PR DESCRIPTION
Replace `convert_to_valid_json` to `get_parsed_json` which should match the behavior of `ConvertBackQuotedStrings`. At least tabs would not previously be handled correctly.

Depending on tasks are used, the input to these functions is either a string (`make_curl_task`) or bytes (`add_file_task`). 

The best thing that a reviewer can do is make sure `test_convert_to_valid_json` is testing appropriate cases (lifted from `TestConvertBackQuotedStrings`).

Removed some unused functions/parameters unrelated to this, but showing that these exceptions _do_ show in the log file of sgcollect:

- log_json_parsing_exceptions
- is_valid_json