### PR TITLE
CBG-3994: fix for race between config poll and db config update

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -116,7 +116,7 @@ func (h *handler) handleCreateDB() error {
 				"Duplicate database name %q", dbName)
 		}
 
-		_, err = h.server._applyConfig(contextNoCancel, loadedConfig, true, false, false)
+		_, err = h.server._applyConfig(contextNoCancel, loadedConfig, true, false)
 		if err != nil {
 			return databaseLoadErrorAsHTTPError(err)
 		}

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -1014,9 +1014,8 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 }
 
 // TestRaceBetweenConfigPollAndDbConfigUpdate:
-//   - Fixes CBG-3994
 //   - Create rest tester with very low config update frequency, so sync gateway polls really often during test
-//   - Creat db wirth collection 1 and perform crud against that collection
+//   - Create db with collection 1 and perform crud against that collection
 //   - Update db with collection 1 and 2
 //   - Fetch runtime config and assert the scope config matches what we expect
 //   - Assert we can perform crud operations against each collection 1 and 2

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/auth"
@@ -1010,4 +1011,60 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &dbCfg))
 	assert.Equal(t, scopesConfig, dbCfg.Scopes)
 	assert.Equal(t, originalDBCfg.Scopes, dbCfg.Scopes)
+}
+
+// TestRaceBetweenConfigPollAndDbConfigUpdate:
+//   - Fixes CBG-3994
+//   - Create rest tester with very low config update frequency, so sync gateway polls really often during test
+//   - Creat db wirth collection 1 and perform crud against that collection
+//   - Update db with collection 1 and 2
+//   - Fetch runtime config and assert the scope config matches what we expect
+//   - Assert we can perform crud operations against each collection 1 and 2
+func TestRaceBetweenConfigPollAndDbConfigUpdate(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	base.TestRequiresCollections(t)
+
+	ctx := base.TestCtx(t)
+	tb := base.GetTestBucket(t)
+	defer tb.Close(ctx)
+
+	rtConfig := &RestTesterConfig{
+		CustomTestBucket: tb,
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *StartupConfig) {
+			// configure the interval time to small interval, so we try fetch configs from the bucket super often
+			config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
+		},
+	}
+	rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+
+	// create db with collection 1
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Scopes = GetCollectionsConfig(t, tb, 1)
+	RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+
+	// perform crud operation against collection 1
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc", `{"test": "doc"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// update config to include collection 1 + 2
+	dbConfig = rt.NewDbConfig()
+	dbConfig.Scopes = GetCollectionsConfig(t, tb, 2)
+	RequireStatus(t, rt.UpsertDbConfig("db1", dbConfig), http.StatusCreated)
+
+	resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config?include_runtime=true", "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	// unmarshal runtime response and assert that the correct collections is shown
+	var dbCfg DbConfig
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &dbCfg))
+	assert.Equal(t, dbConfig.Scopes, dbCfg.Scopes)
+
+	// assert we can perform crud operations against both keyspace (no keyspace not found errors returned)
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/doc1", `{"test": "doc"}`)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/doc1", `{"test": "doc"}`)
+	RequireStatus(t, resp, http.StatusCreated)
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -1753,6 +1753,17 @@ func (sc *ServerContext) fetchConfigsSince(ctx context.Context, refreshInterval 
 	return sc.dbConfigs, nil
 }
 
+// forceRuntimeConfigReload will reset the runtime config cas value to allow fetchAndLoadDatabase to reload the database
+// config from the bucket in event of the runtime config needing to be rolled back to previous version
+func (sc *ServerContext) forceRuntimeConfigReload(nonContextStruct base.NonCancellableContext, dbName string) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+	if dbCfg, ok := sc.dbConfigs[dbName]; ok {
+		base.DebugfCtx(nonContextStruct.Ctx, base.KeyConfig, "resetting runtime config cas to rollback the runtime config")
+		dbCfg.cfgCas = 0
+	}
+}
+
 // GetBucketNames returns a slice of the bucket names associated with the server context
 func (sc *ServerContext) GetBucketNames() (buckets []string, err error) {
 	if sc.Config.IsServerless() {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -297,7 +297,7 @@ func (sc *ServerContext) GetInactiveDatabase(ctx context.Context, name string) (
 			dbConfigFound, _ = sc.fetchAndLoadDatabaseSince(ctx, name, sc.Config.Unsupported.Serverless.MinConfigFetchInterval)
 
 		} else {
-			dbConfigFound, _ = sc.fetchAndLoadDatabase(base.NewNonCancelCtx(), name)
+			dbConfigFound, _ = sc.fetchAndLoadDatabase(base.NewNonCancelCtx(), name, false)
 		}
 		if dbConfigFound {
 			sc.lock.RLock()


### PR DESCRIPTION
CBG-3994

- This issue has arisen due to changes made in CBG-3817
- Add back cas line inside UpdateConfig callback in handlePutDbConfig
- This avoid the background task of fetching db configs from the bucket replacing the runtime config in memory during a db config update. This was found by QE where they would end up with mismatch between runtime collection config and persisted config leading to keyspace not found errors.
- Have added come comments to be sure this isn’t removed in future. Added a new function to remove the cfgCas from runtime cfg to force a reload from the bucket when we need to rollback the config
- New test that reproduced the race condition before the fix

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2516/
