### PR TITLE
Adds `AssertfCtx` which conditionally panics or warns based on dev mode

### DIFF
--- a/base/devmode.go
+++ b/base/devmode.go
@@ -8,10 +8,18 @@
 
 package base
 
+import "context"
+
 // IsDevMode returns true when compiled with the `cb_sg_devmode` build tag, and false otherwise.
 //
 // The compiler will remove this check and all code invoked inside it in non-dev mode, avoiding any impact on production code.
 // https://godbolt.org/z/f1K8a96rE
 func IsDevMode() bool {
 	return cbSGDevModeBuildTagSet
+}
+
+// AssertfCtx panics when compiled with the `cb_sg_devmode` build tag, and just warns otherwise.
+// Callers must be aware that they are responsible for handling returns to cover the non-devmode warn case.
+func AssertfCtx(ctx context.Context, format string, args ...any) {
+	assertLogFn(ctx, format, args...)
 }

--- a/base/devmode_off.go
+++ b/base/devmode_off.go
@@ -12,3 +12,5 @@
 package base
 
 const cbSGDevModeBuildTagSet = false
+
+var assertLogFn logFn = WarnfCtx

--- a/base/devmode_on.go
+++ b/base/devmode_on.go
@@ -12,3 +12,5 @@
 package base
 
 const cbSGDevModeBuildTagSet = true
+
+var assertLogFn logFn = PanicfCtx

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -10,7 +10,6 @@ package base
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 )
@@ -114,12 +113,8 @@ func Audit(ctx context.Context, id AuditID, additionalData AuditFields) {
 	}
 	fieldsJSON, err := JSONMarshal(fields)
 	if err != nil {
-		if IsDevMode() {
-			panic(fmt.Sprintf("failed to marshal audit fields: %v", err))
-		} else {
-			WarnfCtx(ctx, "failed to marshal audit fields: %v", err)
-			return
-		}
+		AssertfCtx(ctx, "failed to marshal audit fields: %v", err)
+		return
 	}
 	auditLogger.logf(string(fieldsJSON))
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -128,8 +128,10 @@ func init() {
 	initExternalLoggers()
 }
 
+type logFn func(ctx context.Context, format string, args ...any)
+
 // PanicfCtx logs the given formatted string and args to the error log level and given log key and then panics.
-func PanicfCtx(ctx context.Context, format string, args ...interface{}) {
+func PanicfCtx(ctx context.Context, format string, args ...any) {
 	// Fall back to stdlib's log.Panicf if SG loggers aren't set up.
 	if errorLogger == nil {
 		log.Panicf(format, args...)
@@ -141,7 +143,7 @@ func PanicfCtx(ctx context.Context, format string, args ...interface{}) {
 }
 
 // FatalfCtx logs the given formatted string and args to the error log level and given log key and then exits.
-func FatalfCtx(ctx context.Context, format string, args ...interface{}) {
+func FatalfCtx(ctx context.Context, format string, args ...any) {
 	// Fall back to stdlib's log.Panicf if SG loggers aren't set up.
 	if errorLogger == nil {
 		log.Fatalf(format, args...)
@@ -153,32 +155,32 @@ func FatalfCtx(ctx context.Context, format string, args ...interface{}) {
 }
 
 // ErrorfCtx logs the given formatted string and args to the error log level and given log key.
-func ErrorfCtx(ctx context.Context, format string, args ...interface{}) {
+func ErrorfCtx(ctx context.Context, format string, args ...any) {
 	logTo(ctx, LevelError, KeyAll, format, args...)
 }
 
 // WarnfCtx logs the given formatted string and args to the warn log level and given log key.
-func WarnfCtx(ctx context.Context, format string, args ...interface{}) {
+func WarnfCtx(ctx context.Context, format string, args ...any) {
 	logTo(ctx, LevelWarn, KeyAll, format, args...)
 }
 
 // InfofCtx logs the given formatted string and args to the info log level and given log key.
-func InfofCtx(ctx context.Context, logKey LogKey, format string, args ...interface{}) {
+func InfofCtx(ctx context.Context, logKey LogKey, format string, args ...any) {
 	logTo(ctx, LevelInfo, logKey, format, args...)
 }
 
 // DebugfCtx logs the given formatted string and args to the debug log level with an optional log key.
-func DebugfCtx(ctx context.Context, logKey LogKey, format string, args ...interface{}) {
+func DebugfCtx(ctx context.Context, logKey LogKey, format string, args ...any) {
 	logTo(ctx, LevelDebug, logKey, format, args...)
 }
 
 // TracefCtx logs the given formatted string and args to the trace log level with an optional log key.
-func TracefCtx(ctx context.Context, logKey LogKey, format string, args ...interface{}) {
+func TracefCtx(ctx context.Context, logKey LogKey, format string, args ...any) {
 	logTo(ctx, LevelTrace, logKey, format, args...)
 }
 
 // LogLevelCtx allows logging where the level can be set via parameter.
-func LogLevelCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
+func LogLevelCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...any) {
 	logTo(ctx, logLevel, logKey, format, args...)
 }
 
@@ -192,7 +194,7 @@ func RecordStats(statsJson string) {
 
 // logTo is the "core" logging function. All other logging functions (like Debugf(), WarnfCtx(), etc.) end up here.
 // The function will fan out the log to all of the various outputs for them to decide if they should log it or not.
-func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
+func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...any) {
 	// Defensive bounds-check for log level. All callers of this function should be within this range.
 	if logLevel < LevelNone || logLevel >= levelCount {
 		return
@@ -256,7 +258,7 @@ var consoleFOutput io.Writer = os.Stderr
 
 // ConsolefCtx logs the given formatted string and args to the given log level and log key,
 // as well as making sure the message is *always* logged to stdout.
-func ConsolefCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
+func ConsolefCtx(ctx context.Context, logLevel LogLevel, logKey LogKey, format string, args ...any) {
 	logTo(ctx, logLevel, logKey, format, args...)
 
 	// If the above logTo didn't already log to stderr, do it directly here


### PR DESCRIPTION
I'm finding myself repeating this `IsDevMode()` pattern regularly now we have it, so I've pulled that logic into its own `AssertfCtx` utility.

e.g.
```go
if IsDevMode() {
	panic(fmt.Sprintf("failed to marshal audit fields: %v", err))
} else {
	WarnfCtx(ctx, "failed to marshal audit fields: %v", err)
	return
}
```

This implementation still allows for returned errors, or warning and carrying on with empty values, but will make failures very obvious during development.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
