### PR TITLE
CBG-3942 tag collection in error message

### DIFF
--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -198,7 +198,8 @@ func (cl *ClusterOnlyN1QLStore) indexManager(scopeName, collectionName string) *
 }
 
 func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error {
-	return WaitForIndexesOnline(ctx, cl.indexManager(cl.scopeName, cl.collectionName), indexNames, failfast)
+	keyspace := strings.Join([]string{cl.bucketName, cl.scopeName, cl.collectionName}, ".")
+	return WaitForIndexesOnline(ctx, keyspace, cl.indexManager(cl.scopeName, cl.collectionName), indexNames, failfast)
 }
 
 func (cl *ClusterOnlyN1QLStore) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -139,7 +139,8 @@ func (c *Collection) CreatePrimaryIndex(ctx context.Context, indexName string, o
 
 // WaitForIndexesOnline takes set of indexes and watches them till they're online.
 func (c *Collection) WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error {
-	return WaitForIndexesOnline(ctx, c.indexManager(), indexNames, failfast)
+	keyspace := strings.Join([]string{c.BucketName(), c.ScopeName(), c.CollectionName()}, ".")
+	return WaitForIndexesOnline(ctx, keyspace, c.indexManager(), indexNames, failfast)
 }
 
 func (c *Collection) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {


### PR DESCRIPTION
avoids back tracking through the logs to find the suspected error.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

