### PR TITLE
CBG-3855: Sequence range removal support

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -880,8 +880,10 @@ func (c *changeCache) RemoveSkipped(x uint64) error {
 }
 
 // Removes a set of sequences.  Logs warning on removal error, returns count of successfully removed.
-func (c *changeCache) RemoveSkippedSequences(ctx context.Context, sequences []uint64) {
+func (c *changeCache) RemoveSkippedSequences(ctx context.Context, startSeq, endSeq uint64) error {
 	// this can be used for removal or ranges, pending CBG-3855
+	err := c.skippedSeqs.removeSeqRange(startSeq, endSeq)
+	return err
 }
 
 func (c *changeCache) WasSkipped(x uint64) bool {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -881,7 +881,6 @@ func (c *changeCache) RemoveSkipped(x uint64) error {
 
 // Removes a set of sequences.  Logs warning on removal error, returns count of successfully removed.
 func (c *changeCache) RemoveSkippedSequences(ctx context.Context, startSeq, endSeq uint64) error {
-	// this can be used for removal or ranges, pending CBG-3855
 	err := c.skippedSeqs.removeSeqRange(startSeq, endSeq)
 	return err
 }

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -212,6 +212,56 @@ func binarySearchFunc(a *SkippedSequenceListEntry, seq uint64) int {
 	return -1
 }
 
+// removeSeqRange will remove sequence between x and y from the skipped sequence slice
+func (s *SkippedSequenceSlice) removeSeqRange(startSeq, endSeq uint64) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	startIndex, found := s._findSequence(startSeq)
+	if !found {
+		return fmt.Errorf("sequence %d not found in the skipped list", startSeq)
+	}
+	endIndex, found := s._findSequence(endSeq)
+	if !found {
+		return fmt.Errorf("sequence %d not found in the skipped list", startSeq)
+	}
+
+	// if both sequence x and y aren't in the same element, the range contains sequences that are not present in
+	// skipped sequence list. This is due to any contiguous sequences in the list will be in the same element. So
+	// if startSeq and endSeq are in different elements there is at least oen sequence between these values not in the list
+	if startIndex != endIndex {
+		return fmt.Errorf("sequence range %d to %d specified has sequences in that are not present in skipped list", startSeq, endSeq)
+	} else {
+		// handle sequence range removal
+		rangeElem := s.list[startIndex]
+
+		// update number of sequences currently in slice stat
+		s.NumCurrentSkippedSequences -= numSequencesInRemovalRange(startSeq, endSeq)
+
+		// if single sequence element
+		if rangeElem.getStartSeq() == startSeq && rangeElem.getLastSeq() == endSeq {
+			// simply remove the element
+			s.list = slices.Delete(s.list, startIndex, startIndex+1)
+			return nil
+		}
+		// check if one of x or y is equal to start or end seq
+		if rangeElem.getStartSeq() == startSeq {
+			rangeElem.setStartSeq(endSeq + 1)
+			return nil
+		}
+		if rangeElem.getLastSeq() == endSeq {
+			rangeElem.setLastSeq(startSeq - 1)
+			return nil
+		}
+		// assume we are removing from middle of the range
+		newElem := NewSkippedSequenceRangeEntryAt(endSeq+1, rangeElem.getLastSeq(), rangeElem.getTimestamp())
+		s._insert(startIndex+1, newElem)
+		rangeElem.setLastSeq(startSeq - 1)
+	}
+	return nil
+
+}
+
 // removeSeq will remove a given sequence from the slice if it exists
 func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 	s.lock.Lock()
@@ -321,4 +371,12 @@ func (s *SkippedSequenceSlice) getStats() SkippedSequenceStats {
 		ListCapacityStat:                  int64(cap(s.list)),
 		ListLengthStat:                    int64(len(s.list)),
 	}
+}
+
+func numSequencesInRemovalRange(startSeq, endSeq uint64) int64 {
+	if startSeq == endSeq {
+		return 1
+	}
+	numSequences := (endSeq - startSeq) + 1
+	return int64(numSequences)
 }


### PR DESCRIPTION
CBG-3855

- Addition of support for removal of a given sequence range from the skipped sequence slice 
- Note: `RemoveSequences` function this is hooked up to doesn't actually get called yet, this will be properly hooked up to cache with the work in CBG-3850 


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
