### PR TITLE
CBG-3976 allow injecting global fields into logger

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -111,11 +111,6 @@ func (f *AuditFields) merge(ctx context.Context, overwrites AuditFields) {
 
 // Audit creates and logs an audit event for the given ID and a set of additional data associated with the request.
 func Audit(ctx context.Context, id AuditID, additionalData AuditFields) {
-	audit(ctx, id, additionalData)
-}
-
-// audit creates and logs an audit event for the given ID and a set of additional data associated with the request, but allows passing a devmode field.
-func audit(ctx context.Context, id AuditID, additionalData AuditFields) {
 	var fields AuditFields
 
 	if IsDevMode() {

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -95,6 +95,32 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	return fields
 }
 
+// Merge will perform a deep overwrite of the fields in the AuditFields. If there are type conflicts, the overwrites will replace the type
+func (f *AuditFields) Merge(overwrites AuditFields) {
+	mergeMap(*f, overwrites)
+}
+
+func mergeMap(base map[string]any, overwrites map[string]any) {
+	for k, v := range overwrites {
+		baseVal, ok := base[k]
+		if !ok {
+			base[k] = v
+		}
+		switch v := v.(type) {
+		case map[string]any:
+			switch baseVal := baseVal.(type) {
+			case map[string]any:
+				mergeMap(baseVal, v)
+			default:
+				base[k] = v
+			}
+		default:
+			base[k] = v
+		}
+		fmt.Printf("baseVal: %v\n", baseVal)
+	}
+}
+
 // Audit creates and logs an audit event for the given ID and a set of additional data associated with the request.
 func Audit(ctx context.Context, id AuditID, additionalData AuditFields) {
 	var fields AuditFields

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -10,6 +10,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 )

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -64,3 +64,108 @@ func TestAuditLogger(t *testing.T) {
 	}
 
 }
+
+func TestAuditFieldsMerge(t *testing.T) {
+	testCases := []struct {
+		name      string
+		base      AuditFields
+		overwrite AuditFields
+		output    AuditFields
+	}{
+		{
+			name:      "no overwrites",
+			base:      map[string]any{"foo": "bar"},
+			overwrite: nil,
+			output:    map[string]any{"foo": "bar"},
+		},
+		{
+			name:      "new fields",
+			base:      map[string]any{"foo": "bar"},
+			overwrite: map[string]any{"baz": "qux"},
+			output: map[string]any{
+				"foo": "bar",
+				"baz": "qux",
+			},
+		},
+		{
+			name:      "overwrite fields",
+			base:      map[string]any{"foo": "bar"},
+			overwrite: map[string]any{"foo": "baz"},
+			output:    map[string]any{"foo": "baz"},
+		},
+		{
+			name: "add to deep map",
+			base: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": map[string]any{
+						"foo": "baz",
+					},
+				},
+			},
+			overwrite: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": map[string]any{
+						"bar": "qux",
+					},
+				},
+			},
+			output: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": map[string]any{
+						"foo": "baz",
+						"bar": "qux",
+					},
+				},
+			},
+		},
+		{
+			name: "overwrite overwrite deep map with int",
+			base: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": map[string]any{
+						"foo": "baz",
+					},
+				},
+			},
+			overwrite: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": 1,
+				},
+			},
+			output: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": 1,
+				},
+			},
+		},
+		{
+			name: "overwrite overwrite deep map with string",
+			base: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": 1,
+				},
+			},
+			overwrite: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": map[string]any{
+						"foo": "baz",
+					},
+				},
+			},
+			output: map[string]any{
+				"lvl1": map[string]any{
+					"lvl2": map[string]any{
+						"foo": "baz",
+					},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.base.Merge(testCase.overwrite)
+			require.Equal(t, testCase.output, testCase.base)
+		})
+	}
+
+}

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -74,7 +74,7 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 			startWarnCount := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 			output := AuditLogContents(t, func() {
 				// Test basic audit event
-				audit(ctx, AuditIDPublicUserAuthenticated, map[string]any{"method": "basic"})
+				Audit(ctx, AuditIDPublicUserAuthenticated, map[string]any{"method": "basic"})
 			},
 			)
 			var event map[string]any

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package base
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditLogger(t *testing.T) {
+	ResetGlobalTestLogging(t)
+
+	tmpdir := t.TempDir()
+
+	ctx := TestCtx(t)
+
+	globalFields := AuditFields{
+		"global": "field",
+	}
+	testCases := []struct {
+		name         string
+		globalFields AuditFields
+	}{
+		{
+			name: "no global fields",
+		},
+		{
+			name:         "with global fields",
+			globalFields: globalFields,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var err error
+			auditLogger, err = NewAuditLogger(ctx, nil, tmpdir, 0, nil, testCase.globalFields)
+			require.NoError(t, err)
+
+			output := AuditLogContents(t, func() {
+				// Test basic audit event
+				Audit(ctx, AuditIDPublicUserAuthenticated, map[string]any{"method": "basic"})
+			},
+			)
+			var event map[string]any
+			require.NoError(t, json.Unmarshal(output, &event))
+			method, ok := event["method"].(string)
+			require.True(t, ok)
+			require.Equal(t, "basic", method)
+			for k := range testCase.globalFields {
+				if testCase.globalFields == nil {
+					require.NotContains(t, event, k)
+				} else {
+					require.Contains(t, event, k)
+				}
+			}
+		})
+	}
+
+}

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -69,9 +69,8 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			ctx := TestCtx(t)
 			var err error
