### PR TITLE
CBG-3847: log value of sync:seq on startup of a database

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -2304,6 +2304,8 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	}
 	initialSequenceTime := time.Now()
 
+	base.InfofCtx(ctx, base.KeyCRUD, "Database has _sync:seq value on startup of %d", initialSequence)
+
 	// Unlock change cache.  Validate that any allocated sequences on other nodes have either been assigned or released
 	// before starting
 	if initialSequence > 0 {


### PR DESCRIPTION
CBG-3847

- simple PR to log at info the value of sync:seq on startup of a database inside StartOnlineProcesses 

```
2024-06-06T10:08:12.071+01:00 [INF] CRUD: db:db1 Database has _sync:seq value on startup of 2
```

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
