### PR TITLE
bugfix: load default audit events into ctx when explicit events are not defined

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1073,7 +1073,8 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 				dbConfig.Logging.Audit.Enabled = nil
 			}
 			for _, id := range dbConfig.Logging.Audit.EnabledEvents {
-				if _, ok := base.AuditEvents[base.AuditID(id)]; !ok {
+				id := base.AuditID(id)
+				if _, ok := base.AuditEvents[id]; !ok {
 					multiError = multiError.Append(fmt.Errorf("unknown audit event ID %q", id))
 				}
 			}

--- a/rest/config.go
+++ b/rest/config.go
@@ -2217,7 +2217,11 @@ func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 	var aud *base.DbAuditLogConfig
 	if l.Audit != nil {
 		enabledEvents := make(map[base.AuditID]struct{}, len(l.Audit.EnabledEvents))
-		for _, event := range l.Audit.EnabledEvents {
+		events := l.Audit.EnabledEvents
+		if events == nil {
+			events = base.DefaultAuditEventIDs
+		}
+		for _, event := range events {
 			enabledEvents[base.AuditID(event)] = struct{}{}
 		}
 		aud = &base.DbAuditLogConfig{


### PR DESCRIPTION
- Allows for the `shouldLog` call to handle default sets of events.
- Print numerical audit event ID instead of a UTF-8 codepoint in error message

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
