### PR TITLE
[3.1.7 backport] CBG-3879 Recovery from cas mismatch on metadata documents when using xattrConfig

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -936,3 +936,10 @@ func InsertBodyAndUserXattrNoMacroExpansion(t testing.TB, ds DataStore, k string
 
 	return uint64(result.Cas())
 }
+
+// MustJSONMarshal marshals the given value to JSON, and errors the test if it can not be turned into json.
+func MustJSONMarshal(t testing.TB, v interface{}) []byte {
+	b, err := JSONMarshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -286,7 +286,7 @@ var viewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 			tbp.Logf(ctx, "%s", err)
 			return err
 		}
-		if _, err := emptyAllDocsIndex(ctx, dataStore, tbp); err != nil {
+		if _, err := purgeWithDCPFeed(ctx, dataStore, tbp); err != nil {
 			return err
 		}
 		if err := EmptyPrimaryIndex(ctx, dataStore); err != nil {
@@ -633,4 +633,99 @@ func (a *ActiveReplicator) GetActiveReplicatorConfig() *ActiveReplicatorConfig {
 
 func (apr *ActivePullReplicator) GetBlipSender() *blip.Sender {
 	return apr.blipSender
+}
+
+// purgeWithDCPFeed purges all documents seen on a DCP feed with system xattrs, including tombstones which aren't found when emptying the primary index.
+func purgeWithDCPFeed(ctx context.Context, dataStore sgbucket.DataStore, tbp *base.TestBucketPool) (numCompacted int, err error) {
+	purgedDocCount := 0
+	purgeTimeout := 60 * time.Second
+	purgeBody := Body{"_purged": true}
+	processedDocCount := 0
+
+	var purgeErrors *base.MultiError
+	collection, err := base.AsCollection(dataStore)
+	if err != nil {
+		return 0, fmt.Errorf("dataStore was not a gocb collection: %w", err)
+	}
+
+	var collectionIDs []uint32
+	if collection.IsSupported(sgbucket.BucketStoreFeatureCollections) {
+		collectionIDs = append(collectionIDs, collection.GetCollectionID())
+	}
+
+	dcpClientOpts := base.DCPClientOptions{
+		OneShot:           true,
+		FailOnRollback:    false,
+		CollectionIDs:     collectionIDs,
+		MetadataStoreType: base.DCPMetadataStoreInMemory,
+	}
+
+	purgeCallback := func(event sgbucket.FeedEvent) bool {
+		var purgeErr error
+
+		processedDocCount++
+		// We only need to purge mutations/deletions
+		if event.Opcode != sgbucket.FeedOpMutation && event.Opcode != sgbucket.FeedOpDeletion {
+			return false
+		}
+
+		// If it's a deletion but doesn't have xattrs, ignore it
+		if event.Opcode == sgbucket.FeedOpDeletion && event.DataType&base.MemcachedDataTypeXattr == 0 {
+			return false
+		}
+
+		key := string(event.Key)
+
+		if base.TestUseXattrs() {
+			purgeErr = dataStore.DeleteWithXattr(ctx, key, base.SyncXattrName)
+		} else {
+			purgeErr = dataStore.Delete(key)
+		}
+		if base.IsKeyNotFoundError(dataStore, purgeErr) {
+			// If key no longer exists, need to add and remove to trigger removal from view
+			_, addErr := dataStore.Add(key, 0, purgeBody)
+			if addErr != nil {
+				purgeErrors = purgeErrors.Append(addErr)
+				tbp.Logf(ctx, "Error adding key %s to force deletion. %v", key, addErr)
+				return false
+			}
+
+			if delErr := dataStore.Delete(key); delErr != nil {
+				purgeErrors = purgeErrors.Append(delErr)
+				tbp.Logf(ctx, "Error deleting key %s.  %v", key, delErr)
+			}
+			purgedDocCount++
+		} else if purgeErr != nil {
+			purgeErrors = purgeErrors.Append(purgeErr)
+			tbp.Logf(ctx, "Error removing key %s (purge). %v", key, purgeErr)
+		}
+		return false
+	}
+	feedID := "purgeFeed-" + collection.CollectionName()
+	dcpClient, err := base.NewDCPClient(ctx, feedID, purgeCallback, dcpClientOpts, collection.Bucket)
+	if err != nil {
+		return 0, err
+	}
+	doneChan, err := dcpClient.Start()
+	if err != nil {
+		return 0, fmt.Errorf("error starting purge DCP feed: %w", err)
+	}
+	// wait for feed to complete
+	timeout := time.After(purgeTimeout)
+	select {
+	case err := <-doneChan:
+		if err != nil {
+			tbp.Logf(ctx, "purgeDCPFeed finished with error: %v", err)
+		}
+	case <-timeout:
+		return 0, fmt.Errorf("timeout waiting for purge DCP feed to complete")
+	}
+	closeErr := dcpClient.Close()
+	if closeErr != nil {
+		tbp.Logf(ctx, "error closing purge DCP feed: %v", closeErr)
+	}
+
+	tbp.Logf(ctx, "Finished purge DCP feed ... Total docs purged: %d", purgedDocCount)
+	tbp.Logf(ctx, "Finished purge DCP feed ... Total docs processed: %d", processedDocCount)
+	return purgedDocCount, purgeErrors.ErrorOrNil()
 }

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -11,7 +11,6 @@ package adminapitest
 import (
 	"fmt"
 	"net/http"
-	"slices"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -255,7 +254,7 @@ func TestRequireResync(t *testing.T) {
 		rest.RequireStatus(t, resp, http.StatusOK)
 		dbRootResponse = rest.DatabaseRoot{}
 		require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
-		return slices.Equal(needsResync, dbRootResponse.RequireResync)
+		return len(dbRootResponse.RequireResync) == 1 && dbRootResponse.RequireResync[0] == scope+"."+collection1
 	}, "expected %+v but got %+v for requireResync", needsResync, dbRootResponse.RequireResync)
 
 	// Run resync for collection

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -526,75 +526,79 @@ func TestPersistentConfigRegistryRollbackAfterDbConfigRollback(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig)
 
-	sc, closeFn := startBootstrapServerWithoutConfigPolling(t)
-	defer closeFn()
+	for _, test := range persistentConfigTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			sc, closeFn := startBootstrapServerWithoutConfigPolling(t, test.xattrConfig)
+			defer closeFn()
 
-	ctx := base.TestCtx(t)
-	tb := base.GetTestBucket(t)
-	defer tb.Close(ctx)
+			ctx := base.TestCtx(t)
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
 
-	oneCollectionScopesConfig := GetCollectionsConfig(t, tb, 1)
-	dataStoreNames := GetDataStoreNamesFromScopesConfig(oneCollectionScopesConfig)
+			oneCollectionScopesConfig := GetCollectionsConfig(t, tb, 1)
+			dataStoreNames := GetDataStoreNamesFromScopesConfig(oneCollectionScopesConfig)
 
-	bucketName := tb.GetName()
-	scopeName := dataStoreNames[0].ScopeName()
-	groupID := sc.Config.Bootstrap.ConfigGroupID
-	bc := sc.BootstrapContext
+			bucketName := tb.GetName()
+			scopeName := dataStoreNames[0].ScopeName()
+			groupID := sc.Config.Bootstrap.ConfigGroupID
+			bc := sc.BootstrapContext
 
-	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Millisecond
+			// reduce retry timeout for testing
+			bc.configRetryTimeout = 1 * time.Millisecond
 
-	// set up ScopesConfigs used by tests
-	collection1Name := dataStoreNames[0].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{CollectionsConfig{collection1Name: {}}}}
+			// set up ScopesConfigs used by tests
+			collection1Name := dataStoreNames[0].CollectionName()
+			collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{CollectionsConfig{collection1Name: {}}}}
 
-	const dbName = "c1_db1"
-	collection1db1Config := getTestDatabaseConfig(bucketName, dbName, collection1ScopesConfig, "2-a")
-	collection1db1Config.RevsLimit = base.Uint32Ptr(1000)
-	cas, err := bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
-	require.NoError(t, err)
-	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Len(t, configs, 1)
+			const dbName = "c1_db1"
+			collection1db1Config := getTestDatabaseConfig(bucketName, dbName, collection1ScopesConfig, "2-a")
+			collection1db1Config.RevsLimit = base.Uint32Ptr(1000)
+			cas, err := bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
+			require.NoError(t, err)
+			configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Len(t, configs, 1)
 
-	db, err := sc.GetDatabase(ctx, dbName)
-	require.NoError(t, err)
-	assert.Equal(t, int64(1000), int64(db.RevsLimit))
+			db, err := sc.GetDatabase(ctx, dbName)
+			require.NoError(t, err)
+			assert.Equal(t, int64(1000), int64(db.RevsLimit))
 
-	// simulate a rollback (not exactly - CAS increments, but lowering the config version is enough)
-	docID := PersistentConfigKey(ctx, groupID, dbName)
-	updatedConfig := *collection1db1Config
-	updatedConfig.Version = "1-a"
-	updatedConfig.RevsLimit = base.Uint32Ptr(500)
-	_, err = bc.Connection.WriteMetadataDocument(ctx, bucketName, docID, cas, &updatedConfig)
-	require.NoError(t, err)
+			// simulate a rollback (not exactly - CAS increments, but lowering the config version is enough)
+			docID := PersistentConfigKey(ctx, groupID, dbName)
+			updatedConfig := *collection1db1Config
+			updatedConfig.Version = "1-a"
+			updatedConfig.RevsLimit = base.Uint32Ptr(500)
+			_, err = bc.Connection.WriteMetadataDocument(ctx, bucketName, docID, cas, &updatedConfig)
+			require.NoError(t, err)
 
-	// we've not polled for config updates yet
-	db, err = sc.GetDatabase(ctx, dbName)
-	require.NoError(t, err)
-	assert.Equal(t, int64(1000), int64(db.RevsLimit))
+			// we've not polled for config updates yet
+			db, err = sc.GetDatabase(ctx, dbName)
+			require.NoError(t, err)
+			assert.Equal(t, int64(1000), int64(db.RevsLimit))
 
-	_, err = sc.fetchAndLoadConfigs(ctx, false)
-	require.NoError(t, err)
+			_, err = sc.fetchAndLoadConfigs(ctx, false)
+			require.NoError(t, err)
 
-	db, err = sc.GetDatabase(ctx, dbName)
-	require.NoError(t, err)
-	assert.Equal(t, int64(500), int64(db.RevsLimit))
+			db, err = sc.GetDatabase(ctx, dbName)
+			require.NoError(t, err)
+			assert.Equal(t, int64(500), int64(db.RevsLimit))
 
-	// at this point the config and registry are re-aligned, but let's just write another config update to make sure it's in an updatable state
-	_, err = bc.UpdateConfig(ctx, bucketName, groupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		bucketDbConfig.Version = "3-c"
-		bucketDbConfig.RevsLimit = base.Uint32Ptr(1234)
-		return bucketDbConfig, nil
-	})
-	require.NoError(t, err)
+			// at this point the config and registry are re-aligned, but let's just write another config update to make sure it's in an updatable state
+			_, err = bc.UpdateConfig(ctx, bucketName, groupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				bucketDbConfig.Version = "3-c"
+				bucketDbConfig.RevsLimit = base.Uint32Ptr(1234)
+				return bucketDbConfig, nil
+			})
+			require.NoError(t, err)
 
-	_, err = sc.fetchAndLoadConfigs(ctx, false)
-	require.NoError(t, err)
+			_, err = sc.fetchAndLoadConfigs(ctx, false)
+			require.NoError(t, err)
 
-	db, err = sc.GetDatabase(ctx, dbName)
-	require.NoError(t, err)
-	assert.Equal(t, int64(1234), int64(db.RevsLimit))
+			db, err = sc.GetDatabase(ctx, dbName)
+			require.NoError(t, err)
+			assert.Equal(t, int64(1234), int64(db.RevsLimit))
+		})
+	}
 }
 
 // TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback simulates a vbucket rollback for the dbconfig,
@@ -608,11 +612,22 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 	tests := []struct {
 		name                  string
 		multiDatabaseRollback bool
+		useXattrConfig        bool
 	}{
-		{"single database rollback",
+		{"single database rollback - document persistence",
+			false,
 			false,
 		},
-		{"multi database rollback",
+		{"single database rollback - xattr persistence",
+			false,
+			true,
+		},
+		{"multi database rollback - document persistence",
+			true,
+			false,
+		},
+		{"multi database rollback - xattr persistence",
+			true,
 			true,
 		},
 	}
@@ -620,7 +635,7 @@ func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			sc, closeFn := startBootstrapServerWithoutConfigPolling(t)
+			sc, closeFn := startBootstrapServerWithoutConfigPolling(t, test.useXattrConfig)
 			defer closeFn()
 
 			ctx := base.TestCtx(t)
@@ -750,134 +765,124 @@ func TestPersistentConfigRegistryRollbackAfterCreateFailure(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
-	serverErr := make(chan error, 0)
-
 	// Set up test for persistent config
 	config := BootstrapStartupConfigForTest(t)
 	// "disable" config polling for this test, to avoid non-deterministic test output based on polling times
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Minute * 10)
 	ctx := base.TestCtx(t)
-	sc, err := SetupServerContext(ctx, &config, true)
-	require.NoError(t, err)
-	defer func() {
-		sc.Close(ctx)
-		require.NoError(t, <-serverErr)
-	}()
 
-	go func() {
-		serverErr <- StartServer(ctx, &config, sc)
-	}()
-	require.NoError(t, sc.WaitForRESTAPIs(ctx))
+	for _, test := range persistentConfigTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			sc, closeFn := startBootstrapServerWithoutConfigPolling(t, test.xattrConfig)
+			defer closeFn()
 
-	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() {
-		fmt.Println("closing test bucket")
-		tb.Close(ctx)
-	}()
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
 
-	threeCollectionScopesConfig := GetCollectionsConfig(t, tb, 3)
-	dataStoreNames := GetDataStoreNamesFromScopesConfig(threeCollectionScopesConfig)
+			threeCollectionScopesConfig := GetCollectionsConfig(t, tb, 3)
+			dataStoreNames := GetDataStoreNamesFromScopesConfig(threeCollectionScopesConfig)
 
-	bucketName := tb.GetName()
-	scopeName := dataStoreNames[0].ScopeName()
-	groupID := sc.Config.Bootstrap.ConfigGroupID
-	bc := sc.BootstrapContext
+			bucketName := tb.GetName()
+			scopeName := dataStoreNames[0].ScopeName()
+			groupID := sc.Config.Bootstrap.ConfigGroupID
+			bc := sc.BootstrapContext
 
-	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Millisecond
+			// reduce retry timeout for testing
+			bc.configRetryTimeout = 1 * time.Millisecond
 
-	// SimulateCreateFailure updates the registry with a new config, but doesn't create the associated config file
-	simulateCreateFailure := func(t *testing.T, config *DatabaseConfig) {
-		registry, err := bc.getGatewayRegistry(ctx, bucketName)
-		require.NoError(t, err)
-		_, err = registry.upsertDatabaseConfig(ctx, groupID, config)
-		require.NoError(t, err)
-		require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+			// SimulateCreateFailure updates the registry with a new config, but doesn't create the associated config file
+			simulateCreateFailure := func(t *testing.T, config *DatabaseConfig) {
+				registry, err := bc.getGatewayRegistry(ctx, bucketName)
+				require.NoError(t, err)
+				_, err = registry.upsertDatabaseConfig(ctx, groupID, config)
+				require.NoError(t, err)
+				require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+			}
+
+			// set up ScopesConfigs used by tests
+			collection1Name := dataStoreNames[0].CollectionName()
+			collection2Name := dataStoreNames[1].CollectionName()
+			collection3Name := dataStoreNames[2].CollectionName()
+			collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
+			collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
+			collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection3Name: {}}}}
+			collection1and2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}, collection2Name: {}}}}
+
+			// Case 1. GetDatabaseConfigs should roll back registry after create failure
+			collection1db1Config := getTestDatabaseConfig(bucketName, "c1_db1", collection1ScopesConfig, "1-a")
+			simulateCreateFailure(t, collection1db1Config)
+			configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(configs))
+
+			// Case 2. InsertConfig with conflicting name should trigger registry rollback and then successful creation
+			simulateCreateFailure(t, collection1db1Config)
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
+			require.NoError(t, err)
+
+			// Case 3. UpdateConfig on the database after create failure should return not found
+			collection2db1Config := getTestDatabaseConfig(bucketName, "c2_db1", collection2ScopesConfig, "2-a")
+			simulateCreateFailure(t, collection2db1Config)
+			_, err = bc.UpdateConfig(ctx, bucketName, groupID, "c2_db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				bucketDbConfig.Version = "2-abc"
+				return bucketDbConfig, nil
+			})
+			require.Error(t, err)
+			require.True(t, err == base.ErrNotFound)
+
+			// Case 4. InsertConfig with a conflicting collection should return error, but should succeed after next GetDatabaseConfigs
+			collection3db1Config := getTestDatabaseConfig(bucketName, "c3_db1", collection3ScopesConfig, "1-a")
+			simulateCreateFailure(t, collection3db1Config)
+			collection3db2Config := getTestDatabaseConfig(bucketName, "c3_db2", collection3ScopesConfig, "1-b")
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection3db2Config)
+			require.Error(t, err) // collection conflict
+
+			configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(configs))
+
+			// Reattempt insert, should now succeed
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection3db2Config)
+			require.NoError(t, err)
+
+			// Case 5. Update different db with conflicting collection after create failure
+			// - create failure adding new db 'c2_db2' that has collection 2
+			// - attempt to update existing database c1db1 to add collection 2
+			collection2db2Config := getTestDatabaseConfig(bucketName, "c2_db2", collection2ScopesConfig, "1-a")
+			simulateCreateFailure(t, collection2db2Config)
+
+			_, err = bc.UpdateConfig(ctx, bucketName, groupID, "c1_db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				bucketDbConfig.Scopes = collection1and2ScopesConfig
+				bucketDbConfig.Version = "2-a"
+				return bucketDbConfig, nil
+			})
+			require.Error(t, err) // collection conflict
+
+			// GetDatabaseConfigs should rollback and remove the failed c2_db2
+			configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 2, len(configs))
+
+			// Update should now succeed
+			_, err = bc.UpdateConfig(ctx, bucketName, groupID, "c1_db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				bucketDbConfig.Scopes = collection1and2ScopesConfig
+				bucketDbConfig.Version = "2-a"
+				return bucketDbConfig, nil
+			})
+			require.NoError(t, err) // collection conflict
+
+			// Remove c3 (clean up for next case)
+			deleteErr := bc.DeleteConfig(ctx, bucketName, groupID, "c3_db2")
+			require.NoError(t, deleteErr)
+
+			// Case 6. Attempt to delete db after create failure for that db
+			//  - create failure for c3_db1 with collection 3
+			//  - attempt to delete c3_db1, rollback will remove from registry, then return 'not found' for the attempted delete
+			simulateCreateFailure(t, collection3db1Config)
+			deleteErr = bc.DeleteConfig(ctx, bucketName, groupID, "c3_db1")
+			require.Equal(t, base.ErrNotFound, deleteErr)
+		})
 	}
