### PR TITLE
CBG-3808: vrs -> ver to match XDCR format

### DIFF
--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -109,7 +109,7 @@ func (channelMap ChannelMap) KeySet() []string {
 type RevAndVersion struct {
 	RevTreeID      string `json:"rev,omitempty"`
 	CurrentSource  string `json:"src,omitempty"`
-	CurrentVersion string `json:"vrs,omitempty"` // String representation of version
+	CurrentVersion string `json:"ver,omitempty"` // String representation of version
 }
 
 // RevAndVersionJSON aliases RevAndVersion to support conditional unmarshalling from either string (revTreeID) or

--- a/db/crud.go
+++ b/db/crud.go
@@ -2825,8 +2825,8 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 const (
 	xattrMacroCas               = "cas"          // SyncData.Cas
 	xattrMacroValueCrc32c       = "value_crc32c" // SyncData.Crc32c
-	xattrMacroCurrentRevVersion = "rev.vrs"      // SyncDataJSON.RevAndVersion.CurrentVersion
-	versionVectorVrsMacro       = "_vv.vrs"      // PersistedHybridLogicalVector.Version
+	xattrMacroCurrentRevVersion = "rev.ver"      // SyncDataJSON.RevAndVersion.CurrentVersion
+	versionVectorVrsMacro       = "_vv.ver"      // PersistedHybridLogicalVector.Version
 	versionVectorCVCASMacro     = "_vv.cvCas"    // PersistedHybridLogicalVector.CurrentVersionCAS
 )
 

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -237,7 +237,7 @@ const doc_meta_with_vv = `{
 	"_vv":{
    		"cvCas":"0x40e2010000000000",
    		"src":"cb06dc003846116d9b66d2ab23887a96",
-   		"vrs":"0x40e2010000000000",
+   		"ver":"0x40e2010000000000",
    		"mv":{
       		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
       		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -115,7 +115,7 @@ type HybridLogicalVector struct {
 	CurrentVersionCAS string            `json:"cvCas,omitempty"`     // current version cas (or cvCAS) stores the current CAS in little endian hex format at the time of replication
 	ImportCAS         string            `json:"importCAS,omitempty"` // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
 	SourceID          string            `json:"src"`                 // source bucket uuid in (base64 encoded format) of where this entry originated from
-	Version           string            `json:"vrs"`                 // current cas in little endian hex format of the current version on the version vector
+	Version           string            `json:"ver"`                 // current cas in little endian hex format of the current version on the version vector
 	MergeVersions     map[string]string `json:"mv,omitempty"`        // map of merge versions for fast efficient lookup
 	PreviousVersions  map[string]string `json:"pv,omitempty"`        // map of previous versions for fast efficient lookup
 }


### PR DESCRIPTION
CBG-3808

Simple PR to change the json key for version from vrs to ver to match XDCR format

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2343/
