### PR TITLE
[3.1.7 backport] CBG-3951 filter principal docs for default collection 

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -936,3 +936,10 @@ func InsertBodyAndUserXattrNoMacroExpansion(t testing.TB, ds DataStore, k string
 
 	return uint64(result.Cas())
 }
+
+// MustJSONMarshal marshals the given value to JSON, and errors the test if it can not be turned into json.
+func MustJSONMarshal(t testing.TB, v interface{}) []byte {
+	b, err := JSONMarshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/db/database.go
+++ b/db/database.go
@@ -1071,6 +1071,10 @@ func (db *DatabaseContext) GetUserNames(ctx context.Context) (users []string, er
 	startKey := dbUserPrefix
 	limit := db.Options.QueryPaginationLimit
 
+	userRe, err := regexp.Compile(`^` + dbUserPrefix + `[^:]*$`)
+	if err != nil {
+		return nil, err
+	}
 	users = []string{}
 
 outerLoop:
@@ -1103,8 +1107,11 @@ outerLoop:
 
 			principalName = queryRow.Name
 			startKey = queryRow.ID
-
 			resultCount++
+
+			if !userRe.MatchString(queryRow.ID) {
+				continue
+			}
 
 			if principalName != "" && !skipAddition {
 				users = append(users, principalName)
@@ -1135,6 +1142,18 @@ func (db *DatabaseContext) getAllPrincipalIDsSyncDocs(ctx context.Context) (user
 	lenDbUserPrefix := len(dbUserPrefix)
 	lenDbRolePrefix := len(dbRolePrefix)
 
+	userRe, err := regexp.Compile(`^` + dbUserPrefix + `[^:]*$`)
+	if err != nil {
+		return nil, nil, err
+	}
+	roleRe, err := regexp.Compile(`^` + dbRolePrefix + `[^:]*$`)
+	if err != nil {
+		return nil, nil, err
+	}
+	anyPrincipalRe, err := regexp.Compile(fmt.Sprintf(`^(%s|%s).*$`, base.DefaultMetadataKeys.UserKeyPrefix(), base.DefaultMetadataKeys.RoleKeyPrefix()))
+	if err != nil {
+		return nil, nil, err
+	}
 	users = []string{}
 	roles = []string{}
 
@@ -1178,11 +1197,15 @@ outerLoop:
 				startKey = queryRow.Name
 			}
 			if len(rowID) < lenDbUserPrefix && len(rowID) < lenDbRolePrefix {
+				// make sure to increment the resultCount to not skip the next row if the results are
+				// _sync:user:alice and we are looking for _sync:user:verylongdbname:alice
+				if resultCount == 0 && anyPrincipalRe.MatchString(rowID) {
+					resultCount++
+				}
 				continue
 			}
-
-			isDbUser = strings.HasPrefix(rowID, dbUserPrefix)
-			isDbRole = strings.HasPrefix(rowID, dbRolePrefix)
+			isDbUser = userRe.MatchString(rowID)
+			isDbRole = roleRe.MatchString(rowID)
 			if !isDbUser && !isDbRole {
 				continue
 			}
@@ -1195,7 +1218,6 @@ outerLoop:
 
 			}
 			resultCount++
-
 			if principalName != "" && !skipAddition {
 				if isDbUser {
 					users = append(users, principalName)
@@ -1231,6 +1253,10 @@ func (db *DatabaseContext) GetUsers(ctx context.Context, limit int) (users []aut
 	// This doesn't happen for AllPrincipalIDs, I believe because the role check forces query to not assume
 	// a contiguous set of results
 	dbUserKeyPrefix := db.MetadataKeys.UserKeyPrefix()
+	userRe, err := regexp.Compile(`^` + dbUserKeyPrefix + `[^:]*$`)
+	if err != nil {
+		return nil, err
+	}
 	startKey := dbUserKeyPrefix
 	paginationLimit := db.Options.QueryPaginationLimit
 	if paginationLimit == 0 {
@@ -1272,6 +1298,9 @@ outerLoop:
 
 			startKey = queryRow.ID
 			resultCount++
+			if !userRe.MatchString(queryRow.ID) {
+				continue
+			}
 			if queryRow.Name != "" && !skipAddition {
 				principal := auth.PrincipalConfig{
 					Name:     &queryRow.Name,
@@ -1307,6 +1336,11 @@ outerLoop:
 func (db *DatabaseContext) getRoleIDsUsingIndex(ctx context.Context, includeDeleted bool) (roles []string, err error) {
 
 	dbRoleIDPrefix := db.MetadataKeys.RoleKeyPrefix()
+
+	roleRe, err := regexp.Compile(`^` + dbRoleIDPrefix + `[^:]*$`)
+	if err != nil {
+		return nil, err
+	}
 	startKey := dbRoleIDPrefix
 	limit := db.Options.QueryPaginationLimit
 
@@ -1358,6 +1392,9 @@ outerLoop:
 
 			resultCount++
 
+			if !roleRe.MatchString(queryRow.Id) {
+				continue
+			}
 			if roleName != "" && !skipAddition {
 				roles = append(roles, roleName)
 			}

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1509,3 +1509,76 @@ func TestUnauthorizedAccessForDB(t *testing.T) {
 	require.Contains(t, response.Body.String(), ErrInvalidLogin.Message)
 
 }
+
+func TestUserMultipleDBs(t *testing.T) {
+	base.RequireNumTestDataStores(t, 2)
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	defaultCollectionDB := "defaultcollectiondb"
+	namedCollectionDB := "namedcollectiondb"
+	// create database using _default._default
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = nil
+	RequireStatus(t, rt.CreateDatabase(defaultCollectionDB, dbConfig), http.StatusCreated)
+
+	// create a database with a named collection
+	dbConfig = rt.NewDbConfig()
+	dbConfig.Scopes = GetCollectionsConfig(t, rt.TestBucket, 1)
+	RequireStatus(t, rt.CreateDatabase(namedCollectionDB, dbConfig), http.StatusCreated)
+
+	// create matching named user and roles in both databases. Use multiple since there is some alphabetical sensitivity.
+	// alice
+	// defaultcollectiondb
+	// john
+	// namedcollectiondb
+	// sam
+	for _, dbName := range []string{defaultCollectionDB, namedCollectionDB} {
+		for _, username := range []string{"alice", "john", "sam"} {
+			userConfig := string(base.MustJSONMarshal(t,
+				auth.PrincipalConfig{
+					Name:     &username,
+					Password: base.StringPtr(RestTesterDefaultUserPassword),
+				}))
+			resp := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_user/"+username, userConfig)
+			RequireStatus(t, resp, http.StatusCreated)
+		}
+		for _, rolename := range []string{"arole1", "jrole2", "srole3"} {
+			roleConfig := string(base.MustJSONMarshal(t,
+				auth.PrincipalConfig{
+					Name: &rolename,
+				}))
+			resp := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/_role/"+rolename, roleConfig)
+			RequireStatus(t, resp, http.StatusCreated)
+		}
+	}
+
+	for _, dbName := range []string{defaultCollectionDB, namedCollectionDB} {
+		t.Run(dbName, func(t *testing.T) {
+			numUsers := 3
+			numRoles := 3
+			// /db/_user?name_only=false only works with GSI
+			if !base.TestsDisableGSI() {
+				resp := rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_user/?name_only=false", "")
+				RequireStatus(t, resp, http.StatusOK)
+				var users []auth.PrincipalConfig
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &users))
+				require.Len(t, users, numUsers)
+			}
+			resp := rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_user/?name_only=true", "")
+			RequireStatus(t, resp, http.StatusOK)
+			var usernames []string
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &usernames))
+			require.Len(t, usernames, numUsers)
+
+			resp = rt.SendAdminRequest(http.MethodGet, "/"+dbName+"/_role/", "")
+			RequireStatus(t, resp, http.StatusOK)
+			var roles []string
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &roles))
+			require.Len(t, roles, numRoles)
+
+		})
+	}
+}

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1511,6 +1511,9 @@ func TestUnauthorizedAccessForDB(t *testing.T) {
 }
 
 func TestUserMultipleDBs(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires CBS/bootstrap")
+	}
 	base.RequireNumTestDataStores(t, 2)
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,


### PR DESCRIPTION
CBG-3951

When using non default metadata id, the /_user/ and /_role/ endpoints need to filter any docs with _sync:user:db:alice from docs that look like _sync:user:alice.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