-
-	// set up ScopesConfigs used by tests
-	collection1Name := dataStoreNames[0].CollectionName()
-	collection2Name := dataStoreNames[1].CollectionName()
-	collection3Name := dataStoreNames[2].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
-	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
-	collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection3Name: {}}}}
-	collection1and2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}, collection2Name: {}}}}
-
-	// Case 1. GetDatabaseConfigs should roll back registry after create failure
-	collection1db1Config := getTestDatabaseConfig(bucketName, "c1_db1", collection1ScopesConfig, "1-a")
-	simulateCreateFailure(t, collection1db1Config)
-	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(configs))
-
-	// Case 2. InsertConfig with conflicting name should trigger registry rollback and then successful creation
-	simulateCreateFailure(t, collection1db1Config)
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
-	require.NoError(t, err)
-
-	// Case 3. UpdateConfig on the database after create failure should return not found
-	collection2db1Config := getTestDatabaseConfig(bucketName, "c2_db1", collection2ScopesConfig, "2-a")
-	simulateCreateFailure(t, collection2db1Config)
-	_, err = bc.UpdateConfig(ctx, bucketName, groupID, "c2_db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		bucketDbConfig.Version = "2-abc"
-		return bucketDbConfig, nil
-	})
-	require.Error(t, err)
-	require.True(t, err == base.ErrNotFound)
-
-	// Case 4. InsertConfig with a conflicting collection should return error, but should succeed after next GetDatabaseConfigs
-	collection3db1Config := getTestDatabaseConfig(bucketName, "c3_db1", collection3ScopesConfig, "1-a")
-	simulateCreateFailure(t, collection3db1Config)
-	collection3db2Config := getTestDatabaseConfig(bucketName, "c3_db2", collection3ScopesConfig, "1-b")
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection3db2Config)
-	require.Error(t, err) // collection conflict
-
-	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
-
-	// Reattempt insert, should now succeed
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection3db2Config)
-	require.NoError(t, err)
-
-	// Case 5. Update different db with conflicting collection after create failure
-	// - create failure adding new db 'c2_db2' that has collection 2
-	// - attempt to update existing database c1db1 to add collection 2
-	collection2db2Config := getTestDatabaseConfig(bucketName, "c2_db2", collection2ScopesConfig, "1-a")
-	simulateCreateFailure(t, collection2db2Config)
-
-	_, err = bc.UpdateConfig(ctx, bucketName, groupID, "c1_db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		bucketDbConfig.Scopes = collection1and2ScopesConfig
-		bucketDbConfig.Version = "2-a"
-		return bucketDbConfig, nil
-	})
-	require.Error(t, err) // collection conflict
-
-	// GetDatabaseConfigs should rollback and remove the failed c2_db2
-	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(configs))
-
-	// Update should now succeed
-	_, err = bc.UpdateConfig(ctx, bucketName, groupID, "c1_db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		bucketDbConfig.Scopes = collection1and2ScopesConfig
-		bucketDbConfig.Version = "2-a"
-		return bucketDbConfig, nil
-	})
-	require.NoError(t, err) // collection conflict
-
-	// Remove c3 (clean up for next case)
-	deleteErr := bc.DeleteConfig(ctx, bucketName, groupID, "c3_db2")
-	require.NoError(t, deleteErr)
-
-	// Case 6. Attempt to delete db after create failure for that db
-	//  - create failure for c3_db1 with collection 3
-	//  - attempt to delete c3_db1, rollback will remove from registry, then return 'not found' for the attempted delete
-	simulateCreateFailure(t, collection3db1Config)
-	deleteErr = bc.DeleteConfig(ctx, bucketName, groupID, "c3_db1")
-	require.Equal(t, base.ErrNotFound, deleteErr)
 }
 
 // TestPersistentConfigRegistryRollbackAfterUpdateFailure simulates node failure during an updateConfig operation, leaving
@@ -897,143 +902,139 @@ func TestPersistentConfigRegistryRollbackAfterUpdateFailure(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
-	serverErr := make(chan error, 0)
-
 	// Set up test for persistent config
 	config := BootstrapStartupConfigForTest(t)
 	// "disable" config polling for this test, to avoid non-deterministic test output based on polling times
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Minute * 10)
 	ctx := base.TestCtx(t)
-	sc, err := SetupServerContext(ctx, &config, true)
-	require.NoError(t, err)
-	defer func() {
-		sc.Close(ctx)
-		require.NoError(t, <-serverErr)
-	}()
 
-	go func() {
-		serverErr <- StartServer(ctx, &config, sc)
-	}()
-	require.NoError(t, sc.WaitForRESTAPIs(ctx))
+	for _, test := range persistentConfigTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			sc, closeFn := startBootstrapServerWithoutConfigPolling(t, test.xattrConfig)
+			defer closeFn()
 
-	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() {
-		fmt.Println("closing test bucket")
-		tb.Close(ctx)
-	}()
+			require.NoError(t, sc.WaitForRESTAPIs(ctx))
 
-	threeCollectionScopesConfig := GetCollectionsConfig(t, tb, 3)
-	dataStoreNames := GetDataStoreNamesFromScopesConfig(threeCollectionScopesConfig)
+			// Get a test bucket, and use it to create the database.
+			tb := base.GetTestBucket(t)
+			defer func() {
+				fmt.Println("closing test bucket")
+				tb.Close(ctx)
+			}()
 
-	bucketName := tb.GetName()
-	scopeName := dataStoreNames[0].ScopeName()
-	groupID := sc.Config.Bootstrap.ConfigGroupID
+			threeCollectionScopesConfig := GetCollectionsConfig(t, tb, 3)
+			dataStoreNames := GetDataStoreNamesFromScopesConfig(threeCollectionScopesConfig)
 
-	collection1Name := dataStoreNames[0].CollectionName()
-	collection2Name := dataStoreNames[1].CollectionName()
-	collection3Name := dataStoreNames[2].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
-	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
-	collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection3Name: {}}}}
+			bucketName := tb.GetName()
+			scopeName := dataStoreNames[0].ScopeName()
+			groupID := sc.Config.Bootstrap.ConfigGroupID
 
-	bc := sc.BootstrapContext
-	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Millisecond
+			collection1Name := dataStoreNames[0].CollectionName()
+			collection2Name := dataStoreNames[1].CollectionName()
+			collection3Name := dataStoreNames[2].CollectionName()
+			collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
+			collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
+			collection3ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection3Name: {}}}}
 
-	// Create database with collection 1
-	collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
-	require.NoError(t, err)
+			bc := sc.BootstrapContext
+			// reduce retry timeout for testing
+			bc.configRetryTimeout = 1 * time.Millisecond
 
-	// simulateUpdateFailure updates the database registry but doesn't persist the updated config. Simulates
-	// node failure between registry update and config update.
-	simulateUpdateFailure := func(t *testing.T, config *DatabaseConfig) {
-		registry, err := bc.getGatewayRegistry(ctx, bucketName)
-		require.NoError(t, err)
-		_, err = registry.upsertDatabaseConfig(ctx, groupID, config)
-		require.NoError(t, err)
-		require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+			// Create database with collection 1
+			collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")
+			_, err := bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
+			require.NoError(t, err)
+
+			// simulateUpdateFailure updates the database registry but doesn't persist the updated config. Simulates
+			// node failure between registry update and config update.
+			simulateUpdateFailure := func(t *testing.T, config *DatabaseConfig) {
+				registry, err := bc.getGatewayRegistry(ctx, bucketName)
+				require.NoError(t, err)
+				_, err = registry.upsertDatabaseConfig(ctx, groupID, config)
+				require.NoError(t, err)
+				require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+			}
+
+			// Case 1. GetDatabaseConfigs should roll back registry after update failure
+			collection2db1Config := getTestDatabaseConfig(bucketName, "db1", collection2ScopesConfig, "2-a")
+			simulateUpdateFailure(t, collection2db1Config)
+			configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(configs))
+			require.Equal(t, "1-a", configs[0].Version)
+
+			// Retrieve registry to ensure the previous version has been removed
+			registry, err := bc.getGatewayRegistry(ctx, bucketName)
+			require.NoError(t, err)
+			registryDb, ok := registry.getRegistryDatabase(groupID, "db1")
+			require.True(t, ok)
+			require.Equal(t, "1-a", registryDb.Version)
+			require.Nil(t, registryDb.PreviousVersion)
+
+			// Case 2. UpdateConfig with a version that conflicts with the failed update. Should trigger registry rollback and then successful update
+			simulateUpdateFailure(t, collection1db1Config)
+			_, err = bc.UpdateConfig(ctx, bucketName, groupID, "db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				bucketDbConfig.Scopes = collection2ScopesConfig
+				bucketDbConfig.Version = "2-b"
+				return bucketDbConfig, nil
+			})
+			require.NoError(t, err)
+			// Retrieve registry to ensure the previous version has been removed and version updated to the new version
+			registry, err = bc.getGatewayRegistry(ctx, bucketName)
+			require.NoError(t, err)
+			registryDb, ok = registry.getRegistryDatabase(groupID, "db1")
+			require.True(t, ok)
+			require.Equal(t, "2-b", registryDb.Version)
+			require.Nil(t, registryDb.PreviousVersion)
+
+			// Case 3. InsertConfig for a different db with collection conflict with the failed update (should fail with conflict, but succeed after GetDatabaseConfigs runs)
+			collection1db1Config_v3 := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "3-a")
+			simulateUpdateFailure(t, collection1db1Config_v3)
+
+			collection1db2Config := getTestDatabaseConfig(bucketName, "db2", collection1ScopesConfig, "1-a")
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db2Config)
+			require.Error(t, err) // collection conflict
+
+			configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(configs))
+
+			// Reattempt insert, should now succeed
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db2Config)
+			require.NoError(t, err)
+
+			// Case 4. InsertConfig for a different db with collection conflict with the version prior to the failed update
+			collection3db1Config := getTestDatabaseConfig(bucketName, "db1", collection3ScopesConfig, "3-a")
+			simulateUpdateFailure(t, collection3db1Config)
+
+			collection2db3Config := getTestDatabaseConfig(bucketName, "db3", collection1ScopesConfig, "1-a")
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db3Config)
+			require.Error(t, err) // collection conflict
+
+			configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 2, len(configs))
+
+			// Reattempt insert, should still be in conflict post-rollback
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db3Config)
+			require.Error(t, err) // collection conflict
+
+			configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 2, len(configs))
+
+			// Case 5. Attempt to delete db after update failure for that db
+			simulateUpdateFailure(t, collection3db1Config)
+			deleteErr := bc.DeleteConfig(ctx, bucketName, groupID, "db1")
+			require.NoError(t, deleteErr)
+
+			// Retrieve registry to ensure the delete was successful
+			registry, err = bc.getGatewayRegistry(ctx, bucketName)
+			require.NoError(t, err)
+			_, ok = registry.getRegistryDatabase(groupID, "db1")
+			require.False(t, ok)
+		})
 	}
