### PR TITLE
CBG-4010 make FileLogger.Close shut down its own goroutines

### DIFF
--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -10,7 +10,6 @@ package base
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -97,9 +96,7 @@ func TestLogRotationInterval(t *testing.T) {
 	countBefore := numFilesInDir(t, logPath, false)
 	t.Logf("countBefore: %d", countBefore)
 
-	ctx, ctxCancel := context.WithCancel(TestCtx(t))
-	defer ctxCancel()
-
+	ctx := TestCtx(t)
 	fl, err := NewFileLogger(ctx, config, LevelTrace, "test", logPath, 0, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, fl.Close()) }()


### PR DESCRIPTION
- close the rotation gorountines when closing the file logger

This failure happens reasonably often in github and is reproduce on mac with high -count numbers after ~20 or so tries. This makes closing the logger slower, but we are only doing this in test so I think the wait time is OK.