### PR TITLE
make blip tests fail with stack traces using testify

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2285,10 +2285,8 @@ func TestUpdateExistingAttachment(t *testing.T) {
 
 		err := btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
-		_, ok := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
-		require.True(t, ok)
-		_, ok = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
-		require.True(t, ok)
+		btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
+		btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
 
 		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
 		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
@@ -2345,8 +2343,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 		err := btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
 
-		_, ok := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
-		require.True(t, ok)
+		btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 
 		// force attachment into test client's store to validate it's fetched
 		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
@@ -2396,8 +2393,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		// Replicate data to client and ensure doc arrives
 		err = btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
-		_, found := btcRunner.WaitForVersion(btc.id, docID, initialVersion)
-		assert.True(t, found)
+		btcRunner.WaitForVersion(btc.id, docID, initialVersion)
 
 		// Push a revision with a bunch of history simulating doc updated on mobile device
 		// Note this references revpos 1 and therefore SGW has it - Shouldn't need proveAttachment
@@ -2438,8 +2434,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		// Pull rev and attachment down to client
 		err = btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
-		_, found := btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, found)
+		btcRunner.WaitForVersion(btc.id, docID, version)
 
 		// Add an attachment to client
 		btcRunner.AttachmentsLock(btc.id).Lock()
@@ -2451,8 +2446,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		require.NoError(t, err)
 
 		// Ensure message and attachment is pushed up
-		_, ok := btc.pushReplication.WaitForMessage(2)
-		assert.True(t, ok)
+		btc.pushReplication.WaitForMessage(2)
 
 		// Get the attachment and ensure the data is updated
 		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc/hello.txt", "")
@@ -2623,10 +2617,8 @@ func TestCBLRevposHandling(t *testing.T) {
 
 		err := btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
-		_, ok := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
-		require.True(t, ok)
-		_, ok = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
-		require.True(t, ok)
+		btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
+		btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
 
 		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
 		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -66,8 +66,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
 		version := btc.rt.PutDoc(docID, bodyText)
 
-		data, ok := btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, ok)
+		data := btcRunner.WaitForVersion(btc.id, docID, version)
 		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 		require.JSONEq(t, bodyTextExpected, string(data))
 
@@ -77,8 +76,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 		require.NoError(t, err)
 
 		// Wait for the document to be replicated at SG
-		_, ok = btc.pushReplication.WaitForMessage(2)
-		assert.True(t, ok)
+		btc.pushReplication.WaitForMessage(2)
 
 		respBody := btc.rt.GetDocVersion(docID, version)
 
@@ -139,8 +137,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
 		version := btc.rt.PutDoc(docID, bodyText)
 
-		data, ok := btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, ok)
+		data := btcRunner.WaitForVersion(btc.id, docID, version)
 		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 		require.JSONEq(t, bodyTextExpected, string(data))
 
@@ -150,8 +147,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 		require.NoError(t, err)
 
 		// Wait for the document to be replicated at SG
-		_, ok = btc.pushReplication.WaitForMessage(2)
-		assert.True(t, ok)
+		btc.pushReplication.WaitForMessage(2)
 
 		respBody := btc.rt.GetDocVersion(docID, version)
 
@@ -215,8 +211,7 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 		doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
 		doc1Version := btc.rt.PutDoc(doc1ID, doc1Body)
 
-		data, ok := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
-		require.True(t, ok)
+		data := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 		bodyTextExpected := fmt.Sprintf(`{"greetings":[{"hi":"alice"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
 		require.JSONEq(t, bodyTextExpected, string(data))
 
@@ -224,8 +219,7 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 		doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
 		doc2Version := btc.rt.PutDoc(doc2ID, doc2Body)
 
-		data, ok = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
-		require.True(t, ok)
+		data = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
 		bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
 		require.JSONEq(t, bodyTextExpected, string(data))
 
@@ -320,8 +314,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 		assert.Equal(t, "2-abc", revId)
 
 		// Wait for the documents to be replicated at SG
-		_, ok := btc.pushReplication.WaitForMessage(2)
-		assert.True(t, ok)
+		btc.pushReplication.WaitForMessage(2)
 
 		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
 		assert.Equal(t, http.StatusOK, resp.Code)
@@ -334,8 +327,7 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 		assert.Equal(t, "4-abc", revId)
 
 		// Wait for the document to be replicated at SG
-		_, ok = btc.pushReplication.WaitForMessage(4)
-		assert.True(t, ok)
+		btc.pushReplication.WaitForMessage(4)
 
 		resp = btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
 		assert.Equal(t, http.StatusOK, resp.Code)
@@ -397,8 +389,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		assert.Equal(t, "4-abc", revId)
 
 		// Wait for the document to be replicated at SG
-		_, ok := btc.pushReplication.WaitForMessage(2)
-		assert.True(t, ok)
+		btc.pushReplication.WaitForMessage(2)
 
 		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+revId, "")
 		assert.Equal(t, http.StatusOK, resp.Code)
@@ -742,8 +733,7 @@ func TestAttachmentComputeStat(t *testing.T) {
 		version := btc.rt.PutDoc(docID, bodyText)
 
 		// Wait for the document to be replicated to client.
-		data, ok := btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, ok)
+		data := btcRunner.WaitForVersion(btc.id, docID, version)
 		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 		require.JSONEq(t, bodyTextExpected, string(data))
 

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -266,8 +266,7 @@ func TestCollectionsReplication(t *testing.T) {
 		err := btcCollection.StartOneshotPull()
 		require.NoError(t, err)
 
-		_, ok := btcCollection.WaitForVersion(docID, version)
-		require.True(t, ok)
+		btcCollection.WaitForVersion(docID, version)
 	})
 }
 
@@ -301,8 +300,7 @@ func TestBlipReplicationMultipleCollections(t *testing.T) {
 		}
 
 		for i, collectionClient := range btc.collectionClients {
-			msg, ok := collectionClient.WaitForVersion(docName, versions[i])
-			require.True(t, ok)
+			msg := collectionClient.WaitForVersion(docName, versions[i])
 			require.Equal(t, body, string(msg))
 		}
 
@@ -358,8 +356,7 @@ func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
 		for _, collectionClient := range btc.collectionClients {
 			versions := collectionVersions[collectionClient.collection]
 			docIDs := collectionDocIDs[collectionClient.collection]
-			msg, ok := collectionClient.WaitForVersion(docIDs[len(docIDs)-1], versions[len(versions)-1])
-			require.True(t, ok)
+			msg := collectionClient.WaitForVersion(docIDs[len(docIDs)-1], versions[len(versions)-1])
 			require.Equal(t, body, string(msg))
 		}
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2963,8 +2963,8 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 		}
 		for i, testCase := range testCases {
 			rt.Run(testCase.name, func(t *testing.T) {
-				docID := fmt.Sprintf("doc%d,", i)
-				markerDoc := fmt.Sprintf("markerDoc%d", i)
+				docID := fmt.Sprintf("doc%d_%s,", i, testCase.name)
+				markerDoc := fmt.Sprintf("markerDoc%d_%s", i, testCase.name)
 				validBody := `{"foo":"bar"}`
 				_ = rt.PutDoc(docID, validBody)
 				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1901,19 +1901,16 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
-		data, ok := btcRunner.WaitForVersion(client.id, docID, version1)
-		assert.True(t, ok)
+		data := btcRunner.WaitForVersion(client.id, docID, version1)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
 		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
 		version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
 
-		data, ok = btcRunner.WaitForVersion(client.id, docID, version2)
-		assert.True(t, ok)
+		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
 
-		msg, ok := client.pullReplication.WaitForMessage(5)
-		assert.True(t, ok)
+		msg := client.pullReplication.WaitForMessage(5)
 		assert.Equal(t, version1.RevID, msg.Properties[db.RevMessageHistory]) // CBG-3268 update to use version
 	})
 }
@@ -1939,15 +1936,13 @@ func TestActiveOnlyContinuous(t *testing.T) {
 
 		// start an initial pull
 		require.NoError(t, btcRunner.StartPullSince(btc.id, "true", "0", "true"))
-		rev, found := btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, found)
+		rev := btcRunner.WaitForVersion(btc.id, docID, version)
 		assert.Equal(t, `{"test":true}`, string(rev))
 
 		// delete the doc and make sure the client still gets the tombstone replicated
 		deletedVersion := rt.DeleteDocReturnVersion(docID, version)
 
-		rev, found = btcRunner.WaitForVersion(btc.id, docID, deletedVersion)
-		assert.True(t, found)
+		rev = btcRunner.WaitForVersion(btc.id, docID, deletedVersion)
 		assert.Equal(t, `{}`, string(rev))
 	})
 }
@@ -2040,8 +2035,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		err = btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
-		_, ok := btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		version = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
 
@@ -2053,8 +2047,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		err = btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
-		_, ok = btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		version = rt.UpdateDoc(docID, version, `{"channels": []}`)
 		const docMarker = "docmarker"
@@ -2074,8 +2067,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		err = btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
-		_, ok = btcRunner.WaitForVersion(btc.id, docMarker, docMarkerVersion)
-		assert.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, docMarker, docMarkerVersion)
 
 		messages := btc.pullReplication.GetMessages()
 
@@ -2154,8 +2146,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 		err = btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
-		_, ok := btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
 		require.NoError(t, rt.WaitForPendingChanges())
@@ -2168,8 +2159,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 		err = btcRunner.StartOneshotPullFiltered(btc.id, "A")
 		assert.NoError(t, err)
-		_, ok = btcRunner.WaitForVersion(btc.id, docID, version)
-		assert.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		_ = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
 		markerID := "docmarker"
@@ -2185,8 +2175,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 		err = btcRunner.StartOneshotPullFiltered(btc.id, "A")
 		assert.NoError(t, err)
-		_, ok = btcRunner.WaitForVersion(btc.id, markerID, markerVersion)
-		assert.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, markerID, markerVersion)
 
 		messages := btc.pullReplication.GetMessages()
 
@@ -2705,8 +2694,7 @@ func TestUnsubChanges(t *testing.T) {
 		require.NoError(t, err)
 
 		doc1Version := rt.PutDoc(doc1ID, `{"key":"val1"}`)
-		_, found := btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
-		require.True(t, found)
+		_ = btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 
 		activeReplStat := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplActiveContinuous
 		require.EqualValues(t, 1, activeReplStat.Value())
@@ -2721,7 +2709,7 @@ func TestUnsubChanges(t *testing.T) {
 		// Confirm no more changes are being sent
 		doc2Version := rt.PutDoc(doc2ID, `{"key":"val1"}`)
 		err = rt.WaitForConditionWithOptions(func() bool {
-			_, found = btcRunner.GetVersion(btc.id, "doc2", doc2Version)
+			_, found := btcRunner.GetVersion(btc.id, "doc2", doc2Version)
 			return found
 		}, 10, 100)
 		assert.Error(t, err)
@@ -2734,8 +2722,7 @@ func TestUnsubChanges(t *testing.T) {
 		// Confirm the pull replication can be restarted and it syncs doc2
 		err = btcRunner.StartPull(btc.id)
 		require.NoError(t, err)
-		_, found = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
-		assert.True(t, found)
+		_ = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
 	})
 }
 
@@ -2792,8 +2779,7 @@ func TestRequestPlusPull(t *testing.T) {
 		require.NoError(t, releaseErr)
 
 		// The one-shot pull should unblock and replicate the document in the granted channel
-		data, ok := btcRunner.WaitForDoc(client.id, "pbs-1")
-		assert.True(t, ok)
+		data := btcRunner.WaitForDoc(client.id, "pbs-1")
 		assert.Equal(t, `{"channel":["PBS"]}`, string(data))
 	})
 }
@@ -2857,8 +2843,7 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 		require.NoError(t, releaseErr)
 
 		// The one-shot pull should unblock and replicate the document in the granted channel
-		data, ok := btcRunner.WaitForDoc(client.id, "pbs-1")
-		assert.True(t, ok)
+		data := btcRunner.WaitForDoc(client.id, "pbs-1")
 		assert.Equal(t, `{"channel":["PBS"]}`, string(data))
 	})
 }
@@ -2907,10 +2892,9 @@ func TestBlipRefreshUser(t *testing.T) {
 		err := btcRunner.StartPullSince(btc.id, "true", "0", "false")
 		require.NoError(t, err)
 
-		_, ok := btcRunner.WaitForDoc(btc.id, docID)
-		require.True(t, ok)
+		_ = btcRunner.WaitForDoc(btc.id, docID)
 
-		_, ok = btcRunner.GetVersion(btc.id, docID, version)
+		_, ok := btcRunner.GetVersion(btc.id, docID, version)
 		require.True(t, ok)
 
 		// delete user with an active blip connection
@@ -2991,8 +2975,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 				defer btc.Close()
 				require.NoError(t, btcRunner.StartOneshotPull(btc.id))
 
-				output, found := btcRunner.WaitForDoc(btc.id, docID)
-				require.True(t, found)
+				output := btcRunner.WaitForDoc(btc.id, docID)
 				require.JSONEq(t, validBody, string(output))
 
 				err := rt.GetSingleDataStore().SetRaw(docID, 0, nil, testCase.invalidBody)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -133,7 +133,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		btcr := btc.getCollectionClientFromMessage(msg)
 
 		attData, err := btcr.getAttachment(digest)
-		require.NoError(btr.TB(), err, "error getting client attachment %v", err)
+		require.NoError(btr.TB(), err, "error getting client attachment: %v", err)
 
 		proof := db.ProveAttachment(ctx, attData, nonce)
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,25 +123,17 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		btr.storeMessage(msg)
 
 		nonce, err := msg.Body()
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(btr.TB(), err)
 
-		if len(nonce) == 0 {
-			panic("no nonce sent with proveAttachment")
-		}
+		require.NotEmpty(btr.TB(), nonce, "no nonce sent with proveAttachment")
 
 		digest, ok := msg.Properties[db.ProveAttachmentDigest]
-		if !ok {
-			panic("no digest sent with proveAttachment")
-		}
+		require.True(btr.TB(), ok, "no digest sent with proveAttachment")
 
 		btcr := btc.getCollectionClientFromMessage(msg)
 
 		attData, err := btcr.getAttachment(digest)
-		if err != nil {
-			panic(fmt.Sprintf("error getting client attachment: %v", err))
-		}
+		require.NoError(btr.TB(), err, "error getting client attachment %v", err)
 
 		proof := db.ProveAttachment(ctx, attData, nonce)
 
@@ -160,18 +153,14 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		}
 
 		body, err := msg.Body()
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(btr.TB(), err)
 
 		knownRevs := []interface{}{}
 
 		if string(body) != "null" {
 			var changesReqs [][]interface{}
 			err = base.JSONUnmarshal(body, &changesReqs)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(btr.TB(), err)
 
 			knownRevs = make([]interface{}, len(changesReqs))
 			// changesReqs == [[sequence, docID, revID, {deleted}, {size (bytes)}], ...]
@@ -233,9 +222,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		}
 
 		b, err := base.JSONMarshal(knownRevs)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(btr.TB(), err)
 
 		response.SetBody(b)
 	}
@@ -254,9 +241,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		deltaSrc := msg.Properties[db.RevMessageDeltaSrc]
 
 		body, err := msg.Body()
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(btr.TB(), err)
 
 		if msg.Properties[db.RevMessageDeleted] == "1" {
 			btcr.docsLock.Lock()
@@ -289,27 +274,24 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					response.SetError("HTTP", http.StatusUnprocessableEntity, "test code intentionally rejected delta")
 					return
 				}
-				panic("expected delta rev message to be sent without noreply flag")
+				require.FailNow(btr.TB(), "expected delta rev message to be sent without noreply flag: %+v", msg)
 			}
 
 			// unmarshal body to extract deltaSrc
 			var delta db.Body
-			if err := delta.Unmarshal(body); err != nil {
-				panic(err)
-			}
+			err := delta.Unmarshal(body)
+			require.NoError(btc.TB(), err)
 
 			var old db.Body
 			btcr.docsLock.RLock()
 			oldBytes := btcr.docs[docID][deltaSrc].body
 			btcr.docsLock.RUnlock()
-			if err := old.Unmarshal(oldBytes); err != nil {
-				panic(err)
-			}
+			err = old.Unmarshal(oldBytes)
+			require.NoError(btc.TB(), err)
 
 			var oldMap = map[string]interface{}(old)
-			if err := base.Patch(&oldMap, delta); err != nil {
-				panic(err)
-			}
+			err = base.Patch(&oldMap, delta)
+			require.NoError(btc.TB(), err)
 
 			bodyJSON = oldMap
 		}
@@ -319,25 +301,20 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 			// We'll need to unmarshal the body in order to do attachment processing
 			if bodyJSON == nil {
-				if err := bodyJSON.Unmarshal(body); err != nil {
-					panic(err)
-				}
+				err := bodyJSON.Unmarshal(body)
+				require.NoError(btr.TB(), err)
 			}
 
 			if atts, ok := bodyJSON[db.BodyAttachments]; ok {
 				attsMap, ok := atts.(map[string]interface{})
-				if !ok {
-					panic("atts in doc wasn't map[string]interface{}")
-				}
+				require.True(btr.TB(), ok, "atts in doc wasn't map[string]interface{}")
 
 				var missingDigests []string
 				var knownDigests []string
 				btcr.attachmentsLock.RLock()
 				for _, attachment := range attsMap {
 					attMap, ok := attachment.(map[string]interface{})
-					if !ok {
-						panic("att in doc wasn't map[string]interface{}")
-					}
+					require.True(btr.TB(), ok, "att in doc wasn't map[string]interface{}")
 					digest := attMap["digest"].(string)
 
 					if _, found := btcr.attachments[digest]; !found {
@@ -353,13 +330,9 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 				for _, digest := range knownDigests {
 					attData, err := btcr.getAttachment(digest)
-					if err != nil {
-						panic(err)
-					}
+					require.NoError(btr.TB(), err)
 					nonce, proof, err := db.GenerateProofOfAttachment(ctx, attData)
-					if err != nil {
-						panic(err)
-					}
+					require.NoError(btr.TB(), err)
 
 					// if we already have this attachment, _we_ should ask the peer whether _they_ have the attachment
 					outrq := blip.NewRequest()
@@ -368,16 +341,12 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					outrq.SetBody(nonce)
 
 					err = btcr.sendPullMsg(outrq)
-					if err != nil {
-						panic(err)
-					}
+					require.NoError(btr.TB(), err)
 
 					resp := outrq.Response()
 					btc.pullReplication.storeMessage(resp)
 					respBody, err := resp.Body()
-					if err != nil {
-						panic(err)
-					}
+					require.NoError(btr.TB(), err)
 
 					if resp.Type() == blip.ErrorType {
 						// forward error from proveAttachment response into rev response
@@ -408,16 +377,12 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					}
 
 					err := btcr.sendPullMsg(outrq)
-					if err != nil {
-						panic(err)
-					}
+					require.NoError(btr.TB(), err)
 
 					resp := outrq.Response()
 					btc.pullReplication.storeMessage(resp)
 					respBody, err := resp.Body()
-					if err != nil {
-						panic(err)
-					}
+					require.NoError(btr.TB(), err)
 
 					if resp.Type() == blip.ErrorType {
 						// forward error from getAttachment response into rev response
@@ -439,9 +404,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 		if bodyJSON != nil {
 			body, err = base.JSONMarshal(bodyJSON)
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(btr.TB(), err)
 		}
 
 		btcr.docsLock.Lock()
@@ -491,6 +454,16 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		btr.storeMessage(msg)
 		base.PanicfCtx(ctx, "Unknown profile: %s caught by client DefaultHandler - msg: %#v", msg.Profile(), msg)
 	}
+}
+
+// TB returns testing.TB for the current test
+func (btr *BlipTesterReplicator) TB() testing.TB {
+	return btr.bt.restTester.TB
+}
+
+// TB returns testing.TB for the current test
+func (btc *BlipTesterCollectionClient) TB() testing.TB {
+	return btc.parent.rt.TB
 }
 
 // saveAttachment takes a content-type, and base64 encoded data and stores the attachment on the client
@@ -594,13 +567,13 @@ func getCollectionsForBLIP(_ testing.TB, rt *RestTester) []string {
 
 func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTester, opts *BlipTesterClientOpts) (client *BlipTesterClient) {
 	if !btcRunner.initialisedInsideRunnerCode {
-		btcRunner.t.Fatalf("must initialise BlipTesterClient inside Run() method")
+		require.FailNow(btcRunner.TB(), "must initialise BlipTesterClient inside Run() method")
 	}
 	if opts == nil {
 		opts = &BlipTesterClientOpts{}
 	}
 	id, err := uuid.NewRandom()
-	require.NoError(btcRunner.t, err)
+	require.NoError(btcRunner.TB(), err)
 
 	client = &BlipTesterClient{
 		BlipTesterClientOpts: *opts,
@@ -609,9 +582,14 @@ func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTes
 	}
 	btcRunner.clients[client.id] = client
 	err = client.createBlipTesterReplications()
-	require.NoError(btcRunner.t, err)
+	require.NoError(btcRunner.TB(), err)
 
 	return client
+}
+
+// TB returns testing.TB for the current test
+func (btc *BlipTesterClient) TB() testing.TB {
+	return btc.rt.TB
 }
 
 func (btc *BlipTesterClient) Close() {
@@ -622,6 +600,11 @@ func (btc *BlipTesterClient) Close() {
 	if btc.nonCollectionAwareClient != nil {
 		btc.nonCollectionAwareClient.Close()
 	}
+}
+
+// TB returns testing.TB for the current test
+func (btcRunner *BlipTestClientRunner) TB() testing.TB {
+	return btcRunner.t
 }
 
 func (btcRunner *BlipTestClientRunner) Run(test func(t *testing.T, SupportedBLIPProtocols []string)) {
@@ -653,14 +636,14 @@ func (btc *BlipTesterClient) createBlipTesterReplications() error {
 		return err
 	}
 
-	if btc.pushReplication, err = newBlipTesterReplication(btc.rt.TB, "push"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization); err != nil {
+	if btc.pushReplication, err = newBlipTesterReplication(btc.TB(), "push"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization); err != nil {
 		return err
 	}
-	if btc.pullReplication, err = newBlipTesterReplication(btc.rt.TB, "pull"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization); err != nil {
+	if btc.pullReplication, err = newBlipTesterReplication(btc.TB(), "pull"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization); err != nil {
 		return err
 	}
 
-	collections := getCollectionsForBLIP(btc.rt.TB, btc.rt)
+	collections := getCollectionsForBLIP(btc.TB(), btc.rt)
 	if !btc.BlipTesterClientOpts.SkipCollectionsInitialization && len(collections) > 0 {
 		btc.collectionClients = make([]*BlipTesterCollectionClient, len(collections))
 		for i, collection := range collections {
@@ -698,15 +681,11 @@ func (btc *BlipTesterClient) initCollectionReplication(collection string, collec
 	return nil
 }
 
-func (btc *BlipTesterClient) waitForReplicationMessage(collection *db.DatabaseCollection, serialNumber blip.MessageNumber) (*blip.Message, bool) {
-	var msg *blip.Message
-	var ok bool
+func (btc *BlipTesterClient) waitForReplicationMessage(collection *db.DatabaseCollection, serialNumber blip.MessageNumber) *blip.Message {
 	if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
-		msg, ok = btc.pushReplication.WaitForMessage(serialNumber)
-	} else {
-		msg, ok = btc.pushReplication.WaitForMessage(serialNumber + 1)
+		return btc.pushReplication.WaitForMessage(serialNumber)
 	}
-	return msg, ok
+	return btc.pushReplication.WaitForMessage(serialNumber + 1)
 }
 
 // SingleCollection returns a single collection blip tester if the RestTester database is configured with only one collection. Otherwise, throw a fatal test error.
@@ -714,7 +693,7 @@ func (btcRunner *BlipTestClientRunner) SingleCollection(clientID uint32) *BlipTe
 	if btcRunner.clients[clientID].nonCollectionAwareClient != nil {
 		return btcRunner.clients[clientID].nonCollectionAwareClient
 	}
-	require.Equal(btcRunner.clients[clientID].rt.TB, 1, len(btcRunner.clients[clientID].collectionClients))
+	require.Equal(btcRunner.clients[clientID].TB(), 1, len(btcRunner.clients[clientID].collectionClients))
 	return btcRunner.clients[clientID].collectionClients[0]
 }
 
@@ -728,7 +707,7 @@ func (btcRunner *BlipTestClientRunner) Collection(clientID uint32, collectionNam
 			return collectionClient
 		}
 	}
-	btcRunner.clients[clientID].rt.TB.Fatalf("Could not find collection %s in BlipTesterClient", collectionName)
+	require.FailNow(btcRunner.clients[clientID].TB(), "Could not find collection %s in BlipTesterClient", collectionName)
 	return nil
 }
 
@@ -1033,24 +1012,17 @@ func (btc *BlipTesterCollectionClient) GetVersion(docID string, docVersion DocVe
 	return nil, false
 }
 
-// WaitForVersion blocks until the given document version has been stored by the client, and returns the data when found.
-func (btc *BlipTesterCollectionClient) WaitForVersion(docID string, docVersion DocVersion) (data []byte, found bool) {
+// WaitForVersion blocks until the given document version has been stored by the client, and returns the data when found. The test will fail after 10 seocnds if a matching document is not found.
+func (btc *BlipTesterCollectionClient) WaitForVersion(docID string, docVersion DocVersion) (data []byte) {
 	if data, found := btc.GetVersion(docID, docVersion); found {
-		return data, found
+		return data
 	}
-	ticker := time.NewTicker(50 * time.Millisecond)
-	timeout := time.After(10 * time.Second)
-	for {
-		select {
-		case <-timeout:
-			require.FailNowf(btc.parent.rt.TB, "BlipTesterClient timed out waiting for doc", "DocID:%+v Version: %+v", docID, docVersion)
-			return nil, false
-		case <-ticker.C:
-			if data, found := btc.GetVersion(docID, docVersion); found {
-				return data, found
-			}
-		}
-	}
+	require.EventuallyWithT(btc.TB(), func(c *assert.CollectT) {
+		var found bool
+		data, found = btc.GetVersion(docID, docVersion)
+		assert.True(c, found, "Could not find docID:%+v Version %+v", docID, docVersion)
+	}, 10*time.Second, 50*time.Millisecond, "BlipTesterClient timed out waiting for doc %+v Version %+v", docID, docVersion)
+	return data
 }
 
 // GetDoc returns a rev stored in the Client under the given docID.  (if multiple revs are present, rev body returned is non-deterministic)
@@ -1067,25 +1039,18 @@ func (btc *BlipTesterCollectionClient) GetDoc(docID string) (data []byte, found 
 	return nil, false
 }
 
-// WaitForDoc blocks until the given doc ID has been stored by the client, and returns the data when found.
-func (btc *BlipTesterCollectionClient) WaitForDoc(docID string) (data []byte, found bool) {
+// WaitForDoc blocks until any document with the doc ID has been stored by the client, and returns the document body when found. If a document will be reported multiple times, the latest copy of the document is returned (not necessarily the first). The test will fail after 10 seconds if the document
+func (btc *BlipTesterCollectionClient) WaitForDoc(docID string) (data []byte) {
 
 	if data, found := btc.GetDoc(docID); found {
-		return data, found
+		return data
 	}
-	ticker := time.NewTicker(50 * time.Millisecond)
-	timeout := time.After(10 * time.Second)
-	for {
-		select {
-		case <-timeout:
-			btc.parent.rt.TB.Fatalf("BlipTesterClient timed out waiting for doc ID: %v", docID)
-			return nil, false
-		case <-ticker.C:
-			if data, found := btc.GetDoc(docID); found {
-				return data, found
-			}
-		}
-	}
+	require.EventuallyWithT(btc.TB(), func(c *assert.CollectT) {
+		var found bool
+		data, found = btc.GetDoc(docID)
+		assert.True(c, found, "Could not find docID:%+v", docID)
+	}, 10*time.Second, 50*time.Millisecond, "BlipTesterClient timed out waiting for doc %+v", docID)
+	return data
 }
 
 // GetMessage returns the message stored in the Client under the given serial number
@@ -1115,21 +1080,14 @@ func (btr *BlipTesterReplicator) GetMessages() map[blip.MessageNumber]blip.Messa
 	return messages
 }
 
-// WaitForMessage blocks until the given message serial number has been stored by the replicator, and returns the message when found.
-func (btr *BlipTesterReplicator) WaitForMessage(serialNumber blip.MessageNumber) (msg *blip.Message, found bool) {
-	ticker := time.NewTicker(50 * time.Millisecond)
-	timeout := time.After(10 * time.Second)
-	for {
-		select {
-		case <-timeout:
-			btr.bt.restTester.TB.Fatalf("BlipTesterReplicator timed out waiting for BLIP message: %v", serialNumber)
-			return nil, false
-		case <-ticker.C:
-			if msg, ok := btr.GetMessage(serialNumber); ok {
-				return msg, ok
-			}
-		}
-	}
+// WaitForMessage blocks until the given message serial number has been stored by the replicator, and returns the message when found. The test will fail if message is not found after 10 seconds.
+func (btr *BlipTesterReplicator) WaitForMessage(serialNumber blip.MessageNumber) (msg *blip.Message) {
+	require.EventuallyWithT(btr.TB(), func(c *assert.CollectT) {
+		var ok bool
+		msg, ok = btr.GetMessage(serialNumber)
+		assert.True(c, ok)
+	}, 10*time.Second, 50*time.Millisecond, "BlipTesterReplicator timed out waiting for BLIP message: %v", serialNumber)
+	return msg
 }
 
 func (btr *BlipTesterReplicator) storeMessage(msg *blip.Message) {
@@ -1138,20 +1096,14 @@ func (btr *BlipTesterReplicator) storeMessage(msg *blip.Message) {
 	btr.messages[msg.SerialNumber()] = msg
 }
 
-func (btc *BlipTesterCollectionClient) WaitForBlipRevMessage(docID string, docVersion DocVersion) (msg *blip.Message, found bool) {
-	ticker := time.NewTicker(50 * time.Millisecond)
-	timeout := time.After(10 * time.Second)
-	for {
-		select {
-		case <-timeout:
-			btc.parent.rt.TB.Fatalf("BlipTesterClient timed out waiting for BLIP message docID: %v, revID: %v", docID, docVersion.RevID)
-			return nil, false
-		case <-ticker.C:
-			if data, found := btc.GetBlipRevMessage(docID, docVersion.RevID); found {
-				return data, found
-			}
-		}
-	}
+// WaitForBlipRevMessage blocks until the given doc ID and rev ID has been stored by the client, and returns the message when found. If not found after 10 seconds, test will fail.
+func (btc *BlipTesterCollectionClient) WaitForBlipRevMessage(docID string, docVersion DocVersion) (msg *blip.Message) {
+	require.EventuallyWithT(btc.TB(), func(c *assert.CollectT) {
+		var ok bool
+		msg, ok = btc.GetBlipRevMessage(docID, docVersion.RevID)
+		assert.True(c, ok, "Could not find docID:%+v, RevID: %+v", docID, docVersion.RevID)
+	}, 10*time.Second, 50*time.Millisecond, "BlipTesterReplicator timed out waiting for BLIP message")
+	return msg
 }
 
 func (btc *BlipTesterCollectionClient) GetBlipRevMessage(docID, revID string) (msg *blip.Message, found bool) {
@@ -1172,16 +1124,18 @@ func (btcRunner *BlipTestClientRunner) StartPull(clientID uint32) error {
 	return btcRunner.SingleCollection(clientID).StartPull()
 }
 
-// WaitForVersion blocks until the given document version has been stored by the client, and returns the data when found.
-func (btcRunner *BlipTestClientRunner) WaitForVersion(clientID uint32, docID string, docVersion DocVersion) (data []byte, found bool) {
+// WaitForVersion blocks until the given document version has been stored by the client, and returns the data when found or fails test if document is not found after 10 seconds.
+func (btcRunner *BlipTestClientRunner) WaitForVersion(clientID uint32, docID string, docVersion DocVersion) (data []byte) {
 	return btcRunner.SingleCollection(clientID).WaitForVersion(docID, docVersion)
 }
 
-func (btcRunner *BlipTestClientRunner) WaitForDoc(clientID uint32, docID string) ([]byte, bool) {
+// WaitForBlipRevMessage blocks until any blip message with a given docID has been stored by the client, and returns the message when found. If document is not not found after 10 seconds, test will fail.
+func (btcRunner *BlipTestClientRunner) WaitForDoc(clientID uint32, docID string) []byte {
 	return btcRunner.SingleCollection(clientID).WaitForDoc(docID)
 }
 
-func (btcRunner *BlipTestClientRunner) WaitForBlipRevMessage(clientID uint32, docID string, docVersion DocVersion) (*blip.Message, bool) {
+// WaitForBlipRevMessage blocks until the given doc ID and rev ID has been stored by the client, and returns the message when found. If document is not found after 10 seconds, test will fail.
+func (btcRunner *BlipTestClientRunner) WaitForBlipRevMessage(clientID uint32, docID string, docVersion DocVersion) *blip.Message {
 	return btcRunner.SingleCollection(clientID).WaitForBlipRevMessage(docID, docVersion)
 }
 
@@ -1254,7 +1208,7 @@ func (btc *BlipTesterCollectionClient) addCollectionProperty(msg *blip.Message) 
 // addCollectionProperty will automatically add a collection. If we are running with the default collection, or a single named collection, automatically add the right value. If there are multiple collections on the database, the test will fatally exit, since the behavior is undefined.
 func (bt *BlipTesterClient) addCollectionProperty(msg *blip.Message) *blip.Message {
 	if bt.nonCollectionAwareClient == nil {
-		require.Equal(bt.rt.TB, 1, len(bt.collectionClients), "Multiple collection clients, exist so assuming that the only named collection is the single element of an array is not valid")
+		require.Equal(bt.TB(), 1, len(bt.collectionClients), "Multiple collection clients, exist so assuming that the only named collection is the single element of an array is not valid")
 		msg.Properties[db.BlipCollection] = "0"
 	}
 
@@ -1267,17 +1221,15 @@ func (btc *BlipTesterClient) getCollectionClientFromMessage(msg *blip.Message) *
 	if !exists {
 		// If a collection property is passed, assume that the BlipTesterClient hasn't been initialized with collections.
 		// If this fails, this means a message wasn't sent with the correct BlipCollection property, see use of addCollectionProperty
-		require.NotNil(btc.rt.TB, btc.nonCollectionAwareClient)
+		require.NotNil(btc.TB(), btc.nonCollectionAwareClient)
 		return btc.nonCollectionAwareClient
 	}
 
-	if collectionIdx == "" {
-		btc.rt.TB.Fatalf("no collection given in %q message", msg.Profile())
-	}
+	require.NotEqual(btc.TB(), "", collectionIdx, "no collection given in %q message", msg.Profile())
 
 	idx, err := strconv.Atoi(collectionIdx)
-	require.NoError(btc.rt.TB, err)
-	require.Greater(btc.rt.TB, len(btc.collectionClients), idx)
+	require.NoError(btc.TB(), err)
+	require.Greater(btc.TB(), len(btc.collectionClients), idx)
 	return btc.collectionClients[idx]
 }
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2257,8 +2257,7 @@ func TestRevocationMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Wait for doc revision to come over
-		_, ok := btcRunner.WaitForBlipRevMessage(btc.id, "doc", version)
-		require.True(t, ok)
+		_ = btcRunner.WaitForBlipRevMessage(btc.id, "doc", version)
 
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
@@ -2276,8 +2275,7 @@ func TestRevocationMessage(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Wait for doc1 rev2 - This is the last rev we expect so we can be sure replication is complete here
-		_, found := btcRunner.WaitForVersion(btc.id, doc1ID, version)
-		require.True(t, found)
+		_ = btcRunner.WaitForVersion(btc.id, doc1ID, version)
 
 		messages := btc.pullReplication.GetMessages()
 
@@ -2374,8 +2372,7 @@ func TestRevocationNoRev(t *testing.T) {
 		err := btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
 
-		_, ok := btcRunner.WaitForVersion(btc.id, docID, version)
-		require.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
@@ -2389,8 +2386,7 @@ func TestRevocationNoRev(t *testing.T) {
 		err = btcRunner.StartPullSince(btc.id, "false", lastSeqStr, "false")
 		assert.NoError(t, err)
 
-		_, ok = btcRunner.WaitForVersion(btc.id, waitMarkerID, waitMarkerVersion)
-		require.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, waitMarkerID, waitMarkerVersion)
 
 		messages := btc.pullReplication.GetMessages()
 
@@ -2472,8 +2468,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		err := btcRunner.StartOneshotPull(btc.id)
 		assert.NoError(t, err)
 		throw = true
-		_, ok := btcRunner.WaitForVersion(btc.id, docID, version)
-		require.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
@@ -2487,8 +2482,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		err = btcRunner.StartPullSince(btc.id, "false", lastSeqStr, "false")
 		assert.NoError(t, err)
 
-		_, ok = btcRunner.WaitForVersion(btc.id, waitMarkerID, waitMarkerVersion)
-		require.True(t, ok)
+		_ = btcRunner.WaitForVersion(btc.id, waitMarkerID, waitMarkerVersion)
 	})
 }
 


### PR DESCRIPTION
This is really only to help debug the CBG-3818 ticket part 1, I have a second round of refactoring just for this test to see what documents aren't coming through.

- Create TB() helper functions to make it easier to pick up the right TB function since it can get reset or hard to pick up
- use require.EventuallyT instead of testing.T.Fatalf to get tracebacks when they fail. Because these functions fail anyway, removed the return of boolean found.
- switch panic to require statements in code
- remove return statements if the test would fail anyway

To review:

- Did I do the removal of the error status correctly, are there any cases where the removal of an argument actually used?
- Did I remove any assertions?
- Do the new assertion messages make sense?

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2369/
