### PR TITLE
CBG-3813 add insertion strings to capture stdout/stderr

### DIFF
--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -580,7 +580,7 @@ def make_event_log_task_sg_info():
                        "SourceName='SyncGateway' and "
                        "TimeGenerated>'%(limit)s'"
                        "\" "
-                       "get TimeGenerated,LogFile,SourceName,EventType,Message,InsertionStrings "
+                       "get TimeGenerated,LogFile,SourceName,EventType,InsertionStrings "
                        "/FORMAT:list" % locals())
 
 

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -562,7 +562,7 @@ def make_event_log_task():
                        "(LogFile='application' or LogFile='system') and "
                        "EventType<3 and TimeGenerated>'%(limit)s'"
                        "\" "
-                       "get TimeGenerated,LogFile,SourceName,EventType,Message "
+                       "get TimeGenerated,LogFile,SourceName,EventType,Message,InsertionStrings "
                        "/FORMAT:list" % locals())
 
 
@@ -580,7 +580,7 @@ def make_event_log_task_sg_info():
                        "SourceName='SyncGateway' and "
                        "TimeGenerated>'%(limit)s'"
                        "\" "
-                       "get TimeGenerated,LogFile,SourceName,EventType,Message "
+                       "get TimeGenerated,LogFile,SourceName,EventType,Message,InsertionStrings "
                        "/FORMAT:list" % locals())
 
 


### PR DESCRIPTION
Stderr/stdout are logged from https://github.com/couchbase/sync_gateway/blob/release/3.1.3/service/sg-windows/sg-service/sg-service.go#L55 which forwards events to the windows event log.

It will return `Message` as `Incorrect Function` as per https://github.com/golang/go/issues/45086. A proposal to fix the code in golang.org/x/sys/windows/svc/eventlog is in https://github.com/golang/go/issues/59780 but it would be hard to implement for our use case.

I left `Message` field present in case it is useful, which it might be for events that are not Sync Gateway events. I could drop it for `make_event_log_task_sg_info` because `Incorrect Function` looks like an error but it is not.