### PR TITLE
Test cleanup: Equal(len()) -> Len()

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1559,9 +1559,9 @@ func TestRevocationScenario1(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1572,9 +1572,9 @@ func TestRevocationScenario1(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1591,9 +1591,9 @@ func TestRevocationScenario1(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(40, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1654,9 +1654,9 @@ func TestRevocationScenario2(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1671,8 +1671,8 @@ func TestRevocationScenario2(t *testing.T) {
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
@@ -1688,8 +1688,8 @@ func TestRevocationScenario2(t *testing.T) {
 	// Verify history
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1711,7 +1711,7 @@ func TestRevocationScenario2(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
 
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
@@ -1755,9 +1755,9 @@ func TestRevocationScenario3(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(55, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1778,7 +1778,7 @@ func TestRevocationScenario3(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
@@ -1793,9 +1793,9 @@ func TestRevocationScenario3(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 1, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 1)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 1)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(60, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
@@ -1821,7 +1821,7 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[1])
 
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
@@ -1865,9 +1865,9 @@ func TestRevocationScenario4(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1885,8 +1885,8 @@ func TestRevocationScenario4(t *testing.T) {
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
@@ -1899,9 +1899,9 @@ func TestRevocationScenario4(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, fooPrincipal.ChannelHistory(), 1)
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(70, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1921,7 +1921,7 @@ func TestRevocationScenario4(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[1])
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
@@ -1962,9 +1962,9 @@ func TestRevocationScenario5(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -1980,9 +1980,9 @@ func TestRevocationScenario5(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -2001,7 +2001,7 @@ func TestRevocationScenario5(t *testing.T) {
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
@@ -2043,9 +2043,9 @@ func TestRevocationScenario6(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	require.Len(t, revokedChannelsCombined, 0)
 
@@ -2066,8 +2066,8 @@ func TestRevocationScenario6(t *testing.T) {
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
@@ -2087,7 +2087,7 @@ func TestRevocationScenario6(t *testing.T) {
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 1)
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
@@ -2128,9 +2128,9 @@ func TestRevocationScenario7(t *testing.T) {
 	// Verify history
 	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -2157,7 +2157,7 @@ func TestRevocationScenario7(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
@@ -2170,9 +2170,9 @@ func TestRevocationScenario7(t *testing.T) {
 	// Verify history
 	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
 
-	assert.Equal(t, 1, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 1)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 1)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(100, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
@@ -2211,9 +2211,9 @@ func TestRevocationScenario8(t *testing.T) {
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
 	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -2234,8 +2234,8 @@ func TestRevocationScenario8(t *testing.T) {
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
@@ -2275,9 +2275,9 @@ func TestRevocationScenario9(t *testing.T) {
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
 	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -2293,9 +2293,9 @@ func TestRevocationScenario9(t *testing.T) {
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
 	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(60, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
@@ -2337,9 +2337,9 @@ func TestRevocationScenario10(t *testing.T) {
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
 	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -2357,8 +2357,8 @@ func TestRevocationScenario10(t *testing.T) {
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(70, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
@@ -2401,9 +2401,9 @@ func TestRevocationScenario11(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.True(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -2425,7 +2425,7 @@ func TestRevocationScenario11(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
 
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
 
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
@@ -2472,9 +2472,9 @@ func TestRevocationScenario12(t *testing.T) {
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
 	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -2489,8 +2489,8 @@ func TestRevocationScenario12(t *testing.T) {
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(90, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
@@ -2536,9 +2536,9 @@ func TestRevocationScenario13(t *testing.T) {
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
 	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined := aliceUserPrincipal.revokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
@@ -2548,9 +2548,9 @@ func TestRevocationScenario13(t *testing.T) {
 	// Ensure user cannot see ch1 (via role)
 	// Verify history
 	assert.False(t, aliceUserPrincipal.canSeeChannel("ch1"))
-	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
-	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+	assert.Len(t, aliceUserPrincipal.RoleHistory(), 0)
+	assert.Len(t, aliceUserPrincipal.ChannelHistory(), 0)
+	assert.Len(t, fooPrincipal.ChannelHistory(), 0)
 	revokedChannelsCombined = aliceUserPrincipal.revokedChannels(100, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
@@ -2631,7 +2631,7 @@ func TestRoleSoftDelete(t *testing.T) {
 	role, err = auth.GetRole(roleName)
 	assert.NoError(t, err)
 	assert.NotNil(t, role)
-	assert.Equal(t, 2, len(role.Channels().AllKeys()))
+	assert.Len(t, role.Channels().AllKeys(), 2)
 	assert.True(t, role.Channels().Contains("channel"))
 
 	// Delete role
@@ -2646,10 +2646,10 @@ func TestRoleSoftDelete(t *testing.T) {
 
 	role, err = auth.GetRoleIncDeleted(roleName)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(role.ChannelHistory()))
-	assert.Equal(t, 0, len(role.Channels().AllKeys()))
-	require.Equal(t, 1, len(role.ChannelHistory()["channel"].Entries))
-	require.Equal(t, 1, len(role.ChannelHistory()["!"].Entries))
+	assert.Len(t, role.ChannelHistory(), 2)
+	assert.Len(t, role.Channels().AllKeys(), 0)
+	require.Len(t, role.ChannelHistory()["channel"].Entries, 1)
+	require.Len(t, role.ChannelHistory()["!"].Entries, 1)
 	assert.Equal(t, expectedChannelHistory, role.ChannelHistory()["channel"].Entries[0])
 	assert.Equal(t, expectedChannelHistory, role.ChannelHistory()["!"].Entries[0])
 
@@ -2671,12 +2671,12 @@ func TestRoleSoftDelete(t *testing.T) {
 	role, err = auth.GetRole(roleName)
 	assert.NoError(t, err)
 	assert.NotNil(t, role)
-	assert.Equal(t, 2, len(role.Channels().AllKeys()))
+	assert.Len(t, role.Channels().AllKeys(), 2)
 	assert.False(t, role.Channels().Contains("channel"))
 	assert.True(t, role.Channels().Contains("channel2"))
-	assert.Equal(t, 2, len(role.ChannelHistory()))
-	require.Equal(t, 1, len(role.ChannelHistory()["channel"].Entries))
-	require.Equal(t, 1, len(role.ChannelHistory()["!"].Entries))
+	assert.Len(t, role.ChannelHistory(), 2)
+	require.Len(t, role.ChannelHistory()["channel"].Entries, 1)
+	require.Len(t, role.ChannelHistory()["!"].Entries, 1)
 	assert.Equal(t, expectedChannelHistory, role.ChannelHistory()["channel"].Entries[0])
 	assert.Equal(t, expectedChannelHistory, role.ChannelHistory()["!"].Entries[0])
 }

--- a/auth/collection_access_test.go
+++ b/auth/collection_access_test.go
@@ -206,7 +206,7 @@ func TestSerializeUserWithCollections(t *testing.T) {
 	require.NoError(t, err)
 	collectionAccess, ok = resu.getCollectionAccess(scope, collection)
 	assert.True(t, ok)
-	assert.Equal(t, 0, len(collectionAccess.ExplicitChannels_))
+	assert.Len(t, collectionAccess.ExplicitChannels_, 0)
 	assert.Equal(t, uint64(2), user.getCollectionChannelInvalSeq(scope, collection))
 }
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -890,7 +890,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 	var retrievedXattr map[string]interface{}
 	_, err = dataStore.GetWithXattr(ctx, key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(retrievedVal))
+	assert.Len(t, retrievedVal, 0)
 	assert.Equal(t, float64(123), retrievedXattr["seq"])
 
 }
@@ -929,7 +929,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	var retrievedXattr map[string]interface{}
 	getCas, err := dataStore.GetWithXattr(ctx, key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(retrievedVal))
+	assert.Len(t, retrievedVal, 0)
 	assert.Equal(t, float64(1), retrievedXattr["seq"])
 	log.Printf("Post-delete xattr (1): %s", retrievedXattr)
 	log.Printf("Post-delete cas (1): %x", getCas)
@@ -947,7 +947,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	getCas2, err := dataStore.GetWithXattr(ctx, key, xattrName, "", &postDeleteVal, &postDeleteXattr, nil)
 	assert.NoError(t, err, "Error getting document post-delete")
 	assert.Equal(t, float64(2), postDeleteXattr["seq"])
-	assert.Equal(t, 0, len(postDeleteVal))
+	assert.Len(t, postDeleteVal, 0)
 	log.Printf("Post-delete xattr (2): %s", postDeleteXattr)
 	log.Printf("Post-delete cas (2): %x", getCas2)
 
@@ -984,7 +984,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 	var retrievedXattr map[string]interface{}
 	mutateCas, err := dataStore.GetWithXattr(ctx, key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(retrievedVal))
+	assert.Len(t, retrievedVal, 0)
 	assert.Equal(t, float64(123), retrievedXattr["seq"])
 	log.Printf("value: %v, xattr: %v", retrievedVal, retrievedXattr)
 	log.Printf("MutateInEx cas: %v", mutateCas)

--- a/base/bucket_view_test.go
+++ b/base/bucket_view_test.go
@@ -86,13 +86,13 @@ func TestView(t *testing.T) {
 	viewParams[ViewQueryParamStale] = false
 	result, viewErr := viewStore.View(ctx, ddocName, viewName, viewParams)
 	require.NoError(t, viewErr)
-	assert.Equal(t, 3, len(result.Rows))
+	assert.Len(t, result.Rows, 3)
 
 	// Limit
 	viewParams[ViewQueryParamLimit] = 1
 	result, viewErr = viewStore.View(ctx, ddocName, viewName, viewParams)
 	require.NoError(t, viewErr)
-	require.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 	assert.Equal(t, "Circle", result.Rows[0].Key)
 
 	// Startkey, Endkey
@@ -101,7 +101,7 @@ func TestView(t *testing.T) {
 	viewParams[ViewQueryParamEndKey] = "Northern"
 	result, viewErr = viewStore.View(ctx, ddocName, viewName, viewParams)
 	require.NoError(t, viewErr)
-	require.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, "District", result.Rows[0].Key)
 	assert.Equal(t, "Northern", result.Rows[1].Key)
 
@@ -109,7 +109,7 @@ func TestView(t *testing.T) {
 	viewParams[ViewQueryParamInclusiveEnd] = false
 	result, viewErr = viewStore.View(ctx, ddocName, viewName, viewParams)
 	require.NoError(t, viewErr)
-	assert.Equal(t, 1, len(result.Rows))
+	assert.Len(t, result.Rows, 1)
 	assert.Equal(t, "District", result.Rows[0].Key)
 
 	// Descending
@@ -117,7 +117,7 @@ func TestView(t *testing.T) {
 	viewParams[ViewQueryParamDescending] = true
 	result, viewErr = viewStore.View(ctx, ddocName, viewName, viewParams)
 	require.NoError(t, viewErr)
-	require.Equal(t, 3, len(result.Rows))
+	require.Len(t, result.Rows, 3)
 	assert.Equal(t, "Northern", result.Rows[0].Key)
 
 	// ...and skip (CBS only)
@@ -125,7 +125,7 @@ func TestView(t *testing.T) {
 		viewParams[ViewQueryParamSkip] = 1
 		result, viewErr = viewStore.View(ctx, ddocName, viewName, viewParams)
 		require.NoError(t, viewErr)
-		require.Equal(t, 2, len(result.Rows))
+		require.Len(t, result.Rows, 2)
 		assert.Equal(t, "District", result.Rows[0].Key)
 	}
 
@@ -134,19 +134,19 @@ func TestView(t *testing.T) {
 	viewParams[ViewQueryParamKey] = "District"
 	result, viewErr = viewStore.View(ctx, ddocName, viewName, viewParams)
 	require.NoError(t, viewErr)
-	require.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 	assert.Equal(t, "District", result.Rows[0].Key)
 
 	viewParams[ViewQueryParamKey] = "Central"
 	result, viewErr = viewStore.View(ctx, ddocName, viewName, viewParams)
 	require.NoError(t, viewErr)
-	require.Equal(t, 0, len(result.Rows))
+	require.Len(t, result.Rows, 0)
 
 	delete(viewParams, ViewQueryParamKey)
 	viewParams[ViewQueryParamKeys] = []interface{}{"Central", "Circle"}
 	result, viewErr = viewStore.View(ctx, ddocName, viewName, viewParams)
 	require.NoError(t, viewErr)
-	require.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 	assert.Equal(t, "Circle", result.Rows[0].Key)
 
 	// ViewCustom

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -247,7 +247,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			// Verify single index exists, and matches expected naming
 			_, indexDefsMap, err := context.Manager.GetIndexDefs(true)
 			require.NoError(t, err)
-			assert.Equal(t, 1, len(indexDefsMap))
+			assert.Len(t, indexDefsMap, 1)
 			indexDef, ok := indexDefsMap[tc.expectedIndexName]
 			assert.True(t, ok, "Expected index name"+tc.expectedIndexName+"not found")
 
@@ -319,7 +319,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	// Verify single index created
 	_, indexDefsMap, err := context.Manager.GetIndexDefs(true)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(indexDefsMap))
+	assert.Len(t, indexDefsMap, 1)
 
 	// Attempt to recreate index
 	err = createCBGTIndex(ctx, context, testDbName, configGroup, bucket, spec, "", nil, 16)
@@ -328,7 +328,7 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	// Verify single index defined (acts as upsert to existing)
 	_, indexDefsMap, err = context.Manager.GetIndexDefs(true)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(indexDefsMap))
+	assert.Len(t, indexDefsMap, 1)
 	_, ok := indexDefsMap[legacyIndexName]
 	assert.True(t, ok)
 }
@@ -397,7 +397,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	// Verify single index created
 	_, indexDefsMap, err := context.Manager.GetIndexDefs(true)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(indexDefsMap))
+	assert.Len(t, indexDefsMap, 1)
 
 	// Attempt to recreate index
 	err = createCBGTIndex(ctx, context, unsafeTestDBName, configGroup, bucket, spec, "", nil, 16)
@@ -406,7 +406,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	// Verify single index defined (acts as upsert to existing)
 	_, indexDefsMap, err = context.Manager.GetIndexDefs(true)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(indexDefsMap))
+	assert.Len(t, indexDefsMap, 1)
 	_, ok := indexDefsMap[legacyIndexName]
 	assert.False(t, ok)
 	_, ok = indexDefsMap[GenerateIndexName(unsafeTestDBName)]

--- a/base/leaky_bucket_test.go
+++ b/base/leaky_bucket_test.go
@@ -37,7 +37,7 @@ func TestDedupeTapEventsLaterSeqSameDoc(t *testing.T) {
 	deduped := dedupeTapEvents(tapEvents)
 
 	// make sure that one was deduped
-	assert.Equal(t, 1, len(deduped))
+	assert.Len(t, deduped, 1)
 
 	// make sure the earlier event was deduped
 	dedupedEvent := deduped[0]

--- a/base/set_test.go
+++ b/base/set_test.go
@@ -31,20 +31,20 @@ func TestSetFromArray(t *testing.T) {
 
 func TestSet(t *testing.T) {
 	set := SetFromArray(nil)
-	assert.Equal(t, 0, len(set))
+	assert.Len(t, set, 0)
 	assert.Equal(t, []string{}, set.ToArray())
 
 	set = SetFromArray([]string{})
-	assert.Equal(t, 0, len(set))
+	assert.Len(t, set, 0)
 
 	set = SetFromArray([]string{"foo"})
-	assert.Equal(t, 1, len(set))
+	assert.Len(t, set, 1)
 	assert.True(t, set.Contains("foo"))
 	assert.False(t, set.Contains("bar"))
 
 	values := []string{"bar", "foo", "zog"}
 	set = SetFromArray(values)
-	assert.Equal(t, 3, len(set))
+	assert.Len(t, set, 3)
 	asArray := set.ToArray()
 	sort.Strings(asArray)
 	assert.Equal(t, values, asArray)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -132,7 +132,7 @@ func TestLateSequenceHandling(t *testing.T) {
 	// Empty late sequence cache should return empty set
 	startSequence := cache.RegisterLateSequenceClient()
 	entries, lastSeq, err := cache.GetLateSequencesSince(startSequence)
-	assert.Equal(t, 0, len(entries))
+	assert.Len(t, entries, 0)
 	assert.Equal(t, uint64(0), lastSeq)
 	assert.True(t, err == nil)
 
@@ -142,7 +142,7 @@ func TestLateSequenceHandling(t *testing.T) {
 	// Retrieve since 0
 	entries, lastSeq, err = cache.GetLateSequencesSince(0)
 	log.Println("entries:", entries)
-	assert.Equal(t, 2, len(entries))
+	assert.Len(t, entries, 2)
 	assert.Equal(t, uint64(8), lastSeq)
 	assert.Equal(t, uint64(1), cache.lateLogs[2].getListenerCount())
 	assert.True(t, err == nil)
@@ -150,7 +150,7 @@ func TestLateSequenceHandling(t *testing.T) {
 	// Add Sequences.  Will trigger purge on old sequences without listeners
 	cache.AddLateSequence(testLogEntry(2, "foo3", "1-a"))
 	cache.AddLateSequence(testLogEntry(7, "foo4", "1-a"))
-	assert.Equal(t, 3, len(cache.lateLogs))
+	assert.Len(t, cache.lateLogs, 3)
 	assert.Equal(t, uint64(8), cache.lateLogs[0].logEntry.Sequence)
 	assert.Equal(t, uint64(2), cache.lateLogs[1].logEntry.Sequence)
 	assert.Equal(t, uint64(7), cache.lateLogs[2].logEntry.Sequence)
@@ -159,7 +159,7 @@ func TestLateSequenceHandling(t *testing.T) {
 	// Retrieve since previous
 	entries, lastSeq, err = cache.GetLateSequencesSince(lastSeq)
 	log.Println("entries:", entries)
-	assert.Equal(t, 2, len(entries))
+	assert.Len(t, entries, 2)
 	assert.Equal(t, uint64(7), lastSeq)
 	assert.Equal(t, uint64(0), cache.lateLogs[0].getListenerCount())
 	assert.Equal(t, uint64(1), cache.lateLogs[2].getListenerCount())
@@ -171,7 +171,7 @@ func TestLateSequenceHandling(t *testing.T) {
 	cache.AddLateSequence(testLogEntry(11, "foo6", "1-a"))
 	log.Println("cache.lateLogs:", cache.lateLogs)
 	cache.purgeLateLogEntries()
-	assert.Equal(t, 3, len(cache.lateLogs))
+	assert.Len(t, cache.lateLogs, 3)
 	assert.Equal(t, uint64(7), cache.lateLogs[0].logEntry.Sequence)
 	assert.Equal(t, uint64(15), cache.lateLogs[1].logEntry.Sequence)
 	assert.Equal(t, uint64(11), cache.lateLogs[2].logEntry.Sequence)
@@ -181,7 +181,7 @@ func TestLateSequenceHandling(t *testing.T) {
 	// Release the listener, and purge again
 	cache.ReleaseLateSequenceClient(uint64(7))
 	cache.purgeLateLogEntries()
-	assert.Equal(t, 1, len(cache.lateLogs))
+	assert.Len(t, cache.lateLogs, 1)
 	assert.True(t, err == nil)
 
 }
@@ -204,7 +204,7 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 	// Add Listener before late entries arrive
 	startSequence := cache.RegisterLateSequenceClient()
 	entries, lastSeq1, err := cache.GetLateSequencesSince(startSequence)
-	assert.Equal(t, 0, len(entries))
+	assert.Len(t, entries, 0)
 	assert.Equal(t, uint64(0), lastSeq1)
 	assert.True(t, err == nil)
 
@@ -626,7 +626,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 	collection.user, _ = authenticator.GetUser("naomi")
 	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 	assert.NoError(t, err, "Couldn't GetChanges")
-	assert.Equal(t, 4, len(changes))
+	assert.Len(t, changes, 4)
 
 	collectionID := collection.GetCollectionID()
 
@@ -664,7 +664,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 	// will be the late arriver (3) along with 5, 6)
 	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
 	require.NoError(t, err)
-	assert.Equal(t, 3, len(changes))
+	assert.Len(t, changes, 3)
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 3, LowSeq: 3},
 		ID:           "doc-3",
@@ -771,7 +771,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 		log.Printf("Received %d unexpected docs", len(expectedDocs))
 	}
 
-	assert.Equal(t, 0, len(expectedDocs))
+	assert.Len(t, expectedDocs, 0)
 }
 
 // Test low sequence handling of late arriving sequences to a continuous changes feed
@@ -1162,7 +1162,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 
 	// Validate the initial sequences arrive as expected
 	assert.True(t, err == nil)
-	assert.Equal(t, 4, len(changes))
+	assert.Len(t, changes, 4)
 	assert.Equal(t, &ChangeEntry{
 		Seq:     SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
 		ID:      "doc-1",
@@ -1176,7 +1176,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 
 	err = appendFromFeed(&changes, feed, 2, base.DefaultWaitForSequence)
 	assert.True(t, err == nil)
-	assert.Equal(t, 6, len(changes))
+	assert.Len(t, changes, 6)
 	assert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4}))
 
 	WriteDirect(t, db, []string{"ABC"}, 7)
@@ -1270,7 +1270,7 @@ func TestChannelRace(t *testing.T) {
 	// Wait for processing of two channels (100 ms each)
 	time.Sleep(250 * time.Millisecond)
 	// Validate the initial sequences arrive as expected
-	assert.Equal(t, 3, len(changes))
+	assert.Len(t, changes, 3)
 
 	// Send update to trigger the start of the next changes iteration
 	WriteDirect(t, db, []string{"Even"}, 4)
@@ -1288,7 +1288,7 @@ func TestChannelRace(t *testing.T) {
 	WriteDirect(t, db, []string{"Even"}, 8)
 	WriteDirect(t, db, []string{"Odd"}, 9)
 	time.Sleep(750 * time.Millisecond)
-	assert.Equal(t, 9, len(changes))
+	assert.Len(t, changes, 9)
 	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}))
 	changesString := ""
 	for _, change := range changes {
@@ -1370,7 +1370,7 @@ func TestChannelCacheSize(t *testing.T) {
 	collection.user, _ = authenticator.GetUser("naomi")
 	changes, err := collection.GetChanges(ctx, base.SetOf("ABC"), getChangesOptionsWithZeroSeq(t))
 	assert.NoError(t, err, "Couldn't GetChanges")
-	assert.Equal(t, 750, len(changes))
+	assert.Len(t, changes, 750)
 
 	// Validate that cache stores the expected number of values
 	collectionID := collection.GetCollectionID()
@@ -1378,7 +1378,7 @@ func TestChannelCacheSize(t *testing.T) {
 	abcCache, err := db.changeCache.getChannelCache().getSingleChannelCache(ctx, channels.NewID("ABC", collectionID))
 	require.NoError(t, err)
 
-	assert.Equal(t, 600, len(abcCache.(*singleChannelCacheImpl).logs))
+	assert.Len(t, abcCache.(*singleChannelCacheImpl).logs, 600)
 }
 
 func shortWaitCache() CacheOptions {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -232,7 +232,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 	require.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
-	assert.Equal(t, 1, len(changes))
+	assert.Len(t, changes, 1)
 	collectionID := collection.GetCollectionID()
 	require.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 1},
@@ -278,7 +278,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
-	assert.Equal(t, 1, len(changes))
+	assert.Len(t, changes, 1)
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 2},
 		ID:           "alpha",
@@ -320,7 +320,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	printChanges(changes)
 
 	collectionID := collection.GetCollectionID()
-	assert.Equal(t, 1, len(changes))
+	assert.Len(t, changes, 1)
 	require.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 1},
 		ID:           "alpha",
@@ -362,7 +362,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
-	assert.Equal(t, 1, len(changes))
+	assert.Len(t, changes, 1)
 	require.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 3},
 		ID:           "alpha",
@@ -410,7 +410,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	// Get changes with active_only=true
 	activeChanges, err := collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
-	require.Equal(t, 5, len(activeChanges))
+	require.Len(t, activeChanges, 5)
 
 	// Ensure the test is triggering a query, and not serving from DCP-generated cache
 	postChangesQueryCount := db.DbStats.Cache().ViewQueries.Value()
@@ -420,7 +420,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	changesOptions.ActiveOnly = false
 	allChanges, err := collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
-	require.Equal(t, 10, len(allChanges))
+	require.Len(t, allChanges, 10)
 
 	postChangesQueryCount = db.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, initQueryCount+2, postChangesQueryCount)
@@ -429,7 +429,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	changesOptions.ActiveOnly = false
 	allChanges, err = collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
 	require.NoError(t, err, "Error getting changes with active_only true")
-	require.Equal(t, 10, len(allChanges))
+	require.Len(t, allChanges, 10)
 
 	postChangesQueryCount = db.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, initQueryCount+2, postChangesQueryCount)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -175,9 +175,9 @@ func TestHasAttachmentsFlag(t *testing.T) {
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
 	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equal(t, 0, len(revTree.BodyMap))
-	assert.Equal(t, 1, len(revTree.BodyKeyMap))
-	assert.Equal(t, 1, len(revTree.HasAttachments))
+	assert.Len(t, revTree.BodyMap, 0)
+	assert.Len(t, revTree.BodyKeyMap, 1)
+	assert.Len(t, revTree.HasAttachments, 1)
 }
 
 func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
@@ -295,7 +295,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
 	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equal(t, 0, len(revTree.HasAttachments))
+	assert.Len(t, revTree.HasAttachments, 0)
 }
 
 // TestRevisionStorageConflictAndTombstones
@@ -360,8 +360,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
 	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equal(t, 0, len(revTree.BodyMap))
-	assert.Equal(t, 1, len(revTree.BodyKeyMap))
+	assert.Len(t, revTree.BodyMap, 0)
+	assert.Len(t, revTree.BodyKeyMap, 1)
 
 	// Retrieve the raw revision body backup of 2-a, and verify it's intact
 	log.Printf("Verify document storage of 2-a")
@@ -412,8 +412,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Validate the tombstone is stored inline (due to small size)
 	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equal(t, 1, len(revTree.BodyMap))
-	assert.Equal(t, 0, len(revTree.BodyKeyMap))
+	assert.Len(t, revTree.BodyMap, 1)
+	assert.Len(t, revTree.BodyKeyMap, 0)
 
 	// Create another conflict (2-c)
 	//      1-a
@@ -457,8 +457,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	log.Printf("Verify raw revtree w/ tombstone 3-c in key map")
 	newRevTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equal(t, 1, len(newRevTree.BodyMap))    // tombstone 3-b
-	assert.Equal(t, 1, len(newRevTree.BodyKeyMap)) // tombstone 3-c
+	assert.Len(t, newRevTree.BodyMap, 1)    // tombstone 3-b
+	assert.Len(t, newRevTree.BodyKeyMap, 1) // tombstone 3-c
 
 	// Retrieve the non-inline tombstone revision
 	collection.FlushRevisionCacheForTest()
@@ -481,8 +481,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equal(t, 1, len(revTree.BodyMap))    // tombstone 3-b
-	assert.Equal(t, 1, len(revTree.BodyKeyMap)) // tombstone 3-c
+	assert.Len(t, revTree.BodyMap, 1)    // tombstone 3-b
+	assert.Len(t, revTree.BodyKeyMap, 1) // tombstone 3-c
 }
 
 // TestRevisionStoragePruneTombstone - tests cleanup of external tombstone bodies when pruned.
@@ -544,8 +544,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
 	revTree, err := getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equal(t, 0, len(revTree.BodyMap))
-	assert.Equal(t, 1, len(revTree.BodyKeyMap))
+	assert.Len(t, revTree.BodyMap, 0)
+	assert.Len(t, revTree.BodyKeyMap, 1)
 
 	// Retrieve the raw revision body backup of 2-a, and verify it's intact
 	log.Printf("Verify document storage of 2-a")
@@ -596,8 +596,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
 	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equal(t, 0, len(revTree.BodyMap))
-	assert.Equal(t, 1, len(revTree.BodyKeyMap))
+	assert.Len(t, revTree.BodyMap, 0)
+	assert.Len(t, revTree.BodyKeyMap, 1)
 	log.Printf("revTree.BodyKeyMap:%v", revTree.BodyKeyMap)
 
 	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
@@ -1623,12 +1623,12 @@ func TestPutStampClusterUUID(t *testing.T) {
 	_, doc, err := collection.Put(ctx, key, body)
 
 	require.NoError(t, err)
-	require.Equal(t, 32, len(doc.ClusterUUID))
+	require.Len(t, doc.ClusterUUID, 32)
 
 	var xattr map[string]string
 	_, err = collection.dataStore.GetWithXattr(ctx, key, base.SyncXattrName, "", &body, &xattr, nil)
 	require.NoError(t, err)
-	require.Equal(t, 32, len(xattr["cluster_uuid"]))
+	require.Len(t, xattr["cluster_uuid"], 32)
 }
 
 // TestAssignSequenceReleaseLoop repros conditions seen in CBG-3516 (where each sequence between nextSequence and docSequence has an unusedSeq doc)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1076,7 +1076,7 @@ func TestConflicts(t *testing.T) {
 
 	changeLog, err := collection.GetChangeLog(ctx, channels.NewID("all", collectionID), 0)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(changeLog))
+	assert.Len(t, changeLog, 1)
 
 	// Create two conflicting changes:
 	body["n"] = 2
@@ -1114,7 +1114,7 @@ func TestConflicts(t *testing.T) {
 	cacheWaiter.Wait()
 	changeLog, err = collection.GetChangeLog(ctx, allChannel, 0)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(changeLog))
+	assert.Len(t, changeLog, 1)
 	assert.Equal(t, uint64(3), changeLog[0].Sequence)
 	assert.Equal(t, "doc", changeLog[0].DocID)
 	assert.Equal(t, "2-b", changeLog[0].RevID)
@@ -1127,7 +1127,7 @@ func TestConflicts(t *testing.T) {
 	}
 	changes, err := collection.GetChanges(ctx, channels.BaseSetOf(t, "all"), options)
 	assert.NoError(t, err, "Couldn't GetChanges")
-	assert.Equal(t, 1, len(changes))
+	assert.Len(t, changes, 1)
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 3},
 		ID:           "doc",
@@ -1162,7 +1162,7 @@ func TestConflicts(t *testing.T) {
 	// Verify the _changes feed:
 	changes, err = collection.GetChanges(ctx, channels.BaseSetOf(t, "all"), options)
 	assert.NoError(t, err, "Couldn't GetChanges")
-	assert.Equal(t, 1, len(changes))
+	assert.Len(t, changes, 1)
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 4},
 		ID:           "doc",
@@ -1821,7 +1821,7 @@ func TestChannelView(t *testing.T) {
 	for i, entry := range entries {
 		log.Printf("View Query returned entry (%d): %v", i, entry)
 	}
-	assert.Equal(t, 1, len(entries))
+	assert.Len(t, entries, 1)
 
 }
 
@@ -2592,7 +2592,7 @@ func TestGetAllUsers(t *testing.T) {
 	log.Printf("Getting users...")
 	users, err := db.GetUsers(ctx, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, 4, len(users))
+	assert.Len(t, users, 4)
 	log.Printf("THE USERS: %+v", users)
 	marshalled, err := json.Marshal(users)
 	require.NoError(t, err)
@@ -2600,7 +2600,7 @@ func TestGetAllUsers(t *testing.T) {
 
 	limitedUsers, err := db.GetUsers(ctx, 2)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(limitedUsers))
+	assert.Len(t, limitedUsers, 2)
 }
 
 func TestGetRoleIDs(t *testing.T) {

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -63,7 +63,7 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 	// Invoke removal in preview mode
 	removedDDocs, removeErr := removeObsoleteDesignDocs(ctx, viewStore, true, true)
 	require.NoError(t, removeErr, "Error removing previous design docs")
-	assert.Equal(t, 2, len(removedDDocs))
+	assert.Len(t, removedDDocs, 2)
 	assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
 	assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
 
@@ -77,7 +77,7 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 	// Invoke removal in non-preview mode
 	removedDDocs, removeErr = removeObsoleteDesignDocs(ctx, viewStore, false, true)
 	require.NoError(t, removeErr, "Error removing previous design docs")
-	assert.Equal(t, 2, len(removedDDocs))
+	assert.Len(t, removedDDocs, 2)
 	assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
 	assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
 

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -51,7 +51,7 @@ func TestInternalHLVFunctions(t *testing.T) {
 
 	// add new version vector with same sourceID as current sourceID and assert it doesn't add to previous versions then restore HLV to previous state
 	require.NoError(t, hlv.AddVersion(newVersionVector))
-	assert.Equal(t, 1, len(hlv.PreviousVersions))
+	assert.Len(t, hlv.PreviousVersions, 1)
 	hlv.Version = currVersion
 
 	// attempt to add new version vector to HLV that has a CAS value less than the current CAS value

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -520,13 +520,13 @@ func TestImportStampClusterUUID(t *testing.T) {
 	importedDoc, err := collection.importDoc(ctx, key, body, nil, false, existingDoc, ImportOnDemand)
 	require.NoError(t, err)
 	if assert.NotNil(t, importedDoc) {
-		require.Equal(t, 32, len(importedDoc.ClusterUUID))
+		require.Len(t, importedDoc.ClusterUUID, 32)
 	}
 
 	var xattr map[string]string
 	_, err = collection.dataStore.GetWithXattr(ctx, key, base.SyncXattrName, "", &body, &xattr, nil)
 	require.NoError(t, err)
-	require.Equal(t, 32, len(xattr["cluster_uuid"]))
+	require.Len(t, xattr["cluster_uuid"], 32)
 }
 
 // TestImporNonZeroStart makes sure docs written before sync gateway start get imported

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -201,7 +201,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	// Validate that removeObsoleteIndexes is a no-op for the default case
 	removedIndexes, removeErr := removeObsoleteIndexes(ctx, n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
-	assert.Equal(t, 0, len(removedIndexes))
+	assert.Len(t, removedIndexes, 0)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
 
 	// Hack sgIndexes to simulate new version of indexes
@@ -218,7 +218,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	// Validate that removeObsoleteIndexes now triggers removal of one index
 	removedIndexes, removeErr = removeObsoleteIndexes(ctx, n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
-	assert.Equal(t, 1, len(removedIndexes))
+	assert.Len(t, removedIndexes, 1)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 
 }
@@ -248,7 +248,7 @@ func TestPostUpgradeMultipleCollections(t *testing.T) {
 	for _, preview := range []bool{true, false} {
 		removedIndexes, removeErr := db.RemoveObsoleteIndexes(base.TestCtx(t), preview)
 		require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
-		require.Equal(t, 0, len(removedIndexes))
+		require.Len(t, removedIndexes, 0)
 	}
 	useXattrs := false
 	options := InitializeIndexOptions{

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -351,14 +351,14 @@ func TestPruneRevisions(t *testing.T) {
 	assert.Equal(t, 0, pruned)
 	pruned, _ = tempmap.pruneRevisions(ctx, 2, "")
 	assert.Equal(t, 1, pruned)
-	assert.Equal(t, 4, len(tempmap))
+	assert.Len(t, tempmap, 4)
 	assert.Equal(t, (*RevInfo)(nil), tempmap["1-one"])
 	assert.Equal(t, "", tempmap["2-two"].Parent)
 
 	// Make sure leaves are never pruned:
 	pruned, _ = tempmap.pruneRevisions(ctx, 1, "")
 	assert.Equal(t, 2, pruned)
-	assert.Equal(t, 2, len(tempmap))
+	assert.Len(t, tempmap, 2)
 	assert.True(t, tempmap["3-three"] != nil)
 	assert.Equal(t, "", tempmap["3-three"].Parent)
 	assert.True(t, tempmap["4-vier"] != nil)
@@ -460,7 +460,7 @@ func TestPruneRevsOneWinningOneOldAndOneRecentTombstonedBranch(t *testing.T) {
 
 	// the "non-winning high-gen tombstoned" branch should still be around, but pruned to maxDepth
 	tombstonedLeaves := revTree.GetTombstonedLeaves()
-	assert.Equal(t, 1, len(tombstonedLeaves))
+	assert.Len(t, tombstonedLeaves, 1)
 	tombstonedLeaf := tombstonedLeaves[0]
 
 	tombstonedBranch, err := revTree.getHistory(tombstonedLeaf)

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -61,28 +61,28 @@ func TestReplicateManagerReplications(t *testing.T) {
 
 	replications, err := manager.GetReplications()
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(replications))
+	assert.Len(t, replications, 2)
 
 	// Remove replication
 	err = manager.DeleteReplication(replication1_id)
 	require.NoError(t, err)
 	replications, err = manager.GetReplications()
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(replications))
+	assert.Len(t, replications, 1)
 
 	// Remove non-existent replication
 	err = manager.DeleteReplication(replication1_id)
 	require.Error(t, base.ErrNotFound, err)
 	replications, err = manager.GetReplications()
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(replications))
+	assert.Len(t, replications, 1)
 
 	// Remove last replication
 	err = manager.DeleteReplication(replication2_id)
 	require.NoError(t, err)
 	replications, err = manager.GetReplications()
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(replications))
+	assert.Len(t, replications, 0)
 }
 
 // Test node operations on SGReplicateManager
@@ -104,14 +104,14 @@ func TestReplicateManagerNodes(t *testing.T) {
 
 	nodes, err := manager.getNodes()
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(nodes))
+	assert.Len(t, nodes, 1)
 
 	err = manager.registerNodeForHost("node2", "host2")
 	require.NoError(t, err)
 
 	nodes, err = manager.getNodes()
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(nodes))
+	assert.Len(t, nodes, 2)
 
 	// re-adding an existing node is a no-op
 	err = manager.registerNodeForHost("node1", "host1")
@@ -119,7 +119,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 
 	nodes, err = manager.getNodes()
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(nodes))
+	assert.Len(t, nodes, 2)
 
 	// Remove node
 	err = manager.RemoveNode("node1")
@@ -127,7 +127,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 
 	nodes, err = manager.getNodes()
 	require.NoError(t, err)
-	require.Equal(t, 1, len(nodes))
+	require.Len(t, nodes, 1)
 	node2, ok := nodes["node2"]
 	require.True(t, ok)
 	require.Equal(t, node2.UUID, "node2")
@@ -138,7 +138,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 
 	replications, err := manager.GetReplications()
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(replications))
+	assert.Len(t, replications, 0)
 }
 
 // Test concurrent node operations on SGReplicateManager
@@ -169,7 +169,7 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 	nodeWg.Wait()
 	nodes, err := manager.getNodes()
 	require.NoError(t, err)
-	require.Equal(t, 20, len(nodes))
+	require.Len(t, nodes, 20)
 
 	for i := 0; i < 20; i++ {
 		nodeWg.Add(1)
@@ -183,7 +183,7 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 	nodeWg.Wait()
 	nodes, err = manager.getNodes()
 	require.NoError(t, err)
-	require.Equal(t, 0, len(nodes))
+	require.Len(t, nodes, 0)
 }
 
 // Test concurrent replication operations on SGReplicateManager
@@ -214,7 +214,7 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 	replicationWg.Wait()
 	replications, err := manager.GetReplications()
 	require.NoError(t, err)
-	require.Equal(t, 20, len(replications))
+	require.Len(t, replications, 20)
 
 	for i := 0; i < 20; i++ {
 		replicationWg.Add(1)
@@ -228,7 +228,7 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 	replicationWg.Wait()
 	replications, err = manager.GetReplications()
 	require.NoError(t, err)
-	require.Equal(t, 0, len(replications))
+	require.Len(t, replications, 0)
 }
 
 func testReplicationCfg(id, assignedNode string) *ReplicationCfg {

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -143,7 +143,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
-	require.Equal(t, 3, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 3)
 	require.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	require.Equal(t, []string{"books"}, allDocsResult.Rows[0].Value.Channels)
 	require.Equal(t, "doc3", allDocsResult.Rows[1].ID)
@@ -160,7 +160,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
-	require.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	since := changes.Results[0].Seq
 	require.Equal(t, "doc1", changes.Results[0].ID)
 	require.Equal(t, uint64(1), since.Seq)
@@ -170,7 +170,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(changes.Results))
+	assert.Len(t, changes.Results, 1)
 	since = changes.Results[0].Seq
 	assert.Equal(t, "doc1", changes.Results[0].ID)
 	assert.Equal(t, uint64(1), since.Seq)
@@ -180,7 +180,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(changes.Results))
+	assert.Len(t, changes.Results, 2)
 	since = changes.Results[0].Seq
 	assert.Equal(t, "doc3", changes.Results[0].ID)
 	assert.Equal(t, uint64(3), since.Seq)
@@ -190,7 +190,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(changes.Results))
+	assert.Len(t, changes.Results, 0)
 
 	//
 	// Part 2 - Tests for user with * channel access
@@ -217,7 +217,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
-	assert.Equal(t, 6, len(allDocsResult.Rows))
+	assert.Len(t, allDocsResult.Rows, 6)
 	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"books"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -226,7 +226,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
-	assert.Equal(t, 6, len(changes.Results))
+	assert.Len(t, changes.Results, 6)
 	since = changes.Results[0].Seq
 	assert.Equal(t, "doc1", changes.Results[0].ID)
 	assert.Equal(t, uint64(1), since.Seq)
@@ -236,7 +236,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(changes.Results))
+	assert.Len(t, changes.Results, 2)
 	since = changes.Results[0].Seq
 	assert.Equal(t, "doc3", changes.Results[0].ID)
 	assert.Equal(t, uint64(3), since.Seq)
@@ -263,7 +263,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(allDocsResult.Rows))
+	assert.Len(t, allDocsResult.Rows, 2)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 
 	// GET /db/_changes
@@ -271,7 +271,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(changes.Results))
+	assert.Len(t, changes.Results, 2)
 	since = changes.Results[0].Seq
 	assert.Equal(t, "doc3", changes.Results[0].ID)
 	assert.Equal(t, uint64(3), since.Seq)
@@ -281,7 +281,7 @@ func TestStarAccess(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(changes.Results))
+	assert.Len(t, changes.Results, 2)
 	since = changes.Results[0].Seq
 	assert.Equal(t, "doc3", changes.Results[0].ID)
 	assert.Equal(t, uint64(3), since.Seq)
@@ -569,7 +569,7 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 	var docs []interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Equal(t, 2, len(docs))
+	assert.Len(t, docs, 2)
 	assert.Equal(t, map[string]interface{}{"rev": "1-afbcffa8a4641a0f4dd94d3fc9593e74", "id": "bulk1"}, docs[0])
 
 	assert.Equal(t, map[string]interface{}{"rev": "1-4d79588b9fe9c38faae61f0c1b9471c0", "id": "bulk2"}, docs[1])
@@ -640,7 +640,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 3)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 	assert.Equal(t, "doc4", allDocsResult.Rows[1].ID)
@@ -656,7 +656,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -668,7 +668,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc5", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -680,7 +680,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc5", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -692,7 +692,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -704,7 +704,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
 
@@ -716,7 +716,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 3)
 	assert.Equal(t, "doc3", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "doc4", allDocsResult.Rows[1].ID)
 	assert.Equal(t, "doc5", allDocsResult.Rows[2].ID)
@@ -730,7 +730,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 4, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 4)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "1-e0351a57554e023a77544d33dd21e56c", allDocsResult.Rows[0].Value.Rev)
@@ -753,7 +753,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 4, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 4)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
@@ -773,7 +773,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].Key)
 	assert.Equal(t, "doc4", allDocsResult.Rows[0].ID)
 	assert.Equal(t, []string{"Cinemax"}, allDocsResult.Rows[0].Value.Channels)
@@ -786,7 +786,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	require.NoError(t, err)
-	require.Equal(t, 5, len(allDocsResult.Rows))
+	require.Len(t, allDocsResult.Rows, 5)
 	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "doc2", allDocsResult.Rows[1].ID)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -446,7 +446,7 @@ func TestBulkDocsIDGeneration(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	log.Printf("response: %s", response.Body.Bytes())
 	RequireStatus(t, response, 201)
-	assert.Equal(t, 2, len(docs))
+	assert.Len(t, docs, 2)
 	assert.Equal(t, "1-50133ddd8e49efad34ad9ecae4cb9907", docs[0]["rev"])
 	assert.True(t, docs[0]["id"] != "")
 	assert.Equal(t, "1-035168c88bd4b80fb098a8da72f881ce", docs[1]["rev"])
@@ -898,7 +898,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
 	RequireStatus(t, response, 201)
 	var docs []interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Equal(t, 2, len(docs))
+	assert.Len(t, docs, 2)
 	assert.Equal(t, map[string]interface{}{"rev": "12-abc", "id": "bdne1"}, docs[0])
 
 	assert.Equal(t, map[string]interface{}{"rev": "34-def", "id": "bdne2"}, docs[1])
@@ -911,7 +911,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_bulk_docs", input)
 	RequireStatus(t, response, 201)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Equal(t, 1, len(docs))
+	assert.Len(t, docs, 1)
 	assert.Equal(t, map[string]interface{}{"rev": "14-jkl", "id": "bdne1"}, docs[0])
 
 }
@@ -1262,7 +1262,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	assert.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "ch1", allDocsResult.Rows[0].Value.Channels[0])
 
@@ -1274,7 +1274,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	assert.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "ch1", allDocsResult.Rows[0].Value.Channels[0])
 
@@ -1290,7 +1290,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	assert.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "ch2", allDocsResult.Rows[0].Value.Channels[0])
 
@@ -1303,7 +1303,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(allDocsResult.Rows))
+	assert.Len(t, allDocsResult.Rows, 1)
 	assert.Equal(t, "doc1", allDocsResult.Rows[0].ID)
 	assert.Equal(t, "ch2", allDocsResult.Rows[0].Value.Channels[0])
 }

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -63,7 +63,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
 		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err)
-		assert.Equal(t, 3, len(changes.Results))
+		assert.Len(t, changes.Results, 3)
 	}()
 
 	// Wait for changes to get into wait mode
@@ -148,7 +148,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 		sinceLastJSON := fmt.Sprintf(changesJSON, lastSeq)
 		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", sinceLastJSON, "bernard")
 		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.Equal(t, 1, len(changes.Results))
+		assert.Len(t, changes.Results, 1)
 	}()
 
 	// Wait to see if the longpoll will terminate on wait before a document shows up on the channel

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -360,7 +360,7 @@ func TestManualAttachment(t *testing.T) {
 	if !ok {
 		t.Errorf("Attachments must be map")
 	} else {
-		assert.Equal(t, 2, len(bodyAttachments))
+		assert.Len(t, bodyAttachments, 2)
 	}
 	// make sure original document property has remained
 	prop, ok := body["prop"]

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -521,7 +521,7 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	// attachment assertions
 	attachments, err := retrievedDoc.GetAttachments()
 	assert.True(t, err == nil)
-	assert.Equal(t, 1, len(attachments))
+	assert.Len(t, attachments, 1)
 	retrievedAttachment := attachments[input.attachmentName]
 	require.NotNil(t, retrievedAttachment)
 	assert.Equal(t, input.attachmentBody, string(retrievedAttachment.Data))

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -67,9 +67,9 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	assert.NoError(t, err, "Error reading changes response body")
 	err = base.JSONUnmarshal(body, &changeList)
 	assert.NoError(t, err, "Error unmarshalling response body")
-	require.Equal(t, 1, len(changeList)) // Should be 1 row, corresponding to the single doc that was queried in changes
+	require.Len(t, changeList, 1) // Should be 1 row, corresponding to the single doc that was queried in changes
 	changeRow := changeList[0]
-	assert.Equal(t, 0, len(changeRow)) // Should be empty, meaning the server is saying it doesn't have the revision yet
+	assert.Len(t, changeRow, 0) // Should be empty, meaning the server is saying it doesn't have the revision yet
 
 	// Send the doc revision in a rev request
 	_, _, revResponse, err := bt.SendRev(
@@ -96,9 +96,9 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	assert.NoError(t, err, "Error reading changes response body")
 	err = base.JSONUnmarshal(body2, &changeList2)
 	assert.NoError(t, err, "Error unmarshalling response body")
-	assert.Equal(t, 1, len(changeList2)) // Should be 1 row, corresponding to the single doc that was queried in changes
+	assert.Len(t, changeList2, 1) // Should be 1 row, corresponding to the single doc that was queried in changes
 	changeRow2 := changeList2[0]
-	assert.Equal(t, 1, len(changeRow2)) // Should have 1 item in row, which is the rev id of the previous revision pushed
+	assert.Len(t, changeRow2, 1) // Should have 1 item in row, which is the rev id of the previous revision pushed
 	assert.Equal(t, "1-abc", changeRow2[0])
 
 	// Call subChanges api and make sure we get expected changes back
@@ -117,9 +117,9 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 			changeListReceived := [][]interface{}{}
 			err = base.JSONUnmarshal(body, &changeListReceived)
 			assert.NoError(t, err, "Error unmarshalling changes received")
-			assert.Equal(t, 1, len(changeListReceived))
+			assert.Len(t, changeListReceived, 1)
 			change := changeListReceived[0] // [1,"foo","1-abc"]
-			assert.Equal(t, 3, len(change))
+			assert.Len(t, change, 3)
 			assert.Equal(t, float64(1), change[0].(float64)) // Expect sequence to be 1, since first item in DB
 			assert.Equal(t, "foo", change[1])                // Doc id of pushed rev
 			assert.Equal(t, "1-abc", change[2])              // Rev id of pushed rev
@@ -199,7 +199,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 
 				// The change should have three items in the array
 				// [1,"foo","1-abc"]
-				assert.Equal(t, 3, len(change))
+				assert.Len(t, change, 3)
 
 				// Make sure sequence numbers are monotonically increasing
 				receivedSeq, ok := change[0].(float64)
@@ -312,7 +312,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 
 				// The change should have three items in the array
 				// [1,"foo","1-abc"]
-				assert.Equal(t, 3, len(change))
+				assert.Len(t, change, 3)
 
 				// Make sure sequence numbers are monotonically increasing
 				receivedSeq, ok := change[0].(float64)
@@ -477,7 +477,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 
 				// The change should have three items in the array
 				// [1,"foo","1-abc"]
-				assert.Equal(t, 3, len(change))
+				assert.Len(t, change, 3)
 
 				// Make sure sequence numbers are monotonically increasing
 				receivedSeq, ok := change[0].(float64)
@@ -632,7 +632,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 
 	// The common case of an empty array response tells the sender to send all of the proposed revisions,
 	// so the changeList returned by Sync Gateway is expected to be empty
-	assert.Equal(t, 0, len(changeList))
+	assert.Len(t, changeList, 0)
 
 }
 
@@ -795,13 +795,13 @@ func TestPublicPortAuthentication(t *testing.T) {
 
 	// Assert that user1 received a single expected change
 	changesChannelUser1 := btUser1.WaitForNumChanges(1)
-	assert.Equal(t, 1, len(changesChannelUser1))
+	assert.Len(t, changesChannelUser1, 1)
 	change := changesChannelUser1[0]
 	AssertChangeEquals(t, change, ExpectedChange{docId: "foo", revId: "1-abc", sequence: "*", deleted: base.BoolPtr(false)})
 
 	// Assert that user2 received user1's change as well as it's own change
 	changesChannelUser2 := btUser2.WaitForNumChanges(2)
-	assert.Equal(t, 2, len(changesChannelUser2))
+	assert.Len(t, changesChannelUser2, 2)
 	change = changesChannelUser2[0]
 	AssertChangeEquals(t, change, ExpectedChange{docId: "foo", revId: "1-abc", sequence: "*", deleted: base.BoolPtr(false)})
 
@@ -931,7 +931,7 @@ function(doc, oldDoc) {
 
 				// The change should have three items in the array
 				// [1,"foo","1-abc"]
-				assert.Equal(t, 3, len(change))
+				assert.Len(t, change, 3)
 
 				// Make sure sequence numbers are monotonically increasing
 				receivedSeq, ok := change[0].(float64)
@@ -1058,7 +1058,7 @@ function(doc, oldDoc) {
 
 				// The change should have three items in the array
 				// [1,"foo","1-abc"]
-				assert.Equal(t, 3, len(change))
+				assert.Len(t, change, 3)
 
 				// Make sure sequence numbers are monotonically increasing
 				receivedSeq, ok := change[0].(float64)
@@ -1463,7 +1463,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 	// Make sure we can see it by getting changes
 	changes := bt.WaitForNumChanges(2)
 	log.Printf("changes: %+v", changes)
-	assert.Equal(t, 2, len(changes))
+	assert.Len(t, changes, 2)
 
 }
 
@@ -1505,7 +1505,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 
 	// Make sure we can see both docs in the changes
 	changes := bt.WaitForNumChanges(2)
-	assert.Equal(t, 2, len(changes))
+	assert.Len(t, changes, 2)
 
 }
 
@@ -1619,7 +1619,7 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
 
 	// Make sure that a one-off GetChanges() returns no documents
 	changes := bt.GetChanges()
-	assert.Equal(t, 0, len(changes))
+	assert.Len(t, changes, 0)
 
 }
 
@@ -1656,7 +1656,7 @@ func TestPutInvalidRevMalformedBody(t *testing.T) {
 
 	// Make sure that a one-off GetChanges() returns no documents
 	changes := bt.GetChanges()
-	assert.Equal(t, 0, len(changes))
+	assert.Len(t, changes, 0)
 
 }
 
@@ -2034,7 +2034,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(changes.Results))
+		assert.Len(t, changes.Results, 1)
 		assert.Equal(t, "doc", changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
@@ -2047,7 +2047,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(changes.Results))
+		assert.Len(t, changes.Results, 1)
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
@@ -2148,7 +2148,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(changes.Results))
+		assert.Len(t, changes.Results, 1)
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
@@ -2162,7 +2162,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		// At this point changes should send revocation, as document isn't in any of the user's channels
 		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(changes.Results))
+		assert.Len(t, changes.Results, 1)
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -218,7 +218,7 @@ func TestChangesFeedOnInheritedChannelsFromRoles(t *testing.T) {
 	// Start changes feed as the user filtered to channel A, expect 6 changes (5 docs + user doc)
 	changes, err := rt.WaitForChanges(6, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A", "alice", false)
 	require.NoError(t, err)
-	assert.Equal(t, 6, len(changes.Results))
+	assert.Len(t, changes.Results, 6)
 }
 
 // TestChangesFeedOnInheritedChannelsFromRolesDefaultCollection:
@@ -251,7 +251,7 @@ func TestChangesFeedOnInheritedChannelsFromRolesDefaultCollection(t *testing.T) 
 	// Start changes feed as the user filtered to channel A, expect 6 changes (5 docs + user doc)
 	changes, err := rt.WaitForChanges(6, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A", "alice", false)
 	require.NoError(t, err)
-	assert.Equal(t, 6, len(changes.Results))
+	assert.Len(t, changes.Results, 6)
 }
 
 func TestPostChanges(t *testing.T) {
@@ -841,7 +841,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	// Issue a second changes request, expect to see last 2 documents.
 	moreChanges, err := rt.WaitForChanges(0, fmt.Sprintf("/{{.keyspace}}/_changes?limit=3&since=%s", lastSeq), "bernard", false)
 	assert.NoError(t, err)
-	require.Equal(t, 2, len(moreChanges.Results))
+	require.Len(t, moreChanges.Results, 2)
 	assert.Equal(t, "abc-2", moreChanges.Results[0].ID)
 	assert.Equal(t, "abc-3", moreChanges.Results[1].ID)
 }
@@ -1095,7 +1095,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	require.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
 	assert.Equal(t, "2::6", changes.Last_Seq.String())
@@ -2936,7 +2936,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, username)
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	require.Equal(t, 50, len(changes.Results))
+	require.Len(t, changes.Results, 50)
 
 	// Verify results ordering
 	for i := 0; i < 50; i++ {
@@ -2951,7 +2951,7 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, username)
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	require.Equal(t, 25, len(changes.Results))
+	require.Len(t, changes.Results, 25)
 
 	// Verify results ordering
 	for i := 0; i < 25; i++ {

--- a/rest/functionsapitest/user_functions_admin_test.go
+++ b/rest/functionsapitest/user_functions_admin_test.go
@@ -272,7 +272,7 @@ func TestFunctionsConfigPutOne(t *testing.T) {
 		rest.RequireStatus(t, response, http.StatusOK)
 
 		assert.Nil(t, rt.GetDatabase().Options.UserFunctions.Definitions["square"])
-		assert.Equal(t, 1, len(rt.GetDatabase().Options.UserFunctions.Definitions))
+		assert.Len(t, rt.GetDatabase().Options.UserFunctions.Definitions, 1)
 
 		response = rt.SendAdminRequest("GET", "/db/_function/square?n=13", "")
 		rest.RequireStatus(t, response, http.StatusNotFound)

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -290,7 +290,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	response := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(scopesConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)
 
-	require.Equal(t, 1, len(rt.GetDbCollections()))
+	require.Len(t, rt.GetDbCollections(), 1)
 	require.Equal(t, strings.ReplaceAll(dataStore1.GetName(), testBucket.GetName(), dbName), rt.GetSingleKeyspace())
 
 	// Wait for auto-import to work
@@ -318,7 +318,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoScopesConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)
 
-	require.Equal(t, 2, len(rt.GetDbCollections()))
+	require.Len(t, rt.GetDbCollections(), 2)
 
 	// Wait for auto-import to work
 	_, err = rt.WaitForChanges(docCount, "/{{.keyspace2}}/_changes", "", true)
@@ -381,7 +381,7 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 	response := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoScopesConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)
 
-	require.Equal(t, 2, len(rt.GetDbCollections()))
+	require.Len(t, rt.GetDbCollections(), 2)
 
 	// Wait for auto-import to work
 	_, err = rt.WaitForChanges(docCount, "/{{.keyspace1}}/_changes", "", true)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -165,7 +165,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 	var rawResponse rest.RawResponse
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &rawResponse))
 	log.Printf("raw response: %s", response.Body.Bytes())
-	assert.Equal(t, 1, len(rawResponse.Sync.Channels))
+	assert.Len(t, rawResponse.Sync.Channels, 1)
 	_, ok := rawResponse.Sync.Channels["oldDocNil"]
 	assert.True(t, ok)
 }
@@ -879,8 +879,8 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 	assert.Equal(t, 200, rawResponse.Code)
 	var doc treeDoc
 	assert.NoError(t, base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc))
-	assert.Equal(t, 3, len(doc.Meta.RevTree.BodyKeyMap))
-	assert.Equal(t, 0, len(doc.Meta.RevTree.BodyMap))
+	assert.Len(t, doc.Meta.RevTree.BodyKeyMap, 3)
+	assert.Len(t, doc.Meta.RevTree.BodyMap, 0)
 
 }
 
@@ -1017,8 +1017,8 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	assert.Equal(t, 200, rawResponse.Code)
 	var doc treeDoc
 	assert.NoError(t, base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc))
-	assert.Equal(t, 1, len(doc.Meta.RevTree.BodyKeyMap))
-	assert.Equal(t, 2, len(doc.Meta.RevTree.BodyMap))
+	assert.Len(t, doc.Meta.RevTree.BodyKeyMap, 1)
+	assert.Len(t, doc.Meta.RevTree.BodyMap, 2)
 }
 
 // Write a doc via SDK with an expiry value.  Verify that expiry is preserved when doc is imported via DCP feed

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -59,7 +59,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	docRev, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(docRev.Channels.ToArray()))
+	assert.Len(t, docRev.Channels.ToArray(), 0)
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
 
 	// Write xattr to trigger import of user xattr

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -514,7 +514,7 @@ func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
 	simulateCreateFailure(t, collection1db1Config)
 	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(configs))
+	require.Len(t, configs, 0)
 
 	// Case 2. InsertConfig with conflicting name should trigger registry rollback and then successful creation
 	simulateCreateFailure(t, collection1db1Config)
@@ -540,7 +540,7 @@ func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
 
 	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
+	require.Len(t, configs, 1)
 
 	// Reattempt insert, should now succeed
 	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection3db2Config)
@@ -562,7 +562,7 @@ func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
 	// GetDatabaseConfigs should rollback and remove the failed c2_db2
 	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(configs))
+	require.Len(t, configs, 2)
 
 	// Update should now succeed
 	_, err = bc.UpdateConfig(ctx, bucketName, groupID, "c1_db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
@@ -642,7 +642,7 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 	simulateUpdateFailure(t, collection2db1Config)
 	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
+	require.Len(t, configs, 1)
 	require.Equal(t, "1-a", configs[0].Version)
 
 	// Retrieve registry to ensure the previous version has been removed
@@ -679,7 +679,7 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 
 	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
+	require.Len(t, configs, 1)
 
 	// Reattempt insert, should now succeed
 	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db2Config)
@@ -695,7 +695,7 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 
 	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(configs))
+	require.Len(t, configs, 2)
 
 	// Reattempt insert, should still be in conflict post-rollback
 	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db3Config)
@@ -703,7 +703,7 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 
 	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(configs))
+	require.Len(t, configs, 2)
 
 	// Case 5. Attempt to delete db after update failure for that db
 	simulateUpdateFailure(t, collection3db1Config)
@@ -771,7 +771,7 @@ func TestPersistentConfigRegistryRollbackAfterDeleteFailure(t *testing.T) {
 	simulateDeleteFailure(t, collection1db1Config)
 	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(configs))
+	require.Len(t, configs, 0)
 
 	// Case 2. Attempt to recreate the config with a matching version generation and digest. Should resolve in-flight delete
 	// and then successfully
@@ -863,7 +863,7 @@ func TestPersistentConfigSlowCreateFailure(t *testing.T) {
 	simulateSlowCreate(t, collection1db1Config)
 	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(configs))
+	require.Len(t, configs, 0)
 
 	err = completeSlowCreate(collection1db1Config)
 	require.NoError(t, err)
@@ -1082,7 +1082,7 @@ func TestLegacyDuplicate(t *testing.T) {
 	// Fetch the registry, verify newDefaultDb still exists and defaultDb30 has not been migrated due to collection conflict
 	configs, err := sc.BootstrapContext.GetDatabaseConfigs(ctx, tb.GetName(), groupID)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
+	require.Len(t, configs, 1)
 	dbConfig := configs[0]
 	assert.Equal(t, "3.1", dbConfig.Version)
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1208,7 +1208,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	var replicationsResponse map[string]db.ReplicationConfig
 	err = json.Unmarshal(response.BodyBytes(), &replicationsResponse)
 	require.NoError(t, err, "Error un-marshalling replication response")
-	assert.Equal(t, 2, len(replicationsResponse), "Replication count mismatch")
+	assert.Lenf(t, replicationsResponse, 2, "Replication count mismatch")
 
 	replication1, ok := replicationsResponse[replication1Config.ID]
 	assert.True(t, ok, "Error getting replication")
@@ -1223,7 +1223,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusOK)
 	var allStatusResponse []*db.ReplicationStatus
 	require.NoError(t, json.Unmarshal(response.BodyBytes(), &allStatusResponse))
-	require.Equal(t, 2, len(allStatusResponse), "Replication count mismatch")
+	require.Lenf(t, allStatusResponse, 2, "Replication count mismatch")
 
 	// Sort replications by replication ID before assertion
 	sort.Slice(allStatusResponse, func(i, j int) bool {
@@ -1458,7 +1458,7 @@ func TestGetStatusWithReplication(t *testing.T) {
 	err := json.Unmarshal(response.BodyBytes(), &status)
 	require.NoError(t, err, "Error un-marshalling replication response")
 	database := status.Databases["db"]
-	require.Equal(t, 2, len(database.ReplicationStatus), "Replication count mismatch")
+	require.Lenf(t, database.ReplicationStatus, 2, "Replication count mismatch")
 
 	// Sort replications by replication ID before asserting replication status
 	sort.Slice(database.ReplicationStatus, func(i, j int) bool {
@@ -1469,8 +1469,8 @@ func TestGetStatusWithReplication(t *testing.T) {
 	assert.Equal(t, "unassigned", database.ReplicationStatus[0].Status)
 	assert.Equal(t, "unassigned", database.ReplicationStatus[1].Status)
 
-	assert.Equal(t, 2, len(database.SGRCluster.Replications), "Replication count mismatch")
-	assert.Equal(t, 0, len(database.SGRCluster.Nodes), "Replication node count mismatch")
+	assert.Lenf(t, database.SGRCluster.Replications, 2, "Replication count mismatch")
+	assert.Lenf(t, database.SGRCluster.Nodes, 0, "Replication node count mismatch")
 	assertReplication := func(expected db.ReplicationConfig, actual *db.ReplicationCfg) {
 		assert.Equal(t, expected.ID, actual.ID)
 		assert.Equal(t, expected.Remote, actual.Remote)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -86,7 +86,7 @@ func TestReplicationAPI(t *testing.T) {
 	log.Printf("response: %s", response.BodyBytes())
 	err = json.Unmarshal(response.BodyBytes(), &replicationsResponse)
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(replicationsResponse))
+	assert.Len(t, replicationsResponse, 2)
 	_, ok := replicationsResponse["replication1"]
 	assert.True(t, ok)
 	_, ok = replicationsResponse["replication2"]
@@ -1508,7 +1508,7 @@ func TestGetStatusWithReplication(t *testing.T) {
 	status = rest.Status{}
 	err = json.Unmarshal(response.BodyBytes(), &status)
 	require.NoError(t, err, "Error un-marshalling replication response")
-	require.Equal(t, 0, len(status.Databases["db"].ReplicationStatus))
+	require.Len(t, status.Databases["db"].ReplicationStatus, 0)
 }
 
 func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -898,7 +898,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 
 	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(changes.Results))
+	assert.Len(t, changes.Results, 2)
 
 	assert.Equal(t, "doc", changes.Results[1].ID)
 	assert.False(t, changes.Results[0].Revoked)
@@ -908,7 +908,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 
 	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&revocations=true", 2), "user", false)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)
@@ -932,7 +932,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 
 	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", false)
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(changes.Results))
+	assert.Len(t, changes.Results, 2)
 
 	assert.Equal(t, "doc", changes.Results[1].ID)
 	assert.False(t, changes.Results[1].Revoked)
@@ -942,7 +942,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 
 	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&revocations=true", 3), "user", false)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -222,7 +222,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 
 	var docs []interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Equal(t, 2, len(docs))
+	assert.Len(t, docs, 2)
 	assert.Equal(t, map[string]interface{}{"rev": "1-17424d2a21bf113768dfdbcd344741ac", "id": "bulk1"}, docs[0])
 
 	assert.Equal(t, map[string]interface{}{"rev": "1-f120ccb33c0a6ef43ef202ade28f98ef", "id": "bulk2"}, docs[1])
@@ -375,7 +375,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "alice")
 	log.Printf("1st _changes looks like: %s", response.Body.Bytes())
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	require.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	assert.Equal(t, "_user/alice", changes.Results[0].ID)
 	assert.Equal(t, "g1", changes.Results[1].ID)
 	assert.Equal(t, "a1", changes.Results[2].ID)
@@ -383,7 +383,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "zegpold")
 	log.Printf("2nd _changes looks like: %s", response.Body.Bytes())
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	require.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 	assert.Equal(t, "_user/zegpold", changes.Results[0].ID)
 	assert.Equal(t, "b1", changes.Results[1].ID)
 	lastSeqPreGrant := changes.Last_Seq
@@ -430,7 +430,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	log.Printf("4th _changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	require.Equal(t, 1, len(changes.Results))
+	require.Len(t, changes.Results, 1)
 	assert.Equal(t, "g1", changes.Results[0].ID)
 }
 

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -52,7 +52,7 @@ func TestUsersAPI(t *testing.T) {
 	RequireStatus(t, response, 200)
 	err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(responseUsers))
+	assert.Len(t, responseUsers, 0)
 
 	// Test for user counts going from 1 to a few multiples of QueryPaginationLimit to check boundary conditions
 	for i := 1; i < 13; i++ {
@@ -184,7 +184,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	RequireStatus(t, response, 200)
 	err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(responseUsers))
+	assert.Len(t, responseUsers, 0)
 
 	// Create users
 	numUsers := 12
@@ -978,7 +978,7 @@ func validateUsersNameOnlyFalse(t *testing.T, rt *RestTester) {
 	RequireStatus(t, response, 200)
 	err := json.Unmarshal(response.Body.Bytes(), &responseUsers)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, len(responseUsers))
+	assert.Len(t, responseUsers, 0)
 
 	// Test for user counts going from 1 to a few multiples of QueryPaginationLimit to check boundary conditions.
 	for i := 1; i <= 12; i++ {

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -60,7 +60,7 @@ func TestDocumentUnmarshal(t *testing.T) {
 	attachments, err := doc.GetAttachments()
 	assert.True(t, err == nil)
 
-	assert.Equal(t, 1, len(attachments))
+	assert.Len(t, attachments, 1)
 	myattachment := attachments["myattachment"]
 	assert.Equal(t, "text", myattachment.ContentType)
 
@@ -87,7 +87,7 @@ func TestAttachmentRoundTrip(t *testing.T) {
 
 	attachments, err := doc.GetAttachments()
 	require.NoError(t, err)
-	require.Equal(t, 3, len(attachments))
+	require.Len(t, attachments, 3)
 
 	require.NotNil(t, attachments["foo"])
 	assert.Equal(t, "application/octet-stream", attachments["foo"].ContentType)

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -731,7 +731,7 @@ func TestViewQueryWithXattrAndNonXattr(t *testing.T) {
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foodoc/_view/foobarview")
 	assert.NoError(t, err)
-	require.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Contains(t, "doc1", result.Rows[0].ID)
 	assert.Contains(t, "doc2", result.Rows[1].ID)
 }


### PR DESCRIPTION
Find and replace fix for `Equal(len())` assertions to testify's Len functions.

Find: `(require|assert)\.Equal\(t, (\d+), len\((.+)\)\)`
Replace: `$1.Len(t, $3, $2)`

and `Lenf` variants

Find: `(require|assert)\.Equalf?\(t, (\d+), len\((.+)\)(, .+)\)`
Replace: `$1.Lenf(t, $3, $2$4)`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2331/
