### PR TITLE
CBG-3856: Add missing permissions to GET /db/ endpoint

### DIFF
--- a/rest/admin_api_auth_routing_permissions.go
+++ b/rest/admin_api_auth_routing_permissions.go
@@ -63,6 +63,7 @@ var (
 	PermCreateDb             = Permission{".sgw.db!create", true}
 	PermDeleteDb             = Permission{".sgw.db!delete", true}
 	PermUpdateDb             = Permission{".sgw.db!update", true}
+	PermGetDb                = Permission{".sgw.db!get", true}
 	PermConfigureSyncFn      = Permission{".sgw.sync_function!configure", true}
 	PermConfigureAuth        = Permission{".sgw.auth!configure", true}
 	PermWritePrincipal       = Permission{".sgw.principal!write", true}

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -1042,7 +1042,7 @@ func TestNewlyCreateSGWPermissions(t *testing.T) {
 		{
 			Method:   "GET",
 			Endpoint: "/db/",
-			Users:    []string{syncGatewayDevOps},
+			Users:    []string{syncGatewayDevOps, syncGatewayConfigurator},
 		},
 		{
 			Method:   "POST",

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -43,7 +43,7 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 	root.Handle("/", makeHandler(sc, privs, nil, nil, (*handler).handleRoot)).Methods("GET", "HEAD")
 
 	// Operations on databases:
-	root.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, []Permission{PermDevOps}, nil, (*handler).handleGetDB)).Methods("GET", "HEAD")
+	root.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, []Permission{PermDevOps, PermGetDb}, nil, (*handler).handleGetDB)).Methods("GET", "HEAD")
 	root.Handle("/{keyspace:"+dbRegex+"}/", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePostDoc)).Methods("POST")
 
 	// Keyspace operations (i.e. collection-specific):


### PR DESCRIPTION
CBG-3856

- Added Architect role for get /db/ endpoint 
- Added test case to TestNewlyCreateSGWPermissions

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2464/
