### PR TITLE
CBG-3963 skip index readiness for GSI

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -192,7 +192,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 
 		// If the principal docs sequences are regenerated, or the user doc need to be invalidated after a dynamic channel grant, db.QueryPrincipals is called to find the principal docs.
 		// In the case that a database is created with "start_offline": true, it is possible the index needed to create this is not yet ready, so make sure it is ready for use.
-		if (regenerateSequences && resyncCollections == nil) || r.DocsChanged.Value() > 0 {
+		if !db.UseViews() && ((regenerateSequences && resyncCollections == nil) || r.DocsChanged.Value() > 0) {
 			err := initializePrincipalDocsIndex(ctx, db)
 			if err != nil {
 				return err

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -19,9 +19,6 @@ import (
 )
 
 func TestResyncWithoutIndexes(t *testing.T) {
-	if base.TestsDisableGSI() {
-		t.Skip("this test is only for GSI")
-	}
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		PersistentConfig: true})
 	defer rt.Close()
@@ -37,10 +34,12 @@ func TestResyncWithoutIndexes(t *testing.T) {
 
 	rt.TakeDbOffline()
 
-	for _, collection := range rt.GetDatabase().CollectionByID {
-		n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())
-		require.True(t, ok)
-		require.NoError(t, base.DropAllIndexes(rt.Context(), n1qlStore))
+	if !base.TestsDisableGSI() {
+		for _, collection := range rt.GetDatabase().CollectionByID {
+			n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())
+			require.True(t, ok)
+			require.NoError(t, base.DropAllIndexes(rt.Context(), n1qlStore))
+		}
 	}
 
 	rt.TakeDbOffline()
@@ -54,19 +53,21 @@ func TestResyncWithoutIndexes(t *testing.T) {
 	defaultDataStore, ok := base.AsN1QLStore(rt.Bucket().DefaultDataStore())
 	require.True(t, ok)
 
-	// the sync docs index)
-	numIndexes, err := defaultDataStore.GetIndexes()
-	require.NoError(t, err)
-	require.Len(t, numIndexes, 1)
-
-	for _, collection := range rt.GetDatabase().CollectionByID {
-		n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())
-		require.True(t, ok)
-		numIndexes, err := n1qlStore.GetIndexes()
+	if !base.TestsDisableGSI() {
+		// the sync docs index)
+		numIndexes, err := defaultDataStore.GetIndexes()
 		require.NoError(t, err)
-		if collection.IsDefaultCollection() {
-			require.Len(t, numIndexes, 1, "Expected 1 index for default collection")
+		require.Len(t, numIndexes, 1)
+
+		for _, collection := range rt.GetDatabase().CollectionByID {
+			n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())
+			require.True(t, ok)
+			numIndexes, err := n1qlStore.GetIndexes()
+			require.NoError(t, err)
+			if collection.IsDefaultCollection() {
+				require.Len(t, numIndexes, 1, "Expected 1 index for default collection")
+			}
+			require.Len(t, numIndexes, 0, "Expected 0 indexes for non-default collection")
 		}
-		require.Len(t, numIndexes, 0, "Expected 0 indexes for non-default collection")
 	}
 }

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestResyncWithoutIndexes(t *testing.T) {
+	base.TestRequiresDCPResync(t)
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		PersistentConfig: true})
 	defer rt.Close()


### PR DESCRIPTION
Tested `rest.indexestest.TestResync` by hand with SG_TEST_USE_GSI=true/SG_TEST_USE_GSI=false
