### PR TITLE
CBG-3785 allow code to work without being in same dir as script

### DIFF
--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -285,7 +285,7 @@ darwin)
     echo "launchctl start /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist"
   else
     pre_install_actions
-    render_template script_templates/com.couchbase.mobile.sync_gateway.plist >/Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist
+    render_template ${SCRIPT_DIR}/script_templates/com.couchbase.mobile.sync_gateway.plist >/Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist
     launchctl load /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist
   fi
   ;;


### PR DESCRIPTION
It is easy to make the mistake of not being in the current directory when running this script and if that happens, you get an opaque error.

```
Load failed: 5: Input/output error
```