### PR TITLE
Skip test in CE

### DIFF
--- a/rest/importtest/import_partition_test.go
+++ b/rest/importtest/import_partition_test.go
@@ -22,6 +22,9 @@ func TestImportPartitionsOnConcurrentStart(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
+	if !base.IsEnterpriseEdition() {
+		t.Skip("This test only works against EE")
+	}
 	// Start multiple rest testers concurrently
 	numNodes := 4
 	numImportPartitions := uint16(16)


### PR DESCRIPTION
This test will panic calling `PartitionCount` if running in CE.