### PR TITLE
[3.1.6 Backport] CBG-3828: add insertion strings to capture stdout/stderr

### DIFF
--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -562,7 +562,7 @@ def make_event_log_task():
                        "(LogFile='application' or LogFile='system') and "
                        "EventType<3 and TimeGenerated>'%(limit)s'"
                        "\" "
-                       "get TimeGenerated,LogFile,SourceName,EventType,Message "
+                       "get TimeGenerated,LogFile,SourceName,EventType,Message,InsertionStrings "
                        "/FORMAT:list" % locals())
 
 
@@ -580,7 +580,7 @@ def make_event_log_task_sg_info():
                        "SourceName='SyncGateway' and "
                        "TimeGenerated>'%(limit)s'"
                        "\" "
-                       "get TimeGenerated,LogFile,SourceName,EventType,Message "
+                       "get TimeGenerated,LogFile,SourceName,EventType,InsertionStrings "
                        "/FORMAT:list" % locals())
 
 


### PR DESCRIPTION
CBG-3828

Backports #6719 to 3.1.6

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
