### PR TITLE
CBG-3823 log warning if released unused sequence count > 1 million

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1684,6 +1684,11 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 			if err != nil {
 				return unusedSequences, err
 			}
+			numSkippedSequences := docSequence - doc.Sequence
+			if numSkippedSequences > oversizeSkippedSequenceWarning {
+				base.WarnfCtx(ctx, "doc %s / previous rev: %s /  new rev: %s be allocated sequence %d. This is significantly ahead of the previous sequence this document had %d.", base.UD(doc.ID), doc.CurrentRev, newRevID, docSequence, doc.Sequence)
+			}
+
 		}
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -1738,7 +1738,7 @@ func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, d
 
 		if rev.ID == doc.CurrentRev {
 			if regenerateSequences {
-				updatedUnusedSequences, err = db.assignSequence(ctx, 0, doc, rev.ID, unusedSequences)
+				updatedUnusedSequences, err = db.assignSequence(ctx, 0, doc, unusedSequences)
 				if err != nil {
 					base.WarnfCtx(ctx, "Unable to assign a sequence number: %v", err)
 				}

--- a/db/database.go
+++ b/db/database.go
@@ -1738,7 +1738,7 @@ func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, d
 
 		if rev.ID == doc.CurrentRev {
 			if regenerateSequences {
-				updatedUnusedSequences, err = db.assignSequence(ctx, 0, doc, unusedSequences)
+				updatedUnusedSequences, err = db.assignSequence(ctx, 0, doc, rev.ID, unusedSequences)
 				if err != nil {
 					base.WarnfCtx(ctx, "Unable to assign a sequence number: %v", err)
 				}

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -253,14 +253,12 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 	s.dbStats.SequenceReservedCount.Add(int64(numberToRelease + numberToAllocate))
 	s.dbStats.SequenceAssignedCount.Add(1)
 
-	if prevAllocReleaseFrom < prevAllocReleaseTo {
-		// Release previously allocated sequences (c), if any
-		released, err := s.releaseSequenceRange(ctx, prevAllocReleaseFrom, prevAllocReleaseTo)
-		if err != nil {
-			base.WarnfCtx(ctx, "Error returned when releasing sequence range [%d-%d] for previously allocated sequences. Will be handled by skipped sequence handling.  Error:%v", prevAllocReleaseFrom, prevAllocReleaseTo, err)
-		}
-		releasedSequenceCount += released
+	// Release previously allocated sequences (c), if any
+	released, err := s.releaseSequenceRange(ctx, prevAllocReleaseFrom, prevAllocReleaseTo)
+	if err != nil {
+		base.WarnfCtx(ctx, "Error returned when releasing sequence range [%d-%d] for previously allocated sequences. Will be handled by skipped sequence handling.  Error:%v", prevAllocReleaseFrom, prevAllocReleaseTo, err)
 	}
+	releasedSequenceCount += released
 	// Release the newly allocated sequences that were used to catch up to existingSequence (d)
 	if numberToRelease > 0 {
 		releaseTo := allocatedToSeq - numberToAllocate

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -121,7 +121,7 @@ func (s *sequenceAllocator) releaseUnusedSequences(ctx context.Context) {
 		return
 	}
 	if s.last < s.max {
-		err := s.releaseSequenceRange(ctx, s.last+1, s.max)
+		_, err := s.releaseSequenceRange(ctx, s.last+1, s.max)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error returned when releasing sequence range [%d-%d]. Falling back to skipped sequence handling.  Error:%v", s.last+1, s.max, err)
 		}
@@ -185,7 +185,7 @@ func (s *sequenceAllocator) nextSequence(ctx context.Context) (sequence uint64, 
 // nextSequenceGreaterThan increments _sync:seq such that it's greater than existingSequence + s.sequenceBatchSize
 // In the case where our local s.max < _sync:seq (another node has incremented _sync:seq), we may be releasing
 // sequences greater than existingSequence, but we will only ever release sequences allocated by this node's incr operation
-func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existingSequence uint64) (sequence uint64, err error) {
+func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existingSequence uint64) (sequence uint64, releasedSequenceCount uint64, err error) {
 
 	targetSequence := existingSequence + 1
 	s.mutex.Lock()
@@ -194,13 +194,13 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 		sequence, sequencesReserved, err := s._nextSequence(ctx)
 		s.mutex.Unlock()
 		if err != nil {
-			return 0, err
+			return 0, 0, err
 		}
 		if sequencesReserved {
 			s.reserveNotify <- struct{}{}
 		}
 		s.dbStats.SequenceAssignedCount.Add(1)
-		return sequence, nil
+		return sequence, 0, nil
 	}
 
 	// If the target sequence is in our existing batch (between s.last and s.max), we want to release all unused sequences in the batch earlier
@@ -210,12 +210,14 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 		s.last = targetSequence
 		s.mutex.Unlock()
 		if releaseFrom < targetSequence {
-			if err := s.releaseSequenceRange(ctx, releaseFrom, targetSequence-1); err != nil {
+			released, err := s.releaseSequenceRange(ctx, releaseFrom, targetSequence-1)
+			if err != nil {
 				base.WarnfCtx(ctx, "Error returned when releasing sequence range [%d-%d] from existing batch. Will be handled by skipped sequence handling.  Error:%v", releaseFrom, targetSequence-1, err)
 			}
+			releasedSequenceCount += released
 		}
 		s.dbStats.SequenceAssignedCount.Add(1)
-		return targetSequence, nil
+		return targetSequence, releasedSequenceCount, nil
 
 	}
 
@@ -237,7 +239,7 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 	if err != nil {
 		base.WarnfCtx(ctx, "Error from incrementSequence in nextSequenceGreaterThan(%d): %v", existingSequence, err)
 		s.mutex.Unlock()
-		return 0, err
+		return 0, 0, err
 	}
 
 	s.max = allocatedToSeq
@@ -251,23 +253,26 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 	s.dbStats.SequenceReservedCount.Add(int64(numberToRelease + numberToAllocate))
 	s.dbStats.SequenceAssignedCount.Add(1)
 
-	// Release previously allocated sequences (c), if any
-	err = s.releaseSequenceRange(ctx, prevAllocReleaseFrom, prevAllocReleaseTo)
-	if err != nil {
-		base.WarnfCtx(ctx, "Error returned when releasing sequence range [%d-%d] for previously allocated sequences. Will be handled by skipped sequence handling.  Error:%v", prevAllocReleaseFrom, prevAllocReleaseTo, err)
+	if prevAllocReleaseFrom < prevAllocReleaseTo {
+		// Release previously allocated sequences (c), if any
+		released, err := s.releaseSequenceRange(ctx, prevAllocReleaseFrom, prevAllocReleaseTo)
+		if err != nil {
+			base.WarnfCtx(ctx, "Error returned when releasing sequence range [%d-%d] for previously allocated sequences. Will be handled by skipped sequence handling.  Error:%v", prevAllocReleaseFrom, prevAllocReleaseTo, err)
+		}
+		releasedSequenceCount += released
 	}
-
 	// Release the newly allocated sequences that were used to catch up to existingSequence (d)
 	if numberToRelease > 0 {
 		releaseTo := allocatedToSeq - numberToAllocate
 		releaseFrom := releaseTo - numberToRelease + 1 // +1, as releaseSequenceRange is inclusive
-		err = s.releaseSequenceRange(ctx, releaseFrom, releaseTo)
+		released, err := s.releaseSequenceRange(ctx, releaseFrom, releaseTo)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error returned when releasing sequence range [%d-%d] to reach target sequence. Will be handled by skipped sequence handling.  Error:%v", releaseFrom, releaseTo, err)
 		}
+		releasedSequenceCount += released
 	}
 
-	return sequence, err
+	return sequence, releasedSequenceCount, err
 }
 
 // _nextSequence reserves if needed, and then returns the next sequence
@@ -345,11 +350,12 @@ func (s *sequenceAllocator) releaseSequence(ctx context.Context, sequence uint64
 // releaseSequenceRange writes a binary document with the key _sync:unusedSeqs:fromSeq:toSeq.
 // fromSeq and toSeq are inclusive (i.e. both fromSeq and toSeq are unused).
 // From and to seq are stored as the document contents to avoid null doc issues.
-func (s *sequenceAllocator) releaseSequenceRange(ctx context.Context, fromSequence, toSequence uint64) error {
+// Returns the number of sequences released.
+func (s *sequenceAllocator) releaseSequenceRange(ctx context.Context, fromSequence, toSequence uint64) (uint64, error) {
 
 	// Exit if there's nothing to release
 	if toSequence == 0 || toSequence < fromSequence {
-		return nil
+		return 0, nil
 	}
 	key := s.metaKeys.UnusedSeqRangeKey(fromSequence, toSequence)
 	body := make([]byte, 16)
@@ -357,11 +363,12 @@ func (s *sequenceAllocator) releaseSequenceRange(ctx context.Context, fromSequen
 	binary.LittleEndian.PutUint64(body[8:16], toSequence)
 	_, err := s.datastore.AddRaw(key, UnusedSequenceTTL, body)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	s.dbStats.SequenceReleasedCount.Add(int64(toSequence - fromSequence + 1))
+	count := toSequence - fromSequence + 1
+	s.dbStats.SequenceReleasedCount.Add(int64(count))
 	base.DebugfCtx(ctx, base.KeyCRUD, "Released unused sequences #%d-#%d", fromSequence, toSequence)
-	return nil
+	return count, nil
 }
 
 // waitForReleasedSequences blocks for 'releaseSequenceWait' past the provided startTime.

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -262,47 +262,54 @@ func TestNextSequenceGreaterThanSingleNode(t *testing.T) {
 	assert.NoError(t, err, "error retrieving last sequence")
 
 	// nextSequenceGreaterThan(0) should perform initial batch allocation of size 10,  and not release any sequences
-	nextSequence, err := a.nextSequenceGreaterThan(ctx, 0)
+	nextSequence, releasedSequenceCount, err := a.nextSequenceGreaterThan(ctx, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), nextSequence)
+	require.Equal(t, 0, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, testStats, 1, 10, 1, 0) // incr, reserved, assigned, released counts
 
 	// Calling the same again should use from the existing batch
-	nextSequence, err = a.nextSequenceGreaterThan(ctx, 0)
+	nextSequence, releasedSequenceCount, err = a.nextSequenceGreaterThan(ctx, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(2), nextSequence)
+	assert.Equal(t, 0, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, testStats, 1, 10, 2, 0)
 
 	// Test case where greaterThan == s.Last + 1
-	nextSequence, err = a.nextSequenceGreaterThan(ctx, 2)
+	nextSequence, releasedSequenceCount, err = a.nextSequenceGreaterThan(ctx, 2)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(3), nextSequence)
+	require.Equal(t, 0, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, testStats, 1, 10, 3, 0)
 
 	// When requested nextSequenceGreaterThan is > s.Last + 1, we should release previously allocated sequences but
 	// don't require a new incr
-	nextSequence, err = a.nextSequenceGreaterThan(ctx, 5)
+	nextSequence, releasedSequenceCount, err = a.nextSequenceGreaterThan(ctx, 5)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(6), nextSequence)
+	require.Equal(t, 2, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, testStats, 1, 10, 4, 2)
 
 	// Test when requested nextSequenceGreaterThan == s.Max; should release previously allocated sequences and allocate a new batch
-	nextSequence, err = a.nextSequenceGreaterThan(ctx, 10)
+	nextSequence, releasedSequenceCount, err = a.nextSequenceGreaterThan(ctx, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(11), nextSequence)
+	assert.Equal(t, 4, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, testStats, 2, 20, 5, 6)
 
 	// Test when requested nextSequenceGreaterThan = s.Max + 1; should release previously allocated sequences AND max+1
-	nextSequence, err = a.nextSequenceGreaterThan(ctx, 21)
+	nextSequence, releasedSequenceCount, err = a.nextSequenceGreaterThan(ctx, 21)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(22), nextSequence)
+	assert.Equal(t, 10, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, testStats, 3, 31, 6, 16)
 
 	// Test when requested nextSequenceGreaterThan > s.Max + batch size; should release 9 previously allocated sequences (23-31)
 	// and 19 in the gap to the requested sequence (32-50)
-	nextSequence, err = a.nextSequenceGreaterThan(ctx, 50)
+	nextSequence, releasedSequenceCount, err = a.nextSequenceGreaterThan(ctx, 50)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(51), nextSequence)
+	assert.Equal(t, 28, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, testStats, 4, 60, 7, 44)
 
 }
@@ -350,21 +357,24 @@ func TestNextSequenceGreaterThanMultiNode(t *testing.T) {
 	assert.NoError(t, err, "error retrieving last sequence")
 
 	// nextSequenceGreaterThan(0) on A should perform initial batch allocation of size 10 (allocs 1-10),  and not release any sequences
-	nextSequence, err := a.nextSequenceGreaterThan(ctx, 0)
+	nextSequence, releasedSequenceCount, err := a.nextSequenceGreaterThan(ctx, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), nextSequence)
+	assert.Equal(t, 0, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, dbStatsA, 1, 10, 1, 0) // incr, reserved, assigned, released counts
 
 	// nextSequenceGreaterThan(0) on B should perform initial batch allocation of size 10 (allocs 11-20),  and not release any sequences
-	nextSequence, err = b.nextSequenceGreaterThan(ctx, 0)
+	nextSequence, releasedSequenceCount, err = b.nextSequenceGreaterThan(ctx, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(11), nextSequence)
+	assert.Equal(t, 0, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, dbStatsB, 1, 10, 1, 0)
 
 	// calling nextSequenceGreaterThan(15) on B will assign from the existing batch, and release 12-15
-	nextSequence, err = b.nextSequenceGreaterThan(ctx, 15)
+	nextSequence, releasedSequenceCount, err = b.nextSequenceGreaterThan(ctx, 15)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(16), nextSequence)
+	assert.Equal(t, 4, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, dbStatsB, 1, 10, 2, 4)
 
 	// calling nextSequenceGreaterThan(15) on A will increment _sync:seq by 5 on it's previously allocated sequence (10).
@@ -372,9 +382,10 @@ func TestNextSequenceGreaterThanMultiNode(t *testing.T) {
 	//   node A releasing sequences 2-10 from it's existing buffer
 	//   node A allocating and releasing sequences 21-24
 	//   node A adding sequences 25-35 to its buffer, and assigning 25 to the current request
-	nextSequence, err = a.nextSequenceGreaterThan(ctx, 15)
+	nextSequence, releasedSequenceCount, err = a.nextSequenceGreaterThan(ctx, 15)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(26), nextSequence)
+	assert.Equal(t, 14, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, dbStatsA, 2, 25, 2, 14)
 
 }


### PR DESCRIPTION
Tested on `TestAssignSequenceReleaseLoop` with a lowered threshold to make sure we'll see a warning message.