### PR TITLE
[3.1.7 backport] CBG-3967 add reason in all_dbs for why db is offline

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2432,3 +2432,8 @@ CollectionNames:
           - Starting
           - Stopping
           - Resyncing
+      reason:
+        description: Optional reason a database is in a particular state.
+        enum:
+          - require_resync
+          - ""

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -257,6 +257,19 @@ func TestRequireResync(t *testing.T) {
 		return len(dbRootResponse.RequireResync) == 1 && dbRootResponse.RequireResync[0] == scope+"."+collection1
 	}, "expected %+v but got %+v for requireResync", needsResync, dbRootResponse.RequireResync)
 
+	resp = rt.SendAdminRequest("GET", "/_all_dbs?verbose=true", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	var allDBsSummary []rest.DbSummary
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &allDBsSummary))
+	require.Len(t, allDBsSummary, 2)
+	// databases sorted alphabetically
+	require.Equal(t, db1Name, allDBsSummary[0].DBName)
+	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
+	require.Equal(t, "", allDBsSummary[0].Reason)
+	require.Equal(t, db2Name, allDBsSummary[1].DBName)
+	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
+	require.Equal(t, rest.OfflineReasonRequireResync, allDBsSummary[1].Reason)
+
 	// Run resync for collection
 	resyncCollections := make(db.ResyncCollections, 0)
 	resyncCollections[scope] = []string{collection1}
@@ -275,6 +288,25 @@ func TestRequireResync(t *testing.T) {
 			return db2.ResyncManager.GetRunState()
 		})
 
+	resp = rt.SendAdminRequest("GET", "/_all_dbs?verbose=true", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	allDBsSummary = nil
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &allDBsSummary))
+	require.Len(t, allDBsSummary, 2)
+	// databases sorted alphabetically
+	require.Equal(t, db1Name, allDBsSummary[0].DBName)
+	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
+	require.Equal(t, "", allDBsSummary[0].Reason)
+	require.Equal(t, db2Name, allDBsSummary[1].DBName)
+	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
+	require.Equal(t, "", allDBsSummary[1].Reason)
+
+	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	dbRootResponse = rest.DatabaseRoot{}
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
+	assert.Nil(t, dbRootResponse.RequireResync)
+
 	// Attempt online again, should now succeed
 	onlineResponse = rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
 	rest.RequireStatus(t, onlineResponse, http.StatusOK)
@@ -284,6 +316,7 @@ func TestRequireResync(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	dbRootResponse = rest.DatabaseRoot{}
 	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
+	assert.Nil(t, dbRootResponse.RequireResync)
 	assert.Nil(t, dbRootResponse.RequireResync)
 
 	resp = rt.SendAdminRequest("GET", "/"+ks_db2_c1+"/testDoc1", "")

--- a/rest/api.go
+++ b/rest/api.go
@@ -407,10 +407,11 @@ type DatabaseRoot struct {
 	Scopes                        map[string]databaseRootScope `json:"scopes,omitempty"` // stats for each scope/collection
 }
 
-type dbSummary struct {
+type DbSummary struct {
 	DBName string `json:"db_name"`
 	Bucket string `json:"bucket"`
 	State  string `json:"state"`
+	Reason string `json:"reason,omitempty"`
 }
 
 type databaseRootScope struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -43,6 +43,8 @@ const kStatsReportInterval = time.Hour
 const kDefaultSlowQueryWarningThreshold = 500 // ms
 const KDefaultNumShards = 16
 
+const OfflineReasonRequireResync = "require_resync"
+
 var errCollectionsUnsupported = base.HTTPErrorf(http.StatusBadRequest, "Named collections specified in database config, but not supported by connected Couchbase Server.")
 
 var ErrSuspendingDisallowed = errors.New("database does not allow suspending")
@@ -322,17 +324,24 @@ func (sc *ServerContext) AllDatabaseNames() []string {
 	return names
 }
 
-func (sc *ServerContext) allDatabaseSummaries() []dbSummary {
+func (sc *ServerContext) allDatabaseSummaries() []DbSummary {
 	sc.lock.RLock()
 	defer sc.lock.RUnlock()
 
-	dbs := make([]dbSummary, 0, len(sc.databases_))
+	dbs := make([]DbSummary, 0, len(sc.databases_))
 	for name, dbctx := range sc.databases_ {
-		dbs = append(dbs, dbSummary{
+		state := db.RunStateString[atomic.LoadUint32(&dbctx.State)]
+		summary := DbSummary{
 			DBName: name,
 			Bucket: dbctx.Bucket.GetName(),
-			State:  db.RunStateString[atomic.LoadUint32(&dbctx.State)],
-		})
+			State:  state,
+		}
+		if state == db.RunStateString[db.DBOffline] {
+			if len(dbctx.RequireResync.ScopeAndCollectionNames()) > 0 {
+				summary.Reason = OfflineReasonRequireResync
+			}
+		}
+		dbs = append(dbs, summary)
 	}
 	sort.Slice(dbs, func(i, j int) bool {
 		return dbs[i].DBName < dbs[j].DBName


### PR DESCRIPTION
backports CBG-3957

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2482/
