### PR TITLE
CBG-3854: Integration of the skipped sequence slice into the cache

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -421,7 +421,7 @@ type CacheStats struct {
 	NonMobileIgnoredCount *SgwIntStat `json:"non_mobile_ignored_count"`
 	// The total number of active channels.
 	NumActiveChannels *SgwIntStat `json:"num_active_channels"`
-	// The total number of skipped sequences.
+	// The total number of skipped sequences. This is a cumulative value.
 	NumSkippedSeqs *SgwIntStat `json:"num_skipped_seqs"`
 	// The total number of pending sequences. These are out-of-sequence entries waiting to be cached.
 	PendingSeqLen *SgwIntStat `json:"pending_seq_len"`
@@ -431,8 +431,12 @@ type CacheStats struct {
 	RevisionCacheHits *SgwIntStat `json:"rev_cache_hits"`
 	// The total number of revision cache misses.
 	RevisionCacheMisses *SgwIntStat `json:"rev_cache_misses"`
-	// The current length of the pending skipped sequence queue.
+	// The current length of the pending skipped sequence slice.
 	SkippedSeqLen *SgwIntStat `json:"skipped_seq_len"`
+	// The current capacity of the skipped sequence slice
+	SkippedSeqCap *SgwIntStat `json:"skipped_seq_cap"`
+	// The number of sequences currently in the skipped sequence slice
+	NumCurrentSeqsSkipped *SgwIntStat `json:"num_seqs_skipped"`
 	// The total view_queries.
 	ViewQueries *SgwIntStat `json:"view_queries"`
 }
@@ -1327,6 +1331,14 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.SkippedSeqCap, err = NewIntStat(SubsystemCacheKey, "skipped_seq_cap", StatUnitNoUnits, SkippedSeqCapDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.NumCurrentSeqsSkipped, err = NewIntStat(SubsystemCacheKey, "num_seqs_skipped", StatUnitNoUnits, NumCurrentSkippedSeq, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.ViewQueries, err = NewIntStat(SubsystemCacheKey, "view_queries", StatUnitNoUnits, ViewQueriesDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1357,6 +1369,8 @@ func (d *DbStats) unregisterCacheStats() {
 	prometheus.Unregister(d.CacheStats.NonMobileIgnoredCount)
 	prometheus.Unregister(d.CacheStats.NumActiveChannels)
 	prometheus.Unregister(d.CacheStats.NumSkippedSeqs)
+	prometheus.Unregister(d.CacheStats.SkippedSeqCap)
+	prometheus.Unregister(d.CacheStats.NumCurrentSeqsSkipped)
 	prometheus.Unregister(d.CacheStats.PendingSeqLen)
 	prometheus.Unregister(d.CacheStats.RevisionCacheBypass)
 	prometheus.Unregister(d.CacheStats.RevisionCacheHits)

--- a/base/stats.go
+++ b/base/stats.go
@@ -422,7 +422,7 @@ type CacheStats struct {
 	// The total number of active channels.
 	NumActiveChannels *SgwIntStat `json:"num_active_channels"`
 	// The total number of skipped sequences. This is a cumulative value.
-	NumSkippedSeqs *SgwIntStat `json:"num_skipped_seqs"`
+	NumSkippedSeqs *SgwIntStat `json:"cumulative_num_skipped_seqs"`
 	// The total number of pending sequences. These are out-of-sequence entries waiting to be cached.
 	PendingSeqLen *SgwIntStat `json:"pending_seq_len"`
 	// The total number of revision cache bypass operations performed.
@@ -436,7 +436,7 @@ type CacheStats struct {
 	// The current capacity of the skipped sequence slice
 	SkippedSeqCap *SgwIntStat `json:"skipped_seq_cap"`
 	// The number of sequences currently in the skipped sequence slice
-	NumCurrentSeqsSkipped *SgwIntStat `json:"num_seqs_skipped"`
+	NumCurrentSeqsSkipped *SgwIntStat `json:"current_skipped_seq_count"`
 	// The total view_queries.
 	ViewQueries *SgwIntStat `json:"view_queries"`
 }
@@ -1307,7 +1307,7 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.NumSkippedSeqs, err = NewIntStat(SubsystemCacheKey, "num_skipped_seqs", StatUnitNoUnits, NumSkippedSeqsDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumSkippedSeqs, err = NewIntStat(SubsystemCacheKey, "cumulative_num_skipped_seqs", StatUnitNoUnits, NumSkippedSeqsDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1335,7 +1335,7 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.NumCurrentSeqsSkipped, err = NewIntStat(SubsystemCacheKey, "num_seqs_skipped", StatUnitNoUnits, NumCurrentSkippedSeq, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumCurrentSeqsSkipped, err = NewIntStat(SubsystemCacheKey, "current_skipped_seq_count", StatUnitNoUnits, NumCurrentSkippedSeq, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -422,7 +422,7 @@ type CacheStats struct {
 	// The total number of active channels.
 	NumActiveChannels *SgwIntStat `json:"num_active_channels"`
 	// The total number of skipped sequences. This is a cumulative value.
-	NumSkippedSeqs *SgwIntStat `json:"cumulative_num_skipped_seqs"`
+	NumSkippedSeqs *SgwIntStat `json:"num_skipped_seqs"`
 	// The total number of pending sequences. These are out-of-sequence entries waiting to be cached.
 	PendingSeqLen *SgwIntStat `json:"pending_seq_len"`
 	// The total number of revision cache bypass operations performed.
@@ -1307,7 +1307,7 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.NumSkippedSeqs, err = NewIntStat(SubsystemCacheKey, "cumulative_num_skipped_seqs", StatUnitNoUnits, NumSkippedSeqsDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.NumSkippedSeqs, err = NewIntStat(SubsystemCacheKey, "num_skipped_seqs", StatUnitNoUnits, NumSkippedSeqsDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -115,7 +115,7 @@ const (
 
 	NumActiveChannelsDesc = "The total number of active channels."
 
-	NumSkippedSeqsDesc = "The total number of skipped sequences."
+	NumSkippedSeqsDesc = "The total number of skipped sequences. This is a cumulative value"
 
 	PendingSeqLengthDesc = "The total number of pending sequences. These are out-of-sequence entries waiting to be cached."
 
@@ -127,7 +127,11 @@ const (
 	RevCacheMissesDesc = "The total number of revision cache misses. This metric can be used to calculate the ratio of revision cache misses: " +
 		"Rev Cache Miss Ratio = rev_cache_misses / (rev_cache_hits + rev_cache_misses)"
 
-	SkippedSeqLengthDesc = "The current length of the pending skipped sequence queue."
+	SkippedSeqLengthDesc = "The current length of the pending skipped sequence slice."
+
+	SkippedSeqCapDesc = "The current capacity of the skipped sequence slice."
+
+	NumCurrentSkippedSeq = "The number of sequences currently in the skipped sequence slice."
 
 	ViewQueriesDesc = "The total view_queries."
 

--- a/base/util.go
+++ b/base/util.go
@@ -874,6 +874,11 @@ func IntPtr(i int) *int {
 	return &i
 }
 
+// Int64Prt returns a pointer to the given int64 literal.
+func Int64Prt(i int64) *int64 {
+	return &i
+}
+
 // BoolPtr returns a pointer to the given bool literal.
 func BoolPtr(b bool) *bool {
 	return &b

--- a/base/util.go
+++ b/base/util.go
@@ -874,11 +874,6 @@ func IntPtr(i int) *int {
 	return &i
 }
 
-// Int64Prt returns a pointer to the given int64 literal.
-func Int64Prt(i int64) *int64 {
-	return &i
-}
-
 // BoolPtr returns a pointer to the given bool literal.
 func BoolPtr(b bool) *bool {
 	return &b

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -305,8 +305,7 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 
 	base.InfofCtx(ctx, base.KeyCache, "Starting CleanSkippedSequenceQueue for database %s", base.MD(c.db.Name))
 
-	maxWait := int64(c.options.CacheSkippedSeqMaxWait.Seconds())
-	compactedSequences := c.skippedSeqs.SkippedSequenceCompact(ctx, maxWait)
+	compactedSequences := c.skippedSeqs.SkippedSequenceCompact(ctx, int64(c.options.CacheSkippedSeqMaxWait.Seconds()))
 	if compactedSequences == 0 {
 		base.InfofCtx(ctx, base.KeyCache, "CleanSkippedSequenceQueue complete.  No sequences to be compacted from skipped sequence list for database %s.", base.MD(c.db.Name))
 		return nil

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -124,11 +124,6 @@ type LogEntries []*LogEntry
 // A priority-queue of LogEntries, kept ordered by increasing sequence #.
 type LogPriorityQueue []*LogEntry
 
-type SkippedSequence struct {
-	seq       uint64
-	timeAdded time.Time
-}
-
 type CacheOptions struct {
 	ChannelCacheOptions
 	CachePendingSeqMaxWait time.Duration // Max wait for pending sequence before skipping
@@ -314,6 +309,9 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 	}
 
 	c.db.DbStats.Cache().AbandonedSeqs.Add(numOldSkippedSequences)
+	c.db.DbStats.Cache().SkippedSeqLen.Set(int64(len(c.skippedSeqs.list)))
+	c.db.DbStats.Cache().SkippedSeqCap.Set(int64(cap(c.skippedSeqs.list)))
+	c.db.DbStats.Cache().NumCurrentSeqsSkipped.Add(-numOldSkippedSequences)
 
 	base.InfofCtx(ctx, base.KeyCache, "CleanSkippedSequenceQueue complete.  Cleaned %d sequences from skipped list for database %s.", numOldSkippedSequences, base.MD(c.db.Name))
 	return nil

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2334,9 +2334,6 @@ func TestSkippedSequenceCompact(t *testing.T) {
 	}
 	_ = testChangeCache.processEntry(ctx, highEntry)
 
-	// update cache stats for assertions
-	testChangeCache.updateStats(ctx)
-
 	// assert this pushes an entry on the skipped sequence slice
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, 1, len(testChangeCache.skippedSeqs.list))

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1346,7 +1346,7 @@ func shortWaitCache() CacheOptions {
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.CachePendingSeqMaxWait = 5 * time.Millisecond
 	cacheOptions.CachePendingSeqMaxNum = 50
-	cacheOptions.CacheSkippedSeqMaxWait = 120
+	cacheOptions.CacheSkippedSeqMaxWait = 2 * time.Minute
 	return cacheOptions
 }
 
@@ -2333,7 +2333,8 @@ func TestSkippedSequenceCompact(t *testing.T) {
 
 	// assert that compaction empties the skipped slice and we have correct value for abandoned sequences
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, 0, len(testChangeCache.skippedSeqs.list))
+		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.SkippedSeqLen.Value())
 		assert.Equal(c, int64(19), dbContext.DbStats.CacheStats.AbandonedSeqs.Value())
+		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 	}, time.Second*10, time.Millisecond*100)
 }

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2181,6 +2181,9 @@ func TestProcessSkippedEntry(t *testing.T) {
 	}
 	_ = testChangeCache.processEntry(ctx, highEntry)
 
+	// update cache stats for assertions
+	testChangeCache.updateStats(ctx)
+
 	// assert this pushes an entry on the skipped sequence slice
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, 1, len(testChangeCache.skippedSeqs.list))
@@ -2191,6 +2194,7 @@ func TestProcessSkippedEntry(t *testing.T) {
 	for j := 0; j < 10; j++ {
 		en := feed.Next()
 		_ = testChangeCache.processEntry(ctx, en)
+		testChangeCache.updateStats(ctx)
 		assert.Equal(t, currNumSkippedSeqs-1, dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		currNumSkippedSeqs = dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value()
 	}
@@ -2251,6 +2255,9 @@ func TestProcessSkippedEntryStats(t *testing.T) {
 	}
 	_ = testChangeCache.processEntry(ctx, highEntry)
 
+	// update cache stats for assertions
+	testChangeCache.updateStats(ctx)
+
 	// assert this pushes an entry on the skipped sequence slice
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, 1, len(testChangeCache.skippedSeqs.list))
@@ -2271,6 +2278,7 @@ func TestProcessSkippedEntryStats(t *testing.T) {
 
 		_ = testChangeCache.processEntry(ctx, newEntry)
 		// assert on skipped sequence slice stats
+		testChangeCache.updateStats(ctx)
 		assert.Equal(t, numSeqsInList-1, dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(t, expSliceLen[j], dbContext.DbStats.CacheStats.SkippedSeqLen.Value())
 		assert.Equal(t, int64(19), dbContext.DbStats.CacheStats.NumSkippedSeqs.Value())
@@ -2326,6 +2334,9 @@ func TestSkippedSequenceCompact(t *testing.T) {
 	}
 	_ = testChangeCache.processEntry(ctx, highEntry)
 
+	// update cache stats for assertions
+	testChangeCache.updateStats(ctx)
+
 	// assert this pushes an entry on the skipped sequence slice
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, 1, len(testChangeCache.skippedSeqs.list))
@@ -2333,6 +2344,7 @@ func TestSkippedSequenceCompact(t *testing.T) {
 
 	// assert that compaction empties the skipped slice and we have correct value for abandoned sequences
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		testChangeCache.updateStats(ctx)
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.SkippedSeqLen.Value())
 		assert.Equal(c, int64(19), dbContext.DbStats.CacheStats.AbandonedSeqs.Value())
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -27,9 +27,11 @@ const (
 // SkippedSequenceSlice stores the set of skipped sequences as an ordered slice of single skipped sequences
 // or skipped sequence ranges
 type SkippedSequenceSlice struct {
-	list                 []*SkippedSequenceListEntry
-	ClipCapacityHeadroom int
-	lock                 sync.RWMutex
+	list                          []*SkippedSequenceListEntry
+	ClipCapacityHeadroom          int
+	NumCurrentSkippedSequences    int64
+	NumCumulativeSkippedSequences int64
+	lock                          sync.RWMutex
 }
 
 // SkippedSequenceListEntry contains start + end sequence for a range of skipped sequences +
@@ -276,6 +278,7 @@ func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry *SkippedSequenceLi
 	} else {
 		s.list = append(s.list, entry)
 	}
+	s.NumCurrentSkippedSequences += entry.getNumSequencesInEntry()
 
 }
 

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -278,7 +278,6 @@ func (s *SkippedSequenceSlice) PushSkippedSequenceEntry(entry *SkippedSequenceLi
 	} else {
 		s.list = append(s.list, entry)
 	}
-	s.NumCurrentSkippedSequences += entry.getNumSequencesInEntry()
 
 }
 

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -43,6 +43,14 @@ type SkippedSequenceListEntry struct {
 	timestamp int64  // timestamp this entry was created in unix format
 }
 
+// SkippedSequenceStats will hold all stats associated with the skipped sequence slice, used for getStats()
+type SkippedSequenceStats struct {
+	NumCurrentSkippedSequencesStat    int64
+	NumCumulativeSkippedSequencesStat int64
+	ListCapacityStat                  int64
+	ListLengthStat                    int64
+}
+
 func NewSkippedSequenceSlice(clipHeadroom int) *SkippedSequenceSlice {
 	return &SkippedSequenceSlice{
 		list:                 []*SkippedSequenceListEntry{},
@@ -302,30 +310,15 @@ func (s *SkippedSequenceSlice) getOldest() uint64 {
 	return s.list[0].getStartSeq()
 }
 
-// getSliceLength retrieves the current skipped sequence slice length
-func (s *SkippedSequenceSlice) getSliceLength() int64 {
+// getStats will return all associated stats with the skipped sequence slice
+func (s *SkippedSequenceSlice) getStats() SkippedSequenceStats {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	return int64(len(s.list))
-}
 
-// getSliceCapacity retrieves the current skipped sequence slice capacity
-func (s *SkippedSequenceSlice) getSliceCapacity() int64 {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return int64(cap(s.list))
-}
-
-// getNumCurrentSkippedSequenceValue retrieves the current skipped sequence count
-func (s *SkippedSequenceSlice) getNumCurrentSkippedSequenceValue() int64 {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.NumCurrentSkippedSequences
-}
-
-// getCumulativeNumSkippedSequenceValue retrieves the cumulative skipped sequence count
-func (s *SkippedSequenceSlice) getCumulativeNumSkippedSequenceValue() int64 {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.NumCumulativeSkippedSequences
+	return SkippedSequenceStats{
+		NumCumulativeSkippedSequencesStat: s.NumCumulativeSkippedSequences,
+		NumCurrentSkippedSequencesStat:    s.NumCurrentSkippedSequences,
+		ListCapacityStat:                  int64(cap(s.list)),
+		ListLengthStat:                    int64(len(s.list)),
+	}
 }


### PR DESCRIPTION
CBG-3854

- Integrates new skipped sequence slice into the cache 
- Adds some additional stats as included in the design doc 
- Adds some test testing both functionality of the slice but also the new stats 
- Initial profiling locally shows a big improvement in terms of memory usage with a unit test that causes a jump in 80 million sequences. Not perfect given there are more areas to optimize yet but much better

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2388/
