### PR TITLE
CBG-3973: Pass HTTP request information into context for audit log data

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -225,7 +225,7 @@ var AuditEvents = events{
 		Name:        "Public API user authenticated",
 		Description: "Public API user successfully authenticated",
 		MandatoryFields: AuditFields{
-			"auth_method": "basic, oidc, cookie, etc.",
+			AuditFieldAuthMethod: "basic, oidc, cookie, etc.",
 		},
 		OptionalFields: AuditFields{
 			"oidc_issuer": "issuer",
@@ -238,7 +238,7 @@ var AuditEvents = events{
 		Name:        "Public API user authentication failed",
 		Description: "Public API user failed to authenticate",
 		MandatoryFields: AuditFields{
-			"auth_method": "basic, oidc, cookie, etc.",
+			AuditFieldAuthMethod: "basic, oidc, cookie, etc.",
 		},
 		OptionalFields: AuditFields{
 			"username": "username",

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -68,23 +68,23 @@ const (
 // mandatoryFieldsByGroup defines which fields are mandatory for each group.
 var mandatoryFieldsByGroup = map[fieldGroup]map[string]any{
 	fieldGroupGlobal: {
-		auditFieldTimestamp:   "timestamp",
-		auditFieldID:          123,
-		auditFieldName:        "event name",
-		auditFieldDescription: "event description",
+		AuditFieldTimestamp:   "timestamp",
+		AuditFieldID:          123,
+		AuditFieldName:        "event name",
+		AuditFieldDescription: "event description",
 	},
 	fieldGroupRequest: {
-		auditFieldLocal: map[string]any{
+		AuditFieldLocal: map[string]any{
 			"ip":   "local ip",
 			"port": "1234"},
-		auditFieldRemote: map[string]any{
+		AuditFieldRemote: map[string]any{
 			"ip":   "remote ip",
 			"port": "5678",
 		},
-		auditFieldCorrelationID: "correlation_id",
+		AuditFieldCorrelationID: "correlation_id",
 	},
 	fieldGroupAuthenticated: {
-		auditFieldRealUserID: map[string]any{
+		AuditFieldRealUserID: map[string]any{
 			"domain": "user domain",
 			"name":   "user name",
 		},
@@ -94,7 +94,7 @@ var mandatoryFieldsByGroup = map[fieldGroup]map[string]any{
 	},
 	fieldGroupKeyspace: {
 		AuditFieldDatabase: "database name",
-		auditFieldKeyspace: "keyspace",
+		AuditFieldKeyspace: "keyspace",
 	},
 }
 

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -68,7 +68,7 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	}
 	userDomain := logCtx.UserDomain
 	userID := logCtx.Username
-	if userDomain != "" && userID != "" {
+	if userDomain != "" || userID != "" {
 		fields[auditFieldRealUserID] = map[string]any{
 			"domain": userDomain,
 			"user":   userID,
@@ -76,22 +76,28 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	}
 	if logCtx.RequestHost != "" {
 		host, port, err := net.SplitHostPort(logCtx.RequestHost)
-		if err != nil && IsDevMode() {
-			panic(fmt.Sprintf("failed to parse local address: %v", err))
-		}
-		fields[auditFieldLocal] = map[string]any{
-			"ip":   host,
-			"port": port,
+		if err != nil {
+			if IsDevMode() {
+				panic(fmt.Sprintf("couldn't parse request host: %v", err))
+			}
+		} else {
+			fields[auditFieldLocal] = map[string]any{
+				"ip":   host,
+				"port": port,
+			}
 		}
 	}
 	if logCtx.RequestRemoteAddr != "" {
 		host, port, err := net.SplitHostPort(logCtx.RequestRemoteAddr)
-		if err != nil && IsDevMode() {
-			panic(fmt.Sprintf("failed to parse remote address: %v", err))
-		}
-		fields[auditFieldRemote] = map[string]any{
-			"ip":   host,
-			"port": port,
+		if err != nil {
+			if IsDevMode() {
+				panic(fmt.Sprintf("couldn't parse request remote addr: %v", err))
+			}
+		} else {
+			fields[auditFieldRemote] = map[string]any{
+				"ip":   host,
+				"port": port,
+			}
 		}
 	}
 

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -10,7 +10,6 @@ package base
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -66,6 +65,7 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	if logCtx.Bucket != "" && logCtx.Scope != "" && logCtx.Collection != "" {
 		fields[auditFieldKeyspace] = FullyQualifiedCollectionName(logCtx.Bucket, logCtx.Scope, logCtx.Collection)
 	}
+	// TODO: CBG-3973 - set fields in ctx
 	userDomain := logCtx.UserDomain
 	userID := logCtx.Username
 	if userDomain != "" || userID != "" {
@@ -77,11 +77,7 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	if logCtx.RequestHost != "" {
 		host, port, err := net.SplitHostPort(logCtx.RequestHost)
 		if err != nil {
-			if IsDevMode() {
-				panic(fmt.Sprintf("couldn't parse request host: %v", err))
-			} else {
-				WarnfCtx(ctx, "couldn't parse request host %q for audit log: %v", logCtx.RequestHost, err)
-			}
+			AssertfCtx(ctx, "couldn't parse request host %q: %v", logCtx.RequestHost, err)
 		} else {
 			fields[auditFieldLocal] = map[string]any{
 				"ip":   host,
@@ -89,14 +85,11 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 			}
 		}
 	}
+
 	if logCtx.RequestRemoteAddr != "" {
 		host, port, err := net.SplitHostPort(logCtx.RequestRemoteAddr)
 		if err != nil {
-			if IsDevMode() {
-				panic(fmt.Sprintf("couldn't parse request remote addr: %v", err))
-			} else {
-				WarnfCtx(ctx, "couldn't parse request remote addr %q for audit log: %v", logCtx.RequestRemoteAddr, err)
-			}
+			AssertfCtx(ctx, "couldn't parse request remote addr %q: %v", logCtx.RequestRemoteAddr, err)
 		} else {
 			fields[auditFieldRemote] = map[string]any{
 				"ip":   host,

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -66,13 +66,12 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	if logCtx.Bucket != "" && logCtx.Scope != "" && logCtx.Collection != "" {
 		fields[auditFieldKeyspace] = FullyQualifiedCollectionName(logCtx.Bucket, logCtx.Scope, logCtx.Collection)
 	}
-	// TODO: CBG-3973 - set fields in ctx
 	userDomain := logCtx.UserDomain
-	userID := logCtx.Username
-	if userDomain != "" || userID != "" {
+	userName := logCtx.Username
+	if userDomain != "" || userName != "" {
 		fields[auditFieldRealUserID] = map[string]any{
 			"domain": userDomain,
-			"user":   userID,
+			"user":   userName,
 		}
 	}
 	if logCtx.RequestHost != "" {

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -23,22 +23,23 @@ const (
 
 // commonly used fields for audit events
 const (
-	auditFieldID                 = "id"
-	auditFieldTimestamp          = "timestamp"
-	auditFieldName               = "name"
-	auditFieldDescription        = "description"
-	auditFieldRealUserID         = "real_userid"
-	auditFieldLocal              = "local"
-	auditFieldRemote             = "remote"
+	AuditFieldID                 = "id"
+	AuditFieldTimestamp          = "timestamp"
+	AuditFieldName               = "name"
+	AuditFieldDescription        = "description"
+	AuditFieldRealUserID         = "real_userid"
+	AuditFieldLocal              = "local"
+	AuditFieldRemote             = "remote"
 	AuditFieldDatabase           = "db"
-	auditFieldCorrelationID      = "cid" // FIXME: how to distinguish between this field (http) and blip id below
-	auditFieldKeyspace           = "ks"
+	AuditFieldCorrelationID      = "cid" // FIXME: how to distinguish between this field (http) and blip id below
+	AuditFieldKeyspace           = "ks"
 	AuditFieldReplicationID      = "replication_id"
 	AuditFieldPayload            = "payload"
 	AuditFieldCompactionType     = "type"
 	AuditFieldCompactionDryRun   = "dry_run"
 	AuditFieldCompactionReset    = "reset"
 	AuditFieldPostUpgradePreview = "preview"
+	AuditFieldAuthMethod         = "auth_method"
 )
 
 // expandFields populates data with information from the id, context and additionalData.
@@ -51,9 +52,9 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	}
 
 	// static event data
-	fields[auditFieldID] = uint64(id)
-	fields[auditFieldName] = AuditEvents[id].Name
-	fields[auditFieldDescription] = AuditEvents[id].Description
+	fields[AuditFieldID] = uint64(id)
+	fields[AuditFieldName] = AuditEvents[id].Name
+	fields[AuditFieldDescription] = AuditEvents[id].Description
 
 	// context data
 	logCtx := getLogCtx(ctx)
@@ -61,15 +62,15 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 		fields[AuditFieldDatabase] = logCtx.Database
 	}
 	if logCtx.CorrelationID != "" {
-		fields[auditFieldCorrelationID] = logCtx.CorrelationID
+		fields[AuditFieldCorrelationID] = logCtx.CorrelationID
 	}
 	if logCtx.Bucket != "" && logCtx.Scope != "" && logCtx.Collection != "" {
-		fields[auditFieldKeyspace] = FullyQualifiedCollectionName(logCtx.Bucket, logCtx.Scope, logCtx.Collection)
+		fields[AuditFieldKeyspace] = FullyQualifiedCollectionName(logCtx.Bucket, logCtx.Scope, logCtx.Collection)
 	}
 	userDomain := logCtx.UserDomain
 	userName := logCtx.Username
 	if userDomain != "" || userName != "" {
-		fields[auditFieldRealUserID] = map[string]any{
+		fields[AuditFieldRealUserID] = map[string]any{
 			"domain": userDomain,
 			"user":   userName,
 		}
@@ -79,7 +80,7 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 		if err != nil {
 			AssertfCtx(ctx, "couldn't parse request host %q: %v", logCtx.RequestHost, err)
 		} else {
-			fields[auditFieldLocal] = map[string]any{
+			fields[AuditFieldLocal] = map[string]any{
 				"ip":   host,
 				"port": port,
 			}
@@ -91,14 +92,14 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 		if err != nil {
 			AssertfCtx(ctx, "couldn't parse request remote addr %q: %v", logCtx.RequestRemoteAddr, err)
 		} else {
-			fields[auditFieldRemote] = map[string]any{
+			fields[AuditFieldRemote] = map[string]any{
 				"ip":   host,
 				"port": port,
 			}
 		}
 	}
 
-	fields[auditFieldTimestamp] = time.Now()
+	fields[AuditFieldTimestamp] = time.Now()
 
 	fields.merge(ctx, globalFields)
 	fields.merge(ctx, logCtx.RequestAdditionalAuditFields)

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -79,6 +79,8 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 		if err != nil {
 			if IsDevMode() {
 				panic(fmt.Sprintf("couldn't parse request host: %v", err))
+			} else {
+				WarnfCtx(ctx, "couldn't parse request host %q for audit log: %v", logCtx.RequestHost, err)
 			}
 		} else {
 			fields[auditFieldLocal] = map[string]any{
@@ -92,6 +94,8 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 		if err != nil {
 			if IsDevMode() {
 				panic(fmt.Sprintf("couldn't parse request remote addr: %v", err))
+			} else {
+				WarnfCtx(ctx, "couldn't parse request remote addr %q for audit log: %v", logCtx.RequestRemoteAddr, err)
 			}
 		} else {
 			fields[auditFieldRemote] = map[string]any{

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -10,6 +10,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 	"time"

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -32,71 +32,71 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 		{
 			name: "no global fields",
 			functionFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			globalFields: nil,
 			finalFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 		},
 		{
 			name: "with global fields",
 			functionFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			globalFields: AuditFields{
 				"global": "field",
 			},
 			finalFields: AuditFields{
-				"auth_method": "basic",
-				"global":      "field",
+				AuditFieldAuthMethod: "basic",
+				"global":             "field",
 			},
 		},
 		{
 			name: "overwrite global fields",
 			functionFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			globalFields: AuditFields{
-				"auth_method": "global",
+				AuditFieldAuthMethod: "global",
 			},
 			finalFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			warningCount: 1,
 		},
 		{
 			name: "context fields only",
 			functionFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			globalFields: nil,
 			contextFields: AuditFields{
 				"context": "field",
 			},
 			finalFields: AuditFields{
-				"auth_method": "basic",
-				"context":     "field",
+				AuditFieldAuthMethod: "basic",
+				"context":            "field",
 			},
 		},
 		{
 			name: "context fields overwrite fields",
 			functionFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			globalFields: nil,
 			contextFields: AuditFields{
-				"auth_method": "context",
+				AuditFieldAuthMethod: "context",
 			},
 			finalFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			warningCount: 1,
 		},
 		{
 			name: "global fields and context fields",
 			functionFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			globalFields: AuditFields{
 				"global": "field",
@@ -105,24 +105,24 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 				"context": "field",
 			},
 			finalFields: AuditFields{
-				"auth_method": "basic",
-				"global":      "field",
-				"context":     "field",
+				AuditFieldAuthMethod: "basic",
+				"global":             "field",
+				"context":            "field",
 			},
 		},
 		{
 			name: "global fields and context fields overwrite fields",
 			functionFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			globalFields: AuditFields{
-				"auth_method": "global",
+				AuditFieldAuthMethod: "global",
 			},
 			contextFields: AuditFields{
-				"auth_method": "context",
+				AuditFieldAuthMethod: "context",
 			},
 			finalFields: AuditFields{
-				"auth_method": "basic",
+				AuditFieldAuthMethod: "basic",
 			},
 			warningCount: 2, // error from global and error from context
 		},
@@ -139,7 +139,7 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 			startWarnCount := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 			output := AuditLogContents(t, func(tb testing.TB) {
 				// Test basic audit event
-				Audit(ctx, AuditIDPublicUserAuthenticated, map[string]any{"auth_method": "basic"})
+				Audit(ctx, AuditIDPublicUserAuthenticated, map[string]any{AuditFieldAuthMethod: "basic"})
 			},
 			)
 			var event map[string]any

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -137,7 +137,7 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 			auditLogger, err = NewAuditLogger(ctx, &AuditLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true)}}, tmpdir, 0, nil, testCase.globalFields)
 			require.NoError(t, err)
 			startWarnCount := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
-			output := AuditLogContents(t, func() {
+			output := AuditLogContents(t, func(tb testing.TB) {
 				// Test basic audit event
 				Audit(ctx, AuditIDPublicUserAuthenticated, map[string]any{"auth_method": "basic"})
 			},

--- a/base/logging.go
+++ b/base/logging.go
@@ -406,7 +406,7 @@ func AssertLogContains(t *testing.T, s string, f func()) {
 }
 
 // AuditLogContents returns that the audit logs produced by function f.
-func AuditLogContents(t *testing.T, f func()) []byte {
+func AuditLogContents(t testing.TB, f func(t testing.TB)) []byte {
 	// Temporarily override logger output
 	b := &bytes.Buffer{}
 	mw := io.MultiWriter(b, os.Stderr)
@@ -414,7 +414,7 @@ func AuditLogContents(t *testing.T, f func()) []byte {
 	defer func() { auditLogger.logger.SetOutput(os.Stderr) }()
 
 	// Call the given function
-	f()
+	f(t)
 
 	FlushLogBuffers()
 	auditLogger.FlushBufferToLog()

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -227,6 +227,7 @@ type userIDDomain string
 const (
 	UserDomainSyncGateway userIDDomain = "sgw"
 	UserDomainCBServer    userIDDomain = "cbs"
+	UserDomainBuiltin                  = "builtin" // internal users (e.g. SG bootstrap user)
 )
 
 func UserLogCtx(parent context.Context, username string, domain userIDDomain) context.Context {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -238,12 +238,14 @@ func UserLogCtx(parent context.Context, username string, domain userIDDomain) co
 }
 
 type RequestData struct {
+	CorrelationID     string
 	RequestHost       string
 	RequestRemoteAddr string
 }
 
 func RequestLogCtx(parent context.Context, d RequestData) context.Context {
 	newCtx := getLogCtx(parent)
+	newCtx.CorrelationID = d.CorrelationID
 	newCtx.RequestHost = d.RequestHost
 	newCtx.RequestRemoteAddr = d.RequestRemoteAddr
 	return LogContextWith(parent, &newCtx)

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -222,6 +222,13 @@ func KeyspaceLogCtx(parent context.Context, bucketName, scopeName, collectionNam
 	return LogContextWith(parent, &newCtx)
 }
 
+func UserLogCtx(parent context.Context, user, domain string) context.Context {
+	newCtx := getLogCtx(parent)
+	newCtx.Username = user
+	newCtx.UserDomain = domain
+	return LogContextWith(parent, &newCtx)
+}
+
 type RequestData struct {
 	RequestHost       string
 	RequestRemoteAddr string

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -49,7 +49,7 @@ type LogContext struct {
 	// Username is the name of the authenticated user
 	Username string
 	// UserDomain can be syncgateway or couchbase depending on whether the authenticated user is a sync gateway user or a couchbase RBAC user
-	UserDomain string
+	UserDomain userIDDomain
 	// RequestHost is the HTTP Host of the request associated with this log.
 	RequestHost string
 	// RequestRemoteAddr is the IP and port of the remote client making the request associated with this log
@@ -222,9 +222,16 @@ func KeyspaceLogCtx(parent context.Context, bucketName, scopeName, collectionNam
 	return LogContextWith(parent, &newCtx)
 }
 
-func UserLogCtx(parent context.Context, user, domain string) context.Context {
+type userIDDomain string
+
+const (
+	UserDomainSyncGateway userIDDomain = "sgw"
+	UserDomainCBServer    userIDDomain = "cbs"
+)
+
+func UserLogCtx(parent context.Context, username string, domain userIDDomain) context.Context {
 	newCtx := getLogCtx(parent)
-	newCtx.Username = user
+	newCtx.Username = username
 	newCtx.UserDomain = domain
 	return LogContextWith(parent, &newCtx)
 }

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -46,15 +46,14 @@ type LogContext struct {
 
 	// RequestAdditionalAuditFields is a map of fields to be included in audit logs
 	RequestAdditionalAuditFields map[string]any
-	// TODO: CBG-3973 - Add request data (user, ips, etc.) - to be used by auditFieldsFromContext
-	//// Username is the name of the authenticated user
-	//Username string
-	//// UserDomain can be syncgateway or couchbase depending on whether the authenticated user is a sync gateway user or a couchbase RBAC user
-	//UserDomain string
-	//// RequestPort is the HTTP port of the request associated with this log.
-	//RequestPort string
-	//// RemoteAddr is the IP and port of the remote client making the request associated with this log
-	//RemoteAddr string
+	// Username is the name of the authenticated user
+	Username string
+	// UserDomain can be syncgateway or couchbase depending on whether the authenticated user is a sync gateway user or a couchbase RBAC user
+	UserDomain string
+	// RequestHost is the HTTP Host of the request associated with this log.
+	RequestHost string
+	// RequestRemoteAddr is the IP and port of the remote client making the request associated with this log
+	RequestRemoteAddr string
 
 	// implicitDefaultCollection is set to true when the context represents the default collection, but we want to omit that value from logging to prevent verbosity.
 	implicitDefaultCollection bool
@@ -132,6 +131,10 @@ func (lc *LogContext) getCopy() LogContext {
 		Collection:                   lc.Collection,
 		TestName:                     lc.TestName,
 		RequestAdditionalAuditFields: lc.RequestAdditionalAuditFields,
+		Username:                     lc.Username,
+		UserDomain:                   lc.UserDomain,
+		RequestHost:                  lc.RequestHost,
+		RequestRemoteAddr:            lc.RequestRemoteAddr,
 	}
 }
 
@@ -216,6 +219,18 @@ func KeyspaceLogCtx(parent context.Context, bucketName, scopeName, collectionNam
 	newCtx.Bucket = bucketName
 	newCtx.Collection = collectionName
 	newCtx.Scope = scopeName
+	return LogContextWith(parent, &newCtx)
+}
+
+type RequestData struct {
+	RequestHost       string
+	RequestRemoteAddr string
+}
+
+func RequestLogCtx(parent context.Context, d RequestData) context.Context {
+	newCtx := getLogCtx(parent)
+	newCtx.RequestHost = d.RequestHost
+	newCtx.RequestRemoteAddr = d.RequestRemoteAddr
 	return LogContextWith(parent, &newCtx)
 }
 

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -153,7 +153,7 @@ func TestAuditLoggingFields(t *testing.T) {
 					// Skip this subtest if running with walrus - it has no support for admin auth
 					t.Skip("Skipping test that requires admin auth - Walrus not supported")
 				}
-				RequireStatus(t, rt.SendAdminRequestWithAuth(http.MethodGet, "/db/", "", base.TestClusterPassword(), base.TestClusterPassword()), http.StatusOK)
+				RequireStatus(t, rt.SendAdminRequestWithAuth(http.MethodGet, "/db/", "", base.TestClusterUsername(), base.TestClusterPassword()), http.StatusOK)
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				// TODO: Admin auth event

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -84,12 +84,7 @@ func TestAuditLoggingFields(t *testing.T) {
 			auditableAction: func(t testing.TB) {
 				RequireStatus(t, rt.SendRequest(http.MethodGet, "/", ""), http.StatusOK)
 			},
-			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
-				base.AuditIDPublicUserAuthenticated: {
-					base.AuditFieldCorrelationID: auditFieldValueIgnored,
-					base.AuditFieldAuthMethod:    "guest",
-				},
-			},
+			expectedAuditEventFields: map[base.AuditID]base.AuditFields{},
 		},
 		{
 			name: "guest request",

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -140,17 +140,19 @@ func TestAuditLoggingFields(t *testing.T) {
 				// TODO: Admin auth event
 				//base.AuditIDAdminUserAuthenticated: {
 				//	"cid":         auditFieldValueIgnored,
-				//	"real_userid": map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
 				//},
 				base.AuditIDReadDatabase: {
-					"cid":         auditFieldValueIgnored,
-					"real_userid": map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
+					"cid": auditFieldValueIgnored,
 				},
 			},
 		},
 		{
 			name: "authed admin request",
 			auditableAction: func(t testing.TB) {
+				if base.UnitTestUrlIsWalrus() {
+					// Skip this subtest if running with walrus - it has no support for admin auth
+					t.Skip("Skipping test that requires admin auth - Walrus not supported")
+				}
 				RequireStatus(t, rt.SendAdminRequestWithAuth(http.MethodGet, "/db/", "", base.TestClusterPassword(), base.TestClusterPassword()), http.StatusOK)
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -78,8 +78,8 @@ func TestAuditLoggingFields(t *testing.T) {
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDPublicUserAuthenticated: {
-					"cid":         auditFieldValueIgnored,
-					"auth_method": "guest",
+					base.AuditFieldCorrelationID: auditFieldValueIgnored,
+					base.AuditFieldAuthMethod:    "guest",
 				},
 				// TODO: GUEST view session event?
 			},
@@ -91,12 +91,12 @@ func TestAuditLoggingFields(t *testing.T) {
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDPublicUserAuthenticated: {
-					"cid":         auditFieldValueIgnored,
-					"real_userid": map[string]any{"domain": "sgw", "user": "alice"},
+					base.AuditFieldCorrelationID: auditFieldValueIgnored,
+					base.AuditFieldRealUserID:    map[string]any{"domain": "sgw", "user": "alice"},
 				},
 				base.AuditIDReadDatabase: {
-					"cid":         auditFieldValueIgnored,
-					"real_userid": map[string]any{"domain": "sgw", "user": "alice"},
+					base.AuditFieldCorrelationID: auditFieldValueIgnored,
+					base.AuditFieldRealUserID:    map[string]any{"domain": "sgw", "user": "alice"},
 				},
 			},
 		},
@@ -111,9 +111,9 @@ func TestAuditLoggingFields(t *testing.T) {
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDPublicUserAuthenticated: {
-					"cid":         auditFieldValueIgnored,
-					"real_userid": map[string]any{"domain": "sgw", "user": "alice"},
-					"extra":       "field",
+					base.AuditFieldCorrelationID: auditFieldValueIgnored,
+					base.AuditFieldRealUserID:    map[string]any{"domain": "sgw", "user": "alice"},
+					"extra":                      "field",
 				},
 			},
 		},
@@ -124,10 +124,10 @@ func TestAuditLoggingFields(t *testing.T) {
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDPublicUserAuthenticationFailed: {
-					"cid":         auditFieldValueIgnored,
-					"auth_method": "basic",
-					"db":          "db",
-					"username":    "incorrect",
+					base.AuditFieldCorrelationID: auditFieldValueIgnored,
+					base.AuditFieldAuthMethod:    "basic",
+					base.AuditFieldDatabase:      "db",
+					"username":                   "incorrect",
 				},
 			},
 		},
@@ -139,10 +139,10 @@ func TestAuditLoggingFields(t *testing.T) {
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				// TODO: Admin auth event
 				//base.AuditIDAdminUserAuthenticated: {
-				//	"cid":         auditFieldValueIgnored,
+				//	base.AuditFieldCorrelationID:         auditFieldValueIgnored,
 				//},
 				base.AuditIDReadDatabase: {
-					"cid": auditFieldValueIgnored,
+					base.AuditFieldCorrelationID: auditFieldValueIgnored,
 				},
 			},
 		},
@@ -158,12 +158,12 @@ func TestAuditLoggingFields(t *testing.T) {
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				// TODO: Admin auth event
 				//base.AuditIDAdminUserAuthenticated: {
-				//	"cid":         auditFieldValueIgnored,
-				//	"real_userid": map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
+				//	base.AuditFieldCorrelationID:         auditFieldValueIgnored,
+				//	base.AuditFieldRealUserID: map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
 				//},
 				base.AuditIDReadDatabase: {
-					"cid":         auditFieldValueIgnored,
-					"real_userid": map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
+					base.AuditFieldCorrelationID: auditFieldValueIgnored,
+					base.AuditFieldRealUserID:    map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
 				},
 			},
 		},

--- a/rest/config.go
+++ b/rest/config.go
@@ -1432,12 +1432,6 @@ func (sc *ServerContext) Serve(ctx context.Context, config *StartupConfig, t ser
 	return serveFn()
 }
 
-func (sc *ServerContext) addHTTPServer(t serverType, s *serverInfo) {
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
-	sc._httpServers[t] = s
-}
-
 // Validate returns errors errors if invalid config is present
 func (sc *StartupConfig) Validate(ctx context.Context, isEnterpriseEdition bool) (errorMessages error) {
 	var multiError *base.MultiError

--- a/rest/config_no_race_test.go
+++ b/rest/config_no_race_test.go
@@ -106,11 +106,11 @@ func TestAuditLoggingGlobals(t *testing.T) {
 			}
 			require.NoError(t, err)
 			output := base.AuditLogContents(t, func(tb testing.TB) {
-				base.Audit(ctx, base.AuditIDPublicUserAuthenticated, map[string]any{"auth_method": "basic"})
+				base.Audit(ctx, base.AuditIDPublicUserAuthenticated, map[string]any{base.AuditFieldAuthMethod: "basic"})
 			})
 			var event map[string]any
 			require.NoError(t, json.Unmarshal(output, &event))
-			require.Contains(t, event, "auth_method")
+			require.Contains(t, event, base.AuditFieldAuthMethod)
 			for k, v := range globalFields {
 				if testCase.globalAuditEvents != nil {
 					require.Equal(t, v, event[k])

--- a/rest/config_no_race_test.go
+++ b/rest/config_no_race_test.go
@@ -105,7 +105,7 @@ func TestAuditLoggingGlobals(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			output := base.AuditLogContents(t, func() {
+			output := base.AuditLogContents(t, func(tb testing.TB) {
 				base.Audit(ctx, base.AuditIDPublicUserAuthenticated, map[string]any{"auth_method": "basic"})
 			})
 			var event map[string]any

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -649,6 +649,11 @@ func (h *handler) handleDelLocalDoc() error {
 	return h.collection.DeleteSpecial(db.DocTypeLocal, docid, h.getQuery("rev"))
 }
 
+// isGuest returns true if the current user is a guest
+func (h *handler) isGuest() bool {
+	return h.user != nil && h.user.Name() == ""
+}
+
 // helper for read only check
 func (h *handler) isReadOnlyGuest() bool {
 	if h.db.IsGuestReadOnly() && h.db.User() != nil && h.db.User().Name() == "" {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -462,11 +462,6 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 				return base.HTTPErrorf(http.StatusForbidden, auth.GuestUserReadOnly)
 			}
 		}
-		if h.isGuest() {
-			h.rqCtx = base.UserLogCtx(h.ctx(), base.GuestUsername, base.UserDomainSyncGateway)
-		} else if h.user != nil {
-			h.rqCtx = base.UserLogCtx(h.ctx(), h.user.Name(), base.UserDomainSyncGateway)
-		}
 	}
 
 	// If the user has OIDC roles/channels configured, we need to check if the OIDC issuer they came from is still valid.
@@ -793,6 +788,12 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 			}
 		} else {
 			dbCtx.DbStats.Security().AuthSuccessCount.Add(1)
+
+			if h.isGuest() {
+				h.rqCtx = base.UserLogCtx(h.ctx(), base.GuestUsername, base.UserDomainSyncGateway)
+			} else if h.user != nil {
+				h.rqCtx = base.UserLogCtx(h.ctx(), h.user.Name(), base.UserDomainSyncGateway)
+			}
 			base.Audit(h.ctx(), base.AuditIDPublicUserAuthenticated, auditFields)
 		}
 	}(time.Now())

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -205,7 +205,7 @@ func (h *handler) ctx() context.Context {
 	if h.rqCtx == nil {
 		ctx := base.CorrelationIDLogCtx(h.rq.Context(), h.formatSerialNumber())
 		ctx = base.RequestLogCtx(ctx, base.RequestData{
-			RequestHost:       h.rq.Host, // FIXME: This is client-supplied data; replace with actual server listener address for API serving request.
+			RequestHost:       h.rq.Host, // FIXME: This is client-supplied data (Host header); replace with actual server listener address for API serving request!
 			RequestRemoteAddr: h.rq.RemoteAddr,
 		})
 		h.rqCtx = ctx

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -203,7 +203,12 @@ func newHandler(server *ServerContext, privs handlerPrivs, serverType serverType
 // ctx returns the request-scoped context for logging/cancellation.
 func (h *handler) ctx() context.Context {
 	if h.rqCtx == nil {
-		h.rqCtx = base.CorrelationIDLogCtx(h.rq.Context(), h.formatSerialNumber())
+		ctx := base.CorrelationIDLogCtx(h.rq.Context(), h.formatSerialNumber())
+		ctx = base.RequestLogCtx(ctx, base.RequestData{
+			RequestHost:       h.rq.Host, // FIXME: This is client-supplied data; replace with actual server listener address for API serving request.
+			RequestRemoteAddr: h.rq.RemoteAddr,
+		})
+		h.rqCtx = ctx
 	}
 	return h.rqCtx
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -801,7 +801,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	// If oidc enabled, check for bearer ID token
 	if dbCtx.Options.OIDCOptions != nil || len(dbCtx.LocalJWTProviders) > 0 {
 		if token := h.getBearerToken(); token != "" {
-			auditFields = base.AuditFields{"auth_method": "bearer"}
+			auditFields = base.AuditFields{base.AuditFieldAuthMethod: "bearer"}
 			var updates auth.PrincipalConfig
 			h.user, updates, err = dbCtx.Authenticator(h.ctx()).AuthenticateUntrustedJWT(token, dbCtx.OIDCProviders, dbCtx.LocalJWTProviders, h.getOIDCCallbackURL)
 			if h.user == nil || err != nil {
@@ -846,7 +846,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	// Check basic auth first
 	if !dbCtx.Options.DisablePasswordAuthentication {
 		if userName, password := h.getBasicAuth(); userName != "" {
-			auditFields = base.AuditFields{"auth_method": "basic"}
+			auditFields = base.AuditFields{base.AuditFieldAuthMethod: "basic"}
 			h.user, err = dbCtx.Authenticator(h.ctx()).AuthenticateUser(userName, password)
 			if err != nil {
 				return err
@@ -864,7 +864,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	}
 
 	// Check cookie
-	auditFields = base.AuditFields{"auth_method": "cookie"}
+	auditFields = base.AuditFields{base.AuditFieldAuthMethod: "cookie"}
 	h.user, err = dbCtx.Authenticator(h.ctx()).AuthenticateCookie(h.rq, h.response)
 	if err != nil && h.privs != publicPrivs {
 		return err
@@ -873,7 +873,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	}
 
 	// No auth given -- check guest access
-	auditFields = base.AuditFields{"auth_method": "guest"}
+	auditFields = base.AuditFields{base.AuditFieldAuthMethod: "guest"}
 	if h.user, err = dbCtx.Authenticator(h.ctx()).GetUser(""); err != nil {
 		return err
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -279,6 +279,10 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 		return err
 	}
 
+	if h.user != nil {
+		h.rqCtx = base.UserLogCtx(h.ctx(), h.user.Name(), "sgw")
+	}
+
 	return method(h) // Call the actual handler code
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -203,12 +203,12 @@ func newHandler(server *ServerContext, privs handlerPrivs, serverType serverType
 // ctx returns the request-scoped context for logging/cancellation.
 func (h *handler) ctx() context.Context {
 	if h.rqCtx == nil {
-		ctx := base.CorrelationIDLogCtx(h.rq.Context(), h.formatSerialNumber())
 		serverAddr, err := h.getServerAddr()
 		if err != nil {
-			base.AssertfCtx(ctx, "Error getting server address: %v", err)
+			base.AssertfCtx(h.rq.Context(), "Error getting server address: %v", err)
 		}
-		ctx = base.RequestLogCtx(ctx, base.RequestData{
+		ctx := base.RequestLogCtx(h.rq.Context(), base.RequestData{
+			CorrelationID:     h.formatSerialNumber(),
 			RequestHost:       serverAddr,
 			RequestRemoteAddr: h.rq.RemoteAddr,
 		})

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -204,13 +204,21 @@ func newHandler(server *ServerContext, privs handlerPrivs, serverType serverType
 func (h *handler) ctx() context.Context {
 	if h.rqCtx == nil {
 		ctx := base.CorrelationIDLogCtx(h.rq.Context(), h.formatSerialNumber())
+		serverAddr, err := h.getServerAddr()
+		if err != nil {
+			base.AssertfCtx(ctx, "Error getting server address: %v", err)
+		}
 		ctx = base.RequestLogCtx(ctx, base.RequestData{
-			RequestHost:       h.rq.Host, // FIXME: This is client-supplied data (Host header); replace with actual server listener address for API serving request!
+			RequestHost:       serverAddr,
 			RequestRemoteAddr: h.rq.RemoteAddr,
 		})
 		h.rqCtx = ctx
 	}
 	return h.rqCtx
+}
+
+func (h *handler) getServerAddr() (string, error) {
+	return h.server.getServerAddr(h.serverType)
 }
 
 func (h *handler) addDatabaseLogContext(dbName string, logConfig *base.DbLogConfig) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -791,7 +791,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 
 			if h.isGuest() {
 				h.rqCtx = base.UserLogCtx(h.ctx(), base.GuestUsername, base.UserDomainSyncGateway)
-			} else if h.user != nil {
+			} else {
 				h.rqCtx = base.UserLogCtx(h.ctx(), h.user.Name(), base.UserDomainSyncGateway)
 			}
 			base.Audit(h.ctx(), base.AuditIDPublicUserAuthenticated, auditFields)

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2880,7 +2880,7 @@ func TestPutDBConfigOIDC(t *testing.T) {
 				}
 			}
 		}`,
-		tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(), sc.getServerAddr(t, publicServer),
+		tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(), mustGetServerAddr(t, sc, publicServer),
 	)
 
 	resp = BootstrapAdminRequest(t, sc, http.MethodPut, "/db/_config", validOIDCConfig)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -280,9 +280,11 @@ func (sc *ServerContext) Close(ctx context.Context) {
 	sc.invalidDatabaseConfigTracking.dbNames = nil
 
 	for _, s := range sc._httpServers {
-		base.InfofCtx(ctx, base.KeyHTTP, "Closing HTTP Server: %v", s.addr)
-		if err := s.server.Close(); err != nil {
-			base.WarnfCtx(ctx, "Error closing HTTP server %q: %v", s.addr, err)
+		if s.server != nil {
+			base.InfofCtx(ctx, base.KeyHTTP, "Closing HTTP Server: %v", s.addr)
+			if err := s.server.Close(); err != nil {
+				base.WarnfCtx(ctx, "Error closing HTTP server %q: %v", s.addr, err)
+			}
 		}
 	}
 	sc._httpServers = nil

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -213,6 +213,32 @@ func (sc *ServerContext) WaitForRESTAPIs(ctx context.Context) error {
 	return err
 }
 
+// getServerAddr returns the address as assigned by the listener. This will return an addressable address, whereas ":0" is a valid value to pass to server.
+func (sc *ServerContext) getServerAddr(s serverType) (string, error) {
+	server, err := sc.getHTTPServer(s)
+	if err != nil {
+		return "", err
+	}
+	return server.addr.String(), nil
+}
+
+func (sc *ServerContext) addHTTPServer(t serverType, s *serverInfo) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+	sc._httpServers[t] = s
+}
+
+// getHTTPServer returns information about the given HTTP server.
+func (sc *ServerContext) getHTTPServer(t serverType) (*serverInfo, error) {
+	sc.lock.RLock()
+	defer sc.lock.RUnlock()
+	s, ok := sc._httpServers[t]
+	if !ok {
+		return nil, fmt.Errorf("server type %q not found running in server context", t)
+	}
+	return s, nil
+}
+
 // PostStartup runs anything that relies on SG being fully started (i.e. sgreplicate)
 func (sc *ServerContext) PostStartup() {
 	// Delay DatabaseContext processes starting up, e.g. to avoid replication reassignment churn when a Sync Gateway Cluster is being initialized

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -356,7 +356,7 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 	sc, closeFn := StartBootstrapServer(t)
 	defer closeFn()
 
-	resp, err := http.Get("http://" + sc.getServerAddr(t, publicServer))
+	resp, err := http.Get("http://" + mustGetServerAddr(t, sc, publicServer))
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -50,7 +50,7 @@ func (h *handler) handleSessionPOST() error {
 
 	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkPublicAuth calls out into AuthenticateUntrustedJWT.
 	// Therefore, if by this point `h.user` is guest, this isn't creating a session from OIDC.
-	if h.db.Options.DisablePasswordAuthentication && (h.user == nil || h.user.Name() == "") {
+	if h.db.Options.DisablePasswordAuthentication && h.isGuest() {
 		return ErrLoginRequired
 	}
 	user, err := h.getUserFromSessionRequestBody()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1212,8 +1212,8 @@ func Request(method, resource, body string) *http.Request {
 	if err != nil {
 		panic(fmt.Sprintf("http.NewRequest failed: %v", err))
 	}
-	request.RemoteAddr = ":0"     // usually populated by actual HTTP requests going into a HTTP Server
-	request.RequestURI = resource // This doesn't get filled in by NewRequest
+	request.RemoteAddr = "test.client.addr:99999" // usually populated by actual HTTP requests going into a HTTP Server
+	request.RequestURI = resource                 // This doesn't get filled in by NewRequest
 	FixQuotedSlashes(request)
 	return request
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -767,6 +767,7 @@ func (rt *RestTester) TestAdminHandlerNoConflictsMode() http.Handler {
 func (rt *RestTester) TestAdminHandler() http.Handler {
 	rt.adminHandlerOnce.Do(func() {
 		rt.AdminHandler = CreateAdminHandler(rt.ServerContext())
+		rt.ServerContext().addHTTPServer(adminServer, &serverInfo{nil, &net.TCPAddr{}})
 	})
 	return rt.AdminHandler
 }
@@ -774,6 +775,7 @@ func (rt *RestTester) TestAdminHandler() http.Handler {
 func (rt *RestTester) TestPublicHandler() http.Handler {
 	rt.publicHandlerOnce.Do(func() {
 		rt.PublicHandler = CreatePublicHandler(rt.ServerContext())
+		rt.ServerContext().addHTTPServer(publicServer, &serverInfo{nil, &net.TCPAddr{}})
 	})
 	return rt.PublicHandler
 }
@@ -781,6 +783,7 @@ func (rt *RestTester) TestPublicHandler() http.Handler {
 func (rt *RestTester) TestMetricsHandler() http.Handler {
 	rt.metricsHandlerOnce.Do(func() {
 		rt.MetricsHandler = CreateMetricHandler(rt.ServerContext())
+		rt.ServerContext().addHTTPServer(metricsServer, &serverInfo{nil, &net.TCPAddr{}})
 	})
 	return rt.MetricsHandler
 }
@@ -789,6 +792,7 @@ func (rt *RestTester) TestMetricsHandler() http.Handler {
 func (rt *RestTester) TestDiagnosticHandler() http.Handler {
 	rt.diagnosticHandlerOnce.Do(func() {
 		rt.DiagnosticHandler = createDiagnosticHandler(rt.ServerContext())
+		rt.ServerContext().addHTTPServer(diagnosticServer, &serverInfo{nil, &net.TCPAddr{}})
 	})
 	return rt.DiagnosticHandler
 }
@@ -1199,6 +1203,7 @@ func Request(method, resource, body string) *http.Request {
 	if err != nil {
 		panic(fmt.Sprintf("http.NewRequest failed: %v", err))
 	}
+	request.RemoteAddr = ":0"     // usually populated by actual HTTP requests going into a HTTP Server
 	request.RequestURI = resource // This doesn't get filled in by NewRequest
 	FixQuotedSlashes(request)
 	return request

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2662,7 +2662,27 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 		config.ImportFilter = stringPtrOrNil(rt.ImportFilter)
 	}
 
+	if rt.GuestEnabled {
+		config.Guest = &auth.PrincipalConfig{
+			Name:     stringPtrOrNil(base.GuestUsername),
+			Disabled: base.BoolPtr(false),
+		}
+		setChannelsAllCollections(config, config.Guest, "*")
+	}
+
 	return config
+}
+
+func setChannelsAllCollections(dbConfig DbConfig, principal *auth.PrincipalConfig, channels ...string) {
+	if dbConfig.Scopes == nil {
+		principal.ExplicitChannels = base.SetOf(channels...)
+		return
+	}
+	for scope, scopeConfig := range dbConfig.Scopes {
+		for collection := range scopeConfig.Collections {
+			principal.SetExplicitChannels(scope, collection, "*")
+		}
+	}
 }
 
 // stringPtrOrNil returns a stringPtr for the given string, or nil if the string is empty

--- a/rest/utilities_testing_bootstrap.go
+++ b/rest/utilities_testing_bootstrap.go
@@ -94,17 +94,14 @@ func BootstrapAdminRequestWithHeaders(t *testing.T, sc *ServerContext, method, p
 	return doBootstrapAdminRequest(t, sc, method, path, body, headers)
 }
 
-// getServerAddr returns the address as assigned by the listener. This will return an addressable address, whereas ":0" is a valid value to pass to server.
-func (sc *ServerContext) getServerAddr(t *testing.T, s serverType) string {
-	sc.lock.RLock()
-	defer sc.lock.RUnlock()
-	server := sc._httpServers[s]
-	require.NotNil(t, server, "Server %s not found in server context", s)
-	return server.addr.String()
+func mustGetServerAddr(t *testing.T, sc *ServerContext, s serverType) string {
+	addr, err := sc.getServerAddr(s)
+	require.NoError(t, err, "Server %s not found in server context", s)
+	return addr
 }
 
 func doBootstrapAdminRequest(t *testing.T, sc *ServerContext, method, path, body string, headers map[string]string) boostrapResponse {
-	host := "http://" + sc.getServerAddr(t, adminServer)
+	host := "http://" + mustGetServerAddr(t, sc, adminServer)
 	url := host + path
 
 	buf := bytes.NewBufferString(body)
@@ -134,7 +131,7 @@ func doBootstrapAdminRequest(t *testing.T, sc *ServerContext, method, path, body
 }
 
 func doBootstrapRequest(t *testing.T, sc *ServerContext, method, path, body string, headers map[string]string, server serverType) boostrapResponse {
-	host := "http://" + sc.getServerAddr(t, server)
+	host := "http://" + mustGetServerAddr(t, sc, server)
 	url := host + path
 
 	buf := bytes.NewBufferString(body)


### PR DESCRIPTION
CBG-3973

- Pass HTTP request information into context for audit log data
  - request host (API addr)
  - remote addr (client IP/port)
  - `real_userid` populatd by auth'd user (public or admin)
- Converted existing audit test to more generic sub-test style to allow future coverage

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2582/
