### PR TITLE
CBG-3804: Reset 3.2, make master 3.3 and rename 4.0 branch

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -86,9 +86,11 @@ const (
 	StatAddedVersion3dot1dot3dot1 = "3.1.3.1"
 	StatAddedVersion3dot1dot4     = "3.1.4"
 	StatAddedVersion3dot2dot0     = "3.2.0"
+	StatAddedVersion3dot3dot0     = "3.3.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
 	StatDeprecatedVersion3dot2dot0     = "3.2.0"
+	StatDeprecatedVersion3dot3dot0     = "3.3.0"
 
 	StatStabilityCommitted = "committed"
 	StatStabilityVolatile  = "volatile"
@@ -1987,39 +1989,39 @@ func (db *DbStats) initServerlessStats() error {
 	labelKeys := []string{DatabaseLabelKey}
 	labelVals := []string{db.dbName}
 
-	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemServerless, "import_process_compute", StatUnitNoUnits, ImportProcessComputeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ImportProcessCompute, err = NewIntStat(SubsystemServerless, "import_process_compute", StatUnitNoUnits, ImportProcessComputeDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SyncProcessCompute, err = NewIntStat(SubsystemServerless, "sync_process_compute", StatUnitNoUnits, SyncProcessComputeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SyncProcessCompute, err = NewIntStat(SubsystemServerless, "sync_process_compute", StatUnitNoUnits, SyncProcessComputeDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumReplicationsRejectedLimit, err = NewIntStat(SubsystemServerless, "num_replications_rejected_limit", StatUnitNoUnits, NumReplicationsRejectedLimitDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumReplicationsRejectedLimit, err = NewIntStat(SubsystemServerless, "num_replications_rejected_limit", StatUnitNoUnits, NumReplicationsRejectedLimitDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.TotalSyncTime, err = NewIntStat(SubsystemServerless, "total_sync_time", StatUnitSeconds, TotalSyncTimeDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.TotalSyncTime, err = NewIntStat(SubsystemServerless, "total_sync_time", StatUnitSeconds, TotalSyncTimeDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.PublicRestBytesWritten, err = NewIntStat(SubsystemServerless, "http_bytes_written", StatUnitBytes, PublicRestBytesWrittenDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.PublicRestBytesWritten, err = NewIntStat(SubsystemServerless, "http_bytes_written", StatUnitBytes, PublicRestBytesWrittenDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.PublicRestBytesRead, err = NewIntStat(SubsystemServerless, "public_rest_bytes_read", StatUnitBytes, PublicRestBytesReadDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.PublicRestBytesRead, err = NewIntStat(SubsystemServerless, "public_rest_bytes_read", StatUnitBytes, PublicRestBytesReadDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemServerless, "num_public_rest_requests", StatUnitNoUnits, NumPublicRestRequestsDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumPublicRestRequests, err = NewIntStat(SubsystemServerless, "num_public_rest_requests", StatUnitNoUnits, NumPublicRestRequestsDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ReplicationBytesReceived, err = NewIntStat(SubsystemServerless, "replication_bytes_received", StatUnitBytes, ReplicationBytesReceivedDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ReplicationBytesReceived, err = NewIntStat(SubsystemServerless, "replication_bytes_received", StatUnitBytes, ReplicationBytesReceivedDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.ReplicationBytesSent, err = NewIntStat(SubsystemServerless, "replication_bytes_sent", StatUnitBytes, ReplicationBytesSentDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.ReplicationBytesSent, err = NewIntStat(SubsystemServerless, "replication_bytes_sent", StatUnitBytes, ReplicationBytesSentDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/version.go
+++ b/base/version.go
@@ -20,7 +20,7 @@ const (
 	ProductName = "Couchbase Sync Gateway"
 
 	ProductAPIVersionMajor = "3"
-	ProductAPIVersionMinor = "2"
+	ProductAPIVersionMinor = "3"
 	ProductAPIVersion      = ProductAPIVersionMajor + "." + ProductAPIVersionMinor
 )
 

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.2.0
+  version: 3.3.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/diagnostic.yaml
+++ b/docs/api/diagnostic.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.2.0
+  version: 3.3.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.2.0
+  version: 3.3.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.2.0
+  version: 3.3.0
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/manifest/3.2.xml
+++ b/manifest/3.2.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
   <project name="build" path="cbbuild" remote="couchbase" revision="cedf9d4ec929eac7e61f8e86488aeac5402c8563">
-    <annotation name="VERSION" value="3.3.0"     keep="true"/>
+    <annotation name="VERSION" value="3.2.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>
 
 
   <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" />
+  <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.2.0" />
 
 </manifest>

--- a/manifest/4.0.xml
+++ b/manifest/4.0.xml
@@ -25,6 +25,6 @@ licenses/APL2.txt.
 
 
   <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="beryllium"/>
+   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/anemone"/>
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -2,7 +2,7 @@
     "product": "sync_gateway",
     "manifests": {
         "manifest/default.xml": {
-            "release": "3.2.0",
+            "release": "3.3.0",
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
@@ -516,6 +516,15 @@
             "go_version": "1.19.5",
             "trigger_blackduck": true,
             "start_build": 586
+        },
+        "manifest/3.2.xml": {
+            "release": "3.2.0",
+            "release_name": "Couchbase Sync Gateway",
+            "production": true,
+            "interval": 30,
+            "go_version": "1.21.8",
+            "trigger_blackduck": true,
+            "start_build": 316
         },
         "manifest/4.0.xml": {
             "release": "4.0.0",

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -524,7 +524,7 @@
             "interval": 30,
             "go_version": "1.21.8",
             "trigger_blackduck": true,
-            "start_build": 316
+            "start_build": 318
         },
         "manifest/4.0.xml": {
             "release": "4.0.0",


### PR DESCRIPTION
CBG-3804

- Add a new "reset" 3.2 (based on 3.1.4)
- Move `master` to 3.3
- Keep 4.0 but change branch to `release/anemone` (a copy of `beryllium` as of opening this PR)

**Reviewer**: Please check that the 3.2 start_build is up to date just prior to merge.
317 is the latest 3.2 build as of opening this PR but that might change if other PRs are merged into master before this one!

https://latestbuilds.service.couchbase.com/builds/latestbuilds/sync_gateway/3.2.0/ 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a