### PR TITLE
CBG-3745: Bail out of config updates when the registry write fails after exceeding retry attempts

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -324,7 +324,7 @@ func (cc *CouchbaseCluster) WriteMetadataDocument(ctx context.Context, location,
 		return 0, errors.New("nil CouchbaseCluster")
 	}
 	if cas == 0 {
-		return 0, RedactErrorf("CAS for %q in bucket %q must be non-zero to call WriteMetadataDocument, to add a new document use InsertMetadataDocument", UD(docID), MD(location))
+		return 0, RedactErrorf("CAS for %q in bucket %q must be non-zero to call WriteMetadataDocument, to add a new document use InsertMetadataDocument", MD(docID), MD(location))
 	}
 
 	b, teardown, err := cc.getBucket(ctx, location)

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -292,7 +292,7 @@ func (b *bootstrapContext) DeleteConfig(ctx context.Context, bucketName, groupID
 		// Check for context cancel before retrying
 		select {
 		case <-ctx.Done():
-			break
+			return fmt.Errorf("Exiting DeleteConfig - context cancelled, last error: %w", writeErr)
 		default:
 		}
 	}


### PR DESCRIPTION
CBG-3745

Partly taken from #6713 

- Ensures config/registry operations abort when the number of retry attempts exceeds the limit
- Logging for `GetDatabaseConfigs` retry attempts
- Use `RedactErrorf` for errors that contained metadata

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2339/
