### PR TITLE
CBG-3899 Write _mou on import, resync

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -137,6 +137,9 @@ const (
 	// SyncXattrName is used when storing sync data in a document's xattrs.
 	SyncXattrName = "_sync"
 
+	// MouXattrName is used when storing metadata-only update information in a document's xattrs.
+	MouXattrName = "_mou"
+
 	// Intended to be used in Meta Map and related tests
 	MetaMapXattrsKey = "xattrs"
 

--- a/base/util.go
+++ b/base/util.go
@@ -1004,6 +1004,10 @@ func HexCasToUint64(cas string) uint64 {
 	return binary.LittleEndian.Uint64(casBytes[0:8])
 }
 
+func CasToString(cas uint64) string {
+	return string(Uint64CASToLittleEndianHex(cas))
+}
+
 func Uint64CASToLittleEndianHex(cas uint64) []byte {
 	littleEndian := make([]byte, 8)
 	binary.LittleEndian.PutUint64(littleEndian, cas)

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -453,6 +454,11 @@ func TestResyncMou(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
 	defer db.Close(ctx)
+
+	if !db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
+		t.Skip("Test requires multi-xattr subdoc operations, CBS 7.6 or higher")
+	}
+
 	db.Options.QueryPaginationLimit = 100 // Required for principal ID query to not deadlock
 
 	initialImportCount := db.DbStats.SharedBucketImport().ImportCount.Value()

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -509,13 +509,13 @@ function sync(doc, oldDoc){
 	err = resyncMgr.Start(ctx, options)
 	require.NoError(t, err)
 
-	err = WaitForConditionWithOptions(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var status BackgroundManagerStatus
-		rawStatus, _ := resyncMgr.GetStatus(ctx)
-		_ = json.Unmarshal(rawStatus, &status)
-		return status.State == BackgroundProcessStateCompleted
-	}, 200, 200)
-	require.NoError(t, err)
+		rawStatus, err := resyncMgr.GetStatus(ctx)
+		assert.NoError(c, err)
+		assert.NoError(c, json.Unmarshal(rawStatus, &status))
+		assert.Equal(c, BackgroundProcessStateCompleted, status.State)
+	}, 40*time.Second, 200*time.Millisecond)
 
 	stats := getResyncStats(resyncMgr.Process)
 	assert.Equal(t, int64(2), stats.DocsChanged)

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -512,8 +512,6 @@ function sync(doc, oldDoc){
 	require.NoError(t, err)
 
 	stats := getResyncStats(resyncMgr.Process)
-	// If there are tombstones from older docs which have been deleted from the bucket, processed docs will
-	// be greater than DocsChanged
 	assert.Equal(t, int64(2), stats.DocsChanged)
 
 	syncData, mou, _ = getSyncAndMou(t, collection, "sgWrite")

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -388,7 +388,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// First unmarshal the doc (just its metadata, to save time/memory):
-	syncData, rawBody, _, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
+	syncData, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
@@ -401,6 +401,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// If using xattrs and this isn't an SG write, we shouldn't attempt to cache.
+	rawUserXattr := rawXattrs[collection.userXattrKey()]
 	if collection.UseXattrs() {
 		if syncData == nil {
 			return

--- a/db/crud.go
+++ b/db/crud.go
@@ -2030,7 +2030,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				docBytes = len(updatedDoc.Doc)
 			}
 			updatedDoc.Xattrs = map[string][]byte{base.SyncXattrName: rawSyncXattr}
-			if rawMouXattr != nil {
+			if rawMouXattr != nil && db.useMou() {
 				updatedDoc.Xattrs[base.MouXattrName] = rawMouXattr
 			}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -73,7 +73,7 @@ func (c *DatabaseCollection) GetDocumentWithRaw(ctx context.Context, docid strin
 		// If existing doc wasn't an SG Write, import the doc.
 		if !isSgWrite {
 			var importErr error
-			doc, importErr = c.OnDemandImportForGet(ctx, docid, rawBucketDoc.Body, rawBucketDoc.Xattrs[base.SyncXattrName], rawBucketDoc.Xattrs[c.userXattrKey()], rawBucketDoc.Cas)
+			doc, importErr = c.OnDemandImportForGet(ctx, docid, rawBucketDoc.Body, rawBucketDoc.Xattrs, rawBucketDoc.Cas)
 			if importErr != nil {
 				return nil, nil, importErr
 			}
@@ -123,7 +123,7 @@ func (c *DatabaseCollection) GetDocWithXattr(ctx context.Context, key string, un
 	}
 
 	var unmarshalErr error
-	doc, unmarshalErr = unmarshalDocumentWithXattr(ctx, key, rawBucketDoc.Body, rawBucketDoc.Xattrs[base.SyncXattrName], rawBucketDoc.Xattrs[c.userXattrKey()], rawBucketDoc.Cas, unmarshalLevel)
+	doc, unmarshalErr = c.unmarshalDocumentWithXattrs(ctx, key, rawBucketDoc.Body, rawBucketDoc.Xattrs, rawBucketDoc.Cas, unmarshalLevel)
 	if unmarshalErr != nil {
 		return nil, nil, unmarshalErr
 	}
@@ -148,11 +148,8 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 			return emptySyncData, getErr
 		}
 
-		rawXattr := xattrs[base.SyncXattrName]
-		rawUserXattr := xattrs[c.userXattrKey()]
-
 		// Unmarshal xattr only
-		doc, unmarshalErr := unmarshalDocumentWithXattr(ctx, docid, nil, rawXattr, rawUserXattr, cas, DocUnmarshalSync)
+		doc, unmarshalErr := c.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, DocUnmarshalSync)
 		if unmarshalErr != nil {
 			return emptySyncData, unmarshalErr
 		}
@@ -166,7 +163,7 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 		if !isSgWrite {
 			var importErr error
 
-			doc, importErr = c.OnDemandImportForGet(ctx, docid, rawDoc, rawXattr, rawUserXattr, cas)
+			doc, importErr = c.OnDemandImportForGet(ctx, docid, rawDoc, xattrs, cas)
 			if importErr != nil {
 				return emptySyncData, importErr
 			}
@@ -203,7 +200,7 @@ func (db *DatabaseCollection) GetDocSyncDataNoImport(ctx context.Context, docid 
 		xattrs, cas, err = db.dataStore.GetXattrs(ctx, docid, []string{base.SyncXattrName})
 		if err == nil {
 			var doc *Document
-			doc, err = unmarshalDocumentWithXattr(ctx, docid, nil, xattrs[base.SyncXattrName], nil, cas, level)
+			doc, err = db.unmarshalDocumentWithXattrs(ctx, docid, nil, xattrs, cas, level)
 			if err == nil {
 				syncData = doc.SyncData
 			}
@@ -237,12 +234,12 @@ func (db *DatabaseCollection) GetDocSyncDataNoImport(ctx context.Context, docid 
 
 // OnDemandImportForGet.  Attempts to import the doc based on the provided id, contents and cas.  ImportDocRaw does cas retry handling
 // if the document gets updated after the initial retrieval attempt that triggered this.
-func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, rawXattr []byte, rawUserXattr []byte, cas uint64) (docOut *Document, err error) {
+func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid string, rawDoc []byte, xattrs map[string][]byte, cas uint64) (docOut *Document, err error) {
 	isDelete := rawDoc == nil
 	importDb := DatabaseCollectionWithUser{DatabaseCollection: c, user: nil}
 	var importErr error
 
-	docOut, importErr = importDb.ImportDocRaw(ctx, docid, rawDoc, rawXattr, rawUserXattr, isDelete, cas, nil, ImportOnDemand)
+	docOut, importErr = importDb.ImportDocRaw(ctx, docid, rawDoc, xattrs, isDelete, cas, nil, ImportOnDemand)
 	if importErr == base.ErrImportCancelledFilter {
 		// If the import was cancelled due to filter, treat as not found
 		return nil, base.HTTPErrorf(404, "Not imported")
@@ -1550,6 +1547,7 @@ func (db *DatabaseCollectionWithUser) storeOldBodyInRevTreeAndUpdateCurrent(ctx 
 	// Store the new revision body into the doc:
 	doc.setRevisionBody(ctx, newRevID, newDoc, db.AllowExternalRevBodyStorage(), newDocHasAttachments)
 	doc.SyncData.Attachments = newDoc.DocAttachments
+	doc.metadataOnlyUpdate = newDoc.metadataOnlyUpdate
 
 	if doc.CurrentRev == newRevID {
 		doc.NewestRev = ""
@@ -1982,17 +1980,16 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		if expiry != nil {
 			initialExpiry = *expiry
 		}
-		casOut, err = db.dataStore.WriteUpdateWithXattrs(ctx, key, db.syncAndUserXattrKeys(), initialExpiry, existingDoc, opts, func(currentValue []byte, currentXattrs map[string][]byte, cas uint64) (updatedDoc sgbucket.UpdatedDoc, err error) {
+		casOut, err = db.dataStore.WriteUpdateWithXattrs(ctx, key, db.syncMouAndUserXattrKeys(), initialExpiry, existingDoc, opts, func(currentValue []byte, currentXattrs map[string][]byte, cas uint64) (updatedDoc sgbucket.UpdatedDoc, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
-			currentXattr := currentXattrs[base.SyncXattrName]
-			currentUserXattr := currentXattrs[db.userXattrKey()]
-			if doc, err = unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll); err != nil {
+			if doc, err = db.unmarshalDocumentWithXattrs(ctx, docid, currentValue, currentXattrs, cas, DocUnmarshalAll); err != nil {
 				return
 			}
 			prevCurrentRev = doc.CurrentRev
 
 			// Check whether Sync Data originated in body
-			if currentXattr == nil && doc.Sequence > 0 {
+			currentSyncXattr := currentXattrs[base.SyncXattrName]
+			if currentSyncXattr == nil && doc.Sequence > 0 {
 				doc.inlineSyncData = true
 			}
 
@@ -2020,21 +2017,27 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			updatedDoc.IsTombstone = currentRevFromHistory.Deleted
+			if doc.metadataOnlyUpdate != nil && doc.metadataOnlyUpdate.CAS != "" {
+				updatedDoc.Spec = append(updatedDoc.Spec, sgbucket.NewMacroExpansionSpec(xattrMouCasPath(), sgbucket.MacroCas))
+			}
 
 			// Return the new raw document value for the bucket to store.
 			doc.SetCrc32cUserXattrHash()
-			var rawXattr, rawDocBody []byte
-			rawDocBody, rawXattr, err = doc.MarshalWithXattr()
+			var rawSyncXattr, rawMouXattr, rawDocBody []byte
+			rawDocBody, rawSyncXattr, rawMouXattr, err = doc.MarshalWithXattrs()
 			if !isImport {
 				updatedDoc.Doc = rawDocBody
 				docBytes = len(updatedDoc.Doc)
 			}
-			updatedDoc.Xattrs = map[string][]byte{base.SyncXattrName: rawXattr}
+			updatedDoc.Xattrs = map[string][]byte{base.SyncXattrName: rawSyncXattr}
+			if rawMouXattr != nil {
+				updatedDoc.Xattrs[base.MouXattrName] = rawMouXattr
+			}
 
 			// Warn when sync data is larger than a configured threshold
 			if db.unsupportedOptions() != nil && db.unsupportedOptions().WarningThresholds != nil {
 				if xattrBytesThreshold := db.unsupportedOptions().WarningThresholds.XattrSize; xattrBytesThreshold != nil {
-					xattrBytes = len(rawXattr)
+					xattrBytes = len(rawSyncXattr)
 					if uint32(xattrBytes) >= *xattrBytesThreshold {
 						db.dbStats().Database().WarnXattrSizeCount.Add(1)
 						base.WarnfCtx(ctx, "Doc id: %v sync metadata size: %d bytes exceeds %d bytes for sync metadata warning threshold", base.UD(doc.ID), xattrBytes, *xattrBytesThreshold)
@@ -2691,4 +2694,8 @@ func xattrCasPath(xattrKey string) string {
 
 func xattrCrc32cPath(xattrKey string) string {
 	return xattrKey + "." + xattrMacroValueCrc32c
+}
+
+func xattrMouCasPath() string {
+	return base.MouXattrName + "." + xattrMacroCas
 }

--- a/db/database.go
+++ b/db/database.go
@@ -1919,6 +1919,10 @@ func (context *DatabaseContext) UseViews() bool {
 	return context.Options.UseViews
 }
 
+func (context *DatabaseContext) UseMou() bool {
+	return context.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations)
+}
+
 // UseQueryBasedResyncManager returns if query bases resync manager should be used for Resync operation
 func (context *DatabaseContext) UseQueryBasedResyncManager() bool {
 	if context.Options.UnsupportedOptions != nil {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -263,7 +264,10 @@ func (c *DatabaseCollection) syncAndUserXattrKeys() []string {
 
 // syncMouAndUserXattrKeys returns the xattr keys for the user, mou and sync xattrs.
 func (c *DatabaseCollection) syncMouAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName, base.MouXattrName}
+	xattrKeys := []string{base.SyncXattrName}
+	if c.useMou() {
+		xattrKeys = append(xattrKeys, base.MouXattrName)
+	}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)
@@ -334,4 +338,8 @@ func (c *DatabaseCollection) UpdateSyncFun(ctx context.Context, syncFun string) 
 		err = nil
 	}
 	return
+}
+
+func (c *DatabaseCollection) useMou() bool {
+	return c.dbCtx.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations)
 }

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"time"
 
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -341,5 +340,5 @@ func (c *DatabaseCollection) UpdateSyncFun(ctx context.Context, syncFun string) 
 }
 
 func (c *DatabaseCollection) useMou() bool {
-	return c.dbCtx.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations)
+	return c.dbCtx.UseMou()
 }

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -261,6 +261,16 @@ func (c *DatabaseCollection) syncAndUserXattrKeys() []string {
 	return xattrKeys
 }
 
+// syncMouAndUserXattrKeys returns the xattr keys for the user, mou and sync xattrs.
+func (c *DatabaseCollection) syncMouAndUserXattrKeys() []string {
+	xattrKeys := []string{base.SyncXattrName, base.MouXattrName}
+	userXattrKey := c.userXattrKey()
+	if userXattrKey != "" {
+		xattrKeys = append(xattrKeys, userXattrKey)
+	}
+	return xattrKeys
+}
+
 // Returns the xattr key that will be accessible from the sync function. This is controlled at a database level.
 func (c *DatabaseCollection) userXattrKey() string {
 	return c.dbCtx.Options.UserXattrKey

--- a/db/document.go
+++ b/db/document.go
@@ -455,7 +455,6 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 
 	var body []byte
 	var xattrValues map[string][]byte
-	var mou *MetadataOnlyUpdate
 
 	// If xattr datatype flag is set, data includes both xattrs and document body.  Check for presence of sync xattr.
 	// Note that there could be a non-sync xattr present
@@ -479,8 +478,6 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 			err = base.JSONUnmarshal(rawSyncXattr, result)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", syncXattr, err)
-			}
-			if mou != nil {
 			}
 			return result, body, xattrValues, nil
 		}
@@ -1180,7 +1177,7 @@ func computeMetadataOnlyUpdate(currentCas uint64, currentMou *MetadataOnlyUpdate
 	var prevCas string
 	currentCasString := string(base.Uint64CASToLittleEndianHex(currentCas))
 	if currentMou != nil && currentCasString == currentMou.CAS {
-		prevCas = currentMou.CAS
+		prevCas = currentMou.PreviousCAS
 	} else {
 		prevCas = currentCasString
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -62,6 +62,11 @@ type ChannelSetEntry struct {
 	Compacted bool   `json:"compacted,omitempty"`
 }
 
+type MetadataOnlyUpdate struct {
+	CAS         string `json:"cas,omitempty"`
+	PreviousCAS string `json:"pCas,omitempty"`
+}
+
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
 type SyncData struct {
 	CurrentRev        string              `json:"rev"`
@@ -168,12 +173,13 @@ func (sd *SyncData) HashRedact(salt string) SyncData {
 // "_sync" property.
 // Document doesn't do any locking - document instances aren't intended to be shared across multiple goroutines.
 type Document struct {
-	SyncData            // Sync metadata
-	_body        Body   // Marshalled document body.  Unmarshalled lazily - should be accessed using Body()
-	_rawBody     []byte // Raw document body, as retrieved from the bucket.  Marshaled lazily - should be accessed using BodyBytes()
-	ID           string `json:"-"` // Doc id.  (We're already using a custom MarshalJSON for *document that's based on body, so the json:"-" probably isn't needed here)
-	Cas          uint64 // Document cas
-	rawUserXattr []byte // Raw user xattr as retrieved from the bucket
+	SyncData                               // Sync metadata
+	_body              Body                // Marshalled document body.  Unmarshalled lazily - should be accessed using Body()
+	_rawBody           []byte              // Raw document body, as retrieved from the bucket.  Marshaled lazily - should be accessed using BodyBytes()
+	ID                 string              `json:"-"` // Doc id.  (We're already using a custom MarshalJSON for *document that's based on body, so the json:"-" probably isn't needed here)
+	Cas                uint64              // Document cas
+	rawUserXattr       []byte              // Raw user xattr as retrieved from the bucket
+	metadataOnlyUpdate *MetadataOnlyUpdate // Contents of _mou xattr, marshalled/unmarshalled with document from xattrs
 
 	Deleted        bool
 	DocExpiry      uint32
@@ -389,19 +395,32 @@ func unmarshalDocument(docid string, data []byte) (*Document, error) {
 	return doc, nil
 }
 
-func unmarshalDocumentWithXattr(ctx context.Context, docid string, data []byte, xattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+// unmarshalDocumentWithXattrs populates individual xattrs on unmarshalDocumentWithXattrs from a provided xattrs map
+func (db *DatabaseCollection) unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, xattrs map[string][]byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+	return unmarshalDocumentWithXattrs(ctx, docid, data, xattrs[base.SyncXattrName], xattrs[base.MouXattrName], xattrs[db.userXattrKey()], cas, unmarshalLevel)
 
-	if xattrData == nil || len(xattrData) == 0 {
+}
+
+func unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, syncXattrData, mouXattrData, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+
+	if syncXattrData == nil || len(syncXattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
 	} else {
 		doc = NewDocument(docid)
-		err = doc.UnmarshalWithXattr(ctx, data, xattrData, unmarshalLevel)
+		err = doc.UnmarshalWithXattr(ctx, data, syncXattrData, unmarshalLevel)
 	}
 	if err != nil {
 		return nil, err
 	}
 
+	if len(mouXattrData) > 0 {
+		if err := base.JSONUnmarshal(mouXattrData, &doc.metadataOnlyUpdate); err != nil {
+			if err != nil {
+				base.WarnfCtx(ctx, "Failed to unmarshal mouXattr for key %v, will be ignored. Err: %v mou:%s", base.UD(docid), err, mouXattrData)
+			}
+		}
+	}
 	if len(userXattrData) > 0 {
 		doc.rawUserXattr = userXattrData
 	}
@@ -432,36 +451,38 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*SyncData, error)
 // Returns the raw body, in case it's needed for import.
 
 // TODO: Using a pool of unmarshal workers may help prevent memory spikes under load
-func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawSyncXattr []byte, rawUserXattr []byte, err error) {
+func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawXattrs map[string][]byte, err error) {
 
 	var body []byte
+	var xattrValues map[string][]byte
+	var mou *MetadataOnlyUpdate
 
 	// If xattr datatype flag is set, data includes both xattrs and document body.  Check for presence of sync xattr.
 	// Note that there could be a non-sync xattr present
 	if dataType&base.MemcachedDataTypeXattr != 0 {
-		var xattrs map[string][]byte
-		xattrKeys := []string{base.SyncXattrName}
+		xattrKeys := []string{base.SyncXattrName, base.MouXattrName}
 		if userXattrKey != "" {
 			xattrKeys = append(xattrKeys, userXattrKey)
 		}
-		body, xattrs, err = sgbucket.DecodeValueWithXattrs(xattrKeys, data)
+		body, xattrValues, err = sgbucket.DecodeValueWithXattrs(xattrKeys, data)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, err
 		}
-		rawSyncXattr = xattrs[base.SyncXattrName]
-		rawUserXattr = xattrs[userXattrKey]
 
+		rawSyncXattr, ok := xattrValues[base.SyncXattrName]
 		// If the sync xattr is present, use that to build SyncData
-		if len(rawSyncXattr) > 0 {
+		if ok && len(rawSyncXattr) > 0 {
 			result = &SyncData{}
 			if needHistory {
 				result.History = make(RevTree)
 			}
 			err = base.JSONUnmarshal(rawSyncXattr, result)
 			if err != nil {
-				return nil, nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", syncXattr, err)
+				return nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", syncXattr, err)
 			}
-			return result, body, rawSyncXattr, rawUserXattr, nil
+			if mou != nil {
+			}
+			return result, body, xattrValues, nil
 		}
 	} else {
 		// Xattr flag not set - data is just the document body
@@ -470,7 +491,7 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 
 	// Non-xattr data, or sync xattr not present.  Attempt to retrieve sync metadata from document body
 	result, err = UnmarshalDocumentSyncData(body, needHistory)
-	return result, body, nil, rawUserXattr, err
+	return result, body, xattrValues, err
 }
 
 func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {
@@ -485,7 +506,7 @@ func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, da
 	if err != nil {
 		return nil, err
 	}
-	return unmarshalDocumentWithXattr(ctx, docid, body, xattrs[base.SyncXattrName], xattrs[userXattrKey], cas, DocUnmarshalAll)
+	return unmarshalDocumentWithXattrs(ctx, docid, body, xattrs[base.SyncXattrName], xattrs[base.MouXattrName], xattrs[userXattrKey], cas, DocUnmarshalAll)
 }
 
 func (doc *SyncData) HasValidSyncData() bool {
@@ -1116,7 +1137,7 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 	return nil
 }
 
-func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
+func (doc *Document) MarshalWithXattrs() (data []byte, syncXattr []byte, mouXattr []byte, err error) {
 	// Grab the rawBody if it's already marshalled, otherwise unmarshal the body
 	if doc._rawBody != nil {
 		if !doc.IsDeleted() {
@@ -1133,16 +1154,40 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 			if !deleted {
 				data, err = base.JSONMarshal(body)
 				if err != nil {
-					return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc body with id: %s.  Error: %v", base.UD(doc.ID), err))
+					return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc body with id: %s.  Error: %v", base.UD(doc.ID), err))
 				}
 			}
 		}
 	}
 
-	xdata, err = base.JSONMarshal(doc.SyncData)
+	syncXattr, err = base.JSONMarshal(doc.SyncData)
 	if err != nil {
-		return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
+		return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
 	}
 
-	return data, xdata, nil
+	if doc.metadataOnlyUpdate != nil {
+		mouXattr, err = base.JSONMarshal(doc.metadataOnlyUpdate)
+		if err != nil {
+			return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc MouData with id: %s.  Error: %v", base.UD(doc.ID), err))
+		}
+	}
+
+	return data, syncXattr, mouXattr, nil
+}
+
+// computeMetadataOnlyUpdate computes a new metadataOnlyUpdate based on the existing document's CAS and metadataOnlyUpdate
+func computeMetadataOnlyUpdate(currentCas uint64, currentMou *MetadataOnlyUpdate) *MetadataOnlyUpdate {
+	var prevCas string
+	currentCasString := string(base.Uint64CASToLittleEndianHex(currentCas))
+	if currentMou != nil && currentCasString == currentMou.CAS {
+		prevCas = currentMou.CAS
+	} else {
+		prevCas = currentCasString
+	}
+
+	metadataOnlyUpdate := &MetadataOnlyUpdate{
+		CAS:         "macro", // when non-empty, this is replaced with cas macro expansion
+		PreviousCAS: prevCas,
+	}
+	return metadataOnlyUpdate
 }

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -136,7 +136,7 @@ func BenchmarkDocUnmarshal(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			ctx := base.TestCtx(b)
 			for i := 0; i < b.N; i++ {
-				_, _ = unmarshalDocumentWithXattr(ctx, "doc_1k", doc1k_body, doc1k_meta, nil, 1, bm.unmarshalLevel)
+				_, _ = unmarshalDocumentWithXattrs(ctx, "doc_1k", doc1k_body, doc1k_meta, nil, nil, 1, bm.unmarshalLevel)
 			}
 		})
 	}
@@ -301,17 +301,15 @@ func TestDCPDecodeValue(t *testing.T) {
 				require.Nil(t, xattrs)
 			}
 			// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
-			result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
+			result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
 			require.ErrorIs(t, err, test.expectedErr)
 			if test.expectedSyncXattr != nil {
 				require.NotNil(t, result)
+				require.Equal(t, test.expectedSyncXattr, rawXattrs[base.SyncXattrName])
 			} else {
 				require.Nil(t, result)
 			}
 			require.Equal(t, test.expectedBody, rawBody)
-			require.Equal(t, test.expectedSyncXattr, rawXattr)
-			require.Nil(t, rawUserXattr)
-
 		})
 	}
 }
@@ -328,12 +326,11 @@ func TestInvalidXattrStreamEmptyBody(t *testing.T) {
 	require.Empty(t, xattrs)
 
 	// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
-	result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
+	result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
 	require.Error(t, err) // unexpected end of JSON input
 	require.Nil(t, result)
 	require.Equal(t, emptyBody, rawBody)
-	require.Nil(t, rawXattr)
-	require.Nil(t, rawUserXattr)
+	require.Nil(t, rawXattrs[base.SyncXattrName])
 
 }
 

--- a/db/import.go
+++ b/db/import.go
@@ -32,7 +32,7 @@ const (
 )
 
 // Imports a document that was written by someone other than sync gateway, given the existing state of the doc in raw bytes
-func (db *DatabaseCollectionWithUser) ImportDocRaw(ctx context.Context, docid string, value []byte, xattrValue []byte, userXattrValue []byte, isDelete bool, cas uint64, expiry *uint32, mode ImportMode) (docOut *Document, err error) {
+func (db *DatabaseCollectionWithUser) ImportDocRaw(ctx context.Context, docid string, value []byte, xattrs map[string][]byte, isDelete bool, cas uint64, expiry *uint32, mode ImportMode) (docOut *Document, err error) {
 
 	var body Body
 	if isDelete {
@@ -53,14 +53,9 @@ func (db *DatabaseCollectionWithUser) ImportDocRaw(ctx context.Context, docid st
 	}
 
 	existingBucketDoc := &sgbucket.BucketDocument{
-		Body: value,
-		Xattrs: map[string][]byte{
-			base.SyncXattrName: xattrValue,
-		},
-		Cas: cas,
-	}
-	if db.userXattrKey() != "" {
-		existingBucketDoc.Xattrs[db.userXattrKey()] = userXattrValue
+		Body:   value,
+		Xattrs: xattrs,
+		Cas:    cas,
 	}
 
 	return db.importDoc(ctx, docid, body, expiry, isDelete, existingBucketDoc, mode)
@@ -91,8 +86,11 @@ func (db *DatabaseCollectionWithUser) ImportDoc(ctx context.Context, docid strin
 	} else {
 		if existingDoc.Deleted {
 			existingBucketDoc.Xattrs[base.SyncXattrName], err = base.JSONMarshal(existingDoc.SyncData)
+			if err == nil && existingDoc.metadataOnlyUpdate != nil {
+				existingBucketDoc.Xattrs[base.MouXattrName], err = base.JSONMarshal(existingDoc.metadataOnlyUpdate)
+			}
 		} else {
-			existingBucketDoc.Body, existingBucketDoc.Xattrs[base.SyncXattrName], err = existingDoc.MarshalWithXattr()
+			existingBucketDoc.Body, existingBucketDoc.Xattrs[base.SyncXattrName], existingBucketDoc.Xattrs[base.MouXattrName], err = existingDoc.MarshalWithXattrs()
 		}
 	}
 
@@ -190,6 +188,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 			}
 		}
 
+		metadataOnlyUpdate := true
 		// If the existing doc is a legacy SG write (_sync in body), check for migrate instead of import.
 		_, ok := body[base.SyncPropertyName]
 		if ok || doc.inlineSyncData {
@@ -202,7 +201,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 				alreadyImportedDoc = migratedDoc
 				return nil, nil, false, updatedExpiry, base.ErrDocumentMigrated
 			}
-
+			metadataOnlyUpdate = false
 			// If document still requires import post-migration attempt, continue with import processing based on the body returned by migrate
 			doc = migratedDoc
 			body = migratedDoc.Body(ctx)
@@ -328,6 +327,11 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 			newDoc.DocAttachments = doc.SyncData.Attachments
 		}
 
+		// If this is a metadata-only update, set metadataOnlyUpdate based on old doc's cas and mou
+		if metadataOnlyUpdate {
+			newDoc.metadataOnlyUpdate = computeMetadataOnlyUpdate(doc.Cas, doc.metadataOnlyUpdate)
+		}
+
 		return newDoc, nil, !shouldGenerateNewRev, updatedExpiry, nil
 	})
 
@@ -388,14 +392,14 @@ func (db *DatabaseCollectionWithUser) migrateMetadata(ctx context.Context, docid
 	}
 
 	// Persist the document in xattr format
-	value, xattrValue, marshalErr := doc.MarshalWithXattr()
+	value, syncXattrValue, _, marshalErr := doc.MarshalWithXattrs()
 	if marshalErr != nil {
 		return nil, false, marshalErr
 	}
 
 	// Use WriteWithXattr to handle both normal migration and tombstone migration (xattr creation, body delete)
 	xattrs := map[string][]byte{
-		base.SyncXattrName: xattrValue,
+		base.SyncXattrName: syncXattrValue,
 	}
 	var casOut uint64
 	var writeErr error

--- a/db/import.go
+++ b/db/import.go
@@ -86,7 +86,7 @@ func (db *DatabaseCollectionWithUser) ImportDoc(ctx context.Context, docid strin
 	} else {
 		if existingDoc.Deleted {
 			existingBucketDoc.Xattrs[base.SyncXattrName], err = base.JSONMarshal(existingDoc.SyncData)
-			if err == nil && existingDoc.metadataOnlyUpdate != nil {
+			if err == nil && existingDoc.metadataOnlyUpdate != nil && db.useMou() {
 				existingBucketDoc.Xattrs[base.MouXattrName], err = base.JSONMarshal(existingDoc.metadataOnlyUpdate)
 			}
 		} else {
@@ -328,7 +328,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		}
 
 		// If this is a metadata-only update, set metadataOnlyUpdate based on old doc's cas and mou
-		if metadataOnlyUpdate {
+		if metadataOnlyUpdate && db.useMou() {
 			newDoc.metadataOnlyUpdate = computeMetadataOnlyUpdate(doc.Cas, doc.metadataOnlyUpdate)
 		}
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -63,16 +63,17 @@ func TestFeedImport(t *testing.T) {
 
 	// verify mou
 	xattrs, _, err = collection.dataStore.GetXattrs(ctx, key, []string{base.MouXattrName})
-	require.NoError(t, err)
-	mouXattr, mouOk := xattrs[base.MouXattrName]
 	if db.UseMou() {
 		var mou *MetadataOnlyUpdate
+		require.NoError(t, err)
+		mouXattr, mouOk := xattrs[base.MouXattrName]
 		require.True(t, mouOk)
 		require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
 		require.Equal(t, base.CasToString(writeCas), mou.PreviousCAS)
 		require.Equal(t, base.CasToString(importCas), mou.CAS)
 	} else {
-		require.False(t, mouOk)
+		// Expect not found fetching mou xattr
+		require.Error(t, err)
 	}
 }
 
@@ -133,16 +134,17 @@ func TestOnDemandImportMou(t *testing.T) {
 		// fetch the mou xattr directly doc to confirm import (to avoid triggering on-demand get import)
 		// verify mou
 		xattrs, importCas, err := collection.dataStore.GetXattrs(ctx, writeKey, []string{base.MouXattrName})
-		require.NoError(t, err)
-		mouXattr, mouOk := xattrs[base.MouXattrName]
 		if db.UseMou() {
+			require.NoError(t, err)
+			mouXattr, mouOk := xattrs[base.MouXattrName]
 			var mou *MetadataOnlyUpdate
 			require.True(t, mouOk)
 			require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
 			require.Equal(t, base.CasToString(writeCas), mou.PreviousCAS)
 			require.Equal(t, base.CasToString(importCas), mou.CAS)
 		} else {
-			require.False(t, mouOk)
+			// expect not found fetching mou xattr
+			require.Error(t, err)
 		}
 	})
 

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -410,11 +410,11 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	}
 	value := sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
-	assert.Equal(t, syncXattr, string(rawXattr))
+	assert.Equal(t, syncXattr, string(rawXattrs[base.SyncXattrName]))
 	assert.Equal(t, uint64(200), syncData.Sequence)
-	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Equal(t, channelName, string(rawXattrs[userXattrKey]))
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with just user xattr defined
@@ -423,21 +423,21 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	}
 	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Nil(t, syncData)
-	assert.Nil(t, rawXattr)
-	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Nil(t, rawXattrs[base.SyncXattrName])
+	assert.Equal(t, channelName, string(rawXattrs[userXattrKey]))
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with no xattr defined
 	xattrs = []sgbucket.Xattr{}
 	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Nil(t, syncData)
-	assert.Nil(t, rawXattr)
-	assert.Nil(t, rawUserXattr)
+	assert.Nil(t, rawXattrs[base.SyncXattrName])
+	assert.Nil(t, rawXattrs[userXattrKey])
 	assert.Equal(t, body, rawBody)
 }


### PR DESCRIPTION
Writes _mou on import and resync, populating cas and pCas.  If an imported or resync'd document already has _mou where doc.cas=_mou.cas, updates _mou.cas but preserves existing pCas.

Stores MetadataOnlyUpdate struct in document but not SyncData, to avoid unmarshalling work when mou isn't needed.

CBG-3899
## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` 7.6.1 https://jenkins.sgwdev.com/job/SyncGateway-Integration/2445/
- [x] `GSI=true,xattrs=true` 7.2.0 https://jenkins.sgwdev.com/job/SyncGateway-Integration/2452/
