### PR TITLE
CBG-3877 Persist HLV to _vv xattr (reapplied to anemone)

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -136,6 +136,7 @@ const (
 	SyncPropertyName = "_sync"
 	// SyncXattrName is used when storing sync data in a document's xattrs.
 	SyncXattrName = "_sync"
+	VvXattrName   = "_vv"
 
 	// Intended to be used in Meta Map and related tests
 	MetaMapXattrsKey = "xattrs"

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -396,7 +396,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// First unmarshal the doc (just its metadata, to save time/memory):
-	syncData, rawBody, _, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
+	syncData, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
@@ -409,6 +409,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	// If using xattrs and this isn't an SG write, we shouldn't attempt to cache.
+	rawUserXattr := rawXattrs[collection.userXattrKey()]
 	if collection.UseXattrs() {
 		if syncData == nil {
 			return

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -245,7 +245,7 @@ func TestHasAttachmentsFlagForLegacyAttachments(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get the existing bucket doc
-		_, existingBucketDoc, err := collection.GetDocWithXattr(ctx, docID, DocUnmarshalAll)
+		_, existingBucketDoc, err := collection.GetDocWithXattrs(ctx, docID, DocUnmarshalAll)
 		require.NoError(t, err)
 
 		// Migrate document metadata from document body to system xattr.

--- a/db/database.go
+++ b/db/database.go
@@ -1792,7 +1792,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 			if currentValue == nil || len(currentValue) == 0 {
 				return sgbucket.UpdatedDoc{}, base.ErrUpdateCancel
 			}
-			doc, err := unmarshalDocumentWithXattr(ctx, docid, currentValue, currentXattrs[base.SyncXattrName], currentXattrs[db.userXattrKey()], cas, DocUnmarshalAll)
+			doc, err := db.unmarshalDocumentWithXattrs(ctx, docid, currentValue, currentXattrs, cas, DocUnmarshalAll)
 			if err != nil {
 				return sgbucket.UpdatedDoc{}, err
 			}
@@ -1808,11 +1808,12 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 				updatedDoc.UpdateExpiry(*updatedExpiry)
 			}
 			doc.SetCrc32cUserXattrHash()
-			_, rawXattr, err := updatedDoc.MarshalWithXattr()
+			_, rawSyncXattr, rawVvXattr, err := updatedDoc.MarshalWithXattrs()
 			return sgbucket.UpdatedDoc{
 				Doc: nil, // Resync does not require document body update
 				Xattrs: map[string][]byte{
-					base.SyncXattrName: rawXattr,
+					base.SyncXattrName: rawSyncXattr,
+					base.VvXattrName:   rawVvXattr,
 				},
 				Expiry: updatedExpiry,
 			}, err

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -253,7 +253,7 @@ func (c *DatabaseCollection) unsupportedOptions() *UnsupportedOptions {
 
 // syncAndUserXattrKeys returns the xattr keys for the user and sync xattrs.
 func (c *DatabaseCollection) syncAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName}
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)

--- a/db/document.go
+++ b/db/document.go
@@ -34,11 +34,11 @@ const DocumentHistoryMaxEntriesPerChannel = 5
 type DocumentUnmarshalLevel uint8
 
 const (
-	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals sync metadata and body
-	DocUnmarshalSync                                     // Unmarshals all sync metadata
-	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding revtree history
+	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals metadata and body
+	DocUnmarshalSync                                     // Unmarshals metadata
+	DocUnmarshalNoHistory                                // Unmarshals metadata excluding revtree history
 	DocUnmarshalHistory                                  // Unmarshals revtree history + rev + CAS only
-	DocUnmarshalRev                                      // Unmarshals rev + CAS only
+	DocUnmarshalRev                                      // Unmarshals revTreeID + CAS only (no HLV)
 	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
 	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
 )
@@ -81,7 +81,7 @@ type SyncData struct {
 	Attachments       AttachmentsMeta      `json:"attachments,omitempty"`
 	ChannelSet        []ChannelSetEntry    `json:"channel_set"`
 	ChannelSetHistory []ChannelSetEntry    `json:"channel_set_history"`
-	HLV               *HybridLogicalVector `json:"_vv,omitempty"`
+	HLV               *HybridLogicalVector `json:"-"` // Marshalled/Unmarshalled separately from SyncData for storage in _vv, see MarshalWithXattrs/UnmarshalWithXattrs
 
 	// Only used for performance metrics:
 	TimeSaved time.Time `json:"time_saved,omitempty"` // Timestamp of save.
@@ -401,14 +401,14 @@ func unmarshalDocument(docid string, data []byte) (*Document, error) {
 	return doc, nil
 }
 
-func unmarshalDocumentWithXattr(ctx context.Context, docid string, data []byte, xattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+func unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, syncXattrData []byte, hlvXattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 
-	if xattrData == nil || len(xattrData) == 0 {
+	if len(syncXattrData) == 0 && len(hlvXattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
 	} else {
 		doc = NewDocument(docid)
-		err = doc.UnmarshalWithXattr(ctx, data, xattrData, unmarshalLevel)
+		err = doc.UnmarshalWithXattrs(ctx, data, syncXattrData, hlvXattrData, unmarshalLevel)
 	}
 	if err != nil {
 		return nil, err
@@ -444,37 +444,47 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*SyncData, error)
 // Returns the raw body, in case it's needed for import.
 
 // TODO: Using a pool of unmarshal workers may help prevent memory spikes under load
-func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawSyncXattr []byte, rawUserXattr []byte, err error) {
 
+func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey string, needHistory bool) (result *SyncData, rawBody []byte, rawXattrs map[string][]byte, err error) {
 	var body []byte
 
 	// If xattr datatype flag is set, data includes both xattrs and document body.  Check for presence of sync xattr.
 	// Note that there could be a non-sync xattr present
+	var xattrValues map[string][]byte
+	var hlv *HybridLogicalVector
 	if dataType&base.MemcachedDataTypeXattr != 0 {
-		var xattrs map[string][]byte
-		xattrKeys := []string{base.SyncXattrName}
-		if userXattrKey != "" {
-			xattrKeys = append(xattrKeys, userXattrKey)
-		}
-		body, xattrs, err = sgbucket.DecodeValueWithXattrs(xattrKeys, data)
+		xattrKeys := []string{base.SyncXattrName, base.VvXattrName, userXattrKey}
+		body, xattrValues, err = sgbucket.DecodeValueWithXattrs(xattrKeys, data)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, err
 		}
-		rawSyncXattr = xattrs[base.SyncXattrName]
-		rawUserXattr = xattrs[userXattrKey]
 
 		// If the sync xattr is present, use that to build SyncData
-		if len(rawSyncXattr) > 0 {
+		syncXattr, ok := xattrValues[base.SyncXattrName]
+
+		if vvXattr, ok := xattrValues[base.VvXattrName]; ok {
+			err = base.JSONUnmarshal(vvXattr, &hlv)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("error unmarshalling HLV: %w", err)
+			}
+		}
+
+		if ok && len(syncXattr) > 0 {
 			result = &SyncData{}
 			if needHistory {
 				result.History = make(RevTree)
 			}
-			err = base.JSONUnmarshal(rawSyncXattr, result)
+			err = base.JSONUnmarshal(syncXattr, result)
 			if err != nil {
-				return nil, nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", syncXattr, err)
+				return nil, nil, nil, fmt.Errorf("Found _sync xattr (%q), but could not unmarshal: %w", string(syncXattr), err)
 			}
-			return result, body, rawSyncXattr, rawUserXattr, nil
+
+			if hlv != nil {
+				result.HLV = hlv
+			}
+			return result, body, xattrValues, nil
 		}
+
 	} else {
 		// Xattr flag not set - data is just the document body
 		body = data
@@ -482,22 +492,16 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 
 	// Non-xattr data, or sync xattr not present.  Attempt to retrieve sync metadata from document body
 	result, err = UnmarshalDocumentSyncData(body, needHistory)
-	return result, body, nil, rawUserXattr, err
-}
 
-func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {
-	if dataType&base.MemcachedDataTypeXattr == 0 {
-		return unmarshalDocument(docid, data)
+	// If no sync data was found but HLV was present, initialize empty sync data
+	if result == nil && hlv != nil {
+		result = &SyncData{}
 	}
-	xattrKeys := []string{base.SyncXattrName}
-	if userXattrKey != "" {
-		xattrKeys = append(xattrKeys, userXattrKey)
+	// If HLV was found, add to sync data
+	if hlv != nil {
+		result.HLV = hlv
 	}
-	body, xattrs, err := sgbucket.DecodeValueWithXattrs(xattrKeys, data)
-	if err != nil {
-		return nil, err
-	}
-	return unmarshalDocumentWithXattr(ctx, docid, body, xattrs[base.SyncXattrName], xattrs[userXattrKey], cas, DocUnmarshalAll)
+	return result, body, xattrValues, err
 }
 
 func (doc *SyncData) HasValidSyncData() bool {
@@ -1055,11 +1059,12 @@ func (doc *Document) MarshalJSON() (data []byte, err error) {
 	return data, err
 }
 
-// UnmarshalWithXattr unmarshals the provided raw document and xattr bytes.  The provided DocumentUnmarshalLevel
+// UnmarshalWithXattrs unmarshals the provided raw document and xattr bytes when present.  The provided DocumentUnmarshalLevel
 // (unmarshalLevel) specifies how much of the provided document/xattr needs to be initially unmarshalled.  If
 // unmarshalLevel is anything less than the full document + metadata, the raw data is retained for subsequent
 // lazy unmarshalling as needed.
-func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata []byte, unmarshalLevel DocumentUnmarshalLevel) error {
+// Must handle cases where document body and hlvXattrData are present without syncXattrData for all DocumentUnmarshalLevel
+func (doc *Document) UnmarshalWithXattrs(ctx context.Context, data, syncXattrData, hlvXattrData []byte, unmarshalLevel DocumentUnmarshalLevel) error {
 	if doc.ID == "" {
 		base.WarnfCtx(ctx, "Attempted to unmarshal document without ID set")
 		return errors.New("Document was unmarshalled without ID set")
@@ -1067,11 +1072,19 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 
 	switch unmarshalLevel {
 	case DocUnmarshalAll, DocUnmarshalSync:
-		// Unmarshal full document and/or sync metadata
+		// Unmarshal full document and/or sync metadata. Documents written by XDCR may have HLV but no sync data
 		doc.SyncData = SyncData{History: make(RevTree)}
-		unmarshalErr := base.JSONUnmarshal(xdata, &doc.SyncData)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), unmarshalErr))
+		if syncXattrData != nil {
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &doc.SyncData)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+		}
+		if hlvXattrData != nil {
+			err := base.JSONUnmarshal(hlvXattrData, &doc.SyncData.HLV)
+			if err != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal HLV during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), err))
+			}
 		}
 		doc._rawBody = data
 		// Unmarshal body if requested and present
@@ -1081,50 +1094,70 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 	case DocUnmarshalNoHistory:
 		// Unmarshal sync metadata only, excluding history
 		doc.SyncData = SyncData{}
-		unmarshalErr := base.JSONUnmarshal(xdata, &doc.SyncData)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+		if syncXattrData != nil {
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &doc.SyncData)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+		}
+		if hlvXattrData != nil {
+			err := base.JSONUnmarshal(hlvXattrData, &doc.SyncData.HLV)
+			if err != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal HLV during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), err))
+			}
 		}
 		doc._rawBody = data
 	case DocUnmarshalHistory:
-		historyOnlyMeta := historyOnlySyncData{History: make(RevTree)}
-		unmarshalErr := base.JSONUnmarshal(xdata, &historyOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			CurrentRev: historyOnlyMeta.CurrentRev.RevTreeID,
-			History:    historyOnlyMeta.History,
-			Cas:        historyOnlyMeta.Cas,
+		if syncXattrData != nil {
+			historyOnlyMeta := historyOnlySyncData{History: make(RevTree)}
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &historyOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				CurrentRev: historyOnlyMeta.CurrentRev.RevTreeID,
+				History:    historyOnlyMeta.History,
+				Cas:        historyOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	case DocUnmarshalRev:
 		// Unmarshal only rev and cas from sync metadata
-		var revOnlyMeta revOnlySyncData
-		unmarshalErr := base.JSONUnmarshal(xdata, &revOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			CurrentRev: revOnlyMeta.CurrentRev.RevTreeID,
-			Cas:        revOnlyMeta.Cas,
+		if syncXattrData != nil {
+			var revOnlyMeta revOnlySyncData
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &revOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				CurrentRev: revOnlyMeta.CurrentRev.RevTreeID,
+				Cas:        revOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	case DocUnmarshalCAS:
 		// Unmarshal only cas from sync metadata
-		var casOnlyMeta casOnlySyncData
-		unmarshalErr := base.JSONUnmarshal(xdata, &casOnlyMeta)
-		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalCAS).  Error: %v", base.UD(doc.ID), unmarshalErr))
-		}
-		doc.SyncData = SyncData{
-			Cas: casOnlyMeta.Cas,
+		if syncXattrData != nil {
+			var casOnlyMeta casOnlySyncData
+			unmarshalErr := base.JSONUnmarshal(syncXattrData, &casOnlyMeta)
+			if unmarshalErr != nil {
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattrs() doc with id: %s (DocUnmarshalCAS).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			}
+			doc.SyncData = SyncData{
+				Cas: casOnlyMeta.Cas,
+			}
+		} else {
+			doc.SyncData = SyncData{}
 		}
 		doc._rawBody = data
 	}
 
 	// If there's no body, but there is an xattr, set deleted flag and initialize an empty body
-	if len(data) == 0 && len(xdata) > 0 {
+	if len(data) == 0 && len(syncXattrData) > 0 {
 		doc._body = Body{}
 		doc._rawBody = []byte(base.EmptyDocument)
 		doc.Deleted = true
@@ -1132,7 +1165,8 @@ func (doc *Document) UnmarshalWithXattr(ctx context.Context, data []byte, xdata 
 	return nil
 }
 
-func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
+// MarshalWithXattrs marshals the Document into body, and sync and vv xattrs for persistence.
+func (doc *Document) MarshalWithXattrs() (data []byte, syncXattr []byte, vvXattr []byte, err error) {
 	// Grab the rawBody if it's already marshalled, otherwise unmarshal the body
 	if doc._rawBody != nil {
 		if !doc.IsDeleted() {
@@ -1149,18 +1183,25 @@ func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 			if !deleted {
 				data, err = base.JSONMarshal(body)
 				if err != nil {
-					return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc body with id: %s.  Error: %v", base.UD(doc.ID), err))
+					return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc body with id: %s.  Error: %v", base.UD(doc.ID), err))
 				}
 			}
 		}
 	}
 
-	xdata, err = base.JSONMarshal(&doc.SyncData)
-	if err != nil {
-		return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
+	if doc.SyncData.HLV != nil {
+		vvXattr, err = base.JSONMarshal(&doc.SyncData.HLV)
+		if err != nil {
+			return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc vv with id: %s.  Error: %v", base.UD(doc.ID), err))
+		}
 	}
 
-	return data, xdata, nil
+	syncXattr, err = base.JSONMarshal(&doc.SyncData)
+	if err != nil {
+		return nil, nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattrs() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
+	}
+
+	return data, syncXattr, vvXattr, nil
 }
 
 // HasCurrentVersion Compares the specified CV with the fetched documents CV, returns error on mismatch between the two

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -137,7 +137,7 @@ func BenchmarkDocUnmarshal(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			ctx := base.TestCtx(b)
 			for i := 0; i < b.N; i++ {
-				_, _ = unmarshalDocumentWithXattr(ctx, "doc_1k", doc1k_body, doc1k_meta, nil, 1, bm.unmarshalLevel)
+				_, _ = unmarshalDocumentWithXattrs(ctx, "doc_1k", doc1k_body, doc1k_meta, nil, nil, 1, bm.unmarshalLevel)
 			}
 		})
 	}
@@ -192,7 +192,7 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 	}
 }
 
-const doc_meta_with_vv = `{
+const doc_meta_no_vv = `{
     "rev": "3-89758294abc63157354c2b08547c2d21",
     "sequence": 7,
     "recent_sequences": [
@@ -235,20 +235,21 @@ const doc_meta_with_vv = `{
       },
       "GHI": null
     },
-	"_vv":{
-   		"cvCas":"0x40e2010000000000",
-   		"src":"cb06dc003846116d9b66d2ab23887a96",
-   		"ver":"0x40e2010000000000",
-   		"mv":{
-      		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
-      		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
-		},
-		"pv":{
-      		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
-   		}
-	},
     "cas": "",
     "time_saved": "2017-10-25T12:45:29.622450174-07:00"
+  }`
+
+const doc_meta_vv = `{
+	"cvCas":"0x40e2010000000000",
+	"src":"cb06dc003846116d9b66d2ab23887a96",
+	"ver":"0x40e2010000000000",
+	"mv":{
+		"s_LhRPsa7CpjEvP5zeXTXEBA":"c0ff05d7ac059a16",
+		"s_NqiIe0LekFPLeX4JvTO6Iw":"1c008cd6ac059a16"
+	},
+	"pv":{
+		"s_YZvBpEaztom9z5V/hDoeIw":"f0ff44d6ac059a16"
+	}
   }`
 
 func TestParseVersionVectorSyncData(t *testing.T) {
@@ -260,8 +261,9 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 
 	ctx := base.TestCtx(t)
 
-	doc_meta := []byte(doc_meta_with_vv)
-	doc, err := unmarshalDocumentWithXattr(ctx, "doc_1k", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	sync_meta := []byte(doc_meta_no_vv)
+	vv_meta := []byte(doc_meta_vv)
+	doc, err := unmarshalDocumentWithXattrs(ctx, "doc_1k", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	strCAS := string(base.Uint64CASToLittleEndianHex(123456))
@@ -272,7 +274,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 
-	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalAll)
+	doc, err = unmarshalDocumentWithXattrs(ctx, "doc1", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalAll)
 	require.NoError(t, err)
 
 	// assert on doc version vector values
@@ -282,7 +284,7 @@ func TestParseVersionVectorSyncData(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(mv, doc.SyncData.HLV.MergeVersions))
 	assert.True(t, reflect.DeepEqual(pv, doc.SyncData.HLV.PreviousVersions))
 
-	doc, err = unmarshalDocumentWithXattr(ctx, "doc1", nil, doc_meta, nil, 1, DocUnmarshalNoHistory)
+	doc, err = unmarshalDocumentWithXattrs(ctx, "doc1", nil, sync_meta, vv_meta, nil, 1, DocUnmarshalNoHistory)
 	require.NoError(t, err)
 
 	// assert on doc version vector values
@@ -347,32 +349,22 @@ func TestRevAndVersion(t *testing.T) {
 			require.NoError(t, err)
 			log.Printf("marshalled:%s", marshalledSyncData)
 
-			var newSyncData SyncData
-			err = base.JSONUnmarshal(marshalledSyncData, &newSyncData)
-			require.NoError(t, err)
-			require.Equal(t, test.revTreeID, newSyncData.CurrentRev)
-			require.Equal(t, expectedSequence, newSyncData.Sequence)
-			if test.source != "" {
-				require.NotNil(t, newSyncData.HLV)
-				require.Equal(t, test.source, newSyncData.HLV.SourceID)
-				require.Equal(t, test.version, newSyncData.HLV.Version)
-			}
-
 			// Document test
 			document := NewDocument("docID")
 			document.SyncData.CurrentRev = test.revTreeID
+			document.SyncData.Sequence = expectedSequence
 			document.SyncData.HLV = &HybridLogicalVector{
 				SourceID: test.source,
 				Version:  test.version,
 			}
-			marshalledDoc, marshalledXattr, err := document.MarshalWithXattr()
+			marshalledDoc, marshalledXattr, marshalledVvXattr, err := document.MarshalWithXattrs()
 			require.NoError(t, err)
 
 			newDocument := NewDocument("docID")
-			err = newDocument.UnmarshalWithXattr(ctx, marshalledDoc, marshalledXattr, DocUnmarshalAll)
+			err = newDocument.UnmarshalWithXattrs(ctx, marshalledDoc, marshalledXattr, marshalledVvXattr, DocUnmarshalAll)
 			require.NoError(t, err)
 			require.Equal(t, test.revTreeID, newDocument.CurrentRev)
-			require.Equal(t, expectedSequence, newSyncData.Sequence)
+			require.Equal(t, expectedSequence, newDocument.Sequence)
 			if test.source != "" {
 				require.NotNil(t, newDocument.HLV)
 				require.Equal(t, test.source, newDocument.HLV.SourceID)
@@ -493,17 +485,15 @@ func TestDCPDecodeValue(t *testing.T) {
 				require.Nil(t, xattrs)
 			}
 			// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
-			result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
+			result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(test.body, base.MemcachedDataTypeXattr, "", false)
 			require.ErrorIs(t, err, test.expectedErr)
 			if test.expectedSyncXattr != nil {
 				require.NotNil(t, result)
+				require.Equal(t, test.expectedSyncXattr, rawXattrs[base.SyncXattrName])
 			} else {
 				require.Nil(t, result)
 			}
 			require.Equal(t, test.expectedBody, rawBody)
-			require.Equal(t, test.expectedSyncXattr, rawXattr)
-			require.Nil(t, rawUserXattr)
-
 		})
 	}
 }
@@ -514,19 +504,17 @@ func TestInvalidXattrStreamEmptyBody(t *testing.T) {
 	emptyBody := []byte{}
 
 	// DecodeValueWithXattrs is the underlying function
-	body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{"_sync"}, inputStream)
+	body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{base.SyncXattrName}, inputStream)
 	require.NoError(t, err)
 	require.Equal(t, emptyBody, body)
 	require.Empty(t, xattrs)
 
 	// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
-	result, rawBody, rawXattr, rawUserXattr, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
+	result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
 	require.Error(t, err) // unexpected end of JSON input
 	require.Nil(t, result)
 	require.Equal(t, emptyBody, rawBody)
-	require.Nil(t, rawXattr)
-	require.Nil(t, rawUserXattr)
-
+	require.Nil(t, rawXattrs[base.SyncXattrName])
 }
 
 // getSingleXattrDCPBytes returns a DCP body with a single xattr pair and body

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -377,14 +377,14 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansionSpec {
 	var outputSpec []sgbucket.MacroExpansionSpec
 	if hlv.Version == hlvExpandMacroCASValue {
-		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionPath(base.SyncXattrName), sgbucket.MacroCas)
+		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionPath(base.VvXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, spec)
 		// If version is being expanded, we need to also specify the macro expansion for the expanded rev property
 		currentRevSpec := sgbucket.NewMacroExpansionSpec(xattrCurrentRevVersionPath(base.SyncXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, currentRevSpec)
 	}
 	if hlv.CurrentVersionCAS == hlvExpandMacroCASValue {
-		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.SyncXattrName), sgbucket.MacroCas)
+		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.VvXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, spec)
 	}
 	return outputSpec

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -298,7 +298,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, DocID, db.DocUnmarshalCAS)
 	require.NoError(t, err)
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)
@@ -330,7 +330,7 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 	changes, err := rt.WaitForChanges(1, fmt.Sprintf(`/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=%s`, DocID), "", true)
 	require.NoError(t, err)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, DocID, db.DocUnmarshalCAS)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, DocID, db.DocUnmarshalCAS)
 	require.NoError(t, err)
 
 	assert.Equal(t, "doc1", changes.Results[0].ID)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -924,7 +924,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	// Write another doc
 	_ = rt.PutDoc("mix-1", `{"channel":["ABC", "PBS", "HBO"]}`)
 
-	fetchedDoc, _, err := collection.GetDocWithXattr(ctx, "mix-1", db.DocUnmarshalSync)
+	fetchedDoc, _, err := collection.GetDocWithXattrs(ctx, "mix-1", db.DocUnmarshalSync)
 	require.NoError(t, err)
 	mixSource, mixVersion := fetchedDoc.HLV.GetCurrentVersion()
 

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -410,11 +410,11 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	}
 	value := sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err := db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
-	assert.Equal(t, syncXattr, string(rawXattr))
+	assert.Equal(t, syncXattr, string(rawXattrs[base.SyncXattrName]))
 	assert.Equal(t, uint64(200), syncData.Sequence)
-	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Equal(t, channelName, string(rawXattrs[userXattrKey]))
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with just user xattr defined
@@ -423,21 +423,21 @@ func TestUnmarshalDocFromImportFeed(t *testing.T) {
 	}
 	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Nil(t, syncData)
-	assert.Nil(t, rawXattr)
-	assert.Equal(t, channelName, string(rawUserXattr))
+	assert.Nil(t, rawXattrs[base.SyncXattrName])
+	assert.Equal(t, channelName, string(rawXattrs[userXattrKey]))
 	assert.Equal(t, body, rawBody)
 
 	// construct data into dcp format with no xattr defined
 	xattrs = []sgbucket.Xattr{}
 	value = sgbucket.EncodeValueWithXattrs(body, xattrs...)
 
-	syncData, rawBody, rawXattr, rawUserXattr, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
+	syncData, rawBody, rawXattrs, err = db.UnmarshalDocumentSyncDataFromFeed(value, 5, userXattrKey, false)
 	require.NoError(t, err)
 	assert.Nil(t, syncData)
-	assert.Nil(t, rawXattr)
-	assert.Nil(t, rawUserXattr)
+	assert.Nil(t, rawXattrs[base.SyncXattrName])
+	assert.Nil(t, rawXattrs[userXattrKey])
 	assert.Equal(t, body, rawBody)
 }


### PR DESCRIPTION
Modifies document marshal and unmarshal to support a set of xattrs (_sync, _vv), and does the same for parsing DCP stream events (including user xattr).

CBG-3877

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
