### PR TITLE
CBG-3869: Fix losing user xattr on import feed for docs with no sync data

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -441,8 +441,7 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 	// Note that there could be a non-sync xattr present
 	if dataType&base.MemcachedDataTypeXattr != 0 {
 		var syncXattr []byte
-		var userXattr []byte
-		body, syncXattr, userXattr, err = parseXattrStreamData(base.SyncXattrName, userXattrKey, data)
+		body, syncXattr, rawUserXattr, err = parseXattrStreamData(base.SyncXattrName, userXattrKey, data)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
@@ -457,7 +456,7 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 			if err != nil {
 				return nil, nil, nil, nil, err
 			}
-			return result, body, syncXattr, userXattr, nil
+			return result, body, syncXattr, rawUserXattr, nil
 		}
 	} else {
 		// Xattr flag not set - data is just the document body
@@ -466,7 +465,7 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 
 	// Non-xattr data, or sync xattr not present.  Attempt to retrieve sync metadata from document body
 	result, err = UnmarshalDocumentSyncData(body, needHistory)
-	return result, body, rawUserXattr, nil, err
+	return result, body, nil, rawUserXattr, err
 }
 
 func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -11,7 +11,9 @@ package importuserxattrtest
 import (
 	"net/http"
 	"testing"
+	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
@@ -310,8 +312,6 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 //   - Insert another doc via SDK with user xattr defined with array of channels
 //   - Wait for import feed to pick the doc up and assert the doc is correctly assigned the channels defined in user xattr
 func TestAutoImportUserXattrNoSyncData(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: `function (doc, oldDoc, meta) {
    if (meta.xattrs.channels === undefined) {
@@ -349,13 +349,12 @@ func TestAutoImportUserXattrNoSyncData(t *testing.T) {
 	val := make(map[string]interface{})
 	val["test"] = "doc"
 	_, err := dataStore.WriteWithXattrs(ctx, docKey, 0, 0, base.MustJSONMarshal(t, val), userXattrVal, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wait for doc to be imported
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 1
-	})
-	assert.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	}, 10*time.Second, 100*time.Millisecond)
 
 	// Ensure sync function has run on import
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
@@ -372,13 +371,12 @@ func TestAutoImportUserXattrNoSyncData(t *testing.T) {
 		"channels": base.MustJSONMarshal(t, userXattrValArray),
 	}
 	_, err = dataStore.WriteWithXattrs(ctx, docKey2, 0, 0, base.MustJSONMarshal(t, val), userXattrVal, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wait for doc to be imported
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 2
-	})
-	assert.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(2), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	}, 10*time.Second, 100*time.Millisecond)
 
 	// Ensure sync function has run on import
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
@@ -386,6 +384,60 @@ func TestAutoImportUserXattrNoSyncData(t *testing.T) {
 	// Assert the sync data has correct channels populated
 	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(ctx, docKey2)
 	require.NoError(t, err)
-	assert.Equal(t, userXattrValArray, syncData.Channels.KeySet())
 	assert.Len(t, syncData.Channels, 2)
+}
+
+// TestUnmarshalDocFromImportFeed:
+//   - Construct data as seen over dcp on the import feed with both _sync and user xattr defined
+//   - Assert each value returned from UnmarshalDocumentSyncDataFromFeed is as expected
+//   - Construct data as seen over dcp on the imp[ort feed with just user xattr defined
+//   - Assert each value returned from UnmarshalDocumentSyncDataFromFeed is as expected
+//   - Construct data as seen over dcp on the import feed with no xattrs at all
+//   - Assert each value returned from UnmarshalDocumentSyncDataFromFeed is as expected
+func TestUnmarshalDocFromImportFeed(t *testing.T) {
+
+	const (
+		userXattrKey = "channels"
+		syncXattr    = `{"rev":"1234"}`
+		channelName  = "chan1"
+	)
+
+	// construct data into dcp format with both _sync xattr and user xattr defined
+	body := []byte(`{"test":"document"}`)
+	xattrs := []sgbucket.Xattr{
+		{Name: base.SyncXattrName, Value: []byte(syncXattr)},
+		{Name: userXattrKey, Value: []byte(channelName)},
+	}
+	value := sgbucket.EncodeValueWithXattrs(body, xattrs...)
+
+	syncData, rawBody, rawXattr, rawUserXattr, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	require.NoError(t, err)
+	assert.Equal(t, syncXattr, string(rawXattr))
+	assert.Equal(t, "1234", syncData.CurrentRev)
+	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Equal(t, body, rawBody)
+
+	// construct data into dcp format with just user xattr defined
+	xattrs = []sgbucket.Xattr{
+		{Name: userXattrKey, Value: []byte(channelName)},
+	}
+	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
+
+	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	require.NoError(t, err)
+	assert.Nil(t, syncData)
+	assert.Nil(t, rawXattr)
+	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Equal(t, body, rawBody)
+
+	// construct data into dcp format with no xattr defined
+	xattrs = []sgbucket.Xattr{}
+	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
+
+	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	require.NoError(t, err)
+	assert.Nil(t, syncData)
+	assert.Nil(t, rawXattr)
+	assert.Nil(t, rawUserXattr)
+	assert.Equal(t, body, rawBody)
 }

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -340,11 +340,15 @@ func TestAutoImportUserXattrNoSyncData(t *testing.T) {
 	ctx := base.TestCtx(t)
 	dataStore := rt.GetSingleDataStore()
 
+	userXattrChan := "chan1"
+	userXattrVal := map[string][]byte{
+		"channels": base.MustJSONMarshal(t, userXattrChan),
+	}
+
 	// Write doc with user xattr defined and assert it correctly imports
-	userXattrVal := "chan1"
 	val := make(map[string]interface{})
 	val["test"] = "doc"
-	_, err := dataStore.WriteCasWithXattr(ctx, docKey, "channels", 0, 0, val, userXattrVal, nil)
+	_, err := dataStore.WriteWithXattrs(ctx, docKey, 0, 0, base.MustJSONMarshal(t, val), userXattrVal, nil)
 	assert.NoError(t, err)
 
 	// Wait for doc to be imported
@@ -359,12 +363,15 @@ func TestAutoImportUserXattrNoSyncData(t *testing.T) {
 	// Assert the sync data has correct channels populated
 	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(ctx, docKey)
 	require.NoError(t, err)
-	assert.Equal(t, []string{userXattrVal}, syncData.Channels.KeySet())
+	assert.Equal(t, []string{userXattrChan}, syncData.Channels.KeySet())
 	assert.Len(t, syncData.Channels, 1)
 
 	// Write doc with array of channels in user xattr and assert it correctly imports
 	userXattrValArray := []string{"chan1", "chan2"}
-	_, err = dataStore.WriteCasWithXattr(ctx, docKey2, "channels", 0, 0, val, userXattrValArray, nil)
+	userXattrVal = map[string][]byte{
+		"channels": base.MustJSONMarshal(t, userXattrValArray),
+	}
+	_, err = dataStore.WriteWithXattrs(ctx, docKey2, 0, 0, base.MustJSONMarshal(t, val), userXattrVal, nil)
 	assert.NoError(t, err)
 
 	// Wait for doc to be imported


### PR DESCRIPTION
CBG-3869

- Hooked `rawUserXattr` to the output of `parseXattrStreamData`
- Changed the `rawXattr` return to be nil (in event of no sync data) and moved the `rawUserXattr` to the correct return value
- Testing for functionality of importing a doc with user xattr defined with no sync data on it through the import feed. In addition have part of the test that writes a doc with array of channels to test that functionality of that. 
- Assert that the above docs are assigned the channels correctly

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2377/
