### PR TITLE
CBG-3157: Add opt-in send replacementRevs feature when encountering norev

### DIFF
--- a/base/set.go
+++ b/base/set.go
@@ -56,10 +56,14 @@ func (set Set) copy() Set {
 	return result
 }
 
-// Returns true if the set includes the channel.
-func (set Set) Contains(ch string) bool {
-	_, exists := set[ch]
-	return exists
+// Contains returns true if the set includes any of the given channels.
+func (set Set) Contains(ch ...string) bool {
+	for _, c := range ch {
+		if _, exists := set[c]; exists {
+			return true
+		}
+	}
+	return false
 }
 
 func (set Set) Equals(other Set) bool {

--- a/base/set.go
+++ b/base/set.go
@@ -66,6 +66,21 @@ func (set Set) Contains(ch ...string) bool {
 	return false
 }
 
+// NumMatches returns the number of matching elements between both sets.
+func (a Set) NumMatches(b Set) (count int) {
+	shortest, longest := a, b
+	// iterate over shortest
+	if len(longest) < len(shortest) {
+		shortest, longest = longest, shortest
+	}
+	for name := range shortest {
+		if _, exists := longest[name]; exists {
+			count++
+		}
+	}
+	return count
+}
+
 func (set Set) Equals(other Set) bool {
 	if len(other) != len(set) {
 		return false

--- a/base/set.go
+++ b/base/set.go
@@ -66,6 +66,21 @@ func (set Set) Contains(ch ...string) bool {
 	return false
 }
 
+// HasMatch returns the true if there is at least one matching element between both sets.
+func (a Set) HasMatch(b Set) bool {
+	shortest, longest := a, b
+	// iterate over shortest
+	if len(longest) < len(shortest) {
+		shortest, longest = longest, shortest
+	}
+	for name := range shortest {
+		if _, exists := longest[name]; exists {
+			return true
+		}
+	}
+	return false
+}
+
 // NumMatches returns the number of matching elements between both sets.
 func (a Set) NumMatches(b Set) (count int) {
 	shortest, longest := a, b

--- a/base/set_test.go
+++ b/base/set_test.go
@@ -53,6 +53,19 @@ func TestSet(t *testing.T) {
 	assert.Equal(t, set, set2)
 }
 
+func TestSetContains(t *testing.T) {
+	set := SetFromArray([]string{"foo", "bar"})
+
+	assert.True(t, set.Contains("foo"))
+	assert.True(t, set.Contains("bar"))
+	assert.False(t, set.Contains("baz"))
+
+	// variadic params
+	assert.True(t, set.Contains("foo", "bar"))
+	assert.True(t, set.Contains("baz", "foo"))
+	assert.False(t, set.Contains("baz", "buzz"))
+}
+
 func TestUnion(t *testing.T) {
 	var nilSet Set
 	empty := Set{}

--- a/base/set_test.go
+++ b/base/set_test.go
@@ -9,6 +9,7 @@
 package base
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -145,4 +146,57 @@ func TestSetUnmarshal(t *testing.T) {
 	assert.NoError(t, err, "Unmarshal")
 	assert.Equal(t, []string{"foo"}, str.Channels.ToArray())
 
+}
+
+func TestSetNumMatches(t *testing.T) {
+	tests := []struct {
+		a, b     Set
+		expected int
+	}{
+		{
+			a:        nil,
+			b:        nil,
+			expected: 0,
+		},
+		{
+			a:        SetOf("a", "b", "c"),
+			b:        nil,
+			expected: 0,
+		},
+		{
+			a:        nil,
+			b:        SetOf("a", "b", "c"),
+			expected: 0,
+		},
+		{
+			a:        SetOf("a", "b", "c"),
+			b:        SetOf("a", "b", "c"),
+			expected: 3,
+		},
+		{
+			a:        SetOf("a", "b", "c"),
+			b:        SetOf("a", "c"),
+			expected: 2,
+		},
+		{
+			a:        SetOf("a", "c"),
+			b:        SetOf("a", "b", "c"),
+			expected: 2,
+		},
+		{
+			a:        SetOf("a", "b", "c"),
+			b:        SetOf("a", "y", "c"),
+			expected: 2,
+		},
+		{
+			a:        SetOf("a", "b", "c"),
+			b:        SetOf("x", "y", "z"),
+			expected: 0,
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v %v=%v", test.a, test.b, test.expected), func(t *testing.T) {
+			assert.Equal(t, test.expected, test.a.NumMatches(test.b))
+		})
+	}
 }

--- a/channels/set.go
+++ b/channels/set.go
@@ -152,10 +152,14 @@ func (s Set) UpdateWithSlice(slice []ID) Set {
 	return s
 }
 
-// Contains returns true if the set includes the channel.
-func (s Set) Contains(ch ID) bool {
-	_, exists := s[ch]
-	return exists
+// Contains returns true if the set includes any of the given channels.
+func (s Set) Contains(ch ...ID) bool {
+	for _, c := range ch {
+		if _, exists := s[c]; exists {
+			return true
+		}
+	}
+	return false
 }
 
 // Convert to String(), necessary for logging.

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -274,19 +274,25 @@ func TestSetContains(t *testing.T) {
 	testCases := []struct {
 		name     string
 		inputSet Set
-		inputID  ID
+		input    []ID
 		contains bool
 	}{
 		{
+			name:     "empty,nilID",
+			inputSet: Set{},
+			input:    nil,
+			contains: false,
+		},
+		{
 			name:     "empty,emptyID",
 			inputSet: Set{},
-			inputID:  ID{},
+			input:    []ID{{}},
 			contains: false,
 		},
 		{
 			name:     "inputSetempty,realID",
 			inputSet: Set{},
-			inputID:  NewID("A", 1),
+			input:    []ID{NewID("A", 1)},
 			contains: false,
 		},
 		{
@@ -296,7 +302,7 @@ func TestSetContains(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			inputID:  ID{},
+			input:    []ID{{}},
 			contains: false,
 		},
 		{
@@ -306,23 +312,43 @@ func TestSetContains(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			inputID:  NewID("A", 1),
+			input:    []ID{NewID("A", 1)},
 			contains: true,
 		},
 		{
-			name: "somedatanotpresent",
+			name: "somedataabsent",
 			inputSet: Set{
 				NewID("A", 1): present{},
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			inputID:  NewID("D", 1),
+			input:    []ID{NewID("D", 1)},
+			contains: false,
+		},
+		{
+			name: "variadicpresent",
+			inputSet: Set{
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
+			},
+			input:    []ID{NewID("A", 3), NewID("C", 1)},
+			contains: true,
+		},
+		{
+			name: "variadicabsent",
+			inputSet: Set{
+				NewID("A", 1): present{},
+				NewID("B", 2): present{},
+				NewID("C", 1): present{},
+			},
+			input:    []ID{NewID("A", 2), NewID("Z", 1)},
 			contains: false,
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.contains, test.inputSet.Contains(test.inputID))
+			require.Equal(t, test.contains, test.inputSet.Contains(test.input...))
 		})
 	}
 }

--- a/db/blip.go
+++ b/db/blip.go
@@ -73,7 +73,7 @@ func defaultBlipLogger(ctx context.Context) blip.LogFn {
 }
 
 // blipRevMessageProperties returns a set of BLIP message properties for the given parameters.
-func blipRevMessageProperties(revisionHistory []string, deleted bool, seq SequenceID) blip.Properties {
+func blipRevMessageProperties(revisionHistory []string, deleted bool, seq SequenceID, replacedRevID string) blip.Properties {
 	properties := make(blip.Properties)
 
 	// TODO: Assert? db.SequenceID.MarshalJSON can never error
@@ -86,6 +86,10 @@ func blipRevMessageProperties(revisionHistory []string, deleted bool, seq Sequen
 
 	if deleted {
 		properties[RevMessageDeleted] = "1"
+	}
+
+	if replacedRevID != "" {
+		properties[RevMessageReplacedRev] = replacedRevID
 	}
 
 	return properties

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -36,6 +36,8 @@ type blipSyncCollectionContext struct {
 
 	// if we encounter a situation where a requested revision is not available, should we try sending an alternative as a replacement revision?
 	sendReplacementRevs bool
+	// set if the client has requested a filtered set of channels
+	channels base.Set
 }
 
 // blipCollections is a container for all collections blip is aware of.

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -34,6 +34,8 @@ type blipSyncCollectionContext struct {
 	sgr2PushAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...SequenceID)           // sgr2PushAlreadyKnownSeqsCallback is called to mark the sequence as being immediately processed
 	emptyChangesMessageCallback      func()                                         // emptyChangesMessageCallback is called when an empty changes message is received
 
+	// if we encounter a situation where a requested revision is not available, should we try sending an alternative as a replacement revision?
+	sendReplacementRevs bool
 }
 
 // blipCollections is a container for all collections blip is aware of.

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -34,7 +34,7 @@ type blipSyncCollectionContext struct {
 	sgr2PushAlreadyKnownSeqsCallback func(alreadyKnownSeqs ...SequenceID)           // sgr2PushAlreadyKnownSeqsCallback is called to mark the sequence as being immediately processed
 	emptyChangesMessageCallback      func()                                         // emptyChangesMessageCallback is called when an empty changes message is received
 
-	// if we encounter a situation where a requested revision is not available, should we try sending an alternative as a replacement revision?
+	// when a requested revision is not available, whether we should send the active revision as a replacement revision (depending on access)
 	sendReplacementRevs bool
 	// set if the client has requested a filtered set of channels
 	channels base.Set

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -300,11 +300,12 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 			return base.HTTPErrorf(http.StatusBadRequest, "%s", err)
 		} else if len(channels) == 0 {
 			return base.HTTPErrorf(http.StatusBadRequest, "Empty channel list")
-
 		}
 	} else if filter != "" {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unknown filter; try sync_gateway/bychannel")
 	}
+
+	collectionCtx.channels = channels
 
 	clientType := clientTypeCBL2
 	if rq.Properties["client_sgr2"] == trueProperty {
@@ -353,7 +354,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 			continuous:        continuous,
 			activeOnly:        subChangesParams.activeOnly(),
 			batchSize:         subChangesParams.batchSize(),
-			channels:          channels,
+			channels:          collectionCtx.channels,
 			revocations:       subChangesParams.revocations(),
 			clientType:        clientType,
 			ignoreNoConflicts: clientType == clientTypeSGR2, // force this side to accept a "changes" message, even in no conflicts mode for SGR2.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -326,7 +326,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		}
 	}
 
-	bh.sendReplacementRevs = subChangesParams.sendReplacementRevs()
+	bh.collectionCtx.sendReplacementRevs = subChangesParams.sendReplacementRevs()
 
 	// Start asynchronous changes goroutine
 	go func() {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -326,6 +326,8 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		}
 	}
 
+	bh.sendReplacementRevs = subChangesParams.sendReplacementRevs()
+
 	// Start asynchronous changes goroutine
 	go func() {
 		// Pull replication stats by type
@@ -859,7 +861,7 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID str
 
 	if redactedRev != nil {
 		history := toHistory(redactedRev.History, knownRevs, maxHistory)
-		properties := blipRevMessageProperties(history, redactedRev.Deleted, seq)
+		properties := blipRevMessageProperties(history, redactedRev.Deleted, seq, "")
 		return bsc.sendRevisionWithProperties(sender, docID, revID, collectionIdx, redactedRev.BodyBytes, nil, properties, seq, nil)
 	}
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -619,12 +619,12 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 	// set if we find an alternative revision to send in the event the originally requested rev is unavailable
 	var replacedRevID string
 
-	collectionCtx, collectionErr := bsc.collections.get(collectionIdx)
-	if collectionErr != nil {
-		return collectionErr
-	}
-
 	if base.IsDocNotFoundError(originalErr) {
+		collectionCtx, collectionErr := bsc.collections.get(collectionIdx)
+		if collectionErr != nil {
+			return collectionErr
+		}
+
 		if !collectionCtx.sendReplacementRevs {
 			base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Sending norev %q %s due to unavailable revision: %v", base.UD(docID), revID, originalErr)
 			return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, originalErr)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -641,7 +641,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 
 		// if this is a filtered replication, ensure the replacement rev is in one of the filtered channels
 		// normal channel access checks are already applied in GetRev above
-		if collectionCtx.channels != nil && replacementRev.Channels.NumMatches(collectionCtx.channels) == 0 {
+		if !replacementRev.Channels.HasMatch(collectionCtx.channels) {
 			base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Sending norev %q %s due to filtered channels (%s) excluding active revision channels (%s)", base.UD(docID), revID, base.UD(collectionCtx.channels), base.UD(replacementRev.Channels))
 			return bsc.sendNoRev(sender, docID, revID, collectionIdx, seq, originalErr)
 		}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -690,11 +690,11 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 	history := toHistory(rev.History, knownRevs, maxHistory)
 	properties := blipRevMessageProperties(history, rev.Deleted, seq, replacedRevID)
 	if base.LogDebugEnabled(bsc.loggingCtx, base.KeySync) {
-		originalRevMsg := ""
+		replacedRevMsg := ""
 		if replacedRevID != "" {
-			originalRevMsg = fmt.Sprintf(" (replaced %s)", replacedRevID)
+			replacedRevMsg = fmt.Sprintf(" (replaced %s)", replacedRevID)
 		}
-		base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Sending rev %q %s%s based on %d known, digests: %v", base.UD(docID), revID, originalRevMsg, len(knownRevs), digests(attachmentStorageMeta))
+		base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Sending rev %q %s%s based on %d known, digests: %v", base.UD(docID), revID, replacedRevMsg, len(knownRevs), digests(attachmentStorageMeta))
 	}
 
 	return bsc.sendRevisionWithProperties(sender, docID, revID, collectionIdx, bodyBytes, attachmentStorageMeta, properties, seq, nil)

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -79,14 +79,16 @@ const (
 	RevMessageHistory     = "history"
 	RevMessageNoConflicts = "noconflicts"
 	RevMessageDeltaSrc    = "deltaSrc"
+	RevMessageReplacedRev = "replacedRev"
 
 	// norev message properties
-	NorevMessageId       = "id"
-	NorevMessageRev      = "rev"
-	NorevMessageSeq      = "seq" // Use when protocol version 2 with client type ISGR
-	NorevMessageSequence = "sequence"
-	NorevMessageError    = "error"
-	NorevMessageReason   = "reason"
+	NorevMessageId          = "id"
+	NorevMessageRev         = "rev"
+	NorevMessageSeq         = "seq" // Use when protocol version 2 with client type ISGR
+	NorevMessageSequence    = "sequence"
+	NorevMessageError       = "error"
+	NorevMessageReason      = "reason"
+	NorevMessageReplacedRev = "replacedRev"
 
 	// getRev (Connected Client) message properties
 	GetRevMessageId = "id"
@@ -487,6 +489,10 @@ func (nrm *noRevMessage) SetId(id string) {
 
 func (nrm *noRevMessage) SetRev(rev string) {
 	nrm.Properties[NorevMessageRev] = rev
+}
+
+func (nrm *noRevMessage) SetReplacedRev(replacedRev string) {
+	nrm.Properties[NorevMessageReplacedRev] = replacedRev
 }
 
 func (nrm *noRevMessage) SetSeq(seq SequenceID) {

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -82,13 +82,12 @@ const (
 	RevMessageReplacedRev = "replacedRev"
 
 	// norev message properties
-	NorevMessageId          = "id"
-	NorevMessageRev         = "rev"
-	NorevMessageSeq         = "seq" // Use when protocol version 2 with client type ISGR
-	NorevMessageSequence    = "sequence"
-	NorevMessageError       = "error"
-	NorevMessageReason      = "reason"
-	NorevMessageReplacedRev = "replacedRev"
+	NorevMessageId       = "id"
+	NorevMessageRev      = "rev"
+	NorevMessageSeq      = "seq" // Use when protocol version 2 with client type ISGR
+	NorevMessageSequence = "sequence"
+	NorevMessageError    = "error"
+	NorevMessageReason   = "reason"
 
 	// getRev (Connected Client) message properties
 	GetRevMessageId = "id"
@@ -489,10 +488,6 @@ func (nrm *noRevMessage) SetId(id string) {
 
 func (nrm *noRevMessage) SetRev(rev string) {
 	nrm.Properties[NorevMessageRev] = rev
-}
-
-func (nrm *noRevMessage) SetReplacedRev(replacedRev string) {
-	nrm.Properties[NorevMessageReplacedRev] = replacedRev
 }
 
 func (nrm *noRevMessage) SetSeq(seq SequenceID) {

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -60,15 +60,16 @@ const (
 	GetCheckpointClient      = "client"
 
 	// subChanges message properties
-	SubChangesActiveOnly  = "activeOnly"
-	SubChangesFilter      = "filter"
-	SubChangesChannels    = "channels"
-	SubChangesSince       = "since"
-	SubChangesContinuous  = "continuous"
-	SubChangesBatch       = "batch"
-	SubChangesRevocations = "revocations"
-	SubChangesRequestPlus = "requestPlus"
-	SubChangesFuture      = "future"
+	SubChangesActiveOnly          = "activeOnly"
+	SubChangesFilter              = "filter"
+	SubChangesChannels            = "channels"
+	SubChangesSince               = "since"
+	SubChangesContinuous          = "continuous"
+	SubChangesBatch               = "batch"
+	SubChangesRevocations         = "revocations"
+	SubChangesRequestPlus         = "requestPlus"
+	SubChangesFuture              = "future"
+	SubChangesSendReplacementRevs = "sendReplacementRevs"
 
 	// rev message properties
 	RevMessageID          = "id"
@@ -141,9 +142,10 @@ type LatestSequenceFunc func() (SequenceID, error)
 
 // SubChangesParams is a helper for handling BLIP subChanges requests.  Supports Stringer() interface to log aspects of the request.
 type SubChangesParams struct {
-	rq      *blip.Message // The underlying BLIP message
-	_since  SequenceID    // Since value on the incoming request
-	_docIDs []string      // Document ID filter specified on the incoming request
+	rq                   *blip.Message // The underlying BLIP message
+	_since               SequenceID    // Since value on the incoming request
+	_docIDs              []string      // Document ID filter specified on the incoming request
+	_sendReplacementRevs bool          // Whether to send a replacement rev in the event that we do not find the requested one.
 }
 
 type SubChangesBody struct {
@@ -180,6 +182,8 @@ func NewSubChangesParams(logCtx context.Context, rq *blip.Message, zeroSeq Seque
 	}
 	params._docIDs = docIDs
 
+	params._sendReplacementRevs = rq.Properties[SubChangesSendReplacementRevs] == trueProperty
+
 	return params, nil
 }
 
@@ -189,6 +193,10 @@ func (s *SubChangesParams) Since() SequenceID {
 
 func (s *SubChangesParams) docIDs() []string {
 	return s._docIDs
+}
+
+func (s *SubChangesParams) sendReplacementRevs() bool {
+	return s._sendReplacementRevs
 }
 
 func readDocIDsFromRequest(rq *blip.Message) (docIDs []string, err error) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1869,6 +1869,98 @@ func TestMissingNoRev(t *testing.T) {
 
 }
 
+// TestSendReplacementRevision ensures that an alternative revision is sent instead of a norev when a client opts for replacement revs.
+// Create doc with rev 1-..., make the client request changes, and then update the document underneath the client's changes request to force a norev, with 2-... being sent as an optional replacement
+func TestSendReplacementRevision(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeyCRUD, base.KeySync, base.KeySyncMsg)
+
+	tests := []struct {
+		clientSendReplacementRevs bool
+		expectedMessageProfile    string
+	}{
+		{
+			clientSendReplacementRevs: true,
+			expectedMessageProfile:    db.MessageRev,
+		},
+		{
+			clientSendReplacementRevs: false,
+			expectedMessageProfile:    db.MessageNoRev,
+		},
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		for _, test := range tests {
+			testName := fmt.Sprintf("clientSendReplacementRevs:%v", test.clientSendReplacementRevs)
+			t.Run(testName, func(t *testing.T) {
+				rt := NewRestTester(t,
+					&RestTesterConfig{
+						GuestEnabled: true,
+					})
+				defer rt.Close()
+
+				docID := testName
+				version1 := rt.PutDoc(docID, `{"foo":"bar"}`)
+				updatedVersion := make(chan DocVersion)
+
+				// underneath the client's response to changes - we'll update the document so the requested rev is not available by the time SG receives the changes response.
+				changesEntryCallbackFn := func(changeEntryDocID, changeEntryRevID string) {
+					if changeEntryDocID == docID && changeEntryRevID == version1.RevID {
+						updatedVersion <- rt.UpdateDoc(docID, version1, `{"foo":"buzz"}`)
+
+						// also purge revision backup and flush cache to ensure request for rev 1-... cannot be fulfilled
+						err := rt.GetSingleTestDatabaseCollection().PurgeOldRevisionJSON(base.TestCtx(t), docID, version1.RevID)
+						require.NoError(t, err)
+						rt.GetSingleTestDatabaseCollection().FlushRevisionCacheForTest()
+					}
+				}
+
+				opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, sendReplacementRevs: test.clientSendReplacementRevs, changesEntryCallback: changesEntryCallbackFn}
+				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+				defer btc.Close()
+
+				// one shot or else we'll carry on to send rev 2-... normally, and we can't assert correctly on the final state of the client
+				err := btcRunner.StartOneshotPull(btc.id)
+				require.NoError(t, err)
+
+				// block until we've written the update and got the new version to use in assertions
+				version2 := <-updatedVersion
+
+				if test.clientSendReplacementRevs {
+					// replacement rev was sent instead
+					_ = btcRunner.SingleCollection(btc.id).WaitForVersion(docID, version2)
+
+					// rev message with a replacedRev property referring to the originally requested rev
+					msg2, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version2.RevID)
+					require.True(t, ok)
+					assert.Equal(t, test.expectedMessageProfile, msg2.Profile())
+					assert.Equal(t, version2.RevID, msg2.Properties[db.RevMessageRev])
+					assert.Equal(t, version1.RevID, msg2.Properties[db.RevMessageReplacedRev])
+
+					// the blip test framework records a message entry for the originally requested rev as well, but it should point to the message sent for rev 2
+					// this is an artifact of the test framework to make assertions for tests not explicitly testing replacement revs easier
+					msg1, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version1.RevID)
+					require.True(t, ok)
+					assert.Equal(t, msg1, msg2)
+				} else {
+					// Make sure requested revision (or any alternative) did not get replicated
+					data := btcRunner.SingleCollection(btc.id).WaitForVersion(docID, version1)
+					assert.Nil(t, data)
+
+					// no message for rev 2
+					_, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version2.RevID)
+					require.False(t, ok)
+
+					// norev message for the requested rev
+					msg, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version1.RevID)
+					require.True(t, ok)
+					assert.Equal(t, test.expectedMessageProfile, msg.Profile())
+				}
+			})
+		}
+	})
+}
+
 // TestBlipPullRevMessageHistory tests that a simple pull replication contains history in the rev message.
 func TestBlipPullRevMessageHistory(t *testing.T) {
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -476,7 +476,6 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 		docID := msg.Properties[db.NorevMessageId]
 		revID := msg.Properties[db.NorevMessageRev]
-		replacedRev := msg.Properties[db.NorevMessageReplacedRev]
 
 		btcr.docsLock.Lock()
 		defer btcr.docsLock.Unlock()
@@ -484,15 +483,9 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		if _, ok := btcr.docs[docID]; ok {
 			bodyMessagePair := &BodyMessagePair{message: msg}
 			btcr.docs[docID][revID] = bodyMessagePair
-			if replacedRev != "" {
-				btcr.docs[docID][replacedRev] = bodyMessagePair
-			}
 		} else {
 			bodyMessagePair := &BodyMessagePair{message: msg}
 			btcr.docs[docID] = map[string]*BodyMessagePair{revID: bodyMessagePair}
-			if replacedRev != "" {
-				btcr.docs[docID][replacedRev] = bodyMessagePair
-			}
 		}
 	}
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -44,6 +44,9 @@ type BlipTesterClientOpts struct {
 
 	// optional Origin header
 	origin *string
+
+	// sendReplacementRevs opts into the replacement rev behaviour in the event that we do not find the requested one.
+	sendReplacementRevs bool
 }
 
 // BlipTesterClient is a fully fledged client to emulate CBL behaviour on both push and pull replications through methods on this type.
@@ -746,6 +749,10 @@ func (btc *BlipTesterCollectionClient) StartPullSince(continuous, since, activeO
 
 	if btc.parent.BlipTesterClientOpts.SendRevocations {
 		subChangesRequest.Properties[db.SubChangesRevocations] = "true"
+	}
+
+	if btc.parent.BlipTesterClientOpts.sendReplacementRevs {
+		subChangesRequest.Properties[db.SubChangesSendReplacementRevs] = "true"
 	}
 
 	if err := btc.sendPullMsg(subChangesRequest); err != nil {

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -42,6 +42,9 @@ type BlipTesterClientOpts struct {
 	// a deltaSrc rev ID for which to reject a delta
 	rejectDeltasForSrcRev string
 
+	// changesEntryCallback is a callback function invoked for each changes entry being received (pull)
+	changesEntryCallback func(docID, revID string)
+
 	// optional Origin header
 	origin *string
 
@@ -172,6 +175,10 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 			for i, changesReq := range changesReqs {
 				docID := changesReq[1].(string)
 				revID := changesReq[2].(string)
+
+				if btc.changesEntryCallback != nil {
+					btc.changesEntryCallback(docID, revID)
+				}
 
 				deletedInt := 0
 				if len(changesReq) > 3 {


### PR DESCRIPTION
CBG-3157

Add opt-in replacement revs feature.
- In the event a requested revision is not sent, and a client has opted into this feature, we'll fetch the active revision of the document and send that instead.
- Access checks for the replacement rev are performed by `GetRev`
- Channel fitlers are checked to ensure the replacement rev is in the set of currently replicated channels

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2460/