### PR TITLE
[3.1.9] bump ci go for slices package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.59.0
+          version: v1.54.2
           args: --config=.golangci-strict.yml --timeout=3m
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.21.8
       - uses: actions/checkout@v3
       - name: go-build
         run: go build "./..."
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.21.8
       - run: go install github.com/google/addlicense@latest
       - uses: actions/checkout@v3
       - run: addlicense -check -f licenses/addlicense.tmpl .
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.21.8
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.21.8
       - uses: actions/checkout@v3
       - name: Build
         run: go build -v "./..."
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.21.8
       - uses: actions/checkout@v3
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.59.0
           args: --config=.golangci-strict.yml --timeout=3m
   test:
     runs-on: ${{ matrix.os }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
 
     tools {
-        go '1.19.5'
+        go '1.21.8'
     }
 
     stages {


### PR DESCRIPTION

- Bumping CI version to the current go version ion this particular branch so CI can run on skipped sequence enhancements.
- Doing temporarily so we don't have to stop with backports till the new go version 1.22.5 on Tuesday. 


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
