### PR TITLE
Add handler serverType to identify HTTP Server associated with requests

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -51,7 +51,7 @@ type vendor struct {
 // HTTP handler for the root ("/")
 func (h *handler) handleRoot() error {
 	resp := rootResponse{
-		Admin:   h.privs == adminPrivs,
+		Admin:   h.serverType == adminServer,
 		CouchDB: "Welcome",
 		Vendor: vendor{
 			Name: base.ProductNameString,

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -57,6 +57,16 @@ func TestRoot(t *testing.T) {
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "Welcome", body["couchdb"])
+	isAdmin, ok := body["admin"].(bool)
+	assert.False(t, ok)
+	assert.False(t, isAdmin)
+
+	response = rt.SendAdminRequest("GET", "/", "")
+	RequireStatus(t, response, 200)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
+	isAdmin, ok = body["admin"].(bool)
+	assert.True(t, ok)
+	assert.True(t, isAdmin)
 
 	response = rt.SendRequest("HEAD", "/", "")
 	RequireStatus(t, response, 200)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -57,14 +57,14 @@ func TestRoot(t *testing.T) {
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "Welcome", body["couchdb"])
-	isAdmin, ok := body["admin"].(bool)
+	isAdmin, ok := body["ADMIN"].(bool)
 	assert.False(t, ok)
 	assert.False(t, isAdmin)
 
 	response = rt.SendAdminRequest("GET", "/", "")
 	RequireStatus(t, response, 200)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
-	isAdmin, ok = body["admin"].(bool)
+	isAdmin, ok = body["ADMIN"].(bool)
 	assert.True(t, ok)
 	assert.True(t, isAdmin)
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -80,13 +80,13 @@ type serverType string
 
 const (
 	// serverTypePublic indicates the public interface for sync gateway
-	publicServer = "public"
+	publicServer serverType = "public"
 	// serverTypeAdmin indicates the admin interface for sync gateway
-	adminServer = "admin"
+	adminServer serverType = "admin"
 	// serverTypeMetrics indicates the metrics interface for sync gateway
-	metricsServer = "metrics"
+	metricsServer serverType = "metrics"
 	// serverTypeDiagnostic indicates the diagnostic interface for sync gateway
-	diagnosticServer = "diagnostic"
+	diagnosticServer serverType = "diagnostic"
 )
 
 // Bucket configuration elements - used by db, index

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -103,6 +103,7 @@ type handler struct {
 	authScopeFunc         authScopeFunc
 	httpLogLevel          *base.LogLevel // if set, always log HTTP information at this level, instead of the default
 	rqCtx                 context.Context
+	serverType            serverType
 }
 
 type authScopeFunc func(context.Context, *handler) (string, error)
@@ -121,7 +122,8 @@ type handlerMethod func(*handler) error
 // makeHandlerWithOptions creates an http.Handler that will run a handler with the given method handlerOptions
 func makeHandlerWithOptions(server *ServerContext, privs handlerPrivs, accessPermissions []Permission, responsePermissions []Permission, method handlerMethod, options handlerOptions) http.Handler {
 	return http.HandlerFunc(func(r http.ResponseWriter, rq *http.Request) {
-		h := newHandler(server, privs, r, rq, options)
+		serverType := getCtxServerType(rq.Context())
+		h := newHandler(server, privs, serverType, r, rq, options)
 		err := h.invoke(method, accessPermissions, responsePermissions)
 		h.writeError(err)
 		if !options.skipLogDuration {
@@ -176,7 +178,7 @@ type handlerOptions struct {
 	httpLogLevel      *base.LogLevel // if set, log HTTP requests to this handler at this level, instead of the usual info level
 }
 
-func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter, rq *http.Request, options handlerOptions) *handler {
+func newHandler(server *ServerContext, privs handlerPrivs, serverType serverType, r http.ResponseWriter, rq *http.Request, options handlerOptions) *handler {
 	h := &handler{
 		server:            server,
 		privs:             privs,
@@ -189,6 +191,7 @@ func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter
 		allowNilDBContext: options.allowNilDBContext,
 		authScopeFunc:     options.authScopeFunc,
 		httpLogLevel:      options.httpLogLevel,
+		serverType:        serverType,
 	}
 
 	// initialize h.rqCtx

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -628,7 +628,7 @@ func (h *handler) shouldUpdateBytesTransferredStats() bool {
 	if h.db == nil {
 		return false
 	}
-	if h.privs != publicPrivs && h.privs != regularPrivs {
+	if h.serverType != publicServer {
 		return false
 	}
 	if h.isBlipSync() {
@@ -682,7 +682,7 @@ func (h *handler) logRESTCount() {
 	if h.db == nil {
 		return
 	}
-	if h.privs != publicPrivs && h.privs != regularPrivs {
+	if h.serverType != publicServer {
 		return
 	}
 	if h.isBlipSync() {
@@ -1582,7 +1582,7 @@ func (h *handler) formatSerialNumber() string {
 // Admin requests can always see this, regardless of the HideProductVersion setting.
 func (h *handler) shouldShowProductVersion() bool {
 	hideProductVersion := base.BoolDefault(h.server.Config.API.HideProductVersion, false)
-	return h.privs == adminPrivs || !hideProductVersion
+	return h.serverType == adminServer || !hideProductVersion
 }
 
 func requiresWritePermission(accessPermissions []Permission) bool {

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -9,6 +9,7 @@
 package rest
 
 import (
+	"context"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -32,12 +33,11 @@ func init() {
 	docWithSlashPathRegex, _ = regexp.Compile("/" + dbRegex + "/([^_]|_user/).*%2[fF]")
 }
 
-// CreateCommonRouter
-// Creates a GorillaMux router containing the basic HTTP handlers for a server.
+// createCommonRouter returns a Gorilla mux router containing the basic HTTP handlers for a server.
 // This is the common functionality of the public and admin ports.
 // The 'privs' parameter specifies the authentication the handler will use.
-func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspace *mux.Router) {
-	root = CreatePingRouter(sc)
+func createCommonRouter(sc *ServerContext, privs handlerPrivs, serverType serverType) (root, db, keyspace *mux.Router) {
+	root = NewRouter(sc, serverType)
 
 	// Global operations:
 	root.Handle("/", makeHandler(sc, privs, nil, nil, (*handler).handleRoot)).Methods("GET", "HEAD")
@@ -120,7 +120,7 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (root, db, keyspa
 
 // CreatePublicHandler Creates the HTTP handler for the public API of a gateway server.
 func CreatePublicHandler(sc *ServerContext) http.Handler {
-	r, dbr, _ := createCommonRouter(sc, regularPrivs)
+	r, dbr, _ := createCommonRouter(sc, regularPrivs, publicServer)
 
 	dbr.Handle("/_session", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleSessionPOST)).Methods("POST")
 	dbr.Handle("/_session", makeHandler(sc, regularPrivs, nil, nil, (*handler).handleSessionDELETE)).Methods("DELETE")
@@ -129,7 +129,8 @@ func CreatePublicHandler(sc *ServerContext) http.Handler {
 	// if the db exists, and 403 if it doesn't.
 	r.Handle("/{targetdb:"+dbRegex+"}/",
 		makeHandler(sc, publicPrivs, nil, nil, (*handler).handleCreateTarget)).Methods("PUT")
-	return wrapRouter(sc, regularPrivs, r)
+
+	return wrapRouter(sc, regularPrivs, publicServer, r)
 }
 
 // ////// ADMIN API:
@@ -137,12 +138,12 @@ func CreatePublicHandler(sc *ServerContext) http.Handler {
 // CreateAdminHandler Creates the HTTP handler for the PRIVATE admin API of a gateway server.
 func CreateAdminHandler(sc *ServerContext) http.Handler {
 	router := CreateAdminRouter(sc)
-	return wrapRouter(sc, adminPrivs, router)
+	return wrapRouter(sc, adminPrivs, adminServer, router)
 }
 
 // CreateAdminRouter Creates the HTTP handler for the PRIVATE admin API of a gateway server.
 func CreateAdminRouter(sc *ServerContext) *mux.Router {
-	r, dbr, keyspace := createCommonRouter(sc, adminPrivs)
+	r, dbr, keyspace := createCommonRouter(sc, adminPrivs, adminServer)
 
 	// Keyspace handlers (single collection):
 	keyspace.Handle("/_purge",
@@ -336,24 +337,51 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 // CreateMetricHandler Creates the HTTP handler for the prometheus metrics API of a gateway server.
 func CreateMetricHandler(sc *ServerContext) http.Handler {
 	router := CreateMetricRouter(sc)
-	return wrapRouter(sc, metricsPrivs, router)
+	return wrapRouter(sc, metricsPrivs, metricsServer, router)
 }
 
 // createDiagnosticHandler Creates the HTTP handler for the diagnostic API of a gateway server.
 func createDiagnosticHandler(sc *ServerContext) http.Handler {
 	router := createDiagnosticRouter(sc)
-	return wrapRouter(sc, adminPrivs, router)
+	return wrapRouter(sc, adminPrivs, diagnosticServer, router)
 }
 
-func CreatePingRouter(sc *ServerContext) *mux.Router {
+// NewRouter returns a basic router for the given server type.
+func NewRouter(sc *ServerContext, serverType serverType) *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
-	r.Handle("/_ping", makeSilentHandler(sc, publicPrivs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
+	r.Use(withServerType(serverType))
+	addSharedRouterHandlers(sc, r)
 	return r
 }
 
+// addSharedRouterHandlers adds the handlers that are defined on all server types.
+func addSharedRouterHandlers(sc *ServerContext, r *mux.Router) {
+	r.Handle("/_ping", makeSilentHandler(sc, publicPrivs, nil, nil, (*handler).handlePing)).Methods("GET", "HEAD")
+}
+
+// withServerType returns a middleware function that stores serverType in the request context for future retrieval.
+func withServerType(serverType serverType) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			next.ServeHTTP(w, req.WithContext(setCtxServerType(req.Context(), serverType)))
+		})
+	}
+}
+
+// serverTypeCtxKey stores the serverType on a request context.
+type serverTypeCtxKey struct{}
+
+func setCtxServerType(ctx context.Context, st serverType) context.Context {
+	return context.WithValue(ctx, serverTypeCtxKey{}, st)
+}
+
+func getCtxServerType(ctx context.Context) serverType {
+	return ctx.Value(serverTypeCtxKey{}).(serverType)
+}
+
 func CreateMetricRouter(sc *ServerContext) *mux.Router {
-	r := CreatePingRouter(sc)
+	r := NewRouter(sc, metricsServer)
 
 	r.Handle("/metrics", makeSilentHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
 	r.Handle("/_metrics", makeSilentHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
@@ -363,7 +391,8 @@ func CreateMetricRouter(sc *ServerContext) *mux.Router {
 }
 
 func createDiagnosticRouter(sc *ServerContext) *mux.Router {
-	r := CreatePingRouter(sc)
+	r := NewRouter(sc, diagnosticServer)
+
 	dbr := r.PathPrefix("/{db:" + dbRegex + "}/").Subrouter()
 	dbr.StrictSlash(true)
 	keyspace := r.PathPrefix("/{keyspace:" + dbRegex + "}/").Subrouter()
@@ -380,7 +409,7 @@ func createDiagnosticRouter(sc *ServerContext) *mux.Router {
 // Returns a top-level HTTP handler for a Router. This adds behavior for URLs that don't
 // match anything -- it handles the OPTIONS method as well as returning either a 404 or 405
 // for URLs that don't match a route.
-func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.Handler {
+func wrapRouter(sc *ServerContext, privs handlerPrivs, serverType serverType, router *mux.Router) http.Handler {
 	return http.HandlerFunc(func(response http.ResponseWriter, rq *http.Request) {
 		FixQuotedSlashes(rq)
 		var match mux.RouteMatch
@@ -388,7 +417,7 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 			router.ServeHTTP(response, rq)
 		} else {
 			// Log the request
-			h := newHandler(sc, privs, response, rq, handlerOptions{})
+			h := newHandler(sc, privs, serverType, response, rq, handlerOptions{})
 			h.logRequestLine()
 
 			// Inject CORS if enabled and requested and not admin port

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -51,7 +51,7 @@ var errCollectionsUnsupported = base.HTTPErrorf(http.StatusBadRequest, "Named co
 
 var ErrSuspendingDisallowed = errors.New("database does not allow suspending")
 
-var allServers = []string{publicServer, adminServer, metricsServer, diagnosticServer}
+var allServers = []serverType{publicServer, adminServer, metricsServer, diagnosticServer}
 
 // serverInfo represents an instance of an HTTP server from sync gateway
 type serverInfo struct {


### PR DESCRIPTION
- Refactor of `CreatePingRouter()` to `NewRouter()` and make it take `serverType` which is used to set `handler.serverType`
- Convert `GET /`, and public API stats to use `handler.serverType`
- Opens up the ability for handlers (or middleware) to read `serverInfo` via `sc._httpServers[st]`, for example to retrieve the API listen address for the given request.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2556/
