### PR TITLE
[3.1.6 Backport] CBG-3845: Ensure sequence update waits for callback invocation

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -120,8 +120,8 @@ func NewDCPCommon(ctx context.Context, callback sgbucket.FeedEventCallbackFunc, 
 }
 
 func (c *DCPCommon) dataUpdate(seq uint64, event sgbucket.FeedEvent) {
-	c.updateSeq(event.VbNo, seq, true)
 	shouldPersistCheckpoint := c.callback(event)
+	c.updateSeq(event.VbNo, seq, true)
 	if c.persistCheckpoints && shouldPersistCheckpoint {
 		c.incrementCheckpointCount(event.VbNo)
 	}


### PR DESCRIPTION
CBG-3845

Backports #6773 to 3.1.6

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
