### PR TITLE
CBG-3853: Implementation of range sequence entry for skipped sequence slice

### DIFF
--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -185,7 +185,7 @@ func (s *SkippedSequenceSlice) SkippedSequenceCompact(ctx context.Context, maxWa
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	timeNow := time.Now().Unix()
+	timeNow := getCurrentUnixTime()
 	indexToDelete := -1
 	for _, v := range s.list {
 		timeStamp := v.getTimestamp()
@@ -349,7 +349,7 @@ func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry SkippedSequenceLis
 				s.list[index] = entry
 			} else {
 				endSeq := entry.getLastSeq()
-				s.list[index] = NewSkippedSequenceRangeEntry(lastEntryStartSeq, endSeq, time.Now().Unix())
+				s.list[index] = NewSkippedSequenceRangeEntry(lastEntryStartSeq, endSeq, getCurrentUnixTime())
 			}
 		}
 	} else {
@@ -367,4 +367,9 @@ func (s *SkippedSequenceSlice) getOldest() uint64 {
 	}
 	// grab fist element in slice and take the start seq of that range/single sequence
 	return s.list[0].getStartSeq()
+}
+
+// getCurrentUnixTime will return the current time in unix time format
+func getCurrentUnixTime() int64 {
+	return time.Now().Unix()
 }

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -69,10 +69,6 @@ func NewSkippedSequenceSlice(clipHeadroom int) *SkippedSequenceSlice {
 // NewSingleSkippedSequenceEntry returns a SingleSkippedSequence with the specified sequence and the current
 // time in unix time
 func NewSingleSkippedSequenceEntry(sequence uint64, timeStamp int64) *SingleSkippedSequence {
-	// if no timestamp provided, take current unix time
-	if timeStamp == 0 {
-		timeStamp = time.Now().Unix()
-	}
 	return &SingleSkippedSequence{
 		seq:       sequence,
 		timestamp: timeStamp,
@@ -82,10 +78,6 @@ func NewSingleSkippedSequenceEntry(sequence uint64, timeStamp int64) *SingleSkip
 // NewSkippedSequenceRangeEntry returns a SkippedSequenceRange with the specified sequence range and the current
 // time in unix time
 func NewSkippedSequenceRangeEntry(start, end uint64, timeStamp int64) *SkippedSequenceRange {
-	// if no timestamp provided, take current unix time
-	if timeStamp == 0 {
-		timeStamp = time.Now().Unix()
-	}
 	return &SkippedSequenceRange{
 		start:     start,
 		end:       end,
@@ -357,7 +349,7 @@ func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry SkippedSequenceLis
 				s.list[index] = entry
 			} else {
 				endSeq := entry.getLastSeq()
-				s.list[index] = NewSkippedSequenceRangeEntry(lastEntryStartSeq, endSeq, 0)
+				s.list[index] = NewSkippedSequenceRangeEntry(lastEntryStartSeq, endSeq, time.Now().Unix())
 			}
 		}
 	} else {

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -225,11 +225,6 @@ func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 		return nil
 	}
 	if rangeElem.getLastSeq() == x {
-		if numSequences == 2 {
-			// make rangeElem single sequence entry
-			rangeElem.setLastSeq(rangeElem.getStartSeq())
-			return nil
-		}
 		rangeElem.setLastSeq(x - 1)
 		return nil
 	}
@@ -242,23 +237,6 @@ func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 		s._insert(index+1, newElem)
 		// make rangeElem a single entry
 		rangeElem.setLastSeq(rangeElem.getStartSeq())
-		return nil
-	}
-
-	// handling for if x is startSeq+1 or lastSeq-1
-	if rangeElem.getStartSeq() == x-1 {
-		// insert single skipped entry + alter start seq to x + 1
-		newElem := NewSingleSkippedSequenceEntryAt(x-1, rangeElem.getTimestamp())
-		s._insert(index, newElem)
-		rangeElem.setStartSeq(x + 1)
-		return nil
-	}
-
-	if rangeElem.getLastSeq() == x+1 {
-		// insert single skipped entry at index+1 + alter last seq to x - 1
-		newElem := NewSingleSkippedSequenceEntryAt(x+1, rangeElem.getTimestamp())
-		s._insert(index+1, newElem)
-		rangeElem.setLastSeq(x - 1)
 		return nil
 	}
 

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -26,11 +26,13 @@ const (
 
 type SkippedSequenceListEntry interface {
 	getTimestamp() int64
+	setTimestamp(time int64)
 	getLastSeq() uint64
+	setStartSeq(seq uint64)
 	setLastSeq(seq uint64)
 	getStartSeq() uint64
 	isRange() bool
-	getNumSequencesInEntry() int
+	getNumSequencesInEntry() int64
 }
 
 // SkippedSequenceSlice stores the set of skipped sequences as an ordered slice of single skipped sequences
@@ -42,10 +44,18 @@ type SkippedSequenceSlice struct {
 }
 
 var _ SkippedSequenceListEntry = &SingleSkippedSequence{}
+var _ SkippedSequenceListEntry = &SkippedSequenceRange{}
 
 // SingleSkippedSequence contains a single skipped sequence value + unix timestamp of the time it's created
 type SingleSkippedSequence struct {
 	seq       uint64
+	timestamp int64
+}
+
+// SkippedSequenceRange contains a skipped sequence range + unix timestamp of the time it's created
+type SkippedSequenceRange struct {
+	start     uint64
+	end       uint64
 	timestamp int64
 }
 
@@ -65,9 +75,23 @@ func NewSingleSkippedSequenceEntry(sequence uint64) *SingleSkippedSequence {
 	}
 }
 
+// NewSkippedSequenceRangeEntry returns a SkippedSequenceRange with the specified sequence range and the current
+// time in unix time
+func NewSkippedSequenceRangeEntry(start, end uint64) *SkippedSequenceRange {
+	return &SkippedSequenceRange{
+		start:     start,
+		end:       end,
+		timestamp: time.Now().Unix(),
+	}
+}
+
 // getTimestamp returns the timestamp of the entry
 func (s *SingleSkippedSequence) getTimestamp() int64 {
 	return s.timestamp
+}
+
+func (s *SingleSkippedSequence) setTimestamp(time int64) {
+	s.timestamp = time
 }
 
 // getLastSeq gets the last sequence in the range on the entry, for single items the sequence will be returned
@@ -75,8 +99,13 @@ func (s *SingleSkippedSequence) getLastSeq() uint64 {
 	return s.seq
 }
 
-// setLastSeq sets the last sequence in the range on the entry, for single items its a no-op
+// setLastSeq sets the last sequence in the range on the entry, for single items it's a no-op
 func (s *SingleSkippedSequence) setLastSeq(seq uint64) {
+	// no-op
+}
+
+// setStartSeq sets the last sequence in the range on the entry, for single items it's a no-op
+func (s *SingleSkippedSequence) setStartSeq(seq uint64) {
 	// no-op
 }
 
@@ -90,10 +119,51 @@ func (s *SingleSkippedSequence) isRange() bool {
 	return false
 }
 
-// getNumSequencesInEntry returns the number of sequences a entry in skipped slice holds,
+// getNumSequencesInEntry returns the number of sequences an entry in skipped slice holds,
 // for single entries it will return just 1
-func (s *SingleSkippedSequence) getNumSequencesInEntry() int {
+func (s *SingleSkippedSequence) getNumSequencesInEntry() int64 {
 	return 1
+}
+
+// getTimestamp returns the timestamp of the entry
+func (s *SkippedSequenceRange) getTimestamp() int64 {
+	return s.timestamp
+}
+
+func (s *SkippedSequenceRange) setTimestamp(time int64) {
+	s.timestamp = time
+}
+
+// getStartSeq gets the start sequence in the range on the entry, for single items the sequence will be returned
+func (s *SkippedSequenceRange) getStartSeq() uint64 {
+	return s.start
+}
+
+// getLastSeq gets the last sequence in the range on the entry, for single items the sequence will be returned
+func (s *SkippedSequenceRange) getLastSeq() uint64 {
+	return s.end
+}
+
+// isRange returns true if the entry is a sequence range entry, false if not
+func (s *SkippedSequenceRange) isRange() bool {
+	return true
+}
+
+// setLastSeq sets the last sequence in the range on the entry, for single items it's a no-op
+func (s *SkippedSequenceRange) setLastSeq(seq uint64) {
+	s.end = seq
+}
+
+// setStartSeq sets the last sequence in the range on the entry, for single items it's a no-op
+func (s *SkippedSequenceRange) setStartSeq(seq uint64) {
+	s.start = seq
+}
+
+// getNumSequencesInEntry returns the number of sequences an entry in skipped slice holds,
+// for single entries it will return just 1
+func (s *SkippedSequenceRange) getNumSequencesInEntry() int64 {
+	numSequences := (s.end - s.start) + 1
+	return int64(numSequences)
 }
 
 // Contains returns true if a given sequence exists in the skipped sequence slice
@@ -106,7 +176,7 @@ func (s *SkippedSequenceSlice) Contains(x uint64) bool {
 
 // SkippedSequenceCompact will compact the entries with timestamp old enough. It will also clip
 // the capacity of the slice to length + 100 if the current capacity is 2.5x the length
-func (s *SkippedSequenceSlice) SkippedSequenceCompact(ctx context.Context, maxWait int64) (numSequencesCompacted int) {
+func (s *SkippedSequenceSlice) SkippedSequenceCompact(ctx context.Context, maxWait int64) (numSequencesCompacted int64) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -153,19 +223,25 @@ func (s *SkippedSequenceSlice) findSequence(x uint64) (int, bool) {
 	return i, found
 }
 
+// binarySearchFunc contains the custom search function for searching the skipped sequence slice for a particular sequence
 func binarySearchFunc(a SkippedSequenceListEntry, seq uint64) int {
-	singleSeq, ok := a.(*SingleSkippedSequence)
-	if ok {
-		if singleSeq.seq > seq {
+	if !a.isRange() {
+		if a.getStartSeq() > seq {
 			return 1
 		}
-		if singleSeq.seq == seq {
+		if a.getStartSeq() == seq {
+			return 0
+		}
+		return -1
+	} else {
+		if a.getStartSeq() > seq {
+			return 1
+		}
+		if a.getStartSeq() <= seq && a.getLastSeq() >= seq {
 			return 0
 		}
 		return -1
 	}
-	// should never get here as it stands, will have extra handling here pending CBG-3853
-	return 1
 }
 
 // removeSeq will remove a given sequence from the slice if it exists
@@ -181,15 +257,60 @@ func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 		// if not a range, we can just remove the single entry from the slice
 		s.list = slices.Delete(s.list, index, index+1)
 		return nil
+	} else {
+		// range entry handling
+		// if x-1 == range start seq we need to replace elem at index-1 with single entry, then alter range start seq to x+1
+		rangeElem := s.list[index]
+		if x-1 == rangeElem.getStartSeq() {
+			if rangeElem.getNumSequencesInEntry() == 3 {
+				// add single entry at elem
+				newElem := NewSingleSkippedSequenceEntry(rangeElem.getStartSeq())
+				newElem.setTimestamp(rangeElem.getTimestamp())
+				s.list[index] = newElem
+				// add single entry at elem + 1
+				newElem = NewSingleSkippedSequenceEntry(rangeElem.getLastSeq())
+				newElem.setTimestamp(rangeElem.getTimestamp())
+				s.insert(index+1, newElem)
+			} else {
+				newElem := NewSingleSkippedSequenceEntry(x - 1)
+				newElem.setTimestamp(rangeElem.getTimestamp())
+				s.insert(index, newElem)
+				rangeElem.setStartSeq(x + 1)
+			}
+			return nil
+		}
+
+		if x+1 == rangeElem.getLastSeq() {
+			newElem := NewSingleSkippedSequenceEntry(x + 1)
+			newElem.setTimestamp(rangeElem.getTimestamp())
+			s.insert(index+1, newElem)
+			rangeElem.setLastSeq(x - 1)
+			return nil
+		}
+
+		// if x != start or end seq on the range we need to alter the range and index and insert a new range at index + 1
+		if rangeElem.getStartSeq() < x && rangeElem.getLastSeq() > x {
+			// split index range
+			newElem := NewSkippedSequenceRangeEntry(x+1, rangeElem.getLastSeq())
+			newElem.setTimestamp(rangeElem.getTimestamp())
+			s.insert(index+1, newElem)
+			rangeElem.setLastSeq(x - 1)
+			return nil
+		}
+		// x is equal to start or end seq on the element so simply alter range start or end values
+		if rangeElem.getStartSeq() == x {
+			rangeElem.setStartSeq(x + 1)
+		} else {
+			rangeElem.setLastSeq(x - 1)
+		}
 	}
-	// more range handling here CBG-3853, temporarily error as we shouldn't get to this point at this time
-	return fmt.Errorf("entered range handling code")
+	return nil
 }
 
 // insert will insert element in middle of slice maintaining order of rest of slice
 func (s *SkippedSequenceSlice) insert(index int, entry SkippedSequenceListEntry) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	//s.lock.Lock()
+	//defer s.lock.Unlock()
 	s.list = append(s.list, nil)
 	copy(s.list[index+1:], s.list[index:])
 	s.list[index] = entry
@@ -197,7 +318,7 @@ func (s *SkippedSequenceSlice) insert(index int, entry SkippedSequenceListEntry)
 
 // PushSkippedSequenceEntry will append a new skipped sequence entry to the end of the slice, if adding a contiguous
 // sequence function will expand the last entry of the slice to reflect this
-func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry *SingleSkippedSequence) {
+func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry SkippedSequenceListEntry) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -205,10 +326,27 @@ func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry *SingleSkippedSequ
 		s.list = append(s.list, entry)
 		return
 	}
-	// adding contiguous sequence handling here, pending CBG-3853
-	s.list = append(s.list, entry)
+	// get index of last entry + last seq of entry
+	index := len(s.list) - 1
+	lastEntryLastSeq := s.list[index].getLastSeq()
+	if (lastEntryLastSeq + 1) == entry.getStartSeq() {
+		// adding contiguous sequence
+		if s.list[index].isRange() {
+			// set last seq in the range to the new arriving sequence
+			s.list[index].setLastSeq(entry.getLastSeq())
+		} else {
+			// take the sequence from the single entry and create a new range entry in its place
+			startSeq := s.list[index].getStartSeq()
+			endSeq := entry.getLastSeq()
+			s.list[index] = NewSkippedSequenceRangeEntry(startSeq, endSeq)
+		}
+	} else {
+		s.list = append(s.list, entry)
+	}
+
 }
 
+// getOldest returns the start sequence of the first element in the skipped sequence slice
 func (s *SkippedSequenceSlice) getOldest() uint64 {
 	s.lock.RLock()
 	defer s.lock.RUnlock()

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -90,6 +90,7 @@ func (s *SingleSkippedSequence) getTimestamp() int64 {
 	return s.timestamp
 }
 
+// setTimestamp sets the timestamp of the skipped sequence list entry
 func (s *SingleSkippedSequence) setTimestamp(time int64) {
 	s.timestamp = time
 }
@@ -130,6 +131,7 @@ func (s *SkippedSequenceRange) getTimestamp() int64 {
 	return s.timestamp
 }
 
+// setTimestamp sets the timestamp of the skipped sequence list entry
 func (s *SkippedSequenceRange) setTimestamp(time int64) {
 	s.timestamp = time
 }
@@ -309,8 +311,6 @@ func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 
 // insert will insert element in middle of slice maintaining order of rest of slice
 func (s *SkippedSequenceSlice) insert(index int, entry SkippedSequenceListEntry) {
-	//s.lock.Lock()
-	//defer s.lock.Unlock()
 	s.list = append(s.list, nil)
 	copy(s.list[index+1:], s.list[index:])
 	s.list[index] = entry

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -28,7 +28,7 @@ func TestPushSingleSkippedSequence(t *testing.T) {
 	skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
 
 	for i := 0; i < 10; i++ {
-		skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), 0))
+		skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), time.Now().Unix()))
 	}
 
 	var prevTime int64 = 0
@@ -39,7 +39,7 @@ func TestPushSingleSkippedSequence(t *testing.T) {
 	}
 	// add a new single entry that is contiguous with end of the slice which should replace last
 	// single entry with a range
-	skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(19, 0))
+	skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(19, time.Now().Unix()))
 	// grab last entry in list
 	index := len(skippedSlice.list) - 1
 	entry := skippedSlice.list[index]
@@ -59,7 +59,7 @@ func TestPushSkippedSequenceRange(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		start := i * 10
-		skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(start), uint64(start+5), 0))
+		skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(start), uint64(start+5), time.Now().Unix()))
 	}
 
 	var prevTime int64 = 0
@@ -73,7 +73,7 @@ func TestPushSkippedSequenceRange(t *testing.T) {
 	}
 
 	// add a new range entry that is contiguous with end of the slice which should alter range last element in list
-	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(96, 110, 0))
+	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(96, 110, time.Now().Unix()))
 	// grab last entry in list
 	index := len(skippedSlice.list) - 1
 	entry := skippedSlice.list[index]
@@ -84,7 +84,7 @@ func TestPushSkippedSequenceRange(t *testing.T) {
 	assert.Equal(t, uint64(110), entry.getLastSeq())
 
 	// add new single entry that is not contiguous with last element on slice
-	skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(500, 0))
+	skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(500, time.Now().Unix()))
 
 	// add new range that is contiguous with the single entry on the last element of the slice + garbage timestamp
 	// for later assertion
@@ -114,9 +114,9 @@ func BenchmarkPushSkippedSequenceEntry(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				if !bm.rangeEntries {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), 0))
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), time.Now().Unix()))
 				} else {
-					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*10), uint64(i*10)+5, 0))
+					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*10), uint64(i*10)+5, time.Now().Unix()))
 				}
 			}
 		})
@@ -153,14 +153,14 @@ func TestIsSequenceSkipped(t *testing.T) {
 
 			if !testCase.rangeItems {
 				for _, input := range testCase.inputList {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input, 0))
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input, time.Now().Unix()))
 				}
 				for _, v := range testCase.inputList {
 					assert.True(t, skippedSlice.Contains(v))
 				}
 			} else {
 				for _, input := range testCase.inputList {
-					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(input, input+5, 0))
+					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(input, input+5, time.Now().Unix()))
 				}
 				for _, v := range testCase.inputList {
 					assert.True(t, skippedSlice.Contains(v))
@@ -173,11 +173,11 @@ func TestIsSequenceSkipped(t *testing.T) {
 			assert.False(t, skippedSlice.Contains(550))
 
 			// push this sequence and assert Contains returns true after
-			skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(550, 0))
+			skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(550, time.Now().Unix()))
 			assert.True(t, skippedSlice.Contains(550))
 
 			// push another range much higher, assert Contains works as expected
-			skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(60000, 70000, 0))
+			skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(60000, 70000, time.Now().Unix()))
 			assert.True(t, skippedSlice.Contains(60000))
 			assert.True(t, skippedSlice.Contains(70000))
 			assert.True(t, skippedSlice.Contains(65000))
@@ -280,11 +280,11 @@ func TestRemoveSeqFromSkipped(t *testing.T) {
 			skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
 			if !testCase.rangeItems {
 				for _, input := range testCase.inputList {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input, 0))
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input, time.Now().Unix()))
 				}
 			} else {
 				for _, input := range testCase.inputList {
-					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(input, input+5, 0))
+					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(input, input+5, time.Now().Unix()))
 				}
 			}
 
@@ -331,10 +331,10 @@ func TestRemoveSeqFromThreeSequenceRange(t *testing.T) {
 	expectedEndSeqList := []uint64{10, 20, 30, 40, 50, 60, 62, 75}
 
 	for _, v := range inputList {
-		skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(v, v+5, 0))
+		skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(v, v+5, time.Now().Unix()))
 	}
-	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(60, 62, 0))
-	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(70, 75, 0))
+	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(60, 62, time.Now().Unix()))
+	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(70, 75, time.Now().Unix()))
 
 	i, found := skippedSlice.findSequence(60)
 	assert.True(t, found)
@@ -418,16 +418,16 @@ func TestInsertItemInSlice(t *testing.T) {
 
 			if !testCase.rangeItems {
 				for _, input := range testCase.inputList {
-					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input, 0))
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input, time.Now().Unix()))
 				}
 			} else {
 				for _, input := range testCase.inputList {
-					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(input, input+5, 0))
+					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(input, input+5, time.Now().Unix()))
 				}
 			}
 
 			// attempt to insert at test case index to keep order
-			skippedSlice.insert(testCase.index, NewSingleSkippedSequenceEntry(testCase.insert, 0))
+			skippedSlice.insert(testCase.index, NewSingleSkippedSequenceEntry(testCase.insert, time.Now().Unix()))
 
 			if !testCase.rangeItems {
 				for i := 0; i < len(skippedSlice.list); i++ {
@@ -459,9 +459,9 @@ func BenchmarkInsertSkippedItem(b *testing.B) {
 			sequenceNum := 40000
 			for i := 0; i < b.N; i++ {
 				if !bm.rangeEntries {
-					bm.inputSlice.insert(i, NewSingleSkippedSequenceEntry(uint64(sequenceNum*i), 0))
+					bm.inputSlice.insert(i, NewSingleSkippedSequenceEntry(uint64(sequenceNum*i), time.Now().Unix()))
 				} else {
-					bm.inputSlice.insert(i, NewSkippedSequenceRangeEntry(uint64(sequenceNum*i), uint64(sequenceNum*i)+5, 0))
+					bm.inputSlice.insert(i, NewSkippedSequenceRangeEntry(uint64(sequenceNum*i), uint64(sequenceNum*i)+5, time.Now().Unix()))
 				}
 			}
 		})
@@ -500,25 +500,26 @@ func TestCompactSkippedList(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
+			inputTime := time.Now().Unix() - 1000
 
 			if !testCase.rangeItems {
 				for _, input := range testCase.inputList {
-					skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(input))
+					// add single entries with old timestamps for compaction
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input, inputTime))
 				}
 			} else {
 				for _, input := range testCase.inputList {
-					skippedSlice.PushSkippedSequenceEntry(testRangeSkippedEntryOldTimestamp(input, input+5))
+					// add range entries with old timestamps for compaction
+					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(input, input+5, inputTime))
 				}
 			}
 
 			// alter timestamp so we don't compact this entry
 			var entry SkippedSequenceListEntry
-			var timeNow int64
+			timeNow := time.Now().Unix()
 			if !testCase.rangeItems {
-				timeNow = time.Now().Unix()
 				entry = NewSingleSkippedSequenceEntry(600, timeNow+10000)
 			} else {
-				timeNow = time.Now().Unix()
 				entry = NewSkippedSequenceRangeEntry(600, 605, timeNow+10000)
 			}
 			skippedSlice.PushSkippedSequenceEntry(entry)
@@ -559,24 +560,25 @@ func TestCompactSkippedListClipHandling(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			// define clip headroom at 100 for test
 			skippedSlice := NewSkippedSequenceSlice(100)
+			inputTime := time.Now().Unix() - 1000
 
 			if !testCase.rangeItems {
 				for i := 0; i < 100; i++ {
-					skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
+					// add single entries with old timestamps for compaction
+					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), inputTime))
 				}
 			} else {
 				for i := 0; i < 100; i++ {
-					skippedSlice.PushSkippedSequenceEntry(testRangeSkippedEntryOldTimestamp(uint64(i*2), uint64(i*2)+5))
+					// add range entries with old timestamps for compaction
+					skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*2), uint64(i*2)+5, inputTime))
 				}
 			}
 			// alter timestamp so we don't compact this entry
 			var entry SkippedSequenceListEntry
