### PR TITLE
CBG-4053: bump go version to 1.22.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.4
       - name: go-build
         run: go build "./..."
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.4
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.4
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.4
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.4
       - name: Run Tests
         run: go test -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.2
+          go-version: 1.22.4
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.22.5
       - name: go-build
         run: go build "./..."
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.22.5
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.22.5
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.22.5
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.22.5
       - name: Run Tests
         run: go test -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.4
+          go-version: 1.22.5
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
 
     tools {
-        go '1.22.4'
+        go '1.22.5'
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
 
     tools {
-        go '1.22.2'
+        go '1.22.4'
     }
 
     stages {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.21
+go 1.22
 
 require (
 	dario.cat/mergo v1.0.0

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.22.4",
+            "go_version": "1.22.5",
             "trigger_blackduck": true,
             "start_build": 320
         },
@@ -454,7 +454,7 @@
             "release_name": "Couchbase Sync Gateway 3.1.9",
             "production": true,
             "interval": 120,
-            "go_version": "1.22.4",
+            "go_version": "1.22.5",
             "trigger_blackduck": true,
             "start_build": 1
         },

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.22.2",
+            "go_version": "1.22.4",
             "trigger_blackduck": true,
             "start_build": 320
         },

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -454,7 +454,7 @@
             "release_name": "Couchbase Sync Gateway 3.1.9",
             "production": true,
             "interval": 120,
-            "go_version": "1.21.8",
+            "go_version": "1.22.4",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
CBG-4053

Bumping go version to 1.22.4


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
