### PR TITLE
[3.1.7 backport] CBG-3965 Do not regenerate principal sequences unless resync is running on default collection

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -764,6 +764,13 @@ func DisableTestWithCollections(t *testing.T) {
 	}
 }
 
+// TestRequiresDCPResync will skip the current test DCP sync is not supported.
+func TestRequiresDCPResync(t testing.TB) {
+	if UnitTestUrlIsWalrus() {
+		t.Skip("Walrus doesn't support DCP resync CBG-2661")
+	}
+}
+
 // SkipImportTestsIfNotEnabled skips test that exercise import features
 func SkipImportTestsIfNotEnabled(t *testing.T) {
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -189,7 +189,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 			return err
 		}
 
-		if regenerateSequences {
+		if regenerateSequences && resyncCollections == nil {
 			var err error
 			for _, databaseCollection := range db.CollectionByID {
 				if updateErr := databaseCollection.updateAllPrincipalsSequences(ctx); updateErr != nil {

--- a/docs/api/paths/admin/db-_resync.yaml
+++ b/docs/api/paths/admin/db-_resync.yaml
@@ -58,7 +58,7 @@ post:
           - stop
     - name: regenerate_sequences
       in: query
-      description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed.'
+      description: '**Use this only when requested to do so by the Couchbase support team** This request will regenerate the sequence numbers for each document processed. If scopes parameter is specified, the principal sequence documents will not have their sequences updated.'
       schema:
         type: boolean
     - name: reset

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -107,8 +107,10 @@ func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
 			dbConfig := rt.NewDbConfig()
 			ds, err := rt.TestBucket.GetNamedDataStore(0)
 			require.NoError(t, err)
-			scopeName := ds.ScopeName()
-			collectionName := ds.CollectionName()
+			dsName, ok := base.AsDataStoreName(ds)
+			require.True(t, ok)
+			scopeName := dsName.ScopeName()
+			collectionName := dsName.CollectionName()
 			if test.defaultCollectionOnly {
 				dbConfig.Scopes = nil
 				scopeName = base.DefaultScope
@@ -126,7 +128,7 @@ func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
 			originalUserSeq := user.Sequence()
 			require.NotEqual(t, 0, originalUserSeq)
 
-			rt.CreateTestDoc(standardDoc)
+			rt.CreateDoc(t, standardDoc)
 			doc, err := rt.GetSingleTestDatabaseCollection().GetDocument(ctx, standardDoc, db.DocUnmarshalSync)
 			require.NoError(t, err)
 			oldDocSeq := doc.Sequence


### PR DESCRIPTION
CBG-3965
