### PR TITLE
move logging test to no race

### DIFF
--- a/rest/changestest/changes_api_no_race_test.go
+++ b/rest/changestest/changes_api_no_race_test.go
@@ -1,0 +1,46 @@
+//  Copyright 2012-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+//go:build !race
+
+package changestest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertLogContains can hit the race detector due to swapping the global loggers
+// TestDocChangedLogging exercises some of the logging in DocChanged
+func TestDocChangedLogging(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeyChanges)
+
+	rt := rest.NewRestTesterMultipleCollections(t, nil, 2)
+	defer rt.Close()
+
+	response := rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc1", `{"foo":"bar"}`)
+	rest.RequireStatus(t, response, http.StatusCreated)
+	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/doc1", `{"foo":"bar"}`)
+	rest.RequireStatus(t, response, http.StatusCreated)
+	require.NoError(t, rt.WaitForPendingChanges())
+
+	base.AssertLogContains(t, "Ignoring non-metadata mutation for doc", func() {
+		err := rt.GetDatabase().MetadataStore.Set("doc1", 0, nil, db.Body{"foo": "bar"})
+		require.NoError(t, err)
+		// write another doc to ensure the previous non-metadata doc has been seen...
+		// no other way of synchronising this no-op as no stats to wait on
+		response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc2", `{"foo":"bar"}`)
+		rest.RequireStatus(t, response, http.StatusCreated)
+		require.NoError(t, rt.WaitForPendingChanges())
+	})
+}

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -4399,27 +4399,3 @@ func WriteDirectWithKey(t *testing.T, key string, channelArray []string, sequenc
 	require.NoError(t, err)
 
 }
-
-// TestDocChangedLogging exercises some of the logging in DocChanged
-func TestDocChangedLogging(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeyChanges)
-
-	rt := rest.NewRestTesterMultipleCollections(t, nil, 2)
-	defer rt.Close()
-
-	response := rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc1", `{"foo":"bar"}`)
-	rest.RequireStatus(t, response, http.StatusCreated)
-	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/doc1", `{"foo":"bar"}`)
-	rest.RequireStatus(t, response, http.StatusCreated)
-	require.NoError(t, rt.WaitForPendingChanges())
-
-	base.AssertLogContains(t, "Ignoring non-metadata mutation for doc", func() {
-		err := rt.GetDatabase().MetadataStore.Set("doc1", 0, nil, db.Body{"foo": "bar"})
-		require.NoError(t, err)
-		// write another doc to ensure the previous non-metadata doc has been seen...
-		// no other way of synchronising this no-op as no stats to wait on
-		response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc2", `{"foo":"bar"}`)
-		rest.RequireStatus(t, response, http.StatusCreated)
-		require.NoError(t, rt.WaitForPendingChanges())
-	})
-}


### PR DESCRIPTION
This test uses `AssertLogContains` which swaps the global logger and is subject to race conditions like in https://mobile.jenkins.couchbase.com/job/sgw-windows-wix/6668/

I think I missed this test when implementing https://github.com/couchbase/sync_gateway/commit/7268258994684eb85bfb0abc93d125dd29ae5781