### PR TITLE
[3.1.7 backport] CBG-3969 include scope name in collections being resynced

### DIFF
--- a/db/background_mgr_resync.go
+++ b/db/background_mgr_resync.go
@@ -23,7 +23,7 @@ import (
 type ResyncManager struct {
 	DocsProcessed       int
 	DocsChanged         int
-	ResyncedCollections []string
+	ResyncedCollections map[string][]string
 	lock                sync.Mutex
 }
 
@@ -113,7 +113,7 @@ func (r *ResyncManager) SetStats(docsProcessed, docsChanged int) {
 	r.DocsChanged = docsChanged
 }
 
-func (r *ResyncManager) SetCollectionStatus(collectionNames []string) {
+func (r *ResyncManager) SetCollectionStatus(collectionNames map[string][]string) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -122,9 +122,9 @@ func (r *ResyncManager) SetCollectionStatus(collectionNames []string) {
 
 type ResyncManagerResponse struct {
 	BackgroundManagerStatus
-	DocsChanged           int      `json:"docs_changed"`
-	DocsProcessed         int      `json:"docs_processed"`
-	CollectionsProcessing []string `json:"collections_processing,omitempty"`
+	DocsChanged           int                 `json:"docs_changed"`
+	DocsProcessed         int                 `json:"docs_processed"`
+	CollectionsProcessing map[string][]string `json:"collections_processing,omitempty"`
 }
 
 func (r *ResyncManager) GetProcessStatus(backgroundManagerStatus BackgroundManagerStatus) ([]byte, []byte, error) {

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -30,7 +30,7 @@ type ResyncManagerDCP struct {
 	ResyncID            string
 	VBUUIDs             []uint64
 	useXattrs           bool
-	ResyncedCollections []string
+	ResyncedCollections map[string][]string
 	lock                sync.RWMutex
 }
 
@@ -254,25 +254,28 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 	return nil
 }
 
-func getCollectionIdsAndNames(db *Database, resyncCollections ResyncCollections) ([]uint32, bool, []string, error) {
+func getCollectionIdsAndNames(db *Database, resyncCollections ResyncCollections) ([]uint32, bool, map[string][]string, error) {
 	collectionIDs := make([]uint32, 0)
 	var hasAllCollections bool
-	var resyncCollectionNames []string
+	scopeAndCollection := make(map[string][]string)
 
 	if len(resyncCollections) == 0 {
 		hasAllCollections = true
 		for collectionID := range db.CollectionByID {
 			collectionIDs = append(collectionIDs, collectionID)
 		}
-		for _, collectionNames := range db.CollectionNames {
+		for scopeName, collectionNames := range db.CollectionNames {
+			var resyncCollectionNames []string
 			for collName := range collectionNames {
 				resyncCollectionNames = append(resyncCollectionNames, collName)
 			}
+			scopeAndCollection[scopeName] = resyncCollectionNames
 		}
 	} else {
 		hasAllCollections = false
 
 		for scopeName, collectionsName := range resyncCollections {
+			var resyncCollectionNames []string
 			for _, collectionName := range collectionsName {
 				collection, err := db.GetDatabaseCollection(scopeName, collectionName)
 				if err != nil {
@@ -281,9 +284,10 @@ func getCollectionIdsAndNames(db *Database, resyncCollections ResyncCollections)
 				collectionIDs = append(collectionIDs, collection.GetCollectionID())
 				resyncCollectionNames = append(resyncCollectionNames, collectionName)
 			}
+			scopeAndCollection[scopeName] = resyncCollectionNames
 		}
 	}
-	return collectionIDs, hasAllCollections, resyncCollectionNames, nil
+	return collectionIDs, hasAllCollections, scopeAndCollection, nil
 }
 
 func (r *ResyncManagerDCP) ResetStatus() {
@@ -303,7 +307,7 @@ func (r *ResyncManagerDCP) SetStatus(docChanged, docProcessed int64) {
 	r.DocsProcessed.Set(docProcessed)
 }
 
-func (r *ResyncManagerDCP) SetCollectionStatus(collectionNames []string) {
+func (r *ResyncManagerDCP) SetCollectionStatus(collectionNames map[string][]string) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -312,10 +316,10 @@ func (r *ResyncManagerDCP) SetCollectionStatus(collectionNames []string) {
 
 type ResyncManagerResponseDCP struct {
 	BackgroundManagerStatus
-	ResyncID              string   `json:"resync_id"`
-	DocsChanged           int64    `json:"docs_changed"`
-	DocsProcessed         int64    `json:"docs_processed"`
-	CollectionsProcessing []string `json:"collections_processing,omitempty"`
+	ResyncID              string              `json:"resync_id"`
+	DocsChanged           int64               `json:"docs_changed"`
+	DocsProcessed         int64               `json:"docs_processed"`
+	CollectionsProcessing map[string][]string `json:"collections_processing,omitempty"`
 }
 
 func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus) ([]byte, []byte, error) {

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1858,6 +1858,9 @@ Resync-status:
     docs_processed:
       description: The amount of docs that have been processed so far in the resync operation.
       type: integer
+    collections_processing:
+      description: The collections that the resync operation is running on.
+      $ref: '#/ResyncScopesMap'
   required:
     - status
     - start_time
@@ -2401,6 +2404,7 @@ ResyncScopesMap:
   type: object
   additionalProperties:
     $ref: '#/CollectionNames'
+  example: {"scopeName": {"collection1", "collection2"}}
 CollectionNames:
   description: 'List of collection names'
   type: array

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -745,18 +745,22 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 	testCases := []struct {
 		name              string
 		collectionNames   []string
-		expectedResult    []string
+		expectedResult    map[string][]string
 		specifyCollection bool
 	}{
 		{
-			name:              "collections_specified",
-			collectionNames:   []string{"sg_test_0"},
-			expectedResult:    []string{"sg_test_0"},
+			name:            "collections_specified",
+			collectionNames: []string{"sg_test_0"},
+			expectedResult: map[string][]string{
+				"sg_test_0": {"sg_test_0"},
+			},
 			specifyCollection: true,
 		},
 		{
-			name:            "collections_not_specified",
-			expectedResult:  []string{"sg_test_0", "sg_test_1", "sg_test_2"},
+			name: "collections_not_specified",
+			expectedResult: map[string][]string{
+				"sg_test_0": {"sg_test_0", "sg_test_1", "sg_test_2"},
+			},
 			collectionNames: nil,
 		},
 	}
@@ -764,6 +768,7 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			rt := rest.NewRestTesterMultipleCollections(t, nil, 3)
 			defer rt.Close()
+			scopeName := "sg_test_0"
 
 			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 			require.True(t, ok)
@@ -781,7 +786,7 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 
 			statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-			assert.ElementsMatch(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
+			assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
 		})
 	}
 }
@@ -795,18 +800,22 @@ func TestQueryResyncCollectionsStatus(t *testing.T) {
 	testCases := []struct {
 		name              string
 		collectionNames   []string
-		expectedResult    []string
+		expectedResult    map[string][]string
 		specifyCollection bool
 	}{
 		{
-			name:              "collections_specified",
-			collectionNames:   []string{"sg_test_0"},
-			expectedResult:    []string{"sg_test_0"},
+			name:            "collections_specified",
+			collectionNames: []string{"sg_test_0"},
+			expectedResult: map[string][]string{
+				"sg_test_0": {"sg_test_0"},
+			},
 			specifyCollection: true,
 		},
 		{
-			name:            "collections_not_specified",
-			expectedResult:  []string{"sg_test_0", "sg_test_1", "sg_test_2"},
+			name: "collections_not_specified",
+			expectedResult: map[string][]string{
+				"sg_test_0": {"sg_test_0", "sg_test_1", "sg_test_2"},
+			},
 			collectionNames: nil,
 		},
 	}
@@ -821,6 +830,7 @@ func TestQueryResyncCollectionsStatus(t *testing.T) {
 				},
 			}, 3)
 			defer rt.Close()
+			scopeName := "sg_test_0"
 
 			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManager)
 			require.True(t, ok)
@@ -838,7 +848,7 @@ func TestQueryResyncCollectionsStatus(t *testing.T) {
 
 			statusResponse := rt.WaitForResyncStatus(db.BackgroundProcessStateCompleted)
 
-			assert.ElementsMatch(t, statusResponse.CollectionsProcessing, testCase.expectedResult)
+			assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
 		})
 	}
 }


### PR DESCRIPTION
backports CBG-3968

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
