### PR TITLE
CBG-3957 add reason in all_dbs for why db is offline

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -215,6 +215,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 
 		// If we regenerated sequences, update syncInfo for all collections affected
 		if regenerateSequences {
+			updatedDsNames := make(map[base.ScopeAndCollectionName]struct{}, len(collectionIDs))
 			for _, collectionID := range collectionIDs {
 				dbc, ok := db.CollectionByID[collectionID]
 				if !ok {
@@ -223,8 +224,16 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 				if err := base.SetSyncInfo(dbc.dataStore, db.DatabaseContext.Options.MetadataID); err != nil {
 					base.WarnfCtx(ctx, "[%s] Completed resync, but unable to update syncInfo for collection %v: %v", resyncLoggingID, collectionID, err)
 				}
-
+				updatedDsNames[base.ScopeAndCollectionName{Scope: dbc.ScopeName, Collection: dbc.Name}] = struct{}{}
 			}
+			collectionsRequiringResync := make([]base.ScopeAndCollectionName, 0)
+			for _, dsName := range db.RequireResync {
+				_, ok := updatedDsNames[dsName]
+				if !ok {
+					collectionsRequiringResync = append(collectionsRequiringResync, dsName)
+				}
+			}
+			db.RequireResync = collectionsRequiringResync
 		}
 	case <-terminator.Done():
 		base.DebugfCtx(ctx, base.KeyAll, "[%s] Terminator closed. Ending Resync process.", resyncLoggingID)
@@ -242,22 +251,6 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		base.InfofCtx(ctx, base.KeyAll, "[%s] resync was terminated. Docs changed: %d Docs Processed: %d", resyncLoggingID, r.DocsChanged.Value(), r.DocsProcessed.Value())
 	}
 
-	collectionsRequiringResync := make([]base.ScopeAndCollectionName, 0)
-	for _, collection := range db.CollectionByID {
-		dataStore := collection.dataStore
-		resyncRequired, err := base.InitSyncInfo(dataStore, db.DatabaseContext.Options.MetadataID)
-		// if we can't write this document but made it here, the resync completed fine, and DatabaseContext.RequireResync will be reset when the database is recreated when it goes online.
-		if err != nil {
-			base.WarnfCtx(ctx, "[%s] error updated sync info for collection %v", resyncLoggingID, err)
-			return nil
-		}
-		if !resyncRequired {
-			continue
-		}
-		dsName := base.ScopeAndCollectionName{Scope: dataStore.ScopeName(), Collection: dataStore.CollectionName()}
-		collectionsRequiringResync = append(collectionsRequiringResync, dsName)
-	}
-	db.RequireResync = collectionsRequiringResync
 	return nil
 }
 

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2512,8 +2512,8 @@ CollectionNames:
           - Starting
           - Stopping
           - Resyncing
-      offline_reason:
-        description: If the database state is offline, this field might be populated with reason `require_resync`.
+      reason:
+        description: Optional reason a database is in a particular state.
         enum:
           - require_resync
           - ""

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2512,6 +2512,11 @@ CollectionNames:
           - Starting
           - Stopping
           - Resyncing
+      offline_reason:
+        description: If the database state is offline, this field might be populated with reason `require_resync`.
+        enum:
+          - require_resync
+          - ""
 all_user_channels:
   description: |-
     All user channels split by how they were assigned to the user and by keyspace.

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -265,10 +265,10 @@ func TestRequireResync(t *testing.T) {
 	// databases sorted alphabetically
 	require.Equal(t, db1Name, allDBsSummary[0].DBName)
 	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
-	require.Equal(t, "", allDBsSummary[0].OfflineReason)
+	require.Equal(t, "", allDBsSummary[0].Reason)
 	require.Equal(t, db2Name, allDBsSummary[1].DBName)
 	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
-	require.Equal(t, rest.OfflineReasonRequireResync, allDBsSummary[1].OfflineReason)
+	require.Equal(t, rest.OfflineReasonRequireResync, allDBsSummary[1].Reason)
 
 	// Run resync for collection
 	resyncCollections := make(db.ResyncCollections, 0)
@@ -296,10 +296,10 @@ func TestRequireResync(t *testing.T) {
 	// databases sorted alphabetically
 	require.Equal(t, db1Name, allDBsSummary[0].DBName)
 	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
-	require.Equal(t, "", allDBsSummary[0].OfflineReason)
+	require.Equal(t, "", allDBsSummary[0].Reason)
 	require.Equal(t, db2Name, allDBsSummary[1].DBName)
 	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
-	require.Equal(t, "", allDBsSummary[1].OfflineReason)
+	require.Equal(t, "", allDBsSummary[1].Reason)
 
 	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -256,6 +256,20 @@ func TestRequireResync(t *testing.T) {
 		require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
 		return slices.Equal(needsResync, dbRootResponse.RequireResync)
 	}, "expected %+v but got %+v for requireResync", needsResync, dbRootResponse.RequireResync)
+
+	resp = rt.SendAdminRequest("GET", "/_all_dbs?verbose=true", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	var allDBsSummary []rest.DbSummary
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &allDBsSummary))
+	require.Len(t, allDBsSummary, 2)
+	// databases sorted alphabetically
+	require.Equal(t, db1Name, allDBsSummary[0].DBName)
+	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
+	require.Equal(t, "", allDBsSummary[0].OfflineReason)
+	require.Equal(t, db2Name, allDBsSummary[1].DBName)
+	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
+	require.Equal(t, rest.OfflineReasonRequireResync, allDBsSummary[1].OfflineReason)
+
 	// Run resync for collection
 	resyncCollections := make(db.ResyncCollections, 0)
 	resyncCollections[scope] = []string{collection1}
@@ -274,6 +288,25 @@ func TestRequireResync(t *testing.T) {
 			return db2.ResyncManager.GetRunState()
 		})
 
+	resp = rt.SendAdminRequest("GET", "/_all_dbs?verbose=true", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	allDBsSummary = nil
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &allDBsSummary))
+	require.Len(t, allDBsSummary, 2)
+	// databases sorted alphabetically
+	require.Equal(t, db1Name, allDBsSummary[0].DBName)
+	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
+	require.Equal(t, "", allDBsSummary[0].OfflineReason)
+	require.Equal(t, db2Name, allDBsSummary[1].DBName)
+	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
+	require.Equal(t, "", allDBsSummary[1].OfflineReason)
+
+	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	dbRootResponse = rest.DatabaseRoot{}
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
+	assert.Nil(t, dbRootResponse.RequireResync)
+
 	// Attempt online again, should now succeed
 	onlineResponse = rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
 	rest.RequireStatus(t, onlineResponse, http.StatusOK)
@@ -283,6 +316,7 @@ func TestRequireResync(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	dbRootResponse = rest.DatabaseRoot{}
 	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
+	assert.Nil(t, dbRootResponse.RequireResync)
 	assert.Nil(t, dbRootResponse.RequireResync)
 
 	resp = rt.SendAdminRequest("GET", "/"+ks_db2_c1+"/testDoc1", "")

--- a/rest/api.go
+++ b/rest/api.go
@@ -407,10 +407,10 @@ type DatabaseRoot struct {
 }
 
 type DbSummary struct {
-	DBName        string `json:"db_name"`
-	Bucket        string `json:"bucket"`
-	State         string `json:"state"`
-	OfflineReason string `json:"offline_reason,omitempty"`
+	DBName string `json:"db_name"`
+	Bucket string `json:"bucket"`
+	State  string `json:"state"`
+	Reason string `json:"reason,omitempty"`
 }
 
 func (h *handler) handleGetDB() error {

--- a/rest/api.go
+++ b/rest/api.go
@@ -410,7 +410,7 @@ type DbSummary struct {
 	DBName        string `json:"db_name"`
 	Bucket        string `json:"bucket"`
 	State         string `json:"state"`
-	OfflineReason string `json:"offline_reason"`
+	OfflineReason string `json:"offline_reason,omitempty"`
 }
 
 func (h *handler) handleGetDB() error {

--- a/rest/api.go
+++ b/rest/api.go
@@ -406,10 +406,11 @@ type DatabaseRoot struct {
 	RequireResync                 []string `json:"require_resync,omitempty"`
 }
 
-type dbSummary struct {
-	DBName string `json:"db_name"`
-	Bucket string `json:"bucket"`
-	State  string `json:"state"`
+type DbSummary struct {
+	DBName        string `json:"db_name"`
+	Bucket        string `json:"bucket"`
+	State         string `json:"state"`
+	OfflineReason string `json:"offline_reason"`
 }
 
 func (h *handler) handleGetDB() error {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -363,7 +363,7 @@ func (sc *ServerContext) allDatabaseSummaries() []DbSummary {
 		}
 		if state == db.RunStateString[db.DBOffline] {
 			if len(dbctx.RequireResync.ScopeAndCollectionNames()) > 0 {
-				summary.OfflineReason = OfflineReasonRequireResync
+				summary.Reason = OfflineReasonRequireResync
 			}
 		}
 		dbs = append(dbs, summary)


### PR DESCRIPTION
- fix issue where DatabaseContext.RequiresResync was only updated when
  creating a Database. Update this value after resync completes

I think I'd rather put `requires_resync` field to match `GET /db/` output, but I thought there was a reason that we didn't do that.

Made the fields public only to assert on them in `rest.adminapitest` package.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2467/
