### PR TITLE
CBG-4070: fix panic in CheckpointHash function

### DIFF
--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -160,6 +160,9 @@ func (arc ActiveReplicatorConfig) CheckpointHash(collectionIdx *int) (string, er
 	if _, err := hash.Write([]byte(arc.RunAs)); err != nil {
 		return "", err
 	}
+	if arc.ActiveDB == nil || arc.ActiveDB.Bucket == nil {
+		return "", fmt.Errorf("error calculating checkpoint hash, cannot fetch bucket UUID")
+	}
 	bucketUUID, err := arc.ActiveDB.Bucket.UUID()
 	if err != nil {
 		return "", err

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8429,6 +8429,63 @@ func TestExistingConfigEmptyReplicationID(t *testing.T) {
 	}
 }
 
+// TestPanicInCheckpointHash:
+//   - Create two rest testers
+//   - Add active replicator for rt1 to push to rt2
+//   - Remove database context off os rt1
+//   - Call start on active replicator, this would normally hit panic in ticket CBG-4070, should now error instead
+func TestPanicInCheckpointHash(t *testing.T) {
+
+	// Create two rest testers
+	rt1 := rest.NewRestTester(t, nil)
+	defer rt1.Close()
+
+	rt2 := rest.NewRestTester(t, nil)
+	defer rt2.Close()
+
+	username := "alice"
+	rt2.CreateUser(username, []string{username})
+
+	// construct remote URL to have _blipsync connect to
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
+
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+
+	ar, err := db.NewActiveReplicator(base.TestCtx(t), &db.ActiveReplicatorConfig{
+		ID:                  t.Name(),
+		Direction:           db.ActiveReplicatorTypePush,
+		ActiveDB:            &db.Database{DatabaseContext: rt1.GetDatabase()},
+		RemoteDBURL:         passiveDBURL,
+		ReplicationStatsMap: dbstats,
+		Continuous:          true,
+		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+	})
+	require.NoError(t, err)
+
+	// remove the db context for rt1 off the server context
+	ok := rt1.ServerContext().RemoveDatabase(base.TestCtx(t), "db")
+	require.True(t, ok)
+
+	// assert that the db context has been removed
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 0, len(rt1.ServerContext().AllDatabases()))
+	}, time.Second*10, time.Millisecond*100)
+
+	// attempt to start active replicator, this will hit panic in CBG-4070 pre this work due to the bucket being nil
+	// on the active db context
+	replicatorErr := ar.Start(base.TestCtx(t))
+	assert.Error(t, replicatorErr)
+	assert.ErrorContains(t, replicatorErr, "cannot fetch bucket UUID")
+
+}
+
 func TestDbConfigNoOverwriteReplications(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("Requires EE since this tests persistence of replication configuration in CfgSg")


### PR DESCRIPTION
CBG-4070

- Added check for database context being nil or the bucket being nil 
- In my repro unit test, the bucket was the one that was nil thus causing the panic 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2581/
