### PR TITLE
CBG-3966: [3.1.9 backport] fix incorrect runtime config after conflict error on collection update

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -627,7 +627,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		if err = base.DeepCopyInefficient(&tmpConfig, bucketDbConfig); err != nil {
 			return nil, err
 		}
-		tmpConfig.cfgCas = bucketDbConfig.cfgCas
+
 		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 		bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
 		if err := tmpConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -149,7 +149,7 @@ func (h *handler) handleCreateDB() error {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket using bootstrap credentials: %s", bucket)
 			} else if errors.Is(err, base.ErrAlreadyExists) {
 				// on-demand config load if someone else beat us to db creation
-				if _, err := h.server._fetchAndLoadDatabase(contextNoCancel, dbName); err != nil {
+				if _, err := h.server._fetchAndLoadDatabase(contextNoCancel, dbName, false); err != nil {
 					base.WarnfCtx(h.ctx(), "Couldn't load database after conflicting create: %v", err)
 				}
 				return base.HTTPErrorf(http.StatusPreconditionFailed, // what CouchDB returns
@@ -628,6 +628,9 @@ func (h *handler) handlePutDbConfig() (err error) {
 			return nil, err
 		}
 
+		// we need to set the new dbConfig cfgCas to the old version to avoid the background task polling server for config changes from reloading a
+		// previous persisted config during the update dbConfig process
+		tmpConfig.cfgCas = bucketDbConfig.cfgCas
 		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 		bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
 		if err := tmpConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
@@ -644,7 +647,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 	if err != nil {
 		base.WarnfCtx(h.ctx(), "Couldn't update config for database - rolling back: %v", err)
 		// failed to start the new database config - rollback and return the original error for the user
-		if _, err := h.server.fetchAndLoadDatabase(contextNoCancel, dbName); err != nil {
+		// pass forceReload flag down stack to reset the cas to force the reload of the previous config from the bucket
+		if _, err := h.server.fetchAndLoadDatabase(contextNoCancel, dbName, true); err != nil {
 			base.WarnfCtx(h.ctx(), "got error rolling back database %q after failed update: %v", base.UD(dbName), err)
 		}
 		return err

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -989,6 +989,9 @@ func TestCollectionStats(t *testing.T) {
 //   - Get conflict error on collection update and assert that the runtime config rolls back to the old config for
 //     database db1
 func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
 	base.TestRequiresCollections(t)
 
 	ctx := base.TestCtx(t)
@@ -1058,6 +1061,9 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 //   - Fetch runtime config and assert the scope config matches what we expect
 //   - Assert we can perform crud operations against each collection 1 and 2
 func TestRaceBetweenConfigPollAndDbConfigUpdate(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	base.TestRequiresCollections(t)
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1506,18 +1506,22 @@ func (sc *ServerContext) fetchAndLoadDatabaseSince(ctx context.Context, dbName s
 	return found, nil
 }
 
-func (sc *ServerContext) fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string) (found bool, err error) {
+func (sc *ServerContext) fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string, forceReload bool) (found bool, err error) {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
-	return sc._fetchAndLoadDatabase(nonContextStruct, dbName)
+	return sc._fetchAndLoadDatabase(nonContextStruct, dbName, forceReload)
 }
 
 // _fetchAndLoadDatabase will attempt to find the given database name first in a matching bucket name,
 // but then fall back to searching through configs in each bucket to try and find a config.
-func (sc *ServerContext) _fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string) (found bool, err error) {
+func (sc *ServerContext) _fetchAndLoadDatabase(nonContextStruct base.NonCancellableContext, dbName string, forceReload bool) (found bool, err error) {
 	found, dbConfig, err := sc._fetchDatabase(nonContextStruct.Ctx, dbName)
 	if err != nil || !found {
 		return false, err
+	}
+	if forceReload {
+		// setting the config cas to 0 will force the reload of the config from the further down stack
+		dbConfig.cfgCas = 0
 	}
 	sc._applyConfigs(nonContextStruct.Ctx, map[string]DatabaseConfig{dbName: *dbConfig}, false)
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -270,7 +270,7 @@ func (sc *ServerContext) GetInactiveDatabase(ctx context.Context, name string) (
 			dbConfigFound, _ = sc.fetchAndLoadDatabaseSince(ctx, name, sc.Config.Unsupported.Serverless.MinConfigFetchInterval)
 
 		} else {
-			dbConfigFound, _ = sc.fetchAndLoadDatabase(base.NewNonCancelCtx(), name)
+			dbConfigFound, _ = sc.fetchAndLoadDatabase(base.NewNonCancelCtx(), name, false)
 		}
 		if dbConfigFound {
 			sc.lock.RLock()


### PR DESCRIPTION
CBG-3966 + CBG-4022

Cherry pick of [CBG-3817](https://issues.couchbase.com/browse/CBG-3817) then follow up of [CBG-3994](https://issues.couchbase.com/browse/CBG-3994)


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2543/
