### PR TITLE
 CBG-3978: Write `AuditEvents` table to CSV for review/use by PM/Docs

### DIFF
--- a/base/auditd_descriptor_test.go
+++ b/base/auditd_descriptor_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestGenerateAuditdModuleDescriptor outputs a generated auditd module descriptor for SGAuditEvents.
+// TestGenerateAuditdModuleDescriptor outputs a generated auditd module descriptor for AuditEvents.
 func TestGenerateAuditdModuleDescriptor(t *testing.T) {
 	b, err := generateAuditdModuleDescriptor(AuditEvents)
 	require.NoError(t, err)


### PR DESCRIPTION
CBG-3978

Writes `AuditEvents` table to CSV for review/use by PM/Docs.

Output:
```
=== RUN   TestGenerateAuditDescriptorCSV
ID,Name,Description,DefaultEnabled,Filterable,EventType,MandatoryFields,OptionalFields
53248,,,false,false,,,
53301,Read database,Information about this database was read.,true,false,user,db,
53260,User authenticated,User successfully authenticated,true,false,user,method,"oidc_issuer, another_optional"
53261,User authentication failed,User authentication failed,true,false,user,method,username
--- PASS: TestGenerateAuditDescriptorCSV (0.00s)
```