### PR TITLE
CBG-3980: Filter audit events based on CB+SG usernames

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -199,6 +199,7 @@ func (al *AuditLogger) shouldLog(id AuditID, ctx context.Context) bool {
 	if !auditLogger.FileLogger.shouldLog(LevelNone) {
 		return false
 	}
+
 	logCtx := getLogCtx(ctx)
 	if logCtx.DbLogConfig != nil && logCtx.DbLogConfig.Audit != nil {
 		if !logCtx.DbLogConfig.Audit.Enabled {
@@ -207,6 +208,30 @@ func (al *AuditLogger) shouldLog(id AuditID, ctx context.Context) bool {
 		if _, ok := logCtx.DbLogConfig.Audit.EnabledEvents[id]; !ok {
 			return false
 		}
+		if !shouldLogAuditEventForUserAndRole(&logCtx) {
+			return false
+		}
 	}
+
+	return true
+}
+
+// shouldLogAuditEventForUserAndRole returns true if the request should be logged
+func shouldLogAuditEventForUserAndRole(logCtx *LogContext) bool {
+	if logCtx.UserDomain == "" && logCtx.Username == "" ||
+		len(logCtx.DbLogConfig.Audit.DisabledUsers) == 0 {
+		// early return for common cases: no user on context or no disabled users or roles
+		return true
+	}
+
+	if logCtx.UserDomain != "" && logCtx.Username != "" {
+		if _, isDisabled := logCtx.DbLogConfig.Audit.DisabledUsers[AuditLoggingPrincipal{
+			Domain: string(logCtx.UserDomain),
+			Name:   logCtx.Username,
+		}]; isDisabled {
+			return false
+		}
+	}
+
 	return true
 }

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -46,10 +46,12 @@ type LogContext struct {
 
 	// RequestAdditionalAuditFields is a map of fields to be included in audit logs
 	RequestAdditionalAuditFields map[string]any
+
 	// Username is the name of the authenticated user
 	Username string
-	// UserDomain can be syncgateway or couchbase depending on whether the authenticated user is a sync gateway user or a couchbase RBAC user
+	// UserDomain can determine whether the authenticated user is a sync gateway user or a couchbase RBAC user
 	UserDomain userIDDomain
+
 	// RequestHost is the HTTP Host of the request associated with this log.
 	RequestHost string
 	// RequestRemoteAddr is the IP and port of the remote client making the request associated with this log
@@ -72,9 +74,16 @@ type DbConsoleLogConfig struct {
 }
 
 // DbAuditLogConfig can be used to customise the audit logging for events associated with this database.
+// These properties are evaluated at logging time and are expected to have O(1) lookup time.
 type DbAuditLogConfig struct {
 	Enabled       bool
 	EnabledEvents map[AuditID]struct{}
+	DisabledUsers map[AuditLoggingPrincipal]struct{}
+}
+
+type AuditLoggingPrincipal struct {
+	Domain string `json:"domain,omitempty"`
+	Name   string `json:"name,omitempty"`
 }
 
 // addContext returns a string format with additional log context if present.

--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -73,12 +73,19 @@ func TestsUseServerCE() bool {
 	return err == nil && !isEE
 }
 
-// TestsRequireMobileRBAC returns true if the server has Sync Gateway RBAC roles.
 func TestsRequireMobileRBAC(t *testing.T) {
-	ok, err := GTestBucketPool.cluster.supportsMobileRBAC()
-	if err != nil || !ok {
+	if !TestCanUseMobileRBAC(t) {
 		t.Skip("Mobile RBAC roles for Sync Gateway are only fully supported in CBS 7.1 or greater")
 	}
+}
+
+// TestCanUseMobileRBAC returns true if the server has Sync Gateway RBAC roles.
+func TestCanUseMobileRBAC(_ *testing.T) bool {
+	if GTestBucketPool.cluster == nil {
+		return false
+	}
+	ok, err := GTestBucketPool.cluster.supportsMobileRBAC()
+	return err == nil && ok
 }
 
 // canUseNamedCollections returns true if the cluster supports named collections, and they are also requested

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 func TestAuditLoggingFields(t *testing.T) {
-	//if !base.UnitTestUrlIsWalrus() {
-	//	t.Skip("This test can panic with gocb logging CBG-4076")
-	//}
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("This test can panic with gocb logging CBG-4076")
+	}
 
 	// get tempdir before resetting global loggers, since the logger cleanup needs to happen before deletion
 	tempdir := t.TempDir()

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -28,6 +28,10 @@ func TestAuditLoggingFields(t *testing.T) {
 		t.Skip("This test can panic with gocb logging CBG-4076")
 	}
 
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Audit logging only works in EE")
+	}
+
 	// get tempdir before resetting global loggers, since the logger cleanup needs to happen before deletion
 	tempdir := t.TempDir()
 	base.ResetGlobalTestLogging(t)

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -12,6 +12,7 @@ package rest
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -23,17 +24,21 @@ import (
 )
 
 func TestAuditLoggingFields(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("This test can panic with gocb logging CBG-4076")
-	}
+	//if !base.UnitTestUrlIsWalrus() {
+	//	t.Skip("This test can panic with gocb logging CBG-4076")
+	//}
 
 	// get tempdir before resetting global loggers, since the logger cleanup needs to happen before deletion
 	tempdir := t.TempDir()
 	base.ResetGlobalTestLogging(t)
 	base.InitializeMemoryLoggers()
+
 	const (
-		requestInfoHeaderName = "extra-audit-logging-header"
-		requestUser           = "alice"
+		requestInfoHeaderName  = "extra-audit-logging-header"
+		requestUser            = "alice"
+		filteredPublicUsername = "bob"
+		filteredAdminUsername  = "TestAuditLoggingFields-charlie"
+		filteredAdminPassword  = "password"
 	)
 
 	rt := NewRestTester(t, &RestTesterConfig{
@@ -57,9 +62,30 @@ func TestAuditLoggingFields(t *testing.T) {
 	})
 	defer rt.Close()
 
+	runServerRBACTests := base.TestCanUseMobileRBAC(t)
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Logging = &DbLoggingConfig{
+		Audit: &DbAuditLoggingConfig{
+			Enabled: base.BoolPtr(true),
+			DisabledUsers: []base.AuditLoggingPrincipal{
+				{Name: filteredPublicUsername, Domain: string(base.UserDomainSyncGateway)},
+				{Name: filteredAdminUsername, Domain: string(base.UserDomainCBServer)},
+			},
+		},
+	}
+
 	// initialize RestTester
-	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
 	rt.CreateUser(requestUser, nil)
+	rt.CreateUser(filteredPublicUsername, nil)
+	if runServerRBACTests {
+		eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+		require.NoError(t, err)
+		MakeUser(t, httpClient, eps[0], filteredAdminUsername, filteredAdminPassword, []string{fmt.Sprintf("%s[%s]", MobileSyncGatewayRole.RoleName, rt.Bucket().GetName())})
+		defer DeleteUser(t, httpClient, eps[0], filteredAdminUsername)
+	}
 
 	// auditFieldValueIgnored is a special value for an audit field to skip value-specific checks whilst still ensuring the field property is set
 	// used for unpredictable values, for example timestamps or request IDs (when the test is making concurrent or unordered requests)
@@ -191,6 +217,24 @@ func TestAuditLoggingFields(t *testing.T) {
 					base.AuditFieldCorrelationID: auditFieldValueIgnored,
 					base.AuditFieldRealUserID:    map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
 				},
+			},
+		},
+		{
+			name: "filtered public request",
+			auditableAction: func(t testing.TB) {
+				RequireStatus(t, rt.SendUserRequest(http.MethodGet, "/db/", "", filteredPublicUsername), http.StatusOK)
+			},
+		},
+		{
+			name: "filtered admin request",
+			auditableAction: func(t testing.TB) {
+				if !runServerRBACTests {
+					t.Skip("Skipping subtest that requires admin RBAC")
+				}
+				if !rt.AdminInterfaceAuthentication {
+					t.Skip("Skipping subtest that requires admin auth")
+				}
+				RequireStatus(t, rt.SendAdminRequestWithAuth(http.MethodGet, "/db/", "", filteredAdminUsername, filteredAdminPassword), http.StatusOK)
 			},
 		},
 	}


### PR DESCRIPTION
CBG-3980

- Option to filter audit events based on usernames from Sync Gateway (public API), or CB Server (Admin API)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
