### PR TITLE
Add TestDeletedRoleMultiCollection

### DIFF
--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1583,6 +1583,7 @@ func TestUserMultipleDBs(t *testing.T) {
 }
 
 func TestDeletedRoleMultiCollection(t *testing.T) {
+	t.Skip("Disable until fix")
 	ctx := base.TestCtx(t)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close(ctx)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -11,13 +11,14 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"golang.org/x/exp/maps"
 	"log"
 	"net/http"
 	"sort"
 	"sync"
 	"testing"
 	"time"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1581,7 +1581,8 @@ func TestUserMultipleDBs(t *testing.T) {
 	}
 }
 
-func TestDeletedRole(t *testing.T) {
+func TestDeletedRoleChanHistory(t *testing.T) {
+	t.Skip("disabled until CBG-4003 is fixed")
 	tests := []struct {
 		defaultCollection bool
 	}{


### PR DESCRIPTION

- Add a test to repro channels not being added to history after a role is deleted
- Fix ticket is CBG-4003

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged
