### PR TITLE
CBG-3278: move serverless stats behind serverless flag

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -1959,7 +1959,6 @@ func (d *DbStats) InitCollectionStats(scopeAndCollectionNames ...string) error {
 }
 
 func (db *DbStats) initServerlessStats() error {
-	// call new int stsat etc for each stat in here
 	var err error
 	resUtil := &ServerlessStats{}
 	labelKeys := []string{DatabaseLabelKey}
@@ -2004,7 +2003,6 @@ func (db *DbStats) initServerlessStats() error {
 
 	db.ServerlessStats = resUtil
 	return nil
-	// unregister function needed for each
 }
 
 func (db *DbStats) unregisterServerlessStats() {

--- a/base/stats.go
+++ b/base/stats.go
@@ -43,6 +43,7 @@ const (
 	SubsystemReplicationPush    = "replication_push"
 	SubsystemSecurity           = "security"
 	SubsystemSharedBucketImport = "shared_bucket_import"
+	SubsystemServerless         = "serverless"
 
 	DatabaseLabelKey    = "database"
 	ReplicationLabelKey = "replication"
@@ -368,6 +369,7 @@ type DbStats struct {
 	SecurityStats           *SecurityStats                `json:"security,omitempty"`
 	SharedBucketImportStats *SharedBucketImportStats      `json:"shared_bucket_import,omitempty"`
 	CollectionStats         map[string]*CollectionStats   `json:"per_collection,omitempty"`
+	ServerlessStats         *ServerlessStats              `json:"serverless_stats,omitempty"`
 	dbReplicatorStatsMutex  sync.Mutex
 }
 
@@ -518,8 +520,6 @@ type CollectionStats struct {
 }
 
 type DatabaseStats struct {
-	ReplicationBytesReceived *SgwIntStat `json:"replication_bytes_received"`
-	ReplicationBytesSent     *SgwIntStat `json:"replication_bytes_sent"`
 	// The compaction_attachment_start_time.
 	CompactionAttachmentStartTime *SgwIntStat `json:"compaction_attachment_start_time"`
 	// The compaction_tombstone_start_time.
@@ -554,17 +554,11 @@ type DatabaseStats struct {
 	NumDocReadsRest *SgwIntStat `json:"num_doc_reads_rest"`
 	// The total number of documents written by any means (replication, rest API interaction or imports) since Sync Gateway node startup.
 	NumDocWrites *SgwIntStat `json:"num_doc_writes"`
-	// The total number of requests sent over the public REST api
-	NumPublicRestRequests *SgwIntStat `json:"num_public_rest_requests"`
 	// The total number of active replications.
 	NumReplicationsActive *SgwIntStat `json:"num_replications_active"`
 	// The total number of replications created since Sync Gateway node startup.
 	NumReplicationsTotal   *SgwIntStat `json:"num_replications_total"`
 	NumTombstonesCompacted *SgwIntStat `json:"num_tombstones_compacted"`
-	// Number of bytes written over public interface for REST api
-	PublicRestBytesWritten *SgwIntStat `json:"public_rest_bytes_written"`
-	// The total amount of bytes read over the public REST api
-	PublicRestBytesRead *SgwIntStat `json:"public_rest_bytes_read"`
 	// The total number of sequence numbers assigned.
 	SequenceAssignedCount *SgwIntStat `json:"sequence_assigned_count"`
 	// The total number of high sequence lookups.
@@ -587,22 +581,34 @@ type DatabaseStats struct {
 	SyncFunctionCount *SgwIntStat `json:"sync_function_count"`
 	// The total time spent evaluating a sync function (across all collections).
 	SyncFunctionTime *SgwIntStat `json:"sync_function_time"`
-	// The total sync time is a proxy for websocket connections. Tracking long lived and potentially idle connections.
-	// This stat represents the continually growing number of connections per sec.
-	TotalSyncTime *SgwIntStat `json:"total_sync_time"`
 	// The total number of times that a sync function encountered an exception (across all collections).
 	SyncFunctionExceptionCount *SgwIntStat `json:"sync_function_exception_count"`
-	// The total number of times a replication connection is rejected due ot it being over the threshold
-	NumReplicationsRejectedLimit *SgwIntStat `json:"num_replications_rejected_limit"`
-	// Represents the compute unit for import processes on the database
-	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
-	// SyncProcessCompute the compute unit for syncing with clients
-	SyncProcessCompute *SgwIntStat `json:"sync_process_compute"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
 	CacheFeedMapStats  *ExpVarMapWrapper `json:"cache_feed"`
 	ImportFeedMapStats *ExpVarMapWrapper `json:"import_feed"`
+}
+
+// ServerlessStats are stats added and dedicated for use of sync gateway in serverless mode
+type ServerlessStats struct {
+	// Represents the compute unit for import processes on the database
+	ImportProcessCompute *SgwIntStat `json:"import_process_compute"`
+	// SyncProcessCompute the compute unit for syncing with clients
+	SyncProcessCompute *SgwIntStat `json:"sync_process_compute"`
+	// The total number of times a replication connection is rejected due ot it being over the threshold
+	NumReplicationsRejectedLimit *SgwIntStat `json:"num_replications_rejected_limit"`
+	// This stat represents the continually growing number of connections per sec.
+	TotalSyncTime *SgwIntStat `json:"total_sync_time"`
+	// Number of bytes written over public interface for REST api
+	PublicRestBytesWritten *SgwIntStat `json:"public_rest_bytes_written"`
+	// The total amount of bytes read over the public REST api
+	PublicRestBytesRead *SgwIntStat `json:"public_rest_bytes_read"`
+	// The total number of requests sent over the public REST api
+	NumPublicRestRequests *SgwIntStat `json:"num_public_rest_requests"`
+
+	ReplicationBytesReceived *SgwIntStat `json:"replication_bytes_received"`
+	ReplicationBytesSent     *SgwIntStat `json:"replication_bytes_sent"`
 }
 
 // This wrapper ensures that an expvar.Map type can be marshalled into JSON. The expvar.Map has no method to go direct to
@@ -1106,7 +1112,7 @@ type QueryStat struct {
 	QueryTime       *SgwIntStat
 }
 
-func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, queryNames []string, collections []string) (*DbStats, error) {
+func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, serverlessEnabled bool, queryNames []string, collections []string) (*DbStats, error) {
 	s.dbStatsMapMutex.Lock()
 	defer s.dbStatsMapMutex.Unlock()
 	dbStats := &DbStats{
@@ -1139,6 +1145,13 @@ func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled 
 	err = dbStats.InitCollectionStats(collections...)
 	if err != nil {
 		return nil, err
+	}
+
+	if serverlessEnabled {
+		err = dbStats.initServerlessStats()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if deltaSyncEnabled {
@@ -1184,6 +1197,10 @@ func (s *SgwStats) ClearDBStats(name string) {
 
 	for scopeAndCollectionName := range s.DbStats[name].CollectionStats {
 		s.DbStats[name].unregisterCollectionStats(scopeAndCollectionName)
+	}
+
+	if s.DbStats[name].ServerlessStats != nil {
+		s.DbStats[name].unregisterServerlessStats()
 	}
 
 	s.DbStats[name].unregisterCacheStats()
@@ -1537,14 +1554,6 @@ func (d *DbStats) initDatabaseStats() error {
 	labelKeys := []string{DatabaseLabelKey}
 	labelVals := []string{d.dbName}
 
-	resUtil.ReplicationBytesReceived, err = NewIntStat(SubsystemDatabaseKey, "replication_bytes_received", StatUnitBytes, ReplicationBytesReceivedDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.ReplicationBytesSent, err = NewIntStat(SubsystemDatabaseKey, "replication_bytes_sent", StatUnitBytes, ReplicationBytesSentDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
 	resUtil.CompactionAttachmentStartTime, err = NewIntStat(SubsystemDatabaseKey, "compaction_attachment_start_time", StatUnitUnixTimestamp, CompactionAttachmentStartTimeDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
@@ -1593,10 +1602,6 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.PublicRestBytesWritten, err = NewIntStat(SubsystemDatabaseKey, "http_bytes_written", StatUnitBytes, PublicRestBytesWrittenDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
 	resUtil.NumAttachmentsCompacted, err = NewIntStat(SubsystemDatabaseKey, "num_attachments_compacted", StatUnitNoUnits, NumAttachmentsCompactedDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1626,10 +1631,6 @@ func (d *DbStats) initDatabaseStats() error {
 		return err
 	}
 	resUtil.NumTombstonesCompacted, err = NewIntStat(SubsystemDatabaseKey, "num_tombstones_compacted", StatUnitNoUnits, NumTombstonesCompactedDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.PublicRestBytesRead, err = NewIntStat(SubsystemDatabaseKey, "public_rest_bytes_read", StatUnitBytes, PublicRestBytesReadDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1681,26 +1682,6 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.NumReplicationsRejectedLimit, err = NewIntStat(SubsystemDatabaseKey, "num_replications_rejected_limit", StatUnitNoUnits, NumReplicationsRejectedLimitDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemDatabaseKey, "num_public_rest_requests", StatUnitNoUnits, NumPublicRestRequestsDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.TotalSyncTime, err = NewIntStat(SubsystemDatabaseKey, "total_sync_time", StatUnitSeconds, TotalSyncTimeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemDatabaseKey, "import_process_compute", StatUnitNoUnits, ImportProcessComputeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
-	resUtil.SyncProcessCompute, err = NewIntStat(SubsystemDatabaseKey, "sync_process_compute", StatUnitNoUnits, SyncProcessComputeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
-	if err != nil {
-		return err
-	}
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
@@ -1710,8 +1691,6 @@ func (d *DbStats) initDatabaseStats() error {
 }
 
 func (d *DbStats) unregisterDatabaseStats() {
-	prometheus.Unregister(d.DatabaseStats.ReplicationBytesReceived)
-	prometheus.Unregister(d.DatabaseStats.ReplicationBytesSent)
 	prometheus.Unregister(d.DatabaseStats.CompactionAttachmentStartTime)
 	prometheus.Unregister(d.DatabaseStats.CompactionTombstoneStartTime)
 	prometheus.Unregister(d.DatabaseStats.ConflictWriteCount)
@@ -1732,7 +1711,6 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsActive)
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsTotal)
 	prometheus.Unregister(d.DatabaseStats.NumTombstonesCompacted)
-	prometheus.Unregister(d.DatabaseStats.PublicRestBytesWritten)
 	prometheus.Unregister(d.DatabaseStats.SequenceAssignedCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceGetCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceIncrCount)
@@ -1745,12 +1723,6 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionCount)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionTime)
 	prometheus.Unregister(d.DatabaseStats.SyncFunctionExceptionCount)
-	prometheus.Unregister(d.DatabaseStats.NumReplicationsRejectedLimit)
-	prometheus.Unregister(d.DatabaseStats.NumPublicRestRequests)
-	prometheus.Unregister(d.DatabaseStats.TotalSyncTime)
-	prometheus.Unregister(d.DatabaseStats.ImportProcessCompute)
-	prometheus.Unregister(d.DatabaseStats.PublicRestBytesRead)
-	prometheus.Unregister(d.DatabaseStats.SyncProcessCompute)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {
@@ -1812,6 +1784,10 @@ func (d *DbStats) unregisterDeltaSyncStats() {
 
 func (d *DbStats) DeltaSync() *DeltaSyncStats {
 	return d.DeltaSyncStats
+}
+
+func (d *DbStats) Serverless() *ServerlessStats {
+	return d.ServerlessStats
 }
 
 func (d *DbStats) initSecurityStats() error {
@@ -1980,6 +1956,67 @@ func (d *DbStats) InitCollectionStats(scopeAndCollectionNames ...string) error {
 	}
 
 	return nil
+}
+
+func (db *DbStats) initServerlessStats() error {
+	// call new int stsat etc for each stat in here
+	var err error
+	resUtil := &ServerlessStats{}
+	labelKeys := []string{DatabaseLabelKey}
+	labelVals := []string{db.dbName}
+
+	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemServerless, "import_process_compute", StatUnitNoUnits, ImportProcessComputeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.SyncProcessCompute, err = NewIntStat(SubsystemServerless, "sync_process_compute", StatUnitNoUnits, SyncProcessComputeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.NumReplicationsRejectedLimit, err = NewIntStat(SubsystemServerless, "num_replications_rejected_limit", StatUnitNoUnits, NumReplicationsRejectedLimitDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.TotalSyncTime, err = NewIntStat(SubsystemServerless, "total_sync_time", StatUnitSeconds, TotalSyncTimeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.PublicRestBytesWritten, err = NewIntStat(SubsystemServerless, "http_bytes_written", StatUnitBytes, PublicRestBytesWrittenDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.PublicRestBytesRead, err = NewIntStat(SubsystemServerless, "public_rest_bytes_read", StatUnitBytes, PublicRestBytesReadDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemServerless, "num_public_rest_requests", StatUnitNoUnits, NumPublicRestRequestsDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.ReplicationBytesReceived, err = NewIntStat(SubsystemServerless, "replication_bytes_received", StatUnitBytes, ReplicationBytesReceivedDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.ReplicationBytesSent, err = NewIntStat(SubsystemServerless, "replication_bytes_sent", StatUnitBytes, ReplicationBytesSentDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+
+	db.ServerlessStats = resUtil
+	return nil
+	// unregister function needed for each
+}
+
+func (db *DbStats) unregisterServerlessStats() {
+	prometheus.Unregister(db.ServerlessStats.ImportProcessCompute)
+	prometheus.Unregister(db.ServerlessStats.SyncProcessCompute)
+	prometheus.Unregister(db.ServerlessStats.NumReplicationsRejectedLimit)
+	prometheus.Unregister(db.ServerlessStats.TotalSyncTime)
+	prometheus.Unregister(db.ServerlessStats.PublicRestBytesWritten)
+	prometheus.Unregister(db.ServerlessStats.PublicRestBytesRead)
+	prometheus.Unregister(db.ServerlessStats.NumPublicRestRequests)
+	prometheus.Unregister(db.ServerlessStats.ReplicationBytesReceived)
+	prometheus.Unregister(db.ServerlessStats.ReplicationBytesSent)
 }
 
 func (d *DbStats) DBReplicatorStats(replicationID string) (*DbReplicatorStats, error) {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -123,7 +123,7 @@ func TestLateSequenceHandling(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collectionID), 0, dbstats.CacheStats)
@@ -195,7 +195,7 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collectionID), 0, dbstats.CacheStats)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -123,7 +123,7 @@ func TestLateSequenceHandling(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collectionID), 0, dbstats.CacheStats)
@@ -195,7 +195,7 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collectionID), 0, dbstats.CacheStats)

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -36,7 +36,7 @@ func TestDuplicateDocID(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collection.GetCollectionID()), 0, dbstats.Cache())
@@ -89,7 +89,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -130,7 +130,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -171,7 +171,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -254,7 +254,7 @@ func TestPrependChanges(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -279,7 +279,7 @@ func TestPrependChanges(t *testing.T) {
 	// 2. Test prepend to populated cache, with overlap and duplicates
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependPopulatedCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.validFrom = 13
@@ -337,7 +337,7 @@ func TestPrependChanges(t *testing.T) {
 	// 3. Test prepend that exceeds cache capacity
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependToFillCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
@@ -378,7 +378,7 @@ func TestPrependChanges(t *testing.T) {
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependDuplicatesOnly", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.validFrom = 13
@@ -412,7 +412,7 @@ func TestPrependChanges(t *testing.T) {
 	// 5. Test prepend for an already full cache
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependFullCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
@@ -462,7 +462,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -510,7 +510,7 @@ func TestChannelCacheStats(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -589,7 +589,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -628,7 +628,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -726,7 +726,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -753,7 +753,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -777,7 +777,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -801,7 +801,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -825,7 +825,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -849,7 +849,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -873,7 +873,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -36,7 +36,7 @@ func TestDuplicateDocID(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	cache := newSingleChannelCache(collection, channels.NewID("Test1", collection.GetCollectionID()), 0, dbstats.Cache())
@@ -89,7 +89,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -130,7 +130,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -171,7 +171,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -254,7 +254,7 @@ func TestPrependChanges(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -279,7 +279,7 @@ func TestPrependChanges(t *testing.T) {
 	// 2. Test prepend to populated cache, with overlap and duplicates
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependPopulatedCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.validFrom = 13
@@ -337,7 +337,7 @@ func TestPrependChanges(t *testing.T) {
 	// 3. Test prepend that exceeds cache capacity
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependToFillCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
@@ -378,7 +378,7 @@ func TestPrependChanges(t *testing.T) {
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependDuplicatesOnly", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.validFrom = 13
@@ -412,7 +412,7 @@ func TestPrependChanges(t *testing.T) {
 	// 5. Test prepend for an already full cache
 	stats, err = base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err = stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err = stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	cache = newSingleChannelCache(collection, channels.NewID("PrependFullCache", collection.GetCollectionID()), 0, dbstats.Cache())
 	cache.options.ChannelCacheMaxLength = 5
@@ -462,7 +462,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -510,7 +510,7 @@ func TestChannelCacheStats(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -589,7 +589,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -628,7 +628,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 
 	collection := GetSingleDatabaseCollection(t, db.DatabaseContext)
@@ -726,7 +726,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -753,7 +753,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
 
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -777,7 +777,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -801,7 +801,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -825,7 +825,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -849,7 +849,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)
@@ -873,7 +873,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(b, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(b, err)
 
 	collection := GetSingleDatabaseCollection(b, db.DatabaseContext)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -79,7 +79,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -121,7 +121,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -181,7 +181,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -278,7 +278,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -353,7 +353,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -423,7 +423,7 @@ func TestChannelCacheBypass(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -529,7 +529,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	options.ChannelCacheAge = 0
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -79,7 +79,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -121,7 +121,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -181,7 +181,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	activeChannelStat := &base.SgwIntStat{}
@@ -278,7 +278,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -353,7 +353,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -423,7 +423,7 @@ func TestChannelCacheBypass(t *testing.T) {
 
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 	queryHandler := &testQueryHandler{}
@@ -529,7 +529,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	options.ChannelCacheAge = 0
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := stats.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := stats.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Cache()
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -236,6 +236,9 @@ func (db *DatabaseCollection) GetDocSyncDataNoImport(ctx context.Context, docid 
 func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
 	startTime := time.Now()
 	defer func() {
+		if !c.dbCtx.IsServerless() {
+			return
+		}
 		functionTime := time.Since(startTime).Milliseconds()
 		var bytes int
 		if docOut != nil {
@@ -244,7 +247,7 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 			return
 		}
 		stat := CalculateComputeStat(int64(bytes), functionTime)
-		c.dbCtx.DbStats.DatabaseStats.ImportProcessCompute.Add(stat)
+		c.dbCtx.DbStats.ServerlessStats.ImportProcessCompute.Add(stat)
 	}()
 	isDelete := rawDoc == nil
 	importDb := DatabaseCollectionWithUser{DatabaseCollection: c, user: nil}
@@ -833,6 +836,9 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context, docid string, doc *Document, deleted bool) error {
 	startTime := time.Now()
 	defer func() {
+		if !db.dbCtx.IsServerless() {
+			return
+		}
 		functionTime := time.Since(startTime).Milliseconds()
 		var bytes int
 		if doc != nil {
@@ -841,7 +847,7 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 			return
 		}
 		stat := CalculateComputeStat(int64(bytes), functionTime)
-		db.dbCtx.DbStats.DatabaseStats.ImportProcessCompute.Add(stat)
+		db.dbCtx.DbStats.ServerlessStats.ImportProcessCompute.Add(stat)
 	}()
 	// Check whether the doc requiring import is an SDK delete
 	isDelete := false

--- a/db/database.go
+++ b/db/database.go
@@ -2025,8 +2025,16 @@ func initDatabaseStats(ctx context.Context, dbName string, autoImport bool, opti
 			}
 		}
 	}
+	dbStatsOpts := base.DbStatsOptions{
+		DeltaSyncEnabled:  enabledDeltaSync,
+		ImportEnabled:     enabledImport,
+		ViewsEnabled:      enabledViews,
+		ServerlessEnabled: options.Serverless,
+		QueryNames:        queryNames,
+		Collections:       collections,
+	}
 
-	return base.SyncGatewayStats.NewDBStats(dbName, enabledDeltaSync, enabledImport, enabledViews, options.Serverless, queryNames, collections)
+	return base.SyncGatewayStats.NewDBStats(dbName, &dbStatsOpts)
 }
 
 func (context *DatabaseContext) AllowConflicts() bool {

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -38,6 +38,8 @@ func (db *DatabaseContext) UpdateCalculatedStats(ctx context.Context) {
 
 // UpdateTotalSyncTimeStat updates the TotalSyncTime to the current value + NumReplicationsActive each time this is called
 func (db *DatabaseContext) UpdateTotalSyncTimeStat() {
-	currentActiveReplications := db.DbStats.DatabaseStats.NumReplicationsActive.Value()
-	db.DbStats.DatabaseStats.TotalSyncTime.Add(currentActiveReplications)
+	if db.IsServerless() {
+		currentActiveReplications := db.DbStats.DatabaseStats.NumReplicationsActive.Value()
+		db.DbStats.ServerlessStats.TotalSyncTime.Add(currentActiveReplications)
+	}
 }

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -28,7 +28,7 @@ func TestSequenceAllocator(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -98,7 +98,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -175,7 +175,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -208,7 +208,7 @@ func TestReleaseSequenceWait(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 	a, err := newSequenceAllocator(ctx, bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
@@ -243,7 +243,7 @@ func TestNextSequenceGreaterThanSingleNode(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -317,9 +317,9 @@ func TestNextSequenceGreaterThanMultiNode(t *testing.T) {
 	// Set sequenceBatchSize=10 to test variations of batching
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	statsA, err := stats.NewDBStats("A", false, false, false, nil, nil)
+	statsA, err := stats.NewDBStats("A", false, false, false, false, nil, nil)
 	require.NoError(t, err)
-	statsB, err := stats.NewDBStats("B", false, false, false, nil, nil)
+	statsB, err := stats.NewDBStats("B", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbStatsA := statsA.DatabaseStats
 	dbStatsB := statsB.DatabaseStats

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -28,7 +28,7 @@ func TestSequenceAllocator(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -98,7 +98,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -175,7 +175,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -208,7 +208,7 @@ func TestReleaseSequenceWait(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 	a, err := newSequenceAllocator(ctx, bucket.GetSingleDataStore(), testStats, base.DefaultMetadataKeys)
@@ -243,7 +243,7 @@ func TestNextSequenceGreaterThanSingleNode(t *testing.T) {
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	dbstats, err := sgw.NewDBStats("", false, false, false, false, nil, nil)
+	dbstats, err := sgw.NewDBStats("", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	testStats := dbstats.Database()
 
@@ -317,9 +317,9 @@ func TestNextSequenceGreaterThanMultiNode(t *testing.T) {
 	// Set sequenceBatchSize=10 to test variations of batching
 	stats, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
-	statsA, err := stats.NewDBStats("A", false, false, false, false, nil, nil)
+	statsA, err := stats.NewDBStats("A", &base.DbStatsOptions{})
 	require.NoError(t, err)
-	statsB, err := stats.NewDBStats("B", false, false, false, false, nil, nil)
+	statsB, err := stats.NewDBStats("B", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbStatsA := statsA.DatabaseStats
 	dbStatsB := statsB.DatabaseStats

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -69,7 +69,6 @@ func TestRoot(t *testing.T) {
 }
 
 func TestPublicRESTStatCount(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -69,41 +69,42 @@ func TestRoot(t *testing.T) {
 }
 
 func TestPublicRESTStatCount(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
+	RequireBucketSpecificCredentials(t)
+	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
 	// create a user to authenticate as for public api calls and assert the stat hasn't incremented as a result
 	rt.CreateUser("greg", []string{"ABC"})
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
+		return rt.GetDatabase().DbStats.ServerlessStats.NumPublicRestRequests.Value()
 	}, 0)
 
 	// use public api to put a doc through SGW then assert the stat has increased by 1
 	resp := rt.SendUserRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar", "channels":["ABC"]}`, "greg")
 	RequireStatus(t, resp, http.StatusCreated)
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
+		return rt.GetDatabase().DbStats.ServerlessStats.NumPublicRestRequests.Value()
 	}, 1)
 
 	// send admin request assert that the public rest count doesn't increase
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc1", "")
 	RequireStatus(t, resp, http.StatusOK)
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
+		return rt.GetDatabase().DbStats.ServerlessStats.NumPublicRestRequests.Value()
 	}, 1)
 
 	// send another public request to assert the stat increases by 1
 	resp = rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/doc1", "", "greg")
 	RequireStatus(t, resp, http.StatusOK)
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
+		return rt.GetDatabase().DbStats.ServerlessStats.NumPublicRestRequests.Value()
 	}, 2)
 
 	resp = rt.SendUserRequest(http.MethodGet, "/{{.db}}/_blipsync", "", "greg")
 	RequireStatus(t, resp, http.StatusUpgradeRequired)
 
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
+		return rt.GetDatabase().DbStats.ServerlessStats.NumPublicRestRequests.Value()
 	}, 2)
 
 	srv := httptest.NewServer(rt.TestMetricsHandler())
