### PR TITLE
show diagnostic interface only in internal API

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -26,7 +26,13 @@ apis:
     decorators:
       remove-x-internal: on
   metric-internal:
-    root: "./docs/api/public.yaml"
+    root: "./docs/api/metric.yaml"
+  diagnostic:
+    root: "./docs/api/diagnostic.yaml"
+    decorators:
+      remove-x-internal: on
+  diagnostic-internal:
+    root: "./docs/api/diagnostic.yaml"
 
 extends:
   - minimal

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2212,6 +2212,14 @@ Startup-config:
             enabled:
               description: Whether HTTP2 support is enabled
               type: boolean
+        diagnostic_interface:
+          description: |-
+            Network interface to bind diagnotic API to.
+
+            By default, this API will not be run unless this string is specified.
+          type: string
+          default: ""
+          x-internal: true
       readOnly: true
     database_credentials:
       description: 'A map of database name to credentials, that can be used instead of the bootstrap ones.'

--- a/docs/api/paths/diagnostic/keyspace-docid-_all_channels.yaml
+++ b/docs/api/paths/diagnostic/keyspace-docid-_all_channels.yaml
@@ -25,7 +25,6 @@ get:
               description: The channels the document has been in.
               type: array
               items:
-                sequences:
                 description: The sequence number that document was added to the channel.
                 type: string
                 example: "28-48"


### PR DESCRIPTION
Tested with:

npx @redocly/cli preview-docs admin (public facing docs, used by automation)
npx @redocly/cli preview-docs admin-internal (private docs)

fixup of an metrics-internal endpoint