### PR TITLE
CBG-3843: include collection names in status of resync 

### DIFF
--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -70,7 +70,7 @@ func (r *ResyncManager) Run(ctx context.Context, options map[string]interface{},
 		return err
 	}
 	// add collection list to manager for use in status call
-	r.ResyncedCollections = collectionNames
+	r.SetCollectionStatus(collectionNames)
 	if hasAllCollections {
 		base.InfofCtx(ctx, base.KeyAll, "running resync against all collections")
 	} else {
@@ -102,6 +102,7 @@ func (r *ResyncManager) ResetStatus() {
 
 	r.DocsProcessed = 0
 	r.DocsChanged = 0
+	r.ResyncedCollections = nil
 }
 
 func (r *ResyncManager) SetStats(docsProcessed, docsChanged int) {
@@ -110,6 +111,13 @@ func (r *ResyncManager) SetStats(docsProcessed, docsChanged int) {
 
 	r.DocsProcessed = docsProcessed
 	r.DocsChanged = docsChanged
+}
+
+func (r *ResyncManager) SetCollectionStatus(collectionNames []string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.ResyncedCollections = collectionNames
 }
 
 type ResyncManagerResponse struct {

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -153,7 +153,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		return err
 	}
 	// add collection list to manager for use in status call
-	r.ResyncedCollections = collectionNames
+	r.SetCollectionStatus(collectionNames)
 	if hasAllCollections {
 		base.InfofCtx(ctx, base.KeyAll, "[%s] running resync against all collections", resyncLoggingID)
 	} else {
@@ -283,6 +283,7 @@ func (r *ResyncManagerDCP) ResetStatus() {
 
 	r.DocsProcessed.Set(0)
 	r.DocsChanged.Set(0)
+	r.ResyncedCollections = nil
 }
 
 func (r *ResyncManagerDCP) SetStatus(docChanged, docProcessed int64) {
@@ -291,6 +292,13 @@ func (r *ResyncManagerDCP) SetStatus(docChanged, docProcessed int64) {
 
 	r.DocsChanged.Set(docChanged)
 	r.DocsProcessed.Set(docProcessed)
+}
+
+func (r *ResyncManagerDCP) SetCollectionStatus(collectionNames []string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.ResyncedCollections = collectionNames
 }
 
 type ResyncManagerResponseDCP struct {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -736,7 +736,7 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 
 			statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-			rest.RequireCollections(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
+			assert.ElementsMatch(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
 		})
 	}
 }
@@ -793,7 +793,7 @@ func TestQueryResyncCollectionsStatus(t *testing.T) {
 
 			statusResponse := rt.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
 
-			rest.RequireCollections(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
+			assert.ElementsMatch(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
 		})
 	}
 }

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -691,6 +691,113 @@ func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
 	assert.Equal(t, int64(2000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 }
 
+func TestDCPResyncCollectionsStatus(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+	base.TestRequiresCollections(t)
+
+	testCases := []struct {
+		name              string
+		collectionNames   []string
+		expectedResult    []string
+		specifyCollection bool
+	}{
+		{
+			name:              "collections_specified",
+			collectionNames:   []string{"sg_test_0"},
+			expectedResult:    []string{"sg_test_0"},
+			specifyCollection: true,
+		},
+		{
+			name:            "collections_not_specified",
+			expectedResult:  []string{"sg_test_0", "sg_test_1", "sg_test_2"},
+			collectionNames: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rt := rest.NewRestTesterMultipleCollections(t, nil, 3)
+			defer rt.Close()
+
+			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+			require.True(t, ok)
+
+			rt.TakeDbOffline()
+
+			if !testCase.specifyCollection {
+				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+				rest.RequireStatus(t, resp, http.StatusOK)
+			} else {
+				payload := `{"scopes": {"sg_test_0":["sg_test_0"]}}`
+				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", payload)
+				rest.RequireStatus(t, resp, http.StatusOK)
+			}
+
+			statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+			rest.RequireCollections(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
+		})
+	}
+}
+
+func TestQueryResyncCollectionsStatus(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+	base.TestRequiresCollections(t)
+
+	testCases := []struct {
+		name              string
+		collectionNames   []string
+		expectedResult    []string
+		specifyCollection bool
+	}{
+		{
+			name:              "collections_specified",
+			collectionNames:   []string{"sg_test_0"},
+			expectedResult:    []string{"sg_test_0"},
+			specifyCollection: true,
+		},
+		{
+			name:            "collections_not_specified",
+			expectedResult:  []string{"sg_test_0", "sg_test_1", "sg_test_2"},
+			collectionNames: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rt := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					Unsupported: &db.UnsupportedOptions{
+						UseQueryBasedResyncManager: true,
+					},
+				},
+				},
+			}, 3)
+			defer rt.Close()
+
+			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+			require.True(t, ok)
+
+			rt.TakeDbOffline()
+
+			if !testCase.specifyCollection {
+				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+				rest.RequireStatus(t, resp, http.StatusOK)
+			} else {
+				payload := `{"scopes": {"sg_test_0":["sg_test_0"]}}`
+				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", payload)
+				rest.RequireStatus(t, resp, http.StatusOK)
+			}
+
+			statusResponse := rt.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
+
+			rest.RequireCollections(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
+		})
+	}
+}
+
 func TestResyncQueryBased(t *testing.T) {
 	base.LongRunningTest(t)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2670,3 +2670,18 @@ func RequireGocbDCPResync(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server since rosmar has no support for DCP resync")
 	}
 }
+
+// RequireCollections Iterates through two lists of collections and asserts they both contain the same collections
+func RequireCollections(t testing.TB, collectionNamesFromStatus, collectionSpecified []string) {
+	require.Equal(t, len(collectionSpecified), len(collectionNamesFromStatus))
+	for _, collName := range collectionNamesFromStatus {
+		var found bool
+		for _, name := range collectionSpecified {
+			if name == collName {
+				found = true
+				break
+			}
+		}
+		require.True(t, found)
+	}
+}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2670,18 +2670,3 @@ func RequireGocbDCPResync(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server since rosmar has no support for DCP resync")
 	}
 }
-
-// RequireCollections Iterates through two lists of collections and asserts they both contain the same collections
-func RequireCollections(t testing.TB, collectionNamesFromStatus, collectionSpecified []string) {
-	require.Equal(t, len(collectionSpecified), len(collectionNamesFromStatus))
-	for _, collName := range collectionNamesFromStatus {
-		var found bool
-		for _, name := range collectionSpecified {
-			if name == collName {
-				found = true
-				break
-			}
-		}
-		require.True(t, found)
-	}
-}


### PR DESCRIPTION
CBG-3843

- Refactored function that gets collection id's for resync to also return the collection names
- Add the list of collection names to the manager object to then be used in the status function
- Change has been made to both DCP resync and query resync 
- Had to make the collection list on status struct omitempty as when calling endpoint to start resync the status is returned but at this point the Run() function hasn't started to calculate the collections its running on. To avoid the initial POST call returning null for collections I have made it omit empty

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2454/
