### PR TITLE
Detect ghcr.io as a non dockerhub source automatically

### DIFF
--- a/integration-test/start_server.sh
+++ b/integration-test/start_server.sh
@@ -63,7 +63,7 @@ docker rm ${SG_TEST_COUCHBASE_SERVER_DOCKER_NAME} || true
 # --volume: Makes and mounts a CBS folder for storing a CBCollect if needed
 
 # use dockerhub if no registry is specified, allows for pre-release images from alternative registries
-if [ "${DOCKERHUB:-}" != "false" ]; then
+if [[ ! "${COUCHBASE_DOCKER_IMAGE_NAME}" =~ ghcr.io/* && "${DOCKERHUB:-}" != "false" ]]; then
     COUCHBASE_DOCKER_IMAGE_NAME="couchbase/server:${COUCHBASE_DOCKER_IMAGE_NAME}"
 fi
 


### PR DESCRIPTION
https://jenkins.sgwdev.com/job/SyncGateway-Integration/2356 (actually passes, found zero tests but was able to run server)

This allows us to not modify jenkins builds but specify docker images starting with ghcr.io