### PR TITLE
CBG-3781 support rhel9 variants and amazon linux 2023

### DIFF
--- a/build/postinst.tmpl
+++ b/build/postinst.tmpl
@@ -68,7 +68,7 @@ You can control the Couchbase Sync Gateway service by using the following comman
 
   ${SERVICE_CMD}
 
-That's it! Sync Gateway is now running on port 4984. See https://docs.couchbase.com/sync-gateway/current/get-started-verify-install.html on how to start.
+That's it! Sync Gateway is now running on port 4984. See https://docs.couchbase.com/sync-gateway/current/get-started-verify-install.html on how to get started.
 
 EOF
     cat <<EOF

--- a/build/postinst.tmpl
+++ b/build/postinst.tmpl
@@ -68,17 +68,7 @@ You can control the Couchbase Sync Gateway service by using the following comman
 
   ${SERVICE_CMD}
 
-That's it! Sync Gateway is now running on port 4984. We've setup a simple in-memory database
-which works great for exploring Sync Gateway's capabilities.
-
-Some command-line options are:
-
-  -adminInterface=":4985": Address to bind admin interface to
-  -interface=":4984": Address to bind to
-  -log="": Log keywords, comma separated
-  -pretty=false: Pretty-print JSON responses
-  -url="walrus:": Address of Couchbase server
-  -verbose=false: Log more info about requests
+That's it! Sync Gateway is now running on port 4984.
 
 EOF
     cat <<EOF

--- a/build/postinst.tmpl
+++ b/build/postinst.tmpl
@@ -68,7 +68,7 @@ You can control the Couchbase Sync Gateway service by using the following comman
 
   ${SERVICE_CMD}
 
-That's it! Sync Gateway is now running on port 4984.
+That's it! Sync Gateway is now running on port 4984. See https://docs.couchbase.com/sync-gateway/current/get-started-verify-install.html on how to start.
 
 EOF
     cat <<EOF

--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -171,17 +171,7 @@ You can control the Couchbase @@PRODUCT_EXEC@@ service by using the following co
 
   ${SERVICE_CMD}
 
-That's it! @@PRODUCT_EXEC@@ is now running on port 4984. We've setup a simple in-memory database
-which works great for exploring @@PRODUCT_EXEC@@'s capabilities.
-
-Some command-line options are:
-
-  -adminInterface=":4985": Address to bind admin interface to
-  -interface=":4984": Address to bind to
-  -log="": Log keywords, comma separated
-  -pretty=false: Pretty-print JSON responses
-  -url="walrus:": Address of Couchbase server
-  -verbose=false: Log more info about requests
+That's it! @@PRODUCT_EXEC@@ is now running on port 4984.
 
 EOF
 

--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -171,7 +171,7 @@ You can control the Couchbase @@PRODUCT_EXEC@@ service by using the following co
 
   ${SERVICE_CMD}
 
-That's it! @@PRODUCT_EXEC@@ is now running on port 4984. See https://docs.couchbase.com/sync-gateway/current/get-started-verify-install.html on how to start.
+That's it! @@PRODUCT_EXEC@@ is now running on port 4984. See https://docs.couchbase.com/sync-gateway/current/get-started-verify-install.html on how to get started.
 
 EOF
 

--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -171,7 +171,7 @@ You can control the Couchbase @@PRODUCT_EXEC@@ service by using the following co
 
   ${SERVICE_CMD}
 
-That's it! @@PRODUCT_EXEC@@ is now running on port 4984.
+That's it! @@PRODUCT_EXEC@@ is now running on port 4984. See https://docs.couchbase.com/sync-gateway/current/get-started-verify-install.html on how to start.
 
 EOF
 

--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -243,34 +243,8 @@ ubuntu)
   esac
   ;;
 redhat* | rhel* | centos | ol)
-  case $OS_MAJOR_VERSION in
-  5)
-    if [ "$SERVICE_CMD_ONLY" = true ]; then
-      echo "service ${SERVICE_NAME} start"
-    else
-      #override location for logs and sync gateway config
-      LOGS_TEMPLATE_VAR=/var/log/${SERVICE_NAME}
-      CONFIG_TEMPLATE_VAR=/opt/${SERVICE_NAME}/etc/sync_gateway.json
-
-      pre_install_actions
-      render_template script_templates/sysv_sync_gateway.tpl >/etc/init.d/${SERVICE_NAME}
-      chmod 755 /etc/init.d/${SERVICE_NAME}
-      PATH=/usr/kerberos/sbin:/usr/kerberos/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
-      chkconfig --add ${SERVICE_NAME}
-      chkconfig ${SERVICE_NAME} on
-      service ${SERVICE_NAME} start
-    fi
-    ;;
-  6)
-    if [ "$SERVICE_CMD_ONLY" = true ]; then
-      echo "initctl start ${SERVICE_NAME}"
-    else
-      pre_install_actions
-      render_template script_templates/upstart_redhat_sync_gateway.tpl >/etc/init/${SERVICE_NAME}.conf
-      initctl start ${SERVICE_NAME}
-    fi
-    ;;
-  7 | 8)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 7))*)
     if [ "$SERVICE_CMD_ONLY" = true ]; then
       echo "systemctl start ${SERVICE_NAME}"
     else
@@ -288,8 +262,8 @@ redhat* | rhel* | centos | ol)
   esac
   ;;
 amzn*)
-  case $OS_MAJOR_VERSION in
-  2)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 2))*)
   if [ "$SERVICE_CMD_ONLY" = true ]; then
       echo "systemctl start ${SERVICE_NAME}"
     else

--- a/service/sync_gateway_service_uninstall.sh
+++ b/service/sync_gateway_service_uninstall.sh
@@ -121,24 +121,8 @@ ubuntu)
   esac
   ;;
 redhat* | rhel* | centos | ol)
-  case $OS_MAJOR_VERSION in
-  5)
-    PATH=/usr/kerberos/sbin:/usr/kerberos/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
-    service ${SERVICE_NAME} stop
-    chkconfig ${SERVICE_NAME} off
-    chkconfig --del ${SERVICE_NAME}
-
-    if [ -f /etc/init.d/${SERVICE_NAME} ]; then
-      rm /etc/init.d/${SERVICE_NAME}
-    fi
-    ;;
-  6)
-    initctl stop ${SERVICE_NAME}
-    if [ -f /etc/init/${SERVICE_NAME}.conf ]; then
-      rm /etc/init/${SERVICE_NAME}.conf
-    fi
-    ;;
-  7 | 8)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 7))*)
     systemctl stop ${SERVICE_NAME}
     systemctl disable ${SERVICE_NAME}
 
@@ -154,8 +138,8 @@ redhat* | rhel* | centos | ol)
   esac
   ;;
 amzn*)
-  case $OS_MAJOR_VERSION in
-  2)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 2))*)
     systemctl stop ${SERVICE_NAME}
     systemctl disable ${SERVICE_NAME}
 

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -111,19 +111,10 @@ ubuntu)
   esac
   ;;
 redhat* | rhel* | centos | ol)
-  case $OS_MAJOR_VERSION in
-  5)
-    PATH=/usr/kerberos/sbin:/usr/kerberos/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 7))*)
     service ${SERVICE_NAME} stop
     service ${SERVICE_NAME} start
-    ;;
-  6)
-    initctl stop ${SERVICE_NAME}
-    initctl start ${SERVICE_NAME}
-    ;;
-  7 | 8)
-    systemctl stop ${SERVICE_NAME}
-    systemctl start ${SERVICE_NAME}
     ;;
   *)
     echo "ERROR: Unsupported RedHat/CentOS Version \"$VER\""
@@ -133,8 +124,8 @@ redhat* | rhel* | centos | ol)
   esac
   ;;
 amzn*)
-  case $OS_MAJOR_VERSION in
-  2)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 2))*)
     systemctl stop ${SERVICE_NAME}
     systemctl start ${SERVICE_NAME}
     ;;

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -113,8 +113,8 @@ ubuntu)
 redhat* | rhel* | centos | ol)
   case 1:${OS_MAJOR_VERSION:--} in
   $((OS_MAJOR_VERSION >= 7))*)
-    service ${SERVICE_NAME} stop
-    service ${SERVICE_NAME} start
+    systemctl stop ${SERVICE_NAME}
+    systemctl start ${SERVICE_NAME}
     ;;
   *)
     echo "ERROR: Unsupported RedHat/CentOS Version \"$VER\""


### PR DESCRIPTION
- modify text to avoid using legacy command line options
- remove code for centos 5/6, not supported for a long time

Test as follows with a toy build:

```
yum install <pkg>

systemctl start sync_gateway

/opt/c
sleep 5

curl -v --fail-with-body http://localhost:4985/_all_dbs
/opt/couchbase-sync-gateway/tools/sgcollect_info foo.zip

systemctl stop sync_gateway
# this should fail, as the service is stopped
curl -v http://localhost:4985/_all_dbs && exit 1 || true

yum remove <pkg>
```
