### PR TITLE
CBG-4046 Populate test ctx to support audit checks within GetDocument calls

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -252,8 +252,7 @@ func TestServerlessChangesEndpointLimit(t *testing.T) {
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/_config", `{"max_concurrent_replications" : 2}`)
 	rest.RequireStatus(t, resp, http.StatusOK)
-	resp = rt.SendAdminRequest("PUT", "/db/_user/alice", rest.GetUserPayload(t, "alice", "letmein", "", rt.GetSingleTestDatabaseCollection(), []string{"ABC"}, nil))
-	rest.RequireStatus(t, resp, 201)
+	rt.CreateUser("alice", []string{"ABC"})
 
 	// Put several documents in channel PBS
 	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs1", `{"value":1, "channel":["PBS"]}`)

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -127,7 +127,8 @@ func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
 			require.NotEqual(t, 0, originalUserSeq)
 
 			rt.CreateTestDoc(standardDoc)
-			doc, err := rt.GetSingleTestDatabaseCollection().GetDocument(ctx, standardDoc, db.DocUnmarshalSync)
+			collection, ctx := rt.GetSingleTestDatabaseCollection()
+			doc, err := collection.GetDocument(ctx, standardDoc, db.DocUnmarshalSync)
 			require.NoError(t, err)
 			oldDocSeq := doc.Sequence
 			require.NotEqual(t, 0, oldDocSeq)
@@ -157,7 +158,7 @@ func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
 			}
 
 			// regular doc will always change sequence
-			doc, err = rt.GetSingleTestDatabaseCollection().GetDocument(ctx, standardDoc, db.DocUnmarshalSync)
+			doc, err = collection.GetDocument(ctx, standardDoc, db.DocUnmarshalSync)
 			require.NoError(t, err)
 			require.NotEqual(t, 0, doc.Sequence)
 			require.NotEqual(t, oldDocSeq, doc.Sequence)
@@ -207,7 +208,7 @@ func TestResyncInvalidatePrincipals(t *testing.T) {
 	}`
 	rt.CreateUser(username, nil)
 
-	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+rolename, rest.GetRolePayload(t, rolename, rt.GetSingleTestDatabaseCollection(), nil))
+	response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+rolename, rest.GetRolePayload(t, rolename, rt.GetSingleDataStore(), nil))
 	rest.RequireStatus(t, response, http.StatusCreated)
 
 	// Write doc to perform dynamic grants

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -483,7 +483,7 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 
 	const docID = "doc1"
 
-	collection := rt.GetSingleTestDatabaseCollection()
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"test":true}`)
 	RequireStatus(t, resp, http.StatusCreated)
@@ -494,7 +494,6 @@ func TestCollectionsBasicIndexQuery(t *testing.T) {
 	require.True(t, ok)
 
 	idxName := t.Name() + "_primary"
-	ctx := base.TestCtx(t)
 	require.NoError(t, n1qlStore.CreatePrimaryIndex(ctx, idxName, nil))
 	require.NoError(t, n1qlStore.WaitForIndexesOnline(ctx, []string{idxName}, base.WaitForIndexesDefault))
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2532,7 +2532,8 @@ func TestDocumentChannelHistory(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 	err := json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
-	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc")
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	syncData, err := collection.GetDocSyncData(ctx, "doc")
 	assert.NoError(t, err)
 
 	require.Len(t, syncData.ChannelSet, 1)
@@ -2545,7 +2546,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
-	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc")
+	syncData, err = collection.GetDocSyncData(ctx, "doc")
 	assert.NoError(t, err)
 
 	require.Len(t, syncData.ChannelSet, 1)
@@ -2558,7 +2559,7 @@ func TestDocumentChannelHistory(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
-	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc")
+	syncData, err = collection.GetDocSyncData(ctx, "doc")
 	assert.NoError(t, err)
 
 	require.Len(t, syncData.ChannelSet, 2)
@@ -2623,7 +2624,8 @@ func TestChannelHistoryLegacyDoc(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 	err = json.Unmarshal(resp.BodyBytes(), &body)
 	assert.NoError(t, err)
-	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc1")
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	syncData, err := collection.GetDocSyncData(ctx, "doc1")
 	assert.NoError(t, err)
 	require.Len(t, syncData.ChannelSet, 1)
 	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{
@@ -2734,7 +2736,8 @@ func TestDocChannelSetPruning(t *testing.T) {
 		version = rt.UpdateDoc(docID, version, `{"channels": ["a"]}`)
 	}
 
-	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), "doc")
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	syncData, err := collection.GetDocSyncData(ctx, "doc")
 	assert.NoError(t, err)
 
 	require.Len(t, syncData.ChannelSetHistory, db.DocumentHistoryMaxEntriesPerChannel)
@@ -2746,7 +2749,7 @@ func TestDocChannelSetPruning(t *testing.T) {
 func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
-	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser(rt.Context())
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	documentRev := db.DocumentRevision{DocID: "doc1", BodyBytes: []byte("null")}
 

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -89,15 +89,11 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 		})
 	defer rt.Close()
 
-	collection := rt.GetSingleTestDatabaseCollection()
-
-	// Create user:
-	userResponse := rt.SendAdminRequest("PUT", "/db/_user/bernard", GetUserPayload(t, "bernard", "letmein", "", collection, []string{"ABC"}, nil))
-	RequireStatus(t, userResponse, 201)
+	rt.CreateUser("bernard", []string{"ABC"})
 
 	// Get user, to trigger all_channels calculation and bump the user change count BEFORE we write the PBS docs - otherwise the user key count
 	// will still be higher than the latest change count.
-	userResponse = rt.SendAdminRequest("GET", "/db/_user/bernard", "")
+	userResponse := rt.SendAdminRequest("GET", "/db/_user/bernard", "")
 	RequireStatus(t, userResponse, 200)
 
 	/*

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2299,9 +2299,10 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
 		assert.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
 
-		_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		collection, ctx := rt.GetSingleTestDatabaseCollection()
+		_, err = collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
 		require.NoError(t, err)
-		_, err = rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
+		_, err = collection.GetDocument(ctx, "doc2", db.DocUnmarshalAll)
 		require.NoError(t, err)
 
 		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
@@ -2309,7 +2310,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 
 		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
 
-		doc1, err := rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		doc1, err := collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
 		assert.NoError(t, err)
 
 		assert.Equal(t, "sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=", doc1.Attachments["attachment"].(map[string]interface{})["digest"])
@@ -2631,9 +2632,10 @@ func TestCBLRevposHandling(t *testing.T) {
 		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
 		assert.NoError(t, btc.rt.WaitForVersion(doc2ID, doc2Version))
 
-		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc1", db.DocUnmarshalAll)
+		collection, ctx := btc.rt.GetSingleTestDatabaseCollection()
+		_, err = collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
 		require.NoError(t, err)
-		_, err = btc.rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), "doc2", db.DocUnmarshalAll)
+		_, err = collection.GetDocument(ctx, "doc2", db.DocUnmarshalAll)
 		require.NoError(t, err)
 
 		// Update doc1, don't change attachment, use correct revpos

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -410,7 +410,7 @@ func TestRedactConfigAsStr(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, testCase.expected, output)
+			require.JSONEq(t, testCase.expected, output)
 
 		})
 	}

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -42,7 +42,7 @@ func TestBlipGetCollections(t *testing.T) {
 
 		checkpointID1 := "checkpoint1"
 		checkpoint1Body := db.Body{"seq": "123"}
-		collection := btc.rt.GetSingleTestDatabaseCollection()
+		collection, _ := btc.rt.GetSingleTestDatabaseCollection()
 		scopeAndCollection := fmt.Sprintf("%s.%s", collection.ScopeName, collection.Name)
 		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 		require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestBlipReplicationNoDefaultCollection(t *testing.T) {
 		defer btc.Close()
 		checkpointID1 := "checkpoint1"
 		checkpoint1Body := db.Body{"seq": "123"}
-		collection := btc.rt.GetSingleTestDatabaseCollection()
+		collection, _ := btc.rt.GetSingleTestDatabaseCollection()
 		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 		require.NoError(t, err)
 		checkpoint1RevID := "0-1"
@@ -196,7 +196,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 
 		checkpointID1 := "checkpoint1"
 		checkpoint1Body := db.Body{"seq": "123"}
-		collection := btc.rt.GetSingleTestDatabaseCollection()
+		collection, _ := btc.rt.GetSingleTestDatabaseCollection()
 		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 		require.NoError(t, err)
 		checkpoint1RevID := "0-1"

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -60,7 +60,8 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 		version, err = btcRunner.PushRev(btc.id, docID, version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
 		require.NoError(t, err)
 
-		syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
+		collection, ctx := rt.GetSingleTestDatabaseCollection()
+		syncData, err := collection.GetDocSyncData(ctx, docID)
 		require.NoError(t, err)
 
 		assert.Len(t, syncData.Attachments, 1)
@@ -80,7 +81,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 		_, err = btcRunner.PushRev(btc.id, docID, version, newBody)
 		require.NoError(t, err)
 
-		syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(base.TestCtx(t), docID)
+		syncData, err = collection.GetDocSyncData(ctx, docID)
 		require.NoError(t, err)
 
 		assert.Len(t, syncData.Attachments, 1)
@@ -814,7 +815,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		rt := NewRestTester(t,
 			&rtConfig)
 		defer rt.Close()
-		collection := rt.GetSingleTestDatabaseCollection()
+		collection, _ := rt.GetSingleTestDatabaseCollection()
 
 		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
@@ -844,8 +845,9 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 
+			collection, ctx := rt.GetSingleTestDatabaseCollection()
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
+			docRev, cacheErr := collection.GetRevisionCacheForTest().Get(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {
@@ -920,7 +922,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		rt := NewRestTester(t,
 			&rtConfig)
 		defer rt.Close()
-		collection := rt.GetSingleTestDatabaseCollection()
+		collection, _ := rt.GetSingleTestDatabaseCollection()
 
 		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -567,7 +567,7 @@ func (btc *BlipTesterCollectionClient) getLastReplicatedRev(docID string) (revID
 
 func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, skipCollectionsInitialization bool) (*BlipTesterReplicator, error) {
 	bt, err := NewBlipTesterFromSpecWithRT(tb, &BlipTesterSpec{
-		connectingPassword:            "test",
+		connectingPassword:            RestTesterDefaultUserPassword,
 		connectingUsername:            btc.Username,
 		connectingUserChannelGrants:   btc.Channels,
 		blipProtocols:                 btc.SupportedBLIPProtocols,

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -370,7 +370,7 @@ func TestBytesReadAuthFailed(t *testing.T) {
 	defer rt.Close()
 
 	// create a user with different password to the default one
-	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", GetUserPayload(t, "alice", "pass", "", rt.GetSingleTestDatabaseCollection(), []string{"ABC"}, nil))
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", GetUserPayload(t, "alice", "pass", "", rt.GetSingleDataStore(), []string{"ABC"}, nil))
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// make a request that will fail on auth

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -94,7 +94,6 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
@@ -103,9 +102,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	guest.SetDisabled(false)
 	assert.NoError(t, a.Save(guest))
 
-	// Create user1
-	response := rt.SendAdminRequest("PUT", "/db/_user/user1", GetUserPayload(t, "user1", "letmein", "user1@couchbase.com", collection, []string{"alpha"}, nil))
-	RequireStatus(t, response, 201)
+	rt.CreateUser("user1", []string{"alpha"})
 
 	// Create 100 docs
 	for i := 0; i < 100; i++ {
@@ -126,9 +123,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	require.Len(t, changesResults.Results, 50)
 	assert.Equal(t, "doc98", changesResults.Results[49].ID)
 
-	// Create user2
-	response = rt.SendAdminRequest("PUT", "/db/_user/user2", GetUserPayload(t, "user2", "letmein", "user2@couchbase.com", collection, []string{"alpha"}, nil))
-	RequireStatus(t, response, 201)
+	rt.CreateUser("user2", []string{"alpha"})
 
 	// Retrieve all changes for user2 with no limits
 	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/{{.keyspace}}/_changes"), "user2", false)
@@ -136,9 +131,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	require.Len(t, changesResults.Results, 101)
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
 
-	// Create user3
-	response = rt.SendAdminRequest("PUT", "/db/_user/user3", GetUserPayload(t, "user3", "letmein", "user3@couchbase.com", collection, []string{"alpha"}, nil))
-	RequireStatus(t, response, 201)
+	rt.CreateUser("user3", []string{"alpha"})
 
 	getUserResponse := rt.SendAdminRequest("GET", "/db/_user/user3", "")
 	RequireStatus(t, getUserResponse, 200)
@@ -162,9 +155,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	require.Len(t, changesResults.Results, 51)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
-	// Create user4
-	response = rt.SendAdminRequest("PUT", "/db/_user/user4", GetUserPayload(t, "user4", "letmein", "user4@couchbase.com", collection, []string{"alpha"}, nil))
-	RequireStatus(t, response, 201)
+	rt.CreateUser("user4", []string{"alpha"})
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
 	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")
 	user4Sequence := user4.Sequence()

--- a/rest/config.go
+++ b/rest/config.go
@@ -1233,7 +1233,6 @@ func redactConfigAsStr(ctx context.Context, dbConfig string) (string, error) {
 		return "", err
 	}
 	redactedConfig := make(map[string]any, len(config))
-	fmt.Printf("config: %+v\n", config)
 	for k, v := range config {
 		if _, ok := config["password"]; ok {
 			redactedConfig["password"] = base.RedactedStr

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -179,7 +179,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 	docID := t.Name()
 	version := rt.PutDoc(docID, `{"val":-1}`)
 	revID := version.RevID
-	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser(rt.Context())
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	for i := 0; i < 10; i++ {
 		version = rt.UpdateDoc(docID, version, fmt.Sprintf(`{"val":%d}`, i))
@@ -524,7 +524,8 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	// Attempt to retrieve via view.  Above operations were all synchronous (on-demand import of SDK delete, SG delete), so
 	// stale=false view results should be immediately updated.
-	results, err := rt.GetDatabase().CollectionChannelViewForTest(t, rt.GetSingleTestDatabaseCollection(), "ABC", 0, 1000)
+	collection, _ := rt.GetSingleTestDatabaseCollection()
+	results, err := rt.GetDatabase().CollectionChannelViewForTest(t, collection, "ABC", 0, 1000)
 	require.NoError(t, err, "Error issuing channel view query")
 	for _, entry := range results {
 		log.Printf("Got view result: %v", entry)

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -360,7 +360,8 @@ func TestAutoImportUserXattrNoSyncData(t *testing.T) {
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	// Assert the sync data has correct channels populated
-	syncData, err := rt.GetSingleTestDatabaseCollection().GetDocSyncData(ctx, docKey)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	syncData, err := collection.GetDocSyncData(ctx, docKey)
 	require.NoError(t, err)
 	assert.Equal(t, []string{userXattrChan}, syncData.Channels.KeySet())
 	assert.Len(t, syncData.Channels, 1)
@@ -382,7 +383,8 @@ func TestAutoImportUserXattrNoSyncData(t *testing.T) {
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 
 	// Assert the sync data has correct channels populated
-	syncData, err = rt.GetSingleTestDatabaseCollection().GetDocSyncData(ctx, docKey2)
+	collection, ctx = rt.GetSingleTestDatabaseCollection()
+	syncData, err = collection.GetDocSyncData(ctx, docKey2)
 	require.NoError(t, err)
 	assert.Len(t, syncData.Channels, 2)
 }

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -59,7 +59,8 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
 
-	docRev, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Len(t, docRev.Channels.ToArray(), 0)
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
@@ -76,12 +77,12 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	// Ensure import worked and sequence incremented but that sequence did not
 	var syncData2 db.SyncData
-	xattrs, _, err = dataStore.GetXattrs(rt.Context(), docKey, []string{base.SyncXattrName})
+	xattrs, _, err = dataStore.GetXattrs(ctx, docKey, []string{base.SyncXattrName})
 	require.NoError(t, err)
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData2))
 
-	docRev2, err := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), docKey, syncData.CurrentRev, true, false)
+	docRev2, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, true, false)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.CurrentRev, docRev2.RevID)
 

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -84,8 +84,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		users := []string{"alice", "bob"}
 
 		for _, user := range users {
-			response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+user, rest.GetUserPayload(t, user, rest.RestTesterDefaultUserPassword, "", rt.GetSingleTestDatabaseCollection(), []string{"ChannelA"}, nil))
-			rest.RequireStatus(t, response, http.StatusCreated)
+			rt.CreateUser(user, []string{"ChannelA"})
 		}
 		response := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_user/", "")
 		rest.RequireStatus(t, response, http.StatusOK)
@@ -101,7 +100,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		roles := []string{"roleA", "roleB"}
 
 		for _, role := range roles {
-			response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+role, rest.GetRolePayload(t, role, rt.GetSingleTestDatabaseCollection(), []string{"ChannelA"}))
+			response := rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+role, rest.GetRolePayload(t, role, rt.GetSingleDataStore(), []string{"ChannelA"}))
 			rest.RequireStatus(t, response, http.StatusCreated)
 		}
 		response := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_role/", "")

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -453,9 +453,9 @@ func TestLocalJWTRolesChannels(t *testing.T) {
 	restTester := NewRestTester(t, &restTesterConfig)
 	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
-	collection := restTester.GetSingleTestDatabaseCollection()
-	c := collection.Name
-	s := collection.ScopeName
+	collection := restTester.GetSingleDataStore()
+	c := collection.CollectionName()
+	s := collection.ScopeName()
 
 	token := auth.CreateTestJWT(t, jose.RS256, testRSAKeypair, auth.JWTHeaders{
 		"alg": jose.RS256,

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -357,7 +357,7 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 	activeRT, _, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
 
-	localCollection := activeRT.GetSingleTestDatabaseCollection().ScopeName + "." + activeRT.GetSingleTestDatabaseCollection().Name
+	localCollection := activeRT.GetSingleDataStore().ScopeName() + "." + activeRT.GetSingleDataStore().CollectionName()
 	localCollections := []string{localCollection}
 	remoteCollections := []string{"missing.collection"}
 
@@ -397,9 +397,9 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 	activeRT, passiveRT, remoteDbURLString, teardown := rest.SetupSGRPeers(t)
 	defer teardown()
 
-	localCollection := activeRT.GetSingleTestDatabaseCollection().ScopeName + ".invalid"
+	localCollection := activeRT.GetSingleDataStore().ScopeName() + ".invalid"
 	localCollections := []string{localCollection}
-	remoteCollection := passiveRT.GetSingleTestDatabaseCollection().ScopeName + "." + passiveRT.GetSingleTestDatabaseCollection().Name
+	remoteCollection := passiveRT.GetSingleDataStore().ScopeName() + "." + passiveRT.GetSingleDataStore().CollectionName()
 	remoteCollections := []string{remoteCollection}
 
 	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -77,7 +77,8 @@ func requireDocumentVersion(t testing.TB, expected rest.DocVersion, doc *db.Docu
 // requireRevID asserts that the specified document version is written to the
 // underlying bucket backed by the given RestTester instance.
 func requireVersion(rt *rest.RestTester, docID string, version rest.DocVersion) {
-	doc, err := rt.GetSingleTestDatabaseCollection().GetDocument(rt.Context(), docID, db.DocUnmarshalAll)
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
 	require.NoError(rt.TB(), err, "Error reading document from bucket")
 	requireDocumentVersion(rt.TB(), version, doc)
 }
@@ -91,9 +92,10 @@ func requireErrorKeyNotFound(t *testing.T, rt *rest.RestTester, docID string) {
 // in the bucket backed by the specified RestTester instance.
 func waitForTombstone(t *testing.T, rt *rest.RestTester, docID string) {
 	require.NoError(t, rt.WaitForPendingChanges())
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
 	require.NoError(t, rt.WaitForCondition(func() bool {
-		doc, _ := rt.GetSingleTestDatabaseCollection().GetDocument(base.TestCtx(t), docID, db.DocUnmarshalAll)
-		return doc.IsDeleted() && len(doc.Body(base.TestCtx(t))) == 0
+		doc, _ := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+		return doc.IsDeleted() && len(doc.Body(ctx)) == 0
 	}))
 }
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -829,7 +829,7 @@ func TestOfflineDatabaseStartup(t *testing.T) {
 	RequireStatus(t, resp, http.StatusServiceUnavailable)
 
 	// put doc2 bypassing offline checks (this step will begin to fail with Elixir - since we're making offline more comprehensive)
-	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser(rt.Context())
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 	_, _, err = collection.Put(ctx, "doc2", db.Body{"type": "doc2"})
 	require.NoError(t, err)
 

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -44,7 +45,6 @@ func TestUsersAPI(t *testing.T) {
 	rt := NewRestTester(t,
 		rtConfig)
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Validate the zero user case
 	var responseUsers []string
@@ -57,7 +57,7 @@ func TestUsersAPI(t *testing.T) {
 	// Test for user counts going from 1 to a few multiples of QueryPaginationLimit to check boundary conditions
 	for i := 1; i < 13; i++ {
 		userName := fmt.Sprintf("user%d", i)
-		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, GetUserPayload(t, "", "letmein", "", collection, []string{"foo", "bar"}, nil))
+		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, GetUserPayload(t, "", "letmein", "", rt.GetSingleDataStore(), []string{"foo", "bar"}, nil))
 		RequireStatus(t, response, 201)
 
 		// check user count
@@ -176,7 +176,6 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	}
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
 	// Validate the zero user case with limit
 	var responseUsers []auth.PrincipalConfig
@@ -190,7 +189,7 @@ func TestUsersAPIDetailsWithLimit(t *testing.T) {
 	numUsers := 12
 	for i := 1; i <= numUsers; i++ {
 		userName := fmt.Sprintf("user%d", i)
-		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, GetUserPayload(t, "", "letmein", "", collection, []string{"foo", "bar"}, nil))
+		response := rt.SendAdminRequest("PUT", "/db/_user/"+userName, GetUserPayload(t, "", "letmein", "", rt.GetSingleDataStore(), []string{"foo", "bar"}, nil))
 		RequireStatus(t, response, 201)
 	}
 
@@ -265,13 +264,13 @@ func TestUserAPI(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	ctx := rt.Context()
-	collection := rt.GetSingleTestDatabaseCollection()
-	c := collection.Name
-	s := collection.ScopeName
+	ds := rt.GetSingleDataStore()
+	c := ds.CollectionName()
+	s := ds.ScopeName()
 
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
 
-	response := rt.SendAdminRequest("PUT", "/db/_user/snej", GetUserPayload(t, "", "letmein", "jens@couchbase.com", collection, []string{"foo", "bar"}, nil))
+	response := rt.SendAdminRequest("PUT", "/db/_user/snej", GetUserPayload(t, "", "letmein", "jens@couchbase.com", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 201)
 
 	user, err := rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("snej")
@@ -306,7 +305,7 @@ func TestUserAPI(t *testing.T) {
 	assert.True(t, user.Authenticate("letmein"))
 
 	// Change the password and verify it:
-	response = rt.SendAdminRequest("PUT", "/db/_user/snej", GetUserPayload(t, "", "123", "", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("PUT", "/db/_user/snej", GetUserPayload(t, "", "123", "", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 200)
 
 	user, _ = rt.ServerContext().Database(ctx, "db").Authenticator(ctx).GetUser("snej")
@@ -317,10 +316,10 @@ func TestUserAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
 
 	// POST a user
-	response = rt.SendAdminRequest("POST", "/db/_user", GetUserPayload(t, "snej", "letmein", "", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("POST", "/db/_user", GetUserPayload(t, "snej", "letmein", "", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 301)
 
-	response = rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "snej", "letmein", "", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "snej", "letmein", "", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
 	RequireStatus(t, response, 200)
@@ -330,11 +329,11 @@ func TestUserAPI(t *testing.T) {
 
 	// Create a role
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
-	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", collection, []string{"fedoras", "fixies"}))
+	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", GetRolePayload(t, "", ds, []string{"fedoras", "fixies"}))
 	RequireStatus(t, response, 201)
 
 	// Give the user that role
-	response = rt.SendAdminRequest("PUT", "/db/_user/snej", GetUserPayload(t, "", "", "", collection, []string{"foo", "bar"}, []string{"hipster"}))
+	response = rt.SendAdminRequest("PUT", "/db/_user/snej", GetUserPayload(t, "", "", "", ds, []string{"foo", "bar"}, []string{"hipster"}))
 	RequireStatus(t, response, 200)
 
 	// GET the user and verify that it shows the channels inherited from the role
@@ -351,7 +350,7 @@ func TestUserAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)
 
 	// POST a user with URL encoded '|' in name see #2870
-	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "0%7C59", "letmein", "", collection, []string{"foo", "bar"}, nil)), 201)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "0%7C59", "letmein", "", ds, []string{"foo", "bar"}, nil)), 201)
 
 	// GET the user, will fail
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%7C59", ""), 404)
@@ -366,7 +365,7 @@ func TestUserAPI(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/0%257C59", ""), 200)
 
 	// POST a user with URL encoded '|' and non-encoded @ in name see #2870
-	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "0%7C@59", "letmein", "", collection, []string{"foo", "bar"}, nil)), 201)
+	RequireStatus(t, rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "0%7C@59", "letmein", "", ds, []string{"foo", "bar"}, nil)), 201)
 
 	// GET the user, will fail
 	RequireStatus(t, rt.SendAdminRequest("GET", "/db/_user/0%7C@59", ""), 404)
@@ -423,7 +422,7 @@ func TestGuestUser(t *testing.T) {
 func TestUserAndRoleResponseContentType(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
+	ds := rt.GetSingleDataStore()
 
 	// Create a user 'christopher' through PUT request with empty request body.
 	var responseBody db.Body
@@ -439,12 +438,12 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody))
 
 	// Create a user 'alice' through PUT request.
-	response = rt.SendAdminRequest(http.MethodPut, "/db/_user/alice", GetUserPayload(t, "", "cGFzc3dvcmQ=", "alice@couchbase.com", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest(http.MethodPut, "/db/_user/alice", GetUserPayload(t, "", "cGFzc3dvcmQ=", "alice@couchbase.com", ds, []string{"foo", "bar"}, nil))
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create another user 'bob' through POST request.
-	response = rt.SendAdminRequest(http.MethodPost, "/db/_user/", GetUserPayload(t, "bob", "cGFzc3dvcmQ=", "bob@couchbase.com", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest(http.MethodPost, "/db/_user/", GetUserPayload(t, "bob", "cGFzc3dvcmQ=", "bob@couchbase.com", ds, []string{"foo", "bar"}, nil))
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
@@ -517,12 +516,12 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create a role 'developer' through POST request
-	response = rt.SendAdminRequest(http.MethodPost, "/db/_role/", GetRolePayload(t, "developer", collection, []string{"channel1", "channel2"}))
+	response = rt.SendAdminRequest(http.MethodPost, "/db/_role/", GetRolePayload(t, "developer", ds, []string{"channel1", "channel2"}))
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
 	// Create another role 'coder' through PUT request.
-	response = rt.SendAdminRequest(http.MethodPut, "/db/_role/coder", GetRolePayload(t, "", collection, []string{"channel3", "channel4"}))
+	response = rt.SendAdminRequest(http.MethodPut, "/db/_role/coder", GetRolePayload(t, "", ds, []string{"channel3", "channel4"}))
 	assert.Equal(t, http.StatusCreated, response.Code)
 	assert.Empty(t, response.Header().Get("Content-Type"))
 
@@ -586,12 +585,12 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 		`,
 				})
 			defer rt.Close()
-			collection := rt.GetSingleTestDatabaseCollection()
-			c := collection.Name
-			s := collection.ScopeName
+			ds := rt.GetSingleDataStore()
+			c := ds.CollectionName()
+			s := ds.ScopeName()
 
 			// Create role
-			resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", collection, []string{"channel"}))
+			resp := rt.SendAdminRequest("PUT", "/db/_role/role", GetRolePayload(t, "", ds, []string{"channel"}))
 			RequireStatus(t, resp, http.StatusCreated)
 
 			// Create user
@@ -644,33 +643,33 @@ func TestUserPasswordValidation(t *testing.T) {
 	// PUT a user
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
+	ds := rt.GetSingleDataStore()
 
-	response := rt.SendAdminRequest("PUT", "/db/_user/snej", GetUserPayload(t, "", "letmein", "jens@couchbase.com", collection, []string{"foo", "bar"}, nil))
+	response := rt.SendAdminRequest("PUT", "/db/_user/snej", GetUserPayload(t, "", "letmein", "jens@couchbase.com", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 201)
 
 	// PUT a user without a password, should fail
-	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", GetUserPayload(t, "", "", "ajres@couchbase.com", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", GetUserPayload(t, "", "", "ajres@couchbase.com", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 400)
 
 	// POST a user without a password, should fail
-	response = rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "ajresnopassword", "", "", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "ajresnopassword", "", "", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 400)
 
 	// PUT a user with a two character password, should fail
-	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", GetUserPayload(t, "ajresnopassword", "in", "", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", GetUserPayload(t, "ajresnopassword", "in", "", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 400)
 
 	// POST a user with a two character password, should fail
-	response = rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "ajresnopassword", "in", "", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "ajresnopassword", "in", "", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 400)
 
 	// PUT a user with a zero character password, should fail
-	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", GetUserPayload(t, "ajresnopassword", "", "", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("PUT", "/db/_user/ajresnopassword", GetUserPayload(t, "ajresnopassword", "", "", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 400)
 
 	// POST a user with a zero character password, should fail
-	response = rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "ajresnopassword", "", "", collection, []string{"foo", "bar"}, nil))
+	response = rt.SendAdminRequest("POST", "/db/_user/", GetUserPayload(t, "ajresnopassword", "", "", ds, []string{"foo", "bar"}, nil))
 	RequireStatus(t, response, 400)
 
 	// PUT update a user with a two character password, should fail
@@ -811,9 +810,8 @@ function(doc, oldDoc) {
 	rt := NewRestTester(t,
 		&rtConfig)
 	defer rt.Close()
-	collection := rt.GetSingleTestDatabaseCollection()
 
-	response := rt.SendAdminRequest("PUT", "/{{.db}}/_user/bernard", GetUserPayload(t, "bernard", "letmein", "", collection, []string{"profile-bernard"}, nil))
+	response := rt.SendAdminRequest("PUT", "/{{.db}}/_user/bernard", GetUserPayload(t, "bernard", "letmein", "", rt.GetSingleDataStore(), []string{"profile-bernard"}, nil))
 	RequireStatus(t, response, 201)
 
 	// Try to force channel initialisation for user bernard
@@ -1290,23 +1288,23 @@ func TestPutUserUnsetAdminChannelsDefaultCollection(t *testing.T) {
 	rt := NewRestTesterDefaultCollection(t, nil)
 	defer rt.Close()
 
-	collection := rt.GetSingleTestDatabaseCollection()
+	ds := rt.GetSingleDataStore()
 	userRoles := []string{"role1"}
 
 	// Create a user with some admin channels and a role
-	payload := GetUserPayload(t, "demo", "password1", "", collection, []string{"foo", "bar"}, userRoles)
+	payload := GetUserPayload(t, "demo", "password1", "", ds, []string{"foo", "bar"}, userRoles)
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_user/demo", payload)
 	RequireStatus(t, response, http.StatusCreated)
 
 	// Note: Password not a required field for updates (only creations)
 	// Update the user with empty payload, ensure no changes
-	payload = GetUserPayload(t, "", "", "", collection, nil, nil)
+	payload = GetUserPayload(t, "", "", "", ds, nil, nil)
 	response = rt.SendAdminRequest(http.MethodPut, "/db/_user/demo", payload)
 	RequireStatus(t, response, http.StatusOK)
 
 	// Check that the user still has access to the channels
 	userConfig := rt.GetUserAdminAPI("demo")
-	requireAdminChannels(t, base.SetFromArray([]string{"foo", "bar"}), userConfig, collection)
+	requireAdminChannels(t, base.SetFromArray([]string{"foo", "bar"}), userConfig, ds)
 	assert.Equal(t, base.SetFromArray(userRoles), userConfig.ExplicitRoleNames)
 
 	// Update the user with an empty admin channels to remove them
@@ -1316,7 +1314,7 @@ func TestPutUserUnsetAdminChannelsDefaultCollection(t *testing.T) {
 
 	// Verify that the user still has access to the channels
 	userConfig = rt.GetUserAdminAPI("demo")
-	requireAdminChannels(t, base.Set(nil), userConfig, collection)
+	requireAdminChannels(t, base.Set(nil), userConfig, ds)
 	assert.Equal(t, base.SetFromArray(userRoles), userConfig.ExplicitRoleNames)
 }
 
@@ -1324,45 +1322,45 @@ func TestPutUserUnsetAdminChannelsDefaultCollection(t *testing.T) {
 // only writable property in collection_access via the REST API.
 // See CBG-3883
 func TestPutUserUnsetAdminChannelsNamedCollection(t *testing.T) {
+	if base.TestsUseNamedCollections() {
+		t.Skip("Named collection test")
+	}
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	collection := rt.GetSingleTestDatabaseCollection()
-	if collection.IsDefaultCollection() {
-		t.Skip("Named collection test")
-	}
 	userRoles := []string{"role1"}
 
+	ds := rt.GetSingleDataStore()
 	// Create a user with some admin channels and a role
-	payload := GetUserPayload(t, "demo", "password1", "", collection, []string{"foo", "bar"}, userRoles)
+	payload := GetUserPayload(t, "demo", "password1", "", ds, []string{"foo", "bar"}, userRoles)
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_user/demo", payload)
 	RequireStatus(t, response, http.StatusCreated)
 
 	// Note: Password not a required field for updates (only creations)
 	// Update the user with empty admin channels, ensure channels are removed but roles are preserved
-	payload = GetUserPayload(t, "", "", "", collection, nil, nil)
+	payload = GetUserPayload(t, "", "", "", ds, nil, nil)
 	response = rt.SendAdminRequest(http.MethodPut, "/db/_user/demo", payload)
 	RequireStatus(t, response, http.StatusOK)
 
 	// Check that channel access has been removed, but role access is unchanged
 	userConfig := rt.GetUserAdminAPI("demo")
-	requireAdminChannels(t, base.Set(nil), userConfig, collection)
+	requireAdminChannels(t, base.Set(nil), userConfig, ds)
 	assert.Equal(t, base.SetFromArray(userRoles), userConfig.ExplicitRoleNames)
 
 }
 
-func requireAdminChannels(t *testing.T, expectedChannels base.Set, principalConfig auth.PrincipalConfig, collection *db.DatabaseCollection) {
+func requireAdminChannels(t *testing.T, expectedChannels base.Set, principalConfig auth.PrincipalConfig, ds sgbucket.DataStore) {
 	configChannels := principalConfig.ExplicitChannels
-	if !collection.IsDefaultCollection() {
-		configChannels = principalConfig.CollectionAccess[collection.ScopeName][collection.Name].ExplicitChannels_
+	if !base.IsDefaultCollection(ds.ScopeName(), ds.CollectionName()) {
+		configChannels = principalConfig.CollectionAccess[ds.ScopeName()][ds.CollectionName()].ExplicitChannels_
 	}
 	require.Equal(t, expectedChannels, configChannels)
 }
 
-func requireJWTChannels(t *testing.T, expectedChannels base.Set, principalConfig auth.PrincipalConfig, collection *db.DatabaseCollection) {
+func requireJWTChannels(t *testing.T, expectedChannels base.Set, principalConfig auth.PrincipalConfig, ds sgbucket.DataStore) {
 	configChannels := principalConfig.JWTChannels
-	if !collection.IsDefaultCollection() {
-		configChannels = principalConfig.CollectionAccess[collection.ScopeName][collection.Name].JWTChannels_
+	if !base.IsDefaultCollection(ds.ScopeName(), ds.CollectionName()) {
+		configChannels = principalConfig.CollectionAccess[ds.ScopeName()][ds.CollectionName()].JWTChannels_
 	}
 	require.Equal(t, expectedChannels, configChannels)
 }
@@ -1600,11 +1598,11 @@ func TestDeletedRoleChanHistory(t *testing.T) {
 				rt = NewRestTesterMultipleCollections(t, nil, 1)
 			}
 
-			collection := rt.GetSingleTestDatabaseCollection()
 			defer rt.Close()
 
+			ds := rt.GetSingleDataStore()
 			const roleName = "role"
-			response := rt.SendAdminRequest("PUT", "/db/_role/role", GetUserPayload(t, "role", "letmein", "", collection, []string{"channel"}, nil))
+			response := rt.SendAdminRequest("PUT", "/db/_role/role", GetUserPayload(t, "role", "letmein", "", ds, []string{"channel"}, nil))
 			RequireStatus(t, response, 201)
 
 			a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
@@ -1613,7 +1611,7 @@ func TestDeletedRoleChanHistory(t *testing.T) {
 			role, err := a.GetRole(roleName)
 			assert.NoError(t, err)
 			assert.NotNil(t, role)
-			channels := role.CollectionChannels(collection.ScopeName, collection.Name)
+			channels := role.CollectionChannels(ds.ScopeName(), ds.CollectionName())
 			assert.Len(t, channels, 2)
 			assert.True(t, channels.Contains("channel"))
 
@@ -1624,7 +1622,7 @@ func TestDeletedRoleChanHistory(t *testing.T) {
 			// get deleted role and assert channel is in channel history
 			role, err = a.GetRoleIncDeleted(roleName)
 			assert.NoError(t, err)
-			channelHistory := role.CollectionChannelHistory(collection.ScopeName, collection.Name)
+			channelHistory := role.CollectionChannelHistory(ds.ScopeName(), ds.CollectionName())
 			assert.Len(t, channelHistory, 2)
 			_, ok := channelHistory["channel"]
 			require.True(t, ok)

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -36,13 +36,14 @@ func (rt *RestTester) WaitForAttachmentCompactionStatus(t *testing.T, state db.B
 	return response
 }
 
-func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser, dataStore base.DataStore, docID string, body []byte, attID string, attBody []byte) string {
+func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser, docID string, body []byte, attID string, attBody []byte) string {
 	if !base.TestUseXattrs() {
 		t.Skip("Requires xattrs")
 	}
 	attDigest := db.Sha1DigestKey(attBody)
 
 	attDocID := db.MakeAttachmentKey(db.AttVersion1, docID, attDigest)
+	dataStore := collection.GetCollectionDatastore()
 	_, err := dataStore.AddRaw(attDocID, 0, attBody)
 	require.NoError(t, err)
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -362,8 +362,7 @@ func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	passiveRT = NewRestTester(t, passiveRTConfig)
-	response := passiveRT.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/alice", GetUserPayload(t, "", RestTesterDefaultUserPassword, "", passiveRT.GetSingleTestDatabaseCollection(), []string{"*"}, nil))
-	RequireStatus(t, response, http.StatusCreated)
+	passiveRT.CreateUser("alice", []string{"*"})
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 	srv := httptest.NewServer(passiveRT.TestPublicHandler())

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -98,12 +98,8 @@ func TestAttachmentCompactionRun(t *testing.T) {
 
 	rt := NewRestTester(t, &RestTesterConfig{CustomTestBucket: tb, useTLSServer: true})
 	defer rt.Close()
-	ctx = rt.Context()
 
-	collection := &db.DatabaseCollectionWithUser{
-		DatabaseCollection: rt.GetSingleTestDatabaseCollection(),
-	}
-	dataStore := rt.GetSingleDataStore()
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	for i := 0; i < 20; i++ {
 		docID := fmt.Sprintf("testDoc-%d", i)
@@ -111,7 +107,7 @@ func TestAttachmentCompactionRun(t *testing.T) {
 		attBody := map[string]interface{}{"value": strconv.Itoa(i)}
 		attJSONBody, err := base.JSONMarshal(attBody)
 		assert.NoError(t, err)
-		CreateLegacyAttachmentDoc(t, ctx, collection, dataStore, docID, []byte("{}"), attID, attJSONBody)
+		CreateLegacyAttachmentDoc(t, ctx, collection, docID, []byte("{}"), attID, attJSONBody)
 	}
 
 	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")


### PR DESCRIPTION
GetDocument may audit information for reads.

- change rt.GetSingleTestDatabaseCollection to return ctx.
	- One place that it was commonly used to was to construct a user. When the user construction was trivial, use rt.CreateUser, otherwise leave as is. Switch the GetUserPayload to use DataStore so it can we accessed with a single API call.
- Switch revocationTestPassword to the default rest tester password to use CreateUser helper functions
- switch `rt.GetSingleTestDatabaseCollectionWithUser` to implicitly get `rt.Context()` to avoid callers having to specify it.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2583/
