### PR TITLE
add manifest/3.2.xml back to product-config.json as a disabled entry.

### DIFF
--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -10,6 +10,16 @@
             "trigger_blackduck": true,
             "start_build": 320
         },
+        "manifest/3.2.xml": {
+            "do-build": false,
+            "release": "3.2.0",
+            "release_name": "Couchbase Sync Gateway",
+            "production": true,
+            "interval": 30,
+            "go_version": "1.21.8",
+            "trigger_blackduck": true,
+            "start_build": 318
+        },
         "manifest/1.4.0.xml": {
             "do-build": false,
             "release": "1.4.0.2",


### PR DESCRIPTION
Describe your PR here...

currently, build-from-manifest-new keeps triggering manifest/3.2.xml and manifest/default.xml.  Since both are 3.2.0, it causes https://github.com/couchbase/build-manifests/blob/master/sync_gateway/3.2.0/3.2.0.xml to be different on every scan.  This results in a new build on every single scan.  Having a disabled manifest/3.2.xml entry should stop "manifest/3.2.xml" from getting triggered.

-Ming


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
