### PR TITLE
Update ci.yml for test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
           go-version: 1.21.8
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55.2
+          version: v1.57.1
           args: --config=.golangci-strict.yml
 
   test:
@@ -87,12 +87,22 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.7.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json
 
   test-race:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            name: macos
+          - os: windows-latest
+            name: windows
+          - os: ubuntu-latest
+            name: ubuntu
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
@@ -105,7 +115,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json
 

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -93,6 +93,21 @@ linters-settings:
   gocritic:
     enabled-checks:
       - ruleguard
+    disabled-checks:
+      - appendAssign
+      - assignOp
+      - badCond
+      - captLocal
+      - commentFormatting
+      - deprecatedComment
+      - elseif
+      - ifElseChain
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - unlambda
+      - valSwap
+      - wrapperFunc
     settings:
       ruleguard:
         rules: '${configDir}/ruleguard/*.go'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,42 +65,6 @@ linters-settings:
       - fieldalignment # detect Go structs that would take less memory if their fields were sorted
   gocritic:
     enabled-checks:
-      # start defaults
-      - appendAssign
-      - argOrder
-      - assignOp
-      - badCall
-      - badCond
-      - captLocal
-      - caseOrder
-      - codegenComment
-      - commentFormatting
-      - defaultCaseOrder
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - elseif
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - ifElseChain
-      - mapKey
-      - newDeref
-      - offBy1
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - sloppyTypeAssert
-      - switchTrue
-      - typeSwitchVar
-      - underef
-      - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
-      # end defaults
       - ruleguard
     settings:
       ruleguard:


### PR DESCRIPTION
- replace node16 actions with node20 actions (golangci/golangci-lint-action@v4, guyarb/golang-test-annotations@v0.8.0)
- update to newer version of golangci-lint and update .golangci.yml to remove enabled checks, since all checks are enabled by default
- add -race coverage to all platforms to try to detect data races at different speeds, making our test more robust