### PR TITLE
CBG-4076 temporarily skip tests that can panic with integration tests

### DIFF
--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestAuditInjectableHeader(t *testing.T) {
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("This test can panic with gocb logging CBG-4076")
+	}
 	// get tempdir before resetting global loggers, since the logger cleanup needs to happen before deletion
 	tempdir := t.TempDir()
 	base.ResetGlobalTestLogging(t)

--- a/rest/config_no_race_test.go
+++ b/rest/config_no_race_test.go
@@ -39,6 +39,9 @@ func TestBadCORSValuesConfig(t *testing.T) {
 
 // TestAuditLoggingGlobals modifies all the global loggers
 func TestAuditLoggingGlobals(t *testing.T) {
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("This test can panic with gocb logging CBG-4076")
+	}
 	globalFields := map[string]any{
 		"global":  "field",
 		"global2": "field2",


### PR DESCRIPTION
Temporarily skip these tests pending a solution to swap the logger atomically.
