### PR TITLE
CBG-3975: Configuration wiring for audit logging and /db/_config APIs

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -73,3 +73,16 @@ var AuditEvents = events{
 		EventType:          eventTypeUser,
 	},
 }
+
+// DefaultAuditEventIDs is a list of audit event IDs that are enabled by default.
+var DefaultAuditEventIDs = buildDefaultAuditIDList(AuditEvents)
+
+func buildDefaultAuditIDList(e events) []uint {
+	var ids []uint
+	for id, event := range e {
+		if event.EnabledByDefault {
+			ids = append(ids, uint(id))
+		}
+	}
+	return ids
+}

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -267,10 +267,10 @@ type AuditLoggerConfig struct {
 	AuditLogFilePath *string `json:"audit_log_file_path,omitempty"` // If set, overrides the output path for the audit log files
 }
 
-func BuildLoggingConfigFromLoggers(redactionLevel RedactionLevel, LogFilePath string) *LoggingConfig {
+func BuildLoggingConfigFromLoggers(originalConfig LoggingConfig) *LoggingConfig {
 	config := LoggingConfig{
-		RedactionLevel: redactionLevel,
-		LogFilePath:    LogFilePath,
+		RedactionLevel: originalConfig.RedactionLevel,
+		LogFilePath:    originalConfig.LogFilePath,
 	}
 
 	config.Console = consoleLogger.getConsoleLoggerConfig()
@@ -280,8 +280,7 @@ func BuildLoggingConfigFromLoggers(redactionLevel RedactionLevel, LogFilePath st
 	config.Debug = debugLogger.getFileLoggerConfig()
 	config.Trace = traceLogger.getFileLoggerConfig()
 	config.Stats = statsLogger.getFileLoggerConfig()
-	// FIXME(bbrks): Once AuditLogger is implemented
-	config.Audit = &AuditLoggerConfig{}
+	config.Audit = auditLogger.getAuditLoggerConfig()
 
 	return &config
 }

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -224,6 +224,12 @@ func EnableStatsLogger(enabled bool) {
 	}
 }
 
+func EnableAuditLogger(enabled bool) {
+	if auditLogger != nil {
+		auditLogger.Enabled.Set(enabled)
+	}
+}
+
 // === Used by tests only ===
 func ErrorLoggerIsEnabled() bool {
 	return errorLogger.Enabled.IsTrue()

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -69,6 +69,7 @@ type DbConsoleLogConfig struct {
 
 // DbAuditLogConfig can be used to customise the audit logging for events associated with this database.
 type DbAuditLogConfig struct {
+	Enabled       bool
 	EnabledEvents map[AuditID]struct{}
 }
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -431,6 +431,7 @@ func (h *handler) handlePutConfig() error {
 			Debug   FileLoggerPutConfig     `json:"debug,omitempty"`
 			Trace   FileLoggerPutConfig     `json:"trace,omitempty"`
 			Stats   FileLoggerPutConfig     `json:"stats,omitempty"`
+			Audit   FileLoggerPutConfig     `json:"audit,omitempty"`
 		} `json:"logging"`
 		ReplicationLimit *int `json:"max_concurrent_replications,omitempty"`
 	}
@@ -482,6 +483,10 @@ func (h *handler) handlePutConfig() error {
 
 	if config.Logging.Stats.Enabled != nil {
 		base.EnableStatsLogger(*config.Logging.Stats.Enabled)
+	}
+
+	if config.Logging.Audit.Enabled != nil {
+		base.EnableAuditLogger(*config.Logging.Audit.Enabled)
 	}
 
 	if config.ReplicationLimit != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -394,7 +394,8 @@ func (h *handler) handleGetConfig() error {
 			}
 		}
 
-		cfg.Logging = *base.BuildLoggingConfigFromLoggers(h.server.Config.Logging.RedactionLevel, h.server.Config.Logging.LogFilePath)
+		// because loggers can be changed at runtime, we need to work backwards to get the config that would've created the actually running instances
+		cfg.Logging = *base.BuildLoggingConfigFromLoggers(h.server.Config.Logging)
 		cfg.Databases = databaseMap
 
 		h.writeJSON(cfg)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -673,6 +673,11 @@ func (h *handler) handleGetDbAuditConfig() error {
 	showOnlyFilterable := h.getBoolQuery("filterable")
 	verbose := h.getBoolQuery("verbose")
 
+	isEnabledFn := func(id base.AuditID) bool {
+		_, ok := h.db.Options.LoggingConfig.Audit.EnabledEvents[id]
+		return ok
+	}
+
 	// TODO: Move to structs
 	events := make(map[string]interface{}, len(base.AuditEvents))
 	for id, descriptor := range base.AuditEvents {
@@ -684,11 +689,11 @@ func (h *handler) handleGetDbAuditConfig() error {
 			events[idStr] = map[string]interface{}{
 				"name":        descriptor.Name,
 				"description": descriptor.Description,
-				"enabled":     descriptor.EnabledByDefault, // TODO: Switch to actual configuration
+				"enabled":     isEnabledFn(id),
 				"filterable":  descriptor.FilteringPermitted,
 			}
 		} else {
-			events[idStr] = descriptor.EnabledByDefault // TODO: Switch to actual configuration
+			events[idStr] = isEnabledFn(id)
 		}
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -2174,7 +2174,7 @@ func RegisterSignalHandler(ctx context.Context) {
 	}()
 }
 
-// toDbLogConfig converts the console logging from a DbConfig to a DbLogConfig
+// toDbLogConfig converts the logging from a DbConfig to a DbLogConfig
 func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 	l := c.Logging
 	if l == nil || (l.Console == nil && l.Audit == nil) {

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -90,17 +90,22 @@ func GenerateDatabaseConfigVersionID(ctx context.Context, previousRevID string, 
 }
 
 func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfig {
+	dblc := &DbLoggingConfig{}
 	if bootstrapLoggingCnf.Console != nil {
 		if *bootstrapLoggingCnf.Console.Enabled {
-			return &DbLoggingConfig{
-				Console: &DbConsoleLoggingConfig{
-					LogLevel: bootstrapLoggingCnf.Console.LogLevel,
-					LogKeys:  bootstrapLoggingCnf.Console.LogKeys,
-				},
+			dblc.Console = &DbConsoleLoggingConfig{
+				LogLevel: bootstrapLoggingCnf.Console.LogLevel,
+				LogKeys:  bootstrapLoggingCnf.Console.LogKeys,
 			}
 		}
 	}
-	return &DbLoggingConfig{}
+	if bootstrapLoggingCnf.Audit != nil {
+		dblc.Audit = &DbAuditLoggingConfig{
+			Enabled:       base.BoolPtr(false),
+			EnabledEvents: base.DefaultAuditEventIDs,
+		}
+	}
+	return dblc
 }
 
 // MergeDatabaseConfigWithDefaults merges the passed in config onto a DefaultDbConfig which results in returned value


### PR DESCRIPTION
CBG-3975

Configuration wiring for audit logging.

- Allows per-database enabled and events via /db/_config API.
- `GET /db/_config/audit` shows correct 'enabled' state for each available event. Read-only until [CBG-3981](https://issues.couchbase.com/browse/CBG-3981)

## Dependencies
- [x] #6908 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/