### PR TITLE
Fix linter error

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1083,7 +1083,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 	if generation < 0 {
 		return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
-	generation++
+	generation++ //nolint
 
 	docUpdateEvent := ExistingVersion
 	allowImport := db.UseXattrs()


### PR DESCRIPTION
```sh
$ golangci-lint run --config .golangci-strict.yml db
db/crud.go:1086:2: ineffectual assignment to generation (ineffassign)
    generation++
    ^ 
```

Filed https://issues.couchbase.com/browse/CBG-3893 to properly fix.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
-  n/a