### PR TITLE
CBG-3839: handle rollback of the _sync:seq document in the bucket

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -542,6 +542,11 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	if err != nil {
 		return nil, err
 	}
+	clust, err := dbContext.SGReplicateMgr.GetSGRCluster()
+	if err != nil {
+		return nil, err
+	}
+	dbContext.sequences.nodes = clust.Nodes
 
 	if dbContext.UseQueryBasedResyncManager() {
 		dbContext.ResyncManager = NewResyncManager(metadataStore, metaKeys)

--- a/db/database.go
+++ b/db/database.go
@@ -542,11 +542,6 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	if err != nil {
 		return nil, err
 	}
-	clust, err := dbContext.SGReplicateMgr.GetSGRCluster()
-	if err != nil {
-		return nil, err
-	}
-	dbContext.sequences.nodes = clust.Nodes
 
 	if dbContext.UseQueryBasedResyncManager() {
 		dbContext.ResyncManager = NewResyncManager(metadataStore, metaKeys)

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -35,7 +35,9 @@ const (
 	// Idle batch size.  Initial batch size if SG is in an idle state (with respect to writes)
 	idleBatchSize = 1
 
-	//minimum number that _sync:seq will be corrected by in event of a rollback
+	// minimum number that _sync:seq will be corrected by in event of a rollback
+	// assumes a SG cluster size of 50 nodes each allocating a full batch size of 10
+	// if this value is too low and this correction has potential to allocate sequences that other nodes have already reserved a batch for
 	syncSeqCorrectionValue = 500
 )
 
@@ -478,5 +480,5 @@ func (s *sequenceAllocator) _fixSyncSeqRollback(ctx context.Context, incrValue, 
 
 // shouldRetrySyncSeqCorrection returns true if value of _sync:seq is less than the expected value, else returns false
 func shouldRetrySyncSeqCorrection(expectedVal, actualVal uint64) bool {
-	return actualVal <= expectedVal
+	return actualVal < expectedVal
 }

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -58,7 +58,6 @@ type sequenceAllocator struct {
 	lastSequenceReserveTime time.Time           // Time of most recent sequence reserve
 	releaseSequenceWait     time.Duration       // Supports test customization
 	metaKeys                *base.MetadataKeys  // Key generator for sequence and unused sequence documents
-	nodes                   map[string]*SGNode
 }
 
 func newSequenceAllocator(ctx context.Context, datastore base.DataStore, dbStatsMap *base.DatabaseStats, metaKeys *base.MetadataKeys) (*sequenceAllocator, error) {

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -138,7 +138,6 @@ func (s *sequenceAllocator) releaseUnusedSequences(ctx context.Context) {
 		s.sequenceBatchSize = s.sequenceBatchSize - unusedAmount
 	}
 
-	fmt.Println("setting last to", s.max, "release")
 	s.last = s.max
 	s.mutex.Unlock()
 }
@@ -149,7 +148,6 @@ func (s *sequenceAllocator) lastSequence(ctx context.Context) (uint64, error) {
 	s.mutex.Lock()
 	lastSeq := s.last
 	s.mutex.Unlock()
-	fmt.Println("lastsequ34ecne")
 
 	if lastSeq > 0 {
 		return lastSeq, nil

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -610,13 +610,13 @@ func TestSyncSeqRollbackMultiNode(t *testing.T) {
 	wg.Add(2)
 
 	go func() {
-		nextSequence, _, err = b.nextSequenceGreaterThan(ctx, 20)
+		_, _, err := b.nextSequenceGreaterThan(ctx, 20)
 		assert.NoError(t, err)
 		wg.Done()
 	}()
 
 	go func() {
-		nextSequence, _, err = a.nextSequenceGreaterThan(ctx, 10)
+		_, _, err := a.nextSequenceGreaterThan(ctx, 10)
 		assert.NoError(t, err)
 		wg.Done()
 	}()

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package db
 
 import (
-	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -432,45 +431,45 @@ func TestSingleNodeSyncSeqRollback(t *testing.T) {
 	// triggers correction value increase to 10 (sequence batch value) thus nextSeq is higher than you would expect
 	nxtSeq, err = a.nextSequence(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(511), nxtSeq)
-	assert.Equal(t, uint64(520), a.max)
+	assert.Equal(t, uint64(521), nxtSeq)
+	assert.Equal(t, uint64(530), a.max)
 
 	// alter _sync:seq in bucket to end seq in prev batch
 	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 10)
 	require.NoError(t, err)
 
 	// alter s.last to mock sequences being allocated
-	a.last = 520
+	a.last = 530
 
 	nxtSeq, err = a.nextSequence(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1021), nxtSeq)
-	assert.Equal(t, uint64(1030), a.max)
+	assert.Equal(t, uint64(1041), nxtSeq)
+	assert.Equal(t, uint64(1050), a.max)
 
 	// alter _sync:seq in bucket to start seq in batch
-	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 511)
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 521)
 	require.NoError(t, err)
 
 	// alter s.last to mock sequences being allocated
-	a.last = 1030
+	a.last = 1050
 
 	// triggers correction value increase to 10 (sequence batch value) thus nextSeq is higher than you would expect
 	nxtSeq, err = a.nextSequence(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1531), nxtSeq)
-	assert.Equal(t, uint64(1540), a.max)
+	assert.Equal(t, uint64(1561), nxtSeq)
+	assert.Equal(t, uint64(1570), a.max)
 
 	// rollback _sync:seq in bucket to start seq to seq outside of batch
 	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 5)
 	require.NoError(t, err)
 
 	// alter s.last to mock sequences being allocated
-	a.last = 1540
+	a.last = 1570
 
 	nxtSeq, err = a.nextSequence(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(2041), nxtSeq)
-	assert.Equal(t, uint64(2050), a.max)
+	assert.Equal(t, uint64(2081), nxtSeq)
+	assert.Equal(t, uint64(2090), a.max)
 }
 
 // TestSingleNodeNextSeqGreaterThanRollbackHandling:
@@ -483,6 +482,7 @@ func TestSingleNodeNextSeqGreaterThanRollbackHandling(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -514,39 +514,39 @@ func TestSingleNodeNextSeqGreaterThanRollbackHandling(t *testing.T) {
 	// triggers correction value increase to 10 (sequence batch value) thus nextSeq is higher than you would expect
 	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 15)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(516), nxtSeq)
-	assert.Equal(t, uint64(516), a.last)
-	assert.Equal(t, uint64(525), a.max)
+	assert.Equal(t, uint64(526), nxtSeq)
+	assert.Equal(t, uint64(526), a.last)
+	assert.Equal(t, uint64(535), a.max)
 
 	// alter _sync:seq in bucket to end seq in prev batch
 	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 10)
 	require.NoError(t, err)
 
-	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 525)
+	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 535)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1026), nxtSeq)
-	assert.Equal(t, uint64(1026), a.last)
-	assert.Equal(t, uint64(1035), a.max)
+	assert.Equal(t, uint64(1046), nxtSeq)
+	assert.Equal(t, uint64(1046), a.last)
+	assert.Equal(t, uint64(1055), a.max)
 
 	// alter _sync:seq in bucket to end seq in prev batch start seq
-	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 516)
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 526)
 	require.NoError(t, err)
 
-	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 1035)
+	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 1055)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1536), nxtSeq)
-	assert.Equal(t, uint64(1536), a.last)
-	assert.Equal(t, uint64(1545), a.max)
+	assert.Equal(t, uint64(1566), nxtSeq)
+	assert.Equal(t, uint64(1566), a.last)
+	assert.Equal(t, uint64(1575), a.max)
 
 	// alter _sync:seq in bucket to prev batch value
 	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 5)
 	require.NoError(t, err)
 
-	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 1545)
+	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 1575)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(2046), nxtSeq)
-	assert.Equal(t, uint64(2046), a.last)
-	assert.Equal(t, uint64(2055), a.max)
+	assert.Equal(t, uint64(2086), nxtSeq)
+	assert.Equal(t, uint64(2086), a.last)
+	assert.Equal(t, uint64(2095), a.max)
 }
 
 // TestSyncSeqRollbackMultiNode:
