### PR TITLE
Skip failing tests on Couchbase 7.6

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1746,13 +1746,7 @@ func TestCouchbaseServerIncorrectLogin(t *testing.T) {
 				testBucket.BucketSpec.Server = strings.ReplaceAll(testBucket.BucketSpec.Server, "couchbase://", "couchbases://")
 			} else {
 				testBucket.BucketSpec.Server = strings.ReplaceAll(testBucket.BucketSpec.Server, "couchbases://", "couchbase://")
-				gocbBucket, err := AsGocbV2Bucket(testBucket)
-				require.NoError(t, err)
-				clusterCompatMajor, clusterCompatMinor, err := getClusterVersion(gocbBucket.cluster)
-				require.NoError(t, err)
-				if clusterCompatMajor == 7 && clusterCompatMinor == 6 {
-					t.Skip("Skipping test for Couchbase Server 7.6 due to GOCBC-1615")
-				}
+				SkipInvalidAuthForCouchbaseServer76(t)
 			}
 
 			// Attempt to open the bucket again using invalid creds. We should expect an error.

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -39,7 +39,7 @@ type TestBucketPool struct {
 
 	// readyBucketPool contains a buffered channel of buckets ready for use
 	readyBucketPool        chan Bucket
-	cluster                tbpCluster
+	cluster                *tbpCluster
 	bucketReadierQueue     chan tbpBucketName
 	bucketReadierWaitGroup *sync.WaitGroup
 	ctxCancelFunc          context.CancelFunc
@@ -122,7 +122,7 @@ func NewTestBucketPoolWithOptions(ctx context.Context, bucketReadierFunc TBPBuck
 		useDefaultScope:        options.UseDefaultScope,
 	}
 
-	tbp.cluster = newTestCluster(ctx, UnitTestUrl(), tbp.Logf)
+	tbp.cluster = newTestCluster(ctx, UnitTestUrl(), &tbp)
 
 	useCollections, err := tbp.canUseNamedCollections(ctx)
 	if err != nil {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -767,6 +767,16 @@ func SkipImportTestsIfNotEnabled(t *testing.T) {
 	}
 }
 
+// SkipInvalidAuthForCouchbaseServer76 temporarily skips test on Couchbase Server 7.6 until invalid credentials return ErrAuthenticationFailure.
+func SkipInvalidAuthForCouchbaseServer76(t *testing.T) {
+	if UnitTestUrlIsWalrus() {
+		return
+	}
+	if GTestBucketPool.cluster.majorVersion == 7 && GTestBucketPool.cluster.minorVersion == 6 {
+		t.Skip("Skipping test for invalid credentials with Couchbase Server 7.6 due to GOCBC-1615")
+	}
+}
+
 // CreateBucketScopesAndCollections will create the given scopes and collections within the given BucketSpec.
 func CreateBucketScopesAndCollections(ctx context.Context, bucketSpec BucketSpec, scopes map[string][]string) error {
 	atLeastOneScope := false

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3183,7 +3183,6 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 
 func TestLegacyCredentialInheritance(t *testing.T) {
 	rest.RequireBucketSpecificCredentials(t)
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	ctx := base.TestCtx(t)
@@ -3921,6 +3920,7 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 // Make sure per DB credentials override per bucket credentials
 func TestPerDBCredsOverride(t *testing.T) {
 	rest.RequireBucketSpecificCredentials(t)
+	base.SkipInvalidAuthForCouchbaseServer76(t)
 
 	ctx := base.TestCtx(t)
 	// Get test bucket


### PR DESCRIPTION
I missed some tests in https://github.com/couchbase/sync_gateway/pull/6729 because https://github.com/couchbase/sync_gateway/pull/6726 wasn't merged yet.

I'm a bit worried about https://github.com/couchbase/sync_gateway/pull/6726 because https://jenkins.sgwdev.com/job/MasterIntegration/722/testReport/junit/github/com_couchbase_sync_gateway_base/TestCouchbaseServerIncorrectLogin_tls_true/ fails in a way I can't reproduce.

I dropped the abstraction of `tbpClusterV2` since we don't support gocb v1/v2 and it allowed me to not write get functions.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2358/
