### PR TITLE
CBG-3960: Add norev and replacement rev stats

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -472,6 +472,8 @@ type CBLReplicationPullStats struct {
 	RevSendCount *SgwIntStat `json:"rev_send_count"`
 	// The total number of norev messages sent during replication.
 	NoRevSendCount *SgwIntStat `json:"norev_send_count"`
+	// The total number of replacement revs sent during replication.
+	ReplacementRevSendCount *SgwIntStat `json:"replacement_rev_send_count"`
 	// The total number of errors in response to sending a rev message.
 	RevErrorCount *SgwIntStat `json:"rev_error_count"`
 	// The total amount of time between Sync Gateway receiving a request for a revision and that revision being sent.
@@ -1456,6 +1458,10 @@ func (d *DbStats) initCBLReplicationPullStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.ReplacementRevSendCount, err = NewIntStat(SubsystemReplicationPull, "replacement_rev_send_count", StatUnitNoUnits, ReplacementRevSendCountDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.RevErrorCount, err = NewIntStat(SubsystemReplicationPull, "rev_error_count", StatUnitNoUnits, RevErrorCountDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1486,6 +1492,7 @@ func (d *DbStats) unregisterCBLReplicationPullStats() {
 	prometheus.Unregister(d.CBLReplicationPullStats.RevProcessingTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.NoRevSendCount)
+	prometheus.Unregister(d.CBLReplicationPullStats.ReplacementRevSendCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevErrorCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendLatency)
 }

--- a/base/stats.go
+++ b/base/stats.go
@@ -469,7 +469,10 @@ type CBLReplicationPullStats struct {
 	// The total amount of time processing rev messages (revisions) during pull revision.
 	RevProcessingTime *SgwIntStat `json:"rev_processing_time"`
 	// The total number of rev messages processed during replication.
-	RevSendCount  *SgwIntStat `json:"rev_send_count"`
+	RevSendCount *SgwIntStat `json:"rev_send_count"`
+	// The total number of norev messages sent during replication.
+	NoRevSendCount *SgwIntStat `json:"norev_send_count"`
+	// The total number of errors in response to sending a rev message.
 	RevErrorCount *SgwIntStat `json:"rev_error_count"`
 	// The total amount of time between Sync Gateway receiving a request for a revision and that revision being sent.
 	//
@@ -1449,6 +1452,10 @@ func (d *DbStats) initCBLReplicationPullStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.NoRevSendCount, err = NewIntStat(SubsystemReplicationPull, "norev_send_count", StatUnitNoUnits, NoRevSendCountDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.RevErrorCount, err = NewIntStat(SubsystemReplicationPull, "rev_error_count", StatUnitNoUnits, RevErrorCountDesc, StatAddedVersion3dot2dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1478,6 +1485,7 @@ func (d *DbStats) unregisterCBLReplicationPullStats() {
 	prometheus.Unregister(d.CBLReplicationPullStats.RequestChangesTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevProcessingTime)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendCount)
+	prometheus.Unregister(d.CBLReplicationPullStats.NoRevSendCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevErrorCount)
 	prometheus.Unregister(d.CBLReplicationPullStats.RevSendLatency)
 }

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -170,6 +170,8 @@ const (
 	RevSendCountDesc = "The total number of rev messages processed during replication. This metric can be used with rev_processing_time to calculate the average processing time per revision: " +
 		"average processing time per revision = rev_processing_time / rev_send_count"
 
+	NoRevSendCountDesc = "The total number of norev messages sent during replication."
+
 	RevSendLatencyDesc = "The total amount of time between Sync Gateway receiving a request for a revision and that revision being sent. In a pull replication, Sync Gateway sends a /_changes request to " +
 		"the client and the client responds with the list of revisions it wants to receive. So, rev_send_latency measures the time between the client asking for those revisions and Sync Gateway sending them to the client. " +
 		"Note: Measuring time from the /_changes response means that this stat will vary significantly depending on the changes batch size A larger batch size will result in a spike of this stat, even if the processing time per revision is unchanged. " +

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -172,6 +172,8 @@ const (
 
 	NoRevSendCountDesc = "The total number of norev messages sent during replication."
 
+	ReplacementRevSendCountDesc = "The total number of replacement revisions sent instead of a norev during replication."
+
 	RevSendLatencyDesc = "The total amount of time between Sync Gateway receiving a request for a revision and that revision being sent. In a pull replication, Sync Gateway sends a /_changes request to " +
 		"the client and the client responds with the list of revisions it wants to receive. So, rev_send_latency measures the time between the client asking for those revisions and Sync Gateway sending them to the client. " +
 		"Note: Measuring time from the /_changes response means that this stat will vary significantly depending on the changes batch size A larger batch size will result in a spike of this stat, even if the processing time per revision is unchanged. " +

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -690,6 +690,10 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 		}
 	}
 
+	if replacedRevID != "" {
+		bsc.replicationStats.SendReplacementRevCount.Add(1)
+	}
+
 	history := toHistory(rev.History, knownRevs, maxHistory)
 	properties := blipRevMessageProperties(history, rev.Deleted, seq, replacedRevID)
 	if base.LogDebugEnabled(bsc.loggingCtx, base.KeySync) {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -600,6 +600,8 @@ func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, 
 		return ErrClosedBLIPSender
 	}
 
+	bsc.replicationStats.SendNoRevCount.Add(1)
+
 	collectionCtx, err := bsc.collections.get(collectionIdx)
 	if err != nil {
 		return err

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -37,6 +37,7 @@ type BlipSyncStats struct {
 	HandlePutRevThrottledTime        *base.SgwIntStat // Connected Client API
 	SendRevCount                     *base.SgwIntStat // sendRev
 	SendNoRevCount                   *base.SgwIntStat // sendNoRev
+	SendReplacementRevCount          *base.SgwIntStat // sendReplacementRev
 	SendRevDeltaRequestedCount       *base.SgwIntStat
 	SendRevDeltaSentCount            *base.SgwIntStat
 	SendRevBytes                     *base.SgwIntStat
@@ -89,6 +90,7 @@ func NewBlipSyncStats() *BlipSyncStats {
 		SendRevCount:                     &base.SgwIntStat{}, // sendRev
 		SendNoRevCount:                   &base.SgwIntStat{}, // sendNoRev
 		SendRevDeltaRequestedCount:       &base.SgwIntStat{},
+		SendReplacementRevCount:          &base.SgwIntStat{}, // sendReplacementRev
 		SendRevDeltaSentCount:            &base.SgwIntStat{},
 		SendRevBytes:                     &base.SgwIntStat{},
 		SendRevErrorTotal:                &base.SgwIntStat{},
@@ -138,6 +140,7 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	blipStats.SendRevBytes = dbStats.Database().DocReadsBytesBlip
 	blipStats.SendRevCount = dbStats.Database().NumDocReadsBlip
 	blipStats.SendNoRevCount = dbStats.CBLReplicationPull().NoRevSendCount
+	blipStats.SendReplacementRevCount = dbStats.CBLReplicationPull().ReplacementRevSendCount
 	blipStats.SendRevErrorTotal = dbStats.CBLReplicationPull().RevErrorCount
 
 	blipStats.HandleRevBytes = dbStats.Database().DocWritesBytesBlip

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -36,6 +36,7 @@ type BlipSyncStats struct {
 	HandlePutRevThrottledCount       *base.SgwIntStat // Connected Client API
 	HandlePutRevThrottledTime        *base.SgwIntStat // Connected Client API
 	SendRevCount                     *base.SgwIntStat // sendRev
+	SendNoRevCount                   *base.SgwIntStat // sendNoRev
 	SendRevDeltaRequestedCount       *base.SgwIntStat
 	SendRevDeltaSentCount            *base.SgwIntStat
 	SendRevBytes                     *base.SgwIntStat
@@ -86,6 +87,7 @@ func NewBlipSyncStats() *BlipSyncStats {
 		HandlePutRevProcessingTime:       &base.SgwIntStat{},
 		HandlePutRevDocsPurgedCount:      &base.SgwIntStat{},
 		SendRevCount:                     &base.SgwIntStat{}, // sendRev
+		SendNoRevCount:                   &base.SgwIntStat{}, // sendNoRev
 		SendRevDeltaRequestedCount:       &base.SgwIntStat{},
 		SendRevDeltaSentCount:            &base.SgwIntStat{},
 		SendRevBytes:                     &base.SgwIntStat{},
@@ -135,6 +137,7 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 
 	blipStats.SendRevBytes = dbStats.Database().DocReadsBytesBlip
 	blipStats.SendRevCount = dbStats.Database().NumDocReadsBlip
+	blipStats.SendNoRevCount = dbStats.CBLReplicationPull().NoRevSendCount
 	blipStats.SendRevErrorTotal = dbStats.CBLReplicationPull().RevErrorCount
 
 	blipStats.HandleRevBytes = dbStats.Database().DocWritesBytesBlip

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1969,6 +1969,9 @@ func TestSendReplacementRevision(t *testing.T) {
 					msg1, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version1.RevID)
 					require.True(t, ok)
 					assert.Equal(t, msg1, msg2)
+
+					base.WaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 1)
+					base.WaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 0)
 				} else {
 					// requested revision (or any alternative) did not get replicated
 					data := btcRunner.SingleCollection(btc.id).WaitForVersion(docID, version1)
@@ -1982,6 +1985,9 @@ func TestSendReplacementRevision(t *testing.T) {
 					msg, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version1.RevID)
 					require.True(t, ok)
 					assert.Equal(t, db.MessageNoRev, msg.Profile())
+
+					base.WaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 1)
+					base.WaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 0)
 				}
 			})
 		}


### PR DESCRIPTION
CBG-3960

Follow-up for #6822 

Add stats to track number of norev and replacement revs sent for CBL pull replications.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2472/
