### PR TITLE
CBG-3920 Use IsDocNotFoundError in purgeWithDCPFeed

### DIFF
--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -264,7 +264,7 @@ func purgeWithDCPFeed(ctx context.Context, dataStore sgbucket.DataStore, tbp *ba
 		} else {
 			purgeErr = dataStore.Delete(key)
 		}
-		if base.IsKeyNotFoundError(dataStore, purgeErr) {
+		if base.IsDocNotFoundError(purgeErr) {
 			// If key no longer exists, need to add and remove to trigger removal from view
 			_, addErr := dataStore.Add(key, 0, purgeBody)
 			if addErr != nil {


### PR DESCRIPTION
DCP feed can include documents in different states than the query-based purge, needs to use IsDocNotFoundError to cover all flavours of not found.

CBG-3920

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2420/
