### PR TITLE
Add the most basic negative testing for audit API for non-existent ID

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4366,6 +4366,11 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	runtimeConfig = rt.RestTesterServerContext.GetDatabaseConfig("db")
 	RequireEventCount(t, runtimeConfig, base.AuditIDISGRStatus, 0)
 	RequireEventCount(t, runtimeConfig, base.AuditIDAttachmentCreate, 0)
+
+	// Set a non-existent audit ID
+	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config/audit", `{"events":{"123":true}}`)
+	rest.RequireStatus(t, resp, http.StatusBadRequest)
+	assert.Contains(t, resp.Body.String(), `unknown audit event ID: "123"`)
 }
 
 func RequireEventCount(t *testing.T, runtimeConfig *rest.RuntimeDatabaseConfig, auditID base.AuditID, expectedCount int) {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4370,7 +4370,7 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	// Set a non-existent audit ID
 	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config/audit", `{"events":{"123":true}}`)
 	rest.RequireStatus(t, resp, http.StatusBadRequest)
-	assert.Contains(t, resp.Body.String(), `unknown audit event ID: "123"`)
+	assert.Contains(t, resp.Body.String(), `unknown audit event ID: \"123\"`)
 }
 
 func RequireEventCount(t *testing.T, runtimeConfig *rest.RuntimeDatabaseConfig, auditID base.AuditID, expectedCount int) {


### PR DESCRIPTION
I had previously manually tested this stuff, and I think QE are also covering... But at least get a basic assertion in for regression and coverage.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a