### PR TITLE
CBG-3891: fix for panic in TestUnmarshalDocFromImportFeed on anemone branch

### DIFF
--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -398,7 +398,7 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 
 	const (
 		userXattrKey = "channels"
-		syncXattr    = `{"rev":"1234"}`
+		syncXattr    = `{"sequence":200}`
 		channelName  = "chan1"
 	)
 
@@ -413,7 +413,7 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	syncData, rawBody, rawXattr, rawUserXattr, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Equal(t, syncXattr, string(rawXattr))
-	assert.Equal(t, "1234", syncData.CurrentRev)
+	assert.Equal(t, uint64(200), syncData.Sequence)
 	assert.Equal(t, channelName, string(rawUserXattr))
 	assert.Equal(t, body, rawBody)
 


### PR DESCRIPTION

CBG-3891

"rev" field is not present in sync data on anemone branch as it is persisted as RevAndVersion on this branch. So switched to use the sync data field "sequence" on the test as this is a field that won't be removed in anemone. 
Once this is merged I will port the PR to anemone branch. 


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2383/
