### PR TITLE
don't panic if logger is nil

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -103,6 +103,9 @@ func NewConsoleLogger(ctx context.Context, shouldLogLocation bool, config *Conso
 }
 
 func (l *ConsoleLogger) logf(format string, args ...interface{}) {
+	if l == nil {
+		return
+	}
 	if l.collateBuffer != nil {
 		l.collateBufferWg.Add(1)
 		l.collateBuffer <- fmt.Sprintf(format, args...)

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -172,6 +172,9 @@ func (l *FileLogger) String() string {
 // logf will put the given message into the collation buffer if it exists,
 // otherwise will log the message directly.
 func (l *FileLogger) logf(format string, args ...interface{}) {
+	if l == nil {
+		return
+	}
 	if l.collateBuffer != nil {
 		l.collateBufferWg.Add(1)
 		l.collateBuffer <- fmt.Sprintf(format, args...)


### PR DESCRIPTION
while logTo function is running, the underlying FileLogger can become nil, and this function will panic

In this case, `TestAuditLoggingGlobals` modifies `infoLogger` to be nil while `logTo` function is running. In the background, gocb can be logging due to the bucket readier.

Fixes a panic:

```
=== RUN   TestAuditLoggingGlobals/empty_env_var
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x24 pc=0x764094]

goroutine 468350 [running]:
log.(*Logger).output(0xc00ffddc30?, 0xc00ffddc60?, 0xc00ffddc60?, 0x101d57e?)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.22.5/src/log/log.go:203 +0x34
log.(*Logger).Printf(...)
	/home/ec2-user/tools/org.jenkinsci.plugins.golang.GolangInstallation/1.22.5/src/log/log.go:268
github.com/couchbase/sync_gateway/base.(*FileLogger).logf(0xc00edfd830?, {0xc0082ac780?, 0x3?}, {0xc00edfd830?, 0xe00000005?, 0xc02fc01c40?})
	/home/ec2-user/workspace/MasterIntegration/base/logger_file.go:179 +0x13e
github.com/couchbase/sync_gateway/base.logTo({0x20e3328, 0x30bb980}, 0x5, 0xe, {0x1adf25b, 0x33}, {0xc00edfd830, 0x3, 0x3})
	/home/ec2-user/workspace/MasterIntegration/base/logging.go:253 +0x929
github.com/couchbase/sync_gateway/base.GoCBLoggerRemapped.Log({}, 0xc006cb7800?, 0x3ffbd70a3d70a301?, {0x1adf25b?, 0xc00ffddda0?}, {0xc00edfd830?, 0x0?, 0x1a1a1a0?})
	/home/ec2-user/workspace/MasterIntegration/base/logger_external.go:116 +0x1f0
github.com/couchbase/sync_gateway/base.GoCBCoreLoggerRemapped.Log(...)
	/home/ec2-user/workspace/MasterIntegration/base/logger_external.go:126
github.com/couchbase/gocbcore/v10.logExf(0xc013c8af00?, 0x1c?, {0x1adf25b?, 0xc00004e780?}, {0xc00edfd830?, 0xc00d676ec0?, 0x4e762d?})
	/home/ec2-user/go/pkg/mod/github.com/couchbase/gocbcore/v10@v10.4.1/logging.go:160 +0xc2
github.com/couchbase/gocbcore/v10.logSchedf(...)
	/home/ec2-user/go/pkg/mod/github.com/couchbase/gocbcore/v10@v10.4.1/logging.go:172
github.com/couchbase/gocbcore/v10.(*memdClient).run.func2()
	/home/ec2-user/go/pkg/mod/github.com/couchbase/gocbcore/v10@v10.4.1/memdclient.go:498 +0x95a
created by github.com/couchbase/gocbcore/v10.(*memdClient).run in goroutine 468346
	/home/ec2-user/go/pkg/mod/github.com/couchbase/gocbcore/v10@v10.4.1/memdclient.go:426 +0x105
```