### PR TITLE
[3.1.9 backport] CBG-4028 Treat on-demand import for GET errors as not found

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -200,11 +200,14 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 	var importErr error
 
 	docOut, importErr = importDb.ImportDocRaw(ctx, docid, rawDoc, rawXattr, rawUserXattr, isDelete, cas, nil, ImportOnDemand)
+
 	if importErr == base.ErrImportCancelledFilter {
-		// If the import was cancelled due to filter, treat as not found
-		return nil, base.HTTPErrorf(404, "Not imported")
+		// If the import was cancelled due to filter, treat as 404 not imported
+		return nil, base.HTTPErrorf(http.StatusNotFound, "Not imported")
 	} else if importErr != nil {
-		return nil, importErr
+		// Treat any other failure to perform an on-demand import as not found
+		base.DebugfCtx(ctx, base.KeyImport, "Unable to import doc %q during on demand import for get - will be treated as not found.  Reason: %v", base.UD(docid), importErr)
+		return nil, base.HTTPErrorf(http.StatusNotFound, "Not found")
 	}
 	return docOut, nil
 }

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1430,7 +1430,7 @@ func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 
 	// Attempt to get the doc via Sync Gateway, triggering a cancelled on-demand import of the null document
 	response := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+key, "")
-	rest.RequireStatus(t, response, http.StatusBadRequest) // import attempted with empty body
+	rest.RequireStatus(t, response, http.StatusNotFound) // import attempted with empty body
 
 	// Attempt to update the doc via Sync Gateway, triggering on-demand import of the null document - should ignore empty body error and proceed with write
 	mobileBody := make(map[string]interface{})
@@ -2351,7 +2351,7 @@ func TestImportInternalPropertiesHandling(t *testing.T) {
 			name:               "_purged true",
 			importBody:         map[string]interface{}{"_purged": true},
 			expectReject:       true,
-			expectedStatusCode: base.IntPtr(200), // Import gets cancelled and returns 200 and blank body
+			expectedStatusCode: base.IntPtr(404), // Import gets cancelled and returns not found
 		},
 		{
 			name:               "_removed",


### PR DESCRIPTION
Ensures that these are correctly handled as norev messages when encountered during replication, as they always represent a case where the requested revision was not available.

Backports CBG-4027 to 3.1.9.

CBG-4028

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2573/
