### PR TITLE
CBG-3914 change timeout to wait for authentication failure

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -72,7 +72,7 @@ func GetGoCBv2Bucket(ctx context.Context, spec BucketSpec) (*GocbV2Bucket, error
 		return nil, err
 	}
 
-	err = cluster.WaitUntilReady(time.Second*15, &gocb.WaitUntilReadyOptions{
+	err = cluster.WaitUntilReady(time.Second*30, &gocb.WaitUntilReadyOptions{
 		DesiredState:  gocb.ClusterStateOnline,
 		ServiceTypes:  []gocb.ServiceType{gocb.ServiceTypeManagement},
 		RetryStrategy: &goCBv2FailFastRetryStrategy{},

--- a/base/collection.go
+++ b/base/collection.go
@@ -72,7 +72,7 @@ func GetGoCBv2Bucket(ctx context.Context, spec BucketSpec) (*GocbV2Bucket, error
 		return nil, err
 	}
 
-	err = cluster.WaitUntilReady(time.Second*5, &gocb.WaitUntilReadyOptions{
+	err = cluster.WaitUntilReady(time.Second*15, &gocb.WaitUntilReadyOptions{
 		DesiredState:  gocb.ClusterStateOnline,
 		ServiceTypes:  []gocb.ServiceType{gocb.ServiceTypeManagement},
 		RetryStrategy: &goCBv2FailFastRetryStrategy{},


### PR DESCRIPTION
gocb.Cluster.WaitForReady will perform the authentication handshake. If this goes slowly for some reason, it will return a timeout error instead of a gocb.ErrAuthenticationFailure

See https://jenkins.sgwdev.com/job/MasterIntegration/733/ for an example of this failure, but this fails a lot in MasterIntegration and weekly-jenkins runs.

I chose 15s as an arbitrary time. https://issues.couchbase.com/browse/MB-61174 contributes to the slowness, but this is from 7.6.0, 7.6.1 regression from 7.2 and the failure above comes from 7.2.3. I actually think we could increase this timeout.

This code behaved differently with gocouchbase buckets so I'm not sure how to 1:1 match the timeouts https://github.com/couchbase/sync_gateway/blob/3426f07e5e0dfd426c7a638bf021869bc6991e64/base/bucket_gocb.go#L116