### PR TITLE
CBG-3925: Add FileLogger RotationInterval

### DIFF
--- a/base/logger.go
+++ b/base/logger.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package base
 
 import (
-	"context"
 	"log"
 	"math"
 	"strings"
@@ -50,7 +49,7 @@ func FlushLogBuffers() {
 
 // logCollationWorker will take log lines over the given channel, and buffer them until either the buffer is full, or the flushTimeout is exceeded.
 // This is to reduce the number of writes to the log files, in order to batch them up as larger collated chunks, whilst maintaining a low-level of latency with the flush timeout.
-func logCollationWorker(_ context.Context, collateBuffer chan string, flushChan chan struct{}, collateBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
+func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, collateBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
 
 	// The initial duration of the timeout timer doesn't matter,
 	// because we reset it whenever we buffer a log without flushing it.

--- a/base/logger.go
+++ b/base/logger.go
@@ -50,7 +50,7 @@ func FlushLogBuffers() {
 
 // logCollationWorker will take log lines over the given channel, and buffer them until either the buffer is full, or the flushTimeout is exceeded.
 // This is to reduce the number of writes to the log files, in order to batch them up as larger collated chunks, whilst maintaining a low-level of latency with the flush timeout.
-func logCollationWorker(ctx context.Context, collateBuffer chan string, flushChan chan struct{}, collateBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
+func logCollationWorker(_ context.Context, collateBuffer chan string, flushChan chan struct{}, collateBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
 
 	// The initial duration of the timeout timer doesn't matter,
 	// because we reset it whenever we buffer a log without flushing it.
@@ -59,8 +59,6 @@ func logCollationWorker(ctx context.Context, collateBuffer chan string, flushCha
 
 	for {
 		select {
-		case <-ctx.Done():
-			return
 		case l := <-collateBuffer:
 			logBuffer = append(logBuffer, l)
 			collateBufferWg.Done()

--- a/base/logger.go
+++ b/base/logger.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package base
 
 import (
+	"context"
 	"log"
 	"math"
 	"strings"
@@ -49,7 +50,7 @@ func FlushLogBuffers() {
 
 // logCollationWorker will take log lines over the given channel, and buffer them until either the buffer is full, or the flushTimeout is exceeded.
 // This is to reduce the number of writes to the log files, in order to batch them up as larger collated chunks, whilst maintaining a low-level of latency with the flush timeout.
-func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, collateBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
+func logCollationWorker(ctx context.Context, collateBuffer chan string, flushChan chan struct{}, collateBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
 
 	// The initial duration of the timeout timer doesn't matter,
 	// because we reset it whenever we buffer a log without flushing it.
@@ -58,6 +59,8 @@ func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, coll
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case l := <-collateBuffer:
 			logBuffer = append(logBuffer, l)
 			collateBufferWg.Done()

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/natefinch/lumberjack"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // ConsoleLogger is a file logger with a default output of stderr, and tunable log level/keys.

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -197,7 +197,7 @@ func (lcc *ConsoleLoggerConfig) init() error {
 			Filename: filepath.FromSlash(lcc.FileOutput),
 			MaxSize:  *lcc.Rotation.MaxSize,
 			MaxAge:   *lcc.Rotation.MaxAge,
-			Compress: false,
+			Compress: BoolDefault(lcc.Rotation.Compress, false),
 		}
 	}
 

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -83,7 +83,7 @@ func NewConsoleLogger(ctx context.Context, shouldLogLocation bool, config *Conso
 		logger.collateBufferWg = &sync.WaitGroup{}
 
 		// Start up a single worker to consume messages from the buffer
-		go logCollationWorker(ctx, logger.collateBuffer, logger.flushChan, logger.collateBufferWg, logger.logger, *config.CollationBufferSize, consoleLoggerCollateFlushTimeout)
+		go logCollationWorker(logger.collateBuffer, logger.flushChan, logger.collateBufferWg, logger.logger, *config.CollationBufferSize, consoleLoggerCollateFlushTimeout)
 	}
 
 	// We can only log the console log location itself when logging has previously been set up and is being re-initialized from a config.

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -83,7 +83,7 @@ func NewConsoleLogger(ctx context.Context, shouldLogLocation bool, config *Conso
 		logger.collateBufferWg = &sync.WaitGroup{}
 
 		// Start up a single worker to consume messages from the buffer
-		go logCollationWorker(logger.collateBuffer, logger.flushChan, logger.collateBufferWg, logger.logger, *config.CollationBufferSize, consoleLoggerCollateFlushTimeout)
+		go logCollationWorker(ctx, logger.collateBuffer, logger.flushChan, logger.collateBufferWg, logger.logger, *config.CollationBufferSize, consoleLoggerCollateFlushTimeout)
 	}
 
 	// We can only log the console log location itself when logging has previously been set up and is being re-initialized from a config.

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -226,7 +226,7 @@ func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name stri
 		rotationTickerCh = rotationTicker.C
 	}
 
-	logDeletionTicker := time.NewTicker(defaultLogDeletionInterval)
+	logDeletionTicker := time.NewTicker(rotatedLogDeletionInterval)
 	go func() {
 		defer func() {
 			if panicked := recover(); panicked != nil {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -76,7 +76,7 @@ type logRotationConfig struct {
 	LocalTime            *bool           `json:"localtime,omitempty"`               // If true, it uses the computer's local time to format the backup timestamp.
 	RotatedLogsSizeLimit *int            `json:"rotated_logs_size_limit,omitempty"` // Max Size of log files before deletion
 	RotationInterval     *ConfigDuration `json:"rotation_interval,omitempty"`       // Interval at which logs are rotated
-	Compress             *bool           `json:"-"`                                 // Enable log compression
+	Compress             *bool           `json:"-"`                                 // Enable log compression - not exposed in config
 }
 
 // NewFileLogger returns a new FileLogger from a config.

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/natefinch/lumberjack"
 	"github.com/pkg/errors"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 var (

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -112,7 +112,7 @@ func NewFileLogger(ctx context.Context, config *FileLoggerConfig, level LogLevel
 		logger.collateBufferWg = &sync.WaitGroup{}
 
 		// Start up a single worker to consume messages from the buffer
-		go logCollationWorker(ctx, logger.collateBuffer, logger.flushChan, logger.collateBufferWg, logger.logger, *config.CollationBufferSize, fileLoggerCollateFlushTimeout)
+		go logCollationWorker(logger.collateBuffer, logger.flushChan, logger.collateBufferWg, logger.logger, *config.CollationBufferSize, fileLoggerCollateFlushTimeout)
 	}
 
 	return logger, nil

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -76,6 +76,7 @@ type logRotationConfig struct {
 	LocalTime            *bool           `json:"localtime,omitempty"`               // If true, it uses the computer's local time to format the backup timestamp.
 	RotatedLogsSizeLimit *int            `json:"rotated_logs_size_limit,omitempty"` // Max Size of log files before deletion
 	RotationInterval     *ConfigDuration `json:"rotation_interval,omitempty"`       // Interval at which logs are rotated
+	Compress             *bool           `json:"-"`                                 // Enable log compression
 }
 
 // NewFileLogger returns a new FileLogger from a config.
@@ -204,6 +205,7 @@ func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name stri
 			filepath.Join(filepath.FromSlash(logFilePath), logFilePrefix+name+".log"),
 			*lfc.Rotation.MaxSize,
 			*lfc.Rotation.MaxAge,
+			BoolDefault(lfc.Rotation.Compress, true),
 		)
 		lfc.Output = rotateableLogger
 	}
@@ -292,12 +294,12 @@ func (lfc *FileLoggerConfig) initRotationConfig(name string, defaultMaxSize, min
 	return nil
 }
 
-func newLumberjackOutput(filename string, maxSize, maxAge int) *lumberjack.Logger {
+func newLumberjackOutput(filename string, maxSize, maxAge int, compress bool) *lumberjack.Logger {
 	return &lumberjack.Logger{
 		Filename: filename,
 		MaxSize:  maxSize,
 		MaxAge:   maxAge,
-		Compress: true,
+		Compress: compress,
 	}
 }
 

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -205,16 +205,16 @@ func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name stri
 		lfc.CollationBufferSize = &bufferSize
 	}
 
-	ticker := time.NewTicker(time.Hour)
+	logDeletionTicker := time.NewTicker(defaultLogDeletionInterval)
 	go func() {
 		defer func() {
 			if panicked := recover(); panicked != nil {
-				WarnfCtx(ctx, "Panic when deleting rotated log files: \n %s", panicked, debug.Stack())
+				WarnfCtx(ctx, "Panic when deleting rotated log files: %s\n%s", panicked, debug.Stack())
 			}
 		}()
 		for {
 			select {
-			case <-ticker.C:
+			case <-logDeletionTicker.C:
 				err := runLogDeletion(ctx, logFilePath, level.String(), int(float64(*lfc.Rotation.RotatedLogsSizeLimit)*rotatedLogsLowWatermarkMultiplier), *lfc.Rotation.RotatedLogsSizeLimit)
 				if err != nil {
 					WarnfCtx(ctx, "%s", err)

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -233,7 +233,9 @@ func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name stri
 				WarnfCtx(ctx, "Panic when deleting rotated log files: %s\n%s", panicked, debug.Stack())
 			}
 		}()
-		defer rotationTicker.Stop()
+		if rotationTicker != nil {
+			defer rotationTicker.Stop()
+		}
 		defer logDeletionTicker.Stop()
 		for {
 			select {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -230,7 +230,7 @@ func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name stri
 	go func() {
 		defer func() {
 			if panicked := recover(); panicked != nil {
-				WarnfCtx(ctx, "Panic when deleting rotated log files: %s\n%s", panicked, debug.Stack())
+				WarnfCtx(ctx, "Panic when rotating or deleting rotated log files: %s\n%s", panicked, debug.Stack())
 			}
 		}()
 		if rotationTicker != nil {

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -38,7 +38,7 @@ const (
 	consoleLoggerCollateFlushTimeout = 1 * time.Millisecond
 	fileLoggerCollateFlushTimeout    = 10 * time.Millisecond
 
-	defaultLogDeletionInterval = time.Hour // not configurable
+	rotatedLogDeletionInterval = time.Hour // not configurable
 )
 
 // ErrUnsetLogFilePath is returned when no log_file_path, or --defaultLogFilePath fallback can be used.

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -37,6 +37,8 @@ const (
 	// we flush to the output if we don't fill the buffer.
 	consoleLoggerCollateFlushTimeout = 1 * time.Millisecond
 	fileLoggerCollateFlushTimeout    = 10 * time.Millisecond
+
+	defaultLogDeletionInterval = time.Hour // not configurable
 )
 
 // ErrUnsetLogFilePath is returned when no log_file_path, or --defaultLogFilePath fallback can be used.

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -60,6 +60,8 @@ func Benchmark_LoggingPerformance(b *testing.B) {
 }
 
 func TestLogRotationInterval(t *testing.T) {
+	LongRunningTest(t)
+
 	// override min rotation interval for testing
 	originalMinRotationInterval := minLogRotationInterval
 	minLogRotationInterval = time.Millisecond * 10
@@ -116,6 +118,10 @@ func TestLogRotationInterval(t *testing.T) {
 	countAfter2 := numFilesInDir(t, logPath, false)
 	t.Logf("countAfter2: %d", countAfter2)
 	assert.GreaterOrEqual(t, countAfter2, countAfterSleep)
+
+	// Wait for Lumberjack to finish its async log compression work
+	// we have no way of waiting for this to finish, or even stopping the millRun() process inside Lumberjack.
+	time.Sleep(time.Millisecond * 500)
 }
 
 // Benchmark the time it takes to write x bytes of data to a logger, and optionally rotate and compress it.

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -104,7 +104,7 @@ func TestLogRotationInterval(t *testing.T) {
 	require.NoError(t, fl.Close())
 
 	// we have to wait for lumberjack to finish its async log rotation work - we don't have a reliable way to do this.
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(time.Millisecond * 500)
 }
 
 // Benchmark the time it takes to write x bytes of data to a logger, and optionally rotate and compress it.

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -71,6 +71,7 @@ func TestLogRotationInterval(t *testing.T) {
 		CollationBufferSize: IntPtr(0),
 		Rotation: logRotationConfig{
 			RotationInterval: NewConfigDuration(rotationInterval),
+			Compress:         BoolPtr(false),
 		},
 	}
 

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/natefinch/lumberjack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func TestRedactedLogFuncs(t *testing.T) {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"math/rand"
 	"os"
@@ -934,4 +935,22 @@ func MustJSONMarshal(t testing.TB, v interface{}) []byte {
 	b, err := JSONMarshal(v)
 	require.NoError(t, err)
 	return b
+}
+
+// numFilesInDir counts the number of files in a given directory
+func numFilesInDir(t *testing.T, dir string, recursive bool) int {
+	numFiles := 0
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if d.Name() == filepath.Base(dir) {
+			// skip counting the root directory
+			return nil
+		}
+		if !recursive && d.IsDir() {
+			return fs.SkipDir
+		}
+		numFiles++
+		return nil
+	})
+	require.NoError(t, err)
+	return numFiles
 }

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2318,7 +2318,10 @@ Log-rotation-config-readonly:
       type: integer
       default: 1024
     rotation_interval:
-      description: If set, the interval at which log files are rotated, even if max_size is not reached.
+      description: |-
+        If set, the interval at which log files are rotated, even if max_size is not reached.
+
+        This is a duration and therefore can be provided with units "h", "m", "s", "ms", "us", and "ns". For example, 5 hours, 20 minutes, and 30 seconds would be `5h20m30s`.
       type: string
       default: 0
   readOnly: true

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2317,6 +2317,10 @@ Log-rotation-config-readonly:
       description: Max Size (in mb) of log files before deletion
       type: integer
       default: 1024
+    rotation_interval:
+      description: If set, the interval at which log files are rotated, even if max_size is not reached.
+      type: string
+      default: 0
   readOnly: true
   title: Log-rotation-config
 Console-logging-config:

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/json-iterator/go v1.1.12
 	github.com/kardianos/service v1.2.2
-	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.3.0
@@ -37,11 +36,11 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/net v0.25.0
 	golang.org/x/oauth2 v0.20.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/square/go-jose.v2 v2.6.0
 )
 
 require (
-	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/aws/aws-sdk-go v1.44.299 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -89,7 +88,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	nhooyr.io/websocket v1.8.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aov
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0 h1:u/LLAOFgsMv7HmNL4Qufg58y+qElGOt5qv0z1mURkRY=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0/go.mod h1:2e8rMJtl2+2j+HXbTBwnyGpm5Nou7KhvSfxOq8JpTag=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
-github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/aws/aws-sdk-go v1.44.299 h1:HVD9lU4CAFHGxleMJp95FV/sRhtg7P4miHD1v88JAQk=
 github.com/aws/aws-sdk-go v1.44.299/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -154,8 +152,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=
-github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -353,8 +349,6 @@ gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -72,6 +72,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.console.rotation.max_age":                 {&config.Logging.Console.Rotation.MaxAge, fs.Int("logging.console.rotation.max_age", 0, "")},
 		"logging.console.rotation.localtime":               {&config.Logging.Console.Rotation.LocalTime, fs.Bool("logging.console.rotation.localtime", false, "")},
 		"logging.console.rotation.rotated_logs_size_limit": {&config.Logging.Console.Rotation.RotatedLogsSizeLimit, fs.Int("logging.console.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.console.rotation.rotation_interval":       {&config.Logging.Console.Rotation.RotationInterval, fs.Duration("logging.console.rotation.rotation_interval", 0, "")},
 		"logging.console.collation_buffer_size":            {&config.Logging.Console.CollationBufferSize, fs.Int("logging.console.collation_buffer_size", 0, "")},
 		"logging.console.log_level":                        {&config.Logging.Console.LogLevel, fs.String("logging.console.log_level", "", "Options: none, error, warn, info, debug, trace")},
 		"logging.console.log_keys":                         {&config.Logging.Console.LogKeys, fs.String("logging.console.log_keys", "", "Comma separated log keys")},
@@ -83,6 +84,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.error.rotation.max_age":                 {&config.Logging.Error.Rotation.MaxAge, fs.Int("logging.error.rotation.max_age", 0, "")},
 		"logging.error.rotation.localtime":               {&config.Logging.Error.Rotation.LocalTime, fs.Bool("logging.error.rotation.localtime", false, "")},
 		"logging.error.rotation.rotated_logs_size_limit": {&config.Logging.Error.Rotation.RotatedLogsSizeLimit, fs.Int("logging.error.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.error.rotation.rotation_interval":       {&config.Logging.Error.Rotation.RotationInterval, fs.Duration("logging.error.rotation.rotation_interval", 0, "")},
 		"logging.error.collation_buffer_size":            {&config.Logging.Error.CollationBufferSize, fs.Int("logging.error.collation_buffer_size", 0, "")},
 
 		"logging.warn.enabled":                          {&config.Logging.Warn.Enabled, fs.Bool("logging.warn.enabled", false, "")},
@@ -90,6 +92,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.warn.rotation.max_age":                 {&config.Logging.Warn.Rotation.MaxAge, fs.Int("logging.warn.rotation.max_age", 0, "")},
 		"logging.warn.rotation.localtime":               {&config.Logging.Warn.Rotation.LocalTime, fs.Bool("logging.warn.rotation.localtime", false, "")},
 		"logging.warn.rotation.rotated_logs_size_limit": {&config.Logging.Warn.Rotation.RotatedLogsSizeLimit, fs.Int("logging.warn.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.warn.rotation.rotation_interval":       {&config.Logging.Warn.Rotation.RotationInterval, fs.Duration("logging.warn.rotation.rotation_interval", 0, "")},
 		"logging.warn.collation_buffer_size":            {&config.Logging.Warn.CollationBufferSize, fs.Int("logging.warn.collation_buffer_size", 0, "")},
 
 		"logging.info.enabled":                          {&config.Logging.Info.Enabled, fs.Bool("logging.info.enabled", false, "")},
@@ -97,6 +100,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.info.rotation.max_age":                 {&config.Logging.Info.Rotation.MaxAge, fs.Int("logging.info.rotation.max_age", 0, "")},
 		"logging.info.rotation.localtime":               {&config.Logging.Info.Rotation.LocalTime, fs.Bool("logging.info.rotation.localtime", false, "")},
 		"logging.info.rotation.rotated_logs_size_limit": {&config.Logging.Info.Rotation.RotatedLogsSizeLimit, fs.Int("logging.info.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.info.rotation.rotation_interval":       {&config.Logging.Info.Rotation.RotationInterval, fs.Duration("logging.info.rotation.rotation_interval", 0, "")},
 		"logging.info.collation_buffer_size":            {&config.Logging.Info.CollationBufferSize, fs.Int("logging.info.collation_buffer_size", 0, "")},
 
 		"logging.debug.enabled":                          {&config.Logging.Debug.Enabled, fs.Bool("logging.debug.enabled", false, "")},
@@ -104,6 +108,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.debug.rotation.max_age":                 {&config.Logging.Debug.Rotation.MaxAge, fs.Int("logging.debug.rotation.max_age", 0, "")},
 		"logging.debug.rotation.localtime":               {&config.Logging.Debug.Rotation.LocalTime, fs.Bool("logging.debug.rotation.localtime", false, "")},
 		"logging.debug.rotation.rotated_logs_size_limit": {&config.Logging.Debug.Rotation.RotatedLogsSizeLimit, fs.Int("logging.debug.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.debug.rotation.rotation_interval":       {&config.Logging.Debug.Rotation.RotationInterval, fs.Duration("logging.debug.rotation.rotation_interval", 0, "")},
 		"logging.debug.collation_buffer_size":            {&config.Logging.Debug.CollationBufferSize, fs.Int("logging.debug.collation_buffer_size", 0, "")},
 
 		"logging.trace.enabled":                          {&config.Logging.Trace.Enabled, fs.Bool("logging.trace.enabled", false, "")},
@@ -111,6 +116,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.trace.rotation.max_age":                 {&config.Logging.Trace.Rotation.MaxAge, fs.Int("logging.trace.rotation.max_age", 0, "")},
 		"logging.trace.rotation.localtime":               {&config.Logging.Trace.Rotation.LocalTime, fs.Bool("logging.trace.rotation.localtime", false, "")},
 		"logging.trace.rotation.rotated_logs_size_limit": {&config.Logging.Trace.Rotation.RotatedLogsSizeLimit, fs.Int("logging.trace.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.trace.rotation.rotation_interval":       {&config.Logging.Trace.Rotation.RotationInterval, fs.Duration("logging.trace.rotation.rotation_interval", 0, "")},
 		"logging.trace.collation_buffer_size":            {&config.Logging.Trace.CollationBufferSize, fs.Int("logging.trace.collation_buffer_size", 0, "")},
 
 		"logging.stats.enabled":                          {&config.Logging.Stats.Enabled, fs.Bool("logging.stats.enabled", false, "")},
@@ -118,6 +124,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.stats.rotation.max_age":                 {&config.Logging.Stats.Rotation.MaxAge, fs.Int("logging.stats.rotation.max_age", 0, "")},
 		"logging.stats.rotation.localtime":               {&config.Logging.Stats.Rotation.LocalTime, fs.Bool("logging.stats.rotation.localtime", false, "")},
 		"logging.stats.rotation.rotated_logs_size_limit": {&config.Logging.Stats.Rotation.RotatedLogsSizeLimit, fs.Int("logging.stats.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.stats.rotation.rotation_interval":       {&config.Logging.Stats.Rotation.RotationInterval, fs.Duration("logging.stats.rotation.rotation_interval", 0, "")},
 		"logging.stats.collation_buffer_size":            {&config.Logging.Stats.CollationBufferSize, fs.Int("logging.stats.collation_buffer_size", 0, "")},
 
 		"auth.bcrypt_cost": {&config.Auth.BcryptCost, fs.Int("auth.bcrypt_cost", 0, "Cost to use for bcrypt password hashes")},

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -72,7 +72,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.console.rotation.max_age":                 {&config.Logging.Console.Rotation.MaxAge, fs.Int("logging.console.rotation.max_age", 0, "")},
 		"logging.console.rotation.localtime":               {&config.Logging.Console.Rotation.LocalTime, fs.Bool("logging.console.rotation.localtime", false, "")},
 		"logging.console.rotation.rotated_logs_size_limit": {&config.Logging.Console.Rotation.RotatedLogsSizeLimit, fs.Int("logging.console.rotation.rotated_logs_size_limit", 0, "")},
-		"logging.console.rotation.rotation_interval":       {&config.Logging.Console.Rotation.RotationInterval, fs.Duration("logging.console.rotation.rotation_interval", 0, "")},
+		"logging.console.rotation.rotation_interval":       {&config.Logging.Console.Rotation.RotationInterval, fs.String("logging.console.rotation.rotation_interval", "", "")},
 		"logging.console.collation_buffer_size":            {&config.Logging.Console.CollationBufferSize, fs.Int("logging.console.collation_buffer_size", 0, "")},
 		"logging.console.log_level":                        {&config.Logging.Console.LogLevel, fs.String("logging.console.log_level", "", "Options: none, error, warn, info, debug, trace")},
 		"logging.console.log_keys":                         {&config.Logging.Console.LogKeys, fs.String("logging.console.log_keys", "", "Comma separated log keys")},
@@ -84,7 +84,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.error.rotation.max_age":                 {&config.Logging.Error.Rotation.MaxAge, fs.Int("logging.error.rotation.max_age", 0, "")},
 		"logging.error.rotation.localtime":               {&config.Logging.Error.Rotation.LocalTime, fs.Bool("logging.error.rotation.localtime", false, "")},
 		"logging.error.rotation.rotated_logs_size_limit": {&config.Logging.Error.Rotation.RotatedLogsSizeLimit, fs.Int("logging.error.rotation.rotated_logs_size_limit", 0, "")},
-		"logging.error.rotation.rotation_interval":       {&config.Logging.Error.Rotation.RotationInterval, fs.Duration("logging.error.rotation.rotation_interval", 0, "")},
+		"logging.error.rotation.rotation_interval":       {&config.Logging.Error.Rotation.RotationInterval, fs.String("logging.error.rotation.rotation_interval", "", "")},
 		"logging.error.collation_buffer_size":            {&config.Logging.Error.CollationBufferSize, fs.Int("logging.error.collation_buffer_size", 0, "")},
 
 		"logging.warn.enabled":                          {&config.Logging.Warn.Enabled, fs.Bool("logging.warn.enabled", false, "")},
@@ -92,7 +92,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.warn.rotation.max_age":                 {&config.Logging.Warn.Rotation.MaxAge, fs.Int("logging.warn.rotation.max_age", 0, "")},
 		"logging.warn.rotation.localtime":               {&config.Logging.Warn.Rotation.LocalTime, fs.Bool("logging.warn.rotation.localtime", false, "")},
 		"logging.warn.rotation.rotated_logs_size_limit": {&config.Logging.Warn.Rotation.RotatedLogsSizeLimit, fs.Int("logging.warn.rotation.rotated_logs_size_limit", 0, "")},
-		"logging.warn.rotation.rotation_interval":       {&config.Logging.Warn.Rotation.RotationInterval, fs.Duration("logging.warn.rotation.rotation_interval", 0, "")},
+		"logging.warn.rotation.rotation_interval":       {&config.Logging.Warn.Rotation.RotationInterval, fs.String("logging.warn.rotation.rotation_interval", "", "")},
 		"logging.warn.collation_buffer_size":            {&config.Logging.Warn.CollationBufferSize, fs.Int("logging.warn.collation_buffer_size", 0, "")},
 
 		"logging.info.enabled":                          {&config.Logging.Info.Enabled, fs.Bool("logging.info.enabled", false, "")},
@@ -100,7 +100,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.info.rotation.max_age":                 {&config.Logging.Info.Rotation.MaxAge, fs.Int("logging.info.rotation.max_age", 0, "")},
 		"logging.info.rotation.localtime":               {&config.Logging.Info.Rotation.LocalTime, fs.Bool("logging.info.rotation.localtime", false, "")},
 		"logging.info.rotation.rotated_logs_size_limit": {&config.Logging.Info.Rotation.RotatedLogsSizeLimit, fs.Int("logging.info.rotation.rotated_logs_size_limit", 0, "")},
-		"logging.info.rotation.rotation_interval":       {&config.Logging.Info.Rotation.RotationInterval, fs.Duration("logging.info.rotation.rotation_interval", 0, "")},
+		"logging.info.rotation.rotation_interval":       {&config.Logging.Info.Rotation.RotationInterval, fs.String("logging.info.rotation.rotation_interval", "", "")},
 		"logging.info.collation_buffer_size":            {&config.Logging.Info.CollationBufferSize, fs.Int("logging.info.collation_buffer_size", 0, "")},
 
 		"logging.debug.enabled":                          {&config.Logging.Debug.Enabled, fs.Bool("logging.debug.enabled", false, "")},
@@ -108,7 +108,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.debug.rotation.max_age":                 {&config.Logging.Debug.Rotation.MaxAge, fs.Int("logging.debug.rotation.max_age", 0, "")},
 		"logging.debug.rotation.localtime":               {&config.Logging.Debug.Rotation.LocalTime, fs.Bool("logging.debug.rotation.localtime", false, "")},
 		"logging.debug.rotation.rotated_logs_size_limit": {&config.Logging.Debug.Rotation.RotatedLogsSizeLimit, fs.Int("logging.debug.rotation.rotated_logs_size_limit", 0, "")},
-		"logging.debug.rotation.rotation_interval":       {&config.Logging.Debug.Rotation.RotationInterval, fs.Duration("logging.debug.rotation.rotation_interval", 0, "")},
+		"logging.debug.rotation.rotation_interval":       {&config.Logging.Debug.Rotation.RotationInterval, fs.String("logging.debug.rotation.rotation_interval", "", "")},
 		"logging.debug.collation_buffer_size":            {&config.Logging.Debug.CollationBufferSize, fs.Int("logging.debug.collation_buffer_size", 0, "")},
 
 		"logging.trace.enabled":                          {&config.Logging.Trace.Enabled, fs.Bool("logging.trace.enabled", false, "")},
@@ -116,7 +116,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.trace.rotation.max_age":                 {&config.Logging.Trace.Rotation.MaxAge, fs.Int("logging.trace.rotation.max_age", 0, "")},
 		"logging.trace.rotation.localtime":               {&config.Logging.Trace.Rotation.LocalTime, fs.Bool("logging.trace.rotation.localtime", false, "")},
 		"logging.trace.rotation.rotated_logs_size_limit": {&config.Logging.Trace.Rotation.RotatedLogsSizeLimit, fs.Int("logging.trace.rotation.rotated_logs_size_limit", 0, "")},
-		"logging.trace.rotation.rotation_interval":       {&config.Logging.Trace.Rotation.RotationInterval, fs.Duration("logging.trace.rotation.rotation_interval", 0, "")},
+		"logging.trace.rotation.rotation_interval":       {&config.Logging.Trace.Rotation.RotationInterval, fs.String("logging.trace.rotation.rotation_interval", "", "")},
 		"logging.trace.collation_buffer_size":            {&config.Logging.Trace.CollationBufferSize, fs.Int("logging.trace.collation_buffer_size", 0, "")},
 
 		"logging.stats.enabled":                          {&config.Logging.Stats.Enabled, fs.Bool("logging.stats.enabled", false, "")},
@@ -124,7 +124,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"logging.stats.rotation.max_age":                 {&config.Logging.Stats.Rotation.MaxAge, fs.Int("logging.stats.rotation.max_age", 0, "")},
 		"logging.stats.rotation.localtime":               {&config.Logging.Stats.Rotation.LocalTime, fs.Bool("logging.stats.rotation.localtime", false, "")},
 		"logging.stats.rotation.rotated_logs_size_limit": {&config.Logging.Stats.Rotation.RotatedLogsSizeLimit, fs.Int("logging.stats.rotation.rotated_logs_size_limit", 0, "")},
-		"logging.stats.rotation.rotation_interval":       {&config.Logging.Stats.Rotation.RotationInterval, fs.Duration("logging.stats.rotation.rotation_interval", 0, "")},
+		"logging.stats.rotation.rotation_interval":       {&config.Logging.Stats.Rotation.RotationInterval, fs.String("logging.stats.rotation.rotation_interval", "", "")},
 		"logging.stats.collation_buffer_size":            {&config.Logging.Stats.CollationBufferSize, fs.Int("logging.stats.collation_buffer_size", 0, "")},
 
 		"auth.bcrypt_cost": {&config.Auth.BcryptCost, fs.Int("auth.bcrypt_cost", 0, "Cost to use for bcrypt password hashes")},

--- a/rest/config_flags_test.go
+++ b/rest/config_flags_test.go
@@ -101,6 +101,12 @@ func TestFillConfigWithFlagsValidVals(t *testing.T) {
 	assert.Equal(t, "warn", config.Logging.Console.LogLevel.String())
 	assert.Equal(t, base.NewConfigDuration(time.Hour*5+time.Minute*2+time.Second*33), config.Replicator.MaxHeartbeat)
 	assert.Equal(t, uint64(12345), config.MaxFileDescriptors)
+
+	// unset values
+	assert.Equal(t, "", config.Bootstrap.X509CertPath)           // String
+	assert.Nil(t, config.API.CORS.Headers)                       // []string
+	assert.Nil(t, config.API.AdminInterfaceAuthentication)       // *bool
+	assert.Nil(t, config.Logging.Warn.Rotation.RotationInterval) // *base.ConfigDuration
 }
 
 // Manually test different types of flags with invalid values


### PR DESCRIPTION
CBG-3925

- Add `FileLogger` `RotationInterval` option to force a periodic log rotation.
- Interval is opt-in and can be set anywhere between 15 minutes and 7 days.
- Logs will rotate even if no log lines have been written, producing an empty file. This makes it very obvious that log coverage is present and empty, rather than just missing.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2465/
