### PR TITLE
CBG-3921 use IsDocNotFoundError everywhere

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -320,20 +320,10 @@ func GetBucket(ctx context.Context, spec BucketSpec) (bucket Bucket, err error) 
 // If the given key is not found in the bucket, this function returns a result of zero.
 func GetCounter(datastore DataStore, k string) (result uint64, err error) {
 	_, err = datastore.Get(k, &result)
-	if datastore.IsError(err, sgbucket.KeyNotFoundError) {
+	if IsDocNotFoundError(err) {
 		return 0, nil
 	}
 	return result, err
-}
-
-func IsKeyNotFoundError(datastore DataStore, err error) bool {
-
-	if err == nil {
-		return false
-	}
-
-	unwrappedErr := pkgerrors.Cause(err)
-	return datastore.IsError(unwrappedErr, sgbucket.KeyNotFoundError)
 }
 
 func IsCasMismatch(err error) bool {

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2275,7 +2275,7 @@ func TestGetExpiry(t *testing.T) {
 	// ensure expiry retrieval on non-existent doc returns key not found
 	_, nonExistentExpiryErr := dataStore.GetExpiry(ctx, "nonExistentKey")
 	assert.Error(t, nonExistentExpiryErr)
-	assert.True(t, IsKeyNotFoundError(dataStore, nonExistentExpiryErr))
+	RequireDocNotFoundError(t, nonExistentExpiryErr)
 }
 
 func TestGetStatsVbSeqNo(t *testing.T) {

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -532,8 +532,8 @@ func TestKeyNotFound(t *testing.T) {
 	ds := bucket.GetSingleDataStore()
 	var body []byte
 	_, getErr := ds.Get("nonexistentKey", &body)
-	require.True(t, IsKeyNotFoundError(ds, getErr))
+	RequireDocNotFoundError(t, getErr)
 
 	_, _, getRawErr := ds.GetRaw("nonexistentKey")
-	require.True(t, IsKeyNotFoundError(ds, getRawErr))
+	RequireDocNotFoundError(t, getRawErr)
 }

--- a/base/collection.go
+++ b/base/collection.go
@@ -363,18 +363,6 @@ func (b *GocbV2Bucket) getConfigSnapshot() (*gocbcore.ConfigSnapshot, error) {
 	return config, nil
 }
 
-func (b *GocbV2Bucket) IsError(err error, errorType sgbucket.DataStoreErrorType) bool {
-	if err == nil {
-		return false
-	}
-	switch errorType {
-	case sgbucket.KeyNotFoundError:
-		return errors.Is(err, gocb.ErrDocumentNotFound)
-	default:
-		return false
-	}
-}
-
 func (b *GocbV2Bucket) GetSpec() BucketSpec {
 	return b.Spec
 }

--- a/base/collection_gocb.go
+++ b/base/collection_gocb.go
@@ -459,10 +459,6 @@ func (c *Collection) Exists(k string) (exists bool, err error) {
 	return res.Exists(), nil
 }
 
-func (c *Collection) IsError(err error, errorType sgbucket.DataStoreErrorType) bool {
-	return c.Bucket.IsError(err, errorType)
-}
-
 // SGJsonTranscoder reads and writes JSON, with relaxed datatype restrictions on decode, and
 // embedded support for writing raw JSON on encode
 type SGJSONTranscoder struct {

--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -374,7 +374,7 @@ func InitSyncInfo(ds DataStore, metadataID string) (requiresResync bool, err err
 
 	var syncInfo SyncInfo
 	_, fetchErr := ds.Get(SGSyncInfo, &syncInfo)
-	if IsKeyNotFoundError(ds, fetchErr) {
+	if IsDocNotFoundError(fetchErr) {
 		if metadataID == "" {
 			return false, nil
 		}

--- a/base/dcp_client_metadata.go
+++ b/base/dcp_client_metadata.go
@@ -245,7 +245,7 @@ func (m *DCPMetadataCS) load(ctx context.Context, workerID int) {
 	var meta WorkerMetadata
 	_, err := m.dataStore.Get(m.getMetadataKey(workerID), &meta)
 	if err != nil {
-		if IsKeyNotFoundError(m.dataStore, err) {
+		if IsDocNotFoundError(err) {
 			return
 		}
 		InfofCtx(ctx, KeyDCP, "Error loading persisted metadata - metadata will be reset for worker %d: %s", workerID, err)
@@ -260,7 +260,7 @@ func (m *DCPMetadataCS) load(ctx context.Context, workerID int) {
 func (m *DCPMetadataCS) Purge(ctx context.Context, numWorkers int) {
 	for i := 0; i < numWorkers; i++ {
 		err := m.dataStore.Delete(m.getMetadataKey(i))
-		if err != nil && !IsKeyNotFoundError(m.dataStore, err) {
+		if err != nil && !IsDocNotFoundError(err) {
 			InfofCtx(ctx, KeyDCP, "Unable to remove DCP checkpoint for key %s: %v", m.getMetadataKey(i), err)
 		}
 	}

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -189,7 +189,7 @@ func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStar
 	rawValue, _, err := c.metaStore.GetRaw(fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo))
 	if err != nil {
 		// On a key not found error, metadata hasn't been persisted for this vbucket
-		if IsKeyNotFoundError(c.metaStore, err) {
+		if IsDocNotFoundError(err) {
 			return []byte{}, 0, 0, nil
 		} else {
 			return []byte{}, 0, 0, err

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -284,7 +284,7 @@ func (h *couchbaseHeartBeater) checkStaleHeartbeats(ctx context.Context) error {
 		_, _, err := h.datastore.GetRaw(timeoutDocID)
 		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
 		if err != nil {
-			if !IsKeyNotFoundError(h.datastore, err) {
+			if !IsDocNotFoundError(err) {
 				// unexpected error
 				return err
 			}
@@ -316,7 +316,7 @@ func (h *couchbaseHeartBeater) sendHeartbeat() error {
 	}
 
 	// On KeyNotFound, recreate heartbeat timeout doc
-	if IsKeyNotFoundError(h.datastore, touchErr) {
+	if IsDocNotFoundError(touchErr) {
 		heartbeatDocBody := []byte(h.nodeUUID)
 		setErr := h.datastore.SetRaw(docID, h.heartbeatExpirySeconds, nil, heartbeatDocBody)
 		SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Add(1)
@@ -473,7 +473,7 @@ func (dh *documentBackedListener) loadNodeIDs() error {
 	if err != nil {
 		dh.cas = 0
 		dh.nodeIDs = []string{}
-		if !IsKeyNotFoundError(dh.datastore, err) {
+		if !IsDocNotFoundError(err) {
 			return err
 		}
 	}

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -71,10 +71,6 @@ func (b *LeakyBucket) GetMaxVbno() (uint16, error) {
 	return b.bucket.GetMaxVbno()
 }
 
-func (b *LeakyBucket) IsError(err error, errorType sgbucket.DataStoreErrorType) bool {
-	return b.bucket.IsError(err, errorType)
-}
-
 func (b *LeakyBucket) DefaultDataStore() sgbucket.DataStore {
 	return NewLeakyDataStore(b, b.bucket.DefaultDataStore(), b.config)
 }

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -326,10 +326,6 @@ func (lds *LeakyDataStore) SetUpdateCallback(callback func(key string)) {
 	lds.config.UpdateCallback = callback
 }
 
-func (lds *LeakyDataStore) IsError(err error, errorType sgbucket.DataStoreErrorType) bool {
-	return lds.dataStore.IsError(err, errorType)
-}
-
 func (lds *LeakyDataStore) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 	return lds.dataStore.IsSupported(feature)
 }

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -75,7 +75,7 @@ func (c *CfgSG) Get(cfgKey string, cas uint64) (
 	bucketKey := c.sgCfgBucketKey(cfgKey)
 	var value []byte
 	casOut, err := c.datastore.Get(bucketKey, &value)
-	if err != nil && !IsKeyNotFoundError(c.datastore, err) {
+	if err != nil && !IsDocNotFoundError(err) {
 		InfofCtx(c.loggingCtx, KeyCluster, "cfg_sg: Get, key: %s, cas: %d, err: %v", cfgKey, cas, err)
 		return nil, 0, err
 	}
@@ -116,7 +116,7 @@ func (c *CfgSG) Del(cfgKey string, cas uint64) error {
 	_, err := c.datastore.Remove(bucketKey, cas)
 	if IsCasMismatch(err) {
 		return ErrCfgCasError
-	} else if err != nil && !IsKeyNotFoundError(c.datastore, err) {
+	} else if err != nil && !IsDocNotFoundError(err) {
 		return err
 	}
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -516,7 +516,7 @@ func (c *Checkpointer) getLocalCheckpoint() (checkpoint *replicationCheckpoint, 
 
 	checkpointBytes, err := getSpecialBytes(c.collectionDataStore, DocTypeLocal, CheckpointDocIDPrefix+c.clientID, c.localDocExpirySecs)
 	if err != nil {
-		if !base.IsKeyNotFoundError(c.collectionDataStore, err) {
+		if !base.IsDocNotFoundError(err) {
 			return &replicationCheckpoint{}, err
 		}
 		base.DebugfCtx(c.ctx, base.KeyReplicate, "couldn't find existing local checkpoint for client %q", c.clientID)

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -389,7 +389,7 @@ func (arc *activeReplicatorCommon) startStatusReporter() error {
 func getLocalStatusDoc(ctx context.Context, metadataStore base.DataStore, statusKey string) (*ReplicationStatusDoc, error) {
 	statusDocBytes, err := getWithTouch(metadataStore, statusKey, 0)
 	if err != nil {
-		if !base.IsKeyNotFoundError(metadataStore, err) {
+		if !base.IsDocNotFoundError(err) {
 			return nil, err
 		}
 		base.DebugfCtx(ctx, base.KeyReplicate, "couldn't find existing local checkpoint for ID %q", statusKey)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1266,7 +1266,7 @@ func (bh *blipHandler) handleProveAttachment(rq *blip.Message) error {
 		if bh.clientType == BLIPClientTypeSGR2 {
 			return ErrAttachmentNotFound
 		}
-		if base.IsKeyNotFoundError(bh.collection.dataStore, err) {
+		if base.IsDocNotFoundError(err) {
 			return ErrAttachmentNotFound
 		}
 		return base.HTTPErrorf(http.StatusInternalServerError, fmt.Sprintf("Error getting client attachment: %v", err))

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -410,7 +410,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	// Ensure previous revision body backup has been removed
 	_, _, err = db.MetadataStore.GetRaw(base.RevBodyPrefix + "4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
-	assert.True(t, base.IsKeyNotFoundError(collection.dataStore, err), "Revision should be not found")
+	base.RequireDocNotFoundError(t, err)
 
 	// Validate the tombstone is stored inline (due to small size)
 	revTree, err = getRevTreeList(ctx, collection.dataStore, "doc1", db.UseXattrs())
@@ -644,7 +644,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Ensure previous tombstone body backup has been removed
 	log.Printf("Verify revision body doc has been removed from bucket")
 	_, _, err = collection.dataStore.GetRaw(base.SyncDocPrefix + "rb:ULDLuEgDoKFJeET2hojeFANXM8SrHdVfAGONki+kPxM=")
-	assert.True(t, base.IsKeyNotFoundError(collection.dataStore, err), "Revision should be not found")
+	base.RequireDocNotFoundError(t, err)
 
 }
 

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -750,7 +750,7 @@ func removeObsoleteDesignDocs(ctx context.Context, viewStore sgbucket.ViewStore,
 	return removedDesignDocs, nil
 }
 
-// Similar to IsKeyNotFoundError(), but for the specific error returned by GetDDoc/DeleteDDoc
+// Similar to IsDocNotFoundError(), but for the specific error returned by GetDDoc/DeleteDDoc
 func IsMissingDDocError(err error) bool {
 	if err == nil {
 		return false

--- a/db/revision.go
+++ b/db/revision.go
@@ -316,7 +316,7 @@ func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, do
 func (db *DatabaseCollectionWithUser) refreshPreviousRevisionBackup(ctx context.Context, docid string, revid string, body []byte, expiry uint32) error {
 
 	_, err := db.dataStore.Touch(oldRevisionKey(docid, revid), expiry)
-	if base.IsKeyNotFoundError(db.dataStore, err) && len(body) > 0 {
+	if base.IsDocNotFoundError(err) && len(body) > 0 {
 		return db.setOldRevisionJSON(ctx, docid, revid, body, expiry)
 	}
 	return err

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -344,7 +344,7 @@ FROM ` + base.KeyspaceQueryToken + ` AS ks USE INDEX (sg_allDocs_x1)`
 		} else {
 			purgeErr = dataStore.Delete(row.Id)
 		}
-		if base.IsKeyNotFoundError(dataStore, purgeErr) {
+		if base.IsDocNotFoundError(purgeErr) {
 			// If key no longer exists, need to add and remove to trigger removal from view
 			_, addErr := dataStore.Add(row.Id, 0, purgeBody)
 			if addErr != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.4.1
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c
+	github.com/couchbase/sg-bucket v0.0.0-20240515192422-65113dc10339
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389
+	github.com/couchbaselabs/rosmar v0.0.0-20240515192921-54683dca426b
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.4
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.4.1
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20240515192422-65113dc10339
+	github.com/couchbase/sg-bucket v0.0.0-20240516142514-d65d1f2192a1
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20240515192921-54683dca426b
+	github.com/couchbaselabs/rosmar v0.0.0-20240516145123-749ae63effda
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.4
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9B
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
 github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c h1:ftZeu97TaEWxBAINW2AaGNk3Icyg+/6XHs7OHnR23qQ=
 github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
+github.com/couchbase/sg-bucket v0.0.0-20240515192422-65113dc10339 h1:19edcUy6ESglvcYHO6CpDgHLTH8xYbXN62HB7hT1edQ=
+github.com/couchbase/sg-bucket v0.0.0-20240515192422-65113dc10339/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=
@@ -76,6 +78,8 @@ github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131 h1:2E
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
 github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389 h1:feX52yzl6wrIXt6gqmcOKzpHOdigwnzJ5TP15M9i3Ow=
 github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
+github.com/couchbaselabs/rosmar v0.0.0-20240515192921-54683dca426b h1:NchKMFWgHE8BYybNJ3pAQ+Zt0oenVaXF6ESHCBlhvEE=
+github.com/couchbaselabs/rosmar v0.0.0-20240515192921-54683dca426b/go.mod h1:2LVm2GopDeIhVuI723AGo4MhxZmvRXUj+9yTlavYsug=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -54,10 +54,8 @@ github.com/couchbase/goprotostellar v1.0.2 h1:yoPbAL9sCtcyZ5e/DcU5PRMOEFaJrF9awX
 github.com/couchbase/goprotostellar v1.0.2/go.mod h1:5/yqVnZlW2/NSbAWu1hPJCFBEwjxgpe0PFFOlRixnp4=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c h1:ftZeu97TaEWxBAINW2AaGNk3Icyg+/6XHs7OHnR23qQ=
-github.com/couchbase/sg-bucket v0.0.0-20240514135815-5f5e7aa8625c/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
-github.com/couchbase/sg-bucket v0.0.0-20240515192422-65113dc10339 h1:19edcUy6ESglvcYHO6CpDgHLTH8xYbXN62HB7hT1edQ=
-github.com/couchbase/sg-bucket v0.0.0-20240515192422-65113dc10339/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
+github.com/couchbase/sg-bucket v0.0.0-20240516142514-d65d1f2192a1 h1:saVwgFjPGNvDf8rM88C/RFsgyg370P1DJOVCy2+lqUA=
+github.com/couchbase/sg-bucket v0.0.0-20240516142514-d65d1f2192a1/go.mod h1:IQisEdcLRfS/pjSgmqG/8gerVm0Q7GrvpQtMIZ7oYt4=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=
@@ -76,10 +74,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131 h1:2EAfFswAfgYn3a05DVcegiw6DgMgn1Mv5eGz6IHt1Cw=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389 h1:feX52yzl6wrIXt6gqmcOKzpHOdigwnzJ5TP15M9i3Ow=
-github.com/couchbaselabs/rosmar v0.0.0-20240417141520-4127f7d4c389/go.mod h1:SM0w4YHwXFMIyfqUbkpXZNWwAQKLwsUH91fsKUooMqw=
-github.com/couchbaselabs/rosmar v0.0.0-20240515192921-54683dca426b h1:NchKMFWgHE8BYybNJ3pAQ+Zt0oenVaXF6ESHCBlhvEE=
-github.com/couchbaselabs/rosmar v0.0.0-20240515192921-54683dca426b/go.mod h1:2LVm2GopDeIhVuI723AGo4MhxZmvRXUj+9yTlavYsug=
+github.com/couchbaselabs/rosmar v0.0.0-20240516145123-749ae63effda h1:mt5WbjJa54UWtuvuxEnqGpO6Zo7WE2gdzt4gt6AOqlo=
+github.com/couchbaselabs/rosmar v0.0.0-20240516145123-749ae63effda/go.mod h1:R/FMQ/bYhulyKzNxZ+LIR0h0KdNLB25WtrrD/Ar2q5o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -83,10 +83,8 @@ func requireVersion(rt *rest.RestTester, docID string, version rest.DocVersion) 
 }
 
 func requireErrorKeyNotFound(t *testing.T, rt *rest.RestTester, docID string) {
-	var body []byte
-	_, err := rt.Bucket().DefaultDataStore().Get(docID, &body)
-	require.Error(t, err)
-	require.True(t, base.IsKeyNotFoundError(rt.Bucket().DefaultDataStore(), err))
+	_, err := rt.Bucket().DefaultDataStore().Get(docID, nil)
+	base.RequireDocNotFoundError(t, err)
 }
 
 // waitForTombstone waits until the specified tombstone revision is available

--- a/xdcr/rosmar_xdcr.go
+++ b/xdcr/rosmar_xdcr.go
@@ -72,7 +72,7 @@ func (r *rosmarManager) processEvent(ctx context.Context, event sgbucket.FeedEve
 		}
 
 		toCas, err := col.Get(docID, nil)
-		if err != nil && !col.IsError(err, sgbucket.KeyNotFoundError) {
+		if err != nil && !base.IsDocNotFoundError(err) {
 			base.WarnfCtx(ctx, "Skipping replicating doc %s, could not perform a kv op get doc in toBucket: %s", event.Key, err)
 			r.errorCount.Add(1)
 			return false

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -85,7 +85,7 @@ func TestMobileXDCRNoSyncDataCopied(t *testing.T) {
 
 		var value any
 		_, err = toDs.Get(syncDoc, &value)
-		require.True(t, base.IsKeyNotFoundError(toDs, err))
+		base.RequireDocNotFoundError(t, err)
 
 		// stats are not updated in real time, so we need to wait a bit
 		require.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
- switch IsKeyNotFoundError and IsError(sgbucket.KeyNotFoundError)
- slightly modify the behavior of `IsDocNotFoundError` to account for errors that might be wrapped without being the lowest level error.

https://github.com/couchbase/sg-bucket/pull/126
https://github.com/couchbaselabs/rosmar/pull/35

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2430
