### PR TITLE
CBG-3835 catch error in case there is a valid json but not a JSON object

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -419,7 +419,7 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*SyncData, error)
 		root.SyncData = &SyncData{History: make(RevTree)}
 	}
 	if err := base.JSONUnmarshal(data, &root); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Could not unmarshal _sync out of document body: %w", err)
 	}
 	if root.SyncData != nil && root.SyncData.Deleted_OLD {
 		root.SyncData.Deleted_OLD = false
@@ -454,7 +454,7 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 			}
 			err = base.JSONUnmarshal(syncXattr, result)
 			if err != nil {
-				return nil, nil, nil, nil, err
+				return nil, nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", string(syncXattr), err)
 			}
 			return result, body, syncXattr, rawUserXattr, nil
 		}

--- a/db/import.go
+++ b/db/import.go
@@ -40,6 +40,7 @@ func (db *DatabaseCollectionWithUser) ImportDocRaw(ctx context.Context, docid st
 	} else {
 		err := body.Unmarshal(value)
 		if err != nil {
+			db.dbStats().SharedBucketImport().ImportErrorCount.Add(1)
 			base.InfofCtx(ctx, base.KeyImport, "Unmarshal error during importDoc %v", err)
 			return nil, base.HTTPErrorf(http.StatusNotFound, "Error unmarshalling %s: %s", base.UD(docid).Redact(), err)
 		}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -158,7 +158,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 
 	// If this is a binary document we can ignore, but update checkpoint to avoid reprocessing upon restart
 	if event.DataType == base.MemcachedDataTypeRaw {
-		base.InfofCtx(ctx, base.KeyImport, "Ignoring binary mutation event for %s.", base.UD(docID))
+		base.DebugfCtx(ctx, base.KeyImport, "Ignoring binary mutation event for %s.", base.UD(docID))
 		return true
 	}
 
@@ -171,10 +171,10 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 	if err != nil {
 		if err == base.ErrEmptyMetadata {
 			base.WarnfCtx(ctx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
-		} else {
-			base.WarnfCtx(ctx, "Found sync metadata, but unable to unmarshal for feed document %q.  Will not be imported.  Error: %v", base.UD(event.Key), err)
+			il.importStats.ImportErrorCount.Add(1)
+			return
 		}
-		il.importStats.ImportErrorCount.Add(1)
+		base.DebugfCtx(ctx, base.KeyImport, "Found sync metadata, but unable to unmarshal for feed document %q. Will not be imported. Error: %v", base.UD(event.Key), err)
 		return
 	}
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -174,7 +174,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 			il.importStats.ImportErrorCount.Add(1)
 			return
 		}
-		base.DebugfCtx(ctx, base.KeyImport, "%s not able to be imported. Error: %v", base.UD(event.Key), err)
+		base.DebugfCtx(ctx, base.KeyImport, "%s will not be imported: %v", base.UD(event.Key), err)
 		return
 	}
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -174,7 +174,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 			il.importStats.ImportErrorCount.Add(1)
 			return
 		}
-		base.DebugfCtx(ctx, base.KeyImport, "Found sync metadata, but unable to unmarshal for feed document %q. Will not be imported. Error: %v", base.UD(event.Key), err)
+		base.DebugfCtx(ctx, base.KeyImport, "%s not able to be imported. Error: %v", base.UD(event.Key), err)
 		return
 	}
 


### PR DESCRIPTION
The code has now been reverted to the state before https://github.com/couchbase/sync_gateway/commit/2bde1ea79a5591e0a15f8fa6d93b45f13ff01bee with two changes:

log debug for event.DataType == base.MemcachedDataTypeRaw, Info logging in 3.1.3/3.1.4 but no logging before
increment ImportErrorCount in the case of valid _sync xattr and valid json but not a json object
Wrote tests for the expected behavior, which is to silently ignore documents with invalid _sync metadata, where it is valid JSON but not a valid JSON object.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2380/
