### PR TITLE
CBG-3950 filter principal docs for default collection

### DIFF
--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1507,3 +1507,68 @@ func TestUnauthorizedAccessForDB(t *testing.T) {
 	require.Contains(t, response.Body.String(), ErrInvalidLogin.Message)
 
 }
+
+func TestUserMultipleDBs(t *testing.T) {
+	base.RequireNumTestDataStores(t, 2)
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	defaultCollectionDB := "defaultcollectiondb"
+	namedCollectionDB := "namedcollectiondb"
+	// create database using _default._default
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = nil
+	RequireStatus(t, rt.CreateDatabase(defaultCollectionDB, dbConfig), http.StatusCreated)
+
+	// create a database with a named collection
+	dbConfig = rt.NewDbConfig()
+	dbConfig.Scopes = GetCollectionsConfig(t, rt.TestBucket, 1)
+	RequireStatus(t, rt.CreateDatabase(namedCollectionDB, dbConfig), http.StatusCreated)
+
+	// create matching named user and roles in both databases
+	for _, dbName := range []string{defaultCollectionDB, namedCollectionDB} {
+		username := "alice"
+		userConfig := string(base.MustJSONMarshal(t,
+			auth.PrincipalConfig{
+				Name:     &username,
+				Password: base.StringPtr(RestTesterDefaultUserPassword),
+			}))
+		resp := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_user/"+username, userConfig)
+		RequireStatus(t, resp, http.StatusCreated)
+
+		rolename := "role1"
+		roleConfig := string(base.MustJSONMarshal(t,
+			auth.PrincipalConfig{
+				Name: &rolename,
+			}))
+		resp = rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_role/"+rolename, roleConfig)
+		RequireStatus(t, resp, http.StatusCreated)
+	}
+
+	for _, dbName := range []string{defaultCollectionDB, namedCollectionDB} {
+		t.Run(dbName, func(t *testing.T) {
+			// /db/_user?name_only=false only works with GSI
+			if !base.TestsDisableGSI() {
+				resp := rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_user/?name_only=false", "")
+				RequireStatus(t, resp, http.StatusOK)
+				var users []auth.PrincipalConfig
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &users))
+				require.Len(t, users, 1)
+			}
+			resp := rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_user/?name_only=true", "")
+			RequireStatus(t, resp, http.StatusOK)
+			var usernames []string
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &usernames))
+			require.Len(t, usernames, 1)
+
+			resp = rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_role/", "")
+			RequireStatus(t, resp, http.StatusOK)
+			var roles []string
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &roles))
+			require.Len(t, roles, 1)
+
+		})
+	}
+}

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1527,47 +1527,55 @@ func TestUserMultipleDBs(t *testing.T) {
 	dbConfig.Scopes = GetCollectionsConfig(t, rt.TestBucket, 1)
 	RequireStatus(t, rt.CreateDatabase(namedCollectionDB, dbConfig), http.StatusCreated)
 
-	// create matching named user and roles in both databases
+	// create matching named user and roles in both databases. Use multiple since there is some alphabetical sensitivity.
+	// alice
+	// defaultcollectiondb
+	// john
+	// namedcollectiondb
+	// sam
 	for _, dbName := range []string{defaultCollectionDB, namedCollectionDB} {
-		username := "alice"
-		userConfig := string(base.MustJSONMarshal(t,
-			auth.PrincipalConfig{
-				Name:     &username,
-				Password: base.StringPtr(RestTesterDefaultUserPassword),
-			}))
-		resp := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_user/"+username, userConfig)
-		RequireStatus(t, resp, http.StatusCreated)
-
-		rolename := "role1"
-		roleConfig := string(base.MustJSONMarshal(t,
-			auth.PrincipalConfig{
-				Name: &rolename,
-			}))
-		resp = rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_role/"+rolename, roleConfig)
-		RequireStatus(t, resp, http.StatusCreated)
+		for _, username := range []string{"alice", "john", "sam"} {
+			userConfig := string(base.MustJSONMarshal(t,
+				auth.PrincipalConfig{
+					Name:     &username,
+					Password: base.StringPtr(RestTesterDefaultUserPassword),
+				}))
+			resp := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_user/"+username, userConfig)
+			RequireStatus(t, resp, http.StatusCreated)
+		}
+		for _, rolename := range []string{"arole1", "jrole2", "srole3"} {
+			roleConfig := string(base.MustJSONMarshal(t,
+				auth.PrincipalConfig{
+					Name: &rolename,
+				}))
+			resp := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_role/"+rolename, roleConfig)
+			RequireStatus(t, resp, http.StatusCreated)
+		}
 	}
 
 	for _, dbName := range []string{defaultCollectionDB, namedCollectionDB} {
 		t.Run(dbName, func(t *testing.T) {
+			numUsers := 3
+			numRoles := 3
 			// /db/_user?name_only=false only works with GSI
 			if !base.TestsDisableGSI() {
 				resp := rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_user/?name_only=false", "")
 				RequireStatus(t, resp, http.StatusOK)
 				var users []auth.PrincipalConfig
 				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &users))
-				require.Len(t, users, 1)
+				require.Len(t, users, numUsers)
 			}
 			resp := rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_user/?name_only=true", "")
 			RequireStatus(t, resp, http.StatusOK)
 			var usernames []string
 			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &usernames))
-			require.Len(t, usernames, 1)
+			require.Len(t, usernames, numUsers)
 
 			resp = rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_role/", "")
 			RequireStatus(t, resp, http.StatusOK)
 			var roles []string
 			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &roles))
-			require.Len(t, roles, 1)
+			require.Len(t, roles, numRoles)
 
 		})
 	}


### PR DESCRIPTION
When using non default metadata id, the /_user/ and /_role/ endpoints need to filter any docs with _sync:user:db:alice from docs that look like _sync:user:alice

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2462/
