### PR TITLE
use golangci-lint v1.59.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.57.2
+          version: v1.59.0
           args: --config=.golangci-strict.yml
 
   test:

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -37,6 +37,7 @@ linters:
     - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
     - depguard # Go linter that checks if package imports are in a list of acceptable packages
     - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
+    - err113 # Golang linter to check the errors handling expressions
     - funlen # Tool for detection of long functions
     - gochecknoglobals # Checks that no globals are present in Go code
     - gochecknoinits # Checks that no init functions are present in Go code
@@ -44,22 +45,18 @@ linters:
     - gocyclo # Computes and checks the cyclomatic complexity of functions
     - godot # Check if comments end in a period
     - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - goerr113 # Golang linter to check the errors handling expressions
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gomnd # An analyzer to detect magic numbers.
     - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - interfacer # Linter that suggests narrower interface types
     - lll # Reports long lines
     - nestif # Reports deeply nested if statements
     - nolintlint # Reports ill-formed or insufficient nolint directives
     - rowserrcheck # checks whether Err of rows is checked successfully
-    - scopelint # Scopelint checks for unpinned variables in go programs
     - stylecheck # Stylecheck is a replacement for golint
     - testpackage # linter that makes you use a separate _test package
     - whitespace # Tool for detection of leading and trailing whitespace
     - wsl # Whitespace Linter - Forces you to use empty lines!
     # Once fixed, should enable
-    - deadcode # Finds unused code
     - dupl # Tool for code clone detection
     - goconst # Finds repeated strings that could be replaced by a constant
     - goprintffuncname # Checks that printf-like functions are named with `f` at the end
@@ -68,9 +65,7 @@ linters:
     - nakedret # Finds naked returns in functions greater than a specified function length
     - prealloc # Finds slice declarations that could potentially be preallocated
     - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - structcheck # Finds unused struct fields
     - unparam # Reports unused function parameters
-    - varcheck # Finds unused global variables and constants
 
 # Don't enable fieldalignment, changing the field alignment requires checking to see if anyone uses constructors
 # without names. If there is a memory issue on a specific field, that is best found with a heap profile.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,7 @@ linters:
     - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
     - depguard # Go linter that checks if package imports are in a list of acceptable packages
     - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
+    - err113 # Golang linter to check the errors handling expressions
     - funlen # Tool for detection of long functions
     - gochecknoglobals # Checks that no globals are present in Go code
     - gochecknoinits # Checks that no init functions are present in Go code
@@ -44,16 +45,13 @@ linters:
     - gocyclo # Computes and checks the cyclomatic complexity of functions
     - godot # Check if comments end in a period
     - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - goerr113 # Golang linter to check the errors handling expressions
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gomnd # An analyzer to detect magic numbers.
     - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - interfacer # Linter that suggests narrower interface types
     - lll # Reports long lines
     - nestif # Reports deeply nested if statements
     - nolintlint # Reports ill-formed or insufficient nolint directives
     - rowserrcheck # checks whether Err of rows is checked successfully
-    - scopelint # Scopelint checks for unpinned variables in go programs
     - stylecheck # Stylecheck is a replacement for golint
     - testpackage # linter that makes you use a separate _test package
     - whitespace # Tool for detection of leading and trailing whitespace


### PR DESCRIPTION
- remove linters disabled in our config that have been disabled by golanci-lint
- rename goerr113 -> err113