### PR TITLE
CBG-3953: [3.1.9 backport] Avoid timeout on creating indexes asynchronously

### DIFF
--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -62,7 +62,7 @@ func TestN1qlQuery(t *testing.T) {
 	}
 
 	// Wait for index readiness
-	onlineErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_value"}, false)
+	onlineErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_value"}, WaitForIndexesDefault)
 	if onlineErr != nil {
 		t.Fatalf("Error waiting for index to come online: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestN1qlQuery(t *testing.T) {
 		}
 	}()
 
-	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_value"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_value"}, WaitForIndexesDefault)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Query the index
@@ -172,7 +172,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 	}
 
 	// Wait for index readiness
-	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_filtered_value"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_filtered_value"}, WaitForIndexesDefault)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -245,7 +245,7 @@ func TestIndexMeta(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_value"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_value"}, WaitForIndexesDefault)
 	require.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -299,7 +299,7 @@ func TestMalformedN1qlQuery(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_value_malformed"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_value_malformed"}, WaitForIndexesDefault)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
@@ -363,7 +363,7 @@ func TestCreateAndDropIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating index: %s", err)
 	}
-	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_sequence"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{"testIndex_sequence"}, WaitForIndexesDefault)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Drop the index
@@ -395,7 +395,7 @@ func TestCreateDuplicateIndex(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{"testIndexDuplicateSequence"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{"testIndexDuplicateSequence"}, WaitForIndexesDefault)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Attempt to create duplicate, validate duplicate error
@@ -431,7 +431,7 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 		t.Fatalf("Error creating index: %s", err)
 	}
 
-	readyErr := n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{"testIndex-sequence"}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{"testIndex-sequence"}, WaitForIndexesDefault)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Drop the index
@@ -482,7 +482,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 	buildErr := buildIndexes(ctx, n1qlStore, []string{indexName})
 	assert.NoError(t, buildErr, "Error building indexes")
 
-	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{indexName}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(ctx, []string{indexName}, WaitForIndexesDefault)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 }
@@ -543,9 +543,9 @@ func TestBuildDeferredIndexes(t *testing.T) {
 	buildErr := n1qlStore.BuildDeferredIndexes(TestCtx(t), []string{deferredIndexName, nonDeferredIndexName})
 	assert.NoError(t, buildErr, "Error building indexes")
 
-	readyErr := n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{deferredIndexName}, false)
+	readyErr := n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{deferredIndexName}, WaitForIndexesDefault)
 	assert.NoError(t, readyErr, "Error validating index online")
-	readyErr = n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{nonDeferredIndexName}, false)
+	readyErr = n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{nonDeferredIndexName}, WaitForIndexesDefault)
 	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Ensure no errors from no-op scenarios
@@ -662,7 +662,7 @@ func TestWaitForBucketExistence(t *testing.T) {
 		err = n1qlStore.CreateIndex(ctx, indexName, expression, filterExpression, options)
 		assert.NoError(t, err, "Index should be created in the bucket")
 	}()
-	assert.NoError(t, n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{indexName}, false))
+	assert.NoError(t, n1qlStore.WaitForIndexesOnline(TestCtx(t), []string{indexName}, WaitForIndexesDefault))
 
 	// Drop the index;
 	err := n1qlStore.DropIndex(ctx, indexName)

--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -188,8 +188,18 @@ func (cl *ClusterOnlyN1QLStore) runQuery(statement string, n1qlOptions *gocb.Que
 	return queryResults, err
 }
 
-func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error {
-	return WaitForIndexesOnline(ctx, cl.cluster, cl.bucketName, cl.scopeName, cl.collectionName, indexNames, failfast)
+func (cl *ClusterOnlyN1QLStore) indexManager(scopeName, collectionName string) *indexManager {
+	return &indexManager{
+		cluster:        cl.cluster.QueryIndexes(),
+		bucketName:     cl.bucketName,
+		scopeName:      scopeName,
+		collectionName: collectionName,
+	}
+}
+
+func (cl *ClusterOnlyN1QLStore) WaitForIndexesOnline(ctx context.Context, indexNames []string, option WaitForIndexesOnlineOption) error {
+	keyspace := strings.Join([]string{cl.bucketName, cl.scopeName, cl.collectionName}, ".")
+	return WaitForIndexesOnline(ctx, keyspace, cl.indexManager(cl.scopeName, cl.collectionName), indexNames, option)
 }
 
 func (cl *ClusterOnlyN1QLStore) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -123,8 +123,10 @@ func (c *Collection) CreatePrimaryIndex(ctx context.Context, indexName string, o
 	return CreatePrimaryIndex(ctx, c, indexName, options)
 }
 
-func (c *Collection) WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error {
-	return WaitForIndexesOnline(ctx, c.Bucket.cluster, c.BucketName(), c.ScopeName(), c.CollectionName(), indexNames, failfast)
+// WaitForIndexesOnline takes set of indexes and watches them till they're online.
+func (c *Collection) WaitForIndexesOnline(ctx context.Context, indexNames []string, option WaitForIndexesOnlineOption) error {
+	keyspace := strings.Join([]string{c.BucketName(), c.ScopeName(), c.CollectionName()}, ".")
+	return WaitForIndexesOnline(ctx, keyspace, c.indexManager(), indexNames, option)
 }
 
 func (c *Collection) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -62,6 +62,20 @@ func (c *Collection) BucketName() string {
 	return c.Bucket.GetName()
 }
 
+func (c *Collection) indexManager() *indexManager {
+	m := &indexManager{
+		bucketName:     c.BucketName(),
+		collectionName: c.CollectionName(),
+		scopeName:      c.ScopeName(),
+	}
+	if !c.IsSupported(sgbucket.BucketStoreFeatureCollections) {
+		m.cluster = c.Bucket.cluster.QueryIndexes()
+	} else {
+		m.collection = c.Collection.QueryIndexes()
+	}
+	return m
+}
+
 // IndexMetaKeyspaceID returns the value of keyspace_id for the system:indexes table for the collection.
 func (c *Collection) IndexMetaKeyspaceID() string {
 	return IndexMetaKeyspaceID(c.BucketName(), c.ScopeName(), c.CollectionName())

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -35,6 +35,18 @@ const (
 	RequestPlus = ConsistencyMode(2)
 )
 
+type WaitForIndexesOnlineOption int8
+
+const (
+	// WaitForIndexesDefault will wait a standard amount of time for indexes to come online
+	WaitForIndexesDefault WaitForIndexesOnlineOption = iota
+
+	// WaitForIndexesFailfast will fail immediately if the indexes are not online
+	WaitForIndexesFailfast
+	// WaitForIndexesInfinite will wait an indefinite amount of time for indexes to come online, or until the context is cancelled.
+	WaitForIndexesInfinite
+)
+
 // N1QLStore defines the set of operations Sync Gateway uses to manage and interact with N1QL
 type N1QLStore interface {
 	GetName() string
@@ -51,7 +63,7 @@ type N1QLStore interface {
 	IndexMetaScopeID() string
 	IndexMetaKeyspaceID() string
 	BucketName() string
-	WaitForIndexesOnline(ctx context.Context, indexNames []string, failfast bool) error
+	WaitForIndexesOnline(ctx context.Context, indexNames []string, option WaitForIndexesOnlineOption) error
 
 	// executeQuery performs the specified query without any built-in retry handling and returns the resultset
 	executeQuery(statement string) (sgbucket.QueryResultIterator, error)
@@ -239,13 +251,10 @@ func buildIndexes(ctx context.Context, s N1QLStore, indexNames []string) error {
 	buildStatement := fmt.Sprintf("BUILD INDEX ON %s(%s)", s.EscapedKeyspace(), indexNameList)
 	err := s.executeStatement(buildStatement)
 
-	// If indexer reports build will be completed in the background, wait to validate build actually happens.
 	if IsIndexerRetryBuildError(err) {
-		InfofCtx(ctx, KeyQuery, "Indexer error creating index - waiting for background build.  Error:%v", err)
-		// Wait for bucket to be created in background before returning
-		return s.WaitForIndexesOnline(ctx, indexNames, false)
+		InfofCtx(ctx, KeyQuery, "Indexer returned error that will be automatically retried by the index service - waiting for that to complete. Error:%v", err)
+		return nil
 	}
-
 	return err
 }
 
@@ -518,29 +527,28 @@ func IndexMetaKeyspaceID(bucketName, scopeName, collectionName string) string {
 }
 
 // WaitForIndexesOnline takes set of indexes and watches them till they're online.
-func WaitForIndexesOnline(ctx context.Context, cluster *gocb.Cluster, bucketName, scopeName, collectionName string, indexNames []string, failfast bool) error {
-	mgr := cluster.QueryIndexes()
-	maxNumAttempts := 180
-	if failfast {
-		maxNumAttempts = 1
+func WaitForIndexesOnline(ctx context.Context, keyspace string, mgr *indexManager, indexNames []string, waitOption WaitForIndexesOnlineOption) error {
+	var retrySleeper RetrySleeper
+	initialWaitTime := 100
+	maxSleepTime := 5000
+	switch waitOption {
+	case WaitForIndexesDefault:
+		retrySleeper = CreateMaxDoublingSleeperFunc(180, initialWaitTime, maxSleepTime)
+	case WaitForIndexesFailfast:
+		retrySleeper = CreateFastFailRetrySleeperFunc()
+	case WaitForIndexesInfinite:
+		retrySleeper = CreateIndefiniteMaxDoublingSleeperFunc(initialWaitTime, maxSleepTime)
+	default:
+		return fmt.Errorf("Invalid WaitForIndexesOnlineOption: %d", waitOption)
 	}
-	retrySleeper := CreateMaxDoublingSleeperFunc(maxNumAttempts, 100, 5000)
-	retryCount := 0
 
 	onlineIndexes := make(map[string]bool)
 
-	indexOption := gocb.GetAllQueryIndexesOptions{
-		ScopeName:      scopeName,
-		CollectionName: collectionName,
-		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
-	}
-
-	startTime := time.Now()
-	for {
+	err, _ := RetryLoop(ctx, "WaitForIndexesOnline", func() (shouldRetry bool, err error, _ any) {
 		watchedOnlineIndexCount := 0
 		currIndexes, err := mgr.GetAllIndexes(bucketName, &indexOption)
 		if err != nil {
-			return err
+			return false, err, nil
 		}
 		// check each of the current indexes state, add to map once finished to make sure each index online is only being logged once
 		for i := 0; i < len(currIndexes); i++ {
@@ -564,17 +572,12 @@ func WaitForIndexesOnline(ctx context.Context, cluster *gocb.Cluster, bucketName
 		}
 
 		if watchedOnlineIndexCount == len(indexNames) {
-			return nil
-		}
-		retryCount++
-		shouldContinue, sleepMs := retrySleeper(retryCount)
-		if !shouldContinue {
-			keyspace := strings.Join([]string{bucketName, scopeName, collectionName}, ".")
-			return fmt.Errorf("Waiting for indexes in %q timed out after %s minutes. The following indexes are still offline: %s ...", MD(keyspace), time.Since(startTime)*time.Minute, strings.Join(offlineIndexes, ", "))
+			return false, nil, nil
 		}
 		InfofCtx(ctx, KeyAll, "Indexes %s not ready - retrying...", strings.Join(offlineIndexes, ", "))
-		time.Sleep(time.Millisecond * time.Duration(sleepMs))
-	}
+		return true, nil, nil
+	}, retrySleeper)
+	return err
 }
 
 func GetAllIndexes(cluster *gocb.Cluster, bucketName, scopeName, collectionName string) (indexes []string, err error) {

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 )
@@ -27,7 +26,7 @@ type LeakyDataStore struct {
 var (
 	_ DataStore         = &LeakyDataStore{}
 	_ WrappingDatastore = &LeakyDataStore{}
-	_ N1QLStore         = &LeakyDataStore{}
+	// _ N1QLStore = &LeakyDataStore{} // TODO: Not implemented
 )
 
 func NewLeakyDataStore(bucket *LeakyBucket, dataStore DataStore, config *LeakyBucketConfig) *LeakyDataStore {
@@ -42,10 +41,6 @@ func NewLeakyDataStore(bucket *LeakyBucket, dataStore DataStore, config *LeakyBu
 func AsLeakyDataStore(ds DataStore) (*LeakyDataStore, bool) {
 	lds, ok := ds.(*LeakyDataStore)
 	return lds, ok
-}
-
-func (lds *LeakyDataStore) BucketName() string {
-	return lds.bucket.GetName()
 }
 
 func (lds *LeakyDataStore) GetUnderlyingDataStore() DataStore {
@@ -326,170 +321,3 @@ func (lds *LeakyDataStore) IsError(err error, errorType sgbucket.DataStoreErrorT
 func (lds *LeakyDataStore) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 	return lds.dataStore.IsSupported(feature)
 }
-
-func (lds *LeakyDataStore) GetSpec() BucketSpec {
-	if b, ok := AsCouchbaseBucketStore(lds.bucket); ok {
-		return b.GetSpec()
-	} else {
-		// Return a minimal struct:
-		return BucketSpec{
-			BucketName: lds.bucket.GetName(),
-			UseXattrs:  true,
-		}
-	}
-}
-
-// getN1QLStore abstracts getting an N1QLStore from the underlying DataStore.
-func (lds *LeakyDataStore) getN1QLStore() (N1QLStore, error) {
-	// rosmar doesn't implement N1QLStore
-	n1qlStore, ok := AsN1QLStore(lds.dataStore)
-	if !ok {
-		return nil, fmt.Errorf("bucket %T does not support N1QL", lds.dataStore)
-	}
-	return n1qlStore, nil
-}
-func (lds *LeakyDataStore) BuildDeferredIndexes(ctx context.Context, indexSet []string) error {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return err
-	}
-	return n1qlStore.BuildDeferredIndexes(ctx, indexSet)
-}
-
-func (lds *LeakyDataStore) CreateIndex(ctx context.Context, indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return err
-	}
-	return n1qlStore.CreateIndex(ctx, indexName, expression, filterExpression, options)
-}
-
-func (lds *LeakyDataStore) CreatePrimaryIndex(ctx context.Context, indexName string, options *N1qlIndexOptions) error {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return err
-	}
-	return n1qlStore.CreatePrimaryIndex(ctx, indexName, options)
-}
-
-func (lds *LeakyDataStore) DropIndex(ctx context.Context, indexName string) error {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return err
-	}
-	return n1qlStore.DropIndex(ctx, indexName)
-}
-
-func (lds *LeakyDataStore) ExplainQuery(ctx context.Context, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return nil, err
-	}
-	return n1qlStore.ExplainQuery(ctx, statement, params)
-}
-
-func (lds *LeakyDataStore) EscapedKeyspace() string {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return fmt.Sprintf("Calling LeakyDataStore.EscapedKeyspace is not supported: %s", err.Error())
-	}
-	return n1qlStore.EscapedKeyspace()
-}
-
-func (lds *LeakyDataStore) GetIndexMeta(ctx context.Context, indexName string) (exists bool, meta *IndexMeta, err error) {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return false, nil, err
-	}
-	return n1qlStore.GetIndexMeta(ctx, indexName)
-}
-
-func (lds *LeakyDataStore) Query(ctx context.Context, statement string, params map[string]interface{}, consistency ConsistencyMode, adhoc bool) (results sgbucket.QueryResultIterator, err error) {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return nil, err
-	}
-	iterator, err := n1qlStore.Query(ctx, statement, params, consistency, adhoc)
-
-	if lds.config.PostN1QLQueryCallback != nil {
-		lds.config.PostN1QLQueryCallback()
-	}
-	return iterator, err
-}
-
-func (lds *LeakyDataStore) IsErrNoResults(err error) bool {
-	n1qlStore, getN1QLStoreErr := lds.getN1QLStore()
-	if getN1QLStoreErr != nil {
-		return false
-	}
-	return n1qlStore.IsErrNoResults(err)
-}
-
-func (lds *LeakyDataStore) IndexMetaBucketID() string {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return fmt.Sprintf("Calling LeakyDataStore.IndexMetaBucketID is not supported: %s", err.Error())
-	}
-	return n1qlStore.IndexMetaBucketID()
-}
-
-func (lds *LeakyDataStore) IndexMetaScopeID() string {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return fmt.Sprintf("Calling LeakyDataStore.IndexMetaScopeID is not supported: %s", err.Error())
-	}
-	return n1qlStore.IndexMetaScopeID()
-}
-
-func (lds *LeakyDataStore) IndexMetaKeyspaceID() string {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return fmt.Sprintf("Calling LeakyDataStore.IndexMetaKeyspaceID is not supported: %s", err.Error())
-	}
-	return n1qlStore.IndexMetaKeyspaceID()
-}
-
-func (lds *LeakyDataStore) WaitForIndexesOnline(ctx context.Context, indexNames []string, option WaitForIndexesOnlineOption) error {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return err
-	}
-	return n1qlStore.WaitForIndexesOnline(ctx, indexNames, option)
-}
-
-func (lds *LeakyDataStore) executeQuery(statement string) (sgbucket.QueryResultIterator, error) {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return nil, err
-	}
-	return n1qlStore.executeQuery(statement)
-}
-
-func (lds *LeakyDataStore) executeStatement(statement string) error {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return err
-	}
-	return n1qlStore.executeStatement(statement)
-}
-
-func (lds *LeakyDataStore) waitUntilQueryServiceReady(timeout time.Duration) error {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return err
-	}
-	return n1qlStore.waitUntilQueryServiceReady(timeout)
-}
-
-func (lds *LeakyDataStore) GetIndexes() (indexes []string, err error) {
-	n1qlStore, err := lds.getN1QLStore()
-	if err != nil {
-		return nil, err
-	}
-	return n1qlStore.GetIndexes()
-}
-
-// Assert interface compliance:
-var (
-	_ sgbucket.DataStore = &LeakyDataStore{}
-)

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 )
@@ -26,7 +27,7 @@ type LeakyDataStore struct {
 var (
 	_ DataStore         = &LeakyDataStore{}
 	_ WrappingDatastore = &LeakyDataStore{}
-	// _ N1QLStore = &LeakyDataStore{} // TODO: Not implemented
+	_ N1QLStore         = &LeakyDataStore{}
 )
 
 func NewLeakyDataStore(bucket *LeakyBucket, dataStore DataStore, config *LeakyBucketConfig) *LeakyDataStore {
@@ -41,6 +42,10 @@ func NewLeakyDataStore(bucket *LeakyBucket, dataStore DataStore, config *LeakyBu
 func AsLeakyDataStore(ds DataStore) (*LeakyDataStore, bool) {
 	lds, ok := ds.(*LeakyDataStore)
 	return lds, ok
+}
+
+func (lds *LeakyDataStore) BucketName() string {
+	return lds.bucket.GetName()
 }
 
 func (lds *LeakyDataStore) GetUnderlyingDataStore() DataStore {
@@ -320,19 +325,6 @@ func (lds *LeakyDataStore) IsError(err error, errorType sgbucket.DataStoreErrorT
 
 func (lds *LeakyDataStore) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 	return lds.dataStore.IsSupported(feature)
-}
-
-func (lds *LeakyDataStore) UpdateXattrs(ctx context.Context, k string, exp uint32, cas uint64, xv map[string][]byte, opts *sgbucket.MutateInOptions) (casOut uint64, err error) {
-	return lds.dataStore.UpdateXattrs(ctx, k, exp, cas, xv, opts)
-}
-
-func (lds *LeakyDataStore) WriteTombstoneWithXattrs(ctx context.Context, k string, exp uint32, cas uint64, xv map[string][]byte, xattrsToDelete []string, deleteBody bool, opts *sgbucket.MutateInOptions) (casOut uint64, err error) {
-	return lds.dataStore.WriteTombstoneWithXattrs(ctx, k, exp, cas, xv, xattrsToDelete, deleteBody, opts)
-
-}
-
-func (lds *LeakyDataStore) WriteResurrectionWithXattrs(ctx context.Context, k string, exp uint32, body []byte, xv map[string][]byte, opts *sgbucket.MutateInOptions) (casOut uint64, err error) {
-	return lds.dataStore.WriteResurrectionWithXattrs(ctx, k, exp, body, xv, opts)
 }
 
 func (lds *LeakyDataStore) GetSpec() BucketSpec {

--- a/base/util.go
+++ b/base/util.go
@@ -466,7 +466,13 @@ func RetryLoop(ctx context.Context, description string, worker RetryWorker, slee
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("Retry loop for %v closed based on context", description), nil
+			verb := "closed"
+			if errors.Is(ctx.Err(), context.Canceled) {
+				verb = "canceled"
+			} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				verb = "timed out"
+			}
+			return fmt.Errorf("Retry loop for %v %s based on context", description, verb), nil
 		case <-time.After(time.Millisecond * time.Duration(sleepMs)):
 		}
 
@@ -608,6 +614,13 @@ func CreateIndefiniteMaxDoublingSleeperFunc(initialTimeToSleepMs int, maxSleepPe
 	}
 
 	return sleeper
+}
+
+// CreateFastFailRetrySleeperFunc returns a retry sleeper that will not retry.
+func CreateFastFailRetrySleeperFunc() RetrySleeper {
+	return func(retryCount int) (bool, int) {
+		return false, -1
+	}
 }
 
 // SortedUint64Slice attaches the methods of sort.Interface to []uint64, sorting in increasing order.

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -375,10 +375,10 @@ func initializePrincipalDocsIndex(ctx context.Context, db *Database) error {
 		return errors.New("Cannot create indexes on non-Couchbase data store.")
 	}
 	options := InitializeIndexOptions{
-		FailFast:        false,
-		NumReplicas:     db.Options.NumIndexReplicas,
-		MetadataIndexes: IndexesPrincipalOnly,
-		UseXattrs:       db.UseXattrs(),
+		WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+		NumReplicas:                db.Options.NumIndexReplicas,
+		MetadataIndexes:            IndexesPrincipalOnly,
+		UseXattrs:                  db.UseXattrs(),
 	}
 
 	return InitializeIndexes(ctx, n1qlStore, options)

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -368,11 +368,11 @@ const (
 
 // InitializeIndexOptions are options used for building Sync Gateway indexes, or waiting for it to come online.
 type InitializeIndexOptions struct {
-	FailFast        bool                  // if set, don't wait for indexes to come online
-	NumReplicas     uint                  // number of indexer nodes for this index
-	MetadataIndexes CollectionIndexesType // indicate which indexes to create
-	Serverless      bool                  // if true, create indexes for serverless
-	UseXattrs       bool                  // if true, create indexes on xattrs, otherwise, use inline sync data
+	WaitForIndexesOnlineOption base.WaitForIndexesOnlineOption // how long to wait for indexes to become online
+	NumReplicas                uint                            // number of indexer nodes for this index
+	MetadataIndexes            CollectionIndexesType           // indicate which indexes to create
+	Serverless                 bool                            // if true, create indexes for serverless
+	UseXattrs                  bool                            // if true, create indexes on xattrs, otherwise, use inline sync data
 }
 
 // Initializes Sync Gateway indexes for bucket.  Creates required indexes if not found, then waits for index readiness.
@@ -427,7 +427,7 @@ func waitForIndexes(ctx context.Context, bucket base.N1QLStore, options Initiali
 		indexes = append(indexes, fullIndexName)
 	}
 
-	err := bucket.WaitForIndexesOnline(ctx, indexes, options.FailFast)
+	err := bucket.WaitForIndexesOnline(ctx, indexes, options.WaitForIndexesOnlineOption)
 	if err != nil {
 		return err
 	}

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -75,7 +75,6 @@ func TestInitializeIndexes(t *testing.T) {
 			// drop and restore indexes between tests, to the way the bucket pool would
 			defer func() {
 				options := InitializeIndexOptions{
-					FailFast:    false,
 					NumReplicas: 0,
 					Serverless:  db.IsServerless(),
 					UseXattrs:   base.TestUseXattrs(),
@@ -90,7 +89,6 @@ func TestInitializeIndexes(t *testing.T) {
 
 			// add and drop indexes that may be different from the way the bucket pool expects, so use specific options here for test
 			xattrSpecificIndexOptions := InitializeIndexOptions{
-				FailFast:    false,
 				NumReplicas: 0,
 				Serverless:  db.IsServerless(),
 				UseXattrs:   test.xattrs,
@@ -126,7 +124,6 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 
 	// construct indexes as the test expects
 	options := InitializeIndexOptions{
-		FailFast:    false,
 		NumReplicas: 0,
 		Serverless:  db.IsServerless(),
 		UseXattrs:   db.UseXattrs(),
@@ -187,7 +184,6 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	defer func() {
 		// Restore indexes after test
 		options := InitializeIndexOptions{
-			FailFast:    false,
 			NumReplicas: 0,
 			Serverless:  db.IsServerless(),
 			UseXattrs:   db.UseXattrs(),
@@ -252,7 +248,6 @@ func TestPostUpgradeMultipleCollections(t *testing.T) {
 	}
 	useXattrs := false
 	options := InitializeIndexOptions{
-		FailFast:    false,
 		NumReplicas: 0,
 		Serverless:  false,
 		UseXattrs:   useXattrs,
@@ -315,7 +310,6 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 		err = InitializeViews(ctx, collection.dataStore)
 		assert.NoError(t, err)
 		options := InitializeIndexOptions{
-			FailFast:    false,
 			NumReplicas: 0,
 			Serverless:  db.IsServerless(),
 			UseXattrs:   base.TestUseXattrs(),
@@ -336,7 +330,6 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, err)
 
 	options := InitializeIndexOptions{
-		FailFast:    false,
 		NumReplicas: 0,
 		Serverless:  db.IsServerless(),
 		UseXattrs:   db.UseXattrs(),

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -423,7 +423,6 @@ func setupN1QLStore(ctx context.Context, bucket base.Bucket, isServerless bool) 
 		}
 
 		options := db.InitializeIndexOptions{
-			FailFast:    false,
 			NumReplicas: 0,
 			Serverless:  isServerless,
 			UseXattrs:   base.TestUseXattrs(),
@@ -445,7 +444,6 @@ var clearIndexes resetN1QLStoreFn = func(n1QLStores []base.N1QLStore, isServerle
 	options := db.InitializeIndexOptions{
 		UseXattrs:       base.TestUseXattrs(),
 		NumReplicas:     0,
-		FailFast:        false,
 		Serverless:      isServerless,
 		MetadataIndexes: db.IndexesAll,
 	}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -366,11 +366,11 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 		}
 		tbp.Logf(ctx, "creating SG bucket indexes")
 		options := InitializeIndexOptions{
-			UseXattrs:       base.TestUseXattrs(),
-			NumReplicas:     0,
-			FailFast:        false,
-			Serverless:      false,
-			MetadataIndexes: IndexesWithoutMetadata,
+			UseXattrs:                  base.TestUseXattrs(),
+			NumReplicas:                0,
+			WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+			Serverless:                 false,
+			MetadataIndexes:            IndexesWithoutMetadata,
 		}
 		dsName, ok := base.AsDataStoreName(dataStore)
 		if !ok {

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -523,7 +523,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	idxName := t.Name() + "_primary"
 	ctx := base.TestCtx(t)
 	require.NoError(t, n1qlStore.CreatePrimaryIndex(ctx, idxName, nil))
-	require.NoError(t, n1qlStore.WaitForIndexesOnline(ctx, []string{idxName}, false))
+	require.NoError(t, n1qlStore.WaitForIndexesOnline(ctx, []string{idxName}, base.WaitForIndexesDefault))
 
 	res, err := n1qlStore.Query(ctx, "SELECT keyspace_id, bucket_id, scope_id from system:indexes WHERE name = $idxName",
 		map[string]interface{}{"idxName": idxName}, base.RequestPlus, true)

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -130,10 +130,10 @@ func (m *DatabaseInitManager) BuildIndexOptions(startupConfig *StartupConfig, db
 		numReplicas = *dbConfig.NumIndexReplicas
 	}
 	return db.InitializeIndexOptions{
-		FailFast:    false,
-		NumReplicas: numReplicas,
-		Serverless:  startupConfig.IsServerless(),
-		UseXattrs:   dbConfig.UseXattrs(),
+		WaitForIndexesOnlineOption: base.WaitForIndexesInfinite,
+		NumReplicas:                numReplicas,
+		Serverless:                 startupConfig.IsServerless(),
+		UseXattrs:                  dbConfig.UseXattrs(),
 	}
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -706,11 +706,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 					return nil, errors.New("Cannot create indexes on non-Couchbase data store.")
 				}
 				options := db.InitializeIndexOptions{
-					FailFast:        false,
-					NumReplicas:     numReplicas,
-					Serverless:      sc.Config.IsServerless(),
-					MetadataIndexes: indexInfo.indexSet,
-					UseXattrs:       config.UseXattrs(),
+					WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
+					NumReplicas:                numReplicas,
+					Serverless:                 sc.Config.IsServerless(),
+					MetadataIndexes:            indexInfo.indexSet,
+					UseXattrs:                  config.UseXattrs(),
 				}
 				dsName, ok := base.AsDataStoreName(ds)
 				if !ok {


### PR DESCRIPTION
[CBG-3953](https://issues.couchbase.com/browse/CBG-3953)

- Review carefully, I had to add some missing code manually such as indexManager so should ensure I haven't missed things or added functionality not needed in 3.1.9

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2552/
