### PR TITLE
CBG-4060: Role-based audit filtering

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -94,6 +94,9 @@ type User interface {
 	// Changes the user's password.
 	SetPassword(password string) error
 
+	// GetRoles returns the set of roles the user belongs to, initializing them if necessary.
+	GetRoles() []Role
+
 	// The set of Roles the user belongs to (including ones given to it by the sync function and by OIDC/JWT)
 	// Returns nil if invalidated
 	RoleNames() ch.TimedSet

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -230,7 +230,7 @@ func shouldLogAuditEventForUserAndRole(logCtx *LogContext) bool {
 	}
 
 	// if any of the user's roles are disabled, then don't log the event
-	for role := range logCtx.UserRoles {
+	for role := range logCtx.UserRolesForAuditFiltering {
 		if _, isDisabled := logCtx.DbLogConfig.Audit.DisabledRoles[AuditLoggingPrincipal{
 			Domain: string(logCtx.UserDomain),
 			Name:   role,

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -214,7 +214,7 @@ func (al *AuditLogger) shouldLog(id AuditID, ctx context.Context) bool {
 
 // shouldLogAuditEventForUserAndRole returns true if the request should be logged
 func shouldLogAuditEventForUserAndRole(logCtx *LogContext) bool {
-	if logCtx.UserDomain == "" && logCtx.Username == "" ||
+	if (logCtx.UserDomain == "" && logCtx.Username == "") ||
 		len(logCtx.DbLogConfig.Audit.DisabledRoles) == 0 && len(logCtx.DbLogConfig.Audit.DisabledUsers) == 0 {
 		// early return for common cases: no user on context or no disabled users or roles
 		return true

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -215,7 +215,7 @@ func (al *AuditLogger) shouldLog(id AuditID, ctx context.Context) bool {
 // shouldLogAuditEventForUserAndRole returns true if the request should be logged
 func shouldLogAuditEventForUserAndRole(logCtx *LogContext) bool {
 	if logCtx.UserDomain == "" && logCtx.Username == "" ||
-		len(logCtx.DbLogConfig.Audit.DisabledUsers) == 0 {
+		len(logCtx.DbLogConfig.Audit.DisabledRoles) == 0 && len(logCtx.DbLogConfig.Audit.DisabledUsers) == 0 {
 		// early return for common cases: no user on context or no disabled users or roles
 		return true
 	}
@@ -224,6 +224,16 @@ func shouldLogAuditEventForUserAndRole(logCtx *LogContext) bool {
 		if _, isDisabled := logCtx.DbLogConfig.Audit.DisabledUsers[AuditLoggingPrincipal{
 			Domain: string(logCtx.UserDomain),
 			Name:   logCtx.Username,
+		}]; isDisabled {
+			return false
+		}
+	}
+
+	// if any of the user's roles are disabled, then don't log the event
+	for role := range logCtx.UserRoles {
+		if _, isDisabled := logCtx.DbLogConfig.Audit.DisabledRoles[AuditLoggingPrincipal{
+			Domain: string(logCtx.UserDomain),
+			Name:   role,
 		}]; isDisabled {
 			return false
 		}

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -160,6 +160,7 @@ func (lc *LogContext) getCopy() LogContext {
 		RequestAdditionalAuditFields: lc.RequestAdditionalAuditFields,
 		Username:                     lc.Username,
 		UserDomain:                   lc.UserDomain,
+		UserRoles:                    lc.UserRoles,
 		RequestHost:                  lc.RequestHost,
 		RequestRemoteAddr:            lc.RequestRemoteAddr,
 		EffectiveUserID:              lc.EffectiveUserID,
@@ -271,10 +272,16 @@ const (
 	UserDomainBuiltin                  = "builtin" // internal users (e.g. SG bootstrap user)
 )
 
-func UserLogCtx(parent context.Context, username string, domain userIDDomain) context.Context {
+func UserLogCtx(parent context.Context, username string, domain userIDDomain, roles []string) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.Username = username
 	newCtx.UserDomain = domain
+	if len(roles) > 0 {
+		newCtx.UserRoles = make(map[string]struct{}, len(roles))
+		for _, role := range roles {
+			newCtx.UserRoles[role] = struct{}{}
+		}
+	}
 	return LogContextWith(parent, &newCtx)
 }
 

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -50,9 +50,9 @@ type LogContext struct {
 	// Username is the name of the authenticated user
 	Username string
 	// UserDomain can determine whether the authenticated user is a sync gateway user or a couchbase RBAC user
-	UserDomain userIDDomain
-	// UserRoles is a list of the authenticated user's roles, the domain for these roles is the same as the UserDomain
-	UserRoles map[string]struct{}
+	UserDomain UserIDDomain
+	// UserRolesForAuditFiltering is a list of the authenticated user's roles to be used to determine audit log filtering, the domain for these roles is the same as the UserDomain
+	UserRolesForAuditFiltering map[string]struct{}
 
 	// RequestHost is the HTTP Host of the request associated with this log.
 	RequestHost string
@@ -160,7 +160,7 @@ func (lc *LogContext) getCopy() LogContext {
 		RequestAdditionalAuditFields: lc.RequestAdditionalAuditFields,
 		Username:                     lc.Username,
 		UserDomain:                   lc.UserDomain,
-		UserRoles:                    lc.UserRoles,
+		UserRolesForAuditFiltering:   lc.UserRolesForAuditFiltering,
 		RequestHost:                  lc.RequestHost,
 		RequestRemoteAddr:            lc.RequestRemoteAddr,
 		EffectiveUserID:              lc.EffectiveUserID,
@@ -264,22 +264,22 @@ type EffectiveUserPair struct {
 	Domain string `json:"domain"`
 }
 
-type userIDDomain string
+type UserIDDomain string
 
 const (
-	UserDomainSyncGateway userIDDomain = "sgw"
-	UserDomainCBServer    userIDDomain = "cbs"
+	UserDomainSyncGateway UserIDDomain = "sgw"
+	UserDomainCBServer    UserIDDomain = "cbs"
 	UserDomainBuiltin                  = "builtin" // internal users (e.g. SG bootstrap user)
 )
 
-func UserLogCtx(parent context.Context, username string, domain userIDDomain, roles []string) context.Context {
+func UserLogCtx(parent context.Context, username string, domain UserIDDomain, roles []string) context.Context {
 	newCtx := getLogCtx(parent)
 	newCtx.Username = username
 	newCtx.UserDomain = domain
 	if len(roles) > 0 {
-		newCtx.UserRoles = make(map[string]struct{}, len(roles))
+		newCtx.UserRolesForAuditFiltering = make(map[string]struct{}, len(roles))
 		for _, role := range roles {
-			newCtx.UserRoles[role] = struct{}{}
+			newCtx.UserRolesForAuditFiltering[role] = struct{}{}
 		}
 	}
 	return LogContextWith(parent, &newCtx)

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -51,6 +51,8 @@ type LogContext struct {
 	Username string
 	// UserDomain can determine whether the authenticated user is a sync gateway user or a couchbase RBAC user
 	UserDomain userIDDomain
+	// UserRoles is a list of the authenticated user's roles, the domain for these roles is the same as the UserDomain
+	UserRoles map[string]struct{}
 
 	// RequestHost is the HTTP Host of the request associated with this log.
 	RequestHost string
@@ -94,6 +96,7 @@ type DbAuditLogConfig struct {
 	Enabled       bool
 	EnabledEvents map[AuditID]struct{}
 	DisabledUsers map[AuditLoggingPrincipal]struct{}
+	DisabledRoles map[AuditLoggingPrincipal]struct{}
 }
 
 type AuditLoggingPrincipal struct {

--- a/base/main_test_bucket_pool_util.go
+++ b/base/main_test_bucket_pool_util.go
@@ -51,8 +51,8 @@ func getTestBucketSpec(testBucketName tbpBucketName) BucketSpec {
 }
 
 // RequireNumTestBuckets skips the given test if there are not enough test buckets available to use.
-func RequireNumTestBuckets(t *testing.T, numRequired int) {
-	usable := GTestBucketPool.numUsableBuckets()
+func RequireNumTestBuckets(t testing.TB, numRequired int) {
+	usable := GTestBucketPool.NumUsableBuckets()
 	if usable < numRequired {
 		t.Skipf("Only had %d usable test buckets available (test requires %d)", usable, numRequired)
 	}
@@ -67,8 +67,8 @@ func RequireNumTestDataStores(t testing.TB, numRequired int) {
 	}
 }
 
-// numUsableBuckets returns the total number of buckets in the pool that can be used by a test.
-func (tbp *TestBucketPool) numUsableBuckets() int {
+// NumUsableBuckets returns the total number of buckets in the pool that can be used by a test.
+func (tbp *TestBucketPool) NumUsableBuckets() int {
 	if !tbp.integrationMode {
 		// we can create virtually endless walrus buckets,
 		// so report back 10 to match a fully available CBS bucket pool.

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,6 +96,7 @@ func TestAuditLoggingFields(t *testing.T) {
 
 	rt.CreateUser(requestUser, nil)
 	rt.CreateUser(filteredPublicUsername, nil)
+	rt.CreateRole(filteredPublicRoleName, []string{channels.AllChannelWildcard})
 	rt.CreateUser(filteredPublicRoleUsername, nil, filteredPublicRoleName)
 	if runServerRBACTests {
 		eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -291,7 +291,7 @@ func TestAuditLoggingFields(t *testing.T) {
 				if !rt.AdminInterfaceAuthentication {
 					t.Skip("Skipping subtest that requires admin auth")
 				}
-				RequireStatus(t, rt.SendAdminRequestWithAuth(http.MethodGet, "/db/", "", unauthorizedAdminUsername, unauthorizedAdminPassword), http.StatusForbidden)
+				RequireStatus(t, rt.SendAdminRequestWithAuth(http.MethodGet, "/db/", "", unauthorizedAdminUsername, RestTesterDefaultUserPassword), http.StatusForbidden)
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDAdminUserAuthorizationFailed: {

--- a/rest/config.go
+++ b/rest/config.go
@@ -2286,14 +2286,19 @@ func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 
 		// user/role filtering
 		disabledUsers := make(map[base.AuditLoggingPrincipal]struct{}, len(c.Logging.Audit.DisabledUsers))
+		disabledRoles := make(map[base.AuditLoggingPrincipal]struct{}, len(c.Logging.Audit.DisabledRoles))
 		for _, user := range c.Logging.Audit.DisabledUsers {
 			disabledUsers[user] = struct{}{}
+		}
+		for _, role := range c.Logging.Audit.DisabledRoles {
+			disabledRoles[role] = struct{}{}
 		}
 
 		aud = &base.DbAuditLogConfig{
 			Enabled:       base.BoolDefault(l.Audit.Enabled, false),
 			EnabledEvents: enabledEvents,
 			DisabledUsers: disabledUsers,
+			DisabledRoles: disabledRoles,
 		}
 	}
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -824,14 +824,16 @@ func (h *handler) logStatus(status int, message string) {
 }
 
 func needRolesForAudit(db *db.DatabaseContext, domain base.UserIDDomain) bool {
+	// early returns when auditing is disabled
 	if db == nil ||
 		db.Options.LoggingConfig == nil ||
 		db.Options.LoggingConfig.Audit == nil ||
-		len(db.Options.LoggingConfig.Audit.DisabledRoles) == 0 {
+		!db.Options.LoggingConfig.Audit.Enabled {
 		return false
 	}
 
 	// if we have any matching domains then we need the given roles
+	// this loop should be ~free for len(0)
 	for principal := range db.Options.LoggingConfig.Audit.DisabledRoles {
 		if principal.Domain == string(domain) {
 			return true

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -513,6 +513,17 @@ func (rt *RestTester) CreateUser(username string, channels []string, roles ...st
 	RequireStatus(rt.TB(), response, http.StatusCreated)
 }
 
+// CreateRole creates a role with channels scoped to a single test collection.
+func (rt *RestTester) CreateRole(rolename string, channels []string) {
+	var response *TestResponse
+	if rt.AdminInterfaceAuthentication {
+		response = rt.SendAdminRequestWithAuth(http.MethodPut, "/{{.db}}/_role/"+rolename, GetRolePayload(rt.TB(), rolename, rt.GetSingleDataStore(), channels), base.TestClusterUsername(), base.TestClusterPassword())
+	} else {
+		response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_role/"+rolename, GetRolePayload(rt.TB(), rolename, rt.GetSingleDataStore(), channels))
+	}
+	RequireStatus(rt.TB(), response, http.StatusCreated)
+}
+
 func (rt *RestTester) GetUserAdminAPI(username string) auth.PrincipalConfig {
 	response := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_user/"+username, "")
 	RequireStatus(rt.TB(), response, http.StatusOK)
@@ -1731,7 +1742,7 @@ func GetUserPayload(t testing.TB, username, password, email string, collection s
 
 // GetRolePayload will take roleName and channels you want to assign a particular role and return the appropriate payload for the _role endpoint
 // For default collection, follows same handling as GetUserPayload for chans.
-func GetRolePayload(t *testing.T, roleName string, collection sgbucket.DataStore, chans []string) string {
+func GetRolePayload(t testing.TB, roleName string, collection sgbucket.DataStore, chans []string) string {
 	config := PrincipalConfigForWrite{}
 	if roleName != "" {
 		config.Name = &roleName

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -503,12 +503,12 @@ func (rt *RestTester) GetDatabase() *db.DatabaseContext {
 }
 
 // CreateUser creates a user with the default password and channels scoped to a single test collection.
-func (rt *RestTester) CreateUser(username string, channels []string) {
+func (rt *RestTester) CreateUser(username string, channels []string, roles ...string) {
 	var response *TestResponse
 	if rt.AdminInterfaceAuthentication {
-		response = rt.SendAdminRequestWithAuth(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB(), "", RestTesterDefaultUserPassword, "", rt.GetSingleDataStore(), channels, nil), base.TestClusterUsername(), base.TestClusterPassword())
+		response = rt.SendAdminRequestWithAuth(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB(), "", RestTesterDefaultUserPassword, "", rt.GetSingleDataStore(), channels, roles), base.TestClusterUsername(), base.TestClusterPassword())
 	} else {
-		response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB(), "", RestTesterDefaultUserPassword, "", rt.GetSingleDataStore(), channels, nil))
+		response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, GetUserPayload(rt.TB(), "", RestTesterDefaultUserPassword, "", rt.GetSingleDataStore(), channels, roles))
 	}
 	RequireStatus(rt.TB(), response, http.StatusCreated)
 }

--- a/rest/utilities_testing_user.go
+++ b/rest/utilities_testing_user.go
@@ -39,11 +39,12 @@ func MakeUser(t *testing.T, httpClient *http.Client, serverURL, username, passwo
 			return true, err, nil
 		}
 		defer func() { assert.NoError(t, resp.Body.Close()) }()
+		var bodyResp []byte
 		if resp.StatusCode != http.StatusOK {
-			bodyResp, err := io.ReadAll(resp.Body)
-			assert.NoError(t, err, "Failed to create user: %s", bodyResp)
+			bodyResp, err = io.ReadAll(resp.Body)
+			require.NoError(t, err, "Failed to create user: %s", bodyResp)
 		}
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equalf(t, http.StatusOK, resp.StatusCode, "Failed to create user: %s", bodyResp)
 		return false, err, nil
 	}
 


### PR DESCRIPTION
CBG-4060

- Add `GetRoles()` to `auth.User` interface for access to roles (and initialization if nessesary)
- Add role filtering logic to `shouldLogAuditEventForUserAndRole`
- Store SG or CB Server roles on LogContext, but only when we have role-based filtering enabled
  - Getting the roles for CB Server RBAC users costs one additional HTTP /whoami request per-authed request when we have auditing and CB Server role filtering enabled.
  - Getting the roles for SG users is free _if_ they are initialized
- Test coverage of role-filtered audit events in `TestAuditLoggingFields`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2600/