-
-	// Case 1. GetDatabaseConfigs should roll back registry after update failure
-	collection2db1Config := getTestDatabaseConfig(bucketName, "db1", collection2ScopesConfig, "2-a")
-	simulateUpdateFailure(t, collection2db1Config)
-	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
-	require.Equal(t, "1-a", configs[0].Version)
-
-	// Retrieve registry to ensure the previous version has been removed
-	registry, err := bc.getGatewayRegistry(ctx, bucketName)
-	require.NoError(t, err)
-	registryDb, ok := registry.getRegistryDatabase(groupID, "db1")
-	require.True(t, ok)
-	require.Equal(t, "1-a", registryDb.Version)
-	require.Nil(t, registryDb.PreviousVersion)
-
-	// Case 2. UpdateConfig with a version that conflicts with the failed update. Should trigger registry rollback and then successful update
-	simulateUpdateFailure(t, collection1db1Config)
-	_, err = bc.UpdateConfig(ctx, bucketName, groupID, "db1", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		bucketDbConfig.Scopes = collection2ScopesConfig
-		bucketDbConfig.Version = "2-b"
-		return bucketDbConfig, nil
-	})
-	require.NoError(t, err)
-	// Retrieve registry to ensure the previous version has been removed and version updated to the new version
-	registry, err = bc.getGatewayRegistry(ctx, bucketName)
-	require.NoError(t, err)
-	registryDb, ok = registry.getRegistryDatabase(groupID, "db1")
-	require.True(t, ok)
-	require.Equal(t, "2-b", registryDb.Version)
-	require.Nil(t, registryDb.PreviousVersion)
-
-	// Case 3. InsertConfig for a different db with collection conflict with the failed update (should fail with conflict, but succeed after GetDatabaseConfigs runs)
-	collection1db1Config_v3 := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "3-a")
-	simulateUpdateFailure(t, collection1db1Config_v3)
-
-	collection1db2Config := getTestDatabaseConfig(bucketName, "db2", collection1ScopesConfig, "1-a")
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db2Config)
-	require.Error(t, err) // collection conflict
-
-	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
-
-	// Reattempt insert, should now succeed
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db2Config)
-	require.NoError(t, err)
-
-	// Case 4. InsertConfig for a different db with collection conflict with the version prior to the failed update
-	collection3db1Config := getTestDatabaseConfig(bucketName, "db1", collection3ScopesConfig, "3-a")
-	simulateUpdateFailure(t, collection3db1Config)
-
-	collection2db3Config := getTestDatabaseConfig(bucketName, "db3", collection1ScopesConfig, "1-a")
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db3Config)
-	require.Error(t, err) // collection conflict
-
-	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(configs))
-
-	// Reattempt insert, should still be in conflict post-rollback
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db3Config)
-	require.Error(t, err) // collection conflict
-
-	configs, err = bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(configs))
-
-	// Case 5. Attempt to delete db after update failure for that db
-	simulateUpdateFailure(t, collection3db1Config)
-	deleteErr := bc.DeleteConfig(ctx, bucketName, groupID, "db1")
-	require.NoError(t, deleteErr)
-
-	// Retrieve registry to ensure the delete was successful
-	registry, err = bc.getGatewayRegistry(ctx, bucketName)
-	require.NoError(t, err)
-	_, ok = registry.getRegistryDatabase(groupID, "db1")
-	require.False(t, ok)
 }
 
 // TestPersistentConfigRegistryRollbackAfterDeleteFailure simulates node failure during an deleteConfig operation, leaving
@@ -1051,108 +1052,99 @@ func TestPersistentConfigRegistryRollbackAfterDeleteFailure(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
-	serverErr := make(chan error, 0)
-
 	// Set up test for persistent config
 	config := BootstrapStartupConfigForTest(t)
 	// "disable" config polling for this test, to avoid noise with explicit reload calls
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Minute * 10)
 	ctx := base.TestCtx(t)
-	sc, err := SetupServerContext(ctx, &config, true)
-	require.NoError(t, err)
-	defer func() {
-		sc.Close(ctx)
-		require.NoError(t, <-serverErr)
-	}()
+	for _, test := range persistentConfigTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			sc, closeFn := startBootstrapServerWithoutConfigPolling(t, test.xattrConfig)
+			defer closeFn()
+			require.NoError(t, sc.WaitForRESTAPIs(ctx))
 
-	go func() {
-		serverErr <- StartServer(ctx, &config, sc)
-	}()
-	require.NoError(t, sc.WaitForRESTAPIs(ctx))
+			// Get a test bucket, and use it to create the database.
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
 
-	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() {
-		fmt.Println("closing test bucket")
-		tb.Close(ctx)
-	}()
+			threeCollectionScopesConfig := GetCollectionsConfig(t, tb, 3)
+			dataStoreNames := GetDataStoreNamesFromScopesConfig(threeCollectionScopesConfig)
 
-	threeCollectionScopesConfig := GetCollectionsConfig(t, tb, 3)
-	dataStoreNames := GetDataStoreNamesFromScopesConfig(threeCollectionScopesConfig)
+			bucketName := tb.GetName()
+			scopeName := dataStoreNames[0].ScopeName()
+			groupID := sc.Config.Bootstrap.ConfigGroupID
 
-	bucketName := tb.GetName()
-	scopeName := dataStoreNames[0].ScopeName()
-	groupID := sc.Config.Bootstrap.ConfigGroupID
+			collection1Name := dataStoreNames[0].CollectionName()
+			collection2Name := dataStoreNames[1].CollectionName()
+			collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
+			collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
 
-	collection1Name := dataStoreNames[0].CollectionName()
-	collection2Name := dataStoreNames[1].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
-	collection2ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection2Name: {}}}}
+			// SimulateDeleteFailure updates the registry with a new config, but doesn't create the associated config file
+			bc := sc.BootstrapContext
 
-	// SimulateDeleteFailure updates the registry with a new config, but doesn't create the associated config file
-	bc := sc.BootstrapContext
+			// reduce retry timeout for testing
+			bc.configRetryTimeout = 1 * time.Millisecond
 
-	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Millisecond
+			// Create database with collection 1
+			collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")
+			_, err := bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
+			require.NoError(t, err)
 
-	// Create database with collection 1
-	collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
-	require.NoError(t, err)
+			// simulateDeleteFailure removes the database from the database registry but doesn't remove the associated config file.
+			// Simulates node failure between registry update and config removal.
+			simulateDeleteFailure := func(t *testing.T, config *DatabaseConfig) {
+				registry, err := bc.getGatewayRegistry(ctx, bucketName)
+				require.NoError(t, err)
+				require.NoError(t, registry.deleteDatabase(groupID, config.Name))
+				require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+			}
 
-	// simulateDeleteFailure removes the database from the database registry but doesn't remove the associated config file.
-	// Simulates node failure between registry update and config removal.
-	simulateDeleteFailure := func(t *testing.T, config *DatabaseConfig) {
-		registry, err := bc.getGatewayRegistry(ctx, bucketName)
-		require.NoError(t, err)
-		require.NoError(t, registry.deleteDatabase(groupID, config.Name))
-		require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+			// Case 1. Retrieval of database after delete failure should not find it (matching versions)
+			simulateDeleteFailure(t, collection1db1Config)
+			configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(configs))
+
+			// Case 2. Attempt to recreate the config with a matching version generation and digest. Should resolve in-flight delete
+			// and then successfully
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
+			require.NoError(t, err)
+
+			// Case 3. Attempt to recreate the config with a different version digest. Should resolve in-flight delete
+			// and then successfully recreate
+			simulateDeleteFailure(t, collection1db1Config)
+			collection1db1bConfig := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-b")
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1bConfig)
+			require.NoError(t, err)
+
+			// Case 4. Attempt to recreate the config with a different version generation and digest. Should resolve in-flight delete
+			// and then successfully recreate
+			collection2db2Config := getTestDatabaseConfig(bucketName, "db2", collection2ScopesConfig, "1-a")
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db2Config)
+			require.NoError(t, err)
+			_, err = bc.UpdateConfig(ctx, bucketName, groupID, "db2", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				bucketDbConfig.Scopes = collection2ScopesConfig
+				bucketDbConfig.Version = "2-a"
+				return bucketDbConfig, nil
+			})
+
+			simulateDeleteFailure(t, collection2db2Config)
+			// Version 2-a is deleted, attempt to recreate as version 1-b.  Expect resolution of in-flight delete and then
+			// successfully recreate
+			collection2db2bConfig := getTestDatabaseConfig(bucketName, "db2", collection2ScopesConfig, "1-b")
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db2bConfig)
+			require.NoError(t, err)
+
+			// Case 5. Attempt to update a config after delete failure.
+			simulateDeleteFailure(t, collection2db2Config)
+			_, err = bc.UpdateConfig(ctx, bucketName, groupID, "db2", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				bucketDbConfig.Scopes = collection2ScopesConfig
+				bucketDbConfig.Version = "2-a"
+				return bucketDbConfig, nil
+			})
+			require.Equal(t, base.ErrNotFound, err)
+		})
 	}
-
-	// Case 1. Retrieval of database after delete failure should not find it (matching versions)
-	simulateDeleteFailure(t, collection1db1Config)
-	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(configs))
-
-	// Case 2. Attempt to recreate the config with a matching version generation and digest. Should resolve in-flight delete
-	// and then successfully
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
-	require.NoError(t, err)
-
-	// Case 3. Attempt to recreate the config with a different version digest. Should resolve in-flight delete
-	// and then successfully recreate
-	simulateDeleteFailure(t, collection1db1Config)
-	collection1db1bConfig := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-b")
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1bConfig)
-	require.NoError(t, err)
-
-	// Case 4. Attempt to recreate the config with a different version generation and digest. Should resolve in-flight delete
-	// and then successfully recreate
-	collection2db2Config := getTestDatabaseConfig(bucketName, "db2", collection2ScopesConfig, "1-a")
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db2Config)
-	require.NoError(t, err)
-	_, err = bc.UpdateConfig(ctx, bucketName, groupID, "db2", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		bucketDbConfig.Scopes = collection2ScopesConfig
-		bucketDbConfig.Version = "2-a"
-		return bucketDbConfig, nil
-	})
-
-	simulateDeleteFailure(t, collection2db2Config)
-	// Version 2-a is deleted, attempt to recreate as version 1-b.  Expect resolution of in-flight delete and then
-	// successfully recreate
-	collection2db2bConfig := getTestDatabaseConfig(bucketName, "db2", collection2ScopesConfig, "1-b")
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection2db2bConfig)
-	require.NoError(t, err)
-
-	// Case 5. Attempt to update a config after delete failure.
-	simulateDeleteFailure(t, collection2db2Config)
-	_, err = bc.UpdateConfig(ctx, bucketName, groupID, "db2", func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		bucketDbConfig.Scopes = collection2ScopesConfig
-		bucketDbConfig.Version = "2-a"
-		return bucketDbConfig, nil
-	})
-	require.Equal(t, base.ErrNotFound, err)
 
 }
 
@@ -1167,74 +1159,65 @@ func TestPersistentConfigSlowCreateFailure(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
-	serverErr := make(chan error, 0)
-
 	// Set up test for persistent config
 	config := BootstrapStartupConfigForTest(t)
 	// "disable" config polling for this test, to avoid non-deterministic test output based on polling times
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Minute * 10)
 	ctx := base.TestCtx(t)
-	sc, err := SetupServerContext(ctx, &config, true)
-	require.NoError(t, err)
-	defer func() {
-		sc.Close(ctx)
-		require.NoError(t, <-serverErr)
-	}()
+	for _, test := range persistentConfigTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			sc, closeFn := startBootstrapServerWithoutConfigPolling(t, false)
+			defer closeFn()
+			require.NoError(t, sc.WaitForRESTAPIs(ctx))
 
-	go func() {
-		serverErr <- StartServer(ctx, &config, sc)
-	}()
-	require.NoError(t, sc.WaitForRESTAPIs(ctx))
+			// Get a test bucket, and use it to create the database.
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
 
-	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() {
-		fmt.Println("closing test bucket")
-		tb.Close(ctx)
-	}()
+			threeCollectionScopesConfig := GetCollectionsConfig(t, tb, 3)
+			dataStoreNames := GetDataStoreNamesFromScopesConfig(threeCollectionScopesConfig)
 
-	threeCollectionScopesConfig := GetCollectionsConfig(t, tb, 3)
-	dataStoreNames := GetDataStoreNamesFromScopesConfig(threeCollectionScopesConfig)
+			bucketName := tb.GetName()
+			scopeName := dataStoreNames[0].ScopeName()
+			groupID := sc.Config.Bootstrap.ConfigGroupID
+			bc := sc.BootstrapContext
 
-	bucketName := tb.GetName()
-	scopeName := dataStoreNames[0].ScopeName()
-	groupID := sc.Config.Bootstrap.ConfigGroupID
-	bc := sc.BootstrapContext
+			// reduce retry timeout for testing
+			bc.configRetryTimeout = 1 * time.Millisecond
 
-	// reduce retry timeout for testing
-	bc.configRetryTimeout = 1 * time.Millisecond
+			// simulateSlowCreate updates the registry with a new config, but doesn't create the associated config file
+			simulateSlowCreate := func(t *testing.T, config *DatabaseConfig) {
+				registry, err := bc.getGatewayRegistry(ctx, bucketName)
+				require.NoError(t, err)
+				_, err = registry.upsertDatabaseConfig(ctx, groupID, config)
+				require.NoError(t, err)
+				require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+			}
 
-	// simulateSlowCreate updates the registry with a new config, but doesn't create the associated config file
-	simulateSlowCreate := func(t *testing.T, config *DatabaseConfig) {
-		registry, err := bc.getGatewayRegistry(ctx, bucketName)
-		require.NoError(t, err)
-		_, err = registry.upsertDatabaseConfig(ctx, groupID, config)
-		require.NoError(t, err)
-		require.NoError(t, bc.setGatewayRegistry(ctx, bucketName, registry))
+			completeSlowCreate := func(t *testing.T, config *DatabaseConfig) error {
+				_, insertError := bc.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey(ctx, groupID, config.Name), config)
+				return insertError
+			}
+
+			// set up ScopesConfigs used by tests
+			collection1Name := dataStoreNames[0].CollectionName()
+			collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
+
+			// Case 1. Complete slow create after rollback
+			collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")
+			simulateSlowCreate(t, collection1db1Config)
+			configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(configs))
+
+			err = completeSlowCreate(t, collection1db1Config)
+			require.NoError(t, err)
+
+			// Re-attempt the insert, verify it's not blocked by the slow write of the config file
+			_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
+			require.NoError(t, err)
+		})
 	}
-
-	completeSlowCreate := func(t *testing.T, config *DatabaseConfig) error {
-		_, insertError := bc.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey(ctx, groupID, config.Name), config)
-		return insertError
-	}
-
-	// set up ScopesConfigs used by tests
-	collection1Name := dataStoreNames[0].CollectionName()
-	collection1ScopesConfig := ScopesConfig{scopeName: ScopeConfig{map[string]*CollectionConfig{collection1Name: {}}}}
-
-	// Case 1. Complete slow create after rollback
-	collection1db1Config := getTestDatabaseConfig(bucketName, "db1", collection1ScopesConfig, "1-a")
-	simulateSlowCreate(t, collection1db1Config)
-	configs, err := bc.GetDatabaseConfigs(ctx, bucketName, groupID)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(configs))
-
-	err = completeSlowCreate(t, collection1db1Config)
-	require.NoError(t, err)
-
-	// Re-attempt the insert, verify it's not blocked by the slow write of the config file
-	_, err = bc.InsertConfig(ctx, bucketName, groupID, collection1db1Config)
-	require.NoError(t, err)
 }
 
 func TestMigratev30PersistentConfig(t *testing.T) {
@@ -1245,79 +1228,70 @@ func TestMigratev30PersistentConfig(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
-	serverErr := make(chan error, 0)
-
 	// Set up test for persistent config
 	config := BootstrapStartupConfigForTest(t)
 	// "disable" config polling for this test, to avoid non-deterministic test output based on polling times
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Minute * 10)
 	ctx := base.TestCtx(t)
-	sc, err := SetupServerContext(ctx, &config, true)
-	require.NoError(t, err)
-	defer func() {
-		sc.Close(ctx)
-		require.NoError(t, <-serverErr)
-	}()
+	for _, test := range persistentConfigTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			sc, closeFn := startBootstrapServerWithoutConfigPolling(t, test.xattrConfig)
+			defer closeFn()
+			require.NoError(t, sc.WaitForRESTAPIs(ctx))
 
-	go func() {
-		serverErr <- StartServer(ctx, &config, sc)
-	}()
-	require.NoError(t, sc.WaitForRESTAPIs(ctx))
+			// Get a test bucket, and use it to create the database.
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
 
-	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() {
-		fmt.Println("closing test bucket")
-		tb.Close(ctx)
-	}()
+			bucketName := tb.GetName()
+			groupID := sc.Config.Bootstrap.ConfigGroupID
+			defaultDbName := "defaultDb"
+			defaultVersion := "1-abc"
+			defaultDbConfig := makeDbConfig(tb.GetName(), defaultDbName, nil)
+			defaultDatabaseConfig := &DatabaseConfig{
+				DbConfig: defaultDbConfig,
+				Version:  defaultVersion,
+			}
 
-	bucketName := tb.GetName()
-	groupID := sc.Config.Bootstrap.ConfigGroupID
-	defaultDbName := "defaultDb"
-	defaultVersion := "1-abc"
-	defaultDbConfig := makeDbConfig(tb.GetName(), defaultDbName, nil)
-	defaultDatabaseConfig := &DatabaseConfig{
-		DbConfig: defaultDbConfig,
-		Version:  defaultVersion,
+			_, insertError := sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+			require.NoError(t, insertError)
+
+			migrateErr := sc.migrateV30Configs(ctx)
+			require.NoError(t, migrateErr)
+
+			// Fetch the registry, verify database has been migrated
+			registry, registryErr := sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
+			require.NoError(t, registryErr)
+			require.NotNil(t, registry)
+			migratedDb, found := registry.getRegistryDatabase(groupID, defaultDbName)
+			require.True(t, found)
+			require.Equal(t, "1-abc", migratedDb.Version)
+			// Verify legacy config has been removed
+			_, getError := sc.BootstrapContext.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+			require.Equal(t, base.ErrNotFound, getError)
+
+			// Update the db in the registry, and recreate legacy config.  Verify migration doesn't overwrite
+			_, insertError = sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+			require.NoError(t, insertError)
+			_, updateError := sc.BootstrapContext.UpdateConfig(ctx, bucketName, groupID, defaultDbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				bucketDbConfig.Version = "2-abc"
+				return bucketDbConfig, nil
+			})
+			require.NoError(t, updateError)
+			migrateErr = sc.migrateV30Configs(ctx)
+			require.NoError(t, migrateErr)
+			registry, registryErr = sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
+			require.NoError(t, registryErr)
+			require.NotNil(t, registry)
+			migratedDb, found = registry.getRegistryDatabase(groupID, defaultDbName)
+			require.True(t, found)
+			require.Equal(t, "2-abc", migratedDb.Version)
+
+			// Verify legacy config has been removed
+			_, getError = sc.BootstrapContext.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
+			require.Equal(t, base.ErrNotFound, getError)
+		})
 	}
-
-	_, insertError := sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
-	require.NoError(t, insertError)
-
-	migrateErr := sc.migrateV30Configs(ctx)
-	require.NoError(t, migrateErr)
-
-	// Fetch the registry, verify database has been migrated
-	registry, registryErr := sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
-	require.NoError(t, registryErr)
-	require.NotNil(t, registry)
-	migratedDb, found := registry.getRegistryDatabase(groupID, defaultDbName)
-	require.True(t, found)
-	require.Equal(t, "1-abc", migratedDb.Version)
-	// Verify legacy config has been removed
-	_, getError := sc.BootstrapContext.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
-	require.Equal(t, base.ErrNotFound, getError)
-
-	// Update the db in the registry, and recreate legacy config.  Verify migration doesn't overwrite
-	_, insertError = sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
-	require.NoError(t, insertError)
-	_, updateError := sc.BootstrapContext.UpdateConfig(ctx, bucketName, groupID, defaultDbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-		bucketDbConfig.Version = "2-abc"
-		return bucketDbConfig, nil
-	})
-	require.NoError(t, updateError)
-	migrateErr = sc.migrateV30Configs(ctx)
-	require.NoError(t, migrateErr)
-	registry, registryErr = sc.BootstrapContext.getGatewayRegistry(ctx, bucketName)
-	require.NoError(t, registryErr)
-	require.NotNil(t, registry)
-	migratedDb, found = registry.getRegistryDatabase(groupID, defaultDbName)
-	require.True(t, found)
-	require.Equal(t, "2-abc", migratedDb.Version)
-
-	// Verify legacy config has been removed
-	_, getError = sc.BootstrapContext.Connection.GetMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), defaultDatabaseConfig)
-	require.Equal(t, base.ErrNotFound, getError)
 
 }
 
@@ -1488,57 +1462,48 @@ func TestLegacyDuplicate(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyConfig)
 
-	serverErr := make(chan error, 0)
-
 	// Set up test for persistent config
 	config := BootstrapStartupConfigForTest(t)
 	// "disable" config polling for this test, to avoid non-deterministic test output based on polling times
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Minute * 10)
 	ctx := base.TestCtx(t)
-	sc, err := SetupServerContext(ctx, &config, true)
-	require.NoError(t, err)
-	defer func() {
-		sc.Close(ctx)
-		require.NoError(t, <-serverErr)
-	}()
+	for _, test := range persistentConfigTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			sc, closeFn := startBootstrapServerWithoutConfigPolling(t, test.xattrConfig)
+			defer closeFn()
+			require.NoError(t, sc.WaitForRESTAPIs(ctx))
 
-	go func() {
-		serverErr <- StartServer(ctx, &config, sc)
-	}()
-	require.NoError(t, sc.WaitForRESTAPIs(ctx))
+			// Get a test bucket, and use it to create the database.
+			tb := base.GetTestBucket(t)
+			defer tb.Close(ctx)
 
-	// Get a test bucket, and use it to create the database.
-	tb := base.GetTestBucket(t)
-	defer func() {
-		fmt.Println("closing test bucket")
-		tb.Close(ctx)
-	}()
+			bucketName := tb.GetName()
+			groupID := sc.Config.Bootstrap.ConfigGroupID
 
-	bucketName := tb.GetName()
-	groupID := sc.Config.Bootstrap.ConfigGroupID
+			// Set up a 3.1 database targeting the default collection
+			defaultDbName := "defaultDb"
+			newDefaultDbConfig := getTestDatabaseConfig(bucketName, defaultDbName, DefaultOnlyScopesConfig, "3.1")
+			_, err := sc.BootstrapContext.InsertConfig(ctx, bucketName, groupID, newDefaultDbConfig)
+			require.NoError(t, err)
 
-	// Set up a 3.1 database targeting the default collection
-	defaultDbName := "defaultDb"
-	newDefaultDbConfig := getTestDatabaseConfig(bucketName, defaultDbName, DefaultOnlyScopesConfig, "3.1")
-	_, err = sc.BootstrapContext.InsertConfig(ctx, bucketName, groupID, newDefaultDbConfig)
-	require.NoError(t, err)
+			// Insert a 3.0 db config for the same database name directly to the bucket
+			legacyVersion := "3.0"
+			legacyDbConfig := makeDbConfig(tb.GetName(), defaultDbName, nil)
+			legacyDatabaseConfig := &DatabaseConfig{
+				DbConfig: legacyDbConfig,
+				Version:  legacyVersion,
+			}
+			_, insertError := sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), legacyDatabaseConfig)
+			require.NoError(t, insertError)
 
-	// Insert a 3.0 db config for the same database name directly to the bucket
-	legacyVersion := "3.0"
-	legacyDbConfig := makeDbConfig(tb.GetName(), defaultDbName, nil)
-	legacyDatabaseConfig := &DatabaseConfig{
-		DbConfig: legacyDbConfig,
-		Version:  legacyVersion,
+			// Fetch the registry, verify newDefaultDb still exists and defaultDb30 has not been migrated due to collection conflict
+			configs, err := sc.BootstrapContext.GetDatabaseConfigs(ctx, tb.GetName(), groupID)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(configs))
+			dbConfig := configs[0]
+			assert.Equal(t, "3.1", dbConfig.Version)
+		})
 	}
-	_, insertError := sc.BootstrapContext.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey30(ctx, groupID), legacyDatabaseConfig)
-	require.NoError(t, insertError)
-
-	// Fetch the registry, verify newDefaultDb still exists and defaultDb30 has not been migrated due to collection conflict
-	configs, err := sc.BootstrapContext.GetDatabaseConfigs(ctx, tb.GetName(), groupID)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(configs))
-	dbConfig := configs[0]
-	assert.Equal(t, "3.1", dbConfig.Version)
 }
 
 func getTestDatabaseConfig(bucketName string, dbName string, scopesConfig ScopesConfig, version string) *DatabaseConfig {
@@ -1670,9 +1635,38 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 }
 
 // startBootstrapServerWithoutConfigPolling starts a server with config polling disabled, and returns the server context.
-func startBootstrapServerWithoutConfigPolling(t *testing.T) (*ServerContext, func()) {
+func startBootstrapServerWithoutConfigPolling(t *testing.T, useXattrConfig bool) (*ServerContext, func()) {
 	config := BootstrapStartupConfigForTest(t)
 	// "disable" config polling for this test, to avoid non-deterministic test output based on polling times
 	config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(time.Hour * 24)
+	config.Unsupported.UseXattrConfig = base.BoolPtr(useXattrConfig)
 	return StartServerWithConfig(t, &config)
+}
+
+type persistentConfigTestCase struct {
+	name        string
+	xattrConfig bool
+}
+
+func persistentConfigTestCases() []persistentConfigTestCase {
+
+	if base.UnitTestUrlIsWalrus() {
+		// rosmar has its own bootstrap implementation that doesn't differentiate between xattr and non-xattr persistence
+		return []persistentConfigTestCase{
+			{
+				name:        "rosmar_persistence",
+				xattrConfig: false,
+			},
+		}
+	} else {
+		return []persistentConfigTestCase{
+			{
+				name:        "xattr_persistence",
+				xattrConfig: true,
+			}, {
+				name:        "document_persistence",
+				xattrConfig: false,
+			},
+		}
+	}
 }

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -601,9 +601,9 @@ func TestPersistentConfigRegistryRollbackAfterDbConfigRollback(t *testing.T) {
 	}
 }
 
-// TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback simulates a vbucket rollback for the dbconfig,
+// TestCollectionConflictAfterDbConfigRollback simulates a vbucket rollback for the dbconfig,
 // leaving the registry version ahead of the config - but also with a collection conflict occurring in the subsequent rollback.
-func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback(t *testing.T) {
+func TestCollectionConflictAfterDbConfigRollback(t *testing.T) {
 	base.TestsRequireBootstrapConnection(t)
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 3)

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,7 +50,9 @@ func BootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("EE-ONLY: Skipping test %s due to requiring non-default Config Group ID", t.Name())
 	}
-	config.Bootstrap.ConfigGroupID = t.Name()
+	uniqueUUID, err := uuid.NewRandom()
+	require.NoError(t, err)
+	config.Bootstrap.ConfigGroupID = uniqueUUID.String()
 
 	return config
 }

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,9 +49,7 @@ func BootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("EE-ONLY: Skipping test %s due to requiring non-default Config Group ID", t.Name())
 	}
-	uniqueUUID, err := uuid.NewRandom()
-	require.NoError(t, err)
-	config.Bootstrap.ConfigGroupID = uniqueUUID.String()
+	config.Bootstrap.ConfigGroupID = t.Name()
 
 	return config
 }


### PR DESCRIPTION
CBG-3879

Preserves write of cas to body for rollback compatibility, but switches to document cas for all optimistic concurrency checks.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2480/
- [x] `sanity test forcing xattrConfig=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2481/ 
