### PR TITLE
CBG-4011 don't add XattrsToDelete on resurrection

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2022,7 +2022,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 					updatedDoc.Spec = append(updatedDoc.Spec, sgbucket.NewMacroExpansionSpec(xattrMouCasPath(), sgbucket.MacroCas))
 				}
 			} else {
-				if currentXattrs[base.MouXattrName] != nil {
+				if currentXattrs[base.MouXattrName] != nil && docExists {
 					updatedDoc.XattrsToDelete = append(updatedDoc.XattrsToDelete, base.MouXattrName)
 				}
 			}

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -924,7 +924,7 @@ func TestImportResurrectionMou(t *testing.T) {
 	}
 	require.NotNil(t, syncData)
 
-	// Delete via SDK, expect mou to be removed
+	// Delete via SDK, the mou will be updated by the import process
 	require.NoError(t, collection.dataStore.Delete(docID))
 	base.RequireWaitForStat(t, func() int64 {
 		return db.DbStats.SharedBucketImport().ImportCount.Value()

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -893,6 +893,59 @@ func TestMetadataOnlyUpdate(t *testing.T) {
 
 }
 
+func TestImportResurrectionMou(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport, base.KeyCRUD)
+	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
+	defer db.Close(ctx)
+
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	docID := "mouResurrection"
+
+	firstBody := Body{"foo": "bar"}
+	_, _, err := collection.Put(ctx, docID, firstBody)
+	require.NoError(t, err)
+
+	syncData, mou, _ := getSyncAndMou(t, collection, docID)
+	require.NotNil(t, syncData)
+	require.Nil(t, mou)
+
+	// Update via SDK, expect mou to be created
+	err = collection.dataStore.Set(docID, 0, nil, []byte(`{"foo": "baz"}`))
+	require.NoError(t, err)
+	base.RequireWaitForStat(t, func() int64 {
+		return db.DbStats.SharedBucketImport().ImportCount.Value()
+	}, 1)
+	syncData, mou, _ = getSyncAndMou(t, collection, docID)
+	if db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
+		require.NotNil(t, mou)
+	} else {
+		require.Nil(t, mou)
+	}
+	require.NotNil(t, syncData)
+
+	// Delete via SDK, expect mou to be removed
+	require.NoError(t, collection.dataStore.Delete(docID))
+	base.RequireWaitForStat(t, func() int64 {
+		return db.DbStats.SharedBucketImport().ImportCount.Value()
+	}, 2)
+	syncData, mou, _ = getSyncAndMou(t, collection, docID)
+	if db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
+		require.NotNil(t, mou)
+	} else {
+		require.Nil(t, mou)
+	}
+	require.NotNil(t, syncData)
+
+	// replace initial doc, expect mou to be removed
+	_, _, err = collection.Put(ctx, docID, firstBody)
+	require.NoError(t, err)
+
+	syncData, mou, _ = getSyncAndMou(t, collection, docID)
+	require.Nil(t, mou)
+	require.NotNil(t, syncData)
+}
+
 func getSyncAndMou(t *testing.T, collection *DatabaseCollectionWithUser, key string) (syncData *SyncData, mou *MetadataOnlyUpdate, cas uint64) {
 
 	ctx := base.TestCtx(t)


### PR DESCRIPTION
resurrections in datastore API check that we are not trying to delete xattrs

Technically the correct if statement is "if resurrection" where docExists and the new doc will not be a tombstone. If we had a case where it goes from tombstone -> tombstone and delete _mou, that would not be supported by `updateAndReturnDoc` but that doesn't happen.

This case is different from others in that _mou is written. The error it hit is https://github.com/couchbase/sync_gateway/blob/630014e5ec77b7c6e66f177841aff5263991f73e/base/collection_xattr_common.go#L31

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2521/
