### PR TITLE
CBG-3988 Ensure documents are imported when collection added to a db 

### DIFF
--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -261,6 +261,20 @@ func (m *MetadataKeys) DCPCheckpointPrefix(groupID string) string {
 	return m.dcpCheckpoint
 }
 
+// DCPVersionedCheckpointPrefix returns the prefix used to store versioned DCP checkpoints.
+//
+//	format: _sync:dcp_ck:{m_$}:{groupID:}{version:}
+func (m *MetadataKeys) DCPVersionedCheckpointPrefix(groupID string, version uint64) string {
+	checkpointPrefix := m.dcpCheckpoint
+	if groupID != "" {
+		checkpointPrefix = checkpointPrefix + groupID + ":"
+	}
+	if version != 0 {
+		checkpointPrefix = checkpointPrefix + strconv.FormatUint(version, 10) + ":"
+	}
+	return checkpointPrefix
+}
+
 // DCPBackfillKey returns the key used to store DCP backfill statistics.
 //
 //	format: _sync:{m_$}:dcp_backfill

--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -88,3 +88,32 @@ func TestMetadataKeyHash(t *testing.T) {
 	require.Equal(t, "_sync:user:foo:afbf3a596bfe3e6687240e011bfccafd51611052", customMetadataKeys.UserKey(hashedUser))
 
 }
+
+// Verify that upgrading from non-versioned to versioned keys doesn't change the checkpoints when the version hasn't been incremented
+func TestDCPMetadataKeyUpgrade(t *testing.T) {
+
+	// Default metadata keys
+	defaultMetadataKeys := NewMetadataKeys("")
+	// Upgrade check with group ID
+	nonVersionedPrefixWithGroup := defaultMetadataKeys.DCPCheckpointPrefix("myGroup")
+	versionPrefixWithGroup := defaultMetadataKeys.DCPVersionedCheckpointPrefix("myGroup", 0)
+	require.Equal(t, nonVersionedPrefixWithGroup, versionPrefixWithGroup)
+
+	// Upgrade check with empty group ID
+	nonVersionedPrefix := defaultMetadataKeys.DCPCheckpointPrefix("")
+	versionPrefix := defaultMetadataKeys.DCPVersionedCheckpointPrefix("", 0)
+	require.Equal(t, nonVersionedPrefix, versionPrefix)
+
+	// Custom metadata keys
+	customMetadataKeys := NewMetadataKeys("foo")
+
+	// Upgrade check with group ID
+	nonVersionedPrefixWithGroup = customMetadataKeys.DCPCheckpointPrefix("myGroup")
+	versionPrefixWithGroup = customMetadataKeys.DCPVersionedCheckpointPrefix("myGroup", 0)
+	require.Equal(t, nonVersionedPrefixWithGroup, versionPrefixWithGroup)
+
+	// Upgrade check with empty group ID
+	nonVersionedPrefix = customMetadataKeys.DCPCheckpointPrefix("")
+	versionPrefix = customMetadataKeys.DCPVersionedCheckpointPrefix("", 0)
+	require.Equal(t, nonVersionedPrefix, versionPrefix)
+}

--- a/db/database.go
+++ b/db/database.go
@@ -177,6 +177,7 @@ type DatabaseContextOptions struct {
 	MaxConcurrentChangesBatches   *int           // Maximum number of changes batches to process concurrently per replication
 	MaxConcurrentRevs             *int           // Maximum number of revs to process concurrently per replication
 	NumIndexReplicas              uint           // Number of replicas for GSI indexes
+	ImportVersion                 uint64         // Version included in import DCP checkpoints, incremented when collections added to db
 }
 
 // DbLogConfig can be used to customise the logging for logs associated with this database.