@@ -734,16 +734,15 @@ func TestFiveNodeRollbackMiddleNodesDetects(t *testing.T) {
 	// sync:seq to be + 500
 	nxtSeq, err := c.nextSequence(ctx)
 	require.NoError(t, err)
-	fmt.Println(nxtSeq, c.last, c.max)
-	assert.Equal(t, uint64(531), nxtSeq)
-	assert.Equal(t, uint64(531), c.last)
-	assert.Equal(t, uint64(540), c.max)
+	assert.Equal(t, uint64(541), nxtSeq)
+	assert.Equal(t, uint64(541), c.last)
+	assert.Equal(t, uint64(550), c.max)
 
 	// mock a getting to end of batch and trigger new batch allocation, assert it continues from corrected value
 	a.last = 10
 	nxtSeq, err = a.nextSequence(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(541), nxtSeq)
-	assert.Equal(t, uint64(541), a.last)
-	assert.Equal(t, uint64(550), a.max)
+	assert.Equal(t, uint64(551), nxtSeq)
+	assert.Equal(t, uint64(551), a.last)
+	assert.Equal(t, uint64(560), a.max)
 }

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -388,4 +389,253 @@ func TestNextSequenceGreaterThanMultiNode(t *testing.T) {
 	assert.Equal(t, 14, int(releasedSequenceCount))
 	assertNewAllocatorStats(t, dbStatsA, 2, 25, 2, 14)
 
+}
+
+// TestSingleNodeSyncSeqRollback:
+//   - Test rollback of _sync:seq doc in bucket for a single node
+//   - Use nextSequence to allocate sequences and trigger the rollback handling code
+//   - Between each sequence allocation alter the _sync:seq doc to some value in the bucket + alter a.last to mock
+//     allocator allocating sequences to end of current batch
+//   - Asserts that handling using nextSequence function is correct
+func TestSingleNodeSyncSeqRollback(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	sgw, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	require.NoError(t, err)
+	testStats := dbstats.Database()
+	ds := bucket.GetSingleDataStore()
+
+	a, err := newSequenceAllocator(ctx, ds, testStats, base.DefaultMetadataKeys)
+	require.NoError(t, err)
+	a.sequenceBatchSize = 10
+
+	nxtSeq, err := a.nextSequence(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), nxtSeq)
+
+	// alter _sync:seq in bucket to 5
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 5)
+	require.NoError(t, err)
+
+	// alter s.last to mock sequences being allocated
+	a.last = 10
+
+	// triggers correction value increase to 10 (sequence batch value) thus nextSeq is higher than you would expect
+	nxtSeq, err = a.nextSequence(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(16), nxtSeq)
+	assert.Equal(t, uint64(25), a.max)
+
+	// alter _sync:seq in bucket to end seq in prev batch
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 10)
+	require.NoError(t, err)
+
+	// alter s.last to mock sequences being allocated
+	a.last = 25
+
+	nxtSeq, err = a.nextSequence(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(26), nxtSeq)
+	assert.Equal(t, uint64(35), a.max)
+
+	// alter _sync:seq in bucket to start seq in batch
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 26)
+	require.NoError(t, err)
+
+	// alter s.last to mock sequences being allocated
+	a.last = 35
+
+	// triggers correction value increase to 10 (sequence batch value) thus nextSeq is higher than you would expect
+	nxtSeq, err = a.nextSequence(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(37), nxtSeq)
+	assert.Equal(t, uint64(46), a.max)
+
+	// rollback _sync:seq in bucket to start seq to seq outside of batch
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 5)
+	require.NoError(t, err)
+
+	// alter s.last to mock sequences being allocated
+	a.last = 46
+
+	nxtSeq, err = a.nextSequence(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(47), nxtSeq)
+	assert.Equal(t, uint64(56), a.max)
+}
+
+// TestSingleNodeNextSeqGreaterThanRollbackHandling:
+//   - Test rollback of _sync:seq doc in bucket for a single node
+//   - Use nextSequenceGreaterThan to allocate sequences and trigger the rollback handling code
+//   - Between each sequence allocation alter the _sync:seq doc to some value in the bucket + alter a.last to mock
+//     allocator allocating sequences to end of current batch
+//   - Asserts that handling using nextSequenceGreaterThan function is correct
+func TestSingleNodeNextSeqGreaterThanRollbackHandling(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	sgw, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	dbstats, err := sgw.NewDBStats("", false, false, false, nil, nil)
+	require.NoError(t, err)
+	testStats := dbstats.Database()
+	ds := bucket.GetSingleDataStore()
+
+	a, err := newSequenceAllocator(ctx, ds, testStats, base.DefaultMetadataKeys)
+	require.NoError(t, err)
+	a.sequenceBatchSize = 10
+
+	// allocate something
+	nxtSeq, err := a.nextSequence(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), nxtSeq)
+
+	// alter _sync:seq in bucket to 5
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 5)
+	require.NoError(t, err)
+
+	// alter s.last to mock sequences being allocated
+	a.last = 10
+
+	// triggers correction value increase to 10 (sequence batch value) thus nextSeq is higher than you would expect
+	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 15)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(21), nxtSeq)
+	assert.Equal(t, uint64(21), a.last)
+	assert.Equal(t, uint64(30), a.max)
+
+	// alter _sync:seq in bucket to end seq in prev batch
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 10)
+	require.NoError(t, err)
+
+	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 30)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(31), nxtSeq)
+	assert.Equal(t, uint64(31), a.last)
+	assert.Equal(t, uint64(40), a.max)
+
+	// alter _sync:seq in bucket to end seq in prev batch start seq
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 21)
+	require.NoError(t, err)
+
+	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 40)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(41), nxtSeq)
+	assert.Equal(t, uint64(41), a.last)
+	assert.Equal(t, uint64(50), a.max)
+
+	// alter _sync:seq in bucket to prev batch value
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 5)
+	require.NoError(t, err)
+
+	nxtSeq, _, err = a.nextSequenceGreaterThan(ctx, 50)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(51), nxtSeq)
+	assert.Equal(t, uint64(51), a.last)
+	assert.Equal(t, uint64(60), a.max)
+}
+
+// TestSyncSeqRollbackMultiNode:
+//   - Test rollback of _sync:seq doc in bucket for a multi node cluster node
+//   - Use nextSequenceGreaterThan to allocate sequences and trigger the rollback handling code
+//   - Alter _sync:seq in the bucket to rollback the value
+//   - Alter last seq on each allocator to mock allocation of some sequences
+//   - Use two go routines to test two nodes racing to update the rollback back _sync:seq document
+//   - Asser that the resulting batches on each node do not overlap
+func TestSyncSeqRollbackMultiNode(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	stats, err := base.NewSyncGatewayStats()
+	require.NoError(t, err)
+	statsA, err := stats.NewDBStats("A", false, false, false, nil, nil)
+	require.NoError(t, err)
+	statsB, err := stats.NewDBStats("B", false, false, false, nil, nil)
+	require.NoError(t, err)
+	dbStatsA := statsA.DatabaseStats
+	dbStatsB := statsB.DatabaseStats
+	ds := bucket.GetSingleDataStore()
+
+	a := &sequenceAllocator{
+		datastore:         bucket.GetSingleDataStore(),
+		dbStats:           dbStatsA,
+		sequenceBatchSize: 10,                      // set initial batch size to 10 to support all test cases
+		reserveNotify:     make(chan struct{}, 50), // Buffered to allow multiple allocations without releaseSequenceMonitor
+		metaKeys:          base.DefaultMetadataKeys,
+	}
+
+	b := &sequenceAllocator{
+		datastore:         bucket.GetSingleDataStore(),
+		dbStats:           dbStatsB,
+		sequenceBatchSize: 10,                      // set initial batch size to 10 to support all test cases
+		reserveNotify:     make(chan struct{}, 50), // Buffered to allow multiple allocations without releaseSequenceMonitor
+		metaKeys:          base.DefaultMetadataKeys,
+	}
+
+	initSequence, err := a.lastSequence(ctx)
+	assert.Equal(t, uint64(0), initSequence)
+	assert.NoError(t, err, "error retrieving last sequence")
+
+	initSequence, err = b.lastSequence(ctx)
+	assert.Equal(t, uint64(0), initSequence)
+	assert.NoError(t, err, "error retrieving last sequence")
+
+	// perform batch allocation on sequence allocator a
+	nextSequence, _, err := a.nextSequenceGreaterThan(ctx, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), nextSequence)
+
+	// perform batch allocation on sequence allocator b
+	nextSequence, _, err = b.nextSequenceGreaterThan(ctx, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(11), nextSequence)
+
+	// alter _sync:seq in bucket to prev value
+	err = ds.Set(a.metaKeys.SyncSeqKey(), 0, nil, 2)
+	require.NoError(t, err)
+
+	// set a.last on this allocator to 5 (mock some sequences being allocated)
+	a.last = 5
+
+	// set b.last on this allocator to 15 (mock some sequences being allocated)
+	b.last = 15
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		nextSequence, _, err = b.nextSequenceGreaterThan(ctx, 20)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+
+	go func() {
+		nextSequence, _, err = a.nextSequenceGreaterThan(ctx, 10)
+		assert.NoError(t, err)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// above goroutines will race each other for access to _sync:seq
+	// to assert that _sync:seq is corrected appropriately we need to determine which sequence allocator got there first
+	// assert that each sequence batch doesn't overlap
+	if a.last < b.last {
+		assert.Greater(t, b.last, a.max)
+	} else {
+		assert.Greater(t, a.last, b.max)
+	}
+
+	// grab sync seq value from bucket
+	syncSeqVal, err := a.getSequence()
+	require.NoError(t, err)
+	// get max batch value
+	maxBatchSeq := math.Max(float64(a.max), float64(b.max))
+	// assert equal to _sync:seq Value
+	assert.Equal(t, syncSeqVal, uint64(maxBatchSeq))
 }


### PR DESCRIPTION
CBG-3839

- After incoming the sync:seq doc in incrementSequence function we can check if the result is less then we are expecting, thus determine the _sync:sequence must’ve been rolled back. 
- Added function _fixSyncSeqRollback for this to handle this
- Need the minimum correction stop be the sequence batch size as when having multiple nodes you can have overlapping sequence batches
- Have testing for single and multi node handling

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2519/
