### PR TITLE
Fix skipped user-functions tests

### DIFF
--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -646,27 +646,5 @@ func setupTestDBWithFunctions(t *testing.T, fnConfig *FunctionsConfig) (*db.Data
 		options.UserFunctions, err = CompileFunctions(base.TestCtx(t), *fnConfig)
 		assert.NoError(t, err)
 	}
-	return setupTestDBWithOptions(t, options)
-}
-
-func setupTestDBWithOptions(t testing.TB, dbcOptions db.DatabaseContextOptions) (*db.Database, context.Context) {
-
-	tBucket := base.GetTestBucket(t)
-	return setupTestDBForBucketWithOptions(t, tBucket, dbcOptions)
-}
-
-func setupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptions db.DatabaseContextOptions) (*db.Database, context.Context) {
-	ctx := base.TestCtx(t)
-	AddOptionsFromEnvironmentVariables(&dbcOptions)
-	dbCtx, err := db.NewDatabaseContext(ctx, "db", tBucket, false, dbcOptions)
-	require.NoError(t, err, "Couldn't create context for database 'db'")
-
-	err = dbCtx.StartOnlineProcesses(ctx)
-	require.NoError(t, err)
-
-	db, err := db.CreateDatabase(dbCtx)
-	require.NoError(t, err, "Couldn't create database 'db'")
-
-	ctx = db.AddDatabaseLogContext(ctx)
-	return db, ctx
+	return db.SetupTestDBWithOptions(t, options)
 }

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -173,9 +173,6 @@ func addUserAlice(t *testing.T, db *db.Database) auth.User {
 
 // Unit test for JS user functions.
 func TestUserFunctions(t *testing.T) {
-	// FIXME : this test doesn't work because the access view does not exist on the collection ???
-	t.Skip("Skipping test until access view is available with collections")
-
 	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, &kUserFunctionConfig)
 	defer db.Close(ctx)
@@ -333,7 +330,6 @@ func testUserFunctionsAsUser(t *testing.T, ctx context.Context, db *db.Database)
 
 // Test CRUD operations
 func TestUserFunctionsCRUD(t *testing.T) {
-	t.Skip("not collection aware")
 	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, &kUserFunctionConfig)
 	defer db.Close(ctx)
@@ -478,9 +474,6 @@ func TestUserFunctionsMaxCodeSize(t *testing.T) {
 
 // Low-level test of channel-name parameter expansion for user query/function auth
 func TestUserFunctionAllow(t *testing.T) {
-	// FIXME : this test doesn't work because the access view does not exist on the collection ???
-	t.Skip("Skipping test until access view is available with collections")
-
 	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, &kUserFunctionConfig)
 	defer db.Close(ctx)


### PR DESCRIPTION
A couple of user-functions tests had `t.Skip()` applied to them because they weren't working at the time. Some of them appear to work fine now, others needed a small fix.

- The skipped tests in db/functions appear to work fine now.
- The functionsapitest failures were due to inadvertently enabling  "admin party" when the intent was for the guest user not to have channel access; fixed that in the config.
- There was another failure in TestJSFunctionAsGuest due to reversed  order of args in assert.Contains.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2444/
