### PR TITLE
Update dependabot.yml to pull from private registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,4 @@ registries:
     type: git
     url: https://github.com
     username: x-access-token
-    password: ${{secrets.GH_PERSONAL_ACCESS_TOKEN_CBROBOTS}}
+    password: ${{secrets.GH_PERSONAL_ACCESS_TOKEN_CBROBOTSG}}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,13 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
-    ignore:
-    - dependency-name: github.com/couchbaselabs/go-fleecedelta
     schedule:
       interval: "weekly"
+    registries:
+      - gh-private
+registries:
+  gh-private:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{secrets.GH_PERSONAL_ACCESS_TOKEN_CBROBOTS}}


### PR DESCRIPTION
I can't quite test this without switching the default branch to this branch which will trigger https://github.com/couchbase/sync_gateway/network/updates

I think it probably is worthwhile to swap the default branch from master to this branch and it should trigger this update to test before we merge. We should be able to switch back quickly.