### PR TITLE
Switch to atomic values for RestTester testing.TB reference

### DIFF
--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -121,7 +121,7 @@ func TestLogRotationInterval(t *testing.T) {
 
 	// Wait for Lumberjack to finish its async log compression work
 	// we have no way of waiting for this to finish, or even stopping the millRun() process inside Lumberjack.
-	time.Sleep(time.Millisecond * 500)
+	time.Sleep(time.Second)
 }
 
 // Benchmark the time it takes to write x bytes of data to a logger, and optionally rotate and compress it.

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1752,10 +1752,10 @@ func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
 
 	// persistence logic construction
 	version, err := rest.GenerateDatabaseConfigVersionID(rt.Context(), "", &dbConfig)
-	require.NoError(rt.TB, err)
+	require.NoError(rt.TB(), err)
 
-	metadataID, metadataIDError := rt.ServerContext().BootstrapContext.ComputeMetadataIDForDbConfig(base.TestCtx(rt.TB), &dbConfig)
-	require.NoError(rt.TB, metadataIDError)
+	metadataID, metadataIDError := rt.ServerContext().BootstrapContext.ComputeMetadataIDForDbConfig(base.TestCtx(rt.TB()), &dbConfig)
+	require.NoError(rt.TB(), metadataIDError)
 
 	badName := "badName"
 	dbConfig.Bucket = &badName

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -67,7 +67,7 @@ func TestDocEtag(t *testing.T) {
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	require.True(t, body["ok"].(bool))
-	afterAttachmentVersion := DocVersionFromPutResponse(rt.TB, response)
+	afterAttachmentVersion := DocVersionFromPutResponse(rt.TB(), response)
 	RequireDocVersionNotEqual(t, version, afterAttachmentVersion)
 
 	// validate Etag returned from adding an attachment
@@ -2746,11 +2746,11 @@ func (rt *RestTester) storeAttachment(docID string, version DocVersion, attName,
 func (rt *RestTester) storeAttachmentWithHeaders(docID string, version DocVersion, attName, attBody string, reqHeaders map[string]string) DocVersion {
 	resource := fmt.Sprintf("/{{.keyspace}}/%s/%s?rev=%s", docID, attName, version.RevID)
 	response := rt.SendAdminRequestWithHeaders(http.MethodPut, resource, attBody, reqHeaders)
-	RequireStatus(rt.TB, response, http.StatusCreated)
+	RequireStatus(rt.TB(), response, http.StatusCreated)
 	var body db.Body
-	require.NoError(rt.TB, base.JSONUnmarshal(response.Body.Bytes(), &body))
-	require.True(rt.TB, body["ok"].(bool))
-	return DocVersionFromPutResponse(rt.TB, response)
+	require.NoError(rt.TB(), base.JSONUnmarshal(response.Body.Bytes(), &body))
+	require.True(rt.TB(), body["ok"].(bool))
+	return DocVersionFromPutResponse(rt.TB(), response)
 }
 
 // storeAttachmentWithIfMatch adds an attachment to a document version and returns the new version, using If-Match.
@@ -2759,9 +2759,9 @@ func (rt *RestTester) storeAttachmentWithIfMatch(docID string, version DocVersio
 	reqHeaders["If-Match"] = `"` + version.RevID + `"`
 	resource := fmt.Sprintf("/{{.keyspace}}/%s/%s", docID, attName)
 	response := rt.SendRequestWithHeaders(http.MethodPut, resource, attBody, reqHeaders)
-	RequireStatus(rt.TB, response, http.StatusCreated)
+	RequireStatus(rt.TB(), response, http.StatusCreated)
 	var body db.Body
-	require.NoError(rt.TB, base.JSONUnmarshal(response.Body.Bytes(), &body))
-	require.True(rt.TB, body["ok"].(bool))
-	return DocVersionFromPutResponse(rt.TB, response)
+	require.NoError(rt.TB(), base.JSONUnmarshal(response.Body.Bytes(), &body))
+	require.True(rt.TB(), body["ok"].(bool))
+	return DocVersionFromPutResponse(rt.TB(), response)
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3008,7 +3008,7 @@ func TestBlipRefreshUser(t *testing.T) {
 		defer btc.Close()
 
 		// add chan1 explicitly
-		response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB, "", RestTesterDefaultUserPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"chan1"}, nil))
+		response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB(), "", RestTesterDefaultUserPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"chan1"}, nil))
 		RequireStatus(t, response, http.StatusOK)
 
 		version := rt.PutDoc(docID, `{"channels":["chan1"]}`)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -124,7 +124,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		btr.replicationStats = db.NewBlipSyncStats()
 	}
 
-	ctx := base.DatabaseLogCtx(base.TestCtx(btr.bt.restTester.TB), btr.bt.restTester.GetDatabase().Name, nil)
+	ctx := base.DatabaseLogCtx(base.TestCtx(btr.bt.restTester.TB()), btr.bt.restTester.GetDatabase().Name, nil)
 	btr.bt.blipContext.HandlerForProfile[db.MessageProveAttachment] = func(msg *blip.Message) {
 		btr.storeMessage(msg)
 
@@ -497,12 +497,12 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 // TB returns testing.TB for the current test
 func (btr *BlipTesterReplicator) TB() testing.TB {
-	return btr.bt.restTester.TB
+	return btr.bt.restTester.TB()
 }
 
 // TB returns testing.TB for the current test
 func (btc *BlipTesterCollectionClient) TB() testing.TB {
-	return btc.parent.rt.TB
+	return btc.parent.rt.TB()
 }
 
 // saveAttachment takes a content-type, and base64 encoded data and stores the attachment on the client
@@ -510,7 +510,7 @@ func (btc *BlipTesterCollectionClient) saveAttachment(_, base64data string) (dat
 	btc.attachmentsLock.Lock()
 	defer btc.attachmentsLock.Unlock()
 
-	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB), btc.parent.rt.GetDatabase().Name, nil)
+	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB()), btc.parent.rt.GetDatabase().Name, nil)
 
 	data, err := base64.StdEncoding.DecodeString(base64data)
 	if err != nil {
@@ -549,7 +549,7 @@ func (btc *BlipTesterCollectionClient) updateLastReplicatedRev(docID, revID stri
 		return
 	}
 
-	ctx := base.TestCtx(btc.parent.rt.TB)
+	ctx := base.TestCtx(btc.parent.rt.TB())
 	currentGen, _ := db.ParseRevID(ctx, currentRevID)
 	incomingGen, _ := db.ParseRevID(ctx, revID)
 	if incomingGen > currentGen {
@@ -628,7 +628,7 @@ func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTes
 
 // TB returns testing.TB for the current test
 func (btc *BlipTesterClient) TB() testing.TB {
-	return btc.rt.TB
+	return btc.rt.TB()
 }
 
 func (btc *BlipTesterClient) Close() {
@@ -857,7 +857,7 @@ func (btc *BlipTesterCollectionClient) PushRev(docID string, parentVersion DocVe
 
 // PushRevWithHistory creates a revision on the client with history, and immediately sends a changes request for it.
 func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev string, body []byte, revCount, prunedRevCount int) (revID string, err error) {
-	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB), btc.parent.rt.GetDatabase().Name, nil)
+	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB()), btc.parent.rt.GetDatabase().Name, nil)
 	parentRevGen, _ := db.ParseRevID(ctx, parentRev)
 	revGen := parentRevGen + revCount + prunedRevCount
 
@@ -978,7 +978,7 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev strin
 }
 
 func (btc *BlipTesterCollectionClient) StoreRevOnClient(docID, revID string, body []byte) error {
-	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB), btc.parent.rt.GetDatabase().Name, nil)
+	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB()), btc.parent.rt.GetDatabase().Name, nil)
 	revGen, _ := db.ParseRevID(ctx, revID)
 	newBody, err := btc.ProcessInlineAttachments(body, revGen)
 	if err != nil {

--- a/rest/blip_stats_test.go
+++ b/rest/blip_stats_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func sendGetCheckpointRequest(bt *BlipTester) {
-	t := bt.restTester.TB
+	t := bt.restTester.TB()
 	rq := bt.newRequest()
 	rq.SetProfile("getCheckpoint")
 	require.True(t, bt.sender.Send(rq))

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -528,14 +528,14 @@ func TestCORSBlipNoConfig(t *testing.T) {
 // requireBlipHandshakeEmptyCORS creates a new blip tester with no Origin header
 func requireBlipHandshakeEmptyCORS(rt *RestTester) {
 	spec := getDefaultBlipTesterSpec()
-	_, err := createBlipTesterWithSpec(rt.TB, spec, rt)
-	require.NoError(rt.TB, err)
+	_, err := createBlipTesterWithSpec(rt.TB(), spec, rt)
+	require.NoError(rt.TB(), err)
 }
 
 // requireBlipHandshakeMatchingHost creates a new blip tester with an Origin header that matches the host name of the test
 func requireBlipHandshakeMatchingHost(rt *RestTester) {
 	spec := getDefaultBlipTesterSpec()
 	spec.useHostOrigin = true
-	_, err := createBlipTesterWithSpec(rt.TB, spec, rt)
-	require.NoError(rt.TB, err)
+	_, err := createBlipTesterWithSpec(rt.TB(), spec, rt)
+	require.NoError(rt.TB(), err)
 }

--- a/rest/diagnostic_api_test.go
+++ b/rest/diagnostic_api_test.go
@@ -25,9 +25,9 @@ type grant interface {
 func compareAllChannelsOutput(rt *RestTester, username string, expectedOutput string) {
 	response := rt.SendDiagnosticRequest(http.MethodGet,
 		"/{{.db}}/_user/"+username+"/_all_channels", ``)
-	RequireStatus(rt.TB, response, http.StatusOK)
-	rt.TB.Logf("All channels response: %s", response.BodyString())
-	require.JSONEq(rt.TB, rt.mustTemplateResource(expectedOutput), response.BodyString())
+	RequireStatus(rt.TB(), response, http.StatusOK)
+	rt.TB().Logf("All channels response: %s", response.BodyString())
+	require.JSONEq(rt.TB(), rt.mustTemplateResource(expectedOutput), response.BodyString())
 
 }
 
@@ -49,13 +49,13 @@ func (g *userGrant) getUserPayload(rt *RestTester) string {
 
 	for keyspace, chans := range g.adminChannels {
 		_, scope, collection, err := ParseKeyspace(rt.mustTemplateResource(keyspace))
-		require.NoError(rt.TB, err)
+		require.NoError(rt.TB(), err)
 		if scope == nil && collection == nil {
 			config.ExplicitChannels = base.SetFromArray(chans)
 			continue
 		}
-		require.NotNil(rt.TB, scope, "Could not find scope from keyspace %s", keyspace)
-		require.NotNil(rt.TB, collection, "Could not find collection from keyspace %s", keyspace)
+		require.NotNil(rt.TB(), scope, "Could not find scope from keyspace %s", keyspace)
+		require.NotNil(rt.TB(), collection, "Could not find collection from keyspace %s", keyspace)
 		if base.IsDefaultCollection(*scope, *collection) {
 			config.ExplicitChannels = base.SetFromArray(chans)
 		} else {
@@ -63,15 +63,15 @@ func (g *userGrant) getUserPayload(rt *RestTester) string {
 		}
 	}
 
-	return string(base.MustJSONMarshal(rt.TB, config))
+	return string(base.MustJSONMarshal(rt.TB(), config))
 }
 
 func (g userGrant) request(rt *RestTester) {
 	payload := g.getUserPayload(rt)
-	rt.TB.Logf("Issuing admin grant: %+v", payload)
+	rt.TB().Logf("Issuing admin grant: %+v", payload)
 	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+g.user, payload)
 	if response.Code != http.StatusCreated && response.Code != http.StatusOK {
-		rt.TB.Fatalf("Expected 200 or 201 exit code")
+		rt.TB().Fatalf("Expected 200 or 201 exit code")
 	}
 	if g.output != "" {
 		compareAllChannelsOutput(rt, g.user, g.output)
@@ -89,28 +89,28 @@ func (g roleGrant) getPayload(rt *RestTester) string {
 	}
 	for keyspace, chans := range g.adminChannels {
 		_, scope, collection, err := ParseKeyspace(rt.mustTemplateResource(keyspace))
-		require.NoError(rt.TB, err)
+		require.NoError(rt.TB(), err)
 		if scope == nil && collection == nil {
 			config.ExplicitChannels = base.SetFromArray(chans)
 			continue
 		}
-		require.NotNil(rt.TB, scope, "Could not find scope from keyspace %s", keyspace)
-		require.NotNil(rt.TB, collection, "Could not find collection from keyspace %s", keyspace)
+		require.NotNil(rt.TB(), scope, "Could not find scope from keyspace %s", keyspace)
+		require.NotNil(rt.TB(), collection, "Could not find collection from keyspace %s", keyspace)
 		if base.IsDefaultCollection(*scope, *collection) {
 			config.ExplicitChannels = base.SetFromArray(chans)
 		} else {
 			config.SetExplicitChannels(*scope, *collection, chans...)
 		}
 	}
-	return string(base.MustJSONMarshal(rt.TB, config))
+	return string(base.MustJSONMarshal(rt.TB(), config))
 }
 
 func (g roleGrant) request(rt *RestTester) {
 	payload := g.getPayload(rt)
-	rt.TB.Logf("Issuing admin grant: %+v", payload)
+	rt.TB().Logf("Issuing admin grant: %+v", payload)
 	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+g.role, payload)
 	if response.Code != http.StatusCreated && response.Code != http.StatusOK {
-		rt.TB.Fatalf("Expected 200 or 201 exit code")
+		rt.TB().Fatalf("Expected 200 or 201 exit code")
 	}
 }
 
@@ -137,10 +137,10 @@ func (g docGrant) getPayload() string {
 
 func (g docGrant) request(rt *RestTester) {
 	payload := g.getPayload()
-	rt.TB.Logf("Issuing dynamic grant: %+v", payload)
+	rt.TB().Logf("Issuing dynamic grant: %+v", payload)
 	response := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc", payload)
 	if response.Code != http.StatusCreated && response.Code != http.StatusOK {
-		rt.TB.Fatalf("Expected 200 or 201 exit code, got %d, output: %s", response.Code, response.Body.String())
+		rt.TB().Fatalf("Expected 200 or 201 exit code, got %d, output: %s", response.Code, response.Body.String())
 	}
 	if g.output != "" {
 		compareAllChannelsOutput(rt, g.userName, g.output)

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -415,12 +415,12 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 func requireSyncData(rt *rest.RestTester, dataStore base.DataStore, docName string, hasSyncData bool) {
 	xattrs, _, err := dataStore.GetXattrs(rt.Context(), docName, []string{base.SyncXattrName})
 	if hasSyncData {
-		require.NoError(rt.TB, err)
-		require.Contains(rt.TB, xattrs, base.SyncXattrName)
-		require.NotEqual(rt.TB, "", string(xattrs[base.SyncXattrName]), "Expected data for %s %s", dataStore.GetName(), docName)
+		require.NoError(rt.TB(), err)
+		require.Contains(rt.TB(), xattrs, base.SyncXattrName)
+		require.NotEqual(rt.TB(), "", string(xattrs[base.SyncXattrName]), "Expected data for %s %s", dataStore.GetName(), docName)
 	} else {
-		require.Error(rt.TB, err)
-		require.True(rt.TB, base.IsXattrNotFoundError(err), "Expected xattr missing error but got %+v", err)
-		require.NotContains(rt.TB, xattrs, base.SyncXattrName)
+		require.Error(rt.TB(), err)
+		require.True(rt.TB(), base.IsXattrNotFoundError(err), "Expected xattr missing error but got %+v", err)
+		require.NotContains(rt.TB(), xattrs, base.SyncXattrName)
 	}
 }

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2109,12 +2109,12 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 				return
 			}
 			if test.expectedStatusCode != nil {
-				rest.RequireStatus(rt.TB, resp, *test.expectedStatusCode)
+				rest.RequireStatus(rt.TB(), resp, *test.expectedStatusCode)
 			} else {
-				rest.RequireStatus(rt.TB, resp, 200)
+				rest.RequireStatus(rt.TB(), resp, 200)
 			}
 			var body db.Body
-			require.NoError(rt.TB, base.JSONUnmarshal(resp.Body.Bytes(), &body))
+			require.NoError(rt.TB(), base.JSONUnmarshal(resp.Body.Bytes(), &body))
 
 			for key, val := range body {
 				assert.EqualValues(t, val, body[key])

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2487,13 +2487,13 @@ func TestTotalSyncTimeStat(t *testing.T) {
 	activeRT.WaitForReplicationStatus(repName, db.ReplicationStateRunning)
 
 	// wait for active replication stat to pick up the replication connection
-	_, ok := base.WaitForStat(passiveRT.TB, func() int64 {
+	_, ok := base.WaitForStat(passiveRT.TB(), func() int64 {
 		return passiveRT.GetDatabase().DbStats.DatabaseStats.NumReplicationsActive.Value()
 	}, 1)
 	require.True(t, ok)
 
 	// wait some time to wait for the stat to increment
-	_, ok = base.WaitForStat(passiveRT.TB, func() int64 {
+	_, ok = base.WaitForStat(passiveRT.TB(), func() int64 {
 		return passiveRT.GetDatabase().DbStats.DatabaseStats.TotalSyncTime.Value()
 	}, 2)
 	require.True(t, ok)
@@ -7899,7 +7899,7 @@ func TestGroupIDReplications(t *testing.T) {
 		if rt.GetDatabase().OnlyDefaultCollection() {
 			dbConfig.Sync = base.StringPtr(channels.DocChannelsSyncFunction)
 		} else {
-			dbConfig.Scopes = rest.GetCollectionsConfigWithFiltering(rt.TB, rt.TestBucket, 1, base.StringPtr(channels.DocChannelsSyncFunction), nil)
+			dbConfig.Scopes = rest.GetCollectionsConfigWithFiltering(rt.TB(), rt.TestBucket, 1, base.StringPtr(channels.DocChannelsSyncFunction), nil)
 		}
 		dbcJSON, err := base.JSONMarshal(dbConfig)
 		require.NoError(t, err)

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -78,8 +78,8 @@ func requireDocumentVersion(t testing.TB, expected rest.DocVersion, doc *db.Docu
 // underlying bucket backed by the given RestTester instance.
 func requireVersion(rt *rest.RestTester, docID string, version rest.DocVersion) {
 	doc, err := rt.GetSingleTestDatabaseCollection().GetDocument(rt.Context(), docID, db.DocUnmarshalAll)
-	require.NoError(rt.TB, err, "Error reading document from bucket")
-	requireDocumentVersion(rt.TB, version, doc)
+	require.NoError(rt.TB(), err, "Error reading document from bucket")
+	requireDocumentVersion(rt.TB(), version, doc)
 }
 
 func requireErrorKeyNotFound(t *testing.T, rt *rest.RestTester, docID string) {
@@ -101,7 +101,7 @@ func waitForTombstone(t *testing.T, rt *rest.RestTester, docID string) {
 func createDoc(rt *rest.RestTester, docID string, bodyValue string) rest.DocVersion {
 	body := fmt.Sprintf(`{"key":%q,"channels":["alice"]}`, bodyValue)
 	updatedVersion := rt.PutDoc(docID, body)
-	require.NoError(rt.TB, rt.WaitForPendingChanges())
+	require.NoError(rt.TB(), rt.WaitForPendingChanges())
 	return updatedVersion
 }
 
@@ -109,7 +109,7 @@ func createDoc(rt *rest.RestTester, docID string, bodyValue string) rest.DocVers
 func updateDoc(rt *rest.RestTester, docID string, version rest.DocVersion, bodyValue string) rest.DocVersion {
 	body := fmt.Sprintf(`{"key":%q,"channels":["alice"]}`, bodyValue)
 	updatedVersion := rt.UpdateDoc(docID, version, body)
-	require.NoError(rt.TB, rt.WaitForPendingChanges())
+	require.NoError(rt.TB(), rt.WaitForPendingChanges())
 	return updatedVersion
 }
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -29,7 +29,7 @@ import (
 
 type ChannelRevocationTester struct {
 	restTester *RestTester
-	test       *testing.T
+	test       testing.TB
 
 	fillerDocVersion   DocVersion
 	roleVersion        DocVersion
@@ -53,7 +53,7 @@ func (tester *ChannelRevocationTester) addRole(user, role string) {
 	}
 
 	tester.roles.Roles[user] = append(tester.roles.Roles[user], fmt.Sprintf("role:%s", role))
-	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.roles)))
+	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(base.MustJSONMarshal(tester.test, tester.roles)))
 }
 
 func (tester *ChannelRevocationTester) removeRole(user, role string) {
@@ -66,7 +66,7 @@ func (tester *ChannelRevocationTester) removeRole(user, role string) {
 		}
 	}
 	tester.roles.Roles[revocationTestUser] = append(roles[:delIdx], roles[delIdx+1:]...)
-	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.roles)))
+	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(base.MustJSONMarshal(tester.test, tester.roles)))
 }
 
 func (tester *ChannelRevocationTester) addRoleChannel(role, channel string) {
@@ -77,7 +77,7 @@ func (tester *ChannelRevocationTester) addRoleChannel(role, channel string) {
 	role = fmt.Sprintf("role:%s", role)
 
 	tester.roleChannels.Channels[role] = append(tester.roleChannels.Channels[role], channel)
-	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.roleChannels)))
+	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(base.MustJSONMarshal(tester.test, tester.roleChannels)))
 }
 
 func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
@@ -91,7 +91,7 @@ func (tester *ChannelRevocationTester) removeRoleChannel(role, channel string) {
 		}
 	}
 	tester.roleChannels.Channels[role] = append(channelsSlice[:delIdx], channelsSlice[delIdx+1:]...)
-	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.roleChannels)))
+	tester.roleChannelVersion = tester.restTester.UpdateDoc("roleChannels", tester.roleChannelVersion, string(base.MustJSONMarshal(tester.test, tester.roleChannels)))
 }
 
 func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
