### PR TITLE
Add the initial working set of audit events

### DIFF
--- a/base/audit_events_test.go
+++ b/base/audit_events_test.go
@@ -69,7 +69,6 @@ func generateCSVModuleDescriptor(e events) ([]byte, error) {
 		event := e[id]
 
 		mandatoryFields := event.MandatoryFields
-		mandatoryFields.withCommonMandatoryFields()
 		mandatoryFieldKeys := maps.Keys(mandatoryFields)
 		slices.Sort(mandatoryFieldKeys)
 		optionalFields := event.OptionalFields

--- a/base/audit_events_test.go
+++ b/base/audit_events_test.go
@@ -70,8 +70,11 @@ func generateCSVModuleDescriptor(e events) ([]byte, error) {
 
 		mandatoryFields := event.MandatoryFields
 		mandatoryFields.withCommonMandatoryFields()
+		mandatoryFieldKeys := maps.Keys(mandatoryFields)
+		slices.Sort(mandatoryFieldKeys)
 		optionalFields := event.OptionalFields
-		//optionalFields.withCommonOptionalFields()
+		optionalFieldKeys := maps.Keys(optionalFields)
+		slices.Sort(optionalFieldKeys)
 		if err := w.Write([]string{
 			id.String(),
 			event.Name,
@@ -79,8 +82,8 @@ func generateCSVModuleDescriptor(e events) ([]byte, error) {
 			strconv.FormatBool(event.EnabledByDefault),
 			strconv.FormatBool(event.FilteringPermitted),
 			string(event.EventType),
-			strings.Join(maps.Keys(mandatoryFields), ", "),
-			strings.Join(maps.Keys(optionalFields), ", "),
+			strings.Join(mandatoryFieldKeys, ", "),
+			strings.Join(optionalFieldKeys, ", "),
 		}); err != nil {
 			return nil, err
 		}

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -61,6 +61,17 @@ type eventType string
 // E.g. Username, IPs, request parameters, etc.
 type AuditFields map[string]any
 
+// withCommonMandatoryFields adds fields that must be present on ALL audit events.
+func (f AuditFields) withCommonMandatoryFields() {
+	if f == nil {
+		f = make(AuditFields)
+	}
+	f[auditFieldTimestamp] = ""
+	f[auditFieldID] = 1
+	f[auditFieldName] = ""
+	f[auditFieldDescription] = ""
+}
+
 func (i AuditID) MustValidateFields(f AuditFields) {
 	if err := i.ValidateFields(f); err != nil {
 		panic(fmt.Errorf("audit event %s invalid:\n%v", i, err))

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -52,7 +52,7 @@ type EventDescriptor struct {
 
 	// isDatabaseEvent indicates whether the event is a database event or a global (SG) event
 	// this controls where this event can be configured (startup config (false) vs. db config (true))
-	isDatabaseEvent bool
+	//isDatabaseEvent bool
 }
 
 type fieldGroup string

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -32,71 +32,71 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 		{
 			name: "no global fields",
 			functionFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			globalFields: nil,
 			finalFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 		},
 		{
 			name: "with global fields",
 			functionFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			globalFields: AuditFields{
 				"global": "field",
 			},
 			finalFields: AuditFields{
-				"method": "basic",
-				"global": "field",
+				"auth_method": "basic",
+				"global":      "field",
 			},
 		},
 		{
 			name: "overwrite global fields",
 			functionFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			globalFields: AuditFields{
-				"method": "global",
+				"auth_method": "global",
 			},
 			finalFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			warningCount: 1,
 		},
 		{
 			name: "context fields only",
 			functionFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			globalFields: nil,
 			contextFields: AuditFields{
 				"context": "field",
 			},
 			finalFields: AuditFields{
-				"method":  "basic",
-				"context": "field",
+				"auth_method": "basic",
+				"context":     "field",
 			},
 		},
 		{
 			name: "context fields overwrite fields",
 			functionFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			globalFields: nil,
 			contextFields: AuditFields{
-				"method": "context",
+				"auth_method": "context",
 			},
 			finalFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			warningCount: 1,
 		},
 		{
 			name: "global fields and context fields",
 			functionFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			globalFields: AuditFields{
 				"global": "field",
@@ -105,24 +105,24 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 				"context": "field",
 			},
 			finalFields: AuditFields{
-				"method":  "basic",
-				"global":  "field",
-				"context": "field",
+				"auth_method": "basic",
+				"global":      "field",
+				"context":     "field",
 			},
 		},
 		{
 			name: "global fields and context fields overwrite fields",
 			functionFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			globalFields: AuditFields{
-				"method": "global",
+				"auth_method": "global",
 			},
 			contextFields: AuditFields{
-				"method": "context",
+				"auth_method": "context",
 			},
 			finalFields: AuditFields{
-				"method": "basic",
+				"auth_method": "basic",
 			},
 			warningCount: 2, // error from global and error from context
 		},
@@ -139,7 +139,7 @@ func TestAuditLoggerGlobalFields(t *testing.T) {
 			startWarnCount := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 			output := AuditLogContents(t, func() {
 				// Test basic audit event
-				Audit(ctx, AuditIDPublicUserAuthenticated, map[string]any{"method": "basic"})
+				Audit(ctx, AuditIDPublicUserAuthenticated, map[string]any{"auth_method": "basic"})
 			},
 			)
 			var event map[string]any

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4293,12 +4293,12 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	responseBody = nil
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &responseBody))
 	assert.Equal(t, true, responseBody["enabled"].(bool))
-	assert.False(t, responseBody["events"].(map[string]interface{})[base.AuditIDAuditEnabled.String()].(bool), "audit enabled event should be disabled by default") // TODO: This will change - replace with an actual non-default event.
+	assert.False(t, responseBody["events"].(map[string]interface{})[base.AuditIDISGRStatus.String()].(bool), "audit enabled event should be disabled by default")
 	assert.True(t, responseBody["events"].(map[string]interface{})[base.AuditIDPublicUserAuthenticated.String()].(bool), "public user authenticated event should be enabled by default")
 
 	// do a PUT to completely replace the full config (events not declared here will be disabled)
 	// enable AuditEnabled event, but implicitly others
-	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config/audit", fmt.Sprintf(`{"enabled":true,"events":{"%s":true}}`, base.AuditIDAuditEnabled))
+	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config/audit", fmt.Sprintf(`{"enabled":true,"events":{"%s":true}}`, base.AuditIDISGRStatus))
 	rest.RequireStatus(t, resp, http.StatusOK)
 
 	// check audit config
@@ -4308,6 +4308,6 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	responseBody = nil
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &responseBody))
 	assert.Equal(t, true, responseBody["enabled"].(bool))
-	assert.True(t, responseBody["events"].(map[string]interface{})[base.AuditIDAuditEnabled.String()].(bool), "audit enabled event should've been enabled via PUT")
+	assert.True(t, responseBody["events"].(map[string]interface{})[base.AuditIDISGRStatus.String()].(bool), "audit enabled event should've been enabled via PUT")
 	assert.False(t, responseBody["events"].(map[string]interface{})[base.AuditIDPublicUserAuthenticated.String()].(bool), "public user authenticated event should've been disabled via PUT")
 }

--- a/rest/config_no_race_test.go
+++ b/rest/config_no_race_test.go
@@ -103,11 +103,11 @@ func TestAuditLoggingGlobals(t *testing.T) {
 			}
 			require.NoError(t, err)
 			output := base.AuditLogContents(t, func() {
-				base.Audit(ctx, base.AuditIDPublicUserAuthenticated, map[string]any{"method": "basic"})
+				base.Audit(ctx, base.AuditIDPublicUserAuthenticated, map[string]any{"auth_method": "basic"})
 			})
 			var event map[string]any
 			require.NoError(t, json.Unmarshal(output, &event))
-			require.Contains(t, event, "method")
+			require.Contains(t, event, "auth_method")
 			for k, v := range globalFields {
 				if testCase.globalAuditEvents != nil {
 					require.Equal(t, v, event[k])

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -762,7 +762,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	// If oidc enabled, check for bearer ID token
 	if dbCtx.Options.OIDCOptions != nil || len(dbCtx.LocalJWTProviders) > 0 {
 		if token := h.getBearerToken(); token != "" {
-			auditFields = base.AuditFields{"method": "bearer"}
+			auditFields = base.AuditFields{"auth_method": "bearer"}
 			var updates auth.PrincipalConfig
 			h.user, updates, err = dbCtx.Authenticator(h.ctx()).AuthenticateUntrustedJWT(token, dbCtx.OIDCProviders, dbCtx.LocalJWTProviders, h.getOIDCCallbackURL)
 			if h.user == nil || err != nil {
@@ -807,7 +807,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	// Check basic auth first
 	if !dbCtx.Options.DisablePasswordAuthentication {
 		if userName, password := h.getBasicAuth(); userName != "" {
-			auditFields = base.AuditFields{"method": "basic"}
+			auditFields = base.AuditFields{"auth_method": "basic"}
 			h.user, err = dbCtx.Authenticator(h.ctx()).AuthenticateUser(userName, password)
 			if err != nil {
 				return err
@@ -825,7 +825,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	}
 
 	// Check cookie
-	auditFields = base.AuditFields{"method": "cookie"}
+	auditFields = base.AuditFields{"auth_method": "cookie"}
 	h.user, err = dbCtx.Authenticator(h.ctx()).AuthenticateCookie(h.rq, h.response)
 	if err != nil && h.privs != publicPrivs {
 		return err
@@ -834,7 +834,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	}
 
 	// No auth given -- check guest access
-	auditFields = base.AuditFields{"method": "guest"}
+	auditFields = base.AuditFields{"auth_method": "guest"}
 	if h.user, err = dbCtx.Authenticator(h.ctx()).GetUser(""); err != nil {
 		return err
 	}


### PR DESCRIPTION
I forgot to open this PR when I shared the spreadsheet of audit events.

Given there's not too much that's controversial with the events themselves (other than "EnabledByDefault" and "Filterable" values) I propose we get this list merged before we start duplicating work to define events.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
