### PR TITLE
Test fix: Enable auto import for TestImportRollback

### DIFF
--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2318,6 +2318,9 @@ func TestImportRollback(t *testing.T) {
 			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 				CustomTestBucket: bucket.NoCloseClone(),
 				PersistentConfig: false,
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					AutoImport: true,
+				}},
 			})
 
 			key := "importRollbackTest"
@@ -2370,6 +2373,9 @@ func TestImportRollback(t *testing.T) {
 			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				CustomTestBucket: bucket.NoCloseClone(),
 				PersistentConfig: false,
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					AutoImport: true,
+				}},
 			})
 			defer rt2.Close()
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2300,6 +2300,10 @@ func TestImportFilterTimeout(t *testing.T) {
 
 func TestImportRollback(t *testing.T) {
 
+	if !base.IsEnterpriseEdition() {
+		t.Skip("This test only works against EE")
+	}
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server - needs cbgt and import checkpointing")
 	}

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2322,9 +2322,6 @@ func TestImportRollback(t *testing.T) {
 			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 				CustomTestBucket: bucket.NoCloseClone(),
 				PersistentConfig: false,
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					AutoImport: true,
-				}},
 			})
 
 			key := "importRollbackTest"
@@ -2377,9 +2374,6 @@ func TestImportRollback(t *testing.T) {
 			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				CustomTestBucket: bucket.NoCloseClone(),
 				PersistentConfig: false,
-				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-					AutoImport: true,
-				}},
 			})
 			defer rt2.Close()
 


### PR DESCRIPTION
Fixes `TestImportRollback`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2424/
