### PR TITLE
Add `IsDevMode()` and `cb_sg_devmode` build tag

### DIFF
--- a/base/devmode.go
+++ b/base/devmode.go
@@ -1,3 +1,11 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 // IsDevMode returns true when compiled with the `cb_sg_devmode` build tag, and false otherwise.

--- a/base/devmode.go
+++ b/base/devmode.go
@@ -1,0 +1,9 @@
+package base
+
+// IsDevMode returns true when compiled with the `cb_sg_devmode` build tag, and false otherwise.
+//
+// The compiler will remove this check and all code invoked inside it in non-dev mode, avoiding any impact on production code.
+// https://godbolt.org/z/f1K8a96rE
+func IsDevMode() bool {
+	return cbSGDevModeBuildTagSet
+}

--- a/base/devmode_off.go
+++ b/base/devmode_off.go
@@ -1,6 +1,14 @@
 //go:build !cb_sg_devmode
 // +build !cb_sg_devmode
 
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 const cbSGDevModeBuildTagSet = false

--- a/base/devmode_off.go
+++ b/base/devmode_off.go
@@ -1,0 +1,6 @@
+//go:build !cb_sg_devmode
+// +build !cb_sg_devmode
+
+package base
+
+const cbSGDevModeBuildTagSet = false

--- a/base/devmode_on.go
+++ b/base/devmode_on.go
@@ -1,0 +1,6 @@
+//go:build cb_sg_devmode
+// +build cb_sg_devmode
+
+package base
+
+const cbSGDevModeBuildTagSet = true

--- a/base/devmode_on.go
+++ b/base/devmode_on.go
@@ -1,6 +1,14 @@
 //go:build cb_sg_devmode
 // +build cb_sg_devmode
 
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package base
 
 const cbSGDevModeBuildTagSet = true


### PR DESCRIPTION
- Adds `IsDevMode()` function for dev-time only assertions.
- Enable with the `cb_sg_devmode` build flag.

Example usage:
```sh
$ go build -tags cb_sg_enterprise,cb_sg_devmode
```

```go
func assertMandatoryFieldsPresent(id audit.ID, props AuditFields) {
	if err := mandatoryFieldsPresent(props, audit.SGAuditEvents[id].MandatoryFields); err != nil {
		panic(fmt.Errorf("mandatory fields for audit event %s missing:\n%v", id, err))
	}
}

func ... {
	if IsDevMode() {
		assertMandatoryFieldsPresent(id, fields)
	}
```

Go compiler will inline `true`, and remove `false` ifs using this `IsDevMode()` guard clause, and everything inside - allowing for dev-time assertions with zero production overhead.

https://godbolt.org/z/f1K8a96rE 

![Screenshot 2024-06-14 at 18 04 13](https://github.com/couchbase/sync_gateway/assets/1525809/69d91844-c042-4f44-9729-3ec7c4287b77)
