### PR TITLE
CBG-3793: [3.1.4 Backport] change getAuthScopeHandleCreateDB method to not expand env variables 

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4833,3 +4833,83 @@ func TestDeleteDatabaseCBGTTeardown(t *testing.T) {
 		time.Sleep(1 * time.Second) // some time for polling
 	}
 }
+
+// TestDatabaseCreationWithEnvVariable:
+//   - Create rest tester that enables admin auth and disallows db config env vars
+//   - Create CBS user to authenticate with over admin port to force auth scope callback call
+//   - Create db with sync function that calls env variable
+//   - Assert that db is created
+func TestDatabaseCreationWithEnvVariable(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	tb := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer tb.Close(ctx)
+
+	// disable AllowDbConfigEnvVars to avoid attempting to expand variables + enable admin auth
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			config.Unsupported.AllowDbConfigEnvVars = base.BoolPtr(false)
+		},
+		AdminInterfaceAuthentication: true,
+		SyncFn:                       `function (doc) { console.log("${environment}"); return true }`,
+		CustomTestBucket:             tb,
+	})
+	defer rt.Close()
+
+	// create a role to authenticate with in admin endpoint
+	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+	rest.MakeUser(t, httpClient, eps[0], rest.MobileSyncGatewayRole.RoleName, "password", []string{fmt.Sprintf("%s[%s]", rest.MobileSyncGatewayRole.RoleName, tb.GetName())})
+	defer rest.DeleteUser(t, httpClient, eps[0], rest.MobileSyncGatewayRole.RoleName)
+
+	cfg := rt.NewDbConfig()
+	input, err := base.JSONMarshal(&cfg)
+	require.NoError(t, err)
+
+	// create db with config and assert it is successful
+	resp := rt.SendAdminRequestWithAuth(http.MethodPut, "/db/", string(input), rest.MobileSyncGatewayRole.RoleName, "password")
+	rest.RequireStatus(t, resp, http.StatusCreated)
+}
+
+func TestDatabaseCreationWithEnvVariableWithBackticks(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	tb := base.GetTestBucket(t)
+	ctx := base.TestCtx(t)
+	defer tb.Close(ctx)
+
+	// disable AllowDbConfigEnvVars to avoid attempting to expand variables + enable admin auth
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *rest.StartupConfig) {
+			config.Unsupported.AllowDbConfigEnvVars = base.BoolPtr(false)
+		},
+		AdminInterfaceAuthentication: true,
+		SyncFn:                       `function (doc) { console.log("${environment}"); return true }`,
+		CustomTestBucket:             tb,
+	})
+	defer rt.Close()
+
+	// create a role to authenticate with in admin endpoint
+	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+	rest.MakeUser(t, httpClient, eps[0], rest.MobileSyncGatewayRole.RoleName, "password", []string{fmt.Sprintf("%s[%s]", rest.MobileSyncGatewayRole.RoleName, tb.GetName())})
+	defer rest.DeleteUser(t, httpClient, eps[0], rest.MobileSyncGatewayRole.RoleName)
+
+	cfg := rt.NewDbConfig()
+	input, err := base.JSONMarshal(&cfg)
+	require.NoError(t, err)
+
+	// change config to include backticks
+	cfg.Bucket = base.StringPtr(fmt.Sprintf("`"+"%s"+"`", tb.GetName()))
+
+	// create db with config and assert it is successful
+	resp := rt.SendAdminRequestWithAuth(http.MethodPut, "/backticks/", string(input), rest.MobileSyncGatewayRole.RoleName, "password")
+	rest.RequireStatus(t, resp, http.StatusCreated)
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1376,7 +1376,7 @@ func TestEventConfigValidationInvalid(t *testing.T) {
 
 	buf := bytes.NewBufferString(dbConfigJSON)
 	var dbConfig DbConfig
-	err := DecodeAndSanitiseConfig(base.TestCtx(t), buf, &dbConfig, true)
+	err := DecodeAndSanitiseStartupConfig(base.TestCtx(t), buf, &dbConfig, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "document_scribbled_on")
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -1110,19 +1110,18 @@ func (config *DbConfig) redactInPlace(ctx context.Context) error {
 	return nil
 }
 
-// DecodeAndSanitiseConfig will sanitise a config from an io.Reader and unmarshal it into the given config parameter.
-func DecodeAndSanitiseConfig(ctx context.Context, r io.Reader, config interface{}, disallowUnknownFields bool) (err error) {
+// DecodeAndSanitiseStartupConfig will sanitise a config from an io.Reader and unmarshal it into the given config parameter.
+func DecodeAndSanitiseStartupConfig(ctx context.Context, r io.Reader, config interface{}, disallowUnknownFields bool) (err error) {
 	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}
 
 	// Expand environment variables.
-	b, err = expandEnv(ctx, b)
+	b, err = sanitiseConfig(ctx, b, base.BoolPtr(true))
 	if err != nil {
 		return err
 	}
-	b = base.ConvertBackQuotedStrings(b)
 
 	d := base.JSONDecoder(bytes.NewBuffer(b))
 	if disallowUnknownFields {
@@ -1130,6 +1129,23 @@ func DecodeAndSanitiseConfig(ctx context.Context, r io.Reader, config interface{
 	}
 	err = d.Decode(config)
 	return base.WrapJSONUnknownFieldErr(err)
+}
+
+// sanitiseConfig will expand environment variables if needed and will convert any back quotes in the config
+func sanitiseConfig(ctx context.Context, configBytes []byte, allowEnvVars *bool) ([]byte, error) {
+	var err error
+	// Expand environment variables if needed
+	if base.BoolDefault(allowEnvVars, true) {
+		configBytes, err = expandEnv(ctx, configBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Convert the back quotes into double-quotes, escapes literal
+	// backslashes, newlines or double-quotes with backslashes.
+	configBytes = base.ConvertBackQuotedStrings(configBytes)
+
+	return configBytes, nil
 }
 
 // expandEnv replaces $var or ${var} in config according to the values of the

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -369,7 +369,7 @@ func LoadLegacyServerConfig(ctx context.Context, path string) (config *LegacySer
 
 // readLegacyServerConfig returns a validated LegacyServerConfig from an io.Reader
 func readLegacyServerConfig(ctx context.Context, r io.Reader) (config *LegacyServerConfig, err error) {
-	err = DecodeAndSanitiseConfig(ctx, r, &config, true)
+	err = DecodeAndSanitiseStartupConfig(ctx, r, &config, true)
 	if err != nil {
 		return config, err
 	}

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -214,7 +214,7 @@ func LoadStartupConfigFromPath(ctx context.Context, path string) (*StartupConfig
 	defer func() { _ = rc.Close() }()
 
 	var sc StartupConfig
-	err = DecodeAndSanitiseConfig(ctx, rc, &sc, true)
+	err = DecodeAndSanitiseStartupConfig(ctx, rc, &sc, true)
 	return &sc, err
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1035,17 +1035,10 @@ func (h *handler) readSanitizeJSON(val interface{}) error {
 		return err
 	}
 
-	// Expand environment variables.
-	if base.BoolDefault(h.server.Config.Unsupported.AllowDbConfigEnvVars, true) {
-		content, err = expandEnv(h.ctx(), content)
-		if err != nil {
-			return err
-		}
+	content, err = sanitiseConfig(h.ctx(), content, h.server.Config.Unsupported.AllowDbConfigEnvVars)
+	if err != nil {
+		return err
 	}
-
-	// Convert the back quotes into double-quotes, escapes literal
-	// backslashes, newlines or double-quotes with backslashes.
-	content = base.ConvertBackQuotedStrings(content)
 
 	// Decode the body bytes into target structure.
 	decoder := base.JSONDecoder(bytes.NewReader(content))


### PR DESCRIPTION
CBG-3793

Backport of CBG-3791: Perform allow_dbconfig_env_vars check in getAuthScopeHandleCreateDB

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2332/
