### PR TITLE
CBG-3783 do not print output of lsb_release

### DIFF
--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -47,7 +47,8 @@ usage() {
 }
 
 ostype() {
-  if command -v lsb_release; then
+  lsb_release 2>&1 > /dev/null
+  if [ $? -eq 0 ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then

--- a/service/sync_gateway_service_uninstall.sh
+++ b/service/sync_gateway_service_uninstall.sh
@@ -36,7 +36,8 @@ usage() {
 }
 
 ostype() {
-  if command -v lsb_release; then
+  lsb_release 2>&1 > /dev/null
+  if [ $? -eq 0 ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -36,7 +36,8 @@ usage() {
 }
 
 ostype() {
-  if command -v lsb_release; then
+  lsb_release 2>&1 > /dev/null
+  if [ $? -eq 0 ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then


### PR DESCRIPTION
When running service/sync_gateway_service_install.sh script with --service-cmd, the output of the command is used. This is used to print value here:

https://github.com/couchbase/sync_gateway/blob/905c896df90dcba8bf43e95abe6c03d4c092b67d/build/postinst.tmpl#L69