### PR TITLE
[3.1.6 Backport] CBG-3878: Fix losing user xattr on import feed for docs with no sync data

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -434,8 +434,7 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 	// Note that there could be a non-sync xattr present
 	if dataType&base.MemcachedDataTypeXattr != 0 {
 		var syncXattr []byte
-		var userXattr []byte
-		body, syncXattr, userXattr, err = parseXattrStreamData(base.SyncXattrName, userXattrKey, data)
+		body, syncXattr, rawUserXattr, err = parseXattrStreamData(base.SyncXattrName, userXattrKey, data)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
@@ -450,7 +449,7 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 			if err != nil {
 				return nil, nil, nil, nil, err
 			}
-			return result, body, syncXattr, userXattr, nil
+			return result, body, syncXattr, rawUserXattr, nil
 		}
 	} else {
 		// Xattr flag not set - data is just the document body
@@ -459,7 +458,7 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 
 	// Non-xattr data, or sync xattr not present.  Attempt to retrieve sync metadata from document body
 	result, err = UnmarshalDocumentSyncData(body, needHistory)
-	return result, body, rawUserXattr, nil, err
+	return result, body, nil, rawUserXattr, err
 }
 
 func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
@@ -389,11 +388,12 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 
 	// construct data into dcp format with both _sync xattr and user xattr defined
 	body := []byte(`{"test":"document"}`)
-	xattrs := []sgbucket.Xattr{
-		{Name: base.SyncXattrName, Value: []byte(syncXattr)},
-		{Name: userXattrKey, Value: []byte(channelName)},
-	}
-	value := sgbucket.EncodeValueWithXattrs(body, xattrs...)
+
+	// 3.1.x backport NOTE:
+	// We don't have sgbucket.Xattr or EncodeValueWithXattrs available, as those changes are mixed with Rosmar refactoring, so it's not easy to cherry-pick.
+	// `value` has been replaced with pre-computed values taken from `main` during this backport.
+
+	value := []byte{0x0, 0x0, 0x0, 0x2e, 0x0, 0x0, 0x0, 0x17, 0x5f, 0x73, 0x79, 0x6e, 0x63, 0x0, 0x7b, 0x22, 0x73, 0x65, 0x71, 0x75, 0x65, 0x6e, 0x63, 0x65, 0x22, 0x3a, 0x32, 0x30, 0x30, 0x7d, 0x0, 0x0, 0x0, 0x0, 0xf, 0x63, 0x68, 0x61, 0x6e, 0x6e, 0x65, 0x6c, 0x73, 0x0, 0x63, 0x68, 0x61, 0x6e, 0x31, 0x0, 0x7b, 0x22, 0x74, 0x65, 0x73, 0x74, 0x22, 0x3a, 0x22, 0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x22, 0x7d}
 
 	syncData, rawBody, rawXattr, rawUserXattr, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
@@ -403,10 +403,7 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with just user xattr defined
-	xattrs = []sgbucket.Xattr{
-		{Name: userXattrKey, Value: []byte(channelName)},
-	}
-	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
+	value = []byte{0x0, 0x0, 0x0, 0x13, 0x0, 0x0, 0x0, 0xf, 0x63, 0x68, 0x61, 0x6e, 0x6e, 0x65, 0x6c, 0x73, 0x0, 0x63, 0x68, 0x61, 0x6e, 0x31, 0x0, 0x7b, 0x22, 0x74, 0x65, 0x73, 0x74, 0x22, 0x3a, 0x22, 0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x22, 0x7d}
 
 	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
@@ -416,8 +413,7 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with no xattr defined
-	xattrs = []sgbucket.Xattr{}
-	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
+	value = []byte{0x0, 0x0, 0x0, 0x0, 0x7b, 0x22, 0x74, 0x65, 0x73, 0x74, 0x22, 0x3a, 0x22, 0x64, 0x6f, 0x63, 0x75, 0x6d, 0x65, 0x6e, 0x74, 0x22, 0x7d}
 
 	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -383,7 +383,7 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 
 	const (
 		userXattrKey = "channels"
-		syncXattr    = `{"rev":"1234"}`
+		syncXattr    = `{"sequence":200}`
 		channelName  = "chan1"
 	)
 
@@ -398,7 +398,7 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	syncData, rawBody, rawXattr, rawUserXattr, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Equal(t, syncXattr, string(rawXattr))
-	assert.Equal(t, "1234", syncData.CurrentRev)
+	assert.Equal(t, uint64(200), syncData.Sequence)
 	assert.Equal(t, channelName, string(rawUserXattr))
 	assert.Equal(t, body, rawBody)
 


### PR DESCRIPTION
CBG-3878

Backports #6755 and #6781 to 3.1.6

- Test fixes for unavailable and not easily cherry-pickable dependencies (multi-xattr and Rosmar SG-bucket API changes)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
