### PR TITLE
CBG-3768 Update only metadata during import

### DIFF
--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -446,6 +446,7 @@ func (c *Collection) UpdateXattrs(ctx context.Context, k string, exp uint32, cas
 		Cas:           gocb.Cas(cas),
 	}
 	options.Internal.DocFlags = gocb.SubdocDocFlagAccessDeleted
+	fillMutateInOptions(ctx, options, opts)
 
 	result, mutateErr := c.Collection.MutateIn(k, mutateOps, options)
 	if mutateErr != nil {

--- a/db/database.go
+++ b/db/database.go
@@ -1790,9 +1790,9 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 				updatedDoc.UpdateExpiry(*updatedExpiry)
 			}
 			doc.SetCrc32cUserXattrHash()
-			raw, rawXattr, err := updatedDoc.MarshalWithXattr()
+			_, rawXattr, err := updatedDoc.MarshalWithXattr()
 			return sgbucket.UpdatedDoc{
-				Doc: raw,
+				Doc: nil, // Resync does not require document body update
 				Xattrs: map[string][]byte{
 					base.SyncXattrName: rawXattr,
 				},

--- a/db/import.go
+++ b/db/import.go
@@ -147,7 +147,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		existingDoc.Expiry = *expiry
 	}
 
-	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, mutationOptions, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, mutationOptions, existingDoc, true, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.
 		if doc.Cas != existingDoc.Cas {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20240402154301-12625d8851a8
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20240416215013-a9e65f8cc53c
+	github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.3
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20240402154301-12625d8851a8
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20240404180245-795e6df684f3
+	github.com/couchbaselabs/rosmar v0.0.0-20240416215013-a9e65f8cc53c
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.3
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/couchbaselabs/rosmar v0.0.0-20240404180245-795e6df684f3 h1:AUvojYsPc2
 github.com/couchbaselabs/rosmar v0.0.0-20240404180245-795e6df684f3/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
 github.com/couchbaselabs/rosmar v0.0.0-20240416215013-a9e65f8cc53c h1:Sqqyk2hTquzQ4oUyTiz65R/kE/0e+PZfjnVgZzmwgbY=
 github.com/couchbaselabs/rosmar v0.0.0-20240416215013-a9e65f8cc53c/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
+github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389 h1:feX52yzl6wrIXt6gqmcOKzpHOdigwnzJ5TP15M9i3Ow=
+github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/couchbase/tools-common/utils v1.0.0 h1:6mWXqWWj7aM0Kp2LWpSKEu9pLAYm7i
 github.com/couchbase/tools-common/utils v1.0.0/go.mod h1:i6cN5Z5hB9vQRLxe2j1v6Nu8bv+pKl9BFXjbQUHSah8=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
+github.com/couchbaselabs/go-fleecedelta v0.0.0-20231219142340-b718c3d1aa79 h1:jdisDg/jzTpgwVDv1qCjwt2mX9bnWMtBRYLhurw1NCU=
+github.com/couchbaselabs/go-fleecedelta v0.0.0-20231219142340-b718c3d1aa79/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
 github.com/couchbaselabs/gocaves/client v0.0.0-20230307083111-cc3960c624b1/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
 github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259 h1:2TXy68EGEzIMHOx9UvczR5ApVecwCfQZ0LjkmwMI6g4=
 github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
@@ -74,6 +76,8 @@ github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131 h1:2E
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
 github.com/couchbaselabs/rosmar v0.0.0-20240404180245-795e6df684f3 h1:AUvojYsPc2WgiO9xRalRQLyXzooRRWemdEkiGl+PZno=
 github.com/couchbaselabs/rosmar v0.0.0-20240404180245-795e6df684f3/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
+github.com/couchbaselabs/rosmar v0.0.0-20240416215013-a9e65f8cc53c h1:Sqqyk2hTquzQ4oUyTiz65R/kE/0e+PZfjnVgZzmwgbY=
+github.com/couchbaselabs/rosmar v0.0.0-20240416215013-a9e65f8cc53c/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -35,11 +35,18 @@ func assertExpiry(t testing.TB, expected uint32, actual uint32) {
 	assert.True(t, base.DiffUint32(expected, actual) < 10, fmt.Sprintf("Unexpected difference between expected: %v actual %v", expected, actual))
 }
 
-// TestImportFeed validates basic feed-based import
+// Test feed-based import
 func TestImportFeed(t *testing.T) {
 
 	base.SkipImportTestsIfNotEnabled(t)
-	rt := rest.NewRestTester(t, nil)
+
+	rtConfig := rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: true,
+		}},
+	}
+
+	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
 
@@ -50,7 +57,7 @@ func TestImportFeed(t *testing.T) {
 	mobileBody := make(map[string]interface{})
 	mobileBody["channels"] = "ABC"
 	_, err := dataStore.Add(mobileKey, 0, mobileBody)
-	require.NoError(t, err, "Error writing SDK doc")
+	assert.NoError(t, err, "Error writing SDK doc")
 
 	// Wait for import
 	err = rt.WaitForCondition(func() bool {

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -35,6 +35,45 @@ func assertExpiry(t testing.TB, expected uint32, actual uint32) {
 	assert.True(t, base.DiffUint32(expected, actual) < 10, fmt.Sprintf("Unexpected difference between expected: %v actual %v", expected, actual))
 }
 
+// TestImportFeed validates basic feed-based import
+func TestImportFeed(t *testing.T) {
+
+	base.SkipImportTestsIfNotEnabled(t)
+
+	rtConfig := rest.RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: true,
+		}},
+	}
+
+	rt := rest.NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	dataStore := rt.GetSingleDataStore()
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
+
+	// Create doc via the SDK
+	mobileKey := t.Name()
+	mobileBody := make(map[string]interface{})
+	mobileBody["channels"] = "ABC"
+	_, err := dataStore.Add(mobileKey, 0, mobileBody)
+	assert.NoError(t, err, "Error writing SDK doc")
+
+	// Wait for import
+	err = rt.WaitForCondition(func() bool {
+		return rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value() == 1
+	})
+	require.NoError(t, err)
+
+	// Attempt to get the document via Sync Gateway.
+	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+mobileKey, "")
+	assert.Equal(t, 200, response.Code)
+
+	// Verify this didn't trigger an on-demand import
+	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value())
+}
+
 // Test import of an SDK delete.
 func TestXattrImportOldDoc(t *testing.T) {
 	rtConfig := rest.RestTesterConfig{

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -39,15 +39,7 @@ func assertExpiry(t testing.TB, expected uint32, actual uint32) {
 func TestImportFeed(t *testing.T) {
 
 	base.SkipImportTestsIfNotEnabled(t)
-
-	rtConfig := rest.RestTesterConfig{
-		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
-		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-			AutoImport: true,
-		}},
-	}
-
-	rt := rest.NewRestTester(t, &rtConfig)
+	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
 
@@ -58,7 +50,7 @@ func TestImportFeed(t *testing.T) {
 	mobileBody := make(map[string]interface{})
 	mobileBody["channels"] = "ABC"
 	_, err := dataStore.Add(mobileKey, 0, mobileBody)
-	assert.NoError(t, err, "Error writing SDK doc")
+	require.NoError(t, err, "Error writing SDK doc")
 
 	// Wait for import
 	err = rt.WaitForCondition(func() bool {


### PR DESCRIPTION
During document import, perform an xattr-only update of the document.

CBG-3768

## Dependencies (if applicable)
- [x] https://github.com/couchbaselabs/rosmar/pull/33
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2387/
