### PR TITLE
Bump Go to 1.21.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.7
+          go-version: 1.21.8
       - name: go-build
         run: go build "./..."
 
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.7
+          go-version: 1.21.8
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.7
+          go-version: 1.21.8
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.7
+          go-version: 1.21.8
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.7
+          go-version: 1.21.8
       - name: Run Tests
         run: go test -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.7
+          go-version: 1.21.8
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
 
     tools {
-        go '1.21.7'
+        go '1.21.8'
     }
 
     stages {

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.21.7",
+            "go_version": "1.21.8",
             "trigger_blackduck": true,
             "start_build": 1
         },
@@ -454,7 +454,7 @@
             "release_name": "Couchbase Sync Gateway 3.1.4",
             "production": true,
             "interval": 120,
-            "go_version": "1.21.7",
+            "go_version": "1.21.8",
             "trigger_blackduck": true,
             "start_build": 1
         },
@@ -522,7 +522,7 @@
             "release_name": "Couchbase Sync Gateway 4.0.0",
             "production": true,
             "interval": 30,
-            "go_version": "1.21.7",
+            "go_version": "1.21.8",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
https://github.com/golang/go/issues?q=milestone%3AGo1.21.8+label%3ACherryPickApproved
https://go.dev/doc/devel/release#go1.21.minor