### PR TITLE
CBG-4063: TestVariableRateAllocators test only data race 

### DIFF
--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -862,7 +862,7 @@ func multiNodeUpdate(t *testing.T, ctx context.Context, importAllocator *sequenc
 			require.NoError(t, err, "nextSequenceGreaterThan error: %v", err)
 			log.Printf("allocator %d released %d sequences because next < current (%d < %d)", numReleased, allocatorIndex, prevNext, currentSequence)
 			// At most clientAllocator should only need to release the current batch
-			assert.LessOrEqual(t, numReleased, clientAllocator.sequenceBatchSize)
+			assert.LessOrEqual(t, numReleased, getClientSequenceBatchSize(clientAllocator))
 			releasedCount += numReleased
 		}
 		currentSequence = nextSequence
@@ -887,4 +887,10 @@ func runAllocator(ctx context.Context, a *sequenceAllocator, frequency time.Dura
 			return allocationCount
 		}
 	}
+}
+
+func getClientSequenceBatchSize(allocator *sequenceAllocator) uint64 {
+	allocator.mutex.Lock()
+	defer allocator.mutex.Unlock()
+	return allocator.sequenceBatchSize
 }


### PR DESCRIPTION

CBG-4063

- Fix for data race found accessing sequence batch size without lock

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
