### PR TITLE
CBG-4003 Revocation handling for deleted roles

### DIFF
--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -69,6 +69,7 @@ func (tester *ChannelRevocationTester) removeRole(user, role string) {
 	tester.roleVersion = tester.restTester.UpdateDoc("userRoles", tester.roleVersion, string(base.MustJSONMarshal(tester.test, tester.roles)))
 }
 
+// addRoleChannel grants a channel for the default collection to a role
 func (tester *ChannelRevocationTester) addRoleChannel(role, channel string) {
 	if tester.roleChannels.Channels == nil {
 		tester.roleChannels.Channels = map[string][]string{}
@@ -116,6 +117,7 @@ func (tester *ChannelRevocationTester) removeUserChannel(user string, channel st
 	tester.userChannelVersion = tester.restTester.UpdateDoc("userChannels", tester.userChannelVersion, string(base.MustJSONMarshal(tester.test, tester.userChannels)))
 }
 
+// fillToSeq writes filler documents (with empty bodies) for each sequence between the current db sequence and the requested sequence
 func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
 	ctx := base.DatabaseLogCtx(base.TestCtx(tester.test), tester.restTester.GetDatabase().Name, nil)
 	currentSeq, err := tester.restTester.GetDatabase().LastSequence(ctx)
@@ -2669,4 +2671,35 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	// Shutdown replicator to close out
 	require.NoError(t, ar.Stop())
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
+}
+
+func TestRevocationDeletedRole(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+	revocationTester, rt := InitScenario(t, nil)
+	defer rt.Close()
+
+	// Add a document in channel a
+	const docID = "doc"
+	_ = rt.PutDoc(docID, `{"channels": "a"}`)
+
+	// Grant role "foo" channel "a"
+	revocationTester.addRoleChannel(revocationTestRole, "a")
+
+	// Grant user "user" role "foo"
+	revocationTester.addRole(revocationTestUser, revocationTestRole)
+
+	// Expect two changes - pseudo-user doc and "doc"
+	changes := revocationTester.getChanges(0, 2)
+	require.Len(t, changes.Results, 2)
+	require.Equal(t, "doc", changes.Results[1].ID)
+
+	// Delete the role
+	resp := rt.SendAdminRequest("DELETE", fmt.Sprintf("/{{.db}}/_role/%s", revocationTestRole), "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	// Issue new changes request, confirm revocation for "doc"
+	changes = revocationTester.getChanges(changes.Last_Seq, 1)
+	assert.Len(t, changes.Results, 1)
+	assert.Equal(t, "doc", changes.Results[0].ID)
+	assert.True(t, changes.Results[0].Revoked)
 }

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1613,14 +1613,9 @@ func TestDeletedRoleChanHistory(t *testing.T) {
 			role, err := a.GetRole(roleName)
 			assert.NoError(t, err)
 			assert.NotNil(t, role)
-			if collection.IsDefaultCollection() {
-				assert.Len(t, role.Channels(), 2)
-				assert.True(t, role.Channels().Contains("channel"))
-			} else {
-				assert.Len(t, role.GetCollectionsAccess()[collection.ScopeName][collection.Name].Channels(), 2)
-				assert.True(t, role.GetCollectionsAccess()[collection.ScopeName][collection.Name].Channels().Contains("channel"))
-			}
-			t.Logf("role %#v", role)
+			channels := role.CollectionChannels(collection.ScopeName, collection.Name)
+			assert.Len(t, channels, 2)
+			assert.True(t, channels.Contains("channel"))
 
 			// Delete role
 			err = a.DeleteRole(role, false, 2)
@@ -1629,16 +1624,11 @@ func TestDeletedRoleChanHistory(t *testing.T) {
 			// get deleted role and assert channel is in channel history
 			role, err = a.GetRoleIncDeleted(roleName)
 			assert.NoError(t, err)
-			t.Logf("role %#v", role)
-			if collection.IsDefaultCollection() {
-				assert.Len(t, role.ChannelHistory(), 2)
-				_, ok := role.ChannelHistory()["channel"]
-				assert.Truef(t, ok, "Channel history should contain 'channel'")
-			} else {
-				assert.Len(t, role.GetCollectionsAccess()[collection.ScopeName][collection.Name].ChannelHistory(), 2)
-				_, ok := role.GetCollectionsAccess()[collection.ScopeName][collection.Name].ChannelHistory()["channel"]
-				assert.Truef(t, ok, "Channel history should contain 'channel'")
-			}
+			channelHistory := role.CollectionChannelHistory(collection.ScopeName, collection.Name)
+			assert.Len(t, channelHistory, 2)
+			_, ok := channelHistory["channel"]
+			require.True(t, ok)
+			assert.Truef(t, ok, "Channel history should contain 'channel'")
 		})
 	}
 


### PR DESCRIPTION
CBG-4003

Deleted roles were not triggering revocation of channels associated with those roles, for two reasons:
- deleted roles weren't being included in the role set used by RevokedCollectionChannels to identify revoked channels
- channel history wasn't being updated on deleted roles for non-default collections

Deleted roles are now populated on the user object, and a new API added (GetRolesIncDeleted) that returns the union of deleted and non-deleted roles.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2548/
