### PR TITLE
CBG-3913 replace parseStreamWithXattr with sg-bucket function

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -35,7 +35,6 @@ var (
 	ErrDocumentMigrated      = &sgError{"Document migrated"}
 	ErrFatalBucketConnection = &sgError{"Fatal error connecting to bucket"}
 	ErrAuthError             = &sgError{"Authentication failure"}
-	ErrEmptyMetadata         = &sgError{"Empty Sync Gateway metadata"}
 	ErrCasFailureShouldRetry = sgbucket.ErrCasFailureShouldRetry
 	ErrIndexerError          = &sgError{"Indexer error"}
 	ErrAlreadyExists         = &sgError{"Already exists"}
@@ -52,9 +51,6 @@ var (
 
 	// ErrXattrPartialFound is returned if only a subset of requested xattrs are found
 	ErrXattrPartialFound = &sgError{"Some Requested Xattrs Not Found"}
-
-	// ErrXattrInvalidLen is returned if the xattr is corrupt.
-	ErrXattrInvalidLen = &sgError{"Xattr stream length"}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -213,6 +213,9 @@ func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionDa
 	if dataType&base.MemcachedDataTypeXattr != 0 {
 		body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{base.SyncXattrName}, data)
 		if err != nil {
+			if errors.Is(err, sgbucket.ErrXattrInvalidLen) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("Could not parse DCP attachment sync data: %w", err)
 		}
 		err = base.JSONUnmarshal(xattrs[base.SyncXattrName], &attachmentData)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -394,7 +394,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		if event.DataType != base.MemcachedDataTypeRaw {
 			base.DebugfCtx(ctx, base.KeyCache, "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", base.UD(docID), err)
 		}
-		if err == base.ErrEmptyMetadata {
+		if errors.Is(err, sgbucket.ErrEmptyMetadata) {
 			base.WarnfCtx(ctx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
 		}
 		return

--- a/db/document.go
+++ b/db/document.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -433,30 +432,38 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*SyncData, error)
 // Returns the raw body, in case it's needed for import.
 
 // TODO: Using a pool of unmarshal workers may help prevent memory spikes under load
-func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawXattr []byte, rawUserXattr []byte, err error) {
+func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawSyncXattr []byte, rawUserXattr []byte, err error) {
 
 	var body []byte
 
-	// If attr datatype flag is set, data includes both xattrs and document body.  Check for presence of sync xattr.
+	// If xattr datatype flag is set, data includes both xattrs and document body.  Check for presence of sync xattr.
 	// Note that there could be a non-sync xattr present
 	if dataType&base.MemcachedDataTypeXattr != 0 {
-		var syncXattr []byte
-		body, syncXattr, rawUserXattr, err = parseXattrStreamData(base.SyncXattrName, userXattrKey, data)
+		var xattrs []sgbucket.Xattr
+		body, xattrs, err = sgbucket.DecodeValueWithXattrs(data)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
+		for _, xattr := range xattrs {
+			switch xattr.Name {
+			case base.SyncXattrName:
+				rawSyncXattr = xattr.Value
+			case userXattrKey:
+				rawUserXattr = xattr.Value
+			}
+		}
 
 		// If the sync xattr is present, use that to build SyncData
-		if syncXattr != nil && len(syncXattr) > 0 {
+		if len(rawSyncXattr) > 0 {
 			result = &SyncData{}
 			if needHistory {
 				result.History = make(RevTree)
 			}
-			err = base.JSONUnmarshal(syncXattr, result)
+			err = base.JSONUnmarshal(rawSyncXattr, result)
 			if err != nil {
-				return nil, nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", string(syncXattr), err)
+				return nil, nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", syncXattr, err)
 			}
-			return result, body, syncXattr, rawUserXattr, nil
+			return result, body, rawSyncXattr, rawUserXattr, nil
 		}
 	} else {
 		// Xattr flag not set - data is just the document body
@@ -469,93 +476,26 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 }
 
 func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {
-	var body []byte
-
-	if dataType&base.MemcachedDataTypeXattr != 0 {
-		var syncXattr []byte
-		var userXattr []byte
-		body, syncXattr, userXattr, err = parseXattrStreamData(base.SyncXattrName, userXattrKey, data)
-		if err != nil {
-			return nil, err
-		}
-		return unmarshalDocumentWithXattr(ctx, docid, body, syncXattr, userXattr, cas, DocUnmarshalAll)
+	if dataType&base.MemcachedDataTypeXattr == 0 {
+		return unmarshalDocument(docid, data)
 	}
+	var xattrs []sgbucket.Xattr
+	var syncXattr []byte
+	var userXattr []byte
 
-	return unmarshalDocument(docid, data)
-}
-
-// parseXattrStreamData returns the raw bytes of the body and the requested xattr (when present) from the raw DCP data bytes.
-// Details on format (taken from https://docs.google.com/document/d/18UVa5j8KyufnLLy29VObbWRtoBn9vs8pcxttuMt6rz8/edit#heading=h.caqiui1pmmmb.):
-/*
-	When the XATTR bit is set the first uint32_t in the body contains the size of the entire XATTR section.
-
-
-	      Byte/     0       |       1       |       2       |       3       |
-	         /              |               |               |               |
-	        |0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|
-	        +---------------+---------------+---------------+---------------+
-	       0| Total xattr length in network byte order                      |
-	        +---------------+---------------+---------------+---------------+
-
-	Following the length you'll find an iovector-style encoding of all of the XATTR key-value pairs with the following encoding:
-
-	uint32_t length of next xattr pair (network order)
-	xattr key in modified UTF-8
-	0x00
-	xattr value in modified UTF-8
-	0x00
-
-	The 0x00 byte after the key saves us from storing a key length, and the trailing 0x00 is just for convenience to allow us to use string functions to search in them.
-*/
-
-func parseXattrStreamData(xattrName string, userXattrName string, data []byte) (body []byte, xattr []byte, userXattr []byte, err error) {
-
-	if len(data) < 4 {
-		return nil, nil, nil, base.ErrEmptyMetadata
+	body, xattrs, err := sgbucket.DecodeValueWithXattrs(data)
+	if err != nil {
+		return nil, err
 	}
-
-	xattrsLen := binary.BigEndian.Uint32(data[0:4])
-	if int(xattrsLen+4) > len(data) {
-		return nil, nil, nil, fmt.Errorf("%w (%d) from bytes %+v", base.ErrXattrInvalidLen, xattrsLen, data[0:4])
+	for _, xattr := range xattrs {
+		switch xattr.Name {
+		case base.SyncXattrName:
+			syncXattr = xattr.Value
+		case userXattrKey:
+			userXattr = xattr.Value
+		}
 	}
-	body = data[xattrsLen+4:]
-	if xattrsLen == 0 {
-		return body, nil, nil, nil
-	}
-
-	// In the xattr key/value pairs, key and value are both terminated by 0x00 (byte(0)).  Use this as a separator to split the byte slice
-	separator := []byte("\x00")
-
-	// Iterate over xattr key/value pairs
-	pos := uint32(4)
-	for pos < xattrsLen {
-		pairLen := binary.BigEndian.Uint32(data[pos : pos+4])
-		if pairLen == 0 || int(pos+pairLen) > len(data) {
-			return nil, nil, nil, fmt.Errorf("Unexpected xattr pair length (%d) - unable to parse xattrs", pairLen)
-		}
-		pos += 4
-		pairBytes := data[pos : pos+pairLen]
-		components := bytes.Split(pairBytes, separator)
-		// xattr pair has the format [key]0x00[value]0x00, and so should split into three components
-		if len(components) != 3 {
-			return nil, nil, nil, fmt.Errorf("Unexpected number of components found in xattr pair: %s", pairBytes)
-		}
-		xattrKey := string(components[0])
-		if xattrName == xattrKey {
-			xattr = components[1]
-		} else if userXattrName != "" && userXattrName == xattrKey {
-			userXattr = components[1]
-		}
-
-		// Exit if we have xattrs we want (either both or one if the latter is disabled)
-		if len(xattr) > 0 && (len(userXattr) > 0 || userXattrName == "") {
-			return body, xattr, userXattr, nil
-		}
-
-		pos += pairLen
-	}
-
-	return body, xattr, userXattr, nil
+	return unmarshalDocumentWithXattr(ctx, docid, body, syncXattr, userXattr, cas, DocUnmarshalAll)
 }
 
 func (doc *SyncData) HasValidSyncData() bool {

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -291,13 +291,12 @@ func TestDCPDecodeValue(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			// DecodeValueWithXattrs is the underlying function
-			body, xattrs, err := sgbucket.DecodeValueWithXattrs(test.body)
+			body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{"_sync"}, test.body)
 			require.ErrorIs(t, err, test.expectedErr)
 			require.Equal(t, test.expectedBody, body)
 			if test.expectedSyncXattr != nil {
 				require.Len(t, xattrs, 1)
-				require.Equal(t, base.SyncXattrName, xattrs[0].Name)
-				require.Equal(t, test.expectedSyncXattr, xattrs[0].Value)
+				require.Equal(t, test.expectedSyncXattr, xattrs["_sync"])
 			} else {
 				require.Nil(t, xattrs)
 			}
@@ -323,7 +322,7 @@ func TestInvalidXattrStreamEmptyBody(t *testing.T) {
 	emptyBody := []byte{}
 
 	// DecodeValueWithXattrs is the underlying function
-	body, xattrs, err := sgbucket.DecodeValueWithXattrs(inputStream)
+	body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{"_sync"}, inputStream)
 	require.NoError(t, err)
 	require.Equal(t, emptyBody, body)
 	require.Empty(t, xattrs)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -169,7 +170,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 func (il *importListener) ImportFeedEvent(ctx context.Context, collection *DatabaseCollectionWithUser, event sgbucket.FeedEvent) {
 	syncData, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(event.Value, event.DataType, collection.userXattrKey(), false)
 	if err != nil {
-		if err == base.ErrEmptyMetadata {
+		if errors.Is(err, sgbucket.ErrEmptyMetadata) {
 			base.WarnfCtx(ctx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
 			il.importStats.ImportErrorCount.Add(1)
 			return

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.3.1
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20240508135641-71c59d7f4bd8
+	github.com/couchbase/sg-bucket v0.0.0-20240510005938-766555de45c4
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.3.1
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20240402154301-12625d8851a8
+	github.com/couchbase/sg-bucket v0.0.0-20240508135641-71c59d7f4bd8
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/couchbase/goprotostellar v1.0.1 h1:mtDVYTgnnDSQ3t7mQRG6jl/tOXKOuuFM9P
 github.com/couchbase/goprotostellar v1.0.1/go.mod h1:gs1eioLVOHETTFWxDY4v7Q/kRPMgqmX6t/TPcI429ls=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20240508135641-71c59d7f4bd8 h1:UB7lHi5rvG14i3rnaXfKI5m4xiieG529C2toZnbsjZ0=
-github.com/couchbase/sg-bucket v0.0.0-20240508135641-71c59d7f4bd8/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
+github.com/couchbase/sg-bucket v0.0.0-20240510005938-766555de45c4 h1:UzmQ2oaCUEPkD/7l1e3s7U9OA4BFptp/Oi5UgaAVwBg=
+github.com/couchbase/sg-bucket v0.0.0-20240510005938-766555de45c4/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/couchbase/goprotostellar v1.0.1 h1:mtDVYTgnnDSQ3t7mQRG6jl/tOXKOuuFM9P
 github.com/couchbase/goprotostellar v1.0.1/go.mod h1:gs1eioLVOHETTFWxDY4v7Q/kRPMgqmX6t/TPcI429ls=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20240402154301-12625d8851a8 h1:kfWMYvUgSg2yIZJx+t63Ucl+zorvFqlYayXPkiXFtSE=
-github.com/couchbase/sg-bucket v0.0.0-20240402154301-12625d8851a8/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
+github.com/couchbase/sg-bucket v0.0.0-20240508135641-71c59d7f4bd8 h1:UB7lHi5rvG14i3rnaXfKI5m4xiieG529C2toZnbsjZ0=
+github.com/couchbase/sg-bucket v0.0.0-20240508135641-71c59d7f4bd8/go.mod h1:5me3TJLTPfR0s3aMJZcPoTu5FT8oelaINz5l7Q3cApE=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=

--- a/xdcr/rosmar_xdcr.go
+++ b/xdcr/rosmar_xdcr.go
@@ -192,8 +192,8 @@ func opWithMeta(ctx context.Context, collection *rosmar.Collection, originalCas 
 	var body []byte
 	if event.DataType&sgbucket.FeedDataTypeXattr != 0 {
 		var err error
-		var dcpXattrs []sgbucket.Xattr
-		body, dcpXattrs, err = sgbucket.DecodeValueWithXattrs(event.Value)
+		var dcpXattrs map[string][]byte
+		body, dcpXattrs, err = sgbucket.DecodeValueWithAllXattrs(event.Value)
 		if err != nil {
 			return err
 		}
@@ -224,11 +224,11 @@ func (r *rosmarManager) Stats(context.Context) (*Stats, error) {
 	}, nil
 }
 
-// xattrToBytes converts a slice of Xattrs to a byte slice of marshalled json.
-func xattrToBytes(xattrs []sgbucket.Xattr) ([]byte, error) {
+// xattrToBytes converts a map of xattrs of marshalled json.
+func xattrToBytes(xattrs map[string][]byte) ([]byte, error) {
 	xattrMap := make(map[string]json.RawMessage)
-	for _, xattr := range xattrs {
-		xattrMap[xattr.Name] = xattr.Value
+	for k, v := range xattrs {
+		xattrMap[k] = v
 	}
 	return json.Marshal(xattrMap)
 }


### PR DESCRIPTION
Depends on https://github.com/couchbase/sg-bucket/pull/122 and https://github.com/couchbase/sg-bucket/pull/123

- Consolidate tests into a table driven test, these tests exist in sg-bucket too with just `DecodeValueWithXattrs`. 
- Replace errors with sgbucket errors and use errors.Is

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2406/
