### PR TITLE
Make mutateDbConfig only return errors for actual errors

### DIFF
--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -35,9 +35,7 @@ func (h *handler) getDBConfig() (config *DbConfig, etagVersion string, err error
 	}
 }
 
-// Updates the database config via a callback function that can modify a `DbConfig`.
-// Note: This always returns a non-nil error; on success it's an HTTPError with status OK.
-// The calling handler method is expected to simply return the result.
+// Updates the database config via a callback function that can modify a `DbConfig`
 func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 	h.assertAdminOnly()
 
@@ -93,5 +91,6 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 		return err
 	}
 	h.setEtag(updatedDbConfig.Version)
+	h.setStatus(http.StatusOK, "updated")
 	return nil
 }


### PR DESCRIPTION
Probably best to view without whitespace changes. The indentation has made the diff look worse than it is.

- Invert the `if h.server.persistentConfig {` condition to reduce nesting with early return
- Return a `nil` error if the thing was successful, and write an explicit response, instead of returning a 200 updated "error"

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
