### PR TITLE
CBG-3820: drop logging volume for pending insertions and doc not found logging 

### DIFF
--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -110,7 +110,7 @@ func (c *Collection) SubdocGetXattr(ctx context.Context, k string, xattrKey stri
 		cas := uint64(res.Cas())
 		return cas, nil
 	} else if errors.Is(lookupErr, gocbcore.ErrDocumentNotFound) {
-		DebugfCtx(ctx, KeyCRUD, "No document found for key=%s", UD(k))
+		TracefCtx(ctx, KeyCRUD, "No document found for key=%s", UD(k))
 		return 0, ErrNotFound
 	} else {
 		return 0, lookupErr

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -65,7 +65,7 @@ func (bsc *blipSyncCollectionContext) notePendingInsertion(docID string) {
 	if len(bsc.pendingInsertions) < kMaxPendingInsertions {
 		bsc.pendingInsertions.Add(docID)
 	} else {
-		base.WarnfCtx(bsc.changesCtx, "Sync client has more than %d pending doc insertions in collection %q", kMaxPendingInsertions, base.UD(bsc.dbCollection.Name))
+		base.DebugfCtx(bsc.changesCtx, base.KeySync, "Sync client has more than %d pending doc insertions in collection %q", kMaxPendingInsertions, base.UD(bsc.dbCollection.Name))
 	}
 }
 


### PR DESCRIPTION

CBG-3820

- Dropped logging from debug to trace for doc not found error in `SubdocGetXattr` as this was being logged for each new doc in a propose changes message. 
![Screenshot 2024-03-15 at 09 15 40](https://github.com/couchbase/sync_gateway/assets/109068393/32fe9391-2801-43f6-9ebb-a7427e5a72fb)

- Changed the full pending insertions logging debug level, this shouldn't happen too often I don't think in real world systems. I think this was hit so much as the perf test was pushing so many proposeChanges messages so fast to sync gateway causing imbalance over time between throughput on handling propose changes message and processing rev messages. 
Below is example two log lines of propose chnages for same blip context only 0.29 of a second apart:
`2024-03-07T14:59:36.652Z [INF] SyncMsg: c:[7b7beccd] db:db-1 #9702: Type:proposeChanges #Changes: 35`
`2024-03-07T14:59:36.681Z [INF] SyncMsg: c:[7b7beccd] db:db-1 #9731: Type:proposeChanges #Changes: 34`

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
