### PR TITLE
[3.1.5 backport] CBG-3887 add Content-Length header

### DIFF
--- a/tools-tests/upload_test.py
+++ b/tools-tests/upload_test.py
@@ -210,10 +210,16 @@ def test_stream_file(tmpdir, httpserver):
     p = tmpdir.join("testfile.txt")
     body = "foobar"
     p.write(body)
+    r = None
     def handler(request):
-        assert request.data == body.encode()
+        nonlocal r
+        r = request
 
     httpserver.expect_request("/").respond_with_handler(handler)
     assert tasks.do_upload(p, httpserver.url_for("/"), "") == 0
 
     httpserver.check()
+
+    assert r.headers.get("Content-Length") == '6'
+    assert r.headers.get("Transfer-Encoding") is None
+    assert r.data == body.encode()

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -1081,6 +1081,7 @@ def do_upload(path, url, proxy):
         opener = urllib.request.build_opener(proxy_handler)
         request = urllib.request.Request(url, data=f, method='PUT')
         request.add_header(str('Content-Type'), str('application/zip'))
+        request.add_header('Content-Length', os.fstat(f.fileno()).st_size)
 
         exit_code = 0
         try:


### PR DESCRIPTION
CBG-3887

cherry-pick of CBG-3882 add Content-Length header (#6767)