### PR TITLE
CBG-3852: Implementation of single sequence entry for skipped sequence slice

### DIFF
--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2016-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+const (
+	ClipCapacityHeadroom = 100
+)
+
+type SkippedSequenceListInterface interface {
+	getTimestamp() int64
+	getLastSeq() uint64
+	setLastSeq(seq uint64)
+	getStartSeq() uint64
+	isRange() bool
+}
+
+// SkippedSequenceSlice stores the set of skipped sequences as an ordered slice of single skipped sequences
+// or skipped sequence ranges
+type SkippedSequenceSlice struct {
+	list []SkippedSequenceListInterface
+	lock sync.RWMutex
+}
+
+var _ SkippedSequenceListInterface = &SingleSkippedSequence{}
+
+// SingleSkippedSequence contains a single skipped sequence value + unix timestamp of the time it's created
+type SingleSkippedSequence struct {
+	seq       uint64
+	timestamp int64
+}
+
+func NewSkippedSequenceSlice() *SkippedSequenceSlice {
+	return &SkippedSequenceSlice{
+		list: []SkippedSequenceListInterface{},
+	}
+}
+
+// NewSingleSkippedSequenceEntry returns a SingleSkippedSequence with the specified sequence and the current
+// time in unix time
+func NewSingleSkippedSequenceEntry(sequence uint64) *SingleSkippedSequence {
+	return &SingleSkippedSequence{
+		seq:       sequence,
+		timestamp: time.Now().Unix(),
+	}
+}
+
+// getTimestamp returns the timestamp of the entry
+func (s *SingleSkippedSequence) getTimestamp() int64 {
+	return s.timestamp
+}
+
+// getLastSeq gets the last sequence in the range on the entry, for single items the sequence will be returned
+func (s *SingleSkippedSequence) getLastSeq() uint64 {
+	return s.seq
+}
+
+// setLastSeq sets the last sequence in the range on the entry, for single items the single sequence will be set
+func (s *SingleSkippedSequence) setLastSeq(seq uint64) {
+	diff := seq - s.seq
+	s.seq = s.seq + diff
+}
+
+// getStartSeq gets the start sequence in the range on the entry, for single items the sequence will be returned
+func (s *SingleSkippedSequence) getStartSeq() uint64 {
+	return s.seq
+}
+
+// isRange returns true if the entry is a sequence range entry, false if not
+func (s *SingleSkippedSequence) isRange() bool {
+	return false
+}
+
+// IsSkipped returns true if a given sequence exists in the skipped sequence slice
+func (s *SkippedSequenceSlice) IsSkipped(x uint64) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	_, found := s.findSequence(x)
+	return found
+}
+
+// SkippedSequenceCompact will compact the entries with timestamp old enough. It will also clip
+// the capacity of the slice to length + 100 if the current capacity is 2.5x the length
+func (s *SkippedSequenceSlice) SkippedSequenceCompact(ctx context.Context, maxWait int64) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	timeNow := time.Now().Unix()
+	indexToDelete := -1
+	for _, v := range s.list {
+		timeStamp := v.getTimestamp()
+		if (timeNow - timeStamp) >= maxWait {
+			indexToDelete++
+		} else {
+			// exit early to avoid iterating through whole slice
+			break
+		}
+	}
+	// if we have incremented the index counter, we need to the index range from the slice
+	if indexToDelete > -1 {
+		s.list = slices.Delete(s.list, 0, indexToDelete+1)
+	}
+	// resize slice to reclaim memory if we need to
+	s.clip(ctx)
+}
+
+// clip will clip the capacity of the slice to a constant value if the current capacity of the slice in 2.5x the length
+func (s *SkippedSequenceSlice) clip(ctx context.Context) {
+	// threshold is 2.5x the current length of the slice
+	threshold := 2.5 * float64(len(s.list))
+
+	if cap(s.list) > int(threshold) {
+		// check if we can safely clip without an out of bound errors
+		if (len(s.list) + ClipCapacityHeadroom) < cap(s.list) {
+			base.DebugfCtx(ctx, base.KeyCache, "clipping skipped list capacity")
+			s.list = s.list[:len(s.list):ClipCapacityHeadroom]
+		}
+	}
+}
+
+// findSequence will use binary search to search the elements in the slice for a given sequence
+func (s *SkippedSequenceSlice) findSequence(x uint64) (int, bool) {
+	i, found := slices.BinarySearchFunc(s.list, x, func(a SkippedSequenceListInterface, seq uint64) int {
+		singleSeq, ok := a.(*SingleSkippedSequence)
+		if ok {
+			if singleSeq.seq > seq {
+				return 1
+			}
+			if singleSeq.seq == seq {
+				return 0
+			}
+			return -1
+		}
+		// should never get here as it stands, will have extra handling here pending CBG-3853
+		return 1
+	})
+	return i, found
+}
+
+// removeSeq will remove a given sequence from the slice if it exists
+func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	index, found := s.findSequence(x)
+	if !found {
+		return fmt.Errorf("sequence %d not found in the skipped list", x)
+	}
+	// handle boarder cases where x is equal to start or end sequence on range (or just sequence for single entries)
+	if !s.list[index].isRange() {
+		// if not a range, we can just remove the single entry from the slice
+		if s.list[index].getLastSeq() == x {
+			s.list = slices.Delete(s.list, index, index+1)
+		}
+		return nil
+	}
+	// more range handling here CBG-3853, temporarily error as we shouldn't get to this point at this time
+	return fmt.Errorf("entered range handling code")
+}
+
+// insert will insert element in middle of slice maintaining order of rest of slice
+func (s *SkippedSequenceSlice) insert(index int, entry SkippedSequenceListInterface) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.list = append(s.list[:index+1], s.list[index:]...)
+	s.list[index] = entry
+}
+
+// PushSkippedSequenceEntry will append a new skipped sequence entry to the end of the slice, if adding a contiguous
+// sequence function will expand the last entry of the slice to reflect this
+// nolint:staticcheck
+func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry SkippedSequenceListInterface) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if len(s.list) == 0 {
+		s.list = append(s.list, entry)
+		return
+	}
+	// get index of last entry + last seq of entry
+	index := len(s.list) - 1
+	lastEntryLastSeq := s.list[index].getLastSeq()
+	if (lastEntryLastSeq + 1) == entry.getStartSeq() {
+		// adding contiguous sequence
+		if s.list[index].isRange() {
+			// set last seq in the range to the new arriving sequence
+			s.list[index].setLastSeq(entry.getLastSeq())
+		} else {
+			// current last entry is single sequence entry
+			// replace last element with range pending CBG-3853
+		}
+	} else {
+		s.list = append(s.list, entry)
+	}
+}

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -72,10 +72,9 @@ func (s *SingleSkippedSequence) getLastSeq() uint64 {
 	return s.seq
 }
 
-// setLastSeq sets the last sequence in the range on the entry, for single items the single sequence will be set
+// setLastSeq sets the last sequence in the range on the entry, for single items its a no-op
 func (s *SingleSkippedSequence) setLastSeq(seq uint64) {
-	diff := seq - s.seq
-	s.seq = s.seq + diff
+	// no-op
 }
 
 // getStartSeq gets the start sequence in the range on the entry, for single items the sequence will be returned
@@ -198,6 +197,7 @@ func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry SkippedSequenceLis
 	lastEntryLastSeq := s.list[index].getLastSeq()
 	if (lastEntryLastSeq + 1) == entry.getStartSeq() {
 		// adding contiguous sequence
+		// below code is untested, pending CBG-3853
 		if s.list[index].isRange() {
 			// set last seq in the range to the new arriving sequence
 			s.list[index].setLastSeq(entry.getLastSeq())

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -190,13 +190,13 @@ func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 func (s *SkippedSequenceSlice) insert(index int, entry SkippedSequenceListEntry) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.list = append(s.list[:index+1], s.list[index:]...)
+	s.list = append(s.list, nil)
+	copy(s.list[index+1:], s.list[index:])
 	s.list[index] = entry
 }
 
 // PushSkippedSequenceEntry will append a new skipped sequence entry to the end of the slice, if adding a contiguous
 // sequence function will expand the last entry of the slice to reflect this
-// nolint:staticcheck
 func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry *SingleSkippedSequence) {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -52,7 +52,7 @@ type SingleSkippedSequence struct {
 func NewSkippedSequenceSlice(clipHeadroom int) *SkippedSequenceSlice {
 	return &SkippedSequenceSlice{
 		list:                 []SkippedSequenceListEntry{},
-		ClipCapacityHeadroom: clipHeadroom, // will make this tunable in
+		ClipCapacityHeadroom: clipHeadroom,
 	}
 }
 
@@ -116,7 +116,7 @@ func (s *SkippedSequenceSlice) SkippedSequenceCompact(ctx context.Context, maxWa
 		timeStamp := v.getTimestamp()
 		if (timeNow - timeStamp) >= maxWait {
 			indexToDelete++
-			// update count of sequences being compacted form the slice
+			// update count of sequences being compacted from the slice
 			numSequencesCompacted = numSequencesCompacted + v.getNumSequencesInEntry()
 		} else {
 			// exit early to avoid iterating through whole slice

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -50,8 +50,8 @@ func BenchmarkPushSingleSkippedSequence(b *testing.B) {
 		{name: "single_entries", rangeEntries: false},
 	}
 	for _, bm := range benchmarks {
+		skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
 		b.Run(bm.name, func(b *testing.B) {
-			skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
 			for i := 0; i < b.N; i++ {
 				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
 			}
@@ -98,25 +98,15 @@ func BenchmarkIsSkippedFunction(b *testing.B) {
 	benchmarks := []struct {
 		name         string
 		rangeEntries bool
-		largeSlice   bool
+		inputSlice   *SkippedSequenceSlice
 	}{
-		{name: "single_entries_large_slice", rangeEntries: false, largeSlice: true},
-		{name: "single_entries_small_slice", rangeEntries: false, largeSlice: false},
+		{name: "single_entries_large_slice", rangeEntries: false, inputSlice: setupBenchmark(true, DefaultClipCapacityHeadroom)},
+		{name: "single_entries_small_slice", rangeEntries: false, inputSlice: setupBenchmark(false, DefaultClipCapacityHeadroom)},
 	}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
-			if bm.largeSlice {
-				for i := 0; i < 10000; i++ {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
-				}
-			} else {
-				for i := 0; i < 100; i++ {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
-				}
-			}
 			for i := 0; i < b.N; i++ {
-				skippedSlice.Contains(uint64(i * 2))
+				bm.inputSlice.Contains(uint64(i * 2))
 			}
 		})
 	}
@@ -168,25 +158,15 @@ func BenchmarkRemoveSeqFromSkippedList(b *testing.B) {
 	benchmarks := []struct {
 		name         string
 		rangeEntries bool
-		largeSlice   bool
+		inputSlice   *SkippedSequenceSlice
 	}{
-		{name: "single_entries_large_slice", rangeEntries: false, largeSlice: true},
-		{name: "single_entries_small_slice", rangeEntries: false, largeSlice: false},
+		{name: "single_entries_large_slice", rangeEntries: false, inputSlice: setupBenchmark(true, DefaultClipCapacityHeadroom)},
+		{name: "single_entries_small_slice", rangeEntries: false, inputSlice: setupBenchmark(false, DefaultClipCapacityHeadroom)},
 	}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
-			if bm.largeSlice {
-				for i := 0; i < 10000; i++ {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
-				}
-			} else {
-				for i := 0; i < 100; i++ {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
-				}
-			}
 			for i := 0; i < b.N; i++ {
-				_ = skippedSlice.removeSeq(uint64(i * 2))
+				_ = bm.inputSlice.removeSeq(uint64(i * 2))
 			}
 		})
 	}
@@ -236,26 +216,16 @@ func BenchmarkInsertSkippedItem(b *testing.B) {
 	benchmarks := []struct {
 		name         string
 		rangeEntries bool
-		largeSlice   bool
+		inputSlice   *SkippedSequenceSlice
 	}{
-		{name: "single_entries_large_slice", rangeEntries: false, largeSlice: true},
-		{name: "single_entries_small_slice", rangeEntries: false, largeSlice: false},
+		{name: "single_entries_large_slice", rangeEntries: false, inputSlice: setupBenchmark(true, DefaultClipCapacityHeadroom)},
+		{name: "single_entries_small_slice", rangeEntries: false, inputSlice: setupBenchmark(false, DefaultClipCapacityHeadroom)},
 	}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
-			if bm.largeSlice {
-				for i := 0; i < 10000; i++ {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
-				}
-			} else {
-				for i := 0; i < 100; i++ {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
-				}
-			}
 			sequenceNum := 40000
 			for i := 0; i < b.N; i++ {
-				skippedSlice.insert(i, NewSingleSkippedSequenceEntry(uint64(sequenceNum*i)))
+				bm.inputSlice.insert(i, NewSingleSkippedSequenceEntry(uint64(sequenceNum*i)))
 			}
 		})
 	}
@@ -342,28 +312,15 @@ func BenchmarkCompactSkippedList(b *testing.B) {
 	benchmarks := []struct {
 		name         string
 		rangeEntries bool
-		largeSlice   bool
+		inputSlice   *SkippedSequenceSlice
 	}{
-		{name: "single_entries_large_slice", rangeEntries: false, largeSlice: true},
-		{name: "single_entries_small_slice", rangeEntries: false, largeSlice: false},
+		{name: "single_entries_large_slice", rangeEntries: false, inputSlice: setupBenchmarkToCompact(true, 100)},
+		{name: "single_entries_small_slice", rangeEntries: false, inputSlice: setupBenchmarkToCompact(false, 100)},
 	}
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
-			// define clip headroom at 100 for test
-			skippedSlice := NewSkippedSequenceSlice(100)
-			if bm.largeSlice {
-				for i := 0; i < 10000; i++ {
-					skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
-				}
-			} else {
-				for i := 0; i < 100; i++ {
-					skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
-				}
-			}
-			// have one entry to not be compacted
-			skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(60000))
 			for i := 0; i < b.N; i++ {
-				skippedSlice.SkippedSequenceCompact(base.TestCtx(b), 100)
+				bm.inputSlice.SkippedSequenceCompact(base.TestCtx(b), 100)
 			}
 		})
 	}
@@ -408,4 +365,36 @@ func TestGetOldestSkippedSequence(t *testing.T) {
 			assert.Equal(t, testCase.expected, skippedSlice.getOldest())
 		})
 	}
+}
+
+// setupBenchmark sets up a skipped sequence slice for benchmark tests
+func setupBenchmark(largeSlice bool, clipHeadroom int) *SkippedSequenceSlice {
+	skippedSlice := NewSkippedSequenceSlice(clipHeadroom)
+	if largeSlice {
+		for i := 0; i < 10000; i++ {
+			skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+		}
+	} else {
+		for i := 0; i < 100; i++ {
+			skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+		}
+	}
+	return skippedSlice
+}
+
+// setupBenchmarkToCompact sets up a skipped sequence slice for compaction based benchmark tests
+func setupBenchmarkToCompact(largeSlice bool, clipHeadroom int) *SkippedSequenceSlice {
+	skippedSlice := NewSkippedSequenceSlice(clipHeadroom)
+	if largeSlice {
+		for i := 0; i < 10000; i++ {
+			skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
+		}
+	} else {
+		for i := 0; i < 100; i++ {
+			skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
+		}
+	}
+	// have one entry to not be compacted
+	skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(60000))
+	return skippedSlice
 }

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -1,0 +1,375 @@
+/*
+Copyright 2016-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPushSingleSkippedSequence:
+//   - Populate 10 single skipped sequence items in the slice
+//   - Assert that each one is added in the correct order
+//   - Assert that timestamp is increasing from the last entry (or equal to)
+//   - Pending CBG-3853 add contiguous sequence to slice and assert that it replaces the last element with a range entry
+func TestPushSingleSkippedSequence(t *testing.T) {
+	skippedSlice := NewSkippedSequenceSlice()
+
+	for i := 0; i < 10; i++ {
+		skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+	}
+
+	var prevTime int64 = 0
+	for j := 0; j < 10; j++ {
+		assert.Equal(t, uint64(j*2), skippedSlice.list[j].getLastSeq())
+		assert.GreaterOrEqual(t, skippedSlice.list[j].getTimestamp(), prevTime)
+		prevTime = skippedSlice.list[j].getTimestamp()
+	}
+	// Pending CBG-3853, add a new single entry that is contiguous with end of the slice which should repalce last
+	// entry with a range
+
+}
+
+func BenchmarkPushSingleSkippedSequence(b *testing.B) {
+	benchmarks := []struct {
+		name         string
+		rangeEntries bool
+	}{
+		{name: "single_entries", rangeEntries: false},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			skippedSlice := NewSkippedSequenceSlice()
+			for i := 0; i < b.N; i++ {
+				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+			}
+		})
+	}
+}
+
+// TestIsSequenceSkipped:
+//   - Create a skipped slice
+//   - Test each sequence added returns true for IsSkipped
+//   - Assert that IsSkipped returns false for a sequence that doesn't exist in the slice
+//
+// Will add more test cases to this as development continues (for sequence ranges + mixed single and ranges) pending CBG-3853
+func TestIsSequenceSkipped(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputList []uint64
+	}{
+		{
+			name:      "list_full_single_items",
+			inputList: []uint64{2, 6, 100, 200, 500},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			skippedSlice := NewSkippedSequenceSlice()
+
+			for _, input := range testCase.inputList {
+				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input))
+			}
+			for _, v := range testCase.inputList {
+				assert.True(t, skippedSlice.IsSkipped(v))
+			}
+
+			// try a non existent sequence
+			assert.False(t, skippedSlice.IsSkipped(150))
+
+		})
+	}
+}
+
+func BenchmarkIsSkippedFunction(b *testing.B) {
+	benchmarks := []struct {
+		name         string
+		rangeEntries bool
+		largeSlice   bool
+	}{
+		{name: "single_entries_large_slice", rangeEntries: false, largeSlice: true},
+		{name: "single_entries_small_slice", rangeEntries: false, largeSlice: false},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			skippedSlice := NewSkippedSequenceSlice()
+			if bm.largeSlice {
+				for i := 0; i < 10000; i++ {
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+				}
+			} else {
+				for i := 0; i < 100; i++ {
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+				}
+			}
+			for i := 0; i < b.N; i++ {
+				skippedSlice.IsSkipped(uint64(i * 2))
+			}
+		})
+	}
+}
+
+// TestRemoveSeqFromSkipped:
+//   - Create skipped sequence slice
+//   - Remove a sequence from that slice and assert the resulting slice is as expected
+//   - Attempt to remove a non-existent sequence and assert it returns an error
+//
+// Will add more test cases to this as development continues (for sequence ranges + mixed single and ranges) pending CBG-3853
+func TestRemoveSeqFromSkipped(t *testing.T) {
+	testCases := []struct {
+		name         string
+		inputList    []uint64
+		expectedList []uint64
+		remove       uint64
+		errorRemove  uint64
+	}{
+		{
+			name:         "list_full_single_items",
+			inputList:    []uint64{2, 6, 100, 200, 500},
+			expectedList: []uint64{2, 6, 200, 500},
+			remove:       100,
+			errorRemove:  150,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			skippedSlice := NewSkippedSequenceSlice()
+			for _, input := range testCase.inputList {
+				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input))
+			}
+
+			err := skippedSlice.removeSeq(testCase.remove)
+			require.NoError(t, err)
+
+			for i := 0; i < len(skippedSlice.list); i++ {
+				assert.Equal(t, testCase.expectedList[i], skippedSlice.list[i].getLastSeq())
+			}
+
+			err = skippedSlice.removeSeq(testCase.errorRemove)
+			require.Error(t, err)
+		})
+	}
+}
+
+func BenchmarkRemoveSeqFromSkippedList(b *testing.B) {
+	benchmarks := []struct {
+		name         string
+		rangeEntries bool
+		largeSlice   bool
+	}{
+		{name: "single_entries_large_slice", rangeEntries: false, largeSlice: true},
+		{name: "single_entries_small_slice", rangeEntries: false, largeSlice: false},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			skippedSlice := NewSkippedSequenceSlice()
+			if bm.largeSlice {
+				for i := 0; i < 10000; i++ {
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+				}
+			} else {
+				for i := 0; i < 100; i++ {
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+				}
+			}
+			for i := 0; i < b.N; i++ {
+				_ = skippedSlice.removeSeq(uint64(i * 2))
+			}
+		})
+	}
+}
+
+// TestInsertItemInSlice:
+//   - Create skipped sequence slice
+//   - Insert a new value in the slice at index 2 to maintain order
+//   - Assert the resulting slice is correct
+//
+// Will add more test cases to this as development continues (for sequence ranges + mixed single and ranges) pending CBG-3853
+func TestInsertItemInSlice(t *testing.T) {
+	testCases := []struct {
+		name         string
+		inputList    []uint64
+		expectedList []uint64
+		insert       uint64
+		index        int
+	}{
+		{
+			name:         "single_items",
+			inputList:    []uint64{2, 6, 100, 200, 500},
+			expectedList: []uint64{2, 6, 70, 100, 200, 500},
+			insert:       70,
+			index:        2,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			skippedSlice := NewSkippedSequenceSlice()
+
+			for _, input := range testCase.inputList {
+				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input))
+			}
+
+			// attempt to insert at test case index to keep order
+			skippedSlice.insert(testCase.index, NewSingleSkippedSequenceEntry(testCase.insert))
+
+			for i := 0; i < len(skippedSlice.list); i++ {
+				assert.Equal(t, testCase.expectedList[i], skippedSlice.list[i].getLastSeq())
+			}
+		})
+	}
+}
+
+func BenchmarkInsertSkippedItem(b *testing.B) {
+	benchmarks := []struct {
+		name         string
+		rangeEntries bool
+		largeSlice   bool
+	}{
+		{name: "single_entries_large_slice", rangeEntries: false, largeSlice: true},
+		{name: "single_entries_small_slice", rangeEntries: false, largeSlice: false},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			skippedSlice := NewSkippedSequenceSlice()
+			if bm.largeSlice {
+				for i := 0; i < 10000; i++ {
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+				}
+			} else {
+				for i := 0; i < 100; i++ {
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i * 2)))
+				}
+			}
+			sequenceNum := 40000
+			for i := 0; i < b.N; i++ {
+				skippedSlice.insert(i, NewSingleSkippedSequenceEntry(uint64(sequenceNum*i)))
+			}
+		})
+	}
+}
+
+// TestCompactSkippedList:
+//   - Create skipped sequence slice with old timestamp
+//   - Push new entry with future timestamp
+//   - Run compact and assert that each item is compacted apart from the last added item
+//
+// Will add more test cases to this as development continues (for sequence ranges + mixed single and ranges) pending CBG-3853
+func TestCompactSkippedList(t *testing.T) {
+	testCases := []struct {
+		name         string
+		inputList    []uint64
+		expectedList []uint64
+	}{
+		{
+			name:         "single_items",
+			inputList:    []uint64{2, 6, 100, 200, 500},
+			expectedList: []uint64{600},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			skippedSlice := NewSkippedSequenceSlice()
+
+			for _, input := range testCase.inputList {
+				skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(input))
+			}
+			// alter timestamp so we don't compact this entry
+			entry := NewSingleSkippedSequenceEntry(600)
+			entry.timestamp = entry.timestamp + 10000
+			skippedSlice.PushSkippedSequenceEntry(entry)
+
+			skippedSlice.SkippedSequenceCompact(base.TestCtx(t), 1)
+
+			require.Len(t, skippedSlice.list, 1)
+			assert.Equal(t, uint64(600), skippedSlice.list[0].getLastSeq())
+		})
+	}
+}
+
+// TestCompactSkippedListClipHandling:
+//   - Creat new skipped sequence slice with old timestamps
+//   - Push new future entry on the slice
+//   - Run compact and assert that the capacity of the slice is correct after clip is run
+//
+// Will add more test cases to this as development continues (for sequence ranges + mixed single and ranges) pending CBG-3853
+func TestCompactSkippedListClipHandling(t *testing.T) {
+	testCases := []struct {
+		name        string
+		expectedCap int
+	}{
+		{
+			name:        "single_items",
+			expectedCap: 100,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			skippedSlice := NewSkippedSequenceSlice()
+
+			for i := 0; i < 100; i++ {
+				skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
+			}
+			// alter timestamp so we don't compact this entry
+			entry := NewSingleSkippedSequenceEntry(600)
+			entry.timestamp = entry.timestamp + 10000
+			skippedSlice.PushSkippedSequenceEntry(entry)
+
+			skippedSlice.SkippedSequenceCompact(base.TestCtx(t), 1)
+
+			assert.Equal(t, testCase.expectedCap, cap(skippedSlice.list))
+		})
+	}
+}
+
+func BenchmarkInsertCompactSkippedList(b *testing.B) {
+	benchmarks := []struct {
+		name         string
+		rangeEntries bool
+		largeSlice   bool
+	}{
+		{name: "single_entries_large_slice", rangeEntries: false, largeSlice: true},
+		{name: "single_entries_small_slice", rangeEntries: false, largeSlice: false},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			skippedSlice := NewSkippedSequenceSlice()
+			if bm.largeSlice {
+				for i := 0; i < 10000; i++ {
+					skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
+				}
+			} else {
+				for i := 0; i < 100; i++ {
+					skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
+				}
+			}
+			// have one entry to not be compacted
+			skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(60000))
+			for i := 0; i < b.N; i++ {
+				skippedSlice.SkippedSequenceCompact(base.TestCtx(b), 100)
+			}
+		})
+	}
+}
+
+// testSingleSkippedEntryOldTimestamp is creating a new single skipped sequence entry with an old timestamp
+func testSingleSkippedEntryOldTimestamp(seq uint64) *SingleSkippedSequence {
+	now := time.Now().Unix()
+	assignedTimestamp := now - 1000
+	return &SingleSkippedSequence{
+		seq:       seq,
+		timestamp: assignedTimestamp,
+	}
+}


### PR DESCRIPTION

CBG-3852

Initial implementation of skipped sequence interfcae and addition of a single skipped sequence entry.
There are some incomplete functions that will require ranges to be implemented so have left comments on these functions/tests. 
Also includes Benchmarks for each operation.  

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