@@ -100,7 +100,7 @@ func (tester *ChannelRevocationTester) addUserChannel(user, channel string) {
 	}
 
 	tester.userChannels.Channels[user] = append(tester.userChannels.Channels[user], channel)
-	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.userChannels)))
+	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(base.MustJSONMarshal(tester.test, tester.userChannels)))
 }
 
 func (tester *ChannelRevocationTester) removeUserChannel(user string, channel string) {
@@ -113,11 +113,11 @@ func (tester *ChannelRevocationTester) removeUserChannel(user string, channel st
 		}
 	}
 	tester.userChannels.Channels[revocationTestUser] = append(channelsSlice[:delIdx], channelsSlice[delIdx+1:]...)
-	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(base.MustJSONMarshal(tester.restTester.TB, tester.userChannels)))
+	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(base.MustJSONMarshal(tester.test, tester.userChannels)))
 }
 
 func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
-	ctx := base.DatabaseLogCtx(base.TestCtx(tester.restTester.TB), tester.restTester.GetDatabase().Name, nil)
+	ctx := base.DatabaseLogCtx(base.TestCtx(tester.test), tester.restTester.GetDatabase().Name, nil)
 	currentSeq, err := tester.restTester.GetDatabase().LastSequence(ctx)
 	require.NoError(tester.test, err)
 
@@ -150,7 +150,7 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 	return changes
 }
 
-func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTester, *RestTester) {
+func InitScenario(t testing.TB, rtConfig *RestTesterConfig) (ChannelRevocationTester, *RestTester) {
 
 	defaultSyncFn := `
 			function (doc, oldDoc){
@@ -185,7 +185,7 @@ func InitScenario(t *testing.T, rtConfig *RestTesterConfig) (ChannelRevocationTe
 	rt := NewRestTester(t, rtConfig)
 
 	revocationTester := ChannelRevocationTester{
-		test:       t,
+		test:       rt.TB(),
 		restTester: rt,
 	}
 

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -161,20 +161,20 @@ func getDbConfigFromLegacyConfig(rt *rest.RestTester) string {
 
 	var legacyConfig rest.LegacyServerConfig
 	err := base.JSONUnmarshal(legacyConfigBytes, &legacyConfig)
-	assert.NoError(rt.TB, err)
+	assert.NoError(rt.TB(), err)
 
 	// Generate a dbConfig from the legacy startup config using ToStartupConfig, and use it to create a database
 	_, dbMap, err := legacyConfig.ToStartupConfig(rt.Context())
-	require.NoError(rt.TB, err)
+	require.NoError(rt.TB(), err)
 
 	dbConfig, ok := dbMap["db"]
-	require.True(rt.TB, ok)
+	require.True(rt.TB(), ok)
 
 	// Need to sanitize the db config, but can't use sanitizeDbConfigs because it assumes non-empty server address
 	dbConfig.Username = ""
 	dbConfig.Password = ""
 	dbConfigBytes, err := base.JSONMarshal(dbConfig)
-	require.NoError(rt.TB, err)
+	require.NoError(rt.TB(), err)
 	return string(dbConfigBytes)
 
 }
@@ -293,6 +293,6 @@ func requireBobUserLocation(rt *rest.RestTester, docName string) {
 	metadataStore := rt.GetDatabase().Bucket.DefaultDataStore()
 
 	_, _, err := metadataStore.GetRaw(docName)
-	require.NoError(rt.TB, err)
+	require.NoError(rt.TB(), err)
 
 }

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1424,7 +1424,7 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	assert.Contains(t, getResponse.ResponseRecorder.Body.String(), `"all_channels":["!"]`)
 
 	dbConfig := rt.NewDbConfig()
-	dbConfig.Scopes = GetCollectionsConfig(rt.TB, rt.TestBucket, 1)
+	dbConfig.Scopes = GetCollectionsConfig(rt.TB(), rt.TestBucket, 1)
 	resp := rt.ReplaceDbConfig(rt.GetDatabase().Name, dbConfig)
 	RequireStatus(t, resp, http.StatusCreated)
 

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -203,7 +203,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
 	dbConfig := rt.NewDbConfig()
-	dbConfig.Scopes = GetCollectionsConfig(rt.TB, rt.TestBucket, numCollections)
+	dbConfig.Scopes = GetCollectionsConfig(rt.TB(), rt.TestBucket, numCollections)
 	dbOne := "dbone"
 	bucket1Datastore1, err := rt.TestBucket.GetNamedDataStore(0)
 	require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestRestTesterTemplateMultipleDatabases(t *testing.T) {
 	bucket2 := base.GetTestBucket(t)
 	defer bucket2.Close(ctx)
 	dbConfig = rt.NewDbConfig()
-	dbConfig.Scopes = GetCollectionsConfig(rt.TB, bucket2, numCollections)
+	dbConfig.Scopes = GetCollectionsConfig(rt.TB(), bucket2, numCollections)
 	dbConfig.BucketConfig = BucketConfig{
 		Bucket: base.StringPtr(bucket2.GetName()),
 	}


### PR DESCRIPTION
- Change `RestTester` `testing.TB` reference to an atomic value to prevent race detector flagging subtests
- Add `TB()` accessor to load atomic value

Files containing changes of note:
- `rest/utilities_testing_resttester.go`
- `rest/utilities_testing.go`

Example race:

https://jenkins.sgwdev.com/job/Sync%20Gateway%20Pipeline/job/main/41

```
=== RUN   TestRevocationMessage/revTree/Revocation
==================
WARNING: DATA RACE
Write at 0x00c001ebc008 by goroutine 79299:
  github.com/couchbase/sync_gateway/rest.(*RestTester).Run.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_main@2/rest/utilities_testing_resttester.go:32 +0x64
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.22.2/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.22.2/src/testing/testing.go:1742 +0x44

Previous read at 0x00c001ebc008 by goroutine 79297:
  github.com/couchbase/sync_gateway/rest.(*BlipTesterClient).TB()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_main@2/rest/blip_client_test.go:631 +0x4ba
  github.com/couchbase/sync_gateway/rest.(*BlipTesterClient).getCollectionClientFromMessage()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_main@2/rest/blip_client_test.go:1275 +0x472
  github.com/couchbase/sync_gateway/rest.(*BlipTesterReplicator).initHandlers.func2()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_main@2/rest/blip_client_test.go:154 +0x73
  github.com/couchbase/go-blip.(*Context).dispatchRequest()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/context.go:304 +0x2a5
  github.com/couchbase/go-blip.(*receiver).getPendingRequest.func1()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/receiver.go:276 +0x6d
  github.com/couchbase/go-blip.(*Message).asyncRead.func1()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/message.go:381 +0x127

Goroutine 79299 (running) created at:
  testing.(*T).Run()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.22.2/src/testing/testing.go:1742 +0x825
  github.com/couchbase/sync_gateway/rest.(*RestTester).Run()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_main@2/rest/utilities_testing_resttester.go:31 +0x1b3
  github.com/couchbase/sync_gateway/rest.TestRevocationMessage.func1()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_main@2/rest/revocation_test.go:2300 +0x904
  github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run.func2()
      /home/ec2-user/workspace/Sync_Gateway_Pipeline_main@2/rest/blip_client_test.go:654 +0x110
  testing.tRunner()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.22.2/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.22.2/src/testing/testing.go:1742 +0x44

Goroutine 79297 (finished) created at:
  github.com/couchbase/go-blip.(*Message).asyncRead()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/message.go:367 +0x264
  github.com/couchbase/go-blip.(*receiver).getPendingRequest()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/receiver.go:275 +0x498
  github.com/couchbase/go-blip.(*receiver).processFrame()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/receiver.go:230 +0x1ca
  github.com/couchbase/go-blip.(*receiver).handleIncomingFrame()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/receiver.go:219 +0xc2d
  github.com/couchbase/go-blip.(*receiver).parseLoop()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/receiver.go:116 +0x205
  github.com/couchbase/go-blip.(*receiver).receiveLoop.gowrap2()
      /home/ec2-user/go/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20231212195435-3490e96d30e3/receiver.go:71 +0x33
==================
    testing.go:1398: race detected during execution of test
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2487/
