### PR TITLE
[3.1.6 backport] CBG-3906 scope message about searching for database config (#6790)

### DIFF
--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -57,14 +57,14 @@ func cbgtRootCAsProvider(bucketName, bucketUUID string) func() *x509.CertPool {
 			return pool
 		}
 	}
-	ctx := bucketNameCtx(context.Background(), bucketName) // this function is global, so reconstruct context
+	ctx := BucketNameCtx(context.Background(), bucketName) // this function is global, so reconstruct context
 	TracefCtx(ctx, KeyDCP, "Bucket %v not found in root cert pools, not using TLS.", MD(bucketName))
 	return nil
 }
 
 // cbgt's default GetPoolsDefaultForBucket only works with cbauth
 func cbgtGetPoolsDefaultForBucket(server, bucket string, scopes bool) ([]byte, error) {
-	ctx := bucketNameCtx(context.Background(), bucket) // this function is global, so reconstruct context
+	ctx := BucketNameCtx(context.Background(), bucket) // this function is global, so reconstruct context
 	cbgtGlobalsLock.Lock()
 	dbName, ok := cbgtBucketToDBName[bucket]
 	if !ok {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -121,9 +121,9 @@ func TestCtx(t testing.TB) context.Context {
 	return LogContextWith(ctx, &LogContext{TestName: t.Name()})
 }
 
-// bucketCtx extends the parent context with a bucket name.
+// BucketCtx extends the parent context with a bucket name.
 func bucketCtx(parent context.Context, b Bucket) context.Context {
-	return bucketNameCtx(parent, b.GetName())
+	return BucketNameCtx(parent, b.GetName())
 }
 
 // getLogContext returns a log context possibly extending from previous context.
@@ -135,8 +135,8 @@ func getLogCtx(ctx context.Context) LogContext {
 	return parentLogCtx.getCopy()
 }
 
-// bucketNameCtx extends the parent context with a bucket name.
-func bucketNameCtx(parent context.Context, bucketName string) context.Context {
+// BucketNameCtx extends the parent context with a bucket name.
+func BucketNameCtx(parent context.Context, bucketName string) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.Bucket = bucketName
 	return LogContextWith(parent, &newCtx)

--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -90,7 +90,7 @@ func TestLogFormat(t *testing.T) {
 		},
 		{
 			name:   "test and bucket only no database",
-			ctx:    bucketNameCtx(TestCtx(t), "testBucket"),
+			ctx:    BucketNameCtx(TestCtx(t), "testBucket"),
 			output: "[INF] t:TestLogFormat b:testBucket foobar\n",
 		},
 
@@ -206,7 +206,7 @@ func TestTestCtx(t *testing.T) {
 }
 
 func TestBucketNameCtx(t *testing.T) {
-	RequireLogMessage(t, bucketNameCtx(TestCtx(t), "fooBucket"), "[INF] t:TestBucketNameCtx b:fooBucket foobar\n", standardMessage)
+	RequireLogMessage(t, BucketNameCtx(TestCtx(t), "fooBucket"), "[INF] t:TestBucketNameCtx b:fooBucket foobar\n", standardMessage)
 }
 
 // Tests the typical request workflow for a database request. Makes sure each level of context does not modify earlier levels.
@@ -224,7 +224,7 @@ func TestCtxWorkflow(t *testing.T) {
 	RequireLogMessage(t, correlationCtx, "[INF] t:TestCtxWorkflow c:correlationID foobar\n", standardMessage)
 	RequireLogMessage(t, ctx, "[INF] t:TestCtxWorkflow foobar\n", standardMessage)
 
-	bucketCtx := bucketNameCtx(correlationCtx, "fooBucket")
+	bucketCtx := BucketNameCtx(correlationCtx, "fooBucket")
 	RequireLogMessage(t, bucketCtx, "[INF] t:TestCtxWorkflow c:correlationID b:fooBucket foobar\n", standardMessage)
 	RequireLogMessage(t, correlationCtx, "[INF] t:TestCtxWorkflow c:correlationID foobar\n", standardMessage)
 	RequireLogMessage(t, ctx, "[INF] t:TestCtxWorkflow foobar\n", standardMessage)

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -383,7 +383,7 @@ func (tbp *TestBucketPool) removeOldTestBuckets(ctx context.Context) error {
 
 	for _, b := range buckets {
 		if strings.HasPrefix(b, tbpBucketNamePrefix) {
-			ctx := bucketNameCtx(ctx, b)
+			ctx := BucketNameCtx(ctx, b)
 			tbp.Logf(ctx, "Removing old test bucket")
 			wg.Add(1)
 
@@ -471,12 +471,12 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets, bucketQuotaMB int, buck
 	// create required number of buckets (skipping any already existing ones)
 	for i := 0; i < numBuckets; i++ {
 		testBucketName := fmt.Sprintf(tbpBucketNameFormat, tbpBucketNamePrefix, i, bucketNameTimestamp)
-		ctx := bucketNameCtx(context.Background(), testBucketName)
+		ctx := BucketNameCtx(context.Background(), testBucketName)
 
 		// Bucket creation takes a few seconds for each bucket,
 		// so create and wait for readiness concurrently.
 		go func(bucketName string) {
-			ctx := bucketNameCtx(ctx, bucketName)
+			ctx := BucketNameCtx(ctx, bucketName)
 
 			tbp.Logf(ctx, "Creating new test bucket")
 			err := tbp.cluster.insertBucket(ctx, bucketName, bucketQuotaMB)
@@ -506,7 +506,7 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets, bucketQuotaMB int, buck
 	// All the buckets are created and opened, so now we can perform some synchronous setup (e.g. Creating GSI indexes)
 	for i := 0; i < numBuckets; i++ {
 		testBucketName := fmt.Sprintf(tbpBucketNameFormat, tbpBucketNamePrefix, i, bucketNameTimestamp)
-		ctx := bucketNameCtx(context.Background(), testBucketName)
+		ctx := BucketNameCtx(context.Background(), testBucketName)
 
 		tbp.Logf(ctx, "running bucketInitFunc")
 		b := openBuckets[testBucketName]
@@ -547,7 +547,7 @@ loop:
 
 		case dirtyBucket := <-tbp.bucketReadierQueue:
 			atomic.AddInt32(&tbp.stats.TotalBucketReadierCount, 1)
-			ctx := bucketNameCtx(ctx, string(dirtyBucket))
+			ctx := BucketNameCtx(ctx, string(dirtyBucket))
 			tbp.Logf(ctx, "bucketReadier got bucket")
 
 			go func(testBucketName tbpBucketName) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1727,16 +1727,16 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 
 	fetchedConfigs := make(map[string]DatabaseConfig, len(buckets))
 	for _, bucket := range buckets {
-
-		base.TracefCtx(ctx, base.KeyConfig, "Checking for configs for group %q from bucket %q", sc.Config.Bootstrap.ConfigGroupID, base.MD(bucket))
+		ctx := base.BucketNameCtx(ctx, bucket)
+		base.TracefCtx(ctx, base.KeyConfig, "Checking for configs for group %q", sc.Config.Bootstrap.ConfigGroupID)
 		configs, err := sc.BootstrapContext.GetDatabaseConfigs(ctx, bucket, sc.Config.Bootstrap.ConfigGroupID)
 		if err != nil {
 			// Unexpected error fetching config - SDK has already performed retries, so we'll treat it as a registry removal
 			// this could be due to invalid JSON or some other non-recoverable error.
 			if isInitialStartup {
-				base.WarnfCtx(ctx, "Unable to fetch configs for group %q from bucket %q on startup: %v", sc.Config.Bootstrap.ConfigGroupID, base.MD(bucket), err)
+				base.WarnfCtx(ctx, "Unable to fetch configs for group %q on startup: %v", sc.Config.Bootstrap.ConfigGroupID, err)
 			} else {
-				base.DebugfCtx(ctx, base.KeyConfig, "Unable to fetch configs for group %q from bucket %q: %v", sc.Config.Bootstrap.ConfigGroupID, base.MD(bucket), err)
+				base.DebugfCtx(ctx, base.KeyConfig, "Unable to fetch configs for group %q: %v", sc.Config.Bootstrap.ConfigGroupID, err)
 			}
 			continue
 		}
@@ -1773,7 +1773,7 @@ func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool
 				cnf.KeyPath = sc.Config.Bootstrap.X509KeyPath
 			}
 
-			base.DebugfCtx(ctx, base.KeyConfig, "Got config for group %q from bucket %q with cas %d", sc.Config.Bootstrap.ConfigGroupID, bucket, cnf.cfgCas)
+			base.DebugfCtx(ctx, base.KeyConfig, "Got config for group %q with cas %d", sc.Config.Bootstrap.ConfigGroupID, cnf.cfgCas)
 			fetchedConfigs[cnf.Name] = *cnf
 		}
 	}

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -345,7 +345,12 @@ func (b *bootstrapContext) GetDatabaseConfigs(ctx context.Context, bucketName, g
 
 	var attempt int
 	for attempt = 1; attempt <= configFetchMaxRetryAttempts; attempt++ {
-		base.InfofCtx(ctx, base.KeyConfig, "GetDatabaseConfigs starting (attempt %d/%d)", attempt, configFetchMaxRetryAttempts)
+		msg := fmt.Sprintf("Checking for database config (attempt %d/%d)", attempt, configFetchMaxRetryAttempts)
+		if attempt == 1 {
+			base.DebugfCtx(ctx, base.KeyConfig, msg)
+		} else {
+			base.InfofCtx(ctx, base.KeyConfig, msg)
+		}
 		registry, err := b.getGatewayRegistry(ctx, bucketName)
 		if err != nil {
 			return nil, err
@@ -399,7 +404,7 @@ func (b *bootstrapContext) GetDatabaseConfigs(ctx context.Context, bucketName, g
 		}
 	}
 
-	base.WarnfCtx(ctx, "Unable to successfully retrieve GetDatabaseConfigs for groupID: %s after %d attempts", base.MD(groupID), attempt)
+	base.WarnfCtx(ctx, "Unable to successfully retrieve GetDatabaseConfigs in %q for groupID: %s after %d attempts", base.MD(bucketName), base.MD(groupID), attempt)
 	return nil, base.ErrConfigRegistryReloadRequired
 }
 


### PR DESCRIPTION
backports scope message about searching for database config (#6790)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