@@ -116,7 +117,7 @@ func TestPublicRESTStatCount(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	// assert the stat doesn't increment
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
+		return rt.GetDatabase().DbStats.ServerlessStats.NumPublicRestRequests.Value()
 	}, 2)
 
 	// test public endpoint but one that doesn't access a db
@@ -124,7 +125,7 @@ func TestPublicRESTStatCount(t *testing.T) {
 	RequireStatus(t, resp, http.StatusOK)
 	// assert the stat doesn't increment
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.NumPublicRestRequests.Value()
+		return rt.GetDatabase().DbStats.ServerlessStats.NumPublicRestRequests.Value()
 	}, 2)
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -69,8 +69,14 @@ func TestRoot(t *testing.T) {
 }
 
 func TestPublicRESTStatCount(t *testing.T) {
-	rt := NewRestTesterPersistentConfigServerless(t)
+	RequireBucketSpecificCredentials(t)
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+		Serverless:       true,
+		SyncFn:           channels.DocChannelsSyncFunction,
+	})
 	defer rt.Close()
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 
 	// create a user to authenticate as for public api calls and assert the stat hasn't incremented as a result
 	rt.CreateUser("greg", []string{"ABC"})

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -715,7 +715,6 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 //   - add doc with attachment
 //   - wait for doc to replicate and assert on attachment stat
 func TestAttachmentComputeStat(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	const docID = "doc1"

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -715,22 +715,25 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 //   - add doc with attachment
 //   - wait for doc to replicate and assert on attachment stat
 func TestAttachmentComputeStat(t *testing.T) {
+	RequireBucketSpecificCredentials(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-	rtConfig := RestTesterConfig{
-		GuestEnabled: true,
-	}
+
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
-		rt := NewRestTester(t, &rtConfig)
+		rt := NewRestTesterPersistentConfigServerless(t)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		opts := &BlipTesterClientOpts{
+			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username:               "test",
+			Channels:               []string{"*"},
+		}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 
-		syncProcessCompute := btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value()
+		syncProcessCompute := btc.rt.GetDatabase().DbStats.ServerlessStats.SyncProcessCompute.Value()
 
 		err := btcRunner.StartPull(btc.id)
 		assert.NoError(t, err)
@@ -746,6 +749,6 @@ func TestAttachmentComputeStat(t *testing.T) {
 		require.JSONEq(t, bodyTextExpected, string(data))
 
 		// assert the attachment read compute stat is incremented
-		require.Greater(t, btc.rt.GetDatabase().DbStats.DatabaseStats.SyncProcessCompute.Value(), syncProcessCompute)
+		require.Greater(t, btc.rt.GetDatabase().DbStats.ServerlessStats.SyncProcessCompute.Value(), syncProcessCompute)
 	})
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2495,7 +2495,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 
 	remoteURL, _ := url.Parse(remoteURLString)
 
-	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats("test", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2495,7 +2495,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 
 	remoteURL, _ := url.Parse(remoteURLString)
 
-	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/blip_stats_test.go
+++ b/rest/blip_stats_test.go
@@ -45,7 +45,6 @@ func waitForStatGreaterThan(t *testing.T, getStatFunc func() int64, expected int
 }
 
 func TestBlipStatsBasic(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
@@ -78,7 +77,6 @@ func TestBlipStatsBasic(t *testing.T) {
 }
 
 func TestBlipStatsFastReport(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -17,14 +17,21 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBytesReadDocOperations(t *testing.T) {
-	rt := NewRestTesterPersistentConfigServerless(t)
+	RequireBucketSpecificCredentials(t)
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+		Serverless:       true,
+		SyncFn:           channels.DocChannelsSyncFunction,
+	})
 	defer rt.Close()
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 
 	// create a user to authenticate as for public api calls and assert the stat hasn't incremented as a result
 	rt.CreateUser("greg", []string{"ABC"})
@@ -121,8 +128,14 @@ func TestBytesReadChanges(t *testing.T) {
 }
 
 func TestBytesReadPutAttachment(t *testing.T) {
-	rt := NewRestTesterPersistentConfigServerless(t)
+	RequireBucketSpecificCredentials(t)
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+		Serverless:       true,
+		SyncFn:           channels.DocChannelsSyncFunction,
+	})
 	defer rt.Close()
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 
 	// create user
 	rt.CreateUser("alice", []string{"ABC"})

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestBytesReadDocOperations(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
@@ -99,7 +98,6 @@ func TestBytesReadDocOperations(t *testing.T) {
 }
 
 func TestBytesReadChanges(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
@@ -123,7 +121,6 @@ func TestBytesReadChanges(t *testing.T) {
 }
 
 func TestBytesReadPutAttachment(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
@@ -170,7 +167,6 @@ func TestBytesReadPutAttachment(t *testing.T) {
 }
 
 func TestBytesReadRevDiff(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
@@ -213,7 +209,6 @@ func TestBytesReadRevDiff(t *testing.T) {
 }
 
 func TestBytesReadAllDocs(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
@@ -254,7 +249,6 @@ func TestBytesReadAllDocs(t *testing.T) {
 }
 
 func TestBytesReadBulkDocs(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
@@ -282,7 +276,6 @@ func TestBytesReadBulkDocs(t *testing.T) {
 }
 
 func TestBytesReadBulkGet(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
@@ -318,7 +311,6 @@ func TestBytesReadBulkGet(t *testing.T) {
 }
 
 func TestBytesReadLocalDocPut(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
@@ -346,22 +338,15 @@ func TestBytesReadLocalDocPut(t *testing.T) {
 }
 
 func TestBytesReadPOSTSession(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
-	rt := NewRestTester(t, &RestTesterConfig{
-		Serverless:       true,
-		PersistentConfig: true,
-	})
+	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
-
-	resp := rt.CreateDatabase("db", rt.NewDbConfig())
-	RequireStatus(t, resp, http.StatusCreated)
 
 	rt.CreateUser("alice", []string{"ABC"})
 
 	// create session
 	input := `{"name":"alice","password":"letmein"}`
 	inputBytes := []byte(input)
-	resp = rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session", input, "alice")
+	resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session", input, "alice")
 	RequireStatus(t, resp, http.StatusOK)
 
 	// assert the stat is increased by the correct amount
@@ -380,18 +365,11 @@ func TestBytesReadPOSTSession(t *testing.T) {
 }
 
 func TestBytesReadAuthFailed(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
-	rt := NewRestTester(t, &RestTesterConfig{
-		Serverless:       true,
-		PersistentConfig: true,
-	})
+	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
-	resp := rt.CreateDatabase("db", rt.NewDbConfig())
-	RequireStatus(t, resp, http.StatusCreated)
-
 	// create a user with different password to the default one
-	resp = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", GetUserPayload(t, "alice", "pass", "", rt.GetSingleTestDatabaseCollection(), []string{"ABC"}, nil))
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", GetUserPayload(t, "alice", "pass", "", rt.GetSingleTestDatabaseCollection(), []string{"ABC"}, nil))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// make a request that will fail on auth
@@ -411,14 +389,12 @@ func TestBytesReadGzipRequest(t *testing.T) {
 	RequireBucketSpecificCredentials(t)
 	// Need default collection as request below doesn't work with {{.keyspace}}
 	rt := NewRestTesterDefaultCollection(t, &RestTesterConfig{
-		GuestEnabled:     true,
 		Serverless:       true,
 		PersistentConfig: true,
 	})
 	defer rt.Close()
 
-	resp := rt.CreateDatabase("db", rt.NewDbConfig())
-	RequireStatus(t, resp, http.StatusCreated)
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 
 	rt.CreateUser("alice", []string{"ABC"})
 	input := `{"channel":["ABC"]}`
@@ -437,7 +413,7 @@ func TestBytesReadGzipRequest(t *testing.T) {
 	require.NoError(t, err)
 	rq.SetBasicAuth("alice", RestTesterDefaultUserPassword)
 	rq.Header.Set("Content-Encoding", "gzip")
-	resp = rt.Send(rq)
+	resp := rt.Send(rq)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	base.RequireWaitForStat(t, func() int64 {
@@ -487,7 +463,6 @@ func TestPutDBBytesRead(t *testing.T) {
 }
 
 func TestOfflineDBBytesRead(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 

--- a/rest/counted_response_writer_test.go
+++ b/rest/counted_response_writer_test.go
@@ -70,7 +70,6 @@ func getResponseWriter(t *testing.T, stat *base.SgwIntStat, name string, updateI
 }
 
 func TestCountableResponseWriterRestTester(t *testing.T) {
-	RequireBucketSpecificCredentials(t)
 	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 

--- a/rest/counted_response_writer_test.go
+++ b/rest/counted_response_writer_test.go
@@ -70,9 +70,8 @@ func getResponseWriter(t *testing.T, stat *base.SgwIntStat, name string, updateI
 }
 
 func TestCountableResponseWriterRestTester(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled: true,
-	})
+	RequireBucketSpecificCredentials(t)
+	rt := NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
 	const alice = "alice"
@@ -81,7 +80,7 @@ func TestCountableResponseWriterRestTester(t *testing.T) {
 	resp := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/", "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	stats := rt.GetDatabase().DbStats.Database()
+	stats := rt.GetDatabase().DbStats.Serverless()
 	require.Equal(t, int64(0), stats.PublicRestBytesWritten.Value())
 
 	resp = rt.SendUserRequest(http.MethodGet, "/{{.db}}/", "", alice)
@@ -89,7 +88,7 @@ func TestCountableResponseWriterRestTester(t *testing.T) {
 	require.Greater(t, stats.PublicRestBytesWritten.Value(), int64(0))
 	stats.PublicRestBytesWritten.Set(0)
 
-	resp = rt.SendUserRequest(http.MethodGet, "/{{.db}}/", "", "")
+	resp = rt.SendUserRequest(http.MethodGet, "/{{.db}}/", "", alice)
 	RequireStatus(t, resp, http.StatusOK)
 	require.Greater(t, stats.PublicRestBytesWritten.Value(), int64(0))
 }

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1756,18 +1756,18 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 
 	importFilter := `function (doc) { return doc.type == "mobile"}`
 	rtConfig := rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			AutoImport:   false,
-			ImportFilter: &importFilter,
-		}},
+		SyncFn:           channels.DocChannelsSyncFunction,
 		Serverless:       true,
 		PersistentConfig: true,
 	}
 	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig)
 	defer rt.Close()
 
-	rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+	// change config to add import filter and turn auto import off then create db with that config
+	cfg := rt.NewDbConfig()
+	cfg.AutoImport = false
+	cfg.ImportFilter = &importFilter
+	rest.RequireStatus(t, rt.CreateDatabase("db", cfg), http.StatusCreated)
 
 	dataStore := rt.GetSingleDataStore()
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1697,15 +1697,21 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 
 func TestImportComputeStatOnDemandGet(t *testing.T) {
 	base.SkipImportTestsIfNotEnabled(t)
+	rest.RequireBucketSpecificCredentials(t)
 
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 			AutoImport: false,
 		}},
+		Serverless:       true,
+		PersistentConfig: true,
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
+
+	rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+
 	dataStore := rt.GetSingleDataStore()
 
 	key := t.Name()
@@ -1714,7 +1720,7 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	// assert the stat starts at 0 for a new database
-	computeStat := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Equal(t, int64(0), computeStat)
 
 	// add doc to bucket
@@ -1726,7 +1732,7 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusOK)
 
 	// assert the process compute stat has incremented
-	computeStat1 := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat1 := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Greater(t, computeStat1, int64(0))
 
 	// update doc in bucket
@@ -1740,12 +1746,13 @@ func TestImportComputeStatOnDemandGet(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+key, "")
 	rest.RequireStatus(t, response, http.StatusOK)
 	// assert the process compute stat has incremented again after another import
-	computeStat2 := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat2 := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Greater(t, computeStat2, computeStat1)
 
 }
 
 func TestImportComputeStatOnDemandWrite(t *testing.T) {
+	rest.RequireBucketSpecificCredentials(t)
 
 	importFilter := `function (doc) { return doc.type == "mobile"}`
 	rtConfig := rest.RestTesterConfig{
@@ -1754,9 +1761,14 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 			AutoImport:   false,
 			ImportFilter: &importFilter,
 		}},
+		Serverless:       true,
+		PersistentConfig: true,
 	}
 	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig)
 	defer rt.Close()
+
+	rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+
 	dataStore := rt.GetSingleDataStore()
 
 	key := t.Name()
@@ -1765,7 +1777,7 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	// assert the stat starts at 0 for a new database
-	computeStat := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Equal(t, int64(0), computeStat)
 
 	// add doc to bucket
@@ -1778,7 +1790,7 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 	assertDocProperty(t, response, "reason", "Not imported")
 
 	// assert stat still no incremented as import filter rejects the doc
-	computeStat1 := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat1 := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Equal(t, int64(0), computeStat1)
 
 	// rewrite through SG - should treat as new insert
@@ -1788,20 +1800,26 @@ func TestImportComputeStatOnDemandWrite(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusCreated)
 
 	// assert stat increases as function OnDemandImportForWrite will have been executed
-	computeStat2 := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat2 := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Greater(t, computeStat2, computeStat1)
 }
 
 func TestAutoImportComputeStat(t *testing.T) {
+	rest.RequireBucketSpecificCredentials(t)
 
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 			AutoImport: true,
 		}},
+		Serverless:       true,
+		PersistentConfig: true,
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
+
+	rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+
 	dataStore := rt.GetSingleDataStore()
 
 	key := t.Name()
@@ -1810,7 +1828,7 @@ func TestAutoImportComputeStat(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	// assert the stat starts at 0 for a new database
-	computeStat := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Equal(t, int64(0), computeStat)
 
 	// add doc to bucket
@@ -1823,7 +1841,7 @@ func TestAutoImportComputeStat(t *testing.T) {
 	}, 1)
 
 	// assert the stat increments for the auto import of the above doc
-	computeStat1 := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat1 := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Greater(t, computeStat1, int64(0))
 }
 
@@ -1831,6 +1849,7 @@ func TestQueryResyncImportComputeStat(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
+	rest.RequireBucketSpecificCredentials(t)
 
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
@@ -1840,9 +1859,14 @@ func TestQueryResyncImportComputeStat(t *testing.T) {
 				UseQueryBasedResyncManager: true,
 			},
 		}},
+		Serverless:       true,
+		PersistentConfig: true,
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
+
+	rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+
 	const numDocs = 100
 	var resp *rest.TestResponse
 
@@ -1851,7 +1875,7 @@ func TestQueryResyncImportComputeStat(t *testing.T) {
 		rest.RequireStatus(t, resp, http.StatusCreated)
 	}
 
-	computeStat := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Equal(t, int64(0), computeStat)
 
 	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_offline", "")
@@ -1862,7 +1886,7 @@ func TestQueryResyncImportComputeStat(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	rt.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
 
-	computeStat1 := rt.GetDatabase().DbStats.DatabaseStats.ImportProcessCompute.Value()
+	computeStat1 := rt.GetDatabase().DbStats.ServerlessStats.ImportProcessCompute.Value()
 	require.Greater(t, computeStat1, computeStat)
 
 }

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -125,7 +125,7 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 	passiveDBURL, err := url.Parse(srv.URL + "/" + rt2DbName)
 	require.NoError(t, err)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -361,7 +361,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 	localCollections := []string{localCollection}
 	remoteCollections := []string{"missing.collection"}
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -402,7 +402,7 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 	remoteCollection := passiveRT.GetSingleTestDatabaseCollection().ScopeName + "." + passiveRT.GetSingleTestDatabaseCollection().Name
 	remoteCollections := []string{remoteCollection}
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -125,7 +125,7 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 	passiveDBURL, err := url.Parse(srv.URL + "/" + rt2DbName)
 	require.NoError(t, err)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -361,7 +361,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 	localCollections := []string{localCollection}
 	remoteCollections := []string{"missing.collection"}
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -402,7 +402,7 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 	remoteCollection := passiveRT.GetSingleTestDatabaseCollection().ScopeName + "." + passiveRT.GetSingleTestDatabaseCollection().Name
 	remoteCollections := []string{remoteCollection}
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2510,7 +2510,6 @@ func TestTotalSyncTimeStat(t *testing.T) {
 //   - assert on the TotalSyncTime stat being incremented
 //   - put doc to end changes feed connection
 func TestChangesEndpointTotalSyncTime(t *testing.T) {
-	rest.RequireBucketSpecificCredentials(t)
 	rt := rest.NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2039,7 +2039,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2125,7 +2125,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2222,7 +2222,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2510,8 +2510,14 @@ func TestTotalSyncTimeStat(t *testing.T) {
 //   - assert on the TotalSyncTime stat being incremented
 //   - put doc to end changes feed connection
 func TestChangesEndpointTotalSyncTime(t *testing.T) {
-	rt := rest.NewRestTesterPersistentConfigServerless(t)
+	rest.RequireBucketSpecificCredentials(t)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		Serverless:       true,
+		SyncFn:           channels.DocChannelsSyncFunction,
+	})
 	defer rt.Close()
+	rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 
 	// to run changes feed as
 	rt.CreateUser("alice", []string{"ABC"})
@@ -2609,7 +2615,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2922,7 +2928,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3096,7 +3102,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3245,7 +3251,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3330,7 +3336,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3410,7 +3416,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3536,7 +3542,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3595,7 +3601,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create a new replicator using the same config, which should use the checkpoint set from the first.
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, false, nil, nil)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3711,7 +3717,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	arConfig.SetCheckpointPrefix(t, "cluster1:")
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3776,7 +3782,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	ctx2 := edge2.Context()
 
 	// Create a new replicator using the same ID, which should NOT use the checkpoint set by the first edge.
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false, false, nil, nil)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3808,7 +3814,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	require.NoError(t, rt1.WaitForPendingChanges())
 
 	// run a replicator on edge1 again to make sure that edge2 didn't blow away its checkpoint
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, false, nil, nil)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3877,7 +3883,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3969,7 +3975,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4065,7 +4071,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4241,7 +4247,8 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 			require.NoError(t, err)
 			replicationStats, err := stats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -4454,7 +4461,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
 
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 			require.NoError(t, err)
 			dbstats, err := stats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -4599,7 +4606,8 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4672,7 +4680,8 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4737,7 +4746,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// Active
 	rt1 := rest.NewRestTester(t, nil) // CBG-2379 test requires default collection
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4908,7 +4917,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4974,7 +4983,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 	arConfig.RemoteDBURL = passiveDBURL
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, false, nil, nil)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5069,7 +5078,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	assert.NoError(t, rt1.WaitForPendingChanges())
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5223,7 +5232,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5340,7 +5349,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5451,7 +5460,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	rt1 := rest.NewRestTesterDefaultCollection(t, nil)
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5656,7 +5665,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					defer rt1.Close()
 					ctx1 := rt1.Context()
 
-					sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+					sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 					require.NoError(t, err)
 					dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 					require.NoError(t, err)
@@ -5745,7 +5754,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 	id, err := base.GenerateRandomID()
 	require.NoError(t, err)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5826,7 +5835,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	rt1 := rest.NewRestTester(t, nil)
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -6099,7 +6108,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
-			dbstats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+			dbstats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 			require.NoError(t, err)
 			replicationStats, err := dbstats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -6553,7 +6562,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			defaultConflictResolver, err := db.NewCustomConflictResolver(
 				ctx1, `function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
-			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 			require.NoError(t, err)
 			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -6709,7 +6718,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			defaultConflictResolver, err := db.NewCustomConflictResolver(
 				ctx1, `function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
-			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 			require.NoError(t, err)
 			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -7036,7 +7045,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7201,7 +7210,7 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 		}`, rt1.GetDatabase().Options.JavascriptTimeout)
 	require.NoError(t, err)
 
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7293,7 +7302,10 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false, false, nil, nil)
+	dbStatOpts := base.DbStatsOptions{
+		DeltaSyncEnabled: true,
+	}
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &dbStatOpts)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7395,7 +7407,10 @@ func TestUnprocessableDeltas(t *testing.T) {
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false, false, nil, nil)
+	dbStatsOpts := base.DbStatsOptions{
+		DeltaSyncEnabled: true,
+	}
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &dbStatsOpts)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7493,7 +7508,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
 
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7548,7 +7563,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	// Set-up replicator
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7654,7 +7669,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats("test", &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -8281,7 +8296,7 @@ func TestReplicatorWithCollectionsFailWithoutCollectionsEnabled(t *testing.T) {
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -549,7 +549,7 @@ func TestStopServerlessConnectionLimitingDuringReplications(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
-	rt1, rt2, remoteURLString, teardown := rest.SetupSGRPeers(t)
+	rt1, rt2, remoteURLString, teardown := rest.SetupSGRPeersServerless(t)
 	defer teardown()
 
 	resp := rt2.SendAdminRequest(http.MethodPut, "/_config", `{"max_concurrent_replications" : 2}`)
@@ -591,7 +591,7 @@ func TestServerlessConnectionLimitingOneshotFeed(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
-	rt1, rt2, remoteURLString, teardown := rest.SetupSGRPeers(t)
+	rt1, rt2, remoteURLString, teardown := rest.SetupSGRPeersServerless(t)
 	defer teardown()
 
 	// update runtime config to limit to 2 concurrent replication connections
@@ -631,7 +631,7 @@ func TestServerlessConnectionLimitingContinuous(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
-	rt1, rt2, remoteURLString, teardown := rest.SetupSGRPeers(t)
+	rt1, rt2, remoteURLString, teardown := rest.SetupSGRPeersServerless(t)
 	defer teardown()
 
 	// update runtime config to limit to 2 concurrent replication connections
@@ -2039,7 +2039,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2125,7 +2125,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2222,7 +2222,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2475,11 +2475,11 @@ func TestTotalSyncTimeStat(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
-	activeRT, passiveRT, remoteURL, teardown := rest.SetupSGRPeers(t)
+	activeRT, passiveRT, remoteURL, teardown := rest.SetupSGRPeersServerless(t)
 	defer teardown()
 	const repName = "replication1"
 
-	startValue := passiveRT.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
+	startValue := passiveRT.GetDatabase().DbStats.ServerlessStats.TotalSyncTime.Value()
 	require.Equal(t, int64(0), startValue)
 
 	// create a replication to just make a long lived websocket connection between two rest testers
@@ -2494,11 +2494,11 @@ func TestTotalSyncTimeStat(t *testing.T) {
 
 	// wait some time to wait for the stat to increment
 	_, ok = base.WaitForStat(passiveRT.TB, func() int64 {
-		return passiveRT.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
+		return passiveRT.GetDatabase().DbStats.ServerlessStats.TotalSyncTime.Value()
 	}, 2)
 	require.True(t, ok)
 
-	syncTimeStat := passiveRT.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
+	syncTimeStat := passiveRT.GetDatabase().DbStats.ServerlessStats.TotalSyncTime.Value()
 	// we can't be certain how long has passed since grabbing the stat so to avoid flake here just assert the stat has incremented
 	require.Greater(t, syncTimeStat, startValue)
 }
@@ -2510,16 +2510,15 @@ func TestTotalSyncTimeStat(t *testing.T) {
 //   - assert on the TotalSyncTime stat being incremented
 //   - put doc to end changes feed connection
 func TestChangesEndpointTotalSyncTime(t *testing.T) {
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: `function(doc) {channel(doc.channel);}`,
-	})
+	rest.RequireBucketSpecificCredentials(t)
+	rt := rest.NewRestTesterPersistentConfigServerless(t)
 	defer rt.Close()
 
 	// to run changes feed as
 	rt.CreateUser("alice", []string{"ABC"})
 
 	// assert stat is zero value to begin with
-	startValue := rt.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
+	startValue := rt.GetDatabase().DbStats.ServerlessStats.TotalSyncTime.Value()
 	require.Equal(t, int64(0), startValue)
 
 	// Put several documents in channel PBS
@@ -2553,10 +2552,10 @@ func TestChangesEndpointTotalSyncTime(t *testing.T) {
 
 	// wait some time to wait for the stat to increment
 	base.RequireWaitForStat(t, func() int64 {
-		return rt.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
+		return rt.GetDatabase().DbStats.ServerlessStats.TotalSyncTime.Value()
 	}, 2)
 
-	syncTimeStat := rt.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
+	syncTimeStat := rt.GetDatabase().DbStats.ServerlessStats.TotalSyncTime.Value()
 	// we can't be certain how long has passed since grabbing the stat so to avoid flake here just assert the stat has incremented
 	require.Greater(t, syncTimeStat, startValue)
 
@@ -2611,7 +2610,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2924,7 +2923,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3098,7 +3097,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3247,7 +3246,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3332,7 +3331,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3412,7 +3411,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3538,7 +3537,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3597,7 +3596,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create a new replicator using the same config, which should use the checkpoint set from the first.
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, nil, nil)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3713,7 +3712,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	arConfig.SetCheckpointPrefix(t, "cluster1:")
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3778,7 +3777,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	ctx2 := edge2.Context()
 
 	// Create a new replicator using the same ID, which should NOT use the checkpoint set by the first edge.
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false, nil, nil)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge2", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3810,7 +3809,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	require.NoError(t, rt1.WaitForPendingChanges())
 
 	// run a replicator on edge1 again to make sure that edge2 didn't blow away its checkpoint
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, nil, nil)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"edge1", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3879,7 +3878,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -3971,7 +3970,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4067,7 +4066,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	defer rt1.Close()
 	ctx1 := rt1.Context()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4243,7 +4242,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 			require.NoError(t, err)
 			replicationStats, err := stats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -4456,7 +4455,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
 
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 			require.NoError(t, err)
 			dbstats, err := stats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -4601,7 +4600,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4674,7 +4673,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4739,7 +4738,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// Active
 	rt1 := rest.NewRestTester(t, nil) // CBG-2379 test requires default collection
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4910,7 +4909,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -4976,7 +4975,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 	arConfig.RemoteDBURL = passiveDBURL
-	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, nil, nil)
+	stats, err = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5071,7 +5070,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	assert.NoError(t, rt1.WaitForPendingChanges())
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5225,7 +5224,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5342,7 +5341,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5453,7 +5452,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	rt1 := rest.NewRestTesterDefaultCollection(t, nil)
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5658,7 +5657,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					defer rt1.Close()
 					ctx1 := rt1.Context()
 
-					sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+					sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 					require.NoError(t, err)
 					dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 					require.NoError(t, err)
@@ -5747,7 +5746,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 	id, err := base.GenerateRandomID()
 	require.NoError(t, err)
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -5828,7 +5827,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	rt1 := rest.NewRestTester(t, nil)
 	defer rt1.Close()
 	ctx1 := rt1.Context()
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -6101,7 +6100,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, test.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err)
-			dbstats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+			dbstats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 			require.NoError(t, err)
 			replicationStats, err := dbstats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -6555,7 +6554,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			defaultConflictResolver, err := db.NewCustomConflictResolver(
 				ctx1, `function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
-			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 			require.NoError(t, err)
 			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -6711,7 +6710,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			defaultConflictResolver, err := db.NewCustomConflictResolver(
 				ctx1, `function(conflict) { return defaultPolicy(conflict); }`, rt1.GetDatabase().Options.JavascriptTimeout)
 			require.NoError(t, err, "Error creating custom conflict resolver")
-			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+			sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 			require.NoError(t, err)
 			dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 			require.NoError(t, err)
@@ -7038,7 +7037,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7203,7 +7202,7 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 		}`, rt1.GetDatabase().Options.JavascriptTimeout)
 	require.NoError(t, err)
 
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7295,7 +7294,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7397,7 +7396,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7495,7 +7494,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
 
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7550,7 +7549,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	// Set-up replicator
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -7656,7 +7655,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
-	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -8283,7 +8282,7 @@ func TestReplicatorWithCollectionsFailWithoutCollectionsEnabled(t *testing.T) {
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := stats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2521,11 +2521,11 @@ func TestChangesEndpointTotalSyncTime(t *testing.T) {
 	require.Equal(t, int64(0), startValue)
 
 	// Put several documents in channel PBS
-	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs2", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs2", `{"value":2, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs3", `{"value":3, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs3", `{"value":3, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
 	changesJSON := `{"style":"all_docs",
@@ -2559,7 +2559,7 @@ func TestChangesEndpointTotalSyncTime(t *testing.T) {
 	require.Greater(t, syncTimeStat, startValue)
 
 	// put doc to end changes feed
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc1", `{"value":3, "channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/abc1", `{"value":3, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
 	wg.Wait()
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1543,7 +1543,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1606,7 +1606,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1677,7 +1677,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1745,7 +1745,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword(revocationTestUser, revocationTestPassword)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1866,7 +1866,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1960,7 +1960,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 	)
 
 	passiveDBURL.User = url.UserPassword(username, password)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2039,7 +2039,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2136,7 +2136,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2561,7 +2561,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2622,7 +2622,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 	require.NoError(t, ar.Stop())
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-	sgwStats, err = base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	sgwStats, err = base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
 	require.NoError(t, err)
 	dbstats, err = sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1543,7 +1543,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1606,7 +1606,7 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1677,7 +1677,7 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1745,7 +1745,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword(revocationTestUser, revocationTestPassword)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1866,7 +1866,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -1960,7 +1960,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 	)
 
 	passiveDBURL.User = url.UserPassword(username, password)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2039,7 +2039,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "test")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2136,7 +2136,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2561,7 +2561,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)
@@ -2622,7 +2622,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 	require.NoError(t, ar.Stop())
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-	sgwStats, err = base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, false, nil, nil)
+	sgwStats, err = base.SyncGatewayStats.NewDBStats(t.Name(), &base.DbStatsOptions{})
 	require.NoError(t, err)
 	dbstats, err = sgwStats.DBReplicatorStats(t.Name())
 	require.NoError(t, err)

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -87,7 +87,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	//assert.Equal(t, 0, count)
 }
 
-// Tests behaviour of CBG-2258 to force per bucket credentials to be used when setting up db in Serverless mode
+// Tests behaviour of CBG-2258 to force per bucket credentials to be used when setting up db in serverless mode
 func TestServerlessDBSetupForceCreds(t *testing.T) {
 	RequireBucketSpecificCredentials(t)
 
@@ -139,7 +139,7 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 }
 
 // Tests behaviour of CBG-2258 to make sure fetch databases only uses buckets listed on StartupConfig.BucketCredentials
-// when running in Serverless mode
+// when running in serverless mode
 func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 	RequireBucketSpecificCredentials(t)
 
@@ -185,12 +185,12 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 		kvConnCount          int
 	}{
 		{
-			name:                 "Serverless connection",
+			name:                 "serverless connection",
 			expectedConnstrQuery: "?dcp_buffer_size=1048576&idle_http_connection_timeout=90000&kv_buffer_size=1048576&kv_pool_size=1&max_idle_http_connections=64000&max_perhost_idle_http_connections=256",
 			kvConnCount:          1,
 		},
 		{
-			name:                 "Serverless connection with kv pool specified",
+			name:                 "serverless connection with kv pool specified",
 			specKvConn:           "?idle_http_connection_timeout=90000&kv_pool_size=3&max_idle_http_connections=64000&max_perhost_idle_http_connections=256",
 			expectedConnstrQuery: "?dcp_buffer_size=1048576&idle_http_connection_timeout=90000&kv_buffer_size=1048576&kv_pool_size=3&max_idle_http_connections=64000&max_perhost_idle_http_connections=256",
 			kvConnCount:          3,
@@ -239,7 +239,7 @@ func TestServerlessUnsupportedOptions(t *testing.T) {
 			dcpBuffer:       3000,
 		},
 		{
-			name:            "default Serverless",
+			name:            "default serverless",
 			expectedConnStr: "?dcp_buffer_size=1048576&idle_http_connection_timeout=90000&kv_buffer_size=1048576&kv_pool_size=1&max_idle_http_connections=64000&max_perhost_idle_http_connections=256",
 		},
 	}
@@ -284,7 +284,7 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 
 	sc := rt.ServerContext()
 
-	// suspendable should default to true when in Serverless
+	// suspendable should default to true when in serverless
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
 		"bucket": "%s",
 		"use_views": %t,
@@ -529,19 +529,19 @@ func TestSuspendingFlags(t *testing.T) {
 		expectCanSuspend bool
 	}{
 		{
-			name:             "Serverless defaults suspendable flag on db to true",
+			name:             "serverless defaults suspendable flag on db to true",
 			serverlessMode:   true,
 			dbSuspendable:    nil,
 			expectCanSuspend: true,
 		},
 		{
-			name:             "Serverless with suspendable db disallowed",
+			name:             "serverless with suspendable db disallowed",
 			serverlessMode:   true,
 			dbSuspendable:    base.BoolPtr(false),
 			expectCanSuspend: false,
 		},
 		{
-			name:             "Non-Serverless with suspendable db",
+			name:             "Non-serverless with suspendable db",
 			serverlessMode:   false,
 			dbSuspendable:    base.BoolPtr(true),
 			expectCanSuspend: true,
@@ -695,18 +695,18 @@ func TestImportPartitionsServerless(t *testing.T) {
 		serverless         bool
 	}{
 		{
-			name:               "Serverless partitions",
+			name:               "serverless partitions",
 			expectedPartitions: base.Uint16Ptr(6),
 			serverless:         true,
 		},
 		{
-			name:               "Serverless partitions with import_partition specified",
+			name:               "serverless partitions with import_partition specified",
 			importPartition:    base.Uint16Ptr(8),
 			expectedPartitions: base.Uint16Ptr(8),
 			serverless:         true,
 		},
 		{
-			name:               "non Serverless partitions",
+			name:               "non serverless partitions",
 			expectedPartitions: base.Uint16Ptr(16),
 			serverless:         false,
 		},
@@ -728,7 +728,7 @@ func TestImportPartitionsServerless(t *testing.T) {
 			sc := rt.ServerContext()
 
 			var dbconf *DbConfig
-			if test.name == "Serverless partitions with import_partition specified" {
+			if test.name == "serverless partitions with import_partition specified" {
 				resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{"bucket": "%s", "use_views": %t, "num_index_replicas": 0, "import_partitions": 8}`,
 					tb.GetName(), base.TestsDisableGSI()))
 				RequireStatus(t, resp, http.StatusCreated)

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -30,7 +30,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb1.NoCloseClone(),
-		serverless:       true,
+		Serverless:       true,
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
@@ -87,7 +87,7 @@ func TestServerlessPollBuckets(t *testing.T) {
 	//assert.Equal(t, 0, count)
 }
 
-// Tests behaviour of CBG-2258 to force per bucket credentials to be used when setting up db in serverless mode
+// Tests behaviour of CBG-2258 to force per bucket credentials to be used when setting up db in Serverless mode
 func TestServerlessDBSetupForceCreds(t *testing.T) {
 	RequireBucketSpecificCredentials(t)
 
@@ -121,7 +121,7 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), serverless: true, PersistentConfig: true})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), Serverless: true, PersistentConfig: true})
 			defer rt.Close()
 
 			if test.perBucketCreds != nil {
@@ -139,14 +139,14 @@ func TestServerlessDBSetupForceCreds(t *testing.T) {
 }
 
 // Tests behaviour of CBG-2258 to make sure fetch databases only uses buckets listed on StartupConfig.BucketCredentials
-// when running in serverless mode
+// when running in Serverless mode
 func TestServerlessBucketCredentialsFetchDatabases(t *testing.T) {
 	RequireBucketSpecificCredentials(t)
 
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
 	defer tb1.Close(ctx)
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), PersistentConfig: true, serverless: true,
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb1.NoCloseClone(), PersistentConfig: true, Serverless: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
 		},
@@ -185,12 +185,12 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 		kvConnCount          int
 	}{
 		{
-			name:                 "serverless connection",
+			name:                 "Serverless connection",
 			expectedConnstrQuery: "?dcp_buffer_size=1048576&idle_http_connection_timeout=90000&kv_buffer_size=1048576&kv_pool_size=1&max_idle_http_connections=64000&max_perhost_idle_http_connections=256",
 			kvConnCount:          1,
 		},
 		{
-			name:                 "serverless connection with kv pool specified",
+			name:                 "Serverless connection with kv pool specified",
 			specKvConn:           "?idle_http_connection_timeout=90000&kv_pool_size=3&max_idle_http_connections=64000&max_perhost_idle_http_connections=256",
 			expectedConnstrQuery: "?dcp_buffer_size=1048576&idle_http_connection_timeout=90000&kv_buffer_size=1048576&kv_pool_size=3&max_idle_http_connections=64000&max_perhost_idle_http_connections=256",
 			kvConnCount:          3,
@@ -209,7 +209,7 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 				tb.BucketSpec.Server = bucketServer + "?kv_pool_size=3"
 			}
 
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, Serverless: true})
 			defer rt.Close()
 			sc := rt.ServerContext()
 			require.True(t, sc.Config.IsServerless())
@@ -239,7 +239,7 @@ func TestServerlessUnsupportedOptions(t *testing.T) {
 			dcpBuffer:       3000,
 		},
 		{
-			name:            "default serverless",
+			name:            "default Serverless",
 			expectedConnStr: "?dcp_buffer_size=1048576&idle_http_connection_timeout=90000&kv_buffer_size=1048576&kv_pool_size=1&max_idle_http_connections=64000&max_perhost_idle_http_connections=256",
 		},
 	}
@@ -251,7 +251,7 @@ func TestServerlessUnsupportedOptions(t *testing.T) {
 			bucketServer := tb.BucketSpec.Server
 			test.expectedConnStr = bucketServer + test.expectedConnStr
 
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, Serverless: true})
 			defer rt.Close()
 			sc := rt.ServerContext()
 			require.True(t, sc.Config.IsServerless())
@@ -279,12 +279,12 @@ func TestServerlessSuspendDatabase(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, Serverless: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
 
-	// suspendable should default to true when in serverless
+	// suspendable should default to true when in Serverless
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{
 		"bucket": "%s",
 		"use_views": %t,
@@ -354,7 +354,7 @@ func TestServerlessUnsuspendFetchFallback(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
-		serverless:       true,
+		Serverless:       true,
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(0)
@@ -541,19 +541,19 @@ func TestSuspendingFlags(t *testing.T) {
 			expectCanSuspend: false,
 		},
 		{
-			name:             "Non-serverless with suspendable db",
+			name:             "Non-Serverless with suspendable db",
 			serverlessMode:   false,
 			dbSuspendable:    base.BoolPtr(true),
 			expectCanSuspend: true,
 		},
 		{
-			name:             "Non-serverless with unsuspendable db",
+			name:             "Non-Serverless with unsuspendable db",
 			serverlessMode:   false,
 			dbSuspendable:    base.BoolPtr(false),
 			expectCanSuspend: false,
 		},
 		{
-			name:             "Non-serverless with db default suspendable option",
+			name:             "Non-Serverless with db default suspendable option",
 			serverlessMode:   false,
 			dbSuspendable:    nil,
 			expectCanSuspend: false,
@@ -566,7 +566,7 @@ func TestSuspendingFlags(t *testing.T) {
 			defer tb.Close(ctx)
 
 			rt := NewRestTester(t,
-				&RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: test.serverlessMode})
+				&RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, Serverless: test.serverlessMode})
 			defer rt.Close()
 
 			sc := rt.ServerContext()
@@ -608,7 +608,7 @@ func TestServerlessUnsuspendAPI(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, Serverless: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -644,7 +644,7 @@ func TestServerlessUnsuspendAdminAuth(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)
 
-	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: true, AdminInterfaceAuthentication: true})
+	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, Serverless: true, AdminInterfaceAuthentication: true})
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -695,18 +695,18 @@ func TestImportPartitionsServerless(t *testing.T) {
 		serverless         bool
 	}{
 		{
-			name:               "serverless partitions",
+			name:               "Serverless partitions",
 			expectedPartitions: base.Uint16Ptr(6),
 			serverless:         true,
 		},
 		{
-			name:               "serverless partitions with import_partition specified",
+			name:               "Serverless partitions with import_partition specified",
 			importPartition:    base.Uint16Ptr(8),
 			expectedPartitions: base.Uint16Ptr(8),
 			serverless:         true,
 		},
 		{
-			name:               "non serverless partitions",
+			name:               "non Serverless partitions",
 			expectedPartitions: base.Uint16Ptr(16),
 			serverless:         false,
 		},
@@ -723,12 +723,12 @@ func TestImportPartitionsServerless(t *testing.T) {
 			ctx := base.TestCtx(t)
 			tb := base.GetTestBucket(t)
 			defer tb.Close(ctx)
-			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, serverless: test.serverless})
+			rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb.NoCloseClone(), PersistentConfig: true, Serverless: test.serverless})
 			defer rt.Close()
 			sc := rt.ServerContext()
 
 			var dbconf *DbConfig
-			if test.name == "serverless partitions with import_partition specified" {
+			if test.name == "Serverless partitions with import_partition specified" {
 				resp := rt.SendAdminRequest(http.MethodPut, "/db/", fmt.Sprintf(`{"bucket": "%s", "use_views": %t, "num_index_replicas": 0, "import_partitions": 8}`,
 					tb.GetName(), base.TestsDisableGSI()))
 				RequireStatus(t, resp, http.StatusCreated)
@@ -740,4 +740,14 @@ func TestImportPartitionsServerless(t *testing.T) {
 			assert.Equal(t, expectedPartitions, dbconf.ImportPartitions)
 		})
 	}
+}
+
+// TestServerlessStatsNoInit:
+//   - Asserts that Serverless stats are not initialised when not in serverless mode
+func TestServerlessStatsNoInit(t *testing.T) {
+	RequireBucketSpecificCredentials(t)
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	require.Nil(t, rt.GetDatabase().DbStats.Serverless())
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -121,12 +121,12 @@ func NewRestTesterPersistentConfig(tb testing.TB) *RestTester {
 	return rt
 }
 
+// NewRestTesterPersistentConfigServerless is a convenience function to set up RestTester in persistent config with serverless mode.
 func NewRestTesterPersistentConfigServerless(tb *testing.T) *RestTester {
 	RequireBucketSpecificCredentials(tb)
 	config := &RestTesterConfig{
 		PersistentConfig: true,
 		Serverless:       true,
-		SyncFn:           channels.DocChannelsSyncFunction,
 	}
 	rt := newRestTester(tb, config, useSingleCollection, 1)
 	RequireStatus(tb, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -122,6 +122,7 @@ func NewRestTesterPersistentConfig(tb testing.TB) *RestTester {
 }
 
 func NewRestTesterPersistentConfigServerless(tb *testing.T) *RestTester {
+	RequireBucketSpecificCredentials(tb)
 	config := &RestTesterConfig{
 		PersistentConfig: true,
 		Serverless:       true,

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -68,7 +68,7 @@ type RestTesterConfig struct {
 	useTLSServer                    bool // If true, TLS will be required for communications with CBS. Default: false
 	PersistentConfig                bool
 	GroupID                         *string
-	serverless                      bool // Runs SG in serverless mode. Must be used in conjunction with persistent config
+	Serverless                      bool // Runs SG in Serverless mode. Must be used in conjunction with persistent config
 	collectionConfig                collectionConfiguration
 	numCollections                  int
 	syncGatewayVersion              *base.ComparableBuildVersion // alternate version of Sync Gateway to use on startup
@@ -115,6 +115,17 @@ func NewRestTester(tb testing.TB, restConfig *RestTesterConfig) *RestTester {
 func NewRestTesterPersistentConfig(tb testing.TB) *RestTester {
 	config := &RestTesterConfig{
 		PersistentConfig: true,
+	}
+	rt := newRestTester(tb, config, useSingleCollection, 1)
+	RequireStatus(tb, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+	return rt
+}
+
+func NewRestTesterPersistentConfigServerless(tb *testing.T) *RestTester {
+	config := &RestTesterConfig{
+		PersistentConfig: true,
+		Serverless:       true,
+		SyncFn:           channels.DocChannelsSyncFunction,
 	}
 	rt := newRestTester(tb, config, useSingleCollection, 1)
 	RequireStatus(tb, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
@@ -226,10 +237,10 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
 	sc.Bootstrap.UseTLSServer = &rt.RestTesterConfig.useTLSServer
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
-	sc.Unsupported.Serverless.Enabled = &rt.serverless
+	sc.Unsupported.Serverless.Enabled = &rt.Serverless
 	sc.Unsupported.AllowDbConfigEnvVars = rt.RestTesterConfig.allowDbConfigEnvVars
 	sc.Replicator.MaxConcurrentRevs = rt.RestTesterConfig.maxConcurrentRevs
-	if rt.serverless {
+	if rt.Serverless {
 		if !rt.PersistentConfig {
 			rt.TB.Fatalf("Persistent config must be used when running in serverless mode")
 		}

--- a/tools/stats-definition-exporter/main.go
+++ b/tools/stats-definition-exporter/main.go
@@ -105,7 +105,7 @@ func registerStats() (*base.GlobalStat, *base.DbStats, error) {
 		return nil, nil, fmt.Errorf("could not create sg stats: %w", err)
 	}
 
-	dbStats, err := sgStats.NewDBStats("", true, true, false, []string{""}, []string{""})
+	dbStats, err := sgStats.NewDBStats("", true, true, false, true, []string{""}, []string{""})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create db stats: %w", err)
 	}

--- a/tools/stats-definition-exporter/main.go
+++ b/tools/stats-definition-exporter/main.go
@@ -105,7 +105,14 @@ func registerStats() (*base.GlobalStat, *base.DbStats, error) {
 		return nil, nil, fmt.Errorf("could not create sg stats: %w", err)
 	}
 
-	dbStats, err := sgStats.NewDBStats("", true, true, false, true, []string{""}, []string{""})
+	dbStatsOpts := base.DbStatsOptions{
+		DeltaSyncEnabled:  true,
+		ImportEnabled:     true,
+		ServerlessEnabled: true,
+		QueryNames:        []string{""},
+		Collections:       []string{""},
+	}
+	dbStats, err := sgStats.NewDBStats("", &dbStatsOpts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create db stats: %w", err)
 	}


### PR DESCRIPTION
CBG-3278

- Moved stats added for serverless into its own struct on stats, will be initiated on db stats if in serverless mode
- Went through tests that asserted on these stats to change them to serverless tests, this meant making them persistent config too
- Some test were testing the stats on ISGR, so created a separate helper to make SGR peers in serverless and persistent config mode, chose this over passing logic into the existing helper method to make it tidier. 
- Added helper `NewRestTesterPersistentConfigServerless` to create serverless rest tester
- NOTE: All tests that assert on these stats will now be skipped for rosmar due to needing bucket specific creds for persistent config 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2330/
