### PR TITLE
[3.1.9 backport] CBG-4029 Revocation handling for deleted roles 

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -441,11 +441,11 @@ func (auth *Authenticator) UpdateSequenceNumber(p Principal, seq uint64) error {
 }
 
 func (auth *Authenticator) InvalidateDefaultChannels(name string, isUser bool, invalSeq uint64) error {
-	return auth.InvalidateChannels(name, isUser, base.DefaultScope, base.DefaultCollection, invalSeq)
+	return auth.InvalidateChannels(name, isUser, base.ScopeAndCollectionNames{base.DefaultScopeAndCollectionName()}, invalSeq)
 }
 
 // Invalidates the channel list of a user/role by setting the ChannelInvalSeq to a non-zero value
-func (auth *Authenticator) InvalidateChannels(name string, isUser bool, scope string, collection string, invalSeq uint64) error {
+func (auth *Authenticator) InvalidateChannels(name string, isUser bool, collections base.ScopeAndCollectionNames, invalSeq uint64) error {
 	var princ Principal
 	var docID string
 
@@ -465,17 +465,23 @@ func (auth *Authenticator) InvalidateChannels(name string, isUser bool, scope st
 
 	base.InfofCtx(auth.LogCtx, base.KeyAccess, "Invalidate access of %q", base.UD(name))
 
-	subdocPath := "channel_inval_seq"
-	if scope != base.DefaultScope || collection != base.DefaultCollection {
-		subdocPath = "collection_access." + scope + "." + collection + "." + subdocPath
-	}
+	// Attempt to use subdoc if we're only modifying a single collection
+	if len(collections) == 1 {
+		scope := collections[0].ScopeName()
+		collection := collections[0].CollectionName()
 
-	if subdocStore, ok := base.AsSubdocStore(auth.datastore); ok {
-		err := subdocStore.SubdocInsert(auth.LogCtx, docID, subdocPath, 0, invalSeq)
-		if err != nil && err != base.ErrNotFound && err != base.ErrAlreadyExists && err != base.ErrPathNotFound {
-			return err
+		subdocPath := "channel_inval_seq"
+		if scope != base.DefaultScope || collection != base.DefaultCollection {
+			subdocPath = "collection_access." + scope + "." + collection + "." + subdocPath
 		}
-		return nil
+
+		if subdocStore, ok := base.AsSubdocStore(auth.datastore); ok {
+			err := subdocStore.SubdocInsert(auth.LogCtx, docID, subdocPath, 0, invalSeq)
+			if err != nil && err != base.ErrAlreadyExists && err != base.ErrPathNotFound && !base.IsDocNotFoundError(err) {
+				return err
+			}
+			return nil
+		}
 	}
 
 	_, err := auth.datastore.Update(docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
@@ -489,14 +495,21 @@ func (auth *Authenticator) InvalidateChannels(name string, isUser bool, scope st
 			return nil, nil, false, err
 		}
 
-		if princ.CollectionChannels(scope, collection) == nil {
+		changed := false
+		for _, collectionName := range collections {
+			scope := collectionName.ScopeName()
+			collection := collectionName.CollectionName()
+			if princ.CollectionChannels(scope, collection) != nil {
+				princ.setCollectionChannelInvalSeq(scope, collection, invalSeq)
+				changed = true
+			}
+		}
+
+		if !changed {
 			return nil, nil, false, base.ErrUpdateCancel
 		}
 
-		princ.setCollectionChannelInvalSeq(scope, collection, invalSeq)
-
 		updated, err = base.JSONMarshal(princ)
-
 		return updated, nil, false, err
 	})
 
@@ -538,6 +551,56 @@ func (auth *Authenticator) InvalidateRoles(username string, invalSeq uint64) err
 		}
 
 		user.SetRoleInvalSeq(invalSeq)
+
+		updated, err = base.JSONMarshal(&user)
+		return updated, nil, false, err
+	})
+
+	if err == base.ErrUpdateCancel {
+		return nil
+	}
+
+	return err
+}
+
+// Invalidates the computed roles and channels of a user by setting the ChannelInvalSeq to a non-zero value for all specified collections.
+func (auth *Authenticator) InvalidateRolesAndChannels(username string, collections base.ScopeAndCollectionNames, invalSeq uint64) error {
+
+	docID := auth.DocIDForUser(username)
+	base.InfofCtx(auth.LogCtx, base.KeyAccess, "Invalidate computed role and channel access of %q for collections %v", base.UD(username), collections)
+
+	_, err := auth.datastore.Update(docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
+		// If user/role doesn't exist cancel update
+		if current == nil {
+			return nil, nil, false, base.ErrUpdateCancel
+		}
+
+		var user userImpl
+		err = base.JSONUnmarshal(current, &user)
+		if err != nil {
+			return nil, nil, false, base.ErrUpdateCancel
+		}
+
+		changed := false
+		// Invalidate channel access per collection
+		for _, collection := range collections {
+			scope := collection.ScopeName()
+			collection := collection.CollectionName()
+			if user.CollectionChannels(scope, collection) != nil {
+				user.setCollectionChannelInvalSeq(scope, collection, invalSeq)
+				changed = true
+			}
+		}
+
+		// Invalidate role access
+		if user.RoleNames() != nil {
+			user.SetRoleInvalSeq(invalSeq)
+			changed = true
+		}
+
+		if !changed {
+			return nil, nil, false, base.ErrUpdateCancel
+		}
 
 		updated, err = base.JSONMarshal(&user)
 		return updated, nil, false, err

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -420,7 +420,7 @@ func TestRebuildUserChannelsMultiCollection(t *testing.T) {
 	err := auth.Save(user)
 	assert.NoError(t, err)
 
-	err = auth.InvalidateChannels("testUser", true, "scope1", "collection1", 2)
+	err = auth.InvalidateChannels("testUser", true, base.ScopeAndCollectionNames{base.NewScopeAndCollectionName("scope1", "collection1")}, 2)
 	assert.NoError(t, err)
 
 	user2, err := auth.GetUser("testUser")
@@ -447,7 +447,7 @@ func TestRebuildUserChannelsNamedCollection(t *testing.T) {
 	err := auth.Save(user)
 	assert.NoError(t, err)
 
-	err = auth.InvalidateChannels("testUser", true, "scope1", "collection1", 2)
+	err = auth.InvalidateChannels("testUser", true, base.ScopeAndCollectionNames{base.NewScopeAndCollectionName("scope1", "collection1")}, 2)
 	assert.NoError(t, err)
 
 	user2, err := auth.GetUser("testUser")

--- a/base/collection_common.go
+++ b/base/collection_common.go
@@ -42,6 +42,13 @@ func DefaultScopeAndCollectionName() ScopeAndCollectionName {
 	return ScopeAndCollectionName{Scope: DefaultScope, Collection: DefaultCollection}
 }
 
+func NewScopeAndCollectionName(scope, collection string) ScopeAndCollectionName {
+	return ScopeAndCollectionName{
+		Scope:      scope,
+		Collection: collection,
+	}
+}
+
 type ScopeAndCollectionNames []ScopeAndCollectionName
 
 // ScopeAndCollectionNames returns a dot-separated formatted slice of scope and collection names.

--- a/base/error.go
+++ b/base/error.go
@@ -214,6 +214,11 @@ func IsDocNotFoundError(err error) bool {
 		return true
 	}
 
+	var missingError sgbucket.MissingError
+	if errors.As(err, &missingError) {
+		return true
+	}
+
 	switch unwrappedErr := unwrappedErr.(type) {
 	case *gomemcached.MCResponse:
 		return unwrappedErr.Status == gomemcached.KEY_ENOENT || unwrappedErr.Status == gomemcached.NOT_STORED

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -216,9 +216,12 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 			if err != nil {
 				return err
 			}
+
+			collectionNames := make(base.ScopeAndCollectionNames, 0)
 			for _, databaseCollection := range db.CollectionByID {
-				databaseCollection.invalidateAllPrincipalsCache(ctx, endSeq)
+				collectionNames = append(collectionNames, databaseCollection.ScopeAndCollectionName())
 			}
+			db.invalidateAllPrincipals(ctx, collectionNames, endSeq)
 
 		}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -2154,7 +2154,7 @@ func (db *DatabaseCollectionWithUser) MarkPrincipalsChanged(ctx context.Context,
 	if len(changedRoleUsers) > 0 {
 		base.InfofCtx(ctx, base.KeyAccess, "Rev %q / %q invalidates roles of %s", base.UD(docid), newRevID, base.UD(changedRoleUsers))
 		for _, name := range changedRoleUsers {
-			db.invalUserRoles(ctx, name, invalSeq)
+			db.dbCtx.invalUserRoles(ctx, name, invalSeq)
 			// If this is the current in memory db.user, reload to generate updated roles
 			if db.user != nil && db.user.Name() == name {
 				base.DebugfCtx(ctx, base.KeyAccess, "Role set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -326,3 +326,34 @@ func (c *DatabaseCollection) UpdateSyncFun(ctx context.Context, syncFun string) 
 	}
 	return
 }
+
+// DatabaseCollection helper methods for channel and role invalidation - invoke the multi-collection version on
+// the databaseContext for a single collection.
+// invalUserOrRoleChannels invalidates a user or role's channels for collection c
+func (c *DatabaseCollection) invalUserOrRoleChannels(ctx context.Context, name string, invalSeq uint64) {
+	principalName, isRole := channels.AccessNameToPrincipalName(name)
+	if isRole {
+		c.invalRoleChannels(ctx, principalName, invalSeq)
+	} else {
+		c.invalUserChannels(ctx, principalName, invalSeq)
+	}
+}
+
+// invalRoleChannels invalidates a user's computed channels for collection c
+func (c *DatabaseCollection) invalUserChannels(ctx context.Context, username string, invalSeq uint64) {
+	c.dbCtx.invalUserChannels(ctx, username, base.ScopeAndCollectionNames{c.ScopeAndCollectionName()}, invalSeq)
+}
+
+// invalRoleChannels invalidates a role's computed channels for collection c
+func (c *DatabaseCollection) invalRoleChannels(ctx context.Context, rolename string, invalSeq uint64) {
+	c.dbCtx.invalRoleChannels(ctx, rolename, base.ScopeAndCollectionNames{c.ScopeAndCollectionName()}, invalSeq)
+}
+
+// invalidateAllPrincipals invalidates computed channels and roles for collection c, for all users and roles
+func (c *DatabaseCollection) invalidateAllPrincipals(ctx context.Context, endSeq uint64) {
+	c.dbCtx.invalidateAllPrincipals(ctx, base.ScopeAndCollectionNames{c.ScopeAndCollectionName()}, endSeq)
+}
+
+func (c *DatabaseCollection) ScopeAndCollectionName() base.ScopeAndCollectionName {
+	return base.NewScopeAndCollectionName(c.ScopeName, c.Name)
+}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2729,7 +2729,7 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Greater(t, endSeq, uint64(0))
 
-	collection.invalidateAllPrincipalsCache(ctx, endSeq)
+	collection.invalidateAllPrincipals(ctx, endSeq)
 	err = collection.WaitForPendingChanges(ctx)
 	assert.NoError(t, err)
 

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -166,3 +166,91 @@ func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
 		})
 	}
 }
+
+func TestResyncInvalidatePrincipals(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+
+	initialSyncFn := `
+	function(doc) {
+		access(doc.userName, "channelABC");
+		access("role:" + doc.roleName, "channelABC");
+		role(doc.userName, "role:roleABC");
+	}`
+
+	updatedSyncFn := `
+	function(doc) {
+		access(doc.userName, "channelDEF");
+		access("role:" + doc.roleName, "channelDEF");
+		role(doc.userName, "role:roleDEF");
+	}`
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		SyncFn:           initialSyncFn,
+	})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	ds := rt.TestBucket.GetSingleDataStore()
+	dsName, ok := base.AsDataStoreName(ds)
+	require.True(t, ok)
+	scopeName := dsName.ScopeName()
+	collectionName := dsName.CollectionName()
+
+	rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+
+	// Set up user and role
+	username := "alice"
+	rolename := "foo"
+	grantingDocID := "grantDoc"
+	grantingDocBody := `{
+		"userName":"alice",
+		"roleName":"foo"
+	}`
+	rt.CreateUser(username, nil)
+
+	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+rolename, rest.GetRolePayload(t, rolename, rt.GetSingleTestDatabaseCollection(), nil))
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	// Write doc to perform dynamic grants
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+grantingDocID, grantingDocBody)
+	rest.RequireStatus(t, response, http.StatusCreated)
+
+	ctx := rt.Context()
+	user, err := rt.GetDatabase().Authenticator(ctx).GetUser(username)
+	require.NoError(t, err)
+	channels := user.CollectionChannels(scopeName, collectionName)
+	_, ok = channels["channelABC"]
+	require.True(t, ok, "user should have channel channelABC")
+	roles := user.RoleNames()
+	_, ok = roles["roleABC"]
+	require.True(t, ok, "user should have role roleABC")
+
+	rt.TakeDbOffline()
+
+	// Update the sync function
+	rt.SyncFn = updatedSyncFn
+	updatedDbConfig := rt.NewDbConfig()
+	rt.UpsertDbConfig("db1", updatedDbConfig)
+	rt.TakeDbOffline()
+
+	// Run resync
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)
+	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+	// validate user channels and roles have been updated
+	user, err = rt.GetDatabase().Authenticator(ctx).GetUser(username)
+	require.NoError(t, err)
+	channels = user.CollectionChannels(scopeName, collectionName)
+	_, ok = channels["channelABC"]
+	require.False(t, ok, "user should not have channel channelABC")
+	_, ok = channels["channelDEF"]
+	require.True(t, ok, "user should have channel channelDEF")
+	roles = user.RoleNames()
+	_, ok = roles["roleABC"]
+	require.False(t, ok, "user should not have role roleABC")
+	_, ok = roles["roleDEF"]
+	require.True(t, ok, "user should have role roleDEF")
+}

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -201,7 +201,7 @@ func TestChangesFeedOnInheritedChannelsFromRoles(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// create role with collection channel access set to channel A
-	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", "", collection, []string{"A"}))
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", collection, []string{"A"}))
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// create user and assign the role create above to that user
@@ -234,7 +234,7 @@ func TestChangesFeedOnInheritedChannelsFromRolesDefaultCollection(t *testing.T) 
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// create role with collection channel access set to channel A
-	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", "", collection, []string{"A"}))
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/role", rest.GetRolePayload(t, "", collection, []string{"A"}))
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// create user and assign the role create above to that user

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -101,7 +101,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		roles := []string{"roleA", "roleB"}
 
 		for _, role := range roles {
-			response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+role, rest.GetRolePayload(t, role, rest.RestTesterDefaultUserPassword, rt.GetSingleTestDatabaseCollection(), []string{"ChannelA"}))
+			response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+role, rest.GetRolePayload(t, role, rt.GetSingleTestDatabaseCollection(), []string{"ChannelA"}))
 			rest.RequireStatus(t, response, http.StatusCreated)
 		}
 		response := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_role/", "")

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -931,7 +931,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	defer rt.Close()
 	collection := rt.GetSingleTestDatabaseCollection()
 
-	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"A"}))
+	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"A"}))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": ["role"], "password": "letmein"}`)
@@ -1777,7 +1777,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	}()
 
 	// perform role grant to allow for all channels
-	resp := rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", "", rt2_collection, []string{"A", "B", "C"}))
+	resp := rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2_collection, []string{"A", "B", "C"}))
 
 	_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusOK)
@@ -1796,7 +1796,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.Len(t, changesResults.Results, 5)
 
 	// Revoke C and ensure docC gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", "", rt2_collection, []string{"A", "B"}))
+	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2_collection, []string{"A", "B"}))
 	RequireStatus(t, resp, http.StatusOK)
 	require.NoError(t, rt2.WaitForPendingChanges())
 
@@ -1807,7 +1807,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Revoke B and ensure docB gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", "", rt2_collection, []string{"A"}))
+	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2_collection, []string{"A"}))
 	RequireStatus(t, resp, http.StatusOK)
 
 	err = rt1.WaitForCondition(func() bool {
@@ -1817,7 +1817,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Revoke A and ensure docA, docAB, docABC gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", "", rt2_collection, []string{}))
+	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2_collection, []string{}))
 	RequireStatus(t, resp, http.StatusOK)
 
 	err = rt1.WaitForCondition(func() bool {

--- a/rest/role_api_test.go
+++ b/rest/role_api_test.go
@@ -31,7 +31,7 @@ func TestRolePurge(t *testing.T) {
 	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Create role
-	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))
+	resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"channel"}))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Delete role
@@ -48,7 +48,7 @@ func TestRolePurge(t *testing.T) {
 	assert.NotNil(t, role)
 
 	// Re-create role
-	resp = rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))
+	resp = rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"channel"}))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Delete role again but with purge flag
@@ -72,10 +72,10 @@ func TestRoleAPI(t *testing.T) {
 
 	// PUT a role
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
-	response := rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", "", collection, []string{"fedoras", "fixies"}))
+	response := rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 
-	response = rt.SendAdminRequest("PUT", "/db/_role/testdeleted", GetRolePayload(t, "", "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("PUT", "/db/_role/testdeleted", GetRolePayload(t, "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/testdeleted", ""), 200)
 
@@ -97,9 +97,9 @@ func TestRoleAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
 
 	// POST a role
-	response = rt.SendAdminRequest("POST", "/db/_role", GetRolePayload(t, "hipster", "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("POST", "/db/_role", GetRolePayload(t, "hipster", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 301)
-	response = rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "hipster", "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "hipster", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_role/hipster", "")
 	RequireStatus(t, response, 200)
@@ -157,7 +157,7 @@ func TestFunkyRoleNames(t *testing.T) {
 			require.NoError(t, a.Save(user))
 
 			// Create role
-			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", url.PathEscape(tc.RoleName)), GetRolePayload(t, "", "", collection, []string{"testchannel"}))
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_role/%s", url.PathEscape(tc.RoleName)), GetRolePayload(t, "", collection, []string{"testchannel"}))
 			RequireStatus(t, response, 201)
 
 			// Create test document
@@ -249,7 +249,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	// POST a role
-	response := rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "role1", "", collection, []string{"chan1"}))
+	response := rt.SendAdminRequest("POST", "/db/_role/", GetRolePayload(t, "role1", collection, []string{"chan1"}))
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_role/role1", "")
 	RequireStatus(t, response, 200)
@@ -308,7 +308,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_user/zegpold", GetUserPayload(t, "zegpold", "letmein", "", collection, []string{"beta"}, nil))
 	RequireStatus(t, response, 201)
 
-	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "hipster", "", collection, []string{"gamma"}))
+	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "hipster", collection, []string{"gamma"}))
 	RequireStatus(t, response, 201)
 	/*
 		alice, err := a.NewUser("alice", "letmein", channels.BaseSetOf(t, "alpha"))

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -1003,7 +1003,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		docSeqArr = append(docSeqArr, body["_sync"].(map[string]interface{})["sequence"].(float64))
 	}
 
-	response = rt.SendAdminRequest("PUT", "/{{.db}}/_role/role1", GetRolePayload(t, "role1", "", collection, []string{"channel_1"}))
+	response = rt.SendAdminRequest("PUT", "/{{.db}}/_role/role1", GetRolePayload(t, "role1", collection, []string{"channel_1"}))
 	RequireStatus(t, response, http.StatusCreated)
 
 	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/user1", GetUserPayload(t, "user1", "letmein", "", collection, []string{"channel_1"}, []string{"role1"}))

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -329,7 +329,7 @@ func TestUserAPI(t *testing.T) {
 
 	// Create a role
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
-	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", collection, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 
 	// Give the user that role
@@ -516,12 +516,12 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create a role 'developer' through POST request
-	response = rt.SendAdminRequest(http.MethodPost, "/db/_role/", GetRolePayload(t, "developer", "", collection, []string{"channel1", "channel2"}))
+	response = rt.SendAdminRequest(http.MethodPost, "/db/_role/", GetRolePayload(t, "developer", collection, []string{"channel1", "channel2"}))
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create another role 'coder' through PUT request.
-	response = rt.SendAdminRequest(http.MethodPut, "/db/_role/coder", GetRolePayload(t, "", "", collection, []string{"channel3", "channel4"}))
+	response = rt.SendAdminRequest(http.MethodPut, "/db/_role/coder", GetRolePayload(t, "", collection, []string{"channel3", "channel4"}))
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
@@ -590,7 +590,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 			s := collection.ScopeName
 
 			// Create role
-			resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", "", collection, []string{"channel"}))
+			resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"channel"}))
 			RequireStatus(t, resp, http.StatusCreated)
 
 			// Create user

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1647,14 +1647,11 @@ func GetUserPayload(t testing.TB, username, password, email string, collection *
 	return string(marshalledConfig)
 }
 
-// GetRolePayload will take roleName, password and channels you want to assign a particular role and return the appropriate payload for the _role endpoint
-func GetRolePayload(t *testing.T, roleName, password string, collection *db.DatabaseCollection, chans []string) string {
+// GetRolePayload will take roleName and channels you want to assign a particular role and return the appropriate payload for the _role endpoint
+func GetRolePayload(t *testing.T, roleName string, collection *db.DatabaseCollection, chans []string) string {
 	config := auth.PrincipalConfig{}
 	if roleName != "" {
 		config.Name = &roleName
-	}
-	if password != "" {
-		config.Password = &password
 	}
 	marshalledConfig, err := addChannelsToPrincipal(config, collection, chans)
 	require.NoError(t, err)


### PR DESCRIPTION
Deleted roles were not triggering revocation of channels associated with those roles, for two reasons:

deleted roles weren't being included in the role set used by RevokedCollectionChannels to identify revoked channels channel history wasn't being updated on deleted roles for non-default collections Deleted roles are now populated on the user object, and a new API added (GetRolesIncDeleted) that returns the union of deleted and non-deleted roles.

CBG-4029, backports CBG-4025

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2568/
