### PR TITLE
make tests pass with 6.6

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3304,10 +3304,10 @@ func (i *testBackgroundProcess) ResetStatus() {
 func TestBadDCPStart(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 	if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {
 		t.Skip("This test requires collections support on server (7.0 or greater)")
 	}
-	defer bucket.Close(ctx)
 	dbcOptions := DatabaseContextOptions{
 		Scopes: GetScopesOptions(t, bucket, 1),
 	}

--- a/xdcr/main_test.go
+++ b/xdcr/main_test.go
@@ -19,6 +19,6 @@ import (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048, RequireXDCR: true}
 	base.TestBucketPoolNoIndexes(ctx, m, tbpOptions)
 }


### PR DESCRIPTION
- xdcr tests have timing issues with creating an XDCR bucket to bucket replication and do not run 95% of the time.
- fix an error with defer bucket.Close() where the tests would panic

make sure rosmar tests work with xdcr

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2371/ (one test fails with a different error)
