### PR TITLE
CBG-4025 Invalidate user roles after resync

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -425,7 +425,7 @@ func TestRebuildUserChannelsMultiCollection(t *testing.T) {
 	err := auth.Save(user)
 	assert.NoError(t, err)
 
-	err = auth.InvalidateChannels("testUser", true, "scope1", "collection1", 2)
+	err = auth.InvalidateChannels("testUser", true, base.ScopeAndCollectionNames{base.NewScopeAndCollectionName("scope1", "collection1")}, 2)
 	assert.NoError(t, err)
 
 	user2, err := auth.GetUser("testUser")
@@ -452,7 +452,7 @@ func TestRebuildUserChannelsNamedCollection(t *testing.T) {
 	err := auth.Save(user)
 	assert.NoError(t, err)
 
-	err = auth.InvalidateChannels("testUser", true, "scope1", "collection1", 2)
+	err = auth.InvalidateChannels("testUser", true, base.ScopeAndCollectionNames{base.NewScopeAndCollectionName("scope1", "collection1")}, 2)
 	assert.NoError(t, err)
 
 	user2, err := auth.GetUser("testUser")

--- a/base/collection_common.go
+++ b/base/collection_common.go
@@ -24,6 +24,13 @@ func DefaultScopeAndCollectionName() ScopeAndCollectionName {
 	return ScopeAndCollectionName{Scope: DefaultScope, Collection: DefaultCollection}
 }
 
+func NewScopeAndCollectionName(scope, collection string) ScopeAndCollectionName {
+	return ScopeAndCollectionName{
+		Scope:      scope,
+		Collection: collection,
+	}
+}
+
 type ScopeAndCollectionNames []ScopeAndCollectionName
 
 // ScopeAndCollectionNames returns a dot-separated formatted slice of scope and collection names.

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -216,9 +216,12 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 			if err != nil {
 				return err
 			}
+
+			collectionNames := make(base.ScopeAndCollectionNames, 0)
 			for _, databaseCollection := range db.CollectionByID {
-				databaseCollection.invalidateAllPrincipalsCache(ctx, endSeq)
+				collectionNames = append(collectionNames, databaseCollection.ScopeAndCollectionName())
 			}
+			db.invalidateAllPrincipals(ctx, collectionNames, endSeq)
 
 		}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -2301,7 +2301,7 @@ func (db *DatabaseCollectionWithUser) MarkPrincipalsChanged(ctx context.Context,
 	if len(changedRoleUsers) > 0 {
 		base.InfofCtx(ctx, base.KeyAccess, "Rev %q / %q invalidates roles of %s", base.UD(docid), newRevID, base.UD(changedRoleUsers))
 		for _, name := range changedRoleUsers {
-			db.invalUserRoles(ctx, name, invalSeq)
+			db.dbCtx.invalUserRoles(ctx, name, invalSeq)
 			// If this is the current in memory db.user, reload to generate updated roles
 			if db.user != nil && db.user.Name() == name {
 				base.DebugfCtx(ctx, base.KeyAccess, "Role set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))

--- a/db/database.go
+++ b/db/database.go
@@ -1679,21 +1679,9 @@ func (db *DatabaseCollectionWithUser) UpdateAllDocChannels(ctx context.Context, 
 	base.InfofCtx(ctx, base.KeyAll, "Finished re-running sync function; %d/%d docs changed", docsChanged, docsProcessed)
 
 	if docsChanged > 0 {
-		db.invalidateAllPrincipalsCache(ctx, endSeq)
+		db.invalidateAllPrincipals(ctx, endSeq)
 	}
 	return docsChanged, nil
-}
-
-// invalidate channel cache of all users/roles:
-func (c *DatabaseCollection) invalidateAllPrincipalsCache(ctx context.Context, endSeq uint64) {
-	base.InfofCtx(ctx, base.KeyAll, "Invalidating channel caches of users/roles...")
-	users, roles, _ := c.allPrincipalIDs(ctx)
-	for _, name := range users {
-		c.invalUserChannels(ctx, name, endSeq)
-	}
-	for _, name := range roles {
-		c.invalRoleChannels(ctx, name, endSeq)
-	}
 }
 
 func (c *DatabaseCollection) updateAllPrincipalsSequences(ctx context.Context) error {
@@ -1893,34 +1881,48 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 	return updatedHighSeq, unusedSequences, err
 }
 
-func (c *DatabaseCollection) invalUserRoles(ctx context.Context, username string, invalSeq uint64) {
-	authr := c.Authenticator(ctx)
+// invalidateAllPrincipals invalidates computed channels and roles for all users/roles, for the specified collections:
+func (dbCtx *DatabaseContext) invalidateAllPrincipals(ctx context.Context, collectionNames base.ScopeAndCollectionNames, endSeq uint64) {
+	base.InfofCtx(ctx, base.KeyAll, "Invalidating channel caches of users/roles...")
+	users, roles, _ := dbCtx.AllPrincipalIDs(ctx)
+	for _, name := range users {
+		dbCtx.invalUserRolesAndChannels(ctx, name, collectionNames, endSeq)
+	}
+	for _, name := range roles {
+		dbCtx.invalRoleChannels(ctx, name, collectionNames, endSeq)
+	}
+}
+
+// invalUserChannels invalidates a user's computed channels for the specified collections
+func (dbCtx *DatabaseContext) invalUserChannels(ctx context.Context, username string, collections base.ScopeAndCollectionNames, invalSeq uint64) {
+	authr := dbCtx.Authenticator(ctx)
+	if err := authr.InvalidateChannels(username, true, collections, invalSeq); err != nil {
+		base.WarnfCtx(ctx, "Error invalidating channels for user %s: %v", base.UD(username), err)
+	}
+}
+
+// invalRoleChannels invalidates a role's computed channels for the specified collections
+func (dbCtx *DatabaseContext) invalRoleChannels(ctx context.Context, rolename string, collections base.ScopeAndCollectionNames, invalSeq uint64) {
+	authr := dbCtx.Authenticator(ctx)
+	if err := authr.InvalidateChannels(rolename, false, collections, invalSeq); err != nil {
+		base.WarnfCtx(ctx, "Error invalidating channels for role %s: %v", base.UD(rolename), err)
+	}
+}
+
+// invalUserRoles invalidates a user's computed roles
+func (dbCtx *DatabaseContext) invalUserRoles(ctx context.Context, username string, invalSeq uint64) {
+
+	authr := dbCtx.Authenticator(ctx)
 	if err := authr.InvalidateRoles(username, invalSeq); err != nil {
 		base.WarnfCtx(ctx, "Error invalidating roles for user %s: %v", base.UD(username), err)
 	}
 }
 
-func (c *DatabaseCollection) invalUserChannels(ctx context.Context, username string, invalSeq uint64) {
-	authr := c.Authenticator(ctx)
-	if err := authr.InvalidateChannels(username, true, c.ScopeName, c.Name, invalSeq); err != nil {
-		base.WarnfCtx(ctx, "Error invalidating channels for user %s: %v", base.UD(username), err)
-	}
-}
-
-func (c *DatabaseCollection) invalRoleChannels(ctx context.Context, rolename string, invalSeq uint64) {
-	authr := c.Authenticator(ctx)
-	if err := authr.InvalidateChannels(rolename, false, c.ScopeName, c.Name, invalSeq); err != nil {
-		base.WarnfCtx(ctx, "Error invalidating channels for role %s: %v", base.UD(rolename), err)
-	}
-}
-
-func (c *DatabaseCollection) invalUserOrRoleChannels(ctx context.Context, name string, invalSeq uint64) {
-
-	principalName, isRole := channels.AccessNameToPrincipalName(name)
-	if isRole {
-		c.invalRoleChannels(ctx, principalName, invalSeq)
-	} else {
-		c.invalUserChannels(ctx, principalName, invalSeq)
+// invalUserRolesAndChannels invalidates the user's computed roles, and invalidates the computed channels for all specified collections
+func (dbCtx *DatabaseContext) invalUserRolesAndChannels(ctx context.Context, username string, collections base.ScopeAndCollectionNames, invalSeq uint64) {
+	authr := dbCtx.Authenticator(ctx)
+	if err := authr.InvalidateRolesAndChannels(username, collections, invalSeq); err != nil {
+		base.WarnfCtx(ctx, "Error invalidating roles for user %s: %v", base.UD(username), err)
 	}
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2731,7 +2731,7 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Greater(t, endSeq, uint64(0))
 
-	collection.invalidateAllPrincipalsCache(ctx, endSeq)
+	collection.invalidateAllPrincipals(ctx, endSeq)
 	err = collection.WaitForPendingChanges(ctx)
 	assert.NoError(t, err)
 

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -239,9 +239,6 @@ func TestResyncInvalidatePrincipals(t *testing.T) {
 	// validate user channels and roles have been updated
 	user, err = rt.GetDatabase().Authenticator(ctx).GetUser(username)
 	require.NoError(t, err)
-
-	user, err = rt.GetDatabase().Authenticator(ctx).GetUser(username)
-	require.NoError(t, err)
 	channels = user.CollectionChannels(scopeName, collectionName)
 	_, ok = channels["channelABC"]
 	require.False(t, ok, "user should not have channel channelABC")

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -164,3 +164,92 @@ func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
 		})
 	}
 }
+
+func TestResyncInvalidatePrincipals(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+
+	initialSyncFn := `
+	function(doc) {
+		access(doc.userName, "channelABC");
+		access("role:" + doc.roleName, "channelABC");
+		role(doc.userName, "role:roleABC");
+	}`
+
+	updatedSyncFn := `
+	function(doc) {
+		access(doc.userName, "channelDEF");
+		access("role:" + doc.roleName, "channelDEF");
+		role(doc.userName, "role:roleDEF");
+	}`
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		SyncFn:           initialSyncFn,
+	})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	ds := rt.TestBucket.GetSingleDataStore()
+	scopeName := ds.ScopeName()
+	collectionName := ds.CollectionName()
+
+	rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+
+	// Set up user and role
+	username := "alice"
+	rolename := "foo"
+	grantingDocID := "grantDoc"
+	grantingDocBody := `{
+		"userName":"alice",
+		"roleName":"foo"
+	}`
+	rt.CreateUser(username, nil)
+
+	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+rolename, rest.GetRolePayload(t, rolename, rt.GetSingleTestDatabaseCollection(), nil))
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	// Write doc to perform dynamic grants
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+grantingDocID, grantingDocBody)
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	ctx := rt.Context()
+	user, err := rt.GetDatabase().Authenticator(ctx).GetUser(username)
+	require.NoError(t, err)
+	channels := user.CollectionChannels(scopeName, collectionName)
+	_, ok := channels["channelABC"]
+	require.True(t, ok, "user should have channel channelABC")
+	roles := user.RoleNames()
+	_, ok = roles["roleABC"]
+	require.True(t, ok, "user should have role roleABC")
+
+	rt.TakeDbOffline()
+
+	// Update the sync function
+	rt.SyncFn = updatedSyncFn
+	updatedDbConfig := rt.NewDbConfig()
+	rt.UpsertDbConfig("db1", updatedDbConfig)
+	rt.TakeDbOffline()
+
+	// Run resync
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)
+	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+	// validate user channels and roles have been updated
+	user, err = rt.GetDatabase().Authenticator(ctx).GetUser(username)
+	require.NoError(t, err)
+
+	user, err = rt.GetDatabase().Authenticator(ctx).GetUser(username)
+	require.NoError(t, err)
+	channels = user.CollectionChannels(scopeName, collectionName)
+	_, ok = channels["channelABC"]
+	require.False(t, ok, "user should not have channel channelABC")
+	_, ok = channels["channelDEF"]
+	require.True(t, ok, "user should have channel channelDEF")
+	roles = user.RoleNames()
+	_, ok = roles["roleABC"]
+	require.False(t, ok, "user should not have role roleABC")
+	_, ok = roles["roleDEF"]
+	require.True(t, ok, "user should have role roleDEF")
+}

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -202,7 +202,7 @@ func TestChangesFeedOnInheritedChannelsFromRoles(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// create role with collection channel access set to channel A
-	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", "", collection, []string{"A"}))
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", collection, []string{"A"}))
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// create user and assign the role create above to that user
@@ -235,7 +235,7 @@ func TestChangesFeedOnInheritedChannelsFromRolesDefaultCollection(t *testing.T) 
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// create role with collection channel access set to channel A
-	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", "", collection, []string{"A"}))
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", collection, []string{"A"}))
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// create user and assign the role create above to that user

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -101,7 +101,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		roles := []string{"roleA", "roleB"}
 
 		for _, role := range roles {
-			response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+role, rest.GetRolePayload(t, role, rest.RestTesterDefaultUserPassword, rt.GetSingleTestDatabaseCollection(), []string{"ChannelA"}))
+			response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+role, rest.GetRolePayload(t, role, rt.GetSingleTestDatabaseCollection(), []string{"ChannelA"}))
 			rest.RequireStatus(t, response, http.StatusCreated)
 		}
 		response := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_role/", "")

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -921,7 +921,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"A"}))
+	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"A"}))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": ["role"], "password": "letmein"}`)
@@ -1780,7 +1780,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	}()
 
 	// perform role grant to allow for all channels
-	resp := rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", "", rt2_collection, []string{"A", "B", "C"}))
+	resp := rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2_collection, []string{"A", "B", "C"}))
 
 	_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusOK)
@@ -1799,7 +1799,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.Len(t, changesResults.Results, 5)
 
 	// Revoke C and ensure docC gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", "", rt2_collection, []string{"A", "B"}))
+	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2_collection, []string{"A", "B"}))
 	RequireStatus(t, resp, http.StatusOK)
 	require.NoError(t, rt2.WaitForPendingChanges())
 
@@ -1810,7 +1810,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Revoke B and ensure docB gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", "", rt2_collection, []string{"A"}))
+	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2_collection, []string{"A"}))
 	RequireStatus(t, resp, http.StatusOK)
 
 	err = rt1.WaitForCondition(func() bool {
@@ -1820,7 +1820,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Revoke A and ensure docA, docAB, docABC gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", "", rt2_collection, []string{}))
+	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2_collection, []string{}))
 	RequireStatus(t, resp, http.StatusOK)
 
 	err = rt1.WaitForCondition(func() bool {

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -31,7 +31,7 @@ func TestRolePurge(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create role
-	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))
+	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"channel"}))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Delete role
@@ -48,7 +48,7 @@ func TestRolePurge(t *testing.T) {
 	assert.NotNil(t, role)
 
 	// Re-create role
-	resp = rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))
+	resp = rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"channel"}))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Delete role again but with purge flag
@@ -72,10 +72,10 @@ func TestRoleAPI(t *testing.T) {
 
 	// PUT a role
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
-	response := rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", "", collection, []string{"fedoras", "fixies"}))
+	response := rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 
-	response = rt.SendAdminRequest("PUT", "/db/_role/testdeleted", GetRolePayload(t, "", "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("PUT", "/db/_role/testdeleted", GetRolePayload(t, "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/testdeleted", ""), 200)
 
@@ -97,9 +97,9 @@ func TestRoleAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
 
 	// POST a role
-	response = rt.SendAdminRequest("POST", "/db/_role", GetRolePayload(t, "hipster", "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("POST", "/db/_role", GetRolePayload(t, "hipster", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 301)
-	response = rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "hipster", "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "hipster", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_role/hipster", "")
 	RequireStatus(t, response, 200)
@@ -157,7 +157,7 @@ func TestFunkyRoleNames(t *testing.T) {
 			require.NoError(t, a.Save(user))
 
 			// Create role
-			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", url.PathEscape(tc.RoleName)), GetRolePayload(t, "", "", collection, []string{"testchannel"}))
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", url.PathEscape(tc.RoleName)), GetRolePayload(t, "", collection, []string{"testchannel"}))
 			RequireStatus(t, response, 201)
 
 			// Create test document
@@ -251,7 +251,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	// POST a role
-	response := rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "role1", "", collection, []string{"chan1"}))
+	response := rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "role1", collection, []string{"chan1"}))
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_role/role1", "")
 	RequireStatus(t, response, 200)
@@ -310,7 +310,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_user/zegpold", GetUserPayload(t, "zegpold", "letmein", "", collection, []string{"beta"}, nil))
 	RequireStatus(t, response, 201)
 
-	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "hipster", "", collection, []string{"gamma"}))
+	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "hipster", collection, []string{"gamma"}))
 	RequireStatus(t, response, 201)
 	/*
 		alice, err := a.NewUser("alice", "letmein", channels.BaseSetOf(t, "alpha"))

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -861,7 +861,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		docSeqArr = append(docSeqArr, body["_sync"].(map[string]interface{})["sequence"].(float64))
 	}
 
-	response = rt.SendAdminRequest("PUT", "/{{.db}}/_role/role1", GetRolePayload(t, "role1", "", collection, []string{"channel_1"}))
+	response = rt.SendAdminRequest("PUT", "/{{.db}}/_role/role1", GetRolePayload(t, "role1", collection, []string{"channel_1"}))
 	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user1", GetUserPayload(t, "user1", "letmein", "", collection, []string{"channel_1"}, []string{"role1"}))

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -330,7 +330,7 @@ func TestUserAPI(t *testing.T) {
 
 	// Create a role
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
-	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 
 	// Give the user that role
@@ -517,12 +517,12 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create a role 'developer' through POST request
-	response = rt.SendAdminRequest(http.MethodPost, "/db/_role/", GetRolePayload(t, "developer", "", collection, []string{"channel1", "channel2"}))
+	response = rt.SendAdminRequest(http.MethodPost, "/db/_role/", GetRolePayload(t, "developer", collection, []string{"channel1", "channel2"}))
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create another role 'coder' through PUT request.
-	response = rt.SendAdminRequest(http.MethodPut, "/db/_role/coder", GetRolePayload(t, "", "", collection, []string{"channel3", "channel4"}))
+	response = rt.SendAdminRequest(http.MethodPut, "/db/_role/coder", GetRolePayload(t, "", collection, []string{"channel3", "channel4"}))
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
@@ -591,7 +591,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 			s := collection.ScopeName
 
 			// Create role
-			resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))
+			resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"channel"}))
 			RequireStatus(t, resp, http.StatusCreated)
 
 			// Create user

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1673,14 +1673,11 @@ func GetUserPayload(t testing.TB, username, password, email string, collection *
 	return string(marshalledConfig)
 }
 
-// GetRolePayload will take roleName, password and channels you want to assign a particular role and return the appropriate payload for the _role endpoint
-func GetRolePayload(t *testing.T, roleName, password string, collection *db.DatabaseCollection, chans []string) string {
+// GetRolePayload will take roleName and channels you want to assign a particular role and return the appropriate payload for the _role endpoint
+func GetRolePayload(t *testing.T, roleName string, collection *db.DatabaseCollection, chans []string) string {
 	config := auth.PrincipalConfig{}
 	if roleName != "" {
 		config.Name = &roleName
-	}
-	if password != "" {
-		config.Password = &password
 	}
 	marshalledConfig, err := addChannelsToPrincipal(config, collection, chans)
 	require.NoError(t, err)


### PR DESCRIPTION
CBG-4025

As part of this change, modified access invalidation functions to perform invalidation in a single update to the principal document, instead of once per collection (and one additional time for roles).  To support this:
- Switched existing invalidation functions (invalRoleChannels, invalUserChannels, etc) to have *DatabaseContext receiver instead of `*DatabaseCollection`, and added a `ScopeAndCollectionNames` parameter to specify the set of collections that should have access invalidated.
- For ease of use, maintained the existing invalidation functions on `*DatabaseCollection` - they now just call in to the `*DatabaseContext` functions with their single collection
- Added a new invalUserRolesAndChannels to invalidate a user’s roles and channels in a single user doc update.  Only currently used by resync

Query based resync still processes a single collection’s updates at a time - it’s structured a bit differently and didn’t seem to be worth refactoring at this point.  It has been updated to properly invalidate user roles.

The new test TestResyncInvalidatePrincipals covers the fix - have verified it with `SG_TEST_USE_DEFAULT_COLLECTION=true/false`.  Also made a test utility change to remove the password parameter from GetRolePayload since roles don’t have passwords.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2551/
