### PR TITLE
CBG-3867 ban empty replications or replication id on REST calls

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1048,7 +1048,7 @@ func (m *sgReplicateManager) validateReplications(ctx context.Context, replicati
 			base.WarnfCtx(ctx, "An ISGR replication with an empty key exists. To fix this, this replication should be removed from database config and directly from edit the database config and the %q document. %s",
 				m.dbContext.MetadataKeys.SGCfgPrefix(m.dbContext.Options.GroupID), resetCheckpointMsg)
 		} else if replication.ID == "" {
-			base.WarnfCtx(ctx, "An ISGR replication with an empty `id` exists. To fix this, update the replication using PUT /%s/_replication/%s. %s", m.dbContext.Name, replicationID, resetCheckpointMsg)
+			base.WarnfCtx(ctx, "An ISGR replication with an empty 'replication_id' exists. To fix this, update the replication using PUT /%s/_replication/%s. %s", m.dbContext.Name, replicationID, resetCheckpointMsg)
 		}
 	}
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1040,6 +1040,7 @@ func (m *sgReplicateManager) AddReplication(replication *ReplicationCfg) error {
 
 // validateReplications checks the replication configs and provides warning messages.
 func (m *sgReplicateManager) validateReplications(ctx context.Context, replications map[string]*ReplicationCfg) {
+	// the replications may exist in a way that is missing ID or name, validate and warn the user.
 	resetCheckpointMsg := "This will reset the ISGR checkpoints but prevent multiple simultaneous replications from overwriting status and checkpoint documents"
 	for replicationID, replication := range replications {
 		if replicationID == "" {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -527,6 +527,7 @@ func (m *sgReplicateManager) StartReplications(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	m.validateReplications(ctx, replications)
 	for replicationID, replicationCfg := range replications {
 		base.DebugfCtx(m.loggingCtx, base.KeyCluster, "Replication %s is assigned to node %s (local node is %s) on start up", replicationID, replicationCfg.AssignedNode, m.localNodeUUID)
 		if replicationCfg.AssignedNode == m.localNodeUUID {
@@ -1037,8 +1038,22 @@ func (m *sgReplicateManager) AddReplication(replication *ReplicationCfg) error {
 	return m.updateCluster(addReplicationCallback)
 }
 
+// validateReplications checks the replication configs and provides warning messages.
+func (m *sgReplicateManager) validateReplications(ctx context.Context, replications map[string]*ReplicationCfg) {
+	resetCheckpointMsg := "This will reset the ISGR checkpoints but prevent multiple simultaneous replications from overwriting status and checkpoint documents"
+	for replicationID, replication := range replications {
+		if replicationID == "" {
+			// we don't know the name
+			base.WarnfCtx(ctx, "An ISGR replication with an empty key exists. To fix this, this replication should be removed from database config and directly from edit the database config and the %q document. %s",
+				m.dbContext.MetadataKeys.SGCfgPrefix(m.dbContext.Options.GroupID), resetCheckpointMsg)
+		} else if replication.ID == "" {
+			base.WarnfCtx(ctx, "An ISGR replication with an empty `id` exists. To fix this, update the replication using PUT /%s/_replication/%s. %s", m.dbContext.Name, replicationID, resetCheckpointMsg)
+		}
+	}
+}
+
 // PutReplications sets the value of one or more replications in the config
-func (m *sgReplicateManager) PutReplications(replications map[string]*ReplicationConfig) error {
+func (m *sgReplicateManager) PutReplications(ctx context.Context, replications map[string]*ReplicationConfig) error {
 	addReplicationCallback := func(cluster *SGRCluster) (cancel bool, err error) {
 		if len(replications) == 0 {
 			return true, nil

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -60,8 +60,8 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
-		isUpsert := true
-		if err := config.validate(h.ctx(), validateOIDC, isUpsert); err != nil {
+		validateReplications := true
+		if err := config.validate(h.ctx(), validateOIDC, validateReplications); err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
@@ -560,13 +560,14 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	validateOIDC := !h.getBoolQuery(paramDisableOIDCValidation)
 
+	validateReplications := true
+	err = dbConfig.validate(h.ctx(), validateOIDC, validateReplications)
+	if err != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, err.Error())
+	}
+
 	if !h.server.persistentConfig {
 		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		isUpsert := true
-		err := updatedDbConfig.validate(h.ctx(), validateOIDC, isUpsert)
-		if err != nil {
-			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
-		}
 		oldDBConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
 		err = updatedDbConfig.validateConfigUpdate(h.ctx(), oldDBConfig,
 			validateOIDC)
@@ -787,8 +788,8 @@ func (h *handler) handlePutCollectionConfigSync() error {
 			bucketDbConfig.Sync = &js
 		}
 
-		isUpsert := true
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), isUpsert); err != nil {
+		validateReplications := false
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
 			return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
@@ -948,8 +949,8 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 			bucketDbConfig.ImportFilter = &js
 		}
 
-		isUpsert := true
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), isUpsert); err != nil {
+		validateReplications := false
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), validateReplications); err != nil {
 			return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -60,7 +60,8 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
-		if err := config.validate(h.ctx(), validateOIDC); err != nil {
+		isUpsert := true
+		if err := config.validate(h.ctx(), validateOIDC, isUpsert); err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
@@ -561,7 +562,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	if !h.server.persistentConfig {
 		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		err := updatedDbConfig.validate(h.ctx(), validateOIDC)
+		isUpsert := true
+		err := updatedDbConfig.validate(h.ctx(), validateOIDC, isUpsert)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
@@ -785,7 +787,8 @@ func (h *handler) handlePutCollectionConfigSync() error {
 			bucketDbConfig.Sync = &js
 		}
 
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+		isUpsert := true
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), isUpsert); err != nil {
 			return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
@@ -945,7 +948,8 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 			bucketDbConfig.ImportFilter = &js
 		}
 
-		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation)); err != nil {
+		isUpsert := true
+		if err := bucketDbConfig.validate(h.ctx(), !h.getBoolQuery(paramDisableOIDCValidation), isUpsert); err != nil {
 			return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -676,8 +676,8 @@ func (dbConfig *DbConfig) validatePersistentDbConfig() (errorMessages error) {
 
 // validateConfigUpdate combines the results of validate and validateChanges.
 func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig, validateOIDCConfig bool) error {
-	isUpsert := true
-	err := dbConfig.validate(ctx, validateOIDCConfig, isUpsert)
+	validateReplications := false
+	err := dbConfig.validate(ctx, validateOIDCConfig, validateReplications)
 	var multiErr *base.MultiError
 	if !errors.As(err, &multiErr) {
 		multiErr = multiErr.Append(err)
@@ -712,12 +712,12 @@ func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) err
 	return nil
 }
 
-// validate checks the DbConfig for any invalid or unsupported values and return a http error. If isUpsert is true, add any checks that might be upposrte
-func (dbConfig *DbConfig) validate(ctx context.Context, validateOIDCConfig bool, isUpsert bool) error {
-	return dbConfig.validateVersion(ctx, base.IsEnterpriseEdition(), validateOIDCConfig, isUpsert)
+// validate checks the DbConfig for any invalid or unsupported values and return a http error. If validateReplications is true, return an error if any replications are not valid. Otherwise issue a warning.
+func (dbConfig *DbConfig) validate(ctx context.Context, validateOIDCConfig, validateReplications bool) error {
+	return dbConfig.validateVersion(ctx, base.IsEnterpriseEdition(), validateOIDCConfig, validateReplications)
 }
 
-func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEdition, validateOIDCConfig, isUpsert bool) error {
+func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEdition, validateOIDCConfig, validateReplications bool) error {
 
 	var multiError *base.MultiError
 	// Make sure a non-zero compact_interval_days config is within the valid range
@@ -1037,30 +1037,17 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		_, err := hostOnlyCORS(dbConfig.CORS.Origin)
 		base.WarnfCtx(ctx, "The cors.origin contains values that may be ignored: %s", err)
 	}
-	// certain checks are only applicable when upserting, since we will allow them for legacy config
-	for name, r := range dbConfig.Replications {
-		if name == "" {
-			if r.ID == "" {
-				msg := "replication name cannot be empty, id is also empty"
-				if isUpsert {
-					multiError = multiError.Append(errors.New(msg))
+
+	if validateReplications {
+		for name, r := range dbConfig.Replications {
+			if name == "" {
+				if r.ID == "" {
+					multiError = multiError.Append(errors.New("replication name cannot be empty, id is also empty"))
 				} else {
-					base.WarnfCtx(ctx, msg)
+					multiError = multiError.Append(fmt.Errorf("replication name cannot be empty, id: %q", r.ID))
 				}
-			} else {
-				msg := fmt.Sprintf("replication name cannot be empty, id: %q", r.ID)
-				if isUpsert {
-					multiError = multiError.Append(errors.New(msg))
-				} else {
-					base.WarnfCtx(ctx, msg)
-				}
-			}
-		} else if r.ID == "" {
-			msg := fmt.Sprintf("replication id cannot be empty, name: %q", name)
-			if isUpsert {
-				multiError = multiError.Append(errors.New(msg))
-			} else {
-				base.WarnfCtx(ctx, msg)
+			} else if r.ID == "" {
+				multiError = multiError.Append(fmt.Errorf("replication id cannot be empty, name: %q", name))
 			}
 		}
 	}

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -411,12 +411,13 @@ func setupServerConfig(ctx context.Context, args []string) (config *LegacyServer
 	return config, nil
 }
 
-func setupAndValidateDatabases(ctx context.Context, databases DbConfigMap) error {
+func SetupAndValidateDatabases(ctx context.Context, databases DbConfigMap) error {
 	for name, dbConfig := range databases {
 		if err := dbConfig.setup(ctx, name, BootstrapConfig{}, nil, nil, false); err != nil {
 			return err
 		}
-		if err := dbConfig.validate(ctx, false); err != nil {
+		isUpsert := false
+		if err := dbConfig.validate(ctx, false, isUpsert); err != nil {
 			return err
 		}
 	}
@@ -427,7 +428,7 @@ func (config *LegacyServerConfig) setupAndValidateDatabases(ctx context.Context)
 	if config == nil {
 		return nil
 	}
-	return setupAndValidateDatabases(ctx, config.Databases)
+	return SetupAndValidateDatabases(ctx, config.Databases)
 }
 
 // validate validates the given server config and returns all invalid options as a slice of errors

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -416,8 +416,9 @@ func SetupAndValidateDatabases(ctx context.Context, databases DbConfigMap) error
 		if err := dbConfig.setup(ctx, name, BootstrapConfig{}, nil, nil, false); err != nil {
 			return err
 		}
-		isUpsert := false
-		if err := dbConfig.validate(ctx, false, isUpsert); err != nil {
+		validateOIDC := false
+		validateReplications := false
+		if err := dbConfig.validate(ctx, validateOIDC, validateReplications); err != nil {
 			return err
 		}
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -417,7 +417,8 @@ func TestConfigValidationJWTAndOIDC(t *testing.T) {
 				t.Fatalf("received unexpected unmarshaling error: %v", err)
 			}
 
-			err = dbConfig.validate(base.TestCtx(t), tc.validateOIDC)
+			isUpsert := true
+			err = dbConfig.validate(base.TestCtx(t), tc.validateOIDC, isUpsert)
 			switch {
 			case tc.expectedError == "":
 				require.NoError(t, err, "failed to validate valid startupConfig")
@@ -996,7 +997,7 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 		},
 	}
 
-	require.Nil(t, setupAndValidateDatabases(ctx, databases), "Unexpected error while validating databases")
+	require.Nil(t, SetupAndValidateDatabases(ctx, databases), "Unexpected error while validating databases")
 
 	sc := NewServerContext(ctx, config, false)
 	defer sc.Close(ctx)
@@ -2355,7 +2356,8 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 				dbConfig.ImportFilter = testCase.ImportFilter
 			}
 
-			err := dbConfig.validate(base.TestCtx(t), false)
+			isUpsert := true
+			err := dbConfig.validate(base.TestCtx(t), false, isUpsert)
 
 			if testCase.ExpectErrorCount == 0 {
 				assert.NoError(t, err)
@@ -2725,7 +2727,8 @@ func TestCollectionsValidation(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			validateOIDCConfig := false
-			err := test.dbConfig.validate(base.TestCtx(t), validateOIDCConfig)
+			isUpsert := true
+			err := test.dbConfig.validate(base.TestCtx(t), validateOIDCConfig, isUpsert)
 			if test.expectedError != nil {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), *test.expectedError)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -417,8 +417,8 @@ func TestConfigValidationJWTAndOIDC(t *testing.T) {
 				t.Fatalf("received unexpected unmarshaling error: %v", err)
 			}
 
-			isUpsert := true
-			err = dbConfig.validate(base.TestCtx(t), tc.validateOIDC, isUpsert)
+			validateReplications := true
+			err = dbConfig.validate(base.TestCtx(t), tc.validateOIDC, validateReplications)
 			switch {
 			case tc.expectedError == "":
 				require.NoError(t, err, "failed to validate valid startupConfig")
@@ -2356,8 +2356,8 @@ func TestInvalidJavascriptFunctions(t *testing.T) {
 				dbConfig.ImportFilter = testCase.ImportFilter
 			}
 
-			isUpsert := true
-			err := dbConfig.validate(base.TestCtx(t), false, isUpsert)
+			validateReplications := true
+			err := dbConfig.validate(base.TestCtx(t), false, validateReplications)
 
 			if testCase.ExpectErrorCount == 0 {
 				assert.NoError(t, err)
@@ -2727,8 +2727,8 @@ func TestCollectionsValidation(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			validateOIDCConfig := false
-			isUpsert := true
-			err := test.dbConfig.validate(base.TestCtx(t), validateOIDCConfig, isUpsert)
+			validateReplications := true
+			err := test.dbConfig.validate(base.TestCtx(t), validateOIDCConfig, validateReplications)
 			if test.expectedError != nil {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), *test.expectedError)

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -58,8 +58,8 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 				return nil, err
 			}
 
-			isUpsert := true
-			if err := bucketDbConfig.validate(h.ctx(), validateOIDC, isUpsert); err != nil {
+			validateReplications := false
+			if err := bucketDbConfig.validate(h.ctx(), validateOIDC, validateReplications); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -58,7 +58,8 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 				return nil, err
 			}
 
-			if err := bucketDbConfig.validate(h.ctx(), validateOIDC); err != nil {
+			isUpsert := true
+			if err := bucketDbConfig.validate(h.ctx(), validateOIDC, isUpsert); err != nil {
 				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 			}
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8401,13 +8401,17 @@ func TestExistingConfigEmptyReplicationID(t *testing.T) {
 }
 
 func TestDbConfigNoOverwriteReplications(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("Requires EE since this tests persistence of replication configuration in CfgSg")
+	}
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
 
 	startReplicationConfig := db.ReplicationConfig{
-		ID:        "replication1",
-		Remote:    "http://remote:4984/db",
-		Direction: "pull",
+		ID:                 "replication1",
+		Remote:             "http://remote:4984/db",
+		Direction:          "pull",
+		CollectionsEnabled: !rt.GetDatabase().OnlyDefaultCollection(),
 	}
 
 	// PUT replication
@@ -8417,9 +8421,10 @@ func TestDbConfigNoOverwriteReplications(t *testing.T) {
 	dbConfig := rt.NewDbConfig()
 	dbConfig.Replications = map[string]*db.ReplicationConfig{
 		"replication1": {
-			ID:        "replication1",
-			Remote:    "http://remote:4984/db",
-			Direction: "push",
+			ID:                 "replication1",
+			Remote:             "http://remote:4984/db",
+			Direction:          "push",
+			CollectionsEnabled: !rt.GetDatabase().OnlyDefaultCollection(),
 		},
 	}
 	rt.UpsertDbConfig("db", dbConfig)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8378,10 +8378,15 @@ func TestBanEmptyReplicationID(t *testing.T) {
 }
 
 func TestExistingConfigEmptyReplicationID(t *testing.T) {
+	bucket := base.GetTestBucket(t)
+
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		PersistentConfig: true,
+		CustomTestBucket: bucket,
 	})
 	defer rt.Close()
+
+	username, password, _ := bucket.BucketSpec.Auth.GetCredentials()
 	// this pathway is used for reading legacy config and also fetchAndLoadConfigs (bootstrap polling). There should be no errors, just warnings.
 	for i, testCase := range emptyReplicationTestCases {
 		rt.Run(testCase.name, func(t *testing.T) {
@@ -8392,6 +8397,8 @@ func TestExistingConfigEmptyReplicationID(t *testing.T) {
 			}()
 			dbConfig := rt.NewDbConfig()
 			dbConfig.Name = dbName
+			dbConfig.Username = username
+			dbConfig.Password = password
 			dbConfig.Replications = testCase.replications
 			_, err := rt.ServerContext().AddDatabaseFromConfig(rt.Context(), rest.DatabaseConfig{DbConfig: dbConfig})
 			require.NoError(t, err)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -910,8 +910,20 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
-	// Upsert replications
-	replicationErr := dbcontext.SGReplicateMgr.PutReplications(config.Replications)
+	cfgReplications, err := dbcontext.SGReplicateMgr.GetReplications()
+	if err != nil {
+		return nil, err
+	}
+	// PUT replications that do not exist
+	newReplications := make(map[string]*db.ReplicationConfig)
+	for name, replication := range config.Replications {
+		_, ok := cfgReplications[name]
+		if ok {
+			continue
+		}
+		newReplications[name] = replication
+	}
+	replicationErr := dbcontext.SGReplicateMgr.PutReplications(newReplications)
 	if replicationErr != nil {
 		return nil, replicationErr
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -923,7 +923,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		newReplications[name] = replication
 	}
-	replicationErr := dbcontext.SGReplicateMgr.PutReplications(newReplications)
+	replicationErr := dbcontext.SGReplicateMgr.PutReplications(ctx, newReplications)
 	if replicationErr != nil {
 		return nil, replicationErr
 	}


### PR DESCRIPTION
allow them for legacy config reading, but print a warning.

This is a follow on to https://github.com/couchbase/sync_gateway/commit/84997a0d39241fafcc926c86771750f2ad60febd

I could potentially remove the call in `PutReplications` because that will now be hit earlier `dbConfig.validate`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2523/ (unrelated failure)
