### PR TITLE
CBG-4019 Add init_in_progress property to db and verbose all_dbs responses

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2528,6 +2528,10 @@ CollectionNames:
         enum:
           - require_resync
           - ""
+      init_in_progress:
+        description: Indicates whether database initialization is in progress.
+        type: boolean
+        example: true
 all_user_channels:
   description: |-
     All user channels split by how they were assigned to the user and by keyspace.

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2523,11 +2523,10 @@ CollectionNames:
           - Starting
           - Stopping
           - Resyncing
-      reason:
-        description: Optional reason a database is in a particular state.
-        enum:
-          - require_resync
-          - ""
+      require_resync:
+        description: Indicates whether the database requires resync before it can be brought online.
+        type: boolean
+        example: true
       init_in_progress:
         description: Indicates whether database initialization is in progress.
         type: boolean

--- a/docs/api/paths/admin/db-.yaml
+++ b/docs/api/paths/admin/db-.yaml
@@ -66,6 +66,9 @@ get:
                 description: Unique server identifier.
                 type: string
                 example: 995618a6a6cc9ac79731bd13240e19b5
+              init_in_progress:
+                description: Indicates whether database initialization is in progress.
+                type: boolean
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -265,10 +265,10 @@ func TestRequireResync(t *testing.T) {
 	// databases sorted alphabetically
 	require.Equal(t, db1Name, allDBsSummary[0].DBName)
 	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
-	require.Equal(t, "", allDBsSummary[0].Reason)
+	require.Equal(t, false, allDBsSummary[0].RequireResync)
 	require.Equal(t, db2Name, allDBsSummary[1].DBName)
 	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
-	require.Equal(t, rest.OfflineReasonRequireResync, allDBsSummary[1].Reason)
+	require.Equal(t, true, allDBsSummary[1].RequireResync)
 
 	// Run resync for collection
 	resyncCollections := make(db.ResyncCollections, 0)
@@ -296,10 +296,10 @@ func TestRequireResync(t *testing.T) {
 	// databases sorted alphabetically
 	require.Equal(t, db1Name, allDBsSummary[0].DBName)
 	require.Equal(t, db.RunStateString[db.DBOnline], allDBsSummary[0].State)
-	require.Equal(t, "", allDBsSummary[0].Reason)
+	require.Equal(t, false, allDBsSummary[0].RequireResync)
 	require.Equal(t, db2Name, allDBsSummary[1].DBName)
 	require.Equal(t, db.RunStateString[db.DBOffline], allDBsSummary[1].State)
-	require.Equal(t, "", allDBsSummary[1].Reason)
+	require.Equal(t, false, allDBsSummary[1].RequireResync)
 
 	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/api.go
+++ b/rest/api.go
@@ -412,7 +412,7 @@ type DbSummary struct {
 	Bucket               string `json:"bucket"`
 	State                string `json:"state"`
 	InitializationActive bool   `json:"init_in_progress,omitempty"`
-	Reason               string `json:"reason,omitempty"`
+	RequireResync        bool   `json:"require_resync,omitempty"`
 }
 
 func (h *handler) handleGetDB() error {

--- a/rest/api.go
+++ b/rest/api.go
@@ -404,13 +404,15 @@ type DatabaseRoot struct {
 	State                         string   `json:"state"`
 	ServerUUID                    string   `json:"server_uuid,omitempty"`
 	RequireResync                 []string `json:"require_resync,omitempty"`
+	InitializationActive          bool     `json:"init_in_progress,omitempty"`
 }
 
 type DbSummary struct {
-	DBName string `json:"db_name"`
-	Bucket string `json:"bucket"`
-	State  string `json:"state"`
-	Reason string `json:"reason,omitempty"`
+	DBName               string `json:"db_name"`
+	Bucket               string `json:"bucket"`
+	State                string `json:"state"`
+	InitializationActive bool   `json:"init_in_progress,omitempty"`
+	Reason               string `json:"reason,omitempty"`
 }
 
 func (h *handler) handleGetDB() error {
@@ -436,6 +438,7 @@ func (h *handler) handleGetDB() error {
 		State:                         runState,
 		ServerUUID:                    h.db.DatabaseContext.ServerUUID,
 		RequireResync:                 h.db.RequireResync.ScopeAndCollectionNames(),
+		InitializationActive:          h.server.DatabaseInitManager.HasActiveInitialization(h.db.Name),
 	}
 
 	h.writeJSON(response)

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -115,6 +115,10 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 }
 
 func (m *DatabaseInitManager) HasActiveInitialization(dbName string) bool {
+	if m == nil {
+		// When not using persistent config, DatabaseInitManager will be nil
+		return false
+	}
 	m.workersLock.Lock()
 	defer m.workersLock.Unlock()
 	_, ok := m.workers[dbName]

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -45,8 +45,6 @@ const defaultBytesStatsReportingInterval = 30 * time.Second
 
 const dbLoadedStateChangeMsg = "DB loaded from config"
 
-const OfflineReasonRequireResync = "require_resync"
-
 var errCollectionsUnsupported = base.HTTPErrorf(http.StatusBadRequest, "Named collections specified in database config, but not supported by connected Couchbase Server.")
 
 var ErrSuspendingDisallowed = errors.New("database does not allow suspending")
@@ -363,7 +361,7 @@ func (sc *ServerContext) allDatabaseSummaries() []DbSummary {
 		}
 		if state == db.RunStateString[db.DBOffline] {
 			if len(dbctx.RequireResync.ScopeAndCollectionNames()) > 0 {
-				summary.Reason = OfflineReasonRequireResync
+				summary.RequireResync = true
 			}
 		}
 		if sc.DatabaseInitManager.HasActiveInitialization(name) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -366,6 +366,9 @@ func (sc *ServerContext) allDatabaseSummaries() []DbSummary {
 				summary.Reason = OfflineReasonRequireResync
 			}
 		}
+		if sc.DatabaseInitManager.HasActiveInitialization(name) {
+			summary.InitializationActive = true
+		}
 		dbs = append(dbs, summary)
 	}
 	sort.Slice(dbs, func(i, j int) bool {


### PR DESCRIPTION
CBG-4019

Adds `init_in_progress` flag to REST API db status calls when async index initialization is in progress.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2529/
