### PR TITLE
CBG-3938: use runtime config for log_file_path

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -265,7 +265,7 @@ def make_collect_logs_tasks(zip_dir, sg_url, sg_config_file_path, sg_username, s
     ]
     # Try to find user-specified log path
     if sg_url:
-        config_url = "{0}/_config".format(sg_url)
+        config_url = "{0}/_config?include_runtime=true".format(sg_url)
         try:
             response = urlopen_with_basic_auth(config_url, sg_username, sg_password)
         except urllib.error.URLError:


### PR DESCRIPTION
CBG-3938

- small change for using runtime config to determine log file path 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