@@ -2322,7 +2323,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.
 	if db.autoImport {
-		db.ImportListener = NewImportListener(ctx, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID), db)
+		db.ImportListener = NewImportListener(ctx, db.MetadataKeys.DCPVersionedCheckpointPrefix(db.Options.GroupID, db.Options.ImportVersion), db)
 		if importFeedErr := db.ImportListener.StartImportFeed(db); importFeedErr != nil {
 			return importFeedErr
 		}

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -77,7 +77,8 @@ func getNewPIndexImplType(ctx context.Context) func(indexType, indexParams, path
 
 		importDest, err := getListenerImportDest(ctx, indexParams, restart)
 		if err != nil {
-			base.ErrorfCtx(ctx, "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
+			// This error can occur when a stale index definition hasn't yet been removed from the plan (e.g. on update to db config)
+			base.InfofCtx(ctx, base.KeyDCP, "No importDest found for indexParams - usually an obsolete index pending removal. %v", err)
 		}
 		return nil, importDest, err
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -588,6 +588,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 		}
 		oldBucketDbConfig := bucketDbConfig.DbConfig
+		previousCollectionMap := bucketDbConfig.Scopes.CollectionMap()
 
 		if h.rq.Method == http.MethodPost {
 			base.TracefCtx(h.ctx(), base.KeyConfig, "merging upserted config into bucket config")
@@ -597,6 +598,12 @@ func (h *handler) handlePutDbConfig() (err error) {
 		} else {
 			base.TracefCtx(h.ctx(), base.KeyConfig, "using config as-is without merge")
 			bucketDbConfig.DbConfig = *dbConfig
+		}
+
+		// Update ImportVersion if new collections are being added to the database
+		if bucketDbConfig.Scopes.HasNewCollection(previousCollectionMap) {
+			bucketDbConfig.ImportVersion++
+			base.InfofCtx(h.ctx(), base.KeyConfig, "Import version incremented to %d, new collections detected", bucketDbConfig.ImportVersion)
 		}
 
 		if err := dbConfig.validatePersistentDbConfig(); err != nil {

--- a/rest/config.go
+++ b/rest/config.go
@@ -302,6 +302,39 @@ type invalidDatabaseConfigs struct {
 	m       sync.RWMutex
 }
 
+// CollectionMap returns the set of collections defined in the ScopesConfig as a map of collections in scope.collection form.
+// Used for comparing sets of collections between configs
+func (sc *ScopesConfig) CollectionMap() map[string]struct{} {
+	collectionMap := make(map[string]struct{})
+	if sc == nil {
+		collectionMap["_default._default"] = struct{}{}
+		return collectionMap
+	}
+	for scopeName, scope := range *sc {
+		for collectionName, _ := range scope.Collections {
+			scName := scopeName + "." + collectionName
+			collectionMap[scName] = struct{}{}
+		}
+	}
+	return collectionMap
+}
+
+func (sc *ScopesConfig) HasNewCollection(previousCollectionMap map[string]struct{}) bool {
+	if sc == nil {
+		_, hasDefault := previousCollectionMap["_default._default"]
+		return !hasDefault
+	}
+	for scopeName, scope := range *sc {
+		for collectionName, _ := range scope.Collections {
+			scName := scopeName + "." + collectionName
+			if _, ok := previousCollectionMap[scName]; !ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // addInvalidDatabase adds a db to invalid dbconfig map if it doesn't exist in there yet and will log for it at warning level
 // if the db already exists there we will calculate if we need to log again according to the config update interval
 func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname string, cnf DatabaseConfig, bucket string) {

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -38,6 +38,10 @@ type DatabaseConfig struct {
 	// MetadataID is the prefix used to store database metadata
 	MetadataID string `json:"metadata_id"`
 
+	// ImportVersion is included in the prefix used to store import checkpoints.
+	// Incremented when collections are added to a db, to trigger import of existing data in those collections.
+	ImportVersion uint64 `json:"import_version,omitempty"`
+
 	// DbConfig embeds database config properties
 	DbConfig
 }

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -169,6 +169,7 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 		}
 
 		base.DebugfCtx(ctx, base.KeyConfig, "UpdateConfig fetched registry and database successfully")
+
 		// Step 2. Update registry to update registry entry, and move previous registry entry to PreviousVersion
 		previousVersion = existingConfig.Version
 		var callbackErr error

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2768,3 +2768,143 @@ func TestDatabaseConfigDropScopes(t *testing.T) {
 	require.Contains(t, resp.Body.String(), "cannot change scope")
 
 }
+
+func TestScopesConfigCollectionMap(t *testing.T) {
+
+	testCases := []struct {
+		name               string
+		scopeName          string
+		initialCollections []string
+		updatedCollections []string
+		expectedHasNew     bool
+	}{
+		{
+			name:               "add collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0"},
+			updatedCollections: []string{"sg_test_0", "sg_test_1"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "replace collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0"},
+			updatedCollections: []string{"sg_test_1"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "same collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0"},
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     false,
+		},
+		{
+			name:               "remove collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0", "sg_test_1"},
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     false,
+		},
+		{
+			name:               "remove all and add collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0", "sg_test_1"},
+			updatedCollections: []string{"sg_test_2"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "default to named",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_default"},
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "default add named",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_default"},
+			updatedCollections: []string{"_default", "sg_test_0"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "named to default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"sg_test_0"},
+			updatedCollections: []string{"_default"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "default remove named",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_default", "sg_test_0"},
+			updatedCollections: []string{"_default"},
+			expectedHasNew:     false,
+		},
+		{
+			name:               "default to scopes default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_default"},
+			updatedCollections: []string{"_scopesdefault"}, // gets converted to scopes config for default/default
+			expectedHasNew:     false,
+		},
+		{
+			name:               "scopes default to default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_scopesdefault"}, // gets converted to scopes config for default/default
+			updatedCollections: []string{"_default"},
+			expectedHasNew:     false,
+		},
+		{
+			name:               "scopes default to named",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_scopesdefault"}, // gets converted to scopes config for default/default
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "named to scopes default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_scopesdefault"}, // gets converted to scopes config for default/default
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "remove scopes default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_scopesdefault", "sg_test_0"}, // gets converted to scopes config for default/default
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Create initial database
+			initialScopesConfig := makeScopesConfigWithDefault(test.scopeName, test.initialCollections)
+			initialCollectionsMap := initialScopesConfig.CollectionMap()
+
+			updatedScopesConfig := makeScopesConfigWithDefault(test.scopeName, test.updatedCollections)
+			require.Equal(t, test.expectedHasNew, updatedScopesConfig.HasNewCollection(initialCollectionsMap))
+		})
+	}
+}
+
+// makeScopesConfig creates a scopes config, with additional handling for explicitly defining the default collection in ScopesConfig
+func makeScopesConfigWithDefault(scopeName string, collections []string) *ScopesConfig {
+
+	// handling for _default._default - treat as no scopes defined
+	if len(collections) == 1 && collections[0] == base.DefaultCollection {
+		return nil
+	}
+
+	// handling for explicit default - ScopesConfig with _default._default only defined
+	if len(collections) == 1 && collections[0] == "_scopesdefault" {
+		scopesConfig := makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection})
+		return &scopesConfig
+	}
+
+	scopesConfig := makeScopesConfig(scopeName, collections)
+	return &scopesConfig
+}

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -244,6 +244,22 @@ const collectionsDbConfig = `{
 		"import_docs": true
 	}`
 
