### PR TITLE
Bump to latest Go - 1.22.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.22.2
       - name: go-build
         run: go build "./..."
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.22.2
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.22.2
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.22.2
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.22.2
       - name: Run Tests
         run: go test -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.8
+          go-version: 1.22.2
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
 
     tools {
-        go '1.21.8'
+        go '1.22.2'
     }
 
     stages {

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.21.8",
+            "go_version": "1.22.2",
             "trigger_blackduck": true,
             "start_build": 320
         },
@@ -532,7 +532,7 @@
             "release_name": "Couchbase Sync Gateway 4.0.0",
             "production": true,
             "interval": 30,
-            "go_version": "1.21.8",
+            "go_version": "1.22.2",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
Skipped 1.21.9 upgrade and straight to latest 1.22.x

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2382/
