### PR TITLE
[3.1.4 Backport] CBG-3751: Cherry-pick CBG-3742: Allow registry rollb…

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -217,7 +217,7 @@ func UnitTestUrlIsWalrus() bool {
 
 func TestsRequireBootstrapConnection(t *testing.T) {
 	if UnitTestUrlIsWalrus() {
-		t.Skipf("Tests requiring a bootstrap connection are not supporting using rosmar yet - CBG-3271")
+		t.Skipf("Tests requiring a bootstrap connection are not supporting using walrus - rosmar support added in CBG-3271 (3.2+ only)")
 	}
 }
 

--- a/base/stats.go
+++ b/base/stats.go
@@ -155,6 +155,10 @@ func (g *GlobalStat) initConfigStats() error {
 	if err != nil {
 		return err
 	}
+	configStat.DatabaseRollbackCollectionCollisions, err = NewIntStat(ConfigSubsystem, "database_config_collection_conflicts", nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	g.ConfigStat = configStat
 	return nil
 }
@@ -319,6 +323,8 @@ type ResourceUtilization struct {
 type ConfigStat struct {
 	// The number of times the bucket specified in a database config doesn't match the bucket it's found in.
 	DatabaseBucketMismatches *SgwIntStat `json:"database_config_bucket_mismatches"`
+	// The number of times the config was rolled back to an invalid state (conflicting collections)
+	DatabaseRollbackCollectionCollisions *SgwIntStat `json:"database_config_rollback_collection_collisions"`
 }
 
 type DbStats struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -271,6 +271,7 @@ type invalidConfigInfo struct {
 	logged              bool
 	configBucketName    string
 	persistedBucketName string
+	collectionConflicts bool
 }
 
 type invalidDatabaseConfigs struct {
@@ -281,27 +282,42 @@ type invalidDatabaseConfigs struct {
 // addInvalidDatabase adds a db to invalid dbconfig map if it doesn't exist in there yet and will log for it at warning level
 // if the db already exists there we will calculate if we need to log again according to the config update interval
 func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname string, cnf DatabaseConfig, bucket string) {
-	configInfo := invalidConfigInfo{
-		configBucketName:    *cnf.Bucket,
-		persistedBucketName: bucket,
-	}
 	d.m.Lock()
 	defer d.m.Unlock()
 	if d.dbNames[dbname] == nil {
 		// db hasn't been tracked as invalid config yet so add it
-		d.dbNames[dbname] = &configInfo
+		d.dbNames[dbname] = &invalidConfigInfo{
+			configBucketName:    *cnf.Bucket,
+			persistedBucketName: bucket,
+			collectionConflicts: cnf.Version == invalidDatabaseConflictingCollectionsVersion,
+		}
 	}
-	logMessage := fmt.Sprintf("Mismatch in database config for database %q bucket name: %q and backend bucket: %q You must update database config immediately", base.MD(dbname), base.MD(d.dbNames[dbname].configBucketName), base.MD(d.dbNames[dbname].persistedBucketName))
+
+	logMessage := "Must repair invalid database config for %q for it to be usable!"
+	logArgs := []interface{}{base.MD(dbname)}
+
+	// build log message
+	if isBucketMismatch := *cnf.Bucket != bucket; isBucketMismatch {
+		base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Add(1)
+		logMessage += " Mismatched buckets (config bucket: %q, actual bucket: %q)"
+		logArgs = append(logArgs, base.MD(d.dbNames[dbname].configBucketName), base.MD(d.dbNames[dbname].persistedBucketName))
+	} else if cnf.Version == invalidDatabaseConflictingCollectionsVersion {
+		base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseRollbackCollectionCollisions.Add(1)
+		logMessage += " Conflicting collections detected"
+	} else {
+		// Nothing is expected to hit this case, but we might add more invalid sentinel values and forget to update this code.
+		logMessage += " Database was marked invalid. See logs for details."
+	}
+
 	// if we get here we already have the db logged as an invalid config, so now we need to work out iof we should log for it now
 	if !d.dbNames[dbname].logged {
 		// we need to log at warning if we haven't already logged for this particular corrupt db config
-		base.WarnfCtx(ctx, logMessage)
+		base.WarnfCtx(ctx, logMessage, logArgs...)
 		d.dbNames[dbname].logged = true
 	} else {
 		// already logged this entry at warning so need to log at info now
-		base.InfofCtx(ctx, base.KeyConfig, logMessage)
+		base.InfofCtx(ctx, base.KeyConfig, logMessage, logArgs...)
 	}
-	base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Add(1)
 }
 
 func (d *invalidDatabaseConfigs) exists(dbname string) (*invalidConfigInfo, bool) {
@@ -1729,20 +1745,20 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 			continue
 		}
 		for _, cnf := range configs {
-
-			// inherit properties the bootstrap config
-			cnf.CACertPath = sc.Config.Bootstrap.CACertPath
-
-			// We need to check for corruption in the database config (CC. CBG-3292). If the fetched config doesn't match the
-			// bucket name we got the config from we need to maker this db context as corrupt. Then remove the context and
-			// in memory representation on the server context.
-			if bucket != cnf.GetBucketName() {
+			// Handle invalid database registry entries. Either:
+			// - CBG-3292: Bucket in config doesn't match the actual bucket
+			// - CBG-3742: Registry entry marked invalid (due to rollback causing collection conflict)
+			if isRegistryDbConfigVersionInvalid(cnf.Version) || bucket != cnf.GetBucketName() {
 				sc.handleInvalidDatabaseConfig(ctx, bucket, *cnf)
 				continue
 			}
+
 			bucketCopy := bucket
 			// no corruption detected carry on as usual
 			cnf.Bucket = &bucketCopy
+
+			// inherit properties the bootstrap config
+			cnf.CACertPath = sc.Config.Bootstrap.CACertPath
 
 			// stamp per-database credentials if set
 			if dbCredentials, ok := sc.Config.DatabaseCredentials[cnf.Name]; ok && dbCredentials != nil {

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -354,7 +354,7 @@ func (b *bootstrapContext) GetDatabaseConfigs(ctx context.Context, bucketName, g
 		reloadRequired := false
 		for dbName, registryDb := range configGroup.Databases {
 			// Ignore databases with deleted version - represents an in-progress delete
-			if registryDb.Version == deletedDatabaseVersion {
+			if registryDb.IsDeleted() {
 				continue
 			}
 			dbConfig, err := b.getDatabaseConfig(ctx, bucketName, groupID, dbName, registryDb.Version, registry)
@@ -405,6 +405,13 @@ func (b *bootstrapContext) getConfigVersionWithRetry(ctx context.Context, bucket
 		}
 
 		config.cfgCas = cas
+
+		if version == invalidDatabaseConflictingCollectionsVersion {
+			// special case - return the invalid config to use in updates (repairs). Configs with this version will not be loaded by SG.
+			config.Version = invalidDatabaseConflictingCollectionsVersion
+			return false, nil, config
+		}
+
 		// If version matches, success!
 		if config.Version == version {
 			return false, nil, config
@@ -417,10 +424,10 @@ func (b *bootstrapContext) getConfigVersionWithRetry(ctx context.Context, bucket
 			// If the config has a newer version than requested, return the config but alert caller that they have
 			// requested a stale version.
 			return false, base.ErrConfigVersionMismatch, config
-		} else {
-			base.InfofCtx(ctx, base.KeyConfig, "getConfigVersionWithRetry for key %s found version mismatch, retrying.  Requested: %s, Found: %s", metadataKey, version, config.Version)
-			return true, base.ErrConfigRegistryRollback, config
 		}
+
+		base.InfofCtx(ctx, base.KeyConfig, "getConfigVersionWithRetry for key %s found version mismatch, retrying.  Requested: %s, Found: %s", metadataKey, version, config.Version)
+		return true, base.ErrConfigRegistryRollback, config
 	}
 
 	// Kick off the retry loop
@@ -558,11 +565,11 @@ func (b *bootstrapContext) rollbackRegistry(ctx context.Context, bucketName, gro
 
 		// non-nil config indicates database version in registry should be updated to match config
 		base.InfofCtx(ctx, base.KeyConfig, "Rolling back config registry to align with db config version %s for db: %s, bucket:%s configGroup:%s", config.Version, base.MD(dbName), base.MD(bucketName), base.MD(groupID))
-		registryErr := registry.rollbackDatabaseConfig(ctx, groupID, dbName)
+		registryErr := registry.rollbackDatabaseConfig(ctx, groupID, dbName, config)
 		if registryErr != nil {
-			// There shouldn't be a case where rollback introduces a collection conflict - it
-			// shouldn't be possible to add a conflicting collection to the registry while a previous
-			// config persistence is in-flight
+			// There is one case where the registry rollback can introduce a collection conflict.
+			// If there's no PreviousVersion present (i.e. we're handling a db config doc rollback, not a registry update)
+			// then it's possible for the db config to contain a collection that is now present on another database in the registry.
 			return fmt.Errorf("Unable to roll back registry to match existing config for database %s(%s): %w", base.MD(dbName), base.MD(groupID), registryErr)
 		}
 	}
@@ -677,7 +684,7 @@ func (b *bootstrapContext) getRegistryAndDatabase(ctx context.Context, bucketNam
 			}
 			return registry, nil, err
 		} else {
-			if registryDb.Version != "" && registryDb.Version != deletedDatabaseVersion {
+			if registryDb.Version != "" && !registryDb.IsDeleted() {
 				// Database exists in registry, go fetch the config
 				config, err = b.getDatabaseConfig(ctx, bucketName, groupID, dbName, registryDb.Version, registry)
 				if err == base.ErrConfigRegistryReloadRequired {

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -558,6 +558,7 @@ func TestPersistentConfigWithCollectionConflicts(t *testing.T) {
 // TestPersistentConfigRegistryRollbackAfterDbConfigRollback simulates a vbucket rollback for the dbconfig,
 // leaving the registry version ahead of the config.
 func TestPersistentConfigRegistryRollbackAfterDbConfigRollback(t *testing.T) {
+	base.TestsRequireBootstrapConnection(t)
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig)
 
@@ -635,6 +636,7 @@ func TestPersistentConfigRegistryRollbackAfterDbConfigRollback(t *testing.T) {
 // TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback simulates a vbucket rollback for the dbconfig,
 // leaving the registry version ahead of the config - but also with a collection conflict occurring in the subsequent rollback.
 func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback(t *testing.T) {
+	base.TestsRequireBootstrapConnection(t)
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 3)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2541,7 +2541,7 @@ func (sc *ServerContext) RequireInvalidDatabaseConfigNames(t *testing.T, expecte
 	for name := range sc.invalidDatabaseConfigTracking.dbNames {
 		dbNames = append(dbNames, name)
 	}
-	require.EqualValues(t, expectedDbNames, dbNames)
+	require.ElementsMatch(t, expectedDbNames, dbNames)
 }
 
 // Calls DropAllIndexes to remove all indexes, then restores the primary index for TestBucketPool readier requirements


### PR DESCRIPTION
CBG-3751

Backports #6709 to 3.1.4

- Non-clean cherry pick
  - Required changes in test code
  - And selectively pulling in some additional bootstrap/server test helpers (they wouldn't cherry-pick in full cleanly either)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2338/
