### PR TITLE
CBG-4002: TestJumpInSequencesAtAllocatorSkippedSequenceFill flake 

### DIFF
--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -330,7 +330,6 @@ func TestJumpInSequencesAtAllocatorSkippedSequenceFill(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rt.GetDatabase().UpdateCalculatedStats(ctx)
 		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.PendingSeqLen.Value())
-		assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.SkippedSeqCap.Value())
 		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
 	}, time.Second*10, time.Millisecond*100)


### PR DESCRIPTION
CBG-4002

Remove assertion on skipped sequence capacity as it is flakey assertion to assume DCP events arriving in a certain order.

At this stage skipped sequence has range 2-19 inside:
We see in the logs range 3-3 arriving : 
```
2024-06-14T09:33:35.294Z [INF] Cache: t:TestJumpInSequencesAtAllocatorSkippedSequenceFill db:db Received #3-#3 (unused sequence range)
2024-06-14T09:33:35.294Z [INF] Cache: t:TestJumpInSequencesAtAllocatorSkippedSequenceFill db:db   Received previously skipped out-of-order change (seq 3, expecting 21) doc "<ud></ud>"
```
Splitting skipped list to contain range 2-2, then 4-19. this pushes capacity of list to 2 from 1 (leading to failing assertion)
Then single unused sequence 2 arrives:
```
2024-06-14T09:33:35.294Z [INF] Cache: t:TestJumpInSequencesAtAllocatorSkippedSequenceFill db:db Received #2 (unused sequence)
2024-06-14T09:33:35.294Z [INF] Cache: t:TestJumpInSequencesAtAllocatorSkippedSequenceFill db:db   Received previously skipped out-of-order change (seq 2, expecting 21) doc "<ud></ud>"
```

Then rest arrive:
```
2024-06-14T09:33:35.295Z [DBG] CRUD+: c:#014 db:db col:sg_test_0 Released unused sequences #4-#20
2024-06-14T09:33:35.295Z [DBG] CRUD+: c:#014 db:db col:sg_test_0 Saving doc (seq: #21, id: <ud>doc</ud> rev: 2-6d80a632a6e27f6045d11ab92835bd5d)
2024-06-14T09:33:35.295Z [INF] Cache: t:TestJumpInSequencesAtAllocatorSkippedSequenceFill db:db Received #4-#20 (unused sequence range)
2024-06-14T09:33:35.295Z [DBG] Cache+: t:TestJumpInSequencesAtAllocatorSkippedSequenceFill db:db sequence range 4 to 20 specified has sequences in that are not present in skipped list
2024-06-14T09:33:35.295Z [DBG] Cache+: t:TestJumpInSequencesAtAllocatorSkippedSequenceFill db:db Sequence range has sequences that aren't present in skipped list
```

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
(Running the test in question 100 times)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2518/
