### PR TITLE
CBD-5866, advance build repo SHA

### DIFF
--- a/manifest/3.1.xml
+++ b/manifest/3.1.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+  <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
     <annotation name="VERSION" value="3.1.5"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>

--- a/manifest/4.0.xml
+++ b/manifest/4.0.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+  <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
     <annotation name="VERSION" value="4.0.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="cedf9d4ec929eac7e61f8e86488aeac5402c8563">
+  <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
     <annotation name="VERSION" value="3.2.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
CBD-5866

Use latest build repo SHA.  Latest build repo change removes hardcoded UBUNTU version in the build script. This is necessary for upgrading build agent to ubuntu20.

-Ming
## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
