### PR TITLE
CBG-3926: Initial implementation of Audit()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           go-version: 1.22.2
       - name: Run Tests
-        run: go test -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: go test -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -19,27 +19,12 @@ const (
 )
 
 const (
-	AuditIDAuditEnabled  AuditID = 53248 // audit enabled
-	AuditIDAuditDisabled AuditID = 53249 // audit disabled
-	AuditIDAuditChanged  AuditID = 53250 // audit configuration changed
+	AuditIDAuditEnabled AuditID = 53248
 
-	AuditIDUserAuthenticated        AuditID = 53260 // successful login
-	AuditIDUserAuthenticationFailed AuditID = 53261 // incorrect login
-	AuditIDUserAuthorizationFailed  AuditID = 53262 // correct login but incorrect permissions
+	AuditIDPublicUserAuthenticated        AuditID = 53260
+	AuditIDPublicUserAuthenticationFailed AuditID = 53261
 
-	AuditIDCreateDatabase       AuditID = 53300 // create database
-	AuditIDReadDatabase         AuditID = 53301 // view database information
-	AuditIDReadDatabaseConfig   AuditID = 53302 // view database config
-	AuditIDUpdateDatabaseConfig AuditID = 53303 // update database config
-	AuditIDDeleteDatabase       AuditID = 53304 // delete database
-
-	AuditIDDocumentCreate AuditID = 54300 // create document
-	AuditIDDocumentRead   AuditID = 54301 // read document
-	AuditIDDocumentUpdate AuditID = 54302 // update document
-	AuditIDDocumentDelete AuditID = 54303 // delete document
-
-	AuditIDReplicationConnect    AuditID = 55300 // new replication connection
-	AuditIDReplicationDisconnect AuditID = 55301 // replication connection closed
+	AuditIDReadDatabase AuditID = 53301
 )
 
 // AuditEvents is a table of audit events created by Sync Gateway.
@@ -61,7 +46,7 @@ var AuditEvents = events{
 		FilteringPermitted: false,
 		EventType:          eventTypeUser,
 	},
-	AuditIDUserAuthenticated: {
+	AuditIDPublicUserAuthenticated: {
 		Name:        "User authenticated",
 		Description: "User successfully authenticated",
 		MandatoryFields: AuditFields{
@@ -74,7 +59,7 @@ var AuditEvents = events{
 		FilteringPermitted: false,
 		EventType:          eventTypeUser,
 	},
-	AuditIDUserAuthenticationFailed: {
+	AuditIDPublicUserAuthenticationFailed: {
 		Name:        "User authentication failed",
 		Description: "User authentication failed",
 		MandatoryFields: AuditFields{

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -12,7 +12,23 @@ const (
 	// auditdSyncGatewayStartID is the start of an ID range allocated for Sync Gateway by auditd
 	auditdSyncGatewayStartID AuditID = 53248
 
-	AuditIDPlaceholder AuditID = 54000
+	AuditIDCreateDatabase       AuditID = 53300 // create database
+	AuditIDReadDatabase         AuditID = 53301 // view database information
+	AuditIDReadDatabaseConfig   AuditID = 53302 // view database config
+	AuditIDUpdateDatabaseConfig AuditID = 53303 // update database config
+	AuditIDDeleteDatabase       AuditID = 53304 // delete database
+
+	AuditIDUserAuthenticated        AuditID = 53400 // successful login
+	AuditIDUserAuthenticationFailed AuditID = 53401 // incorrect login
+	AuditIDUserAuthorizationFailed  AuditID = 53402 // correct login but incorrect permissions
+
+	AuditIDDocumentCreate AuditID = 53500 // create document
+	AuditIDDocumentRead   AuditID = 53501 // read document
+	AuditIDDocumentUpdate AuditID = 53502 // update document
+	AuditIDDocumentDelete AuditID = 53503 // delete document
+
+	AuditIDReplicationConnect    AuditID = 53600 // new replication connection
+	AuditIDReplicationDisconnect AuditID = 53601 // replication connection closed
 )
 
 // AuditEvents is a table of audit events created by Sync Gateway.
@@ -22,20 +38,15 @@ const (
 //   - a kv-auditd-compatible descriptor with TestGenerateAuditdModuleDescriptor
 //   - CSV output for each event to be used to document
 var AuditEvents = events{
-	AuditIDPlaceholder: {
-		Name:        "Placeholder audit event",
-		Description: "This is a placeholder.",
-		MandatoryFields: map[string]any{
-			"context": map[string]any{
-				"provider": "example provider",
-				"username": "alice",
-			},
+	AuditIDReadDatabase: {
+		Name:        "Read database",
+		Description: "Information about this database was read.",
+		MandatoryFields: AuditFields{
+			"db": "database_name",
 		},
-		OptionalFields: map[string]any{
-			"operationID": 123,
-			"isSomething": false,
-		},
+		OptionalFields:     AuditFields{},
+		EnabledByDefault:   true,
 		FilteringPermitted: false,
-		EventType:          eventTypeAdmin,
+		EventType:          eventTypeUser,
 	},
 }

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -11,6 +11,21 @@ package base
 const (
 	// auditdSyncGatewayStartID is the start of an ID range allocated for Sync Gateway by auditd
 	auditdSyncGatewayStartID AuditID = 53248
+	// auditdSyncGatewayEndID is the maximum ID that can be allocated to a Sync Gateway audit descriptor.
+	auditdSyncGatewayEndID = auditdSyncGatewayStartID + auditdIDBlockSize // 57343
+
+	// auditdIDBlockSize is the number of IDs allocated to each module in auditd.
+	auditdIDBlockSize = 0xFFF
+)
+
+const (
+	AuditIDAuditEnabled  AuditID = 53248 // audit enabled
+	AuditIDAuditDisabled AuditID = 53249 // audit disabled
+	AuditIDAuditChanged  AuditID = 53250 // audit configuration changed
+
+	AuditIDUserAuthenticated        AuditID = 53260 // successful login
+	AuditIDUserAuthenticationFailed AuditID = 53261 // incorrect login
+	AuditIDUserAuthorizationFailed  AuditID = 53262 // correct login but incorrect permissions
 
 	AuditIDCreateDatabase       AuditID = 53300 // create database
 	AuditIDReadDatabase         AuditID = 53301 // view database information
@@ -18,17 +33,13 @@ const (
 	AuditIDUpdateDatabaseConfig AuditID = 53303 // update database config
 	AuditIDDeleteDatabase       AuditID = 53304 // delete database
 
-	AuditIDUserAuthenticated        AuditID = 53400 // successful login
-	AuditIDUserAuthenticationFailed AuditID = 53401 // incorrect login
-	AuditIDUserAuthorizationFailed  AuditID = 53402 // correct login but incorrect permissions
+	AuditIDDocumentCreate AuditID = 54300 // create document
+	AuditIDDocumentRead   AuditID = 54301 // read document
+	AuditIDDocumentUpdate AuditID = 54302 // update document
+	AuditIDDocumentDelete AuditID = 54303 // delete document
 
-	AuditIDDocumentCreate AuditID = 53500 // create document
-	AuditIDDocumentRead   AuditID = 53501 // read document
-	AuditIDDocumentUpdate AuditID = 53502 // update document
-	AuditIDDocumentDelete AuditID = 53503 // delete document
-
-	AuditIDReplicationConnect    AuditID = 53600 // new replication connection
-	AuditIDReplicationDisconnect AuditID = 53601 // replication connection closed
+	AuditIDReplicationConnect    AuditID = 55300 // new replication connection
+	AuditIDReplicationDisconnect AuditID = 55301 // replication connection closed
 )
 
 // AuditEvents is a table of audit events created by Sync Gateway.
@@ -38,6 +49,7 @@ const (
 //   - a kv-auditd-compatible descriptor with TestGenerateAuditdModuleDescriptor
 //   - CSV output for each event to be used to document
 var AuditEvents = events{
+	AuditIDAuditEnabled: {}, // TODO: unreferenced event - somehow find this mistake via test or lint!
 	AuditIDReadDatabase: {
 		Name:        "Read database",
 		Description: "Information about this database was read.",

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -61,4 +61,30 @@ var AuditEvents = events{
 		FilteringPermitted: false,
 		EventType:          eventTypeUser,
 	},
+	AuditIDUserAuthenticated: {
+		Name:        "User authenticated",
+		Description: "User successfully authenticated",
+		MandatoryFields: AuditFields{
+			"method": "auth_method", // e.g. "basic", "oidc", "cookie", ...
+		},
+		OptionalFields: AuditFields{
+			"oidc_issuer": "issuer",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeUser,
+	},
+	AuditIDUserAuthenticationFailed: {
+		Name:        "User authentication failed",
+		Description: "User authentication failed",
+		MandatoryFields: AuditFields{
+			"method": "auth_method", // e.g. "basic", "oidc", "cookie", ...
+		},
+		OptionalFields: AuditFields{
+			"username": "username",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeUser,
+	},
 }

--- a/base/audit_events_test.go
+++ b/base/audit_events_test.go
@@ -15,14 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	// auditdSyncGatewayEndID is the maximum ID that can be allocated to a Sync Gateway audit descriptor.
-	auditdSyncGatewayEndID = auditdSyncGatewayStartID + auditdIDBlockSize // 57343
-
-	// auditdIDBlockSize is the number of IDs allocated to each module in auditd.
-	auditdIDBlockSize = 0xFFF
-)
-
 func TestValidateAuditEvents(t *testing.T) {
 	// Ensures that the above audit event IDs are within the allocated range and are valid.
 	require.NoError(t, validateAuditEvents(AuditEvents))

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -77,7 +77,7 @@ func (i AuditID) ValidateFields(f AuditFields) error {
 func mandatoryFieldsPresent(fields, mandatoryFields AuditFields) error {
 	me := &MultiError{}
 	for k, v := range mandatoryFields {
-		// recuse if map
+		// recurse if map
 		if vv, ok := v.(map[string]any); ok {
 			if pv, ok := fields[k].(map[string]any); ok {
 				me = me.Append(mandatoryFieldsPresent(pv, vv))

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -59,12 +59,19 @@ type AuditFields map[string]any
 
 func (i AuditID) MustValidateFields(f AuditFields) {
 	if err := i.ValidateFields(f); err != nil {
-		panic(fmt.Errorf("fields for audit event %s invalid:\n%v", i, err))
+		panic(fmt.Errorf("audit event %s invalid:\n%v", i, err))
 	}
 }
 
 func (i AuditID) ValidateFields(f AuditFields) error {
-	return mandatoryFieldsPresent(f, AuditEvents[i].MandatoryFields)
+	if i < auditdSyncGatewayStartID || i > auditdSyncGatewayEndID {
+		return fmt.Errorf("invalid audit event ID: %d (allowed range: %d-%d)", i, auditdSyncGatewayStartID, auditdSyncGatewayEndID)
+	}
+	event, ok := AuditEvents[i]
+	if !ok {
+		return fmt.Errorf("unknown audit event ID %d", i)
+	}
+	return mandatoryFieldsPresent(f, event.MandatoryFields)
 }
 
 func mandatoryFieldsPresent(fields, mandatoryFields AuditFields) error {

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -1,4 +1,4 @@
-// Copyright 2024-Present Couchbase, Inc.
+// Copyright 2024-Pres	ent Couchbase, Inc.
 //
 // Use of this software is governed by the Business Source License included
 // in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
@@ -10,7 +10,6 @@ package base
 
 import (
 	"fmt"
-	"log/slog"
 	"strconv"
 )
 
@@ -88,26 +87,4 @@ func mandatoryFieldsPresent(fields, mandatoryFields AuditFields) error {
 		}
 	}
 	return me.ErrorOrNil()
-}
-
-func (f AuditFields) toSlogAttrs() []slog.Attr {
-	attrs := make([]slog.Attr, 0, len(f))
-	for k, v := range f {
-		switch val := v.(type) {
-		case map[string]any:
-			groupAttrs := AuditFields(val).toSlogAttrs()
-			attrs = append(attrs, slog.Group(k, attrsToAny(groupAttrs)...))
-		default:
-			attrs = append(attrs, slog.Any(k, val))
-		}
-	}
-	return attrs
-}
-
-func attrsToAny(attrs []slog.Attr) []any {
-	anySlice := make([]any, 0, len(attrs))
-	for _, attr := range attrs {
-		anySlice = append(anySlice, attr)
-	}
-	return anySlice
 }

--- a/base/logger.go
+++ b/base/logger.go
@@ -36,6 +36,10 @@ func FlushLogBuffers() {
 		&consoleLogger.FileLogger,
 	}
 
+	if auditLogger != nil {
+		loggers = append(loggers, &auditLogger.FileLogger)
+	}
+
 	for _, logger := range loggers {
 		if logger != nil && cap(logger.collateBuffer) > 1 {
 			logger.collateBufferWg.Wait()

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -1,0 +1,195 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package base
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	auditLogName = "audit"
+)
+
+// commonly used fields for audit events
+const (
+	auditFieldID            = "id"
+	auditFieldTimestamp     = "timestamp"
+	auditFieldName          = "name"
+	auditFieldDescription   = "description"
+	auditFieldRealUserID    = "real_userid"
+	auditFieldLocal         = "local"
+	auditFieldRemote        = "remote"
+	auditFieldDatabase      = "db"
+	auditFieldCorrelationID = "cid"
+	auditFieldKeyspace      = "ks"
+)
+
+// expandFields populates data with information from the id, context and additionalData.
+func expandFields(id AuditID, ctx context.Context, additionalData AuditFields) AuditFields {
+	var fields AuditFields
+	if additionalData != nil {
+		fields = additionalData
+	} else {
+		fields = make(AuditFields)
+	}
+
+	// static event data
+	fields[auditFieldID] = uint64(id)
+	fields[auditFieldName] = AuditEvents[id].Name
+	fields[auditFieldDescription] = AuditEvents[id].Description
+
+	// context data
+	logCtx := getLogCtx(ctx)
+	if logCtx.Database != "" {
+		fields[auditFieldDatabase] = logCtx.Database
+	}
+	if logCtx.CorrelationID != "" {
+		fields[auditFieldCorrelationID] = logCtx.CorrelationID
+	}
+	if logCtx.Bucket != "" && logCtx.Scope != "" && logCtx.Collection != "" {
+		fields[auditFieldKeyspace] = FullyQualifiedCollectionName(logCtx.Bucket, logCtx.Scope, logCtx.Collection)
+	}
+	// TODO: CBG-3973 - Pull fields from ctx
+	userDomain := "placeholder"
+	userID := "placeholder"
+	if userDomain != "" && userID != "" {
+		fields[auditFieldRealUserID] = map[string]any{
+			"domain": userDomain,
+			"user":   userID,
+		}
+	}
+	localIP := "192.0.2.1"
+	localPort := "4984"
+	if localIP != "" && localPort != "" {
+		fields[auditFieldLocal] = map[string]any{
+			"ip":   localIP,
+			"port": localPort,
+		}
+	}
+	remoteIP := "203.0.113.1"
+	remotePort := "12345"
+	if remoteIP != "" && remotePort != "" {
+		fields[auditFieldRemote] = map[string]any{
+			"ip":   remoteIP,
+			"port": remotePort,
+		}
+	}
+
+	fields[auditFieldTimestamp] = time.Now()
+
+	// TODO: CBG-3976 - Inject and merge data from env var
+	// TODO: CBG-3977 - Inject and merge data from request header
+
+	return fields
+}
+
+// Audit creates and logs an audit event for the given ID and a set of additional data associated with the request.
+func Audit(ctx context.Context, id AuditID, additionalData AuditFields) {
+	var fields AuditFields
+
+	if IsDevMode() {
+		// NOTE: This check is expensive and indicates a dev-time mistake that needs addressing.
+		// Don't bother in production code, but also delay expandFields until we know we will log.
+		fields = expandFields(id, ctx, additionalData)
+		id.MustValidateFields(fields)
+	}
+
+	if auditLogger == nil || !auditLogger.Enabled.IsTrue() {
+		return
+	}
+	logCtx := getLogCtx(ctx)
+	if logCtx.DbLogConfig != nil && logCtx.DbLogConfig.Audit != nil {
+		if _, ok := logCtx.DbLogConfig.Audit.EnabledEvents[id]; !ok {
+			return
+		}
+	}
+
+	// delayed expansion until after enabled checks in non-dev mode
+	if fields == nil {
+		fields = expandFields(id, ctx, additionalData)
+	}
+	attrs := fields.toSlogAttrs()
+	auditLogger.sl.LogAttrs(ctx, slog.LevelInfo, "", attrs...)
+}
+
+// AuditLogger is a file logger with audit-specific behaviour.
+type AuditLogger struct {
+	FileLogger
+
+	sl *slog.Logger
+
+	// AuditLoggerConfig stores the initial config used to instantiate AuditLogger
+	config AuditLoggerConfig
+}
+
+// NewAuditLogger returns a new AuditLogger from a config.
+func NewAuditLogger(ctx context.Context, config *AuditLoggerConfig, logFilePath string, minAge int, buffer *strings.Builder) (*AuditLogger, error) {
+	if config == nil {
+		config = &AuditLoggerConfig{}
+	}
+
+	// validate and set defaults
+	if err := config.init(ctx, LevelNone, auditLogName, logFilePath, minAge); err != nil {
+		return nil, err
+	}
+
+	// removeKeys returns a function suitable for HandlerOptions.ReplaceAttr
+	// that removes all Attrs with the given keys.
+	removeKeys := func(keys ...string) func([]string, slog.Attr) slog.Attr {
+		return func(_ []string, a slog.Attr) slog.Attr {
+			for _, k := range keys {
+				if a.Key == k {
+					return slog.Attr{}
+				}
+			}
+			return a
+		}
+	}
+
+	// TODO: May end up removing slog and doing manual JSON marshalling -> write to file logger.
+	h := slog.NewJSONHandler(config.Output, &slog.HandlerOptions{
+		// strip all builtin slog keys
+		ReplaceAttr: removeKeys(slog.TimeKey, slog.MessageKey, slog.LevelKey, slog.SourceKey),
+	})
+	sl := slog.New(h)
+
+	logger := &AuditLogger{
+		FileLogger: FileLogger{
+			Enabled: AtomicBool{},
+			level:   LevelNone,
+			name:    auditLogName,
+			output:  config.Output,
+			logger:  log.New(config.Output, "", 0),
+		},
+		config: *config,
+		sl:     sl,
+	}
+	logger.Enabled.Set(*config.Enabled)
+
+	if buffer != nil {
+		logger.buffer = *buffer
+	}
+
+	// Only create the collateBuffer channel and worker if required.
+	if *config.CollationBufferSize > 1 {
+		logger.collateBuffer = make(chan string, *config.CollationBufferSize)
+		logger.flushChan = make(chan struct{}, 1)
+		logger.collateBufferWg = &sync.WaitGroup{}
+
+		// Start up a single worker to consume messages from the buffer
+		go logCollationWorker(logger.collateBuffer, logger.flushChan, logger.collateBufferWg, logger.logger, *config.CollationBufferSize, fileLoggerCollateFlushTimeout)
+	}
+
+	return logger, nil
+}

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -137,12 +137,12 @@ func shouldLogConsoleDatabase(ctx context.Context, logLevel LogLevel, logKey Log
 		return false, false
 	}
 
-	config := logCtx.DbConsoleLogConfig
-	if config == nil {
+	config := logCtx.DbLogConfig
+	if config == nil || config.Console == nil {
 		return false, false
 	}
 
-	return shouldLog(config.LogLevel, config.LogKeys, logLevel, logKey), true
+	return shouldLog(config.Console.LogLevel, config.Console.LogKeys, logLevel, logKey), true
 }
 
 // shouldLog returns true if a log at the given logLineLevel/logLineKey should get logged for the given logger levels/keys.

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -140,29 +140,29 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 func TestConsoleShouldLogWithDatabase(t *testing.T) {
 	for _, test := range consoleShouldLogTests {
 		for _, dbConfig := range []struct {
-			config   *DbConsoleLogConfig
-			expected bool
+			consoleConfig *DbConsoleLogConfig
+			expected      bool
 		}{
 			{
-				config:   nil,
-				expected: test.expected, // fully inherit from console logger when dbConfig nil
+				consoleConfig: nil,
+				expected:      test.expected, // fully inherit from console logger when dbConfig nil
 			},
 			{
-				config: &DbConsoleLogConfig{
+				consoleConfig: &DbConsoleLogConfig{
 					LogLevel: logLevelPtr(LevelNone),
 					LogKeys:  logKeyMask(KeyAll),
 				},
 				expected: false, // log nothing from db
 			},
 			{
-				config: &DbConsoleLogConfig{
+				consoleConfig: &DbConsoleLogConfig{
 					LogLevel: logLevelPtr(LevelTrace),
 					LogKeys:  logKeyMask(KeyAll),
 				},
 				expected: true, // log everything from db
 			},
 			{
-				config: &DbConsoleLogConfig{
+				consoleConfig: &DbConsoleLogConfig{
 					LogLevel: logLevelPtr(LevelInfo),
 					LogKeys:  logKeyMask(KeyDCP),
 				},
@@ -170,7 +170,7 @@ func TestConsoleShouldLogWithDatabase(t *testing.T) {
 				expected: test.logToKey == KeyDCP && test.logToLevel <= LevelInfo,
 			},
 			{
-				config: &DbConsoleLogConfig{
+				consoleConfig: &DbConsoleLogConfig{
 					LogLevel: logLevelPtr(LevelInfo),
 					LogKeys:  logKeyMask(KeyHTTP),
 				},
@@ -179,12 +179,12 @@ func TestConsoleShouldLogWithDatabase(t *testing.T) {
 			},
 		} {
 			dbConfigLevel := "<nil>"
-			if dbConfig.config != nil && dbConfig.config.LogLevel != nil {
-				dbConfigLevel = dbConfig.config.LogLevel.StringShort()
+			if dbConfig.consoleConfig != nil && dbConfig.consoleConfig.LogLevel != nil {
+				dbConfigLevel = dbConfig.consoleConfig.LogLevel.StringShort()
 			}
 			dbConfigKeys := "<nil>"
-			if dbConfig.config != nil && dbConfig.config.LogKeys != nil {
-				dbConfigKeys = dbConfig.config.LogKeys.String()
+			if dbConfig.consoleConfig != nil && dbConfig.consoleConfig.LogKeys != nil {
+				dbConfigKeys = dbConfig.consoleConfig.LogKeys.String()
 			}
 
 			name := fmt.Sprintf("logger{%s,%s}.shouldLog(dbConfig(%s,%s), %s,%s)",
@@ -202,7 +202,8 @@ func TestConsoleShouldLogWithDatabase(t *testing.T) {
 				}})
 
 			t.Run(name, func(ts *testing.T) {
-				ctx := DatabaseLogCtx(TestCtx(ts), "db", dbConfig.config)
+				config := &DbLogConfig{Console: dbConfig.consoleConfig}
+				ctx := DatabaseLogCtx(TestCtx(ts), "db", config)
 				got := l.shouldLog(ctx, test.logToLevel, test.logToKey)
 				assert.Equal(ts, dbConfig.expected, got)
 			})

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -81,7 +81,6 @@ type logRotationConfig struct {
 
 // NewFileLogger returns a new FileLogger from a config.
 func NewFileLogger(ctx context.Context, config *FileLoggerConfig, level LogLevel, name string, logFilePath string, minAge int, buffer *strings.Builder) (*FileLogger, error) {
-
 	if config == nil {
 		config = &FileLoggerConfig{}
 	}

--- a/base/logging.go
+++ b/base/logging.go
@@ -88,6 +88,8 @@ var (
 	consoleLogger                                                              *ConsoleLogger
 	traceLogger, debugLogger, infoLogger, warnLogger, errorLogger, statsLogger *FileLogger
 
+	auditLogger = &AuditLogger{}
+
 	// envColorCapable evaluated only once to prevent unnecessary
 	// overhead of checking os.Getenv on each colorEnabled() invocation
 	envColorCapable = runtime.GOOS != "windows" && os.Getenv("TERM") != "dumb"

--- a/base/util.go
+++ b/base/util.go
@@ -62,8 +62,8 @@ func NewNonCancelCtx() NonCancellableContext {
 }
 
 // NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
-func NewNonCancelCtxForDatabase(dbName string, dbConsoleLogConfig *DbConsoleLogConfig) NonCancellableContext {
-	dbLogContext := DatabaseLogCtx(context.Background(), dbName, dbConsoleLogConfig)
+func NewNonCancelCtxForDatabase(dbName string, dbLogConfig *DbLogConfig) NonCancellableContext {
+	dbLogContext := DatabaseLogCtx(context.Background(), dbName, dbLogConfig)
 	ctxStruct := NonCancellableContext{
 		Ctx: dbLogContext,
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -172,17 +172,12 @@ type DatabaseContextOptions struct {
 	BlipStatsReportingInterval    int64          // interval to report blip stats in milliseconds
 	ChangesRequestPlus            bool           // Sets the default value for request_plus, for non-continuous changes feeds
 	ConfigPrincipals              *ConfigPrincipals
-	PurgeInterval                 *time.Duration // Add a custom purge interval, as a testing seam. If nil, this parameter is filled in by Couchbase Server, with a fallback to a default value SG has.
-	LoggingConfig                 DbLogConfig    // Per-database log configuration
-	MaxConcurrentChangesBatches   *int           // Maximum number of changes batches to process concurrently per replication
-	MaxConcurrentRevs             *int           // Maximum number of revs to process concurrently per replication
-	NumIndexReplicas              uint           // Number of replicas for GSI indexes
-	ImportVersion                 uint64         // Version included in import DCP checkpoints, incremented when collections added to db
-}
-
-// DbLogConfig can be used to customise the logging for logs associated with this database.
-type DbLogConfig struct {
-	Console *base.DbConsoleLogConfig
+	PurgeInterval                 *time.Duration    // Add a custom purge interval, as a testing seam. If nil, this parameter is filled in by Couchbase Server, with a fallback to a default value SG has.
+	LoggingConfig                 *base.DbLogConfig // Per-database log configuration
+	MaxConcurrentChangesBatches   *int              // Maximum number of changes batches to process concurrently per replication
+	MaxConcurrentRevs             *int              // Maximum number of revs to process concurrently per replication
+	NumIndexReplicas              uint              // Number of replicas for GSI indexes
+	ImportVersion                 uint64            // Version included in import DCP checkpoints, incremented when collections added to db
 }
 
 type ConfigPrincipals struct {
@@ -375,7 +370,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 
 	// add db info to ctx before having a DatabaseContext (cannot call AddDatabaseLogContext),
 	// in order to pass it to RegisterImportPindexImpl
-	ctx = base.DatabaseLogCtx(ctx, dbName, options.LoggingConfig.Console)
+	ctx = base.DatabaseLogCtx(ctx, dbName, options.LoggingConfig)
 
 	if err := base.RequireNoBucketTTL(ctx, bucket); err != nil {
 		return nil, err
@@ -2110,7 +2105,7 @@ func CheckTimeout(ctx context.Context) error {
 // AddDatabaseLogContext adds database name to the parent context for logging
 func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context.Context {
 	if dbCtx != nil && dbCtx.Name != "" {
-		dbLogCtx := base.DatabaseLogCtx(ctx, dbCtx.Name, dbCtx.Options.LoggingConfig.Console)
+		dbLogCtx := base.DatabaseLogCtx(ctx, dbCtx.Name, dbCtx.Options.LoggingConfig)
 		return dbLogCtx
 	}
 	return ctx

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -107,9 +107,9 @@ fi
 
 if [ "${RUN_WALRUS}" == "true" ]; then
     # EE
-    go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
+    go test -coverprofile=coverage_walrus_ee.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_devmode,cb_sg_enterprise $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ee.out.raw 2>&1 | true
     # CE
-    go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ce.out.raw 2>&1 | true
+    go test -coverprofile=coverage_walrus_ce.out -coverpkg=github.com/couchbase/sync_gateway/... -tags cb_sg_devmode $GO_TEST_FLAGS github.com/couchbase/sync_gateway/${TARGET_PACKAGE} > verbose_unit_ce.out.raw 2>&1 | true
 fi
 
 # Run CBS
@@ -132,7 +132,9 @@ export SG_TEST_BUCKET_POOL_DEBUG=${SG_TEST_BUCKET_POOL_DEBUG}
 export SG_TEST_TLS_SKIP_VERIFY=${TLS_SKIP_VERIFY}
 
 if [ "${SG_EDITION}" == "EE" ]; then
-    GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_enterprise"
+    GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_devmode,cb_sg_enterprise"
+else
+    GO_TEST_FLAGS="${GO_TEST_FLAGS} -tags cb_sg_devmode"
 fi
 
 go test ${GO_TEST_FLAGS} -coverprofile=coverage_int.out -coverpkg=github.com/couchbase/sync_gateway/... github.com/couchbase/sync_gateway/${TARGET_PACKAGE} 2>&1 | stdbuf -oL tee "${INT_LOG_FILE_NAME}.out.raw" | stdbuf -oL grep -a -E '(--- (FAIL|PASS|SKIP):|github.com/couchbase/sync_gateway(/.+)?\t|TEST: |panic: )'

--- a/rest/api.go
+++ b/rest/api.go
@@ -414,6 +414,8 @@ type DbSummary struct {
 }
 
 func (h *handler) handleGetDB() error {
+	base.Audit(h.ctx(), base.AuditIDReadDatabase, nil)
+
 	if h.rq.Method == "HEAD" {
 		return nil
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1298,6 +1298,7 @@ func (sc *StartupConfig) SetupAndValidateLogging(ctx context.Context) (err error
 		sc.Logging.Debug,
 		sc.Logging.Trace,
 		sc.Logging.Stats,
+		sc.Logging.Audit,
 	)
 }
 
@@ -2157,15 +2158,35 @@ func RegisterSignalHandler(ctx context.Context) {
 	}()
 }
 
-// toDbConsoleLogConfig converts the console logging from a DbConfig to a DbConsoleLogConfig
-func (c *DbConfig) toDbConsoleLogConfig(ctx context.Context) *base.DbConsoleLogConfig {
-	// Per-database console logging config overrides
-	if c.Logging != nil && c.Logging.Console != nil {
-		logKey := base.ToLogKey(ctx, c.Logging.Console.LogKeys)
-		return &base.DbConsoleLogConfig{
-			LogLevel: c.Logging.Console.LogLevel,
+// toDbLogConfig converts the console logging from a DbConfig to a DbLogConfig
+func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
+	l := c.Logging
+	if l == nil || (l.Console == nil && l.Audit == nil) {
+		return nil
+	}
+
+	var con *base.DbConsoleLogConfig
+	if l.Console != nil {
+		logKey := base.ToLogKey(ctx, l.Console.LogKeys)
+		con = &base.DbConsoleLogConfig{
+			LogLevel: l.Console.LogLevel,
 			LogKeys:  &logKey,
 		}
 	}
-	return nil
+
+	var aud *base.DbAuditLogConfig
+	if l.Audit != nil {
+		enabledEvents := make(map[base.AuditID]struct{}, len(l.Audit.EnabledEvents))
+		for _, event := range l.Audit.EnabledEvents {
+			enabledEvents[base.AuditID(event)] = struct{}{}
+		}
+		aud = &base.DbAuditLogConfig{
+			EnabledEvents: enabledEvents,
+		}
+	}
+
+	return &base.DbLogConfig{
+		Console: con,
+		Audit:   aud,
+	}
 }

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -740,7 +740,7 @@ func (b *bootstrapContext) getRegistryAndDatabase(ctx context.Context, bucketNam
 }
 
 func (b *bootstrapContext) addDatabaseLogContext(ctx context.Context, config *DbConfig) context.Context {
-	return base.DatabaseLogCtx(ctx, config.Name, config.toDbConsoleLogConfig(ctx))
+	return base.DatabaseLogCtx(ctx, config.Name, config.toDbLogConfig(ctx))
 }
 
 func (b *bootstrapContext) ComputeMetadataIDForDbConfig(ctx context.Context, config *DbConfig) (string, error) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -734,7 +734,7 @@ func (h *handler) checkAuth(dbCtx *db.DatabaseContext) (err error) {
 		if err != nil {
 			dbCtx.DbStats.Security().AuthFailedCount.Add(1)
 			if errors.Is(err, ErrInvalidLogin) {
-				base.Audit(h.ctx(), base.AuditIDUserAuthorizationFailed, auditFields)
+				base.Audit(h.ctx(), base.AuditIDUserAuthenticationFailed, auditFields)
 			}
 		} else {
 			dbCtx.DbStats.Security().AuthSuccessCount.Add(1)

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -297,7 +297,7 @@ func (h *handler) getOIDCProvider(providerName string) (*auth.OIDCProvider, erro
 // Builds the OIDC callback based on the current request. Used during OIDC Client lazy initialization.
 // Need to pass providerName and isDefault for the requested provider to determine whether we need to append it to the callback URL or not.
 func (h *handler) getOIDCCallbackURL(providerName string, isDefault bool) string {
-	// h.db not initialized at this point (checkAuth) from validateAndWriteHeaders
+	// h.db not initialized at this point (checkPublicAuth) from validateAndWriteHeaders
 	// we'll have to pull it out of the router path rather than using h.db.Name
 	dbName := h.PathVar("db")
 	if dbName == "" {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -793,7 +793,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
-	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig.Console)
+	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig)
 
 	contextOptions.UseViews = useViews
 
@@ -968,7 +968,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// If asyncOnline is requested, set state to Starting and spawn a separate goroutine to wait for init completion
 		// before going online
 		base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete asynchonously...")
-		nonCancelCtx := base.NewNonCancelCtxForDatabase(dbName, dbcontext.Options.LoggingConfig.Console)
+		nonCancelCtx := base.NewNonCancelCtxForDatabase(dbName, dbcontext.Options.LoggingConfig)
 		go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
 		return dbcontext, nil
 	}
@@ -1284,8 +1284,8 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		contextOptions.NumIndexReplicas = DefaultNumIndexReplicas
 	}
 
-	// Per-database console logging config overrides
-	contextOptions.LoggingConfig.Console = config.toDbConsoleLogConfig(ctx)
+	// Per-database logging config overrides
+	contextOptions.LoggingConfig = config.toDbLogConfig(ctx)
 
 	if sc.Config.Unsupported.UserQueries != nil && *sc.Config.Unsupported.UserQueries {
 		var err error

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -48,7 +48,7 @@ func (h *handler) handleSessionPOST() error {
 		}
 	}
 
-	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkAuth calls out into AuthenticateUntrustedJWT.
+	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkPublicAuth calls out into AuthenticateUntrustedJWT.
 	// Therefore, if by this point `h.user` is guest, this isn't creating a session from OIDC.
 	if h.db.Options.DisablePasswordAuthentication && (h.user == nil || h.user.Name() == "") {
 		return ErrLoginRequired


### PR DESCRIPTION
CBG-3926

- Enable devmode flag in CI/Integration tests
- Changes required to produce 3 audit events (ReadDatabase, UserAuthenticated, UserAuthenticationFailed)
- `Audit()` function to create/log audit event
- Currently uses `slog` but plan to replace with more basic JSON->FileLogger

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2526/