### PR TITLE
CBG-4054: update 3.1.9 branch go version to 1.22.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.22.5
       - uses: actions/checkout@v3
       - name: go-build
         run: go build "./..."
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.22.5
       - run: go install github.com/google/addlicense@latest
       - uses: actions/checkout@v3
       - run: addlicense -check -f licenses/addlicense.tmpl .
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.22.5
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.22.5
       - uses: actions/checkout@v3
       - name: Build
         run: go build -v "./..."
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.22.5
       - uses: actions/checkout@v3
       - name: Run Tests
         run: go test -race -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.59.0
           args: --config=.golangci-strict.yml --timeout=3m
   test:
     runs-on: ${{ matrix.os }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
 
     tools {
-        go '1.19.5'
+        go '1.22.5'
     }
 
     stages {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -446,7 +446,7 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	// Create the first revision of doc1.
 	rev1Body := Body{
 		"k1":       "v1",
-		"channels": append([]string{"ABC", "NBC"}),
+		"channels": []string{"ABC", "NBC"},
 	}
 	rev1ID, _, err := collection.Put(ctx, "doc1", rev1Body)
 	require.NoError(t, err, "Error creating doc")
@@ -540,7 +540,7 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 	// Create the first revision of doc1.
 	rev1Body := Body{
 		"k1":       "v1",
-		"channels": append([]string{"ABC", "NBC"}),
+		"channels": []string{"ABC", "NBC"},
 	}
 	rev1ID, _, err := collection.Put(ctx, "doc1", rev1Body)
 	require.NoError(t, err, "Error creating doc")
@@ -607,7 +607,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 	// Create the first revision of doc1.
 	rev1Body := Body{
 		"k1":       "v1",
-		"channels": append([]string{"ABC", "NBC"}),
+		"channels": []string{"ABC", "NBC"},
 	}
 	rev1ID, _, err := collection.Put(ctx, "doc1", rev1Body)
 	require.NoError(t, err, "Error creating doc")


### PR DESCRIPTION
CBG-4054

- Updates CI and Jenkins version to 1.22.5 
- Upgrades lint to match main 
- Fixes lint append issue to match what is on main in tests TestDeltaSyncWhenToRevIsChannelRemoval TestDeltaSyncWhenFromRevIsChannelRemoval TestGetRemovalMultiChannel


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
