### PR TITLE
CBG-3883 Restore 3.1 handling for admin_channels, admin_roles

### DIFF
--- a/db/users.go
+++ b/db/users.go
@@ -113,7 +113,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		if updatedExplicitChannels == nil {
 			updatedExplicitChannels = ch.TimedSet{}
 		}
-		if !updatedExplicitChannels.Equals(updates.ExplicitChannels) {
+		if updates.ExplicitChannels != nil && !updatedExplicitChannels.Equals(updates.ExplicitChannels) {
 			changed = true
 		}
 		collectionAccessChanged, err := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
@@ -149,7 +149,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			if updatedExplicitRoles == nil {
 				updatedExplicitRoles = ch.TimedSet{}
 			}
-			if !updatedExplicitRoles.Equals(updates.ExplicitRoleNames) {
+			if updates.ExplicitRoleNames != nil && !updatedExplicitRoles.Equals(updates.ExplicitRoleNames) {
 				changed = true
 			}
 
@@ -190,7 +190,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		princ.SetSequence(nextSeq)
 
 		// Now update the Principal object from the properties in the request, first the channels:
-		if updatedExplicitChannels.UpdateAtSequence(updates.ExplicitChannels, nextSeq) {
+		if updates.ExplicitChannels != nil && updatedExplicitChannels.UpdateAtSequence(updates.ExplicitChannels, nextSeq) {
 			princ.SetExplicitChannels(updatedExplicitChannels, nextSeq)
 		}
 
@@ -199,7 +199,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		}
 
 		if isUser {
-			if updatedExplicitRoles.UpdateAtSequence(updates.ExplicitRoleNames, nextSeq) {
+			if updates.ExplicitRoleNames != nil && updatedExplicitRoles.UpdateAtSequence(updates.ExplicitRoleNames, nextSeq) {
 				user.SetExplicitRoles(updatedExplicitRoles, nextSeq)
 			}
 			var hasJWTUpdates bool

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -494,6 +494,15 @@ func (rt *RestTester) CreateUser(username string, channels []string) {
 	RequireStatus(rt.TB, response, http.StatusCreated)
 }
 
+func (rt *RestTester) GetUserAdminAPI(username string) auth.PrincipalConfig {
+	response := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_user/"+username, "")
+	RequireStatus(rt.TB, response, http.StatusOK)
+	var responseConfig auth.PrincipalConfig
+	err := json.Unmarshal(response.Body.Bytes(), &responseConfig)
+	require.NoError(rt.TB, err)
+	return responseConfig
+}
+
 // GetSingleTestDatabaseCollection will return a DatabaseCollection if there is only one. Depending on test environment configuration, it may or may not be the default collection.
 func (rt *RestTester) GetSingleTestDatabaseCollection() *db.DatabaseCollection {
 	return db.GetSingleDatabaseCollection(rt.TB, rt.GetDatabase())


### PR DESCRIPTION
Omitting default collection admin_channels, admin_roles on a PUT /db/_user should not remove those channels - callers must explicitly specify an empty array.

Handling for named collections is unchanged - if scopes/collection is specified in collection_access, contents are treated as a replace.

Added tests for interaction with JWT channel updates.

CBG-3883

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2379/
