### PR TITLE
Mark minimum version of CBS 7.6.2 for XDCR

### DIFF
--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -22,7 +22,7 @@ var firstServerVersionToSupportMobileXDCR = &ComparableBuildVersion{
 	epoch: 0,
 	major: 7,
 	minor: 6,
-	patch: 1,
+	patch: 2,
 }
 
 type clusterLogFunc func(ctx context.Context, format string, args ...interface{})


### PR DESCRIPTION
The release of server 7.6.1 will error as follows:

```
    xdcr_test.go:44: 
        	Error Trace:	/home/ec2-user/workspace/SyncGateway-Integration/xdcr/xdcr_test.go:44
        	Error:      	Received unexpected error:
        	            	Could not create xdcr cluster: sync_gateway_xdcr. POST /controller/createReplication -> (400) {"errors":{"mobile":"The only allowed values for setting mobile are [Off]"}}
        	Test:       	TestMobileXDCRNoSyncDataCopied
```

This was not true for pre-release builds. The pre-release 7.6.2 builds allow turning on XDCR.