### PR TITLE
CBG-4050 add auditing for some database events

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -65,14 +65,11 @@ const (
 	AuditIDReadDatabaseConfig   AuditID = 54010
 	AuditIDUpdateDatabaseConfig AuditID = 54011
 	// Database operation events
-	AuditIDDatabaseOffline                 AuditID = 54020
-	AuditIDDatabaseOnline                  AuditID = 54021
-	AuditIDDatabaseAttachmentCompactStatus AuditID = 54030
-	AuditIDDatabaseAttachmentCompactStart  AuditID = 54031
-	AuditIDDatabaseAttachmentCompactStop   AuditID = 54032
-	AuditIDDatabaseTombstoneCompactStatus  AuditID = 54033
-	AuditIDDatabaseTombstoneCompactStart   AuditID = 54034
-	AuditIDDatabaseTombstoneCompactStop    AuditID = 54035
+	AuditIDDatabaseOffline       AuditID = 54020
+	AuditIDDatabaseOnline        AuditID = 54021
+	AuditIDDatabaseCompactStatus AuditID = 54030
+	AuditIDDatabaseCompactStart  AuditID = 54031
+	AuditIDDatabaseCompactStop   AuditID = 54032
 
 	AuditIDDatabaseResyncStatus AuditID = 54040
 	AuditIDDatabaseResyncStart  AuditID = 54041
@@ -411,8 +408,10 @@ var AuditEvents = events{
 	AuditIDDatabaseOffline: {
 		Name:        "Database offline",
 		Description: "Database was taken offline",
-		MandatoryFields: AuditFields{
-			"db": "database name",
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -421,70 +420,59 @@ var AuditEvents = events{
 	AuditIDDatabaseOnline: {
 		Name:        "Database online",
 		Description: "Database was brought online",
-		MandatoryFields: AuditFields{
-			"db": "database name",
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		EventType:          eventTypeAdmin,
 	},
-	AuditIDDatabaseAttachmentCompactStatus: {
-		Name:        "Database attachment compaction status",
-		Description: "Database attachment compaction status was viewed",
-		MandatoryFields: AuditFields{
-			"db": "database name",
-		},
-		EnabledByDefault:   true,
-		FilteringPermitted: false,
-		EventType:          eventTypeAdmin,
-	},
-	AuditIDDatabaseAttachmentCompactStart: {
+	AuditIDDatabaseCompactStart: {
 		Name:        "Database attachment compaction start",
 		Description: "Database attachment compaction was started",
 		MandatoryFields: AuditFields{
-			"db":      "database name",
-			"dry_run": false,
-			"reset":   false,
+			AuditFieldCompactionType: "attachment or tombstone",
+		},
+		OptionalFields: AuditFields{
+			AuditFieldCompactionDryRun: false,
+			AuditFieldCompactionReset:  false,
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		EventType:          eventTypeAdmin,
 	},
-	AuditIDDatabaseAttachmentCompactStop: {
-		Name:        "Database attachment compaction stop",
-		Description: "Database attachment compaction was stopped",
+	AuditIDDatabaseCompactStop: {
+		Name:        "Database compaction stop",
+		Description: "Database compaction was stopped",
 		MandatoryFields: AuditFields{
-			"db": "database name",
+			AuditFieldCompactionType: "attachment or tombstone",
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		EventType:          eventTypeAdmin,
 	},
-	AuditIDDatabaseTombstoneCompactStatus: {
-		Name:        "Database tombstone compaction status",
-		Description: "Database tombstone compaction status was viewed",
+	AuditIDDatabaseCompactStatus: {
+		Name:        "Database compaction status",
+		Description: "Database compaction status was viewed",
 		MandatoryFields: AuditFields{
-			"db": "database name",
+			AuditFieldCompactionType: "attachment or tombstone",
 		},
-		EnabledByDefault:   true,
-		FilteringPermitted: false,
-		EventType:          eventTypeAdmin,
-	},
-	AuditIDDatabaseTombstoneCompactStart: {
-		Name:        "Database tombstone compaction start",
-		Description: "Database tombstone compaction was started from REST",
-		MandatoryFields: AuditFields{
-			"db": "database name",
-		},
-		EnabledByDefault:   true,
-		FilteringPermitted: false,
-		EventType:          eventTypeAdmin,
-	},
-	AuditIDDatabaseTombstoneCompactStop: {
-		Name:        "Database tombstone compaction stop",
-		Description: "Database tombstone compaction was stopped from REST",
-		MandatoryFields: AuditFields{
-			"db": "database name",
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -493,8 +481,10 @@ var AuditEvents = events{
 	AuditIDDatabaseResyncStatus: {
 		Name:        "Database resync status",
 		Description: "Database resync status was viewed",
-		MandatoryFields: AuditFields{
-			"db": "database name",
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -504,10 +494,14 @@ var AuditEvents = events{
 		Name:        "Database resync start",
 		Description: "Database resync was started",
 		MandatoryFields: AuditFields{
-			"db":                   "database name",
 			"collections":          map[string][]string{"scopeName": {"collectionA", "collectionB"}},
 			"regenerate_sequences": true,
 			"reset":                true,
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -516,8 +510,10 @@ var AuditEvents = events{
 	AuditIDDatabaseResyncStop: {
 		Name:        "Database resync stop",
 		Description: "Database resync was stopped",
-		MandatoryFields: AuditFields{
-			"db": "database name",
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -527,7 +523,11 @@ var AuditEvents = events{
 		Name:        "Post-upgrade",
 		Description: "Post-upgrade was run for Sync Gateway databases",
 		MandatoryFields: AuditFields{
-			"preview": false,
+			AuditFieldPostUpgradePreview: true,
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -536,8 +536,10 @@ var AuditEvents = events{
 	AuditIDDatabaseRepair: {
 		Name:        "Database repair",
 		Description: "Database repair was run",
-		MandatoryFields: AuditFields{
-			"db": "database name",
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -546,8 +548,10 @@ var AuditEvents = events{
 	AuditIDDatabaseFlush: {
 		Name:        "Database flush",
 		Description: "Database flush was run",
-		MandatoryFields: AuditFields{
-			"db": "database name",
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupRequest,
+			//fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -25,6 +25,19 @@ const (
 	AuditIDPublicUserAuthenticationFailed AuditID = 53261
 
 	AuditIDReadDatabase AuditID = 53301
+
+	// Database operation events
+	AuditIDDatabaseOffline       AuditID = 54020
+	AuditIDDatabaseOnline        AuditID = 54021
+	AuditIDDatabaseCompactStatus AuditID = 54030
+	AuditIDDatabaseCompactStart  AuditID = 54031
+	AuditIDDatabaseCompactStop   AuditID = 54032
+	AuditIDDatabaseResyncStatus  AuditID = 54040
+	AuditIDDatabaseResyncStart   AuditID = 54041
+	AuditIDDatabaseResyncStop    AuditID = 54042
+	AuditIDDatabasePostUpgrade   AuditID = 54043
+	AuditIDDatabaseRepair        AuditID = 54044
+	AuditIDDatabaseFlush         AuditID = 54045
 )
 
 // AuditEvents is a table of audit events created by Sync Gateway.
@@ -71,6 +84,127 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		EventType:          eventTypeUser,
+	},
+	AuditIDDatabaseOffline: {
+		Name:        "Database offline",
+		Description: "Database was taken offline",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseOnline: {
+		Name:        "Database online",
+		Description: "Database was brought online",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseCompactStatus: {
+		Name:        "Database compaction status",
+		Description: "Database compaction status was viewed",
+		MandatoryFields: AuditFields{
+			"db":              "database name",
+			"compaction_type": "tombstone or attachment",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseCompactStart: {
+		Name:        "Database compaction start",
+		Description: "Database compaction was started",
+		MandatoryFields: AuditFields{
+			"db":              "database name",
+			"compaction_type": "tombstone or attachment",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseCompactStop: {
+		Name:        "Database compaction stop",
+		Description: "Database compaction was stopped",
+		MandatoryFields: AuditFields{
+			"db":              "database name",
+			"compaction_type": "tombstone or attachment",
+		},
+		OptionalFields: AuditFields{
+			"dry_run": "true or false",
+			"reset":   "true, false, or none (resume when able)",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseResyncStatus: {
+		Name:        "Database resync status",
+		Description: "Database resync status was viewed",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseResyncStart: {
+		Name:        "Database resync start",
+		Description: "Database resync was started",
+		MandatoryFields: AuditFields{
+			"db":                   "database name",
+			"collections":          map[string][]string{"scopeName": []string{"list", "of", "collections"}},
+			"regenerate_sequences": true,
+			"reset":                "true, false, or none (resume when able)",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseResyncStop: {
+		Name:        "Database resync stop",
+		Description: "Database resync was stopped",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabasePostUpgrade: {
+		Name:        "Database post-upgrade",
+		Description: "Database post-upgrade was run",
+		MandatoryFields: AuditFields{
+			"db":      "database name",
+			"preview": "true or false",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseRepair: {
+		Name:        "Database repair",
+		Description: "Database repair was run",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseFlush: {
+		Name:        "Database flush",
+		Description: "Database flush was run",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
 	},
 }
 

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -26,18 +26,22 @@ const (
 
 	AuditIDReadDatabase AuditID = 53301
 
+	AuditIDPostUpgrade AuditID = 53501
+
 	// Database operation events
-	AuditIDDatabaseOffline       AuditID = 54020
-	AuditIDDatabaseOnline        AuditID = 54021
-	AuditIDDatabaseCompactStatus AuditID = 54030
-	AuditIDDatabaseCompactStart  AuditID = 54031
-	AuditIDDatabaseCompactStop   AuditID = 54032
-	AuditIDDatabaseResyncStatus  AuditID = 54040
-	AuditIDDatabaseResyncStart   AuditID = 54041
-	AuditIDDatabaseResyncStop    AuditID = 54042
-	AuditIDDatabasePostUpgrade   AuditID = 54043
-	AuditIDDatabaseRepair        AuditID = 54044
-	AuditIDDatabaseFlush         AuditID = 54045
+	AuditIDDatabaseOffline                 AuditID = 54020
+	AuditIDDatabaseOnline                  AuditID = 54021
+	AuditIDDatabaseAttachmentCompactStatus AuditID = 54030
+	AuditIDDatabaseAttachmentCompactStart  AuditID = 54031
+	AuditIDDatabaseAttachmentCompactStop   AuditID = 54032
+	AuditIDDatabaseTombstoneCompactStatus  AuditID = 54033
+	AuditIDDatabaseTombstoneCompactStart   AuditID = 54034
+	AuditIDDatabaseTombstoneCompactStop    AuditID = 54035
+	AuditIDDatabaseResyncStatus            AuditID = 54040
+	AuditIDDatabaseResyncStart             AuditID = 54041
+	AuditIDDatabaseResyncStop              AuditID = 54042
+	AuditIDDatabaseRepair                  AuditID = 54044
+	AuditIDDatabaseFlush                   AuditID = 54045
 )
 
 // AuditEvents is a table of audit events created by Sync Gateway.
@@ -105,43 +109,69 @@ var AuditEvents = events{
 		FilteringPermitted: false,
 		EventType:          eventTypeAdmin,
 	},
-	AuditIDDatabaseCompactStatus: {
-		Name:        "Database compaction status",
-		Description: "Database compaction status was viewed",
+	AuditIDDatabaseAttachmentCompactStatus: {
+		Name:        "Database attachment compaction status",
+		Description: "Database attachment compaction status was viewed",
 		MandatoryFields: AuditFields{
-			"db":              "database name",
-			"compaction_type": "tombstone or attachment",
+			"db": "database name",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		EventType:          eventTypeAdmin,
 	},
-	AuditIDDatabaseCompactStart: {
-		Name:        "Database compaction start",
-		Description: "Database compaction was started",
+	AuditIDDatabaseAttachmentCompactStart: {
+		Name:        "Database attachment compaction start",
+		Description: "Database attachment compaction was started",
 		MandatoryFields: AuditFields{
-			"db":              "database name",
-			"compaction_type": "tombstone or attachment",
+			"db":      "database name",
+			"dry_run": false,
+			"reset":   false,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		EventType:          eventTypeAdmin,
 	},
-	AuditIDDatabaseCompactStop: {
-		Name:        "Database compaction stop",
-		Description: "Database compaction was stopped",
+	AuditIDDatabaseAttachmentCompactStop: {
+		Name:        "Database attachment compaction stop",
+		Description: "Database attachment compaction was stopped",
 		MandatoryFields: AuditFields{
-			"db":              "database name",
-			"compaction_type": "tombstone or attachment",
-		},
-		OptionalFields: AuditFields{
-			"dry_run": "true or false",
-			"reset":   "true, false, or none (resume when able)",
+			"db": "database name",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		EventType:          eventTypeAdmin,
 	},
+	AuditIDDatabaseTombstoneCompactStatus: {
+		Name:        "Database tombstone compaction status",
+		Description: "Database tombstone compaction status was viewed",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseTombstoneCompactStart: {
+		Name:        "Database tombstone compaction start",
+		Description: "Database tombstone compaction was started from REST",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDDatabaseTombstoneCompactStop: {
+		Name:        "Database tombstone compaction stop",
+		Description: "Database tombstone compaction was stopped from REST",
+		MandatoryFields: AuditFields{
+			"db": "database name",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: false,
+		EventType:          eventTypeAdmin,
+	},
+
 	AuditIDDatabaseResyncStatus: {
 		Name:        "Database resync status",
 		Description: "Database resync status was viewed",
@@ -158,8 +188,8 @@ var AuditEvents = events{
 		MandatoryFields: AuditFields{
 			"db":                   "database name",
 			"collections":          map[string][]string{"scopeName": []string{"list", "of", "collections"}},
-			"regenerate_sequences": true,
-			"reset":                "true, false, or none (resume when able)",
+			"regenerate_sequences": false,
+			"reset":                false,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -175,12 +205,11 @@ var AuditEvents = events{
 		FilteringPermitted: false,
 		EventType:          eventTypeAdmin,
 	},
-	AuditIDDatabasePostUpgrade: {
-		Name:        "Database post-upgrade",
-		Description: "Database post-upgrade was run",
+	AuditIDPostUpgrade: {
+		Name:        "Post-upgrade",
+		Description: "Post-upgrade was run for Sync Gateway databases",
 		MandatoryFields: AuditFields{
-			"db":      "database name",
-			"preview": "true or false",
+			"preview": false,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -22,16 +22,20 @@ const (
 
 // commonly used fields for audit events
 const (
-	auditFieldID            = "id"
-	auditFieldTimestamp     = "timestamp"
-	auditFieldName          = "name"
-	auditFieldDescription   = "description"
-	auditFieldRealUserID    = "real_userid"
-	auditFieldLocal         = "local"
-	auditFieldRemote        = "remote"
-	auditFieldDatabase      = "db"
-	auditFieldCorrelationID = "cid"
-	auditFieldKeyspace      = "ks"
+	auditFieldID                 = "id"
+	auditFieldTimestamp          = "timestamp"
+	auditFieldName               = "name"
+	auditFieldDescription        = "description"
+	auditFieldRealUserID         = "real_userid"
+	auditFieldLocal              = "local"
+	auditFieldRemote             = "remote"
+	auditFieldDatabase           = "db"
+	auditFieldCorrelationID      = "cid"
+	auditFieldKeyspace           = "ks"
+	AuditFieldCompactionType     = "type"
+	AuditFieldCompactionDryRun   = "dry_run"
+	AuditFieldCompactionReset    = "reset"
+	AuditFieldPostUpgradePreview = "preview"
 )
 
 // expandFields populates data with information from the id, context and additionalData.

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -247,6 +247,7 @@ func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	if err := h.db.TakeDbOffline(base.NewNonCancelCtx(), "ADMIN Request"); err != nil {
 		base.InfofCtx(h.ctx(), base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
+		return err
 	}
 	base.Audit(h.ctx(), base.AuditIDDatabaseOffline, nil)
 	return nil

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -237,6 +237,7 @@ func (h *handler) handleDbOnline() error {
 		time.Sleep(time.Duration(input.Delay) * time.Second)
 		h.server.TakeDbOnline(base.NewNonCancelCtx(), h.db.DatabaseContext)
 	}()
+	base.Audit(h.ctx(), base.AuditIDDatabaseOnline, nil)
 
 	return nil
 }
@@ -244,12 +245,11 @@ func (h *handler) handleDbOnline() error {
 // Take a DB offline
 func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
-	var err error
-	if err = h.db.TakeDbOffline(base.NewNonCancelCtx(), "ADMIN Request"); err != nil {
+	if err := h.db.TakeDbOffline(base.NewNonCancelCtx(), "ADMIN Request"); err != nil {
 		base.InfofCtx(h.ctx(), base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
 	}
-
-	return err
+	base.Audit(h.ctx(), base.AuditIDDatabaseOffline, nil)
+	return nil
 }
 
 // Get admin database info

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -262,7 +262,7 @@ func (h *handler) handleDump() error {
 
 // HTTP handler for _repair
 func (h *handler) handleRepair() error {
-
+	base.Audit(h.ctx(), base.AuditIDDatabaseRepair, nil)
 	// TODO: If repair is re-enabled, it may need to be modified to support xattrs and GSI
 	return errors.New("_repair endpoint disabled")
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -262,10 +262,12 @@ func (h *handler) handleDump() error {
 
 // HTTP handler for _repair
 func (h *handler) handleRepair() error {
-	base.Audit(h.ctx(), base.AuditIDDatabaseRepair, nil)
 	// TODO: If repair is re-enabled, it may need to be modified to support xattrs and GSI
-	return errors.New("_repair endpoint disabled")
-
+	err := errors.New("_repair endpoint disabled")
+	if err != nil {
+		base.Audit(h.ctx(), base.AuditIDDatabaseRepair, nil)
+	}
+	return err
 	/*base.InfofCtx(h.ctx(), base.KeyHTTP, "Repair bucket")
 
 	// Todo: is this actually needed or does something else in the handler do it?  I can't find that..

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -408,6 +408,7 @@ type PostUpgradeResult map[string]PostUpgradeDatabaseResult
 type PostUpgradeDatabaseResult struct {
 	RemovedDDocs   []string `json:"removed_design_docs"`
 	RemovedIndexes []string `json:"removed_indexes"`
+	err            error    // this is not exported, to be used for additional information
 }
 
 // PostUpgrade performs post-upgrade processing for each database
@@ -418,18 +419,27 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 	postUpgradeResults = make(map[string]PostUpgradeDatabaseResult, len(sc.databases_))
 
 	for name, database := range sc.databases_ {
+		var multiError *base.MultiError
 		// View cleanup
-		removedDDocs, _ := database.RemoveObsoleteDesignDocs(ctx, preview)
+		removedDDocs, err := database.RemoveObsoleteDesignDocs(ctx, preview)
+		if err != nil {
+			multiError = multiError.Append(err)
+		}
 
 		// Index cleanup
 		var removedIndexes []string
 		if !base.TestsDisableGSI() {
-			removedIndexes, _ = database.RemoveObsoleteIndexes(ctx, preview)
+			var indexError error
+			removedIndexes, indexError = database.RemoveObsoleteIndexes(ctx, preview)
+			if indexError != nil {
+				multiError = multiError.Append(indexError)
+			}
 		}
 
 		postUpgradeResults[name] = PostUpgradeDatabaseResult{
 			RemovedDDocs:   removedDDocs,
 			RemovedIndexes: removedIndexes,
+			err:            multiError,
 		}
 	}
 	return postUpgradeResults, nil


### PR DESCRIPTION
NOTE: `EnabledByDefault` and `FilteringPermitted` are not up to date, they are going to be hit in a separate pass by a PM.

Proposals not in the PR:

- rename "reset" parameter for resync/attachment compaction to something else? It's tricky because it is true (wipe checkpoints) or false (resume checkpoints if applicable). I wonder if this should be renamed.
- should we validate that fields that are not injected by globally by the merge function are defined in optional fields?
- if we have a type that is a nested map type like `collections: map[string][]string`, should we validate the correct type? I prefer this syntax since it is scalable to multiple scopes, but I'm not set on this type.

I kept audit events at the end of the functions in the REST apis.

When doing the PR:

- Are there parameters that are missing?
- Are the descriptions of the event parameters correct?
- Are there any fields that should be mandatory (validated by `-tags cb_sg_devmode` which will cause panic)?
- Are there optional fields that should be documented?
- Did I add all the events that are present?

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2561/
