### PR TITLE
CBG-3850: Optimise releaseUnusedSequenceRange 

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -74,6 +74,9 @@ var (
 
 	// ErrReplicationLimitExceeded is returned when then replication connection threshold is exceeded
 	ErrReplicationLimitExceeded = &sgError{"Replication limit exceeded. Try again later."}
+
+	// ErrSequencesMissing is returned when attempting to remove a sequence range form the skipped sequence list and at least one sequence in that range is not present
+	ErrSequencesMissing = &sgError{"Sequence range has sequences that aren't present in skipped list"}
 )
 
 func (e *sgError) Error() string {

--- a/base/error.go
+++ b/base/error.go
@@ -75,8 +75,8 @@ var (
 	// ErrReplicationLimitExceeded is returned when then replication connection threshold is exceeded
 	ErrReplicationLimitExceeded = &sgError{"Replication limit exceeded. Try again later."}
 
-	// ErrSequencesMissing is returned when attempting to remove a sequence range form the skipped sequence list and at least one sequence in that range is not present
-	ErrSequencesMissing = &sgError{"Sequence range has sequences that aren't present in skipped list"}
+	// ErrSkippedSequencesMissing is returned when attempting to remove a sequence range form the skipped sequence list and at least one sequence in that range is not present
+	ErrSkippedSequencesMissing = &sgError{"Sequence range has sequences that aren't present in skipped list"}
 )
 
 func (e *sgError) Error() string {

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -17,17 +17,6 @@ import (
 	"time"
 )
 
-// LogEntry
-type LogEntryType uint8
-
-const (
-	LogEntryDocument = LogEntryType(iota)
-	LogEntryPrincipal
-	LogEntryCheckpoint
-	LogEntryRollback
-	LogEntryPurge
-)
-
 // Bits in LogEntry.Flags
 const (
 	Deleted  = 1 << iota // This rev is a deletion
@@ -40,30 +29,32 @@ const (
 )
 
 type LogEntry struct {
-	Sequence     uint64       // Sequence number
-	DocID        string       // Document ID
-	RevID        string       // Revision ID
-	Flags        uint8        // Deleted/Removed/Hidden flags
-	VbNo         uint16       // vbucket number
-	TimeSaved    time.Time    // Time doc revision was saved (just used for perf metrics)
-	TimeReceived time.Time    // Time received from tap feed
-	Channels     ChannelMap   // Channels this entry is in or was removed from
-	Skipped      bool         // Late arriving entry
-	Type         LogEntryType // Log entry type
-	Value        []byte       // Snapshot metadata (when Type=LogEntryCheckpoint)
-	PrevSequence uint64       // Sequence of previous active revision
-	IsPrincipal  bool         // Whether the log-entry is a tracking entry for a principal doc
-	CollectionID uint32       // Collection ID
+	Sequence      uint64               // Sequence number
+	DocID         string               // Document ID
+	RevID         string               // Revision ID
+	Flags         uint8                // Deleted/Removed/Hidden flags
+	TimeSaved     time.Time            // Time doc revision was saved (just used for perf metrics)
+	TimeReceived  time.Time            // Time received from tap feed
+	Channels      ChannelMap           // Channels this entry is in or was removed from
+	Skipped       bool                 // Late arriving entry
+	PrevSequence  uint64               // Sequence of previous active revision
+	IsPrincipal   bool                 // Whether the log-entry is a tracking entry for a principal doc
+	CollectionID  uint32               // Collection ID
+	SequenceRange *UnusedSequenceRange // Range of sequence that have been released by the sequence allocator
+}
+
+// UnusedSequenceRange will hold a range of sequences that have been released by the sequence allocator in log entry
+type UnusedSequenceRange struct {
+	StartSeq uint64
+	EndSeq   uint64
 }
 
 func (l LogEntry) String() string {
 	return fmt.Sprintf(
-		"seq: %d docid: %s revid: %s vbno: %d type: %v collectionID: %d",
+		"seq: %d docid: %s revid: %s collectionID: %d",
 		l.Sequence,
 		l.DocID,
 		l.RevID,
-		l.VbNo,
-		l.Type,
 		l.CollectionID,
 	)
 }

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -29,24 +29,18 @@ const (
 )
 
 type LogEntry struct {
-	Sequence      uint64               // Sequence number
-	DocID         string               // Document ID
-	RevID         string               // Revision ID
-	Flags         uint8                // Deleted/Removed/Hidden flags
-	TimeSaved     time.Time            // Time doc revision was saved (just used for perf metrics)
-	TimeReceived  time.Time            // Time received from tap feed
-	Channels      ChannelMap           // Channels this entry is in or was removed from
-	Skipped       bool                 // Late arriving entry
-	PrevSequence  uint64               // Sequence of previous active revision
-	IsPrincipal   bool                 // Whether the log-entry is a tracking entry for a principal doc
-	CollectionID  uint32               // Collection ID
-	SequenceRange *UnusedSequenceRange // Range of sequence that have been released by the sequence allocator
-}
-
-// UnusedSequenceRange will hold a range of sequences that have been released by the sequence allocator in log entry
-type UnusedSequenceRange struct {
-	StartSeq uint64
-	EndSeq   uint64
+	Sequence     uint64     // Sequence number
+	EndSequence  uint64     // End sequence on range of sequences that have been released by the sequence allocator (0 if entry is single sequence)
+	DocID        string     // Document ID
+	RevID        string     // Revision ID
+	Flags        uint8      // Deleted/Removed/Hidden flags
+	TimeSaved    time.Time  // Time doc revision was saved (just used for perf metrics)
+	TimeReceived time.Time  // Time received from tap feed
+	Channels     ChannelMap // Channels this entry is in or was removed from
+	Skipped      bool       // Late arriving entry
+	PrevSequence uint64     // Sequence of previous active revision
+	IsPrincipal  bool       // Whether the log-entry is a tracking entry for a principal doc
+	CollectionID uint32     // Collection ID
 }
 
 func (l LogEntry) String() string {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -608,19 +608,19 @@ func (c *changeCache) releaseUnusedSequenceRange(ctx context.Context, fromSequen
 
 	if toSequence < c.nextSequence {
 		// batch remove from skipped
-		err := c.RemoveSkippedSequences(ctx, fromSequence, toSequence-1)
+		err := c.RemoveSkippedSequences(ctx, fromSequence, toSequence)
 		if err != nil {
 			base.DebugfCtx(ctx, base.KeyCache, err.Error())
-		}
-		// we have sequences (possibly duplicate sequences) in the unused range that don't exist in skipped list
-		seqRange := &channels.UnusedSequenceRange{
-			StartSeq: fromSequence,
-			EndSeq:   toSequence,
-		}
-		// handle any potential duplicate sequences between the unused range and the skipped list
-		err = c.skippedSeqs._removeSubsetOfRangeFromSkipped(ctx, seqRange)
-		if err != nil {
-			base.DebugfCtx(ctx, base.KeyCache, "error processing subset of unused sequences in skipped list: %v", err)
+			// we have sequences (possibly duplicate sequences) in the unused range that don't exist in skipped list
+			seqRange := &channels.UnusedSequenceRange{
+				StartSeq: fromSequence,
+				EndSeq:   toSequence,
+			}
+			// handle any potential duplicate sequences between the unused range and the skipped list
+			err = c.skippedSeqs._removeSubsetOfRangeFromSkipped(ctx, seqRange)
+			if err != nil {
+				base.DebugfCtx(ctx, base.KeyCache, "error processing subset of unused sequences in skipped list: %v", err)
+			}
 		}
 	} else if fromSequence >= c.nextSequence {
 		// whole range to pending

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2798,7 +2798,6 @@ func TestReleasedSequenceRangeHandlingEdgeCase2(t *testing.T) {
 		assert.Equal(c, int64(1), dbContext.DbStats.CacheStats.SkippedSeqLen.Value())
 		assert.Equal(c, int64(19), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
-		assert.Equal(c, uint64(21), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
 		assert.Equal(c, int64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2321,7 +2321,7 @@ func TestReleasedSequenceRangeHandlingEverythingSkipped(t *testing.T) {
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
 		CachePendingSeqMaxWait: 5 * time.Millisecond,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
 		t.Fail()
@@ -2386,8 +2386,8 @@ func TestReleasedSequenceRangeHandlingEverythingPending(t *testing.T) {
 	ctx = dbContext.AddDatabaseLogContext(ctx)
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
-		CachePendingSeqMaxWait: 2 * time.Minute,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CachePendingSeqMaxWait: 20 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 		CachePendingSeqMaxNum:  5,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
@@ -2446,8 +2446,8 @@ func TestReleasedSequenceRangeHandlingEverythingPendingAndProcessPending(t *test
 	ctx = dbContext.AddDatabaseLogContext(ctx)
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
-		CachePendingSeqMaxWait: 2 * time.Minute,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CachePendingSeqMaxWait: 20 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 		CachePendingSeqMaxNum:  5,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
@@ -2513,8 +2513,8 @@ func TestReleasedSequenceRangeHandlingEverythingPendingLowPendingCapacity(t *tes
 	ctx = dbContext.AddDatabaseLogContext(ctx)
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
-		CachePendingSeqMaxWait: 2 * time.Minute,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CachePendingSeqMaxWait: 20 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 		CachePendingSeqMaxNum:  1,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
@@ -2613,8 +2613,8 @@ func TestReleasedSequenceRangeHandlingSingleSequence(t *testing.T) {
 	ctx = dbContext.AddDatabaseLogContext(ctx)
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
-		CachePendingSeqMaxWait: 2 * time.Minute,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CachePendingSeqMaxWait: 20 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 		CachePendingSeqMaxNum:  1,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
@@ -2697,8 +2697,8 @@ func TestReleasedSequenceRangeHandlingEdgeCase1(t *testing.T) {
 	ctx = dbContext.AddDatabaseLogContext(ctx)
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
-		CachePendingSeqMaxWait: 2 * time.Minute,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CachePendingSeqMaxWait: 20 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 		CachePendingSeqMaxNum:  1,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
@@ -2768,7 +2768,7 @@ func TestReleasedSequenceRangeHandlingEdgeCase2(t *testing.T) {
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
 		CachePendingSeqMaxWait: 100 * time.Millisecond,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 		CachePendingSeqMaxNum:  1,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
@@ -2839,8 +2839,8 @@ func TestReleasedSequenceRangeHandlingDuplicateSequencesInPending(t *testing.T) 
 	ctx = dbContext.AddDatabaseLogContext(ctx)
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
-		CachePendingSeqMaxWait: 2 * time.Minute,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CachePendingSeqMaxWait: 20 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 		CachePendingSeqMaxNum:  20,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
@@ -2925,8 +2925,8 @@ func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) 
 	ctx = dbContext.AddDatabaseLogContext(ctx)
 	testChangeCache := &changeCache{}
 	if err := testChangeCache.Init(ctx, dbContext, dbContext.channelCache, nil, &CacheOptions{
-		CachePendingSeqMaxWait: 2 * time.Minute,
-		CacheSkippedSeqMaxWait: 2 * time.Minute,
+		CachePendingSeqMaxWait: 20 * time.Minute,
+		CacheSkippedSeqMaxWait: 20 * time.Minute,
 		CachePendingSeqMaxNum:  0,
 	}, dbContext.MetadataKeys); err != nil {
 		log.Printf("Init failed for testChangeCache: %v", err)
@@ -2940,7 +2940,7 @@ func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) 
 	defer testChangeCache.Stop(ctx)
 	require.NoError(t, err)
 
-	// push two entries that will be pushed to pending and subsequently skipped
+	// push two entries that will be pushed to pending and subsequently skipped will be filled with sequence gaps
 	entry := &LogEntry{
 		Sequence:     14,
 		DocID:        fmt.Sprintf("doc_%d", 50),

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -226,13 +226,13 @@ func (s *SkippedSequenceSlice) _removeSeqRange(ctx context.Context, startSeq, en
 	// if startSeq and endSeq are in different elements there is at least one sequence between these values not in the list
 	if !found {
 		base.DebugfCtx(ctx, base.KeyCache, "sequence range %d to %d specified has sequences in that are not present in skipped list", startSeq, endSeq)
-		return base.ErrSequencesMissing
+		return base.ErrSkippedSequencesMissing
 	}
 	// put this below a check for !found to avoid out of bound error
 	rangeElem := s.list[startIndex]
 	if endSeq > rangeElem.getLastSeq() {
 		base.DebugfCtx(ctx, base.KeyCache, "sequence range %d to %d specified has sequences in that are not present in skipped list", startSeq, endSeq)
-		return base.ErrSequencesMissing
+		return base.ErrSkippedSequencesMissing
 	}
 
 	// handle sequence range removal
@@ -387,7 +387,7 @@ func (s *SkippedSequenceSlice) processUnusedSequenceRangeAtSkipped(ctx context.C
 
 	// batch remove from skipped
 	err := s._removeSeqRange(ctx, fromSequence, toSequence)
-	if err != nil && err == base.ErrSequencesMissing {
+	if err != nil && err == base.ErrSkippedSequencesMissing {
 		base.DebugfCtx(ctx, base.KeyCache, err.Error())
 		// we have sequences (possibly duplicate sequences) in the unused range that don't exist in skipped list
 		// handle any potential duplicate sequences between the unused range and the skipped list

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -218,6 +218,10 @@ func (s *SkippedSequenceSlice) removeSeqRange(startSeq, endSeq uint64) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	if len(s.list) == 0 {
+		return fmt.Errorf("skipped sequence list is empty, unable to remove sequence range %d to %d", startSeq, endSeq)
+	}
+
 	startIndex, found := s._findSequence(startSeq)
 	// if both sequence x and y aren't in the same element, the range contains sequences that are not present in
 	// skipped sequence list. This is due to any contiguous sequences in the list will be in the same element. So
@@ -259,6 +263,11 @@ func (s *SkippedSequenceSlice) removeSeqRange(startSeq, endSeq uint64) error {
 func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
+	if len(s.list) == 0 {
+		return fmt.Errorf("skipped sequence list is empty, unable to remove sequence %d", x)
+	}
+
 	index, found := s._findSequence(x)
 	if !found {
 		return fmt.Errorf("sequence %d not found in the skipped list", x)

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -432,9 +432,10 @@ func BenchmarkRemoveSeqFromSkippedList(b *testing.B) {
 }
 
 func BenchmarkRemoveSeqRangeFromSkippedList(b *testing.B) {
+	ctx := base.TestCtx(b)
 	skipedSlice := setupBenchmark(true, true, DefaultClipCapacityHeadroom)
 	for i := 0; i < b.N; i++ {
-		_ = skipedSlice._removeSeqRange(uint64(i*2), uint64(i*2)+5)
+		_ = skipedSlice._removeSeqRange(ctx, uint64(i*2), uint64(i*2)+5)
 	}
 }
 
@@ -810,6 +811,7 @@ func TestRemoveSequenceRange(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			skippedSlice := NewSkippedSequenceSlice(DefaultClipCapacityHeadroom)
+			ctx := base.TestCtx(t)
 			for _, input := range testCase.inputList {
 				if len(input) == 1 {
 					skippedSlice.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntry(input[0]))
@@ -818,7 +820,7 @@ func TestRemoveSequenceRange(t *testing.T) {
 				}
 			}
 
-			err := skippedSlice._removeSeqRange(testCase.rangeToRemove[0], testCase.rangeToRemove[1])
+			err := skippedSlice._removeSeqRange(ctx, testCase.rangeToRemove[0], testCase.rangeToRemove[1])
 			if testCase.errorCase {
 				require.Error(t, err)
 			} else {

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -434,7 +434,7 @@ func BenchmarkRemoveSeqFromSkippedList(b *testing.B) {
 func BenchmarkRemoveSeqRangeFromSkippedList(b *testing.B) {
 	skipedSlice := setupBenchmark(true, true, DefaultClipCapacityHeadroom)
 	for i := 0; i < b.N; i++ {
-		_ = skipedSlice.removeSeqRange(uint64(i*2), uint64(i*2)+5)
+		_ = skipedSlice._removeSeqRange(uint64(i*2), uint64(i*2)+5)
 	}
 }
 
@@ -713,7 +713,7 @@ func TestGetOldestSkippedSequence(t *testing.T) {
 // TestRemoveSequenceRange:
 //   - Setup skipped list
 //   - Remove the range specified in the test case
-//   - Assert on error returned from removeSeqRange depending on whether testcase is a error case
+//   - Assert on error returned from _removeSeqRange depending on whether testcase is a error case
 //   - Assert on expected resulting skipped list
 //   - Assert on number of skipped sequences in the list after removal
 func TestRemoveSequenceRange(t *testing.T) {
@@ -818,7 +818,7 @@ func TestRemoveSequenceRange(t *testing.T) {
 				}
 			}
 
-			err := skippedSlice.removeSeqRange(testCase.rangeToRemove[0], testCase.rangeToRemove[1])
+			err := skippedSlice._removeSeqRange(testCase.rangeToRemove[0], testCase.rangeToRemove[1])
 			if testCase.errorCase {
 				require.Error(t, err)
 			} else {

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -273,3 +273,139 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 	assert.Equal(t, 5, int(atomic.LoadUint32(&WinningRevChangedCount)))
 	assert.Equal(t, 6, int(atomic.LoadUint32(&DocumentChangedCount)))
 }
+
+// TestJumpInSequencesAtAllocatorSkippedSequenceFill:
+//   - High level test
+//   - Add a doc through Sync Gateway
+//   - Alter that allocated sequence to be higher value. Mocking this document arriving from different env
+//     (e.g. via XDCR)
+//   - Wait for this sequence to arrive over cache feed and wait for skipped sequences to subsequently fill
+//   - Update this doc again, triggering unused sequence range release
+//   - Write another doc and assert that the changes feed returns all expected docs
+func TestJumpInSequencesAtAllocatorSkippedSequenceFill(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport: false,
+			CacheConfig: &CacheConfig{
+				ChannelCacheConfig: &ChannelCacheConfig{
+					MaxWaitPending: base.Uint32Ptr(10),
+				},
+			},
+		}},
+	})
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+
+	vrs := rt.PutDoc("doc", `{"prop":true}`)
+
+	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes", "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	ds := rt.GetSingleDataStore()
+	xattrs, cas, err := ds.GetXattrs(ctx, "doc", []string{base.SyncXattrName})
+	require.NoError(t, err)
+
+	var retrievedXattr map[string]interface{}
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &retrievedXattr))
+	retrievedXattr["sequence"] = uint64(20)
+	newXattrVal := map[string][]byte{
+		base.SyncXattrName: base.MustJSONMarshal(t, retrievedXattr),
+	}
+
+	_, err = ds.UpdateXattrs(ctx, "doc", 0, cas, newXattrVal, nil)
+	require.NoError(t, err)
+
+	// wait for value to move from pending to cache and skipped list to fill
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rt.GetDatabase().UpdateCalculatedStats(ctx)
+		assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+	}, time.Second*10, time.Millisecond*100)
+
+	docVrs := rt.UpdateDoc("doc", vrs, `{"prob": "lol"}`)
+
+	// wait skipped list to be emptied by release of sequence range
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rt.GetDatabase().UpdateCalculatedStats(ctx)
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.PendingSeqLen.Value())
+		assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.SkippedSeqCap.Value())
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+	}, time.Second*10, time.Millisecond*100)
+
+	doc1Vrs := rt.PutDoc("doc1", `{"prop":true}`)
+
+	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+	changes.RequireDocIDs(t, []string{"doc1", "doc"})
+	changes.RequireRevID(t, []string{docVrs.RevID, doc1Vrs.RevID})
+}
+
+// TestJumpInSequencesAtAllocatorRangeInPending:
+//   - High level test
+//   - Add a doc through Sync Gateway
+//   - Alter that allocated sequence to be higher value. Mocking this document arriving from different env
+//     (e.g. via XDCR)
+//   - Wait for this sequence to arrive over cache feed and subsequently pushed to pending
+//   - Update this doc again, triggering unused sequence range release
+//   - Write another doc and assert that the changes feed returns all expected docs
+func TestJumpInSequencesAtAllocatorRangeInPending(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			AutoImport: false,
+			CacheConfig: &CacheConfig{
+				ChannelCacheConfig: &ChannelCacheConfig{
+					MaxWaitPending: base.Uint32Ptr(1500),
+				},
+			},
+		}},
+	})
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+
+	vrs := rt.PutDoc("doc", `{"prop":true}`)
+
+	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes", "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	ds := rt.GetSingleDataStore()
+	xattrs, cas, err := ds.GetXattrs(ctx, "doc", []string{base.SyncXattrName})
+	require.NoError(t, err)
+
+	var retrievedXattr map[string]interface{}
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &retrievedXattr))
+	retrievedXattr["sequence"] = uint64(20)
+	newXattrVal := map[string][]byte{
+		base.SyncXattrName: base.MustJSONMarshal(t, retrievedXattr),
+	}
+
+	_, err = ds.UpdateXattrs(ctx, "doc", 0, cas, newXattrVal, nil)
+	require.NoError(t, err)
+
+	// wait for value top be added to pending
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rt.GetDatabase().UpdateCalculatedStats(ctx)
+		assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.PendingSeqLen.Value())
+	}, time.Second*10, time.Millisecond*100)
+
+	docVrs := rt.UpdateDoc("doc", vrs, `{"prob": "lol"}`)
+
+	// assert that nothing has been pushed to skipped
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rt.GetDatabase().UpdateCalculatedStats(ctx)
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqCap.Value())
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+	}, time.Second*10, time.Millisecond*100)
+
+	doc1Vrs := rt.PutDoc("doc1", `{"prop":true}`)
+
+	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
+	require.NoError(t, err)
+	changes.RequireDocIDs(t, []string{"doc1", "doc"})
+	changes.RequireRevID(t, []string{docVrs.RevID, doc1Vrs.RevID})
+}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -781,6 +781,20 @@ func (cr ChangesResults) RequireDocIDs(t testing.TB, docIDs []string) {
 	}
 }
 
+func (cr ChangesResults) RequireRevID(t testing.TB, revIDs []string) {
+	require.Equal(t, len(revIDs), len(cr.Results))
+	for _, rev := range revIDs {
+		var found bool
+		for _, changeEntry := range cr.Results {
+			if changeEntry.Changes[0]["rev"] == rev {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "RevID %q missing from results %v", rev, cr.Results)
+	}
+}
+
 // RequireChangeRevVersion asserts that the given ChangeRev has the expected version for a given entry returned by _changes feed
 func RequireChangeRevVersion(t *testing.T, expected DocVersion, changeRev db.ChangeRev) {
 	RequireDocVersionEqual(t, expected, DocVersion{RevID: changeRev["rev"]})


### PR DESCRIPTION
CBG-3850

- Removed unused entries in log entry 
- Added sequence range element to log entry, only populated when entry is a sequence range
- releaseUnusedSequenceRange to handle sequence ranges in the way discussed in skipped sequence discussions 
- In addition to that refactor had to handle single range entries, to do this I have just run the sequence through processEntry and returned early
- _addPendingLogs has some extra handling in it for popping off pending a sequence range + disallowing the decrease of the next sequence expected at the cache
- PushSkipped has handling to disallow adding entries where startSeq > endSeq (I hit this in a few bug areas when testing) 
- Bunch of low level tests forcing cache in lots of different scenarios and calling releaseUnusedSequenceRange directly on certain ranges 
- removeSeqRange and removeSeq range needed checks for empty lists. I found during testing that if you call the binary search function on empty list, whist found is false it returns a non 0 index. This caused a index out of bound panic in few areas. 
- High level tests TestJumpInSequencesAtAllocatorSkippedSequenceFill + TestJumpInSequencesAtAllocatorRangeInPending which have some low level counter parts TestReleasedSequenceRangeHandlingEdgeCase1 + TestReleasedSequenceRangeHandlingEdgeCase2
- New functions _removeSubsetOfRangeFromSkipped + _pushRangeToPending to handle duplicate sequences between unused range and pending/skipped lists 

Doc for reviewers contains:
- Refresher on outcome of original meeting on this 
- Two scenarios I was stuck on for a while
- At bottom find the solution we went with to solve
https://docs.google.com/document/d/1SsQ2pjA_1nOZe-ZdvBpRzwJsY7ic0XnlQ_m2bMQ4jtc/edit?usp=sharing

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2459/