-			var timeNow int64
+			timeNow := time.Now().Unix()
 			if !testCase.rangeItems {
-				timeNow = time.Now().Unix()
 				entry = NewSingleSkippedSequenceEntry(600, timeNow+10000)
 			} else {
-				timeNow = time.Now().Unix()
 				entry = NewSkippedSequenceRangeEntry(600, 605, timeNow+10000)
 			}
 			skippedSlice.PushSkippedSequenceEntry(entry)
@@ -605,27 +607,6 @@ func BenchmarkCompactSkippedList(b *testing.B) {
 				bm.inputSlice.SkippedSequenceCompact(base.TestCtx(b), 100)
 			}
 		})
-	}
-}
-
-// testSingleSkippedEntryOldTimestamp is creating a new single skipped sequence entry with an old timestamp
-func testSingleSkippedEntryOldTimestamp(seq uint64) *SingleSkippedSequence {
-	now := time.Now().Unix()
-	assignedTimestamp := now - 1000
-	return &SingleSkippedSequence{
-		seq:       seq,
-		timestamp: assignedTimestamp,
-	}
-}
-
-// testRangeSkippedEntryOldTimestamp is creating a new single skipped sequence entry with an old timestamp
-func testRangeSkippedEntryOldTimestamp(start, end uint64) *SkippedSequenceRange {
-	now := time.Now().Unix()
-	assignedTimestamp := now - 1000
-	return &SkippedSequenceRange{
-		start:     start,
-		end:       end,
-		timestamp: assignedTimestamp,
 	}
 }
 
@@ -662,11 +643,11 @@ func TestGetOldestSkippedSequence(t *testing.T) {
 			if !testCase.empty {
 				if !testCase.rangeItems {
 					for _, v := range testCase.inputList {
-						skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(v, 0))
+						skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(v, time.Now().Unix()))
 					}
 				} else {
 					for _, v := range testCase.inputList {
-						skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(v, v+5, 0))
+						skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(v, v+5, time.Now().Unix()))
 					}
 				}
 			}
@@ -681,17 +662,17 @@ func setupBenchmark(largeSlice bool, rangeEntries bool, clipHeadroom int) *Skipp
 	if largeSlice {
 		for i := 0; i < 10000; i++ {
 			if rangeEntries {
-				skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*2), uint64(i*2)+5, 0))
+				skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*2), uint64(i*2)+5, time.Now().Unix()))
 			} else {
-				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), 0))
+				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), time.Now().Unix()))
 			}
 		}
 	} else {
 		for i := 0; i < 100; i++ {
 			if rangeEntries {
-				skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*2), uint64(i*2)+5, 0))
+				skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*2), uint64(i*2)+5, time.Now().Unix()))
 			} else {
-				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), 0))
+				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), time.Now().Unix()))
 			}
 		}
 	}
@@ -701,24 +682,29 @@ func setupBenchmark(largeSlice bool, rangeEntries bool, clipHeadroom int) *Skipp
 // setupBenchmarkToCompact sets up a skipped sequence slice for compaction based benchmark tests
 func setupBenchmarkToCompact(largeSlice bool, rangeEntries bool, clipHeadroom int) *SkippedSequenceSlice {
 	skippedSlice := NewSkippedSequenceSlice(clipHeadroom)
+	inputTime := time.Now().Unix() - 1000
 	if largeSlice {
 		for i := 0; i < 10000; i++ {
 			if rangeEntries {
-				skippedSlice.PushSkippedSequenceEntry(testRangeSkippedEntryOldTimestamp(uint64(i*2), uint64(i*2)+5))
+				// add range entries with old timestamps for compaction
+				skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*2), uint64(i*2)+5, inputTime))
 			} else {
-				skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
+				// add single entries with old timestamps for compaction
+				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), inputTime))
 			}
 		}
 	} else {
 		for i := 0; i < 100; i++ {
 			if rangeEntries {
-				skippedSlice.PushSkippedSequenceEntry(testRangeSkippedEntryOldTimestamp(uint64(i*2), uint64(i*2)+5))
+				// add range entries with old timestamps for compaction
+				skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(uint64(i*2), uint64(i*2)+5, inputTime))
 			} else {
-				skippedSlice.PushSkippedSequenceEntry(testSingleSkippedEntryOldTimestamp(uint64(i * 2)))
+				// add single entries with old timestamps for compaction
+				skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(uint64(i*2), inputTime))
 			}
 		}
 	}
 	// have one entry to not be compacted
-	skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(60000, 0))
+	skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(60000, time.Now().Unix()))
 	return skippedSlice
 }

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -362,7 +362,7 @@ func TestRemoveSeqFromThreeSequenceRange(t *testing.T) {
 	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(60, 62))
 	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(70, 75))
 
-	i, found := skippedSlice.findSequence(60)
+	i, found := skippedSlice._findSequence(60)
 	assert.True(t, found)
 
 	// grab timestamp from range that is getting split
@@ -482,7 +482,7 @@ func TestInsertItemInSlice(t *testing.T) {
 			}
 
 			// attempt to insert at test case index to keep order
-			skippedSlice.insert(testCase.index, NewSingleSkippedSequenceEntry(testCase.insert))
+			skippedSlice._insert(testCase.index, NewSingleSkippedSequenceEntry(testCase.insert))
 
 			if !testCase.rangeItems {
 				for i := 0; i < len(skippedSlice.list); i++ {
@@ -520,9 +520,9 @@ func BenchmarkInsertSkippedItem(b *testing.B) {
 			sequenceNum := 40000
 			for i := 0; i < b.N; i++ {
 				if !bm.rangeEntries {
-					bm.inputSlice.insert(i, NewSingleSkippedSequenceEntry(uint64(sequenceNum*i)))
+					bm.inputSlice._insert(i, NewSingleSkippedSequenceEntry(uint64(sequenceNum*i)))
 				} else {
-					bm.inputSlice.insert(i, NewSkippedSequenceRangeEntry(uint64(sequenceNum*i), uint64(sequenceNum*i)+5))
+					bm.inputSlice._insert(i, NewSkippedSequenceRangeEntry(uint64(sequenceNum*i), uint64(sequenceNum*i)+5))
 				}
 			}
 		})
@@ -599,7 +599,7 @@ func TestCompactSkippedList(t *testing.T) {
 // TestCompactSkippedListClipHandling:
 //   - Create new skipped sequence slice with old timestamps + clip headroom defined at 100
 //   - Push new future entry on the slice
-//   - Run compact and assert that the capacity of the slice is correct after clip is run
+//   - Run compact and assert that the capacity of the slice is correct after _clip is run
 func TestCompactSkippedListClipHandling(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
CBG-3853

- Addition of the range entry handling of the skipped slice
- Addition of test cases for range entries in the slice 
- Careful testing of edge case scenarios (especially when it comes to removing sequences from the slice). Test comments describe these edge cases.
- Updates to benchmarks
- Changed compact method top return int64 instead for ease of adding this output to a stat
- Refactored binarySearchFunc for simplicity 
- Removed mutex from insert as its unnecessary (its always called form method already acquiring the mutex)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

