### PR TITLE
CBG-4048 add audit events for replication

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -157,9 +157,13 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		MandatoryFields: AuditFields{
-			"db":          "database name",
-			"audit_scope": "global or db",
-			"new_config":  "JSON representation of new db audit config",
+			"audit_scope":     "global or db",
+			AuditFieldPayload: "JSON representation of new db audit config",
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			// fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EventType: eventTypeAdmin,
 	},
@@ -355,8 +359,8 @@ var AuditEvents = events{
 		Name:        "Create database",
 		Description: "A new database was created",
 		MandatoryFields: AuditFields{
-			"db":     "database name",
-			"config": "JSON representation of db config",
+			"db":              "database name",
+			AuditFieldPayload: "JSON representation of db config",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -397,8 +401,8 @@ var AuditEvents = events{
 		Name:        "Update database config",
 		Description: "Database configuration was updated",
 		MandatoryFields: AuditFields{
-			"db":     "database name",
-			"config": "JSON representation of new db config",
+			"db":              "database name",
+			AuditFieldPayload: "payload",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -636,7 +640,6 @@ var AuditEvents = events{
 		Name:        "Replication connect",
 		Description: "A replication client connected",
 		MandatoryFields: AuditFields{
-			"cid":         "context id", // this is blip context id
 			"client_type": "isgr, cbl, other",
 		},
 		OptionalFields: AuditFields{
@@ -655,7 +658,6 @@ var AuditEvents = events{
 		Name:        "Replication disconnect",
 		Description: "A replication client disconnected",
 		MandatoryFields: AuditFields{
-			"cid":         "context id", // this is blip context id
 			"client_type": "isgr, cbl, other",
 		},
 		mandatoryFieldGroups: []fieldGroup{
@@ -672,7 +674,7 @@ var AuditEvents = events{
 		Description: "A new Inter-Sync Gateway Replication was created",
 		MandatoryFields: AuditFields{
 			AuditFieldReplicationID: "replication id",
-			"config":                "JSON representation of replication config",
+			AuditFieldPayload:       "payload",
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
@@ -703,7 +705,7 @@ var AuditEvents = events{
 		Description: "Inter-Sync Gateway Replication was updated",
 		MandatoryFields: AuditFields{
 			AuditFieldReplicationID: "replication id",
-			"config":                "JSON representation of new replication config",
+			AuditFieldPayload:       "payload",
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -636,12 +636,16 @@ var AuditEvents = events{
 		Name:        "Replication connect",
 		Description: "A replication client connected",
 		MandatoryFields: AuditFields{
-			"db":  "database name",
-			"cid": "context id",
+			"cid":         "context id", // this is blip context id
+			"client_type": "isgr, cbl, other",
 		},
 		OptionalFields: AuditFields{
-			"client_type":    "isgr, cbl, other",
 			"client_version": "client version",
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			// fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -651,8 +655,13 @@ var AuditEvents = events{
 		Name:        "Replication disconnect",
 		Description: "A replication client disconnected",
 		MandatoryFields: AuditFields{
-			"db":  "database name",
-			"cid": "context id",
+			"cid":         "context id", // this is blip context id
+			"client_type": "isgr, cbl, other",
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			// fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -25,6 +25,21 @@ const (
 	AuditIDPublicUserAuthenticationFailed AuditID = 53261
 
 	AuditIDReadDatabase AuditID = 53301
+
+	// BLIP Replication events
+	AuditIDReplicationConnect    AuditID = 54300
+	AuditIDReplicationDisconnect AuditID = 54301
+	// ISGR events
+	AuditIDISGRCreate    AuditID = 54400
+	AuditIDISGRRead      AuditID = 54401
+	AuditIDISGRUpdate    AuditID = 54402
+	AuditIDISGRDelete    AuditID = 54403
+	AuditIDISGRStatus    AuditID = 54410
+	AuditIDISGRStart     AuditID = 54411
+	AuditIDISGRStop      AuditID = 54412
+	AuditIDISGRReset     AuditID = 54413
+	AuditIDISGRAllStatus AuditID = 54420
+	AuditIDISGRAllRead   AuditID = 54421
 )
 
 // AuditEvents is a table of audit events created by Sync Gateway.
@@ -71,6 +86,120 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		EventType:          eventTypeUser,
+	},
+	AuditIDReplicationConnect: {
+		Name:        "Replication connected",
+		Description: "Replication connected (Inter-Sync Gateway or Couchbase Lite)",
+		MandatoryFields: AuditFields{
+			AuditFieldReplicationID: "replication_correlation_id", // don't collide with http correlation id, or ISGR replication ID
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeUser,
+	},
+	AuditIDReplicationDisconnect: {
+		Name:        "Replication disconnected",
+		Description: "Replication disconnected (Inter-Sync Gateway or Couchbase Lite)",
+		MandatoryFields: AuditFields{
+			AuditFieldReplicationID: "replication_correlation_id", // don't collide with http correlation ID, or ISGR replication ID
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeUser,
+	},
+	AuditIDISGRCreate: {
+		Name:        "ISGR replication created",
+		Description: "Inter-Sync Gateway Replication created",
+		MandatoryFields: AuditFields{
+			AuditFieldISGRReplicationID: "replication_name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRRead: {
+		Name:        "ISGR replication read",
+		Description: "Inter-Sync Gateway Replication read single replication",
+		MandatoryFields: AuditFields{
+			AuditFieldISGRReplicationID: "replication_name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRUpdate: {
+		Name:        "ISGR replication updated",
+		Description: "Inter-Sync Gateway Replication updated",
+		MandatoryFields: AuditFields{
+			AuditFieldISGRReplicationID: "replication_name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRDelete: {
+		Name:        "ISGR replication deleted",
+		Description: "Inter-Sync Gateway Replication deleted",
+		MandatoryFields: AuditFields{
+			AuditFieldISGRReplicationID: "replication_name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRStatus: {
+		Name:        "ISGR replication status",
+		Description: "Inter-Sync Gateway Replication status",
+		MandatoryFields: AuditFields{
+			AuditFieldISGRReplicationID: "replication_name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRStart: {
+		Name:        "ISGR replication started",
+		Description: "Inter-Sync Gateway Replication started",
+		MandatoryFields: AuditFields{
+			AuditFieldISGRReplicationID: "replication_name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRStop: {
+		Name:        "ISGR replication stopped",
+		Description: "Inter-Sync Gateway Replication stopped",
+		MandatoryFields: AuditFields{
+			AuditFieldISGRReplicationID: "replication_name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRReset: {
+		Name:        "ISGR replication reset",
+		Description: "Inter-Sync Gateway Replication reset",
+		MandatoryFields: AuditFields{
+			AuditFieldISGRReplicationID: "replication_name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRAllStatus: {
+		Name:               "ISGR all replications status",
+		Description:        "Inter-Sync Gateway get all replication statuses",
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDISGRAllRead: {
+		Name:               "ISGR read all replications",
+		Description:        "Inter-Sync Gateway read all replications",
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
 	},
 }
 

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -33,6 +33,7 @@ const (
 	auditFieldCorrelationID = "cid" // FIXME: how to distinguish between this field (http) and blip id below
 	auditFieldKeyspace      = "ks"
 	AuditFieldReplicationID = "replication_id"
+	AuditFieldPayload       = "payload"
 )
 
 // expandFields populates data with information from the id, context and additionalData.

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -22,16 +22,18 @@ const (
 
 // commonly used fields for audit events
 const (
-	auditFieldID            = "id"
-	auditFieldTimestamp     = "timestamp"
-	auditFieldName          = "name"
-	auditFieldDescription   = "description"
-	auditFieldRealUserID    = "real_userid"
-	auditFieldLocal         = "local"
-	auditFieldRemote        = "remote"
-	auditFieldDatabase      = "db"
-	auditFieldCorrelationID = "cid"
-	auditFieldKeyspace      = "ks"
+	auditFieldID                = "id"
+	auditFieldTimestamp         = "timestamp"
+	auditFieldName              = "name"
+	auditFieldDescription       = "description"
+	auditFieldRealUserID        = "real_userid"
+	auditFieldLocal             = "local"
+	auditFieldRemote            = "remote"
+	auditFieldDatabase          = "db"
+	auditFieldCorrelationID     = "cid" // FIXME: how to distinguish between this field (http) and blip id below
+	auditFieldKeyspace          = "ks"
+	AuditFieldReplicationID     = "replication_correlation_id"
+	AuditFieldISGRReplicationID = "isgr_replication_id"
 )
 
 // expandFields populates data with information from the id, context and additionalData.

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -60,20 +60,23 @@ func (h *handler) handleBLIPSync() error {
 	// Overwrite the existing logging context with the blip context ID
 	h.rqCtx = base.CorrelationIDLogCtx(h.ctx(), base.FormatBlipContextID(blipContext.ID))
 	h.response.Header().Set(db.BLIPCorrelationIDResponseHeader, blipContext.ID)
-	auditFields := base.AuditFields{base.AuditFieldReplicationID: base.FormatBlipContextID(blipContext.ID)}
-	base.Audit(h.rqCtx, base.AuditIDReplicationConnect, auditFields)
-	defer func() {
-		base.Audit(h.rqCtx, base.AuditIDReplicationDisconnect, auditFields)
-	}()
 	// Create a new BlipSyncContext attached to the given blipContext.
 	ctx := db.NewBlipSyncContext(h.rqCtx, blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))
 	defer ctx.Close()
 
+	auditFields := base.AuditFields{base.AuditFieldReplicationID: base.FormatBlipContextID(blipContext.ID)}
 	if string(db.BLIPClientTypeSGR2) == h.getQuery(db.BLIPSyncClientTypeQueryParam) {
 		ctx.SetClientType(db.BLIPClientTypeSGR2)
+		auditFields["client_type"] = db.BLIPClientTypeSGR2
 	} else {
+		// we could pull the exact CBL client and version from User-Agent
 		ctx.SetClientType(db.BLIPClientTypeCBL2)
+		auditFields["client_type"] = db.BLIPClientTypeCBL2
 	}
+	base.Audit(h.rqCtx, base.AuditIDReplicationConnect, auditFields)
+	defer func() {
+		base.Audit(h.rqCtx, base.AuditIDReplicationDisconnect, auditFields)
+	}()
 
 	// Create a BLIP WebSocket handler and have it handle the request:
 	server := blipContext.WebSocketServer()

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7789,7 +7789,7 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 	assert.Equal(t, "", config.RemoteUsername)
 	assert.Equal(t, "", config.RemotePassword)
 
-	_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), t.Name(), "stop")
+	_, _, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), t.Name(), "stop")
 	require.NoError(t, err)
 	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
 	err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(t.Name())
@@ -8113,7 +8113,7 @@ function (doc) {
 			}
 
 			// Stop and remove replicator (to stop checkpointing after teardown causing panic)
-			_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), replName, "stop")
+			_, _, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), replName, "stop")
 			require.NoError(t, err)
 			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateStopped)
 			err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(replName)
@@ -8138,7 +8138,7 @@ function (doc) {
 			base.RequireWaitForStat(t, receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 10)
 
 			// Stop and remove replicator
-			_, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), replName, "stop")
+			_, _, err = activeRT.GetDatabase().SGReplicateMgr.PutReplicationStatus(activeRT.Context(), replName, "stop")
 			require.NoError(t, err)
 			activeRT.WaitForReplicationStatus(replName, db.ReplicationStateStopped)
 			err = activeRT.GetDatabase().SGReplicateMgr.DeleteReplication(replName)


### PR DESCRIPTION
- For events that are on the admin api, should they have `eventTypeAdmin`, or if they are triggered by an admin user are they going to have `eventTypeUser`? For requests that are actually over the admin OR user port, such as `_blipsync`, how should these get typed? It is my understanding that this is only going to be used for user documentation.
- ~correlation ID is overloaded for us, it can mean blip correlation ID or http correlation id. I tried to create a separate field but its name is really really long. Given that the logs are going to be compressed, are long field names a problem?~ We are going to determine whether it is blip or http based on whether it is `[id]` or `#id`
- ~If we are creating replications as a result of creating a database, should these get logged? This might indicate we should put the logging code inside `sg_replicate_cfg.go`. The caution I have about doing this is that this is tricky because some of the functions to create local maps of replications occur because another SG in the same cluster created the replication and this SG is just picking it up for sharding. In this case, we don't know which user caused this action so I was thinking we would only log that on the SG node that had the REST call.~ Decided offline to only log admin actions initiated directly as part of REST API.

There are a few pathways to change the state on ISGR replications:

PUT /db/_replication -> this will create a replication and start it, unless `initialState` is not `running`. Therefore, it seems like a this should generally be both a Create and Start audit event unless `initialState` is specified to something other than running.
POST /db/_replicationStatus/replicationID?action= or POST /db/_replication/replicationID with `initialState` -> this can update a replication.

Due to these complexities, I think it is worth adding some tests for the cases above to make sure we get multiple events if we want them. I am holding off doing this based on whether you think this logic belongs in the rest package or the db package? I thought about not returning the auditEventIDs back to the rest call, but you have to be very careful not to log if there is any error and that seemed easiest to do from the rest handlers since they check for error before returning.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`