### PR TITLE
CBG-3844 Ensure sequence update waits for callback invocation

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -96,8 +96,8 @@ func NewDCPCommon(ctx context.Context, callback sgbucket.FeedEventCallbackFunc, 
 }
 
 func (c *DCPCommon) dataUpdate(seq uint64, event sgbucket.FeedEvent) {
-	c.updateSeq(event.VbNo, seq, true)
 	shouldPersistCheckpoint := c.callback(event)
+	c.updateSeq(event.VbNo, seq, true)
 	if c.persistCheckpoints && shouldPersistCheckpoint {
 		c.incrementCheckpointCount(event.VbNo)
 	}


### PR DESCRIPTION
During rebalance, DCP metadata may be updated independent of SGW's checkpointing.  To account for this, need to ensure last seq isn't updated until callback is invoked.

CBG-3844

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2831/
