### PR TITLE
CBG-3947 Do not remove loaded database on transient fetch error

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -248,6 +248,25 @@ func IsXattrNotFoundError(err error) bool {
 	return false
 }
 
+func IsRecoverableReadError(err error) bool {
+
+	if err == nil {
+		return false
+	}
+	// SG timeout error
+	if errors.Is(err, ErrTimeout) {
+		return true
+	}
+	// gocb timeouts or transient errors
+	if errors.Is(err, gocb.ErrTemporaryFailure) ||
+		errors.Is(err, gocb.ErrOverload) ||
+		errors.Is(err, gocb.ErrTimeout) ||
+		errors.Is(err, gocb.ErrCircuitBreakerOpen) {
+		return true
+	}
+	return false
+}
+
 // MultiError manages a set of errors.  Callers must use ErrorOrNil when returning MultiError to callers
 // in order to properly handle nil checks on the returned MultiError
 //  Sample usage:

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1776,6 +1776,91 @@ func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
 
 }
 
+// TestConfigPollingRemoveDatabase:
+//
+//	Validates db is removed when polling detects that the config is not found
+func TestConfigPollingRemoveDatabase(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyConfig)
+	testCases := []struct {
+		useXattrConfig bool
+	}{
+		{
+			useXattrConfig: false,
+		},
+		{
+			useXattrConfig: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("xattrConfig_%v", testCase.useXattrConfig), func(t *testing.T) {
+
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+				CustomTestBucket: base.GetTestBucket(t),
+				PersistentConfig: true,
+				MutateStartupConfig: func(config *rest.StartupConfig) {
+					// configure the interval time to pick up new configs from the bucket to every 50 milliseconds
+					config.Bootstrap.ConfigUpdateFrequency = base.NewConfigDuration(50 * time.Millisecond)
+				},
+				DatabaseConfig: nil,
+				UseXattrConfig: testCase.useXattrConfig,
+			})
+			defer rt.Close()
+
+			ctx := base.TestCtx(t)
+			// create a new db
+			dbName := "db1"
+			dbConfig := rt.NewDbConfig()
+			dbConfig.Name = dbName
+			dbConfig.BucketConfig.Bucket = base.StringPtr(rt.CustomTestBucket.GetName())
+			resp := rt.CreateDatabase(dbName, dbConfig)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+
+			// Validate that db is loaded
+			_, err := rt.ServerContext().GetDatabase(ctx, dbName)
+			require.NoError(t, err)
+
+			// Force timeouts - dev-time only test enhancement to validate CBG-3947, requires manual "leaky bootstrap" handling
+			// To enable:
+			//  - Add "var ForceTimeouts bool" to bootstrap.go
+			//  - In CouchbaseCluster.GetMetadataDocument, add the following after loadConfig:
+			//    	if ForceTimeouts {
+			//			return 0, gocb.ErrTimeout
+			//		}
+			//  - enable the code block below
+			/*
+				base.ForceTimeouts = true
+
+				// Wait to ensure database doesn't disappear
+				err = rt.WaitForConditionWithOptions(func() bool {
+					_, err := rt.ServerContext().GetActiveDatabase(dbName)
+					return errors.Is(err, base.ErrNotFound)
+
+				}, 200, 50)
+				require.Error(t, err)
+
+				base.ForceTimeouts = false
+			*/
+
+			// Delete the config directly
+			rt.RemoveDbConfigFromBucket("db1", rt.CustomTestBucket.GetName())
+
+			// assert that the database is unloaded
+			err = rt.WaitForConditionWithOptions(func() bool {
+				_, err := rt.ServerContext().GetActiveDatabase(dbName)
+				return errors.Is(err, base.ErrNotFound)
+
+			}, 200, 1000)
+			require.NoError(t, err)
+
+			// assert that a request to the database fails with correct error message
+			resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
+			rest.RequireStatus(t, resp, http.StatusNotFound)
+			assert.Contains(t, resp.Body.String(), "no such database")
+		})
+	}
+}
+
 func TestResyncStopUsingDCPStream(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		// This test requires a gocb bucket

--- a/rest/config.go
+++ b/rest/config.go
@@ -1605,7 +1605,7 @@ func (sc *ServerContext) fetchAndLoadConfigs(ctx context.Context, isInitialStart
 			base.DebugfCtx(ctx, base.KeyConfig, "Database %q already removed from server context after acquiring write lock - do not need to remove not removing database", base.MD(dbName))
 			continue
 		}
-		
+
 		// It's possible that the "deleted" database was not written to the server until after sc.FetchConfigs had returned...
 		// we'll need to pay for the cost of getting the config again now that we've got the write lock to double-check this db is definitely ok to remove...
 		var cnf DatabaseConfig

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -76,6 +76,7 @@ type RestTesterConfig struct {
 	syncGatewayVersion              *base.ComparableBuildVersion // alternate version of Sync Gateway to use on startup
 	allowDbConfigEnvVars            *bool
 	maxConcurrentRevs               *int
+	UseXattrConfig                  bool
 }
 
 type collectionConfiguration uint8
@@ -234,6 +235,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
 	sc.Unsupported.Serverless.Enabled = &rt.serverless
 	sc.Unsupported.AllowDbConfigEnvVars = rt.RestTesterConfig.allowDbConfigEnvVars
+	sc.Unsupported.UseXattrConfig = &rt.UseXattrConfig
 	sc.Replicator.MaxConcurrentRevs = rt.RestTesterConfig.maxConcurrentRevs
 	if rt.serverless {
 		if !rt.PersistentConfig {

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -323,6 +323,11 @@ func (rt *RestTester) InsertDbConfigToBucket(config *DatabaseConfig, bucketName 
 	require.NoError(rt.TB(), insertErr)
 }
 
+func (rt *RestTester) RemoveDbConfigFromBucket(dbName string, bucketName string) {
+	deleteErr := rt.ServerContext().BootstrapContext.DeleteConfig(base.TestCtx(rt.TB()), bucketName, rt.ServerContext().Config.Bootstrap.ConfigGroupID, dbName)
+	require.NoError(rt.TB(), deleteErr)
+}
+
 func (rt *RestTester) PersistDbConfigToBucket(dbConfig DbConfig, bucketName string) {
 	version, err := GenerateDatabaseConfigVersionID(rt.Context(), "", &dbConfig)
 	require.NoError(rt.TB(), err)


### PR DESCRIPTION
For transient fetch errors (recoverable read errors), leave the database intact to avoid database unload/reload churn during transient connectivity issues with server.

Required changing the pre-delete validation check on the config  from _fetchDatabase (which scans all buckets) to GetConfig (which targets the known bucket), as _fetchDatabase can't bubble up the transient error for a particular bucket.

Added a test to ensure the actual delete behaviour still works as expected (TestConfigPollingRemoveDatabase), and performed some manual testing to simulate the transient error (see Force timeouts notes in that test) - this will be required until we implement "leaky bootstrap" test support.

CBG-3947

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2591/