-			auditLogger, err = NewAuditLogger(ctx, nil, tmpdir, 0, nil, testCase.globalFields)
+			auditLogger, err = NewAuditLogger(ctx, &AuditLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true)}}, tmpdir, 0, nil, testCase.globalFields)
 			require.NoError(t, err)
-
 			startWarnCount := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 			output := AuditLogContents(t, func() {
 				// Test basic audit event

--- a/base/logging.go
+++ b/base/logging.go
@@ -402,3 +402,19 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 	consoleLogger.FlushBufferToLog()
 	assert.Contains(t, b.String(), s)
 }
+
+// AuditLogContents returns that the audit logs produced by function f.
+func AuditLogContents(t *testing.T, f func()) []byte {
+	// Temporarily override logger output
+	b := &bytes.Buffer{}
+	mw := io.MultiWriter(b, os.Stderr)
+	auditLogger.logger.SetOutput(mw)
+	defer func() { auditLogger.logger.SetOutput(os.Stderr) }()
+
+	// Call the given function
+	f()
+
+	FlushLogBuffers()
+	auditLogger.FlushBufferToLog()
+	return b.Bytes()
+}

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -60,7 +60,7 @@ type LegacyLoggingConfig struct {
 func InitLogging(ctx context.Context, logFilePath string,
 	console *ConsoleLoggerConfig,
 	error, warn, info, debug, trace, stats *FileLoggerConfig,
-	audit *AuditLoggerConfig) (err error) {
+	audit *AuditLoggerConfig, auditLogGlobalFields map[string]any) (err error) {
 
 	consoleLogger, err = NewConsoleLogger(ctx, true, console)
 	if err != nil {
@@ -101,7 +101,6 @@ func InitLogging(ctx context.Context, logFilePath string,
 		}
 		ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Audit to %v", auditLogFilePath)
 	}
-
 	errorLogger, err = NewFileLogger(ctx, error, LevelError, LevelError.String(), logFilePath, errorMinAge, &errorLogger.buffer)
 	if err != nil {
 		return err
@@ -133,7 +132,7 @@ func InitLogging(ctx context.Context, logFilePath string,
 		return err
 	}
 
-	auditLogger, err = NewAuditLogger(ctx, audit, auditLogFilePath, auditMinage, &auditLogger.buffer)
+	auditLogger, err = NewAuditLogger(ctx, audit, auditLogFilePath, auditMinage, &auditLogger.buffer, auditLogGlobalFields)
 	if err != nil {
 		return err
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -598,6 +598,28 @@ func SetUpTestLogging(tb testing.TB, logLevel LogLevel, logKeys ...LogKey) {
 	tb.Cleanup(cleanup)
 }
 
+// ResetGlobalTestLogging will ensure that the loggers are replaced at the endof the the test. This is only safe to call with go:build !race since swapping the global loggers can trigger a race condition from background processes of the test harness.
+func ResetGlobalTestLogging(t *testing.T) {
+	oldErrorLogger := errorLogger
+	oldWarnLogger := warnLogger
+	oldInfoLogger := infoLogger
+	oldDebugLogger := debugLogger
+	oldTraceLogger := traceLogger
+	oldStatsLogger := statsLogger
+	oldAuditLogger := auditLogger
+	oldConsoleLogger := consoleLogger
+	t.Cleanup(func() {
+		errorLogger = oldErrorLogger
+		warnLogger = oldWarnLogger
+		infoLogger = oldInfoLogger
+		debugLogger = oldDebugLogger
+		traceLogger = oldTraceLogger
+		statsLogger = oldStatsLogger
+		auditLogger = oldAuditLogger
+		consoleLogger = oldConsoleLogger
+	})
+}
+
 // DisableTestLogging is an alias for SetUpTestLogging(LevelNone, KeyNone)
 // This function will panic if called multiple times in the same test.
 func DisableTestLogging(tb testing.TB) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1305,6 +1305,14 @@ func (sc *StartupConfig) SetupAndValidateLogging(ctx context.Context) (err error
 		sc.Logging.LogFilePath = defaultLogFilePath
 	}
 
+	var auditLoggingFields map[string]any
+	if sc.Unsupported.AuditInfoProvider != nil && sc.Unsupported.AuditInfoProvider.GlobalInfoEnvVarName != nil {
+		v := os.Getenv(*sc.Unsupported.AuditInfoProvider.GlobalInfoEnvVarName)
+		err := base.JSONUnmarshal([]byte(v), &auditLoggingFields)
+		if err != nil {
+			return fmt.Errorf("Unable to unmarshal audit info from environment variable %s=%s %w", *sc.Unsupported.AuditInfoProvider.GlobalInfoEnvVarName, v, err)
+		}
+	}
 	return base.InitLogging(ctx,
 		sc.Logging.LogFilePath,
 		sc.Logging.Console,
@@ -1315,6 +1323,7 @@ func (sc *StartupConfig) SetupAndValidateLogging(ctx context.Context) (err error
 		sc.Logging.Trace,
 		sc.Logging.Stats,
 		sc.Logging.Audit,
+		auditLoggingFields,
 	)
 }
 

--- a/rest/config_no_race_test.go
+++ b/rest/config_no_race_test.go
@@ -11,10 +11,14 @@
 package rest
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+
+	"github.com/stretchr/testify/require"
 )
 
 // AssertLogContains can hit the race detector due to swapping the global loggers
@@ -31,4 +35,87 @@ func TestBadCORSValuesConfig(t *testing.T) {
 	base.AssertLogContains(t, "cors.origin contains values", func() {
 		rt.CreateDatabase("db", dbConfig)
 	})
+}
+
+// TestAuditLoggingGlobals modifies all the global loggers
+func TestAuditLoggingGlobals(t *testing.T) {
+	globalFields := map[string]any{
+		"global":  "field",
+		"global2": "field2",
+	}
+
+	globalEnvVarName := "SG_TEST_GLOBAL_AUDIT_LOGGING"
+
+	testCases := []struct {
+		name              string
+		globalAuditEvents *string
+		startupErrorMsg   string
+	}{
+		{
+			name: "no global fields",
+		},
+		{
+			name:              "with global fields",
+			globalAuditEvents: base.StringPtr(string(base.MustJSONMarshal(t, globalFields))),
+		},
+		{
+			name:              "invalid json",
+			globalAuditEvents: base.StringPtr(`notjson`),
+			startupErrorMsg:   "Unable to unmarshal",
+		},
+		{
+			name:              "empty env var",
+			globalAuditEvents: base.StringPtr(""),
+			startupErrorMsg:   "Unable to unmarshal",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			base.ResetGlobalTestLogging(t)
+			base.InitializeMemoryLoggers()
+			ctx := base.TestCtx(t)
+			if testCase.globalAuditEvents != nil {
+				require.NoError(t, os.Setenv(globalEnvVarName, *testCase.globalAuditEvents))
+				defer func() {
+					require.NoError(t, os.Unsetenv(globalEnvVarName))
+				}()
+			} else {
+				require.NoError(t, os.Unsetenv(globalEnvVarName))
+			}
+			startupConfig := DefaultStartupConfig("")
+			startupConfig.Logging = base.LoggingConfig{
+				LogFilePath: t.TempDir(),
+				Audit: &base.AuditLoggerConfig{
+					FileLoggerConfig: base.FileLoggerConfig{
+						Enabled: base.BoolPtr(true),
+					},
+				},
+			}
+			if testCase.globalAuditEvents != nil {
+				startupConfig.Unsupported.AuditInfoProvider = &AuditInfoProviderConfig{
+					GlobalInfoEnvVarName: base.StringPtr(globalEnvVarName),
+				}
+			}
+			err := startupConfig.SetupAndValidateLogging(ctx)
+			if testCase.startupErrorMsg != "" {
+				require.ErrorContains(t, err, testCase.startupErrorMsg)
+				return
+			}
+			require.NoError(t, err)
+			output := base.AuditLogContents(t, func() {
+				base.Audit(ctx, base.AuditIDPublicUserAuthenticated, map[string]any{"method": "basic"})
+			})
+			var event map[string]any
+			require.NoError(t, json.Unmarshal(output, &event))
+			require.Contains(t, event, "method")
+			for k, v := range globalFields {
+				if testCase.globalAuditEvents != nil {
+					require.Equal(t, v, event[k])
+				} else {
+					require.NotContains(t, event, k)
+				}
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
I tried to imagine if there was a more performanant way to accomplish this, but I didn't come up with anything obvious - the other alternative was to marshal the "real" output and then reconstruct the string with the new marshalled field. With 1 or 2 fields in the marshalled struct this wasn't faster in my experiments.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

