### PR TITLE
CBG-3749 [3.1.4 backport] Bail out of config updates when the registry write fails after exceeding retry attempts

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -355,6 +355,10 @@ func (cc *CouchbaseCluster) WriteMetadataDocument(ctx context.Context, location,
 		return 0, errors.New("nil CouchbaseCluster")
 	}
 
+	if cas == 0 {
+		return 0, RedactErrorf("CAS for %q in bucket %q must be non-zero to call WriteMetadataDocument, to add a new document use InsertMetadataDocument", MD(docID), MD(location))
+	}
+
 	b, teardown, err := cc.getBucket(ctx, location)
 	if err != nil {
 		return 0, err

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -65,11 +65,11 @@ func (b *bootstrapContext) GetConfig(ctx context.Context, bucketName, groupID, d
 //  3. Write the config
 func (b *bootstrapContext) InsertConfig(ctx context.Context, bucketName, groupID string, config *DatabaseConfig) (newCAS uint64, err error) {
 	dbName := config.Name
-	attempts := 0
 	ctx = b.addDatabaseLogContext(ctx, &config.DbConfig)
-	for attempts < configUpdateMaxRetryAttempts {
-		attempts++
-		base.InfofCtx(ctx, base.KeyConfig, "InsertConfig into bucket %s starting (attempt %d/%d)", bucketName, attempts, configUpdateMaxRetryAttempts)
+
+	registryUpdated := false
+	for attempt := 1; attempt <= configUpdateMaxRetryAttempts; attempt++ {
+		base.InfofCtx(ctx, base.KeyConfig, "InsertConfig into bucket %s starting (attempt %d/%d)", bucketName, attempt, configUpdateMaxRetryAttempts)
 
 		// Step 1. Fetch registry and databases - enforces registry/config synchronization
 		registry, existingConfig, err := b.getRegistryAndDatabase(ctx, bucketName, groupID, dbName)
@@ -100,20 +100,25 @@ func (b *bootstrapContext) InsertConfig(ctx context.Context, bucketName, groupID
 			if err != nil {
 				return 0, err
 			}
+			// try again
 			continue
 		}
 
 		// Persist registry
 		writeErr := b.setGatewayRegistry(ctx, bucketName, registry)
 		if writeErr == nil {
+			base.DebugfCtx(ctx, base.KeyConfig, "Registry updated successfully")
+			registryUpdated = true
 			break
 		}
+
 		// retry on cas mismatch, otherwise return error
 		if !base.IsCasMismatch(writeErr) {
 			base.InfofCtx(ctx, base.KeyConfig, "InsertConfig unable to persist registry: %v", writeErr)
 			return 0, writeErr
 		}
-		base.DebugfCtx(ctx, base.KeyConfig, "Registry updated successfully")
+
+		base.InfofCtx(ctx, base.KeyConfig, "InsertConfig encountered cas mismatch error while persisting registry: %v", writeErr)
 
 		// Check for context cancel before retrying
 		select {
@@ -122,14 +127,18 @@ func (b *bootstrapContext) InsertConfig(ctx context.Context, bucketName, groupID
 		default:
 		}
 	}
+	if !registryUpdated {
+		return 0, fmt.Errorf("InsertConfig failed to persist registry after %d attempts", configUpdateMaxRetryAttempts)
+	}
 	// Step 3. Write the database config
 	cas, configErr := b.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey(ctx, groupID, dbName), config)
 	if configErr != nil {
 		base.InfofCtx(ctx, base.KeyConfig, "Insert for database config returned error %v", configErr)
-	} else {
-		base.DebugfCtx(ctx, base.KeyConfig, "Insert for database config was successful")
+		return cas, configErr
 	}
-	return cas, configErr
+
+	base.DebugfCtx(ctx, base.KeyConfig, "Insert for database config was successful")
+	return cas, nil
 }
 
 // UpdateConfig updates an existing database config for a given bucket and config group ID. This is a four-step process:
@@ -141,12 +150,10 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 	var updatedConfig *DatabaseConfig
 	var registry *GatewayRegistry
 	var previousVersion string
-	attempts := 0
 
-outer:
-	for attempts < configUpdateMaxRetryAttempts {
-		attempts++
-		base.InfofCtx(ctx, base.KeyConfig, "UpdateConfig starting (attempt %d/%d)", attempts, configUpdateMaxRetryAttempts)
+	registryUpdated := false
+	for attempt := 1; attempt <= configUpdateMaxRetryAttempts; attempt++ {
+		base.InfofCtx(ctx, base.KeyConfig, "UpdateConfig starting (attempt %d/%d)", attempt, configUpdateMaxRetryAttempts)
 		// Step 1. Fetch registry and databases - enforces registry/config synchronization
 		var existingConfig *DatabaseConfig
 		registry, existingConfig, err = b.getRegistryAndDatabase(ctx, bucketName, groupID, dbName)
@@ -190,21 +197,28 @@ outer:
 		// Persist registry
 		writeErr := b.setGatewayRegistry(ctx, bucketName, registry)
 		if writeErr == nil {
+			base.DebugfCtx(ctx, base.KeyConfig, "UpdateConfig persisted updated registry successfully")
+			registryUpdated = true
 			break
 		}
+
 		// retry on cas mismatch, otherwise return error
 		if !base.IsCasMismatch(writeErr) {
 			base.InfofCtx(ctx, base.KeyConfig, "UpdateConfig encountered error while persisting updated registry: %v", writeErr)
 			return 0, writeErr
 		}
-		base.DebugfCtx(ctx, base.KeyConfig, "UpdateConfig persisted updated registry successfully")
+
+		base.InfofCtx(ctx, base.KeyConfig, "UpdateConfig encountered cas mismatch error while persisting updated registry: %v", writeErr)
 
 		// Check for context cancel before retrying
 		select {
 		case <-ctx.Done():
-			break outer
+			return 0, fmt.Errorf("Exiting UpdateConfig - context cancelled, last error: %w", writeErr)
 		default:
 		}
+	}
+	if !registryUpdated {
+		return 0, fmt.Errorf("UpdateConfig failed to persist updated registry after %d attempts:", configUpdateMaxRetryAttempts)
 	}
 
 	// Step 2. Update the config document
@@ -218,11 +232,11 @@ outer:
 	// Step 3. After config is successfully updated, finalize the update by removing the previous version from the registry
 	err = registry.removePreviousVersion(groupID, dbName, previousVersion)
 	if err != nil {
-		return 0, fmt.Errorf("Error removing previous version of config group: %s, database: %s from registry after successful update: %w", base.MD(groupID), base.MD(dbName), err)
+		return 0, base.RedactErrorf("Error removing previous version of config group: %s, database: %s from registry after successful update: %w", base.MD(groupID), base.MD(dbName), err)
 	}
 	writeErr := b.setGatewayRegistry(ctx, bucketName, registry)
 	if writeErr != nil {
-		return 0, fmt.Errorf("Error persisting removal of previous version of config group: %s, database: %s from registry after successful update: %w", base.MD(groupID), base.MD(dbName), writeErr)
+		return 0, base.RedactErrorf("Error persisting removal of previous version of config group: %s, database: %s from registry after successful update: %w", base.MD(groupID), base.MD(dbName), writeErr)
 	}
 
 	return casOut, nil
@@ -236,11 +250,10 @@ outer:
 func (b *bootstrapContext) DeleteConfig(ctx context.Context, bucketName, groupID, dbName string) (err error) {
 	var existingCas uint64
 	var registry *GatewayRegistry
-	attempts := 0
-outer:
-	for attempts < configUpdateMaxRetryAttempts {
-		attempts++
-		base.InfofCtx(ctx, base.KeyConfig, "DeleteConfig starting (attempt %d/%d)", attempts, configUpdateMaxRetryAttempts)
+
+	registryUpdated := false
+	for attempt := 1; attempt <= configUpdateMaxRetryAttempts; attempt++ {
+		base.InfofCtx(ctx, base.KeyConfig, "DeleteConfig starting (attempt %d/%d)", attempt, configUpdateMaxRetryAttempts)
 		var existingConfig *DatabaseConfig
 		// Step 1. Fetch registry and databases - enforces registry/config synchronization
 		registry, existingConfig, err = b.getRegistryAndDatabase(ctx, bucketName, groupID, dbName)
@@ -263,20 +276,28 @@ outer:
 		// Persist registry
 		writeErr := b.setGatewayRegistry(ctx, bucketName, registry)
 		if writeErr == nil {
+			base.DebugfCtx(ctx, base.KeyConfig, "DeleteConfig persisted updated registry successfully")
+			registryUpdated = true
 			break
 		}
+
 		// retry on cas mismatch, otherwise return error
 		if !base.IsCasMismatch(writeErr) {
 			base.InfofCtx(ctx, base.KeyConfig, "DeleteConfig failed to write updated registry: %v", writeErr)
 			return writeErr
 		}
 
+		base.InfofCtx(ctx, base.KeyConfig, "DeleteConfig encountered cas mismatch error while persisting updated registry: %v", writeErr)
+
 		// Check for context cancel before retrying
 		select {
 		case <-ctx.Done():
-			break outer
+			return fmt.Errorf("Exiting DeleteConfig - context cancelled, last error: %w", writeErr)
 		default:
 		}
+	}
+	if !registryUpdated {
+		return fmt.Errorf("DeleteConfig failed to persist updated registry after %d attempts:", configUpdateMaxRetryAttempts)
 	}
 
 	err = b.Connection.DeleteMetadataDocument(ctx, bucketName, PersistentConfigKey(ctx, groupID, dbName), existingCas)
@@ -293,7 +314,7 @@ outer:
 	} else {
 		writeErr := b.setGatewayRegistry(ctx, bucketName, registry)
 		if writeErr != nil {
-			return fmt.Errorf("Error persisting removal of previous version of config group: %s, database: %s from registry after successful delete: %w", base.MD(groupID), base.MD(dbName), writeErr)
+			return base.RedactErrorf("Error persisting removal of previous version of config group: %s, database: %s from registry after successful delete: %w", base.MD(groupID), base.MD(dbName), writeErr)
 		}
 	}
 
@@ -322,10 +343,9 @@ func (b *bootstrapContext) WaitForConflictingUpdates(ctx context.Context, bucket
 // GetDatabaseConfigs returns all configs for the bucket and config group.
 func (b *bootstrapContext) GetDatabaseConfigs(ctx context.Context, bucketName, groupID string) ([]*DatabaseConfig, error) {
 
-	attempts := 0
-	for attempts < configFetchMaxRetryAttempts {
-		attempts++
-
+	var attempt int
+	for attempt = 1; attempt <= configFetchMaxRetryAttempts; attempt++ {
+		base.InfofCtx(ctx, base.KeyConfig, "GetDatabaseConfigs starting (attempt %d/%d)", attempt, configFetchMaxRetryAttempts)
 		registry, err := b.getGatewayRegistry(ctx, bucketName)
 		if err != nil {
 			return nil, err
@@ -335,8 +355,8 @@ func (b *bootstrapContext) GetDatabaseConfigs(ctx context.Context, bucketName, g
 		var legacyConfig DatabaseConfig
 		var legacyDbName string
 		cas, legacyErr := b.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey(ctx, groupID, ""), &legacyConfig)
-		if legacyErr != nil && legacyErr != base.ErrNotFound {
-			return nil, fmt.Errorf("Error checking for legacy config for %s, %s: %w", base.MD(bucketName), base.MD(groupID), legacyErr)
+		if legacyErr != nil && !base.IsDocNotFoundError(legacyErr) {
+			return nil, base.RedactErrorf("Error checking for legacy config for %s, %s: %w", base.MD(bucketName), base.MD(groupID), legacyErr)
 		}
 		if legacyErr == nil {
 			legacyConfig.cfgCas = cas
@@ -378,7 +398,8 @@ func (b *bootstrapContext) GetDatabaseConfigs(ctx context.Context, bucketName, g
 			return dbConfigs, nil
 		}
 	}
-	base.WarnfCtx(ctx, "Unable to successfully retrieve GetDatabaseConfigs for groupID: %s after %d attempts", base.MD(groupID), attempts)
+
+	base.WarnfCtx(ctx, "Unable to successfully retrieve GetDatabaseConfigs for groupID: %s after %d attempts", base.MD(groupID), attempt)
 	return nil, base.ErrConfigRegistryReloadRequired
 }
 
@@ -552,7 +573,7 @@ func (b *bootstrapContext) rollbackRegistry(ctx context.Context, bucketName, gro
 		found := registry.removeDatabase(groupID, dbName)
 		if !found {
 			// The registry hasn't been reloaded since we tried to find this config, failing to find it now is unexpected
-			return fmt.Errorf("Attempted to remove database %s (%s) from registry, was not found", base.MD(dbName), base.MD(groupID))
+			return base.RedactErrorf("Attempted to remove database %s (%s) from registry, was not found", base.MD(dbName), base.MD(groupID))
 		}
 	} else {
 		// Mark the database config being rolled back first to update CAS, to ensure a slow writer doesn't succeed while we're rolling back.
@@ -570,7 +591,7 @@ func (b *bootstrapContext) rollbackRegistry(ctx context.Context, bucketName, gro
 			// There is one case where the registry rollback can introduce a collection conflict.
 			// If there's no PreviousVersion present (i.e. we're handling a db config doc rollback, not a registry update)
 			// then it's possible for the db config to contain a collection that is now present on another database in the registry.
-			return fmt.Errorf("Unable to roll back registry to match existing config for database %s(%s): %w", base.MD(dbName), base.MD(groupID), registryErr)
+			return base.RedactErrorf("Unable to roll back registry to match existing config for database %s(%s): %w", base.MD(dbName), base.MD(groupID), registryErr)
 		}
 	}
 


### PR DESCRIPTION
CBG-3749

Also improves logging for config registry changes.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2340/
