### PR TITLE
CBG-4027 Treat on-demand import for GET errors as not found 

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -246,7 +246,7 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 		return nil, base.HTTPErrorf(http.StatusNotFound, "Not imported")
 	} else if importErr != nil {
 		// Treat any other failure to perform an on-demand import as not found
-		base.DebugfCtx(ctx, base.KeyImport, "Unable to import doc %q during on demand import for get - will be treated as not found.  Reason: %v", base.UD(docid), err)
+		base.DebugfCtx(ctx, base.KeyImport, "Unable to import doc %q during on demand import for get - will be treated as not found.  Reason: %v", base.UD(docid), importErr)
 		return nil, base.HTTPErrorf(http.StatusNotFound, "Not found")
 	}
 	return docOut, nil

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3077,63 +3077,53 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 			ImportFilter: importFilter,
 			AutoImport:   base.BoolPtr(false),
 		})
-		rt.Bucket()
 		defer rt.Close()
 
 		testCases := []struct {
 			name        string
 			channel     string // used to avoid cross-traffic between tests
 			updatedBody []byte
-			expectNoRev bool
 		}{
 
 			{
 				name:        "_id property",
 				channel:     "a",
 				updatedBody: []byte(`{"_id": "doc1"}`),
-				expectNoRev: true,
 			},
 			{
 				name:        "_exp property",
 				channel:     "b",
 				updatedBody: []byte(`{"_exp": 1}`),
-				expectNoRev: true,
 			},
 			{
 				name:        "_rev property",
 				channel:     "c",
 				updatedBody: []byte(`{"_rev": "abc1"}`),
-				expectNoRev: true,
 			},
 			{
 				name:        "_revisions property",
 				channel:     "d",
 				updatedBody: []byte(`{"_revisions": {"start": 0, "ids": ["foo", "def]"}}`),
-				expectNoRev: true,
 			},
 			{
 				name:        "_purged property",
 				channel:     "e",
 				updatedBody: []byte(`{"_purged": true}`),
-				expectNoRev: true,
 			},
 			{
 				name:        "invalid json",
 				channel:     "f",
 				updatedBody: []byte(``),
-				expectNoRev: true,
 			},
 			{
 				name:        "rejected by sync function",
 				channel:     "g",
 				updatedBody: []byte(`{"invalid": true}`),
-				expectNoRev: true,
 			},
 			{
 				name:        "rejected by import filter",
 				channel:     "h",
 				updatedBody: []byte(`{"doNotImport": true}`),
-				expectNoRev: true,
 			},
 		}
 		for i, testCase := range testCases {
@@ -3169,7 +3159,6 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 				})
 				defer btc2.Close()
 
-				log.Printf("IDs: %v %q", btc.id, btc2.id)
 				require.NoError(t, btcRunner.StartOneshotPull(btc2.id))
 
 				btcRunner.WaitForDoc(btc2.id, markerDoc)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1152,7 +1152,7 @@ func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 
 	// Attempt to get the doc via Sync Gateway, triggering a cancelled on-demand import of the null document
 	response := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+key, "")
-	rest.RequireStatus(t, response, http.StatusBadRequest) // import attempted with empty body
+	rest.RequireStatus(t, response, http.StatusNotFound) // import attempted with empty body
 
 	// Attempt to update the doc via Sync Gateway, triggering on-demand import of the null document - should ignore empty body error and proceed with write
 	mobileBody := make(map[string]interface{})
@@ -2064,7 +2064,7 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 			name:               "_purged true",
 			importBody:         map[string]interface{}{"_purged": true},
 			expectReject:       true,
-			expectedStatusCode: base.IntPtr(200), // Import gets cancelled and returns 200 and blank body
+			expectedStatusCode: base.IntPtr(404), // Import gets cancelled and returns not found
 		},
 		{
 			name:               "_removed",

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -62,6 +62,7 @@ type RestTesterConfig struct {
 	leakyBucketConfig               *base.LeakyBucketConfig     // Set to create and use a leaky bucket on the RT and DB. A test bucket cannot be passed in if using this option.
 	adminInterface                  string                      // adminInterface overrides the default admin interface.
 	SgReplicateEnabled              bool                        // SgReplicateManager disabled by default for RestTester
+	AutoImport                      *bool
 	HideProductInfo                 bool
 	AdminInterfaceAuthentication    bool
 	metricsInterfaceAuthentication  bool
@@ -346,6 +347,10 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(rt.RestTesterConfig.SgReplicateEnabled)
 
+		// Check for override of AutoImport in the rt config
+		if rt.AutoImport != nil {
+			rt.DatabaseConfig.AutoImport = *rt.AutoImport
+		}
 		autoImport, _ := rt.DatabaseConfig.AutoImportEnabled(ctx)
 		if rt.DatabaseConfig.ImportPartitions == nil && base.TestUseXattrs() && base.IsEnterpriseEdition() && autoImport {
 			// Speed up test setup - most tests don't need more than one partition given we only have one node


### PR DESCRIPTION
CBG-4027

Ensures that these are correctly handled as norev messages when encountered during replication, as they always represent a case where the requested revision was not available.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2572/
