### PR TITLE
[3.1.7 backport] CBG-3959 include collection names in status of resync

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -25,12 +25,13 @@ import (
 // =====================================================================
 
 type ResyncManagerDCP struct {
-	DocsProcessed base.AtomicInt
-	DocsChanged   base.AtomicInt
-	ResyncID      string
-	VBUUIDs       []uint64
-	useXattrs     bool
-	lock          sync.RWMutex
+	DocsProcessed       base.AtomicInt
+	DocsChanged         base.AtomicInt
+	ResyncID            string
+	VBUUIDs             []uint64
+	useXattrs           bool
+	ResyncedCollections []string
+	lock                sync.RWMutex
 }
 
 // ResyncCollections contains map of scope names with collection names against which resync needs to run
@@ -147,10 +148,12 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 	}
 
 	// Get collectionIds
-	collectionIDs, hasAllCollections, err := getCollectionIds(db, resyncCollections)
+	collectionIDs, hasAllCollections, collectionNames, err := getCollectionIdsAndNames(db, resyncCollections)
 	if err != nil {
 		return err
 	}
+	// add collection list to manager for use in status call
+	r.SetCollectionStatus(collectionNames)
 	if hasAllCollections {
 		base.InfofCtx(ctx, base.KeyAll, "[%s] running resync against all collections", resyncLoggingID)
 	} else {
@@ -242,14 +245,20 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 	return nil
 }
 
-func getCollectionIds(db *Database, resyncCollections ResyncCollections) ([]uint32, bool, error) {
+func getCollectionIdsAndNames(db *Database, resyncCollections ResyncCollections) ([]uint32, bool, []string, error) {
 	collectionIDs := make([]uint32, 0)
 	var hasAllCollections bool
+	var resyncCollectionNames []string
 
 	if len(resyncCollections) == 0 {
 		hasAllCollections = true
 		for collectionID := range db.CollectionByID {
 			collectionIDs = append(collectionIDs, collectionID)
+		}
+		for _, collectionNames := range db.CollectionNames {
+			for collName := range collectionNames {
+				resyncCollectionNames = append(resyncCollectionNames, collName)
+			}
 		}
 	} else {
 		hasAllCollections = false
@@ -258,13 +267,14 @@ func getCollectionIds(db *Database, resyncCollections ResyncCollections) ([]uint
 			for _, collectionName := range collectionsName {
 				collection, err := db.GetDatabaseCollection(scopeName, collectionName)
 				if err != nil {
-					return nil, hasAllCollections, fmt.Errorf("failed to find ID for collection %s.%s", base.MD(scopeName).Redact(), base.MD(collectionName).Redact())
+					return nil, hasAllCollections, nil, fmt.Errorf("failed to find ID for collection %s.%s", base.MD(scopeName).Redact(), base.MD(collectionName).Redact())
 				}
 				collectionIDs = append(collectionIDs, collection.GetCollectionID())
+				resyncCollectionNames = append(resyncCollectionNames, collectionName)
 			}
 		}
 	}
-	return collectionIDs, hasAllCollections, nil
+	return collectionIDs, hasAllCollections, resyncCollectionNames, nil
 }
 
 func (r *ResyncManagerDCP) ResetStatus() {
@@ -273,6 +283,7 @@ func (r *ResyncManagerDCP) ResetStatus() {
 
 	r.DocsProcessed.Set(0)
 	r.DocsChanged.Set(0)
+	r.ResyncedCollections = nil
 }
 
 func (r *ResyncManagerDCP) SetStatus(docChanged, docProcessed int64) {
@@ -283,11 +294,19 @@ func (r *ResyncManagerDCP) SetStatus(docChanged, docProcessed int64) {
 	r.DocsProcessed.Set(docProcessed)
 }
 
+func (r *ResyncManagerDCP) SetCollectionStatus(collectionNames []string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.ResyncedCollections = collectionNames
+}
+
 type ResyncManagerResponseDCP struct {
 	BackgroundManagerStatus
-	ResyncID      string `json:"resync_id"`
-	DocsChanged   int64  `json:"docs_changed"`
-	DocsProcessed int64  `json:"docs_processed"`
+	ResyncID              string   `json:"resync_id"`
+	DocsChanged           int64    `json:"docs_changed"`
+	DocsProcessed         int64    `json:"docs_processed"`
+	CollectionsProcessing []string `json:"collections_processing,omitempty"`
 }
 
 func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus) ([]byte, []byte, error) {
@@ -299,6 +318,7 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus) ([]b
 		ResyncID:                r.ResyncID,
 		DocsChanged:             r.DocsChanged.Value(),
 		DocsProcessed:           r.DocsProcessed.Value(),
+		CollectionsProcessing:   r.ResyncedCollections,
 	}
 
 	meta := AttachmentManagerMeta{

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -736,7 +736,114 @@ func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
 	assert.Equal(t, int64(2000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 }
 
-func TestResync(t *testing.T) {
+func TestDCPResyncCollectionsStatus(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+	base.TestRequiresCollections(t)
+
+	testCases := []struct {
+		name              string
+		collectionNames   []string
+		expectedResult    []string
+		specifyCollection bool
+	}{
+		{
+			name:              "collections_specified",
+			collectionNames:   []string{"sg_test_0"},
+			expectedResult:    []string{"sg_test_0"},
+			specifyCollection: true,
+		},
+		{
+			name:            "collections_not_specified",
+			expectedResult:  []string{"sg_test_0", "sg_test_1", "sg_test_2"},
+			collectionNames: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rt := rest.NewRestTesterMultipleCollections(t, nil, 3)
+			defer rt.Close()
+
+			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
+			require.True(t, ok)
+
+			rt.TakeDbOffline()
+
+			if !testCase.specifyCollection {
+				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+				rest.RequireStatus(t, resp, http.StatusOK)
+			} else {
+				payload := `{"scopes": {"sg_test_0":["sg_test_0"]}}`
+				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", payload)
+				rest.RequireStatus(t, resp, http.StatusOK)
+			}
+
+			statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+			assert.ElementsMatch(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
+		})
+	}
+}
+
+func TestQueryResyncCollectionsStatus(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+	base.TestRequiresCollections(t)
+
+	testCases := []struct {
+		name              string
+		collectionNames   []string
+		expectedResult    []string
+		specifyCollection bool
+	}{
+		{
+			name:              "collections_specified",
+			collectionNames:   []string{"sg_test_0"},
+			expectedResult:    []string{"sg_test_0"},
+			specifyCollection: true,
+		},
+		{
+			name:            "collections_not_specified",
+			expectedResult:  []string{"sg_test_0", "sg_test_1", "sg_test_2"},
+			collectionNames: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rt := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					Unsupported: &db.UnsupportedOptions{
+						UseQueryBasedResyncManager: true,
+					},
+				},
+				},
+			}, 3)
+			defer rt.Close()
+
+			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
+			require.True(t, ok)
+
+			rt.TakeDbOffline()
+
+			if !testCase.specifyCollection {
+				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
+				rest.RequireStatus(t, resp, http.StatusOK)
+			} else {
+				payload := `{"scopes": {"sg_test_0":["sg_test_0"]}}`
+				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", payload)
+				rest.RequireStatus(t, resp, http.StatusOK)
+			}
+
+			statusResponse := rt.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
+
+			assert.ElementsMatch(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
+		})
+	}
+}
+
+func TestResyncQueryBased(t *testing.T) {
 	base.LongRunningTest(t)
 
 	testCases := []struct {


### PR DESCRIPTION
backports CBG-3843

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2476/