+const collectionsDbConfigRevsLimit = `{
+		"bucket": "%s",
+		"num_index_replicas": 0,
+		"enable_shared_bucket_access": true,
+		"scopes": %s,
+		"import_docs": true,
+		"revs_limit": 21
+	}`
+
+const collectionsDbConfigUpsertRevsLimit = `{
+		"revs_limit": 22
+	}`
+const collectionsDbConfigUpsertScopes = `{
+		"scopes": %s
+	}`
+
 func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 
 	base.SkipImportTestsIfNotEnabled(t)
@@ -275,9 +291,9 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	docBody := make(map[string]interface{})
 	docBody["foo"] = "bar"
 	docCount := 10
-	for i, dataStore := range dataStores {
+	for _, dataStore := range dataStores {
 		for j := 0; j < docCount; j++ {
-			_, err := dataStore.Add(fmt.Sprintf("datastore%d_%d", i, j), 0, docBody)
+			_, err := dataStore.Add(fmt.Sprintf("datastore%d", j), 0, docBody)
 			require.NoError(t, err, "Error writing SDK doc")
 		}
 	}
@@ -297,9 +313,9 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	_, err = rt.WaitForChanges(docCount, "/{{.keyspace}}/_changes", "", true)
 	require.NoError(t, err)
 
-	for i, dataStore := range dataStores {
+	for _, dataStore := range dataStores {
 		for j := 0; j < docCount; j++ {
-			docName := fmt.Sprintf("datastore%d_%d", i, j)
+			docName := fmt.Sprintf("datastore%d", j)
 			if dataStore == dataStore1 {
 				requireSyncData(rt, dataStore, docName, true)
 			} else {
@@ -310,12 +326,12 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 
 	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
-	// update with 2 scopes
-	twoScopesConfig := rest.GetCollectionsConfig(t, testBucket, 2)
-	twoScopesConfigJSON, err := json.Marshal(twoScopesConfig)
+	// update config to add second collection
+	twoCollectionConfig := rest.GetCollectionsConfig(t, testBucket, 2)
+	twoCollectionConfigJSON, err := json.Marshal(twoCollectionConfig)
 	require.NoError(t, err)
 
-	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoScopesConfigJSON)))
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoCollectionConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)
 
 	require.Len(t, rt.GetDbCollections(), 2)
@@ -324,16 +340,16 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	_, err = rt.WaitForChanges(docCount, "/{{.keyspace2}}/_changes", "", true)
 	require.NoError(t, err)
 
-	for i, dataStore := range dataStores {
+	for _, dataStore := range dataStores {
 		for j := 0; j < docCount; j++ {
-			docName := fmt.Sprintf("datastore%d_%d", i, j)
+			docName := fmt.Sprintf("datastore%d", j)
 			requireSyncData(rt, dataStore, docName, true)
 		}
 	}
 
 	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
-	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoScopesConfigJSON)))
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoCollectionConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)
 
 }
@@ -372,13 +388,13 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 		}
 	}
 
-	// update with 2 scopes
-	twoScopesConfig := rest.GetCollectionsConfig(t, testBucket, 2)
-	twoScopesConfigJSON, err := json.Marshal(twoScopesConfig)
+	// update with 2 collections
+	twoCollectionConfig := rest.GetCollectionsConfig(t, testBucket, 2)
+	twoCollectionConfigJSON, err := json.Marshal(twoCollectionConfig)
 	require.NoError(t, err)
 
 	dbName := "db"
-	response := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoScopesConfigJSON)))
+	response := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoCollectionConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)
 
 	require.Len(t, rt.GetDbCollections(), 2)
@@ -393,6 +409,9 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 	oneScopeConfig := rest.GetCollectionsConfig(t, testBucket, 1)
 	oneScopeConfigJSON, err := json.Marshal(oneScopeConfig)
 	require.NoError(t, err)
+
+	// Get the persisted config to check import version
+	initialImportVersion := GetImportVersion(t, rt, dbName)
 
 	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(oneScopeConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)
@@ -410,6 +429,100 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 	// there should be 10 documents datastore1_{10..19}
 	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
+	// Get the import version from the persisted config to ensure it didn't change
+	updatedImportVersion := GetImportVersion(t, rt, dbName)
+	require.Equal(t, initialImportVersion, updatedImportVersion)
+
+}
+
+// TestImportVersionWriteVariations - ensure import version is updated for all different APIs that can modify the collection set
+func TestImportVersionWriteVariations(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyDCP)
+	base.SkipImportTestsIfNotEnabled(t)
+	numCollections := 3
+	base.RequireNumTestDataStores(t, numCollections)
+
+	ctx := base.TestCtx(t)
+	testBucket := base.GetPersistentTestBucket(t)
+	defer testBucket.Close(ctx)
+
+	rtConfig := &rest.RestTesterConfig{
+		CustomTestBucket: testBucket.NoCloseClone(),
+		PersistentConfig: true,
+	}
+
+	rt := rest.NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	// Set up collection payloads for 1, 2, 3 collections
+	oneCollectionConfig := rest.GetCollectionsConfig(t, testBucket, 1)
+	oneCollectionConfigJSON, err := json.Marshal(oneCollectionConfig)
+	require.NoError(t, err)
+	twoCollectionConfig := rest.GetCollectionsConfig(t, testBucket, 2)
+	twoCollectionConfigJSON, err := json.Marshal(twoCollectionConfig)
+	require.NoError(t, err)
+	threeCollectionConfig := rest.GetCollectionsConfig(t, testBucket, 3)
+	threeCollectionConfigJSON, err := json.Marshal(threeCollectionConfig)
+	require.NoError(t, err)
+
+	// Insert with PUT and single collection
+	dbName := "db"
+	response := rt.SendAdminRequest(http.MethodPut, "/"+dbName+"/", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(oneCollectionConfigJSON)))
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	importVersion := GetImportVersion(t, rt, dbName)
+	require.Equal(t, uint64(0), importVersion)
+
+	// Update with PUT, change collection set, version should change
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoCollectionConfigJSON)))
+	rest.RequireStatus(t, response, http.StatusCreated)
+	importVersion = GetImportVersion(t, rt, dbName)
+	require.Equal(t, uint64(1), importVersion)
+
+	// Update with PUT, do not change collection set, version should not change
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfigRevsLimit, testBucket.GetName(), string(twoCollectionConfigJSON)))
+	rest.RequireStatus(t, response, http.StatusCreated)
+	importVersion = GetImportVersion(t, rt, dbName)
+	require.Equal(t, uint64(1), importVersion)
+
+	// Upsert with POST, do not include or change collection set, version should not change
+	response = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", collectionsDbConfigUpsertRevsLimit)
+	rest.RequireStatus(t, response, http.StatusCreated)
+	importVersion = GetImportVersion(t, rt, dbName)
+	require.Equal(t, uint64(1), importVersion)
+
+	// Upsert with POST, include scopes but do not change collection set, version should not change
+	response = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfigUpsertScopes, string(twoCollectionConfigJSON)))
+	rest.RequireStatus(t, response, http.StatusCreated)
+	importVersion = GetImportVersion(t, rt, dbName)
+	require.Equal(t, uint64(1), importVersion)
+
+	// Update with POST, add collection, version should change
+	response = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfigUpsertScopes, string(threeCollectionConfigJSON)))
+	rest.RequireStatus(t, response, http.StatusCreated)
+	importVersion = GetImportVersion(t, rt, dbName)
+	require.Equal(t, uint64(2), importVersion)
+
+	// Update with PUT, remove collection, version should not change
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfigRevsLimit, testBucket.GetName(), string(twoCollectionConfigJSON)))
+	rest.RequireStatus(t, response, http.StatusCreated)
+	importVersion = GetImportVersion(t, rt, dbName)
+	require.Equal(t, uint64(2), importVersion)
+
+	// Update with POST, remove collection, version should not change
+	response = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfigUpsertScopes, string(oneCollectionConfigJSON)))
+	rest.RequireStatus(t, response, http.StatusCreated)
+	importVersion = GetImportVersion(t, rt, dbName)
+	require.Equal(t, uint64(2), importVersion)
+
+}
+
+func GetImportVersion(t *testing.T, rt *rest.RestTester, dbName string) uint64 {
+	var databaseConfig rest.DatabaseConfig
+	_, err := rt.ServerContext().BootstrapContext.GetConfig(rt.Context(), rt.CustomTestBucket.GetName(), rt.ServerContext().Config.Bootstrap.ConfigGroupID, dbName, &databaseConfig)
+	require.NoError(t, err)
+	return databaseConfig.ImportVersion
 }
 
 func requireSyncData(rt *rest.RestTester, dataStore base.DataStore, docName string, hasSyncData bool) {

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -444,7 +444,7 @@ func TestImportVersionWriteVariations(t *testing.T) {
 	base.RequireNumTestDataStores(t, numCollections)
 
 	ctx := base.TestCtx(t)
-	testBucket := base.GetPersistentTestBucket(t)
+	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)
 
 	rtConfig := &rest.RestTesterConfig{

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2298,7 +2298,7 @@ func TestImportRollback(t *testing.T) {
 
 			// Close db while we mess with checkpoints
 			db := rt.GetDatabase()
-			checkpointPrefix = rt.GetDatabase().MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID)
+			checkpointPrefix = rt.GetDatabase().MetadataKeys.DCPVersionedCheckpointPrefix(db.Options.GroupID, db.Options.ImportVersion)
 
 			rt.Close()
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -861,6 +861,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	contextOptions.BlipStatsReportingInterval = defaultBytesStatsReportingInterval.Milliseconds()
+	contextOptions.ImportVersion = config.ImportVersion
+
 	// Create the DB Context
 	dbcontext, err = db.NewDatabaseContext(ctx, dbName, bucket, autoImport, contextOptions)
 	if err != nil {


### PR DESCRIPTION
CBG-3988

Adds an import version to the database config that's incremented when a collection is added to a db. Removing a collection from a db does not increment version. When non-zero, the version is included in the import feed's DCP checkpoint prefix.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2496/
