### PR TITLE
[3.1.7 Backport] CBG-3990 Ensure documents are imported when collection added to a db

### DIFF
--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -261,6 +261,20 @@ func (m *MetadataKeys) DCPCheckpointPrefix(groupID string) string {
 	return m.dcpCheckpoint
 }
 
+// DCPVersionedCheckpointPrefix returns the prefix used to store versioned DCP checkpoints.
+//
+//	format: _sync:dcp_ck:{m_$}:{groupID:}{version:}
+func (m *MetadataKeys) DCPVersionedCheckpointPrefix(groupID string, version uint64) string {
+	checkpointPrefix := m.dcpCheckpoint
+	if groupID != "" {
+		checkpointPrefix = checkpointPrefix + groupID + ":"
+	}
+	if version != 0 {
+		checkpointPrefix = checkpointPrefix + strconv.FormatUint(version, 10) + ":"
+	}
+	return checkpointPrefix
+}
+
 // DCPBackfillKey returns the key used to store DCP backfill statistics.
 //
 //	format: _sync:{m_$}:dcp_backfill

--- a/base/constants_syncdocs_test.go
+++ b/base/constants_syncdocs_test.go
@@ -88,3 +88,32 @@ func TestMetadataKeyHash(t *testing.T) {
 	require.Equal(t, "_sync:user:foo:afbf3a596bfe3e6687240e011bfccafd51611052", customMetadataKeys.UserKey(hashedUser))
 
 }
+
+// Verify that upgrading from non-versioned to versioned keys doesn't change the checkpoints if the version hasn't been incremented
+func TestDCPMetadataKeyUpgrade(t *testing.T) {
+
+	// Default metadata keys
+	defaultMetadataKeys := NewMetadataKeys("")
+	// Upgrade check with group ID
+	nonVersionedPrefixWithGroup := defaultMetadataKeys.DCPCheckpointPrefix("myGroup")
+	versionPrefixWithGroup := defaultMetadataKeys.DCPVersionedCheckpointPrefix("myGroup", 0)
+	require.Equal(t, nonVersionedPrefixWithGroup, versionPrefixWithGroup)
+
+	// Upgrade check with empty group ID
+	nonVersionedPrefix := defaultMetadataKeys.DCPCheckpointPrefix("")
+	versionPrefix := defaultMetadataKeys.DCPVersionedCheckpointPrefix("", 0)
+	require.Equal(t, nonVersionedPrefix, versionPrefix)
+
+	// Custom metadata keys
+	customMetadataKeys := NewMetadataKeys("foo")
+
+	// Upgrade check with group ID
+	nonVersionedPrefixWithGroup = customMetadataKeys.DCPCheckpointPrefix("myGroup")
+	versionPrefixWithGroup = customMetadataKeys.DCPVersionedCheckpointPrefix("myGroup", 0)
+	require.Equal(t, nonVersionedPrefixWithGroup, versionPrefixWithGroup)
+
+	// Upgrade check with empty group ID
+	nonVersionedPrefix = customMetadataKeys.DCPCheckpointPrefix("")
+	versionPrefix = customMetadataKeys.DCPVersionedCheckpointPrefix("", 0)
+	require.Equal(t, nonVersionedPrefix, versionPrefix)
+}

--- a/db/database.go
+++ b/db/database.go
@@ -180,6 +180,7 @@ type DatabaseContextOptions struct {
 	MaxConcurrentChangesBatches   *int        // Maximum number of changes batches to process concurrently per replication
 	MaxConcurrentRevs             *int        // Maximum number of revs to process concurrently per replication
 	NumIndexReplicas              uint        // Number of replicas for GSI indexes
+	ImportVersion                 uint64      // Version included in import DCP checkpoints, incremented when collections added to db
 }
 
 // DbLogConfig can be used to customise the logging for logs associated with this database.
@@ -2287,7 +2288,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.
 	if importEnabled {
-		db.ImportListener = NewImportListener(ctx, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID), db)
+		db.ImportListener = NewImportListener(ctx, db.MetadataKeys.DCPVersionedCheckpointPrefix(db.Options.GroupID, db.Options.ImportVersion), db)
 		if importFeedErr := db.ImportListener.StartImportFeed(db); importFeedErr != nil {
 			return importFeedErr
 		}

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -72,7 +72,8 @@ func getNewPIndexImplType(ctx context.Context) func(indexType, indexParams, path
 
 		importDest, err := getListenerImportDest(ctx, indexParams, restart)
 		if err != nil {
-			base.ErrorfCtx(ctx, "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
+			// This error can occur when a stale index definition hasn't yet been removed from the plan (e.g. on update to db config)
+			base.InfofCtx(ctx, base.KeyDCP, "No importDest found for indexParams - usually an obsolete index pending removal. %v", err)
 		}
 		return nil, importDest, err
 	}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -38,6 +38,10 @@ type DatabaseConfig struct {
 	// MetadataID is the prefix used to store database metadata
 	MetadataID string `json:"metadata_id"`
 
+	// ImportVersion is included in the prefix used to store import checkpoints.
+	// Incremented when collections are added to a db, to trigger import of existing data in those collections.
+	ImportVersion uint64 `json:"import_version,omitempty"`
+
 	// DbConfig embeds database config properties
 	DbConfig
 }

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -169,7 +169,6 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 		}
 
 		base.DebugfCtx(ctx, base.KeyConfig, "UpdateConfig fetched registry and database successfully")
-
 		// Step 2. Update registry to update registry entry, and move previous registry entry to PreviousVersion
 		previousVersion = existingConfig.Version
 		var callbackErr error

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -169,6 +169,7 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 		}
 
 		base.DebugfCtx(ctx, base.KeyConfig, "UpdateConfig fetched registry and database successfully")
+
 		// Step 2. Update registry to update registry entry, and move previous registry entry to PreviousVersion
 		previousVersion = existingConfig.Version
 		var callbackErr error

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2785,3 +2785,157 @@ func TestBadCORSValuesConfig(t *testing.T) {
 		rt.CreateDatabase("db", dbConfig)
 	})
 }
+
+func TestScopesConfigCollectionMap(t *testing.T) {
+
+	testCases := []struct {
+		name               string
+		scopeName          string
+		initialCollections []string
+		updatedCollections []string
+		expectedHasNew     bool
+	}{
+		{
+			name:               "add collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0"},
+			updatedCollections: []string{"sg_test_0", "sg_test_1"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "replace collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0"},
+			updatedCollections: []string{"sg_test_1"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "same collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0"},
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     false,
+		},
+		{
+			name:               "remove collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0", "sg_test_1"},
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     false,
+		},
+		{
+			name:               "remove all and add collection",
+			scopeName:          "s1",
+			initialCollections: []string{"sg_test_0", "sg_test_1"},
+			updatedCollections: []string{"sg_test_2"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "default to named",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_default"},
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "default add named",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_default"},
+			updatedCollections: []string{"_default", "sg_test_0"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "named to default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"sg_test_0"},
+			updatedCollections: []string{"_default"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "default remove named",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_default", "sg_test_0"},
+			updatedCollections: []string{"_default"},
+			expectedHasNew:     false,
+		},
+		{
+			name:               "default to scopes default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_default"},
+			updatedCollections: []string{"_scopesdefault"}, // gets converted to scopes config for default/default
+			expectedHasNew:     false,
+		},
+		{
+			name:               "scopes default to default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_scopesdefault"}, // gets converted to scopes config for default/default
+			updatedCollections: []string{"_default"},
+			expectedHasNew:     false,
+		},
+		{
+			name:               "scopes default to named",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_scopesdefault"}, // gets converted to scopes config for default/default
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "named to scopes default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_scopesdefault"}, // gets converted to scopes config for default/default
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     true,
+		},
+		{
+			name:               "remove scopes default",
+			scopeName:          base.DefaultScope,
+			initialCollections: []string{"_scopesdefault", "sg_test_0"}, // gets converted to scopes config for default/default
+			updatedCollections: []string{"sg_test_0"},
+			expectedHasNew:     false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Create initial database
+			initialScopesConfig := makeScopesConfigWithDefault(test.scopeName, test.initialCollections)
+			initialCollectionsMap := initialScopesConfig.CollectionMap()
+
+			updatedScopesConfig := makeScopesConfigWithDefault(test.scopeName, test.updatedCollections)
+			require.Equal(t, test.expectedHasNew, updatedScopesConfig.HasNewCollection(initialCollectionsMap))
+		})
+	}
+}
+
+// makeScopesConfig creates a scopes config, with additional handling for explicitly defining the default collection in ScopesConfig
+func makeScopesConfigWithDefault(scopeName string, collections []string) *ScopesConfig {
+
+	// handling for _default._default - treat as no scopes defined
+	if len(collections) == 1 && collections[0] == base.DefaultCollection {
+		return nil
+	}
+
+	// handling for explicit default - ScopesConfig with _default._default only defined
+	if len(collections) == 1 && collections[0] == "_scopesdefault" {
+		scopesConfig := makeScopesConfig(base.DefaultScope, []string{base.DefaultCollection})
+		return &scopesConfig
+	}
+
+	scopesConfig := makeScopesConfig(scopeName, collections)
+	return &scopesConfig
+}
+
+/*
+type ScopeConfig struct {
+	Collections CollectionsConfig `json:"collections,omitempty"` // Collection-specific config options.
+}
+
+type CollectionsConfig map[string]*CollectionConfig
+type CollectionConfig struct {
+	SyncFn       *string `json:"sync,omitempty"`          // The sync function applied to write operations in this collection.
+	ImportFilter *string `json:"import_filter,omitempty"` // The import filter applied to import operations in this collection.
+}
+
+
+*/

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2925,17 +2925,3 @@ func makeScopesConfigWithDefault(scopeName string, collections []string) *Scopes
 	scopesConfig := makeScopesConfig(scopeName, collections)
 	return &scopesConfig
 }
-
-/*
-type ScopeConfig struct {
-	Collections CollectionsConfig `json:"collections,omitempty"` // Collection-specific config options.
-}
-
-type CollectionsConfig map[string]*CollectionConfig
-type CollectionConfig struct {
-	SyncFn       *string `json:"sync,omitempty"`          // The sync function applied to write operations in this collection.
-	ImportFilter *string `json:"import_filter,omitempty"` // The import filter applied to import operations in this collection.
-}
-
-
-*/

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2601,7 +2601,7 @@ func TestImportRollback(t *testing.T) {
 
 			// Close db while we mess with checkpoints
 			db := rt.GetDatabase()
-			checkpointPrefix = rt.GetDatabase().MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID)
+			checkpointPrefix = rt.GetDatabase().MetadataKeys.DCPVersionedCheckpointPrefix(db.Options.GroupID, db.Options.ImportVersion)
 
 			rt.Close()
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -846,6 +846,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		contextOptions.MetadataID = config.MetadataID
 	}
 
+	contextOptions.ImportVersion = config.ImportVersion
+
 	// Create the DB Context
 	dbcontext, err = db.NewDatabaseContext(ctx, dbName, bucket, autoImport, contextOptions)
 	if err != nil {


### PR DESCRIPTION
CBG-3990, backports CBG-3988

Defines an import version in the config that's incremented when a collection is added to a db.  Removing a collection from a db does not increment version.  When non-zero, the version is included in the import feed's DCP checkpoint prefix.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2497/
