### PR TITLE
CBG-3965 Do not regenerate sequences for principals if collections are specified

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -749,7 +749,7 @@ func TestRequiresCollections(t testing.TB) {
 
 // TestRequiresDCPResync will skip the current test DCP sync is not supported.
 func TestRequiresDCPResync(t testing.TB) {
-	if !UnitTestUrlIsWalrus() {
+	if UnitTestUrlIsWalrus() {
 		t.Skip("Walrus doesn't support DCP resync CBG-2661")
 	}
 }

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -189,7 +189,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 			return err
 		}
 
-		if regenerateSequences {
+		if regenerateSequences && resyncCollections == nil {
 			var err error
 			for _, databaseCollection := range db.CollectionByID {
 				if updateErr := databaseCollection.updateAllPrincipalsSequences(ctx); updateErr != nil {

--- a/docs/api/paths/admin/db-_resync.yaml
+++ b/docs/api/paths/admin/db-_resync.yaml
@@ -58,7 +58,7 @@ post:
           - stop
     - name: regenerate_sequences
       in: query
-      description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed.'
+      description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed. If scopes parameter is specified, the principal sequence documents will not have their sequences updated.'
       schema:
         type: boolean
     - name: reset

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -70,6 +70,7 @@ func TestResyncRollback(t *testing.T) {
 }
 
 func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
+	base.TestRequiresDCPResync(t)
 	testCases := []struct {
 		name                  string
 		defaultCollectionOnly bool

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -68,3 +68,98 @@ func TestResyncRollback(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusOK)
 	status = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 }
+
+func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		defaultCollectionOnly bool
+		specifyCollections    bool
+	}{
+		{
+			name:                  "defaultCollectionOnly=true, specifyCollections=false",
+			defaultCollectionOnly: true,
+			specifyCollections:    false,
+		},
+		{
+			name:                  "defaultCollectionOnly=true, specifyCollections=true",
+			defaultCollectionOnly: true,
+			specifyCollections:    true,
+		},
+		{
+			name:                  "defaultCollectionOnly=false, specifyCollections=true",
+			defaultCollectionOnly: false,
+			specifyCollections:    true,
+		},
+		{
+			name:                  "defaultCollectionOnly=false, specifyCollections=false",
+			defaultCollectionOnly: false,
+			specifyCollections:    false,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+				PersistentConfig: true,
+			})
+			defer rt.Close()
+
+			dbConfig := rt.NewDbConfig()
+			ds, err := rt.TestBucket.GetNamedDataStore(0)
+			require.NoError(t, err)
+			scopeName := ds.ScopeName()
+			collectionName := ds.CollectionName()
+			if test.defaultCollectionOnly {
+				dbConfig.Scopes = nil
+				scopeName = base.DefaultScope
+				collectionName = base.DefaultCollection
+			}
+			rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+
+			username := "alice"
+			standardDoc := "doc"
+			rt.CreateUser(username, nil)
+
+			ctx := rt.Context()
+			user, err := rt.GetDatabase().Authenticator(ctx).GetUser(username)
+			require.NoError(t, err)
+			originalUserSeq := user.Sequence()
+			require.NotEqual(t, 0, originalUserSeq)
+
+			rt.CreateTestDoc(standardDoc)
+			doc, err := rt.GetSingleTestDatabaseCollection().GetDocument(ctx, standardDoc, db.DocUnmarshalSync)
+			require.NoError(t, err)
+			oldDocSeq := doc.Sequence
+			require.NotEqual(t, 0, oldDocSeq)
+
+			rt.TakeDbOffline()
+
+			body := ""
+			if test.specifyCollections {
+				// regenerate_sequences=true with collections will not regenerate sequences of principals
+				collectionsToResync := map[string][]string{
+					scopeName: []string{collectionName},
+				}
+				body = fmt.Sprintf(`{"scopes": %s}`, base.MustJSONMarshal(t, collectionsToResync))
+			}
+			rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start&regenerate_sequences=true", body), http.StatusOK)
+			_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+			// validate if user doc has changed sequence
+			user, err = rt.GetDatabase().Authenticator(ctx).GetUser(username)
+			require.NoError(t, err)
+
+			require.NotEqual(t, 0, user.Sequence())
+			if test.specifyCollections {
+				require.Equal(t, originalUserSeq, user.Sequence())
+			} else {
+				require.NotEqual(t, originalUserSeq, user.Sequence())
+			}
+
+			// regular doc will always change sequence
+			doc, err = rt.GetSingleTestDatabaseCollection().GetDocument(ctx, standardDoc, db.DocUnmarshalSync)
+			require.NoError(t, err)
+			require.NotEqual(t, 0, doc.Sequence)
+			require.NotEqual(t, oldDocSeq, doc.Sequence)
+		})
+	}
+}


### PR DESCRIPTION

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2477/
