### PR TITLE
[3.1.7 backport] CBG-3964 wait for principal doc index readiness on r…

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -189,16 +190,24 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 			return err
 		}
 
-		if regenerateSequences {
-			var err error
+		// If the principal docs sequences are regenerated, or the user doc need to be invalidated after a dynamic channel grant, db.QueryPrincipals is called to find the principal docs.
+		// In the case that a database is created with "start_offline": true, it is possible the index needed to create this is not yet ready, so make sure it is ready for use.
+		if (regenerateSequences && resyncCollections == nil) || r.DocsChanged.Value() > 0 {
+			err := initializePrincipalDocsIndex(ctx, db)
+			if err != nil {
+				return err
+			}
+		}
+		if regenerateSequences && resyncCollections == nil {
+			var multiError *base.MultiError
 			for _, databaseCollection := range db.CollectionByID {
 				if updateErr := databaseCollection.updateAllPrincipalsSequences(ctx); updateErr != nil {
-					err = updateErr
+					multiError = multiError.Append(updateErr)
 				}
 			}
 
-			if err != nil {
-				return err
+			if multiError.Len() > 0 {
+				return fmt.Errorf("Error updating principal sequences: %s", multiError.Error())
 			}
 		}
 
@@ -353,6 +362,22 @@ type ResyncManagerMeta struct {
 type ResyncManagerStatusDocDCP struct {
 	ResyncManagerResponseDCP `json:"status"`
 	ResyncManagerMeta        `json:"meta"`
+}
+
+// initializePrincipalDocsIndex creates the metadata indexes required for resync
+func initializePrincipalDocsIndex(ctx context.Context, db *Database) error {
+	n1qlStore, ok := base.AsN1QLStore(db.MetadataStore)
+	if !ok {
+		return errors.New("Cannot create indexes on non-Couchbase data store.")
+	}
+	options := InitializeIndexOptions{
+		FailFast:        false,
+		NumReplicas:     db.Options.NumIndexReplicas,
+		MetadataIndexes: IndexesPrincipalOnly,
+		UseXattrs:       db.UseXattrs(),
+	}
+
+	return InitializeIndexes(ctx, n1qlStore, options)
 }
 
 // getResyncDCPClientOptions returns the default set of DCPClientOptions suitable for resync

--- a/db/database.go
+++ b/db/database.go
@@ -179,6 +179,7 @@ type DatabaseContextOptions struct {
 	LoggingConfig                 DbLogConfig // Per-database log configuration
 	MaxConcurrentChangesBatches   *int        // Maximum number of changes batches to process concurrently per replication
 	MaxConcurrentRevs             *int        // Maximum number of revs to process concurrently per replication
+	NumIndexReplicas              uint        // Number of replicas for GSI indexes
 }
 
 // DbLogConfig can be used to customise the logging for logs associated with this database.

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -1,0 +1,72 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package indextest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResyncWithoutIndexes(t *testing.T) {
+	if base.TestsDisableGSI() {
+		t.Skip("this test is only for GSI")
+	}
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true})
+	defer rt.Close()
+
+	dbName := "db"
+
+	rest.RequireStatus(t, rt.CreateDatabase(dbName, rt.NewDbConfig()), http.StatusCreated)
+	// create test doc to change sequence number
+	rt.CreateDoc(t, "doc1")
+
+	rt.SyncFn = `function(doc, oldDoc) {channel("A")}`
+	rest.RequireStatus(t, rt.UpsertDbConfig(dbName, rt.NewDbConfig()), http.StatusCreated)
+
+	rt.TakeDbOffline()
+
+	for _, collection := range rt.GetDatabase().CollectionByID {
+		n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())
+		require.True(t, ok)
+		require.NoError(t, base.DropAllIndexes(rt.Context(), n1qlStore))
+	}
+
+	rt.TakeDbOffline()
+	// gocb pipeline boostrap errors can occur before this stage
+	warningsBeforeResync := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)
+	resyncStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+	require.Equal(t, int64(1), resyncStatus.DocsChanged)
+	require.Equal(t, int64(0), base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()-warningsBeforeResync)
+
+	defaultDataStore, ok := base.AsN1QLStore(rt.Bucket().DefaultDataStore())
+	require.True(t, ok)
+
+	// the sync docs index)
+	numIndexes, err := defaultDataStore.GetIndexes()
+	require.NoError(t, err)
+	require.Len(t, numIndexes, 1)
+
+	for _, collection := range rt.GetDatabase().CollectionByID {
+		n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())
+		require.True(t, ok)
+		numIndexes, err := n1qlStore.GetIndexes()
+		require.NoError(t, err)
+		if collection.IsDefaultCollection() {
+			require.Len(t, numIndexes, 1, "Expected 1 index for default collection")
+		}
+		require.Len(t, numIndexes, 0, "Expected 0 indexes for non-default collection")
+	}
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1255,6 +1255,11 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		MaxConcurrentChangesBatches: sc.Config.Replicator.MaxConcurrentChangesBatches,
 		MaxConcurrentRevs:           sc.Config.Replicator.MaxConcurrentRevs,
 	}
+	if config.NumIndexReplicas != nil {
+		contextOptions.NumIndexReplicas = *config.NumIndexReplicas
+	} else {
+		contextOptions.NumIndexReplicas = DefaultNumIndexReplicas
+	}
 
 	// Per-database console logging config overrides
 	contextOptions.LoggingConfig.Console = config.toDbConsoleLogConfig(ctx)


### PR DESCRIPTION
…esync

backports CBG-3963


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2486/
