### PR TITLE
CBG-3867 disallow creating a replication with an empty ID

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -807,7 +807,7 @@ func (m *sgReplicateManager) RefreshReplicationCfg(ctx context.Context) error {
 			if !exists {
 				replicator, initError := m.InitializeReplication(replicationCfg)
 				if initError != nil {
-					base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", initError)
+					base.WarnfCtx(m.loggingCtx, "Error initializing replication %s: %v", replicationID, initError)
 					continue
 				}
 				m.activeReplicators[replicationID] = replicator
@@ -1071,7 +1071,9 @@ func (m *sgReplicateManager) PutReplications(replications map[string]*Replicatio
 
 // PUT _replication/replicationID
 func (m *sgReplicateManager) UpsertReplication(ctx context.Context, replication *ReplicationUpsertConfig) (created bool, err error) {
-
+	if replication.ID == "" {
+		return false, base.HTTPErrorf(http.StatusBadRequest, "Replication ID is required")
+	}
 	created = true
 	addReplicationCallback := func(cluster *SGRCluster) (cancel bool, err error) {
 		_, exists := cluster.Replications[replication.ID]

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8304,6 +8304,15 @@ func TestReplicatorWithCollectionsFailWithoutCollectionsEnabled(t *testing.T) {
 
 }
 
+func TestBanEmptyReplicationID(t *testing.T) {
+	rt := rest.NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest("POST", "/{{.db}}/_replication/", `{"remote": "fakeremote", "direction": "pull", "initial_state": "stopped"}`)
+	rest.RequireStatus(t, resp, http.StatusBadRequest)
+	require.Contains(t, string(resp.Body.Bytes()), "Replication ID is required")
+}
+
 func requireBodyEqual(t *testing.T, expected string, doc *db.Document) {
 	var expectedBody db.Body
 	require.NoError(t, base.JSONUnmarshal([]byte(expected), &expectedBody))


### PR DESCRIPTION

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2458/
