### PR TITLE
[3.1.7 backport] CBG-3955 allow specifying empty string import and sync fn

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -257,7 +257,7 @@ func TestMultiCollectionDCP(t *testing.T) {
 				AutoImport: true,
 				Scopes: ScopesConfig{
 					"foo": ScopeConfig{
-						Collections: map[string]CollectionConfig{
+						Collections: map[string]*CollectionConfig{
 							"bar": {},
 							"baz": {},
 						},
@@ -302,8 +302,8 @@ func TestMultiCollectionChannelAccess(t *testing.T) {
 	collection1 := dataStoreNames[0].CollectionName()
 	collection2 := dataStoreNames[1].CollectionName()
 
-	scopesConfig[scope].Collections[collection1] = CollectionConfig{SyncFn: &c1SyncFunction}
-	scopesConfig[scope].Collections[collection2] = CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[scope].Collections[collection1] = &CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[scope].Collections[collection2] = &CollectionConfig{SyncFn: &c1SyncFunction}
 
 	fmt.Println(scopesConfig)
 	rtConfig := &RestTesterConfig{
@@ -365,9 +365,9 @@ func TestMultiCollectionChannelAccess(t *testing.T) {
 	dataStoreNames = GetDataStoreNamesFromScopesConfig(scopesConfig)
 
 	collection3 := dataStoreNames[2].CollectionName()
-	scopesConfig[scope].Collections[collection1] = CollectionConfig{SyncFn: &c1SyncFunction}
-	scopesConfig[scope].Collections[collection2] = CollectionConfig{SyncFn: &c1SyncFunction}
-	scopesConfig[scope].Collections[collection3] = CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[scope].Collections[collection1] = &CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[scope].Collections[collection2] = &CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[scope].Collections[collection3] = &CollectionConfig{SyncFn: &c1SyncFunction}
 	scopesConfigString, err := json.Marshal(scopesConfig)
 	require.NoError(t, err)
 
@@ -404,8 +404,8 @@ func TestMultiCollectionChannelAccess(t *testing.T) {
 	// Remove collection and update the db config
 	scopesConfig = GetCollectionsConfig(t, tb, 2)
 
-	scopesConfig[scope].Collections[collection1] = CollectionConfig{SyncFn: &c1SyncFunction}
-	scopesConfig[scope].Collections[collection2] = CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[scope].Collections[collection1] = &CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[scope].Collections[collection2] = &CollectionConfig{SyncFn: &c1SyncFunction}
 	scopesConfigString, err = json.Marshal(scopesConfig)
 	require.NoError(t, err)
 
@@ -435,8 +435,8 @@ func TestMultiCollectionDynamicChannelAccess(t *testing.T) {
                   channel(doc.chan);
             }`
 
-	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = CollectionConfig{SyncFn: &c1SyncFunction}
-	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = &CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = &CollectionConfig{SyncFn: &c1SyncFunction}
 
 	rtConfig := &RestTesterConfig{
 		CustomTestBucket: tb,
@@ -870,8 +870,8 @@ func TestCollectionStats(t *testing.T) {
 
 	scope1Name, collection1Name := dataStoreNames[0].ScopeName(), dataStoreNames[0].CollectionName()
 	scope2Name, collection2Name := dataStoreNames[1].ScopeName(), dataStoreNames[1].CollectionName()
-	scopesConfig[scope1Name].Collections[collection1Name] = CollectionConfig{SyncFn: &syncFn}
-	scopesConfig[scope2Name].Collections[collection2Name] = CollectionConfig{SyncFn: &syncFn}
+	scopesConfig[scope1Name].Collections[collection1Name] = &CollectionConfig{SyncFn: &syncFn}
+	scopesConfig[scope2Name].Collections[collection2Name] = &CollectionConfig{SyncFn: &syncFn}
 
 	rtConfig := &RestTesterConfig{
 		CustomTestBucket: tb,

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -463,8 +463,8 @@ func TestMultiCollectionChangesCustomSyncFunctions(t *testing.T) {
 			channel("!")
 		}
 	}`
-	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = rest.CollectionConfig{SyncFn: &c1SyncFunction}
-	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = rest.CollectionConfig{SyncFn: &c2SyncFunction}
+	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = &rest.CollectionConfig{SyncFn: &c1SyncFunction}
+	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = &rest.CollectionConfig{SyncFn: &c2SyncFunction}
 
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket: testBucket,

--- a/rest/config.go
+++ b/rest/config.go
@@ -176,7 +176,7 @@ type ScopeConfig struct {
 	Collections CollectionsConfig `json:"collections,omitempty"` // Collection-specific config options.
 }
 
-type CollectionsConfig map[string]CollectionConfig
+type CollectionsConfig map[string]*CollectionConfig
 type CollectionConfig struct {
 	SyncFn       *string `json:"sync,omitempty"`          // The sync function applied to write operations in this collection.
 	ImportFilter *string `json:"import_filter,omitempty"` // The import filter applied to import operations in this collection.

--- a/rest/config_manager_test.go
+++ b/rest/config_manager_test.go
@@ -118,7 +118,7 @@ func TestComputeMetadataID(t *testing.T) {
 	require.True(t, registry.removeDatabase(t.Name(), existingDbName))
 
 	// Database that includes the default collection (where _sync:seq exists) should use default metadata ID
-	defaultAndNamedScopesConfig := ScopesConfig{base.DefaultScope: ScopeConfig{map[string]CollectionConfig{base.DefaultCollection: {}, "collection1": {}}}}
+	defaultAndNamedScopesConfig := ScopesConfig{base.DefaultScope: ScopeConfig{map[string]*CollectionConfig{base.DefaultCollection: {}, "collection1": {}}}}
 	defaultDbConfig.Scopes = defaultAndNamedScopesConfig
 	metadataID = bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
 	assert.Equal(t, defaultMetadataID, metadataID)
@@ -139,7 +139,7 @@ func TestComputeMetadataID(t *testing.T) {
 	require.Equal(t, multiConfigGroupDbName, metadataID)
 
 	// Single, non-default collection should use standard metadata ID
-	namedOnlyScopesConfig := ScopesConfig{base.DefaultScope: ScopeConfig{map[string]CollectionConfig{"collection1": {}}}}
+	namedOnlyScopesConfig := ScopesConfig{base.DefaultScope: ScopeConfig{map[string]*CollectionConfig{"collection1": {}}}}
 	defaultDbConfig.Scopes = namedOnlyScopesConfig
 	metadataID = bootstrapContext.computeMetadataID(ctx, registry, &defaultDbConfig)
 	assert.Equal(t, standardMetadataID, metadataID)

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -104,7 +104,7 @@ type RegistryScope struct {
 }
 
 var defaultOnlyRegistryScopes = map[string]RegistryScope{base.DefaultScope: {Collections: []string{base.DefaultCollection}}}
-var DefaultOnlyScopesConfig = ScopesConfig{base.DefaultScope: {Collections: map[string]CollectionConfig{base.DefaultCollection: {}}}}
+var DefaultOnlyScopesConfig = ScopesConfig{base.DefaultScope: {Collections: map[string]*CollectionConfig{base.DefaultCollection: {}}}}
 
 func NewGatewayRegistry(syncGatewayVersion base.ComparableVersion) *GatewayRegistry {
 	return &GatewayRegistry{

--- a/rest/config_registry_test.go
+++ b/rest/config_registry_test.go
@@ -291,11 +291,11 @@ func makeDatabaseConfig(dbName string, scopeName string, collectionNames []strin
 	var scopesConfig ScopesConfig
 	scopesConfig = ScopesConfig{
 		scopeName: ScopeConfig{
-			map[string]CollectionConfig{},
+			map[string]*CollectionConfig{},
 		},
 	}
 	for _, collectionName := range collectionNames {
-		scopesConfig[scopeName].Collections[collectionName] = CollectionConfig{}
+		scopesConfig[scopeName].Collections[collectionName] = &CollectionConfig{}
 	}
 
 	return &DatabaseConfig{

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2669,7 +2669,7 @@ func TestCollectionsValidation(t *testing.T) {
 				UseViews: base.BoolPtr(true),
 				Scopes: ScopesConfig{
 					"fooScope": ScopeConfig{
-						map[string]CollectionConfig{
+						map[string]*CollectionConfig{
 							"fooCollection:": {},
 						},
 					},
@@ -2692,7 +2692,7 @@ func TestCollectionsValidation(t *testing.T) {
 				UseViews: base.BoolPtr(false),
 				Scopes: ScopesConfig{
 					"fooScope": ScopeConfig{
-						map[string]CollectionConfig{
+						map[string]*CollectionConfig{
 							"fooCollection:": {},
 						},
 					},
@@ -2713,7 +2713,7 @@ func TestCollectionsValidation(t *testing.T) {
 				Name: "db",
 				Scopes: ScopesConfig{
 					"fooScope": ScopeConfig{
-						map[string]CollectionConfig{
+						map[string]*CollectionConfig{
 							"fooCollection:": {},
 						},
 					},

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -502,7 +502,7 @@ func makeScopesConfig(scopeName string, collectionNames []string) ScopesConfig {
 
 	collectionsConfig := make(CollectionsConfig)
 	for _, collectionName := range collectionNames {
-		collectionsConfig[collectionName] = CollectionConfig{}
+		collectionsConfig[collectionName] = &CollectionConfig{}
 	}
 	return ScopesConfig{
 		scopeName: ScopeConfig{

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -38,8 +38,8 @@ func TestMultiCollectionImportFilter(t *testing.T) {
 	importFilter2 := `function (doc) { return doc.type == "onprem"}`
 	importFilter3 := `function (doc) { return doc.type == "private"}`
 
-	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = rest.CollectionConfig{ImportFilter: &importFilter1}
-	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = rest.CollectionConfig{ImportFilter: &importFilter2}
+	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = &rest.CollectionConfig{ImportFilter: &importFilter1}
+	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = &rest.CollectionConfig{ImportFilter: &importFilter2}
 
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket: testBucket.NoCloseClone(),
@@ -153,9 +153,9 @@ func TestMultiCollectionImportFilter(t *testing.T) {
 	scopesConfig = rest.GetCollectionsConfig(t, testBucket, 3)
 	dataStoreNames = rest.GetDataStoreNamesFromScopesConfig(scopesConfig)
 
-	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = rest.CollectionConfig{ImportFilter: &importFilter1}
-	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = rest.CollectionConfig{ImportFilter: &importFilter2}
-	scopesConfig[dataStoreNames[2].ScopeName()].Collections[dataStoreNames[2].CollectionName()] = rest.CollectionConfig{ImportFilter: &importFilter3}
+	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = &rest.CollectionConfig{ImportFilter: &importFilter1}
+	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = &rest.CollectionConfig{ImportFilter: &importFilter2}
+	scopesConfig[dataStoreNames[2].ScopeName()].Collections[dataStoreNames[2].CollectionName()] = &rest.CollectionConfig{ImportFilter: &importFilter3}
 
 	scopesConfigString, err := json.Marshal(scopesConfig)
 	require.NoError(t, err)
@@ -200,8 +200,8 @@ func TestMultiCollectionImportFilter(t *testing.T) {
 	scopesConfig = rest.GetCollectionsConfig(t, testBucket, 2)
 	dataStoreNames = rest.GetDataStoreNamesFromScopesConfig(scopesConfig)
 
-	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = rest.CollectionConfig{ImportFilter: &importFilter1}
-	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = rest.CollectionConfig{ImportFilter: &importFilter2}
+	scopesConfig[dataStoreNames[0].ScopeName()].Collections[dataStoreNames[0].CollectionName()] = &rest.CollectionConfig{ImportFilter: &importFilter1}
+	scopesConfig[dataStoreNames[1].ScopeName()].Collections[dataStoreNames[1].CollectionName()] = &rest.CollectionConfig{ImportFilter: &importFilter2}
 	scopesConfigString, err = json.Marshal(scopesConfig)
 	require.NoError(t, err)
 

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -663,7 +663,7 @@ func makeDbConfig(t *testing.T, tb *base.TestBucket, syncFunction string, import
 	scopesConfig := rest.GetCollectionsConfig(t, tb, 3)
 	for scopeName, scope := range scopesConfig {
 		for collectionName, _ := range scope.Collections {
-			collectionConfig := rest.CollectionConfig{}
+			collectionConfig := &rest.CollectionConfig{}
 			if syncFunction != "" {
 				collectionConfig.SyncFn = &syncFunction
 			}

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -338,82 +338,46 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 }
 
 func TestImportFilterEndpoint(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Bootstrap works with Couchbase Server only")
-	}
+	base.TestsRequireBootstrapConnection(t)
+	base.SkipImportTestsIfNotEnabled(t)
 
-	if !base.TestUseXattrs() {
-		t.Skip("Test requires xattrs")
-	}
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
+	defer rt.Close()
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
-
-	serverErr := make(chan error, 0)
-
-	// Start SG with no databases
-	ctx := base.TestCtx(t)
-	config := BootstrapStartupConfigForTest(t)
-	sc, err := SetupServerContext(ctx, &config, true)
-	require.NoError(t, err)
-	defer func() {
-		sc.Close(ctx)
-		require.NoError(t, <-serverErr)
-	}()
-
-	go func() {
-		serverErr <- StartServer(ctx, &config, sc)
-	}()
-	require.NoError(t, sc.WaitForRESTAPIs(ctx))
-
-	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() {
-		fmt.Println("closing test bucket")
-		tb.Close(ctx)
-	}()
-	resp := BootstrapAdminRequest(t, http.MethodPut, "/db1/",
-		fmt.Sprintf(
-			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": true, "use_views": %t}`,
-			tb.GetName(), base.TestsDisableGSI(),
-		),
-	)
-	resp.RequireStatus(http.StatusCreated)
+	rt.CreateDatabase("db1", rt.NewDbConfig())
 
 	// Ensure we won't fail with an empty import filter
-	resp = BootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", "")
-	resp.RequireStatus(http.StatusOK)
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/import_filter", "")
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Add a document
-	err = tb.Bucket.DefaultDataStore().Set("importDoc1", 0, nil, []byte("{}"))
-	assert.NoError(t, err)
+	require.NoError(t, rt.GetSingleDataStore().Set("importDoc1", 0, nil, []byte("{}")))
 
 	// Ensure document is imported based on default import filter
-	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc1", "")
-	resp.RequireStatus(http.StatusOK)
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/importDoc1", "")
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Modify the import filter to always reject import
-	resp = BootstrapAdminRequest(t, http.MethodPut, "/db1/_config/import_filter", `function(){return false}`)
-	resp.RequireStatus(http.StatusOK)
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/import_filter", `function(){return false}`)
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Add a document
-	err = tb.Bucket.DefaultDataStore().Set("importDoc2", 0, nil, []byte("{}"))
-	assert.NoError(t, err)
+	require.NoError(t, rt.GetSingleDataStore().Set("importDoc2", 0, nil, []byte("{}")))
 
 	// Ensure document is not imported and is rejected based on updated filter
-	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc2", "")
-	resp.RequireStatus(http.StatusNotFound)
-	assert.Contains(t, resp.Body, "Not imported")
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/importDoc2", "")
+	RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "Not imported")
 
-	resp = BootstrapAdminRequest(t, http.MethodDelete, "/db1/_config/import_filter", "")
-	resp.RequireStatus(http.StatusOK)
+	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/_config/import_filter", "")
+	RequireStatus(t, resp, http.StatusOK)
 
 	// Add a document
-	err = tb.Bucket.DefaultDataStore().Set("importDoc3", 0, nil, []byte("{}"))
-	assert.NoError(t, err)
+	require.NoError(t, rt.GetSingleDataStore().Set("importDoc3", 0, nil, []byte("{}")))
 
 	// Ensure document is imported based on default import filter
-	resp = BootstrapAdminRequest(t, http.MethodGet, "/db1/importDoc3", "")
-	resp.RequireStatus(http.StatusOK)
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/importDoc3", "")
+	RequireStatus(t, resp, http.StatusOK)
 }
 
 func TestPersistentConfigWithCollectionConflicts(t *testing.T) {
@@ -454,11 +418,11 @@ func TestPersistentConfigWithCollectionConflicts(t *testing.T) {
 	collection1Name := dataStoreNames[0].CollectionName()
 	collection2Name := dataStoreNames[1].CollectionName()
 	collection3Name := dataStoreNames[2].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection1Name: {}}}}
-	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection2Name: {}}}}
-	collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection3Name: {}}}}
-	collection1and2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection1Name: {}, collection2Name: {}}}}
-	collection2and3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection2Name: {}, collection3Name: {}}}}
+	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
+	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
+	collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection3Name: {}}}}
+	collection1and2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}, collection2Name: {}}}}
+	collection2and3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}, collection3Name: {}}}}
 	log.Printf("dataStoreNames: %v", dataStoreNames)
 
 	bucketName := tb.GetName()
@@ -836,10 +800,10 @@ func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
 	collection1Name := dataStoreNames[0].CollectionName()
 	collection2Name := dataStoreNames[1].CollectionName()
 	collection3Name := dataStoreNames[2].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection1Name: {}}}}
-	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection2Name: {}}}}
-	collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection3Name: {}}}}
-	collection1and2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection1Name: {}, collection2Name: {}}}}
+	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
+	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
+	collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection3Name: {}}}}
+	collection1and2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}, collection2Name: {}}}}
 
 	// Case 1. GetDatabaseConfigs should roll back registry after create failure
 	collection1db1Config := getTestDatabaseConfig(bucketName, "c1_db1", collection1ScopesConfig, "1-a")
