### PR TITLE
CBG-3783 don't output error if command doesn't exist by using variable

### DIFF
--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -47,7 +47,7 @@ usage() {
 }
 
 ostype() {
-  lsb_release 2>&1 > /dev/null
+  _lsb_release_exists=$(command -v lsb_release)
   if [ $? -eq 0 ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)

--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -47,8 +47,7 @@ usage() {
 }
 
 ostype() {
-  _lsb_release_exists=$(command -v lsb_release)
-  if [ $? -eq 0 ]; then
+  if [ -x "$(command -v lsb_release)" ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then

--- a/service/sync_gateway_service_uninstall.sh
+++ b/service/sync_gateway_service_uninstall.sh
@@ -36,7 +36,7 @@ usage() {
 }
 
 ostype() {
-  lsb_release 2>&1 > /dev/null
+  _lsb_release_exists=$(command -v lsb_release)
   if [ $? -eq 0 ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)

--- a/service/sync_gateway_service_uninstall.sh
+++ b/service/sync_gateway_service_uninstall.sh
@@ -36,8 +36,7 @@ usage() {
 }
 
 ostype() {
-  _lsb_release_exists=$(command -v lsb_release)
-  if [ $? -eq 0 ]; then
+  if [ -x "$(command -v lsb_release)" ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -36,7 +36,7 @@ usage() {
 }
 
 ostype() {
-  lsb_release 2>&1 > /dev/null
+  _lsb_release_exists=$(command -v lsb_release)
   if [ $? -eq 0 ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -36,8 +36,7 @@ usage() {
 }
 
 ostype() {
-  _lsb_release_exists=$(command -v lsb_release)
-  if [ $? -eq 0 ]; then
+  if [ -x "$(command -v lsb_release)" ]; then
     OS=$(lsb_release -si)
     VER=$(lsb_release -sr)
   elif [ -f /etc/os-release ]; then


### PR DESCRIPTION
The previous command wasn't right because it would print out an error. I think I made a last minute change without testing to https://github.com/couchbase/sync_gateway/commit/80d09c9fa758357afc2ae6b5569df2ccbdd3fbf3

