### PR TITLE
Audit Pre-req: Flatten `base/audit` package into `base`

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -6,17 +6,23 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
-package audit
+package base
 
 const (
 	// auditdSyncGatewayStartID is the start of an ID range allocated for Sync Gateway by auditd
-	auditdSyncGatewayStartID ID = 53248
+	auditdSyncGatewayStartID AuditID = 53248
 
-	IDPlaceholder ID = 54000
+	AuditIDPlaceholder AuditID = 54000
 )
 
-var SGAuditEvents = events{
-	IDPlaceholder: {
+// AuditEvents is a table of audit events created by Sync Gateway.
+//
+// This is used to generate:
+//   - events themselves
+//   - a kv-auditd-compatible descriptor with TestGenerateAuditdModuleDescriptor
+//   - CSV output for each event to be used to document
+var AuditEvents = events{
+	AuditIDPlaceholder: {
 		Name:        "Placeholder audit event",
 		Description: "This is a placeholder.",
 		MandatoryFields: map[string]any{

--- a/base/audit_events_test.go
+++ b/base/audit_events_test.go
@@ -6,7 +6,7 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
-package audit
+package base
 
 import (
 	"fmt"
@@ -25,7 +25,7 @@ const (
 
 func TestValidateAuditEvents(t *testing.T) {
 	// Ensures that the above audit event IDs are within the allocated range and are valid.
-	require.NoError(t, validateAuditEvents(SGAuditEvents))
+	require.NoError(t, validateAuditEvents(AuditEvents))
 }
 
 func validateAuditEvents(e events) error {

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -6,20 +6,20 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
-package audit
+package base
 
 import "strconv"
 
-// ID is a unique identifier for an audit event.
-type ID uint
+// AuditID is a unique identifier for an audit event.
+type AuditID uint
 
-// String implements Stringer
-func (i ID) String() string {
+// String implements Stringer for AuditID
+func (i AuditID) String() string {
 	return strconv.FormatUint(uint64(i), 10)
 }
 
 // events is a map of audit event IDs to event descriptors.
-type events map[ID]EventDescriptor
+type events map[AuditID]EventDescriptor
 
 // EventDescriptor is an audit event. The fields closely (but not exactly) follows kv_engine's auditd descriptor implementation.
 type EventDescriptor struct {

--- a/base/auditd_descriptor.go
+++ b/base/auditd_descriptor.go
@@ -6,7 +6,7 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
-package audit
+package base
 
 import (
 	"encoding/json"

--- a/base/auditd_descriptor_test.go
+++ b/base/auditd_descriptor_test.go
@@ -6,7 +6,7 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
-package audit
+package base
 
 import (
 	"testing"
@@ -16,7 +16,7 @@ import (
 
 // TestGenerateAuditdModuleDescriptor outputs a generated auditd module descriptor for SGAuditEvents.
 func TestGenerateAuditdModuleDescriptor(t *testing.T) {
-	b, err := generateAuditdModuleDescriptor(SGAuditEvents)
+	b, err := generateAuditdModuleDescriptor(AuditEvents)
 	require.NoError(t, err)
 	t.Log(string(b))
 }

--- a/base/auditd_types.go
+++ b/base/auditd_types.go
@@ -6,7 +6,7 @@
 // software will be governed by the Apache License, Version 2.0, included in
 // the file licenses/APL2.txt.
 
-package audit
+package base
 
 // auditdModuleDescriptor describes an audit module descriptor in the auditd JSON format.
 type auditdModuleDescriptor struct {
@@ -17,7 +17,7 @@ type auditdModuleDescriptor struct {
 
 // auditdEventDescriptor describes an audit event in the auditd JSON format.
 type auditdEventDescriptor struct {
-	ID                 ID             `json:"id"`
+	ID                 AuditID        `json:"id"`
 	Name               string         `json:"name"`
 	Description        string         `json:"description"`
 	Sync               bool           `json:"sync,omitempty"`
@@ -29,7 +29,7 @@ type auditdEventDescriptor struct {
 
 // toAuditdEventDescriptor converts an EventDescriptor to an auditdEventDescriptor.
 // These are _mostly_ the same, but each event holds its own ID in an array in the JSON format.
-func toAuditdEventDescriptor(id ID, e EventDescriptor) auditdEventDescriptor {
+func toAuditdEventDescriptor(id AuditID, e EventDescriptor) auditdEventDescriptor {
 	return auditdEventDescriptor{
 		ID:                 id,
 		Name:               e.Name,

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/base/audit"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -671,8 +670,8 @@ func (h *handler) handleGetDbAuditConfig() error {
 	verbose := h.getBoolQuery("verbose")
 
 	// TODO: Move to structs
-	events := make(map[string]interface{}, len(audit.SGAuditEvents))
-	for id, descriptor := range audit.SGAuditEvents {
+	events := make(map[string]interface{}, len(base.AuditEvents))
+	for id, descriptor := range base.AuditEvents {
 		if showOnlyFilterable && !descriptor.FilteringPermitted {
 			continue
 		}


### PR DESCRIPTION
Pre-requisite for upcoming work - Flatten `base/audit` package into `base`

Split for easier review due to git rename detection.

Ran into issues pretty quickly with import cycles due to audit code requiring utils in base (e.g. MultiError).
This is just an inherent problem with SG's base package structure that we have to deal with.

No easy way around this without larger refactoring and splitting of base, so just flatten audit into base.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a