### PR TITLE
CBG-3817: fix incorrect runtime config after conflict error on collection update 

### DIFF
--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -1000,9 +1000,6 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 
 	delete(scopesConfig[scope].Collections, collection1)
 	assert.Equal(t, scopesConfig, dbCfg.Scopes)
-	// nil original server config as we don't persist this (and the new runtime config is reloaded from the bucket after
-	// the update error)
-	originalDBCfg.Server = nil
 	assert.Equal(t, originalDBCfg, dbCfg)
 
 	// now assert that _config shows the same

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -1000,6 +1000,7 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 
 	delete(scopesConfig[scope].Collections, collection1)
 	assert.Equal(t, scopesConfig, dbCfg.Scopes)
+	originalDBCfg.Server = nil
 	assert.Equal(t, originalDBCfg, dbCfg)
 
 	// now assert that _config shows the same

--- a/rest/config.go
+++ b/rest/config.go
@@ -1635,6 +1635,9 @@ func (sc *ServerContext) _fetchDatabase(ctx context.Context, dbName string) (fou
 			cnf.CertPath = sc.Config.Bootstrap.X509CertPath
 			cnf.KeyPath = sc.Config.Bootstrap.X509KeyPath
 		}
+		if cnf.Server == nil || *cnf.Server == "" {
+			cnf.Server = &sc.Config.Bootstrap.Server
+		}
 		base.TracefCtx(ctx, base.KeyConfig, "Got database config %s for bucket %q with cas %d and groupID %q", base.MD(dbName), base.MD(bucket), cas, base.MD(sc.Config.Bootstrap.ConfigGroupID))
 		return true, nil
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1635,9 +1635,6 @@ func (sc *ServerContext) _fetchDatabase(ctx context.Context, dbName string) (fou
 			cnf.CertPath = sc.Config.Bootstrap.X509CertPath
 			cnf.KeyPath = sc.Config.Bootstrap.X509KeyPath
 		}
-		if cnf.Server == nil || *cnf.Server == "" {
-			cnf.Server = &sc.Config.Bootstrap.Server
-		}
 		base.TracefCtx(ctx, base.KeyConfig, "Got database config %s for bucket %q with cas %d and groupID %q", base.MD(dbName), base.MD(bucket), cas, base.MD(sc.Config.Bootstrap.ConfigGroupID))
 		return true, nil
 	}


### PR DESCRIPTION
CBG-3817

- Remove the cas update for the update to runtime config at line 622 in admin_api.go. We should only update the cas on successful update of the config in the bucket which we do at line 648 in same file. 
- The issue with updating the runtime config but keeping the current cas before the successful operations at the bucket level (as we were before) is when we fail at the registry operation due to the collection conflict and attempt to rollback the runtime config, we get to line 1870 inside `_applyConfig` and don't force the reload as the (failed) runtime config has the same cas as the config fetched from the bucket, thus doesn't force the update in the runtime config on the server context 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2473/