@@ -969,9 +933,9 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 	collection1Name := dataStoreNames[0].CollectionName()
 	collection2Name := dataStoreNames[1].CollectionName()
 	collection3Name := dataStoreNames[2].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection1Name: {}}}}
-	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection2Name: {}}}}
-	collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection3Name: {}}}}
+	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
+	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
+	collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection3Name: {}}}}
 
 	bc := sc.BootstrapContext
 	// reduce retry timeout for testing
@@ -1122,8 +1086,8 @@ func TestPersistentConfigRegistryRollbackAfterDeleteFailure(t *testing.T) {
 
 	collection1Name := dataStoreNames[0].CollectionName()
 	collection2Name := dataStoreNames[1].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection1Name: {}}}}
-	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection2Name: {}}}}
+	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
+	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
 
 	// SimulateDeleteFailure updates the registry with a new config, but doesn't create the associated config file
 	bc := sc.BootstrapContext
@@ -1256,7 +1220,7 @@ func TestPersistentConfigSlowCreateFailure(t *testing.T) {
 
 	// set up ScopesConfigs used by tests
 	collection1Name := dataStoreNames[0].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]CollectionConfig{collection1Name: {}}}}
+	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
 
 	// Case 1. Complete slow create after rollback
 	collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -620,7 +620,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 		Scopes: ScopesConfig{
 			"foo": ScopeConfig{
 				Collections: CollectionsConfig{
-					"bar": CollectionConfig{},
+					"bar": &CollectionConfig{},
 				},
 			},
 		},

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1214,7 +1214,7 @@ func TestGetUserCollectionAccess(t *testing.T) {
 	scope1Name := rt.GetDbCollections()[0].ScopeName
 	collection1Name := rt.GetDbCollections()[0].Name
 	collection2Name := rt.GetDbCollections()[1].Name
-	scopesConfig[scope1Name].Collections[collection1Name] = CollectionConfig{}
+	scopesConfig[scope1Name].Collections[collection1Name] = &CollectionConfig{}
 
 	collectionPayload := fmt.Sprintf(`,"%s": {
 					"admin_channels":["foo", "bar1"]
@@ -1382,7 +1382,7 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	scopeName := rt.GetDbCollections()[0].ScopeName
 	collection1Name := rt.GetDbCollections()[0].Name
 	collection2Name := rt.GetDbCollections()[1].Name
-	scopesConfig[scopeName].Collections[collection1Name] = CollectionConfig{}
+	scopesConfig[scopeName].Collections[collection1Name] = &CollectionConfig{}
 
 	collectionPayload := fmt.Sprintf(`,"%s": {
 					"admin_channels":["a"]

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -383,7 +383,7 @@ func GetCollectionsConfigWithSyncFn(t testing.TB, testBucket *base.TestBucket, s
 	// Get a datastore as provided by the test
 	stores := testBucket.GetNonDefaultDatastoreNames()
 	require.True(t, len(stores) >= numCollections, "Requested more collections %d than found on testBucket %d", numCollections, len(stores))
-	defaultCollectionConfig := CollectionConfig{}
+	defaultCollectionConfig := &CollectionConfig{}
 	if syncFn != nil {
 		defaultCollectionConfig.SyncFn = syncFn
 	}
@@ -398,7 +398,7 @@ func GetCollectionsConfigWithSyncFn(t testing.TB, testBucket *base.TestBucket, s
 			}
 		} else {
 			scopesConfig[dataStoreName.ScopeName()] = ScopeConfig{
-				Collections: map[string]CollectionConfig{
+				Collections: map[string]*CollectionConfig{
 					dataStoreName.CollectionName(): defaultCollectionConfig,
 				}}
 		}


### PR DESCRIPTION
backports CBG-3520 make /keyspace/_config/import_filter work (#6512)

This is a trivial cherry-pick.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2469/
