### PR TITLE
CBG-3877 Persist HLV to _vv xattr

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -136,6 +136,7 @@ const (
 	SyncPropertyName = "_sync"
 	// SyncXattrName is used when storing sync data in a document's xattrs.
 	SyncXattrName = "_sync"
+	VvXattrName   = "_vv"
 
 	// Intended to be used in Meta Map and related tests
 	MetaMapXattrsKey = "xattrs"

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -396,7 +396,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// First unmarshal the doc (just its metadata, to save time/memory):
-	syncData, rawBody, _, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
+	syncData, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
@@ -409,6 +409,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// If using xattrs and this isn't an SG write, we shouldn't attempt to cache.
+	rawUserXattr := rawXattrs[collection.userXattrKey()]
 	if collection.UseXattrs() {
 		if syncData == nil {
 			return

--- a/db/crud.go
+++ b/db/crud.go
@@ -2255,6 +2255,9 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			var rawSyncXattr, rawVvXattr, rawDocBody []byte
 			rawDocBody, rawSyncXattr, rawVvXattr, err = doc.MarshalWithXattrs()
+			if err != nil {
+				return updatedDoc, err
+			}
 			if !isImport {
 				updatedDoc.Doc = rawDocBody
 				docBytes = len(updatedDoc.Doc)

--- a/db/crud.go
+++ b/db/crud.go
@@ -60,7 +60,7 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 		return nil, nil, base.HTTPErrorf(400, "Invalid doc ID")
 	}
 	if c.UseXattrs() {
-		doc, rawBucketDoc, err = c.GetDocWithXattr(ctx, key, unmarshalLevel)
+		doc, rawBucketDoc, err = c.GetDocWithXattrs(ctx, key, unmarshalLevel)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -73,7 +73,7 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 		// If existing doc wasn't an SG Write, import the doc.
 		if !isSgWrite {
 			var importErr error
-			doc, importErr = c.OnDemandImportForGet(ctx, docid, rawBucketDoc.Body, rawBucketDoc.Xattrs[base.SyncXattrName], rawBucketDoc.Xattrs[c.userXattrKey()], rawBucketDoc.Cas)
+			doc, importErr = c.OnDemandImportForGet(ctx, docid, rawBucketDoc.Body, rawBucketDoc.Xattrs, rawBucketDoc.Cas)
 			if importErr != nil {
 				return nil, nil, importErr
 			}
@@ -114,7 +114,7 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 	return doc, rawBucketDoc, nil
 }
 
-func (c *DatabaseCollection) GetDocWithXattr(ctx context.Context, key string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, rawBucketDoc *sgbucket.BucketDocument, err error) {
+func (c *DatabaseCollection) GetDocWithXattrs(ctx context.Context, key string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, rawBucketDoc *sgbucket.BucketDocument, err error) {
 	rawBucketDoc = &sgbucket.BucketDocument{}
 	var getErr error
 	rawBucketDoc.Body, rawBucketDoc.Xattrs, rawBucketDoc.Cas, getErr = c.dataStore.GetWithXattrs(ctx, key, c.syncAndUserXattrKeys())
@@ -123,7 +123,7 @@ func (c *DatabaseCollection) GetDocWithXattr(ctx context.Context, key string, un
 	}
 
 	var unmarshalErr error
-	doc, unmarshalErr = unmarshalDocumentWithXattr(ctx, key, rawBucketDoc.Body, rawBucketDoc.Xattrs[base.SyncXattrName], rawBucketDoc.Xattrs[c.userXattrKey()], rawBucketDoc.Cas, unmarshalLevel)
+	doc, unmarshalErr = c.unmarshalDocumentWithXattrs(ctx, key, rawBucketDoc.Body, rawBucketDoc.Xattrs, rawBucketDoc.Cas, unmarshalLevel)
 	if unmarshalErr != nil {
 		return nil, nil, unmarshalErr
 	}
@@ -148,11 +148,8 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 			return emptySyncData, getErr
 		}
 
-		rawXattr := xattrs[base.SyncXattrName]
-		rawUserXattr := xattrs[c.userXattrKey()]
-
 		// Unmarshal xattr only
-		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, docid, nil, rawXattr, rawUserXattr, cas, DocUnmarshalSync)
+		doc, unmarshalErr := c.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, DocUnmarshalSync)
 		if unmarshalErr != nil {
 			return emptySyncData, unmarshalErr
 		}
@@ -166,7 +163,7 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 		if !isSgWrite {
 			var importErr error
 
-			doc, importErr = c.OnDemandImportForGet(ctx, docid, rawDoc, rawXattr, rawUserXattr, cas)
+			doc, importErr = c.OnDemandImportForGet(ctx, docid, rawDoc, xattrs, cas)
 			if importErr != nil {
 				return emptySyncData, importErr
 			}
@@ -193,6 +190,12 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 
 }
 
+// unmarshalDocumentWithXattrs populates individual xattrs on unmarshalDocumentWithXattrs from a provided xattrs map
+func (db *DatabaseCollection) unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, xattrs map[string][]byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+	return unmarshalDocumentWithXattrs(ctx, docid, data, xattrs[base.SyncXattrName], xattrs[base.VvXattrName], xattrs[db.userXattrKey()], cas, unmarshalLevel)
+
+}
+
 // This gets *just* the Sync Metadata (_sync field) rather than the entire doc, for efficiency
 // reasons. Unlike GetDocSyncData it does not check for on-demand import; this means it does not
 // need to read the doc body from the bucket.
@@ -200,10 +203,10 @@ func (db *DatabaseCollection) GetDocSyncDataNoImport(ctx context.Context, docid 
 	if db.UseXattrs() {
 		var xattrs map[string][]byte
 		var cas uint64
-		xattrs, cas, err = db.dataStore.GetXattrs(ctx, docid, []string{base.SyncXattrName})
+		xattrs, cas, err = db.dataStore.GetXattrs(ctx, docid, []string{base.SyncXattrName, base.VvXattrName})
 		if err == nil {
 			var doc *Document
-			doc, err = unmarshalDocumentWithXattr(ctx, docid, nil, xattrs[base.SyncXattrName], nil, cas, level)
+			doc, err = db.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, level)
 			if err == nil {
 				syncData = doc.SyncData
 			}
@@ -235,14 +238,14 @@ func (db *DatabaseCollection) GetDocSyncDataNoImport(ctx context.Context, docid 
 	return
 }
 
-// OnDemandImportForGet.  Attempts to import the doc based on the provided id, contents and cas.  ImportDocRaw does cas retry handling
+// OnDemandImportForGet. Attempts to import the doc based on the provided id, contents and cas. ImportDocRaw does cas retry handling
 // if the document gets updated after the initial retrieval attempt that triggered this.
-func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
+func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, xattrs map[string][]byte, cas uint64) (docOut *Document, err error) {
 	isDelete := rawDoc == nil
 	importDb := DatabaseCollectionWithUser{DatabaseCollection: c, user: nil}
 	var importErr error
 
-	docOut, importErr = importDb.ImportDocRaw(ctx, docid, rawDoc, rawXattr, rawUserXattr, isDelete, cas, nil, ImportOnDemand)
+	docOut, importErr = importDb.ImportDocRaw(ctx, docid, rawDoc, xattrs, isDelete, cas, nil, ImportOnDemand)
 	if importErr == base.ErrImportCancelledFilter {
 		// If the import was cancelled due to filter, treat as not found
 		return nil, base.HTTPErrorf(404, "Not imported")
@@ -1076,7 +1079,7 @@ func (db *DatabaseCollectionWithUser) Put(ctx context.Context, docid string, bod
 func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Context, newDoc *Document, newDocHLV HybridLogicalVector, existingDoc *sgbucket.BucketDocument) (doc *Document, cv *Version, newRevID string, err error) {
 	var matchRev string
 	if existingDoc != nil {
-		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattrs[base.SyncXattrName], existingDoc.Xattrs[db.userXattrKey()], existingDoc.Cas, DocUnmarshalRev)
+		doc, unmarshalErr := db.unmarshalDocumentWithXattrs(ctx, newDoc.ID, existingDoc.Body, existingDoc.Xattrs, existingDoc.Cas, DocUnmarshalRev)
 		if unmarshalErr != nil {
 			return nil, nil, "", base.HTTPErrorf(http.StatusBadRequest, "Error unmarshaling existing doc")
 		}
@@ -2204,15 +2207,15 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		}
 		casOut, err = db.dataStore.WriteUpdateWithXattrs(ctx, key, db.syncAndUserXattrKeys(), initialExpiry, existingDoc, opts, func(currentValue []byte, currentXattrs map[string][]byte, cas uint64) (updatedDoc sgbucket.UpdatedDoc, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
-			currentXattr := currentXattrs[base.SyncXattrName]
-			currentUserXattr := currentXattrs[db.userXattrKey()]
-			if doc, err = unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll); err != nil {
+
+			if doc, err = db.unmarshalDocumentWithXattrs(ctx, docid, currentValue, currentXattrs, cas, DocUnmarshalAll); err != nil {
 				return
 			}
 			prevCurrentRev = doc.CurrentRev
 
 			// Check whether Sync Data originated in body
-			if currentXattr == nil && doc.Sequence > 0 {
+			currentSyncXattr := currentXattrs[base.SyncXattrName]
+			if currentSyncXattr == nil && doc.Sequence > 0 {
 				doc.inlineSyncData = true
 			}
 
@@ -2249,18 +2252,19 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			// Return the new raw document value for the bucket to store.
 			doc.SetCrc32cUserXattrHash()
-			var rawXattr, rawDocBody []byte
-			rawDocBody, rawXattr, err = doc.MarshalWithXattr()
+
+			var rawSyncXattr, rawVvXattr, rawDocBody []byte
+			rawDocBody, rawSyncXattr, rawVvXattr, err = doc.MarshalWithXattrs()
 			if !isImport {
 				updatedDoc.Doc = rawDocBody
 				docBytes = len(updatedDoc.Doc)
 			}
-			updatedDoc.Xattrs = map[string][]byte{base.SyncXattrName: rawXattr}
+			updatedDoc.Xattrs = map[string][]byte{base.SyncXattrName: rawSyncXattr, base.VvXattrName: rawVvXattr}
 
 			// Warn when sync data is larger than a configured threshold
 			if db.unsupportedOptions() != nil && db.unsupportedOptions().WarningThresholds != nil {
 				if xattrBytesThreshold := db.unsupportedOptions().WarningThresholds.XattrSize; xattrBytesThreshold != nil {
-					xattrBytes = len(rawXattr)
+					xattrBytes = len(rawSyncXattr)
 					if uint32(xattrBytes) >= *xattrBytesThreshold {
 						db.dbStats().Database().WarnXattrSizeCount.Add(1)
 						base.WarnfCtx(ctx, "Doc id: %v sync metadata size: %d bytes exceeds %d bytes for sync metadata warning threshold", base.UD(doc.ID), xattrBytes, *xattrBytesThreshold)
@@ -2815,7 +2819,7 @@ func (c *DatabaseCollection) checkForUpgrade(ctx context.Context, key string, un
 		return nil, nil
 	}
 
-	doc, rawDocument, err := c.GetDocWithXattr(ctx, key, unmarshalLevel)
+	doc, rawDocument, err := c.GetDocWithXattrs(ctx, key, unmarshalLevel)
 	if err != nil || doc == nil || !doc.HasValidSyncData() {
 		return nil, nil
 	}
@@ -2968,8 +2972,8 @@ const (
 	xattrMacroCas               = "cas"          // SyncData.Cas
 	xattrMacroValueCrc32c       = "value_crc32c" // SyncData.Crc32c
 	xattrMacroCurrentRevVersion = "rev.ver"      // SyncDataJSON.RevAndVersion.CurrentVersion
-	versionVectorVrsMacro       = "_vv.ver"      // PersistedHybridLogicalVector.Version
-	versionVectorCVCASMacro     = "_vv.cvCas"    // PersistedHybridLogicalVector.CurrentVersionCAS
+	versionVectorVrsMacro       = "ver"          // PersistedHybridLogicalVector.Version
+	versionVectorCVCASMacro     = "cvCas"        // PersistedHybridLogicalVector.CurrentVersionCAS
 )
 
 func macroExpandSpec(xattrName string) []sgbucket.MacroExpansionSpec {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -245,7 +245,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get the existing bucket doc
-		_, existingBucketDoc, err := collection.GetDocWithXattr(ctx, docID, DocUnmarshalAll)
+		_, existingBucketDoc, err := collection.GetDocWithXattrs(ctx, docID, DocUnmarshalAll)
 		require.NoError(t, err)
 
 		// Migrate document metadata from document body to system xattr.

--- a/db/database.go
+++ b/db/database.go
@@ -1792,7 +1792,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 			if currentValue == nil || len(currentValue) == 0 {
 				return sgbucket.UpdatedDoc{}, base.ErrUpdateCancel
 			}
-			doc, err := unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattrs[base.SyncXattrName], currentXattrs[db.userXattrKey()], cas, DocUnmarshalAll)
+			doc, err := db.unmarshalDocumentWithXattrs(ctx, docid, currentValue, currentXattrs, cas, DocUnmarshalAll)
 			if err != nil {
 				return sgbucket.UpdatedDoc{}, err
 			}
@@ -1808,11 +1808,12 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 				updatedDoc.UpdateExpiry(*updatedExpiry)
 			}
 			doc.SetCrc32cUserXattrHash()
-			_, rawXattr, err := updatedDoc.MarshalWithXattr()
+			_, rawSyncXattr, rawVvXattr, err := updatedDoc.MarshalWithXattrs()
 			return sgbucket.UpdatedDoc{
 				Doc: nil, // Resync does not require document body update
 				Xattrs: map[string][]byte{
-					base.SyncXattrName: rawXattr,
+					base.SyncXattrName: rawSyncXattr,
+					base.VvXattrName:   rawVvXattr,
 				},
 				Expiry: updatedExpiry,
 			}, err

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -253,7 +253,7 @@ func (c *DatabaseCollection) unsupportedOptions() *UnsupportedOptions {
 
 // syncAndUserXattrKeys returns the xattr keys for the user and sync xattrs.
 func (c *DatabaseCollection) syncAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName}
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)

--- a/db/document.go
+++ b/db/document.go
@@ -38,7 +38,7 @@ const (
 	DocUnmarshalSync                                     // Unmarshals metadata
 	DocUnmarshalNoHistory                                // Unmarshals metadata excluding revtree history
 	DocUnmarshalHistory                                  // Unmarshals revtree history + rev + CAS only
-	DocUnmarshalRev                                      // Unmarshals rev + CAS only
+	DocUnmarshalRev                                      // Unmarshals revTreeID + CAS only (no HLV)
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )

--- a/db/document.go
+++ b/db/document.go
@@ -403,7 +403,7 @@ func unmarshalDocument(docid string, data []byte) (*Document, error) {
 
 func unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, syncXattrData []byte, hlvXattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 
-	if (syncXattrData == nil || len(syncXattrData) == 0) && hlvXattrData == nil {
+	if len(syncXattrData) == 0 && len(hlvXattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
 	} else {

--- a/db/document.go
+++ b/db/document.go
@@ -34,9 +34,9 @@ const DocumentHistoryMaxEntriesPerChannel = 5
 type DocumentUnmarshalLevel uint8
 
 const (
-	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals sync metadata and body
-	DocUnmarshalSync                                     // Unmarshals all sync metadata
-	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding revtree history
+	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals metadata and body
+	DocUnmarshalSync                                     // Unmarshals metadata
+	DocUnmarshalNoHistory                                // Unmarshals metadata excluding revtree history
 	DocUnmarshalHistory                                  // Unmarshals revtree history + rev + CAS only
 	DocUnmarshalRev                                      // Unmarshals rev + CAS only
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
@@ -81,7 +81,7 @@ type SyncData struct {
 	Attachments       AttachmentsMeta      `json:"attachments,omitempty"`
 	ChannelSet        []ChannelSetEntry    `json:"channel_set"`
 	ChannelSetHistory []ChannelSetEntry    `json:"channel_set_history"`
-	HLV               *HybridLogicalVector `json:"_vv,omitempty"`
+	HLV               *HybridLogicalVector `json:"-"` // Marshalled/Unmarshalled separately from SyncData for storage in _vv, see MarshalWithXattrs/UnmarshalWithXattrs
 
 	// Only used for performance metrics:
 	TimeSaved time.Time `json:"time_saved,omitempty"` // Timestamp of save.
@@ -401,14 +401,14 @@ func unmarshalDocument(docid string, data []byte) (*Document, error) {
 	return doc, nil
 }
 
-func unmarshalDocumentWithXattr(ctx context.Context, docid string, data []byte, xattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+func unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, syncXattrData []byte, hlvXattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 
-	if xattrData == nil || len(xattrData) == 0 {
+	if (syncXattrData == nil || len(syncXattrData) == 0) && hlvXattrData == nil {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
 	} else {
 		doc = NewDocument(docid)
-		err = doc.UnmarshalWithXattr(ctx, data, xattrData, unmarshalLevel)
+		err = doc.UnmarshalWithXattrs(ctx, data, syncXattrData, hlvXattrData, unmarshalLevel)
 	}
 	if err != nil {
 		return nil, err
@@ -444,37 +444,47 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*SyncData, error)
 // Returns the raw body, in case it's needed for import.
 
 // TODO: Using a pool of unmarshal workers may help prevent memory spikes under load
-func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawSyncXattr []byte, rawUserXattr []byte, err error) {
 
+func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawXattrs map[string][]byte, err error) {
 	var body []byte
 
 	// If xattr datatype flag is set, data includes both xattrs and document body.  Check for presence of sync xattr.
 	// Note that there could be a non-sync xattr present
+	var xattrValues map[string][]byte
+	var hlv *HybridLogicalVector
 	if dataType&base.MemcachedDataTypeXattr != 0 {
-		var xattrs map[string][]byte
-		xattrKeys := []string{base.SyncXattrName}
-		if userXattrKey != "" {
-			xattrKeys = append(xattrKeys, userXattrKey)
-		}
-		body, xattrs, err = sgbucket.DecodeValueWithXattrs(xattrKeys, data)
+		xattrKeys := []string{base.SyncXattrName, base.VvXattrName, userXattrKey}
+		body, xattrValues, err = sgbucket.DecodeValueWithXattrs(xattrKeys, data)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, err
 		}
-		rawSyncXattr = xattrs[base.SyncXattrName]
-		rawUserXattr = xattrs[userXattrKey]
 
 		// If the sync xattr is present, use that to build SyncData
-		if len(rawSyncXattr) > 0 {
+		syncXattr, ok := xattrValues[base.SyncXattrName]
+
+		if vvXattr, ok := xattrValues[base.VvXattrName]; ok {
+			err = base.JSONUnmarshal(vvXattr, &hlv)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("error unmarshalling HLV: %w", err)
+			}
+		}
+
+		if ok && len(syncXattr) > 0 {
 			result = &SyncData{}
 			if needHistory {
 				result.History = make(RevTree)
 			}
-			err = base.JSONUnmarshal(rawSyncXattr, result)
+			err = base.JSONUnmarshal(syncXattr, result)
 			if err != nil {
-				return nil, nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", syncXattr, err)
+				return nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", string(syncXattr), err)
 			}
-			return result, body, rawSyncXattr, rawUserXattr, nil
+
+			if hlv != nil {
+				result.HLV = hlv
+			}
+			return result, body, xattrValues, nil
 		}
+
 	} else {
 		// Xattr flag not set - data is just the document body
 		body = data
@@ -482,22 +492,16 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 
 	// Non-xattr data, or sync xattr not present.  Attempt to retrieve sync metadata from document body
 	result, err = UnmarshalDocumentSyncData(body, needHistory)
-	return result, body, nil, rawUserXattr, err
-}
 
-func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {
-	if dataType&base.MemcachedDataTypeXattr == 0 {
-		return unmarshalDocument(docid, data)
+	// If no sync data was found but HLV was present, initialize empty sync data
+	if result == nil && hlv != nil {
+		result = &SyncData{}
 	}
-	xattrKeys := []string{base.SyncXattrName}
-	if userXattrKey != "" {
-		xattrKeys = append(xattrKeys, userXattrKey)
+	// If HLV was found, add to sync data
+	if hlv != nil {
+		result.HLV = hlv
 	}
-	body, xattrs, err := sgbucket.DecodeValueWithXattrs(xattrKeys, data)
-	if err != nil {
-		return nil, err
-	}
-	return unmarshalDocumentWithXattr(ctx, docid, body, xattrs[base.SyncXattrName], xattrs[userXattrKey], cas, DocUnmarshalAll)
+	return result, body, xattrValues, err
 }
 
 func (doc *SyncData) HasValidSyncData() bool {
@@ -1055,11 +1059,12 @@ func (doc *Document) MarshalJSON() (data []byte, err error) {
 	return data, err
 }
 
-// UnmarshalWithXattr unmarshals the provided raw document and xattr bytes.  The provided DocumentUnmarshalLevel
+// UnmarshalWithXattrs unmarshals the provided raw document and xattr bytes when present.  The provided DocumentUnmarshalLevel
 // (unmarshalLevel) specifies how much of the provided document/xattr needs to be initially unmarshalled.  If
 // unmarshalLevel is anything less than the full document + metadata, the raw data is retained for subsequent
 // lazy unmarshalling as needed.
-func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata []byte, unmarshalLevel DocumentUnmarshalLevel) error {
+// Must handle cases where document body and hlvXattrData are present without syncXattrData for all DocumentUnmarshalLevel
+func (doc *Document) UnmarshalWithXattrs(ctx context.Context, data, syncXattrData, hlvXattrData []byte, unmarshalLevel DocumentUnmarshalLevel) error {
 	if doc.ID == "" {
 		base.WarnfCtx(ctx, "Attempted to unmarshal document without ID set")
 		return errors.New("Document was unmarshalled without ID set")
@@ -1067,11 +1072,19 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 
 	switch unmarshalLevel {
 	case DocUnmarshalAll, DocUnmarshalSync:
-		// Unmarshal full document and/or sync metadata
+		// Unmarshal full document and/or sync metadata. Documents written by XDCR may have HLV but no sync data
 		doc.SyncData = SyncData{History: make(RevTree)}
-		unmarshalErr := base.JSONUnmarshal(xdata, &doc.SyncData)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), unmarshalErr))
+		if syncXattrData != nil {
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &doc.SyncData)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+		}
+		if hlvXattrData != nil {
+			err := base.JSONUnmarshal(hlvXattrData, &doc.SyncData.HLV)
+			if err != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal HLV during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), err))
+			}
 		}
 		doc._rawBody = data
 		// Unmarshal body if requested and present
@@ -1081,50 +1094,70 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 	case DocUnmarshalNoHistory:
 		// Unmarshal sync metadata only, excluding history
 		doc.SyncData = SyncData{}
-		unmarshalErr := base.JSONUnmarshal(xdata, &doc.SyncData)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+		if syncXattrData != nil {
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &doc.SyncData)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+		}
+		if hlvXattrData != nil {
+			err := base.JSONUnmarshal(hlvXattrData, &doc.SyncData.HLV)
+			if err != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal HLV during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), err))
+			}
 		}
 		doc._rawBody = data
 	case DocUnmarshalHistory:
-		historyOnlyMeta := historyOnlySyncData{History: make(RevTree)}
-		unmarshalErr := base.JSONUnmarshal(xdata, &historyOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			CurrentRev: historyOnlyMeta.CurrentRev.RevTreeID,
-			History:    historyOnlyMeta.History,
-			Cas:        historyOnlyMeta.Cas,
+		if syncXattrData != nil {
+			historyOnlyMeta := historyOnlySyncData{History: make(RevTree)}
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &historyOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				CurrentRev: historyOnlyMeta.CurrentRev.RevTreeID,
+				History:    historyOnlyMeta.History,
+				Cas:        historyOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	case DocUnmarshalRev:
 		// Unmarshal only rev and cas from sync metadata
-		var revOnlyMeta revOnlySyncData
-		unmarshalErr := base.JSONUnmarshal(xdata, &revOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			CurrentRev: revOnlyMeta.CurrentRev.RevTreeID,
-			Cas:        revOnlyMeta.Cas,
+		if syncXattrData != nil {
+			var revOnlyMeta revOnlySyncData
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &revOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				CurrentRev: revOnlyMeta.CurrentRev.RevTreeID,
+				Cas:        revOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	case DocUnmarshalCAS:
 		// Unmarshal only cas from sync metadata
-		var casOnlyMeta casOnlySyncData
-		unmarshalErr := base.JSONUnmarshal(xdata, &casOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalCAS).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			Cas: casOnlyMeta.Cas,
+		if syncXattrData != nil {
+			var casOnlyMeta casOnlySyncData
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &casOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalCAS).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				Cas: casOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	}
 
 	// If there's no body, but there is an xattr, set deleted flag and initialize an empty body
-	if len(data) == 0 && len(xdata) > 0 {
+	if len(data) == 0 && len(syncXattrData) > 0 {
 		doc._body = Body{}
 		doc._rawBody = []byte(base.EmptyDocument)
 		doc.Deleted = true
@@ -1132,7 +1165,8 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 	return nil
 }
 
-func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
+// MarshalWithXattrs marshals the Document into body, and sync and vv xattrs for persistence.
+func (doc *Document) MarshalWithXattrs() (data []byte, syncXattr []byte, vvXattr []byte, err error) {
 	// Grab the rawBody if it's already marshalled, otherwise unmarshal the body
 	if doc._rawBody != nil {
 		if !doc.IsDeleted() {
@@ -1149,18 +1183,25 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 			if !deleted {
 				data, err = base.JSONMarshal(body)
 				if err != nil {
-					return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc body with id: %s.  Error: %v", base.UD(doc.ID), err))
+					return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc body with id: %s.  Error: %v", base.UD(doc.ID), err))
 				}
 			}
 		}
 	}
 
-	xdata, err = base.JSONMarshal(&doc.SyncData)
-	if err != nil {
-		return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
+	if doc.SyncData.HLV != nil {
+		vvXattr, err = base.JSONMarshal(&doc.SyncData.HLV)
+		if err != nil {
+			return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc vv with id: %s.  Error: %v", base.UD(doc.ID), err))
+		}
 	}
 
-	return data, xdata, nil
+	syncXattr, err = base.JSONMarshal(&doc.SyncData)
+	if err != nil {
+		return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
+	}
+
+	return data, syncXattr, vvXattr, nil
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -137,7 +137,7 @@ func BenchmarkDocUnmarshal(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			ctx := base.TestCtx(b)
 			for i := 0; i < b.N; i++ {
-				_, _ = unmarshalDocumentWithXattr(ctx, "doc_1k", doc1k_body, doc1k_meta, nil, 1, bm.unmarshalLevel)
+				_, _ = unmarshalDocumentWithXattrs(ctx, "doc_1k", doc1k_body, doc1k_meta, nil, nil, 1, bm.unmarshalLevel)
 			}
 		})
 	}
@@ -192,7 +192,7 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 	}
 }
 
-const doc_meta_with_vv = `{
+const doc_meta_no_vv = `{
     "rev": "3-89758294abc63157354c2b08547c2d21",
     "sequence": 7,
     "recent_sequences": [
@@ -235,20 +235,21 @@ const doc_meta_with_vv = `{
       },
       "GHI": null
     },
-	"_vv":{
-   		"cvCas":"0x40e2010000000000",
-   		"src":"cb06dc003846116d9b66d2ab23887a96",
-   		"ver":"0x40e2010000000000",
-   		"mv":{
-      		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
-      		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
-		},
-		"pv":{
-      		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
-   		}
-	},
     "cas": "",
     "time_saved": "2017-10-25T12:45:29.622450174-07:00"
+  }`
+
+const doc_meta_vv = `{
+	"cvCas":"0x40e2010000000000",
+	"src":"cb06dc003846116d9b66d2ab23887a96",
+	"ver":"0x40e2010000000000",
+	"mv":{
+		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
+		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
+	},
+	"pv":{
+		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
+	}
   }`
 
 func TestParseVersionVectorSyncData(t *testing.T) {
@@ -260,8 +261,9 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 
-	doc_meta := []byte(doc_meta_with_vv)
-	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	sync_meta := []byte(doc_meta_no_vv)
+	vv_meta := []byte(doc_meta_vv)
+	doc, err := unmarshalDocumentWithXattrs(ctx, "doc_1k", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	strCAS := string(base.Uint64CASToLittleEndianHex(123456))
@@ -272,7 +274,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 
-	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalAll)
+	doc, err = unmarshalDocumentWithXattrs(ctx, "doc1", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalAll)
 	require.NoError(t, err)
 
 	// assert on doc version vector values
@@ -282,7 +284,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 
-	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	doc, err = unmarshalDocumentWithXattrs(ctx, "doc1", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	// assert on doc version vector values
@@ -347,32 +349,22 @@ func TestRevAndVersion(t *testing.T) {
 			require.NoError(t, err)
 			log.Printf("marshalled:%s", marshalledSyncData)
 
-			var newSyncData SyncData
-			err = base.JSONUnmarshal(marshalledSyncData, &newSyncData)
-			require.NoError(t, err)
-			require.Equal(t, test.revTreeID, newSyncData.CurrentRev)
-			require.Equal(t, expectedSequence, newSyncData.Sequence)
-			if test.source != "" {
-				require.NotNil(t, newSyncData.HLV)
-				require.Equal(t, test.source, newSyncData.HLV.SourceID)
-				require.Equal(t, test.version, newSyncData.HLV.Version)
-			}
-
 			// Document test
 			document := NewDocument("docID")
 			document.SyncData.CurrentRev = test.revTreeID
+			document.SyncData.Sequence = expectedSequence
 			document.SyncData.HLV = &HybridLogicalVector{
 				SourceID: test.source,
 				Version:  test.version,
 			}
-			marshalledDoc, marshalledXattr, err := document.MarshalWithXattr()
+			marshalledDoc, marshalledXattr, marshalledVvXattr, err := document.MarshalWithXattrs()
 			require.NoError(t, err)
 
 			newDocument := NewDocument("docID")
-			err = newDocument.UnmarshalWithXattr(ctx, marshalledDoc, marshalledXattr, DocUnmarshalAll)
+			err = newDocument.UnmarshalWithXattrs(ctx, marshalledDoc, marshalledXattr, marshalledVvXattr, DocUnmarshalAll)
 			require.NoError(t, err)
 			require.Equal(t, test.revTreeID, newDocument.CurrentRev)
-			require.Equal(t, expectedSequence, newSyncData.Sequence)
+			require.Equal(t, expectedSequence, newDocument.Sequence)
 			if test.source != "" {
 				require.NotNil(t, newDocument.HLV)
 				require.Equal(t, test.source, newDocument.HLV.SourceID)
@@ -493,17 +485,15 @@ func TestDCPDecodeValue(t *testing.T) {
 				require.Nil(t, xattrs)
 			}
 			// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
-			result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
+			result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
 			require.ErrorIs(t, err, test.expectedErr)
 			if test.expectedSyncXattr != nil {
 				require.NotNil(t, result)
+				require.Equal(t, test.expectedSyncXattr, rawXattrs[base.SyncXattrName])
 			} else {
 				require.Nil(t, result)
 			}
 			require.Equal(t, test.expectedBody, rawBody)
-			require.Equal(t, test.expectedSyncXattr, rawXattr)
-			require.Nil(t, rawUserXattr)
-
 		})
 	}
 }
@@ -514,19 +504,17 @@ func TestInvalidXattrStreamEmptyBody(t *testing.T) {
 	emptyBody := []byte{}
 
 	// DecodeValueWithXattrs is the underlying function
-	body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{"_sync"}, inputStream)
+	body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{base.SyncXattrName}, inputStream)
 	require.NoError(t, err)
 	require.Equal(t, emptyBody, body)
 	require.Empty(t, xattrs)
 
 	// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
-	result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
+	result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
 	require.Error(t, err) // unexpected end of JSON input
 	require.Nil(t, result)
 	require.Equal(t, emptyBody, rawBody)
-	require.Nil(t, rawXattr)
-	require.Nil(t, rawUserXattr)
-
+	require.Nil(t, rawXattrs[base.SyncXattrName])
 }
 
 // getSingleXattrDCPBytes returns a DCP body with a single xattr pair and body

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -377,14 +377,14 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansionSpec {
 	var outputSpec []sgbucket.MacroExpansionSpec
 	if hlv.Version == hlvExpandMacroCASValue {
-		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionPath(base.SyncXattrName), sgbucket.MacroCas)
+		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionPath(base.VvXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, spec)
 		// If version is being expanded, we need to also specify the macro expansion for the expanded rev property
 		currentRevSpec := sgbucket.NewMacroExpansionSpec(xattrCurrentRevVersionPath(base.SyncXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, currentRevSpec)
 	}
 	if hlv.CurrentVersionCAS == hlvExpandMacroCASValue {
-		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.SyncXattrName), sgbucket.MacroCas)
+		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.VvXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, spec)
 	}
 	return outputSpec

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -260,7 +260,7 @@ func purgeWithDCPFeed(ctx context.Context, dataStore sgbucket.DataStore, tbp *ba
 		key := string(event.Key)
 
 		if base.TestUseXattrs() {
-			purgeErr = dataStore.DeleteWithXattrs(ctx, key, []string{base.SyncXattrName})
+			purgeErr = dataStore.DeleteWithXattrs(ctx, key, []string{base.SyncXattrName, base.VvXattrName})
 		} else {
 			purgeErr = dataStore.Delete(key)
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.4.1
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c
+	github.com/couchbase/sg-bucket v0.0.0-20240514223028-c60b57e39e26
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20240424002439-5fd321c3b01b

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389
+	github.com/couchbaselabs/rosmar v0.0.0-20240424002439-5fd321c3b01b
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.4
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.4.1
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20240514223028-c60b57e39e26
+	github.com/couchbase/sg-bucket v0.0.0-20240514232448-927889ef9624
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20240424002439-5fd321c3b01b

--- a/go.sum
+++ b/go.sum
@@ -54,10 +54,8 @@ github.com/couchbase/goprotostellar v1.0.2 h1:yoPbAL9sCtcyZ5e/DcU5PRMOEFaJrF9awX
 github.com/couchbase/goprotostellar v1.0.2/go.mod h1:5/yqVnZlW2/NSbAWu1hPJCFBEwjxgpe0PFFOlRixnp4=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c h1:ftZeu97TaEWxBAINW2AaGNk3Icyg+/6XHs7OHnR23qQ=
-github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
-github.com/couchbase/sg-bucket v0.0.0-20240514223028-c60b57e39e26 h1:+3NTyrdEKxDQPycYPlfLxife5n7fMWWqSLvHH137+44=
-github.com/couchbase/sg-bucket v0.0.0-20240514223028-c60b57e39e26/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
+github.com/couchbase/sg-bucket v0.0.0-20240514232448-927889ef9624 h1:0vkmiPDRCNiJIv570e9DW1v0tqCQ4RHs3KiqGCB0X/4=
+github.com/couchbase/sg-bucket v0.0.0-20240514232448-927889ef9624/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9B
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
 github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c h1:ftZeu97TaEWxBAINW2AaGNk3Icyg+/6XHs7OHnR23qQ=
 github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
+github.com/couchbase/sg-bucket v0.0.0-20240514223028-c60b57e39e26 h1:+3NTyrdEKxDQPycYPlfLxife5n7fMWWqSLvHH137+44=
+github.com/couchbase/sg-bucket v0.0.0-20240514223028-c60b57e39e26/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131 h1:2EAfFswAfgYn3a05DVcegiw6DgMgn1Mv5eGz6IHt1Cw=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389 h1:feX52yzl6wrIXt6gqmcOKzpHOdigwnzJ5TP15M9i3Ow=
-github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
+github.com/couchbaselabs/rosmar v0.0.0-20240424002439-5fd321c3b01b h1:aP8cbbI/CiRyL0mOGA4HJ9jjhcOgx1M9V78i2tAAdJ4=
+github.com/couchbaselabs/rosmar v0.0.0-20240424002439-5fd321c3b01b/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -298,7 +298,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, DocID, db.DocUnmarshalCAS)
 	require.NoError(t, err)
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)
@@ -330,7 +330,7 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 	changes, err := rt.WaitForChanges(1, fmt.Sprintf(`/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=%s`, DocID), "", true)
 	require.NoError(t, err)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, DocID, db.DocUnmarshalCAS)
 	require.NoError(t, err)
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -924,7 +924,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	// Write another doc
 	_ = rt.PutDoc("mix-1", `{"channel":["ABC", "PBS", "HBO"]}`)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, "mix-1", db.DocUnmarshalSync)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, "mix-1", db.DocUnmarshalSync)
 	require.NoError(t, err)
 	mixSource, mixVersion := fetchedDoc.HLV.GetCurrentVersion()
 

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -410,11 +410,11 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	}
 	value := sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
-	assert.Equal(t, syncXattr, string(rawXattr))
+	assert.Equal(t, syncXattr, string(rawXattrs[base.SyncXattrName]))
 	assert.Equal(t, uint64(200), syncData.Sequence)
-	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Equal(t, channelName, string(rawXattrs[userXattrKey]))
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with just user xattr defined
@@ -423,21 +423,21 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	}
 	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Nil(t, syncData)
-	assert.Nil(t, rawXattr)
-	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Nil(t, rawXattrs[base.SyncXattrName])
+	assert.Equal(t, channelName, string(rawXattrs[userXattrKey]))
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with no xattr defined
 	xattrs = []sgbucket.Xattr{}
 	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Nil(t, syncData)
-	assert.Nil(t, rawXattr)
-	assert.Nil(t, rawUserXattr)
+	assert.Nil(t, rawXattrs[base.SyncXattrName])
+	assert.Nil(t, rawXattrs[userXattrKey])
 	assert.Equal(t, body, rawBody)
 }


### PR DESCRIPTION
Modifies document marshal and unmarshal to support a set of xattrs (_sync, _vv), and does the same for parsing DCP stream events (including user xattr). 

Bumps rosmar commit to pick up the already merged enhancement for multi-xattr support.

CBG-3877

Depends on:
- [x] https://github.com/couchbase/sg-bucket/pull/125

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2427/
