### PR TITLE
CBG-3956 replace GetAllScopes call to work with CBS 7.6

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -578,7 +578,7 @@ func (b *GocbV2Bucket) ListDataStores() ([]sgbucket.DataStoreName, error) {
 		return []sgbucket.DataStoreName{ScopeAndCollectionName{DefaultScope, DefaultCollection}}, nil
 	}
 
-	// ListDataStores is used only by integration test harness, so call mgmt API directly as a workaround ING-747, fixed in newer gocb, see CBG-3711
+	// ListDataStores is used only by integration test harness, so call mgmt API directly as a workaround for GOCBC-1586, fixed in newer gocb, see CBG-3711
 	uri := fmt.Sprintf("/pools/default/buckets/%s/scopes", b.GetName())
 	resp, err := b.mgmtRequest(context.Background(), http.MethodGet, uri, "application/json", nil)
 	if err != nil {


### PR DESCRIPTION
There is an upstream fix in gocb, but upgrading gocb on Sync Gateway 3.1 is more risky.

This code is only used by the integration test harness.