### PR TITLE
support golangci-lint 1.57.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
           go-version: 1.21.8
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.55.2
+          version: v1.57.2
           args: --config=.golangci-strict.yml
 
   test:

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -93,6 +93,21 @@ linters-settings:
   gocritic:
     enabled-checks:
       - ruleguard
+    disabled-checks:
+      - appendAssign
+      - assignOp
+      - badCond
+      - captLocal
+      - commentFormatting
+      - deprecatedComment
+      - elseif
+      - ifElseChain
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - unlambda
+      - valSwap
+      - wrapperFunc
     settings:
       ruleguard:
         rules: '${configDir}/ruleguard/*.go'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,42 +65,6 @@ linters-settings:
       - fieldalignment # detect Go structs that would take less memory if their fields were sorted
   gocritic:
     enabled-checks:
-      # start defaults
-      - appendAssign
-      - argOrder
-      - assignOp
-      - badCall
-      - badCond
-      - captLocal
-      - caseOrder
-      - codegenComment
-      - commentFormatting
-      - defaultCaseOrder
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - elseif
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - ifElseChain
-      - mapKey
-      - newDeref
-      - offBy1
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - sloppyTypeAssert
-      - switchTrue
-      - typeSwitchVar
-      - underef
-      - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
-      # end defaults
       - ruleguard
     settings:
       ruleguard:


### PR DESCRIPTION
- golangci-lint now changes defaults to enabled
- update golangci-lint-action to v4 to avoid node deprecation warnings from action