### PR TITLE
CBG-3971 delete mou on normal doc write

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2017,8 +2017,14 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			updatedDoc.IsTombstone = currentRevFromHistory.Deleted
-			if doc.metadataOnlyUpdate != nil && doc.metadataOnlyUpdate.CAS != "" {
-				updatedDoc.Spec = append(updatedDoc.Spec, sgbucket.NewMacroExpansionSpec(xattrMouCasPath(), sgbucket.MacroCas))
+			if doc.metadataOnlyUpdate != nil {
+				if doc.metadataOnlyUpdate.CAS != "" {
+					updatedDoc.Spec = append(updatedDoc.Spec, sgbucket.NewMacroExpansionSpec(xattrMouCasPath(), sgbucket.MacroCas))
+				}
+			} else {
+				if currentXattrs[base.MouXattrName] != nil {
+					updatedDoc.XattrsToDelete = append(updatedDoc.XattrsToDelete, base.MouXattrName)
+				}
 			}
 
 			// Return the new raw document value for the bucket to store.

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -81,8 +81,6 @@ func TestFeedImport(t *testing.T) {
 func TestOnDemandImportMou(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyMigrate, base.KeyImport)
 	base.SkipImportTestsIfNotEnabled(t)
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close(base.TestCtx(t))
 
 	// SetupTestDBWithOptions sets autoImport=false
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{})
@@ -887,15 +885,11 @@ func TestMetadataOnlyUpdate(t *testing.T) {
 	_, _, err = collection.Put(ctx, "sdkWrite", updatedBody)
 	require.NoError(t, err)
 
-	syncData, mou, updatedCas := getSyncAndMou(t, collection, "sdkWrite")
+	syncData, mou, _ = getSyncAndMou(t, collection, "sdkWrite")
 	require.NotNil(t, syncData)
 	require.NotZero(t, syncData.Sequence, "Sequence should not be zero for SG write")
 
-	// verify mou wasn't updated on non-import (CAS should no longer match document cas)
-	// TODO: When CBG-3895 is complete, expect mou removal (delete mou atomically on non-mou SG writes)
-	require.Equal(t, base.CasToString(writeCas), mou.PreviousCAS)
-	require.Equal(t, base.CasToString(importCas), mou.CAS)
-	require.NotEqual(t, base.CasToString(updatedCas), mou.CAS)
+	require.Nil(t, mou, "Mou should not be updated on SG write")
 
 }
 


### PR DESCRIPTION
I'm not sure when `doc.metadataOnlyUpdate = true and `doc.metadataOnlyUpdate.CAS == ""` so I left the logic as is with the test.

The only other place where we update `_mou` is on a resync but there it _is_ a metadata only update and we would want to keep/update `_mou`.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2507 (7.2)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2506/ (7.6) unrelated failure
