### PR TITLE
CBG-4079: Wire up non-filterable events for validation/auto-enabling

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -791,6 +791,14 @@ func (h *handler) handlePutDbAuditConfig() error {
 				eventEnabled = valT["enabled"].(bool)
 			}
 
+			// check if explicitly disabled events are allowed to be filtered
+			// we'll ensure that non-filterable events are always considered enabled at runtime instead of at config persistence time
+			// this will ensure we are able to add events in the future that are non-filterable and have them work correctly
+			if _, ok := base.NonFilterableEvents[auditID]; ok && !eventEnabled {
+				multiError = multiError.Append(fmt.Errorf("event %q is not filterable", id))
+				continue
+			}
+
 			toChange[auditID] = eventEnabled
 		}
 		if err := multiError.ErrorOrNil(); err != nil {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4353,6 +4353,12 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	RequireEventCount(t, runtimeConfig, base.AuditIDISGRStatus, 1)
 	RequireEventCount(t, runtimeConfig, base.AuditIDAttachmentCreate, 0)
 
+	// Try disabling a non-filterable event
+	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config/audit", fmt.Sprintf(`{"enabled": true,"events":{"%s":false}}"`, base.AuditIDAuditEnabled))
+	rest.RequireStatus(t, resp, http.StatusBadRequest)
+	assert.Contains(t, resp.Body.String(), "couldn't update audit configuration")
+	assert.Contains(t, resp.Body.String(), fmt.Sprintf(`event \"%s\" is not filterable`, base.AuditIDAuditEnabled))
+
 	// Re-enable the event via PUT, should remove other events
 	resp = rt.SendAdminRequest(http.MethodPut, "/db/_config/audit", fmt.Sprintf(`{"enabled":true,"events":{"%s":true}}`, base.AuditIDAttachmentCreate))
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/config.go
+++ b/rest/config.go
@@ -2222,6 +2222,11 @@ func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 		if events == nil {
 			events = base.DefaultAuditEventIDs
 		}
+		// always enable the non-filterable events
+		for id := range base.NonFilterableEvents {
+			enabledEvents[id] = struct{}{}
+		}
+		// enable the events specified in the config
 		for _, event := range events {
 			enabledEvents[base.AuditID(event)] = struct{}{}
 		}


### PR DESCRIPTION
CBG-4079

Use the set of non-filterable events to ensure they are not being disabled on config updates, and also to populate the set of enabled events for a database.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a