### PR TITLE
Produce 3.2.0 from `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,16 @@ on:
   push:
     branches:
       - 'master'
+      - 'main'
       - 'release/*'
+      - 'feature/*'
       - 'beryllium'
       - 'CBG*'
       - 'ci-*'
   pull_request:
     branches:
       - 'master'
+      - 'main'
       - 'release/*'
       - 'beryllium'
 

--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -15,6 +15,7 @@ on:
       - 'docs/api/**'
     branches:
       - 'master'
+      - 'main'
       - 'release/*'
       - 'beryllium'
 

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -15,7 +15,9 @@ on:
       - 'docs/api/**'
     branches:
       - 'master'
+      - 'main'
       - 'release/*'
+      - 'feature/*'
       - 'beryllium'
       - 'CBG*'
       - 'ci-*'
@@ -26,6 +28,7 @@ on:
       - 'docs/api/**'
     branches:
       - 'master'
+      - 'main'
       - 'release/*'
       - 'beryllium'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ It's great if you can scan the open issues to see if your problem/idea has been 
 
 ## Version
 
-Please indicate **what version of the software** you're using. If you compiled it yourself from source, it helps if you give the Git commit ID, or at least the branch name and date ("I last pulled from master on 6/30.")
+Please indicate **what version of the software** you're using. If you compiled it yourself from source, it helps if you give the Git commit ID, or at least the branch name and date ("I last pulled from main on 6/30.")
 
 If the bug involves replication, also indicate what software and version is on the other end of the line, i.e. "Couchbase Lite Android 1.0" or "Sync Gateway 1.0" or "Sync Gateway commit f3d3229c" or "CouchDB 1.6".
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 FROM golang:1.11.5-stretch as builder
 
 # Customize this with the commit hash or branch name you want to build
-ARG COMMIT=master
+ARG COMMIT=main
 
 # Refresh apt repository, install git
 RUN apt-get update && apt-get install -y \
@@ -25,7 +25,7 @@ RUN git config --global color.ui false
 
 # Download and run the bootstrap.sh script which will download and invoke the repo
 # tool to grap all required repositories
-RUN wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh && \
+RUN wget https://raw.githubusercontent.com/couchbase/sync_gateway/main/bootstrap.sh && \
     cat bootstrap.sh && \
     chmod +x bootstrap.sh && \
     ./bootstrap.sh -c $COMMIT -e ce

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,7 @@ pipeline {
                 stage('Unit') {
                     stages {
                         stage('CE') {
-                            when { branch 'master' }
+                            when { branch 'main' }
                             steps{
                                 // Travis-related variables are required as coveralls.io only officially supports a certain set of CI tools.
                                 withEnv(["PATH+GO=${env.GOTOOLS}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {
@@ -332,11 +332,11 @@ pipeline {
 
                 stage('Integration') {
                     stages {
-                        stage('Master') {
-                            when { branch 'master' }
+                        stage('main') {
+                            when { branch 'main' }
                             steps {
-                                echo 'Queueing Integration test for branch "master" ...'
-                                // Queues up an async integration test run using default build params (master branch),
+                                echo 'Queueing Integration test for branch "main" ...'
+                                // Queues up an async integration test run using default build params (main branch),
                                 // but waits up to an hour for batches of PR merges before actually running (via quietPeriod)
                                 build job: 'MasterIntegration', quietPeriod: 3600, wait: false
                             }
@@ -362,9 +362,9 @@ pipeline {
             }
         }
         stage('Benchmarks'){
-            when { branch 'master' }
+            when { branch 'main' }
             steps{
-                echo 'Queueing Benchmark Run test for branch "master" ...'
+                echo 'Queueing Benchmark Run test for branch "main" ...'
                 // TODO: Add this back with new system
                 // build job: 'sync-gateway-benchmark', parameters: [string(name: 'SG_COMMIT', value: env.SG_COMMIT)], wait: false
             }
@@ -389,8 +389,8 @@ pipeline {
             // archive non-verbose outputs upon failure for inspection (each verbose output is conditionally archived on stage failure)
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
-                if ("${env.BRANCH_NAME}" == 'master') {
-                    slackSend color: "danger", message: "Failed tests in master SGW pipeline: ${currentBuild.fullDisplayName}\nAt least one test failed: ${env.BUILD_URL}"
+                if ("${env.BRANCH_NAME}" == 'main') {
+                    slackSend color: "danger", message: "Failed tests in main SGW pipeline: ${currentBuild.fullDisplayName}\nAt least one test failed: ${env.BUILD_URL}"
                 }
             }
         }
@@ -398,16 +398,16 @@ pipeline {
             // archive non-verbose outputs upon failure for inspection (each verbose output is conditionally archived on stage failure)
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
-                if ("${env.BRANCH_NAME}" == 'master') {
-                    slackSend color: "danger", message: "Build failure!!!\nA build failure occurred in the master SGW pipeline: ${currentBuild.fullDisplayName}\nSomething went wrong building: ${env.BUILD_URL}"
+                if ("${env.BRANCH_NAME}" == 'main') {
+                    slackSend color: "danger", message: "Build failure!!!\nA build failure occurred in the main SGW pipeline: ${currentBuild.fullDisplayName}\nSomething went wrong building: ${env.BUILD_URL}"
                 }
             }
         }
         aborted {
             archiveArtifacts excludes: 'verbose_*.out', artifacts: '*.out', fingerprint: false, allowEmptyArchive: true
             script {
-                if ("${env.BRANCH_NAME}" == 'master') {
-                    slackSend color: "danger", message: "Master SGW pipeline build aborted: ${currentBuild.fullDisplayName}\nCould be due to build timeout: ${env.BUILD_URL}"
+                if ("${env.BRANCH_NAME}" == 'main') {
+                    slackSend color: "danger", message: "main SGW pipeline build aborted: ${currentBuild.fullDisplayName}\nCould be due to build timeout: ${env.BUILD_URL}"
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GoDoc](https://godoc.org/github.com/couchbase/sync_gateway?status.svg)](https://godoc.org/github.com/couchbase/sync_gateway)
 [![Go Report Card](https://goreportcard.com/badge/github.com/couchbase/sync_gateway)](https://goreportcard.com/report/github.com/couchbase/sync_gateway)
 [![Code Coverage](https://img.shields.io/coveralls/github/couchbase/sync_gateway.svg)](https://coveralls.io/github/couchbase/sync_gateway)
-[![License](https://img.shields.io/badge/license-BSL%201.1-lightgrey)](https://github.com/couchbase/sync_gateway/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-BSL%201.1-lightgrey)](https://github.com/couchbase/sync_gateway/blob/main/LICENSE)
 
 Sync Gateway is a horizontally scalable web server that securely manages the access control and
 synchronization of data between [Couchbase Lite][CB_LITE] and [Couchbase Server][CB_SERVER].
@@ -46,7 +46,7 @@ See the [Extended Build Instructions](docs/BUILD.md) to build with dependency pi
 
 ## License
 
-[Business Source License 1.1](https://github.com/couchbase/sync_gateway/blob/master/LICENSE)
+[Business Source License 1.1](https://github.com/couchbase/sync_gateway/blob/main/LICENSE)
 
 [CB_MOBILE]: https://www.couchbase.com/products/mobile
 [CB_GATEWAY]: https://www.couchbase.com/products/sync-gateway

--- a/db/crud.go
+++ b/db/crud.go
@@ -833,7 +833,7 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 	// Use an admin-scoped database for import
 	importDb := DatabaseCollectionWithUser{DatabaseCollection: db.DatabaseCollection, user: nil}
 
-	importedDoc, importErr := importDb.ImportDoc(ctx, docid, doc, isDelete, nil, ImportOnDemand)
+	importedDoc, importErr := importDb.ImportDoc(ctx, docid, doc, isDelete, nil, ImportOnDemand) // nolint:staticcheck
 
 	if importErr == base.ErrImportCancelledFilter {
 		// Document exists, but existing doc wasn't imported based on import filter.  Treat write as insert
@@ -841,7 +841,7 @@ func (db *DatabaseCollectionWithUser) OnDemandImportForWrite(ctx context.Context
 	} else if importErr != nil {
 		return importErr
 	} else {
-		doc = importedDoc
+		doc = importedDoc // nolint:staticcheck
 	}
 	return nil
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
   <project name="build" path="cbbuild" remote="couchbase" revision="cedf9d4ec929eac7e61f8e86488aeac5402c8563">
-    <annotation name="VERSION" value="3.3.0"     keep="true"/>
+    <annotation name="VERSION" value="3.2.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>
 
 
   <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" />
+   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="main" />
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -2,13 +2,13 @@
     "product": "sync_gateway",
     "manifests": {
         "manifest/default.xml": {
-            "release": "3.3.0",
+            "release": "3.2.0",
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
             "go_version": "1.21.8",
             "trigger_blackduck": true,
-            "start_build": 1
+            "start_build": 320
         },
         "manifest/1.4.0.xml": {
             "do-build": false,
@@ -516,15 +516,6 @@
             "go_version": "1.19.5",
             "trigger_blackduck": true,
             "start_build": 586
-        },
-        "manifest/3.2.xml": {
-            "release": "3.2.0",
-            "release_name": "Couchbase Sync Gateway",
-            "production": true,
-            "interval": 30,
-            "go_version": "1.21.8",
-            "trigger_blackduck": true,
-            "start_build": 318
         },
         "manifest/4.0.xml": {
             "release": "4.0.0",


### PR DESCRIPTION
- Produce 3.2 builds from `main` branch
  - `main` is identical to `master`, minus the 4 serverless commits (now in `feature/serverless`)
- Remove 3.3 build config
- Add `main` in CI config

## ⚠️ Post-merge ⚠️
- [x] Make `master` branch read-only (same rules as old `beryllium` branch)
- [x] Change default branch in GitHub to `main` from `master`
- [ ] Change Jenkins jobs building from `master` (e.g. The automated post-merge Integration test job)
- [ ] Notify build team of default branch change for awareness

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2373/
