### PR TITLE
Add `SkipTestMain` utility function for clearer output

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -729,9 +729,9 @@ func TestBucketPoolMain(ctx context.Context, m *testing.M, bucketReadierFunc TBP
 	teardownFuncs = append(teardownFuncs, SetUpTestGoroutineDump(m))
 
 	if options.RequireXDCR && GTestBucketPool.cluster != nil && GTestBucketPool.cluster.majorVersion < 7 {
-		fmt.Println("Test requires XDCR, but the cluster version is less than 7. Skipping test.")
-		return
+		SkipTestMain(m, "Test requires XDCR, but the cluster version is less than 7. Skipping test.")
 	}
+
 	// Run the test suite
 	status := m.Run()
 

--- a/base/main_test_util.go
+++ b/base/main_test_util.go
@@ -1,3 +1,11 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 import (

--- a/base/main_test_util.go
+++ b/base/main_test_util.go
@@ -1,0 +1,26 @@
+package base
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// SkipTestMain logs in the same format as actual test output that we're skipping the current package.
+func SkipTestMain(m *testing.M, format string, args ...interface{}) {
+	fmt.Println("=== RUN   TestMain")
+	printfFromLine(2, format+"\n", args...)
+	fmt.Println("--- SKIP: TestMain (0.00s)")
+	os.Exit(0)
+}
+
+// printfFromLine prints the given message with the filename and line number from the caller
+func printfFromLine(skip int, format string, args ...interface{}) {
+	_, filename, line, _ := runtime.Caller(skip)
+	filename = filepath.Base(filename) // trim
+	args = append([]interface{}{filename, line}, args...)
+	// E.g: main_test.go:25: msg
+	fmt.Printf("%s:%d: "+format, args...)
+}

--- a/base/main_test_util.go
+++ b/base/main_test_util.go
@@ -19,7 +19,7 @@ import (
 // SkipTestMain logs in the same format as actual test output that we're skipping the current package.
 func SkipTestMain(m *testing.M, format string, args ...interface{}) {
 	fmt.Println("=== RUN   TestMain")
-	printfFromLine(2, format+"\n", args...)
+	printfFromLine(2, "    "+format+"\n", args...)
 	fmt.Println("--- SKIP: TestMain (0.00s)")
 	os.Exit(0)
 }

--- a/db/indextest/main_test.go
+++ b/db/indextest/main_test.go
@@ -23,8 +23,9 @@ import (
 func TestMain(m *testing.M) {
 	// these tests are only meant to be be run against Couchbase Server with GSI
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
-		return
+		base.SkipTestMain(m, "these tests are only meant to be be run against Couchbase Server with GSI")
 	}
+
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
 	base.TestBucketPoolMain(ctx, m, primaryIndexReadier, primaryIndexInit, tbpOptions)

--- a/rest/importtest/main_test.go
+++ b/rest/importtest/main_test.go
@@ -20,8 +20,9 @@ import (
 
 func TestMain(m *testing.M) {
 	if !base.TestUseXattrs() { // import tests only run if xattrs are enabled
-		return
+		base.SkipTestMain(m, "import tests only run if xattrs are enabled")
 	}
+
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)

--- a/rest/importuserxattrtest/main_test.go
+++ b/rest/importuserxattrtest/main_test.go
@@ -21,7 +21,7 @@ import (
 func TestMain(m *testing.M) {
 	// user xattr tests require xattrs and EE
 	if !base.TestUseXattrs() || !base.IsEnterpriseEdition() {
-		return
+		base.SkipTestMain(m, "user xattr tests require xattrs and EE")
 	}
 
 	ctx := context.Background() // start of test process


### PR DESCRIPTION
This change makes it much more obvious that the package's tests are being completely skipped.

Formatting details can be negotiated. I tried to match the regular test output format for any parsers that may be interpreting this, however that may be more trouble than it's worth.

There's also no special exit code that we can return other than `0` for `TestMain` that would show `skipped` instead of `ok`. Any non-zero code shows `FAIL`.

## Before

```sh
$ go test -v -count=1 -run '^TestAutoImportUserXattrNoSyncData$' ./rest/importuserxattrtest
ok  	github.com/couchbase/sync_gateway/rest/importuserxattrtest	0.574s
```

## After

```sh
$ go test -v -count=1 -run '^TestAutoImportUserXattrNoSyncData$' ./rest/importuserxattrtest
=== RUN   TestMain
    main_test.go:24: user xattr tests require xattrs and EE
--- SKIP: TestMain (0.00s)
ok  	github.com/couchbase/sync_gateway/rest/importuserxattrtest	0.582s
```