### PR TITLE
CBG-4064: stamp effective user ID from header

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -40,6 +40,7 @@ const (
 	AuditFieldCompactionReset    = "reset"
 	AuditFieldPostUpgradePreview = "preview"
 	AuditFieldAuthMethod         = "auth_method"
+	AuditEffectiveUserID         = "effective_userid"
 )
 
 // expandFields populates data with information from the id, context and additionalData.
@@ -73,6 +74,14 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 		fields[AuditFieldRealUserID] = map[string]any{
 			"domain": userDomain,
 			"user":   userName,
+		}
+	}
+	effectiveDomain := logCtx.EffectiveDomain
+	effectiveUser := logCtx.EffectiveUserID
+	if effectiveDomain != "" || effectiveUser != "" {
+		fields[AuditEffectiveUserID] = map[string]any{
+			"domain": effectiveDomain,
+			"user":   effectiveUser,
 		}
 	}
 	if logCtx.RequestHost != "" {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -57,6 +57,12 @@ type LogContext struct {
 
 	// implicitDefaultCollection is set to true when the context represents the default collection, but we want to omit that value from logging to prevent verbosity.
 	implicitDefaultCollection bool
+
+	// Effective user ID from HTTP header
+	EffectiveUserID string
+
+	// Domain defined in the HTTP request header
+	EffectiveDomain string
 }
 
 // DbLogConfig can be used to customise the logging for logs associated with this database.
@@ -135,6 +141,8 @@ func (lc *LogContext) getCopy() LogContext {
 		UserDomain:                   lc.UserDomain,
 		RequestHost:                  lc.RequestHost,
 		RequestRemoteAddr:            lc.RequestRemoteAddr,
+		EffectiveUserID:              lc.EffectiveUserID,
+		EffectiveDomain:              lc.EffectiveDomain,
 	}
 }
 
@@ -213,6 +221,13 @@ func AuditLogCtx(parent context.Context, additionalAuditFields map[string]any) c
 	return LogContextWith(parent, &newCtx)
 }
 
+func EffectiveUserIDLogCtx(parent context.Context, domain, userID string) context.Context {
+	newCtx := getLogCtx(parent)
+	newCtx.EffectiveDomain = domain
+	newCtx.EffectiveUserID = userID
+	return LogContextWith(parent, &newCtx)
+}
+
 // KeyspaceLogCtx extends the parent context with a fully qualified keyspace (bucket.scope.collection)
 func KeyspaceLogCtx(parent context.Context, bucketName, scopeName, collectionName string) context.Context {
 	newCtx := getLogCtx(parent)
@@ -220,6 +235,11 @@ func KeyspaceLogCtx(parent context.Context, bucketName, scopeName, collectionNam
 	newCtx.Collection = collectionName
 	newCtx.Scope = scopeName
 	return LogContextWith(parent, &newCtx)
+}
+
+type EffectiveUserPair struct {
+	UserID string `json:"user"`
+	Domain string `json:"domain"`
 }
 
 type userIDDomain string

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -426,12 +426,12 @@ func TestEffectiveUserID(t *testing.T) {
 		domain     = "domain"
 		cnfDomain  = "myDomain"
 		cnfUser    = "bob"
-		authUser   = "alice"
+		realUser   = "alice"
 		realDomain = "sgw"
 	)
 	reqHeaders := map[string]string{
 		"user_header":   fmt.Sprintf(`{"%s": "%s", "%s":"%s"}`, domain, cnfDomain, user, cnfUser),
-		"Authorization": getBasicAuthHeader(authUser, RestTesterDefaultUserPassword),
+		"Authorization": getBasicAuthHeader(realUser, RestTesterDefaultUserPassword),
 	}
 
 	rt := NewRestTester(t, &RestTesterConfig{
@@ -452,7 +452,7 @@ func TestEffectiveUserID(t *testing.T) {
 	})
 	defer rt.Close()
 	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
-	rt.CreateUser(authUser, nil)
+	rt.CreateUser(realUser, nil)
 
 	action := func(t testing.TB) {
 		RequireStatus(t, rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/", "", reqHeaders), http.StatusOK)
@@ -464,8 +464,8 @@ func TestEffectiveUserID(t *testing.T) {
 		effective := event[base.AuditEffectiveUserID].(map[string]any)
 		assert.Equal(t, cnfDomain, effective[domain])
 		assert.Equal(t, cnfUser, effective[user])
-		realUser := event[base.AuditFieldRealUserID].(map[string]any)
-		assert.Equal(t, realDomain, realUser[domain])
-		assert.Equal(t, authUser, realUser[user])
+		realUserEvent := event[base.AuditFieldRealUserID].(map[string]any)
+		assert.Equal(t, realDomain, realUserEvent[domain])
+		assert.Equal(t, realUser, realUserEvent[user])
 	}
 }

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -418,9 +418,6 @@ func TestRedactConfigAsStr(t *testing.T) {
 }
 
 func TestEffectiveUserID(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("This test can panic with gocb logging CBG-4076")
-	}
 	tempdir := t.TempDir()
 	base.ResetGlobalTestLogging(t)
 	base.InitializeMemoryLoggers()
@@ -435,9 +432,8 @@ func TestEffectiveUserID(t *testing.T) {
 	}
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled:                 true,
-		AdminInterfaceAuthentication: !base.UnitTestUrlIsWalrus(), // disable admin auth for walrus so we can get coverage of both subtests
-		PersistentConfig:             true,
+		GuestEnabled:     true,
+		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Unsupported.EffectiveUserHeaderName = base.StringPtr("user_header")
 			config.Logging = base.LoggingConfig{

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -158,6 +158,7 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"unsupported.user_queries":                                 {&config.Unsupported.UserQueries, fs.Bool("unsupported.user_queries", false, "Whether user-query APIs are enabled")},
 		"unsupported.audit_info_provider.global_info_env_var_name": {&config.Unsupported.AuditInfoProvider.GlobalInfoEnvVarName, fs.String("unsupported.audit_info_provider.global_info_env_var_name", "", "Environment variable name to get global audit event info from")},
 		"unsupported.audit_info_provider.request_info_header_name": {&config.Unsupported.AuditInfoProvider.RequestInfoHeaderName, fs.String("unsupported.audit_info_provider.request_info_header_name", "", "Header name to get request audit event info from")},
+		"unsupported.effective_user_header_name":                   {&config.Unsupported.EffectiveUserHeaderName, fs.String("unsupported.effective_user_header_name", "", "HTTP header name to get effective user id from")},
 
 		"database_credentials": {&config.DatabaseCredentials, fs.String("database_credentials", "null", "JSON-encoded per-database credentials, that can be used instead of the bootstrap ones. This will override bucket_credentials that target the bucket that the database is in.")},
 		"bucket_credentials":   {&config.BucketCredentials, fs.String("bucket_credentials", "null", "JSON-encoded per-bucket credentials, that can be used instead of the bootstrap ones.")},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -156,15 +156,16 @@ type ReplicatorConfig struct {
 }
 
 type UnsupportedConfig struct {
-	StatsLogFrequency    *base.ConfigDuration     `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
-	UseStdlibJSON        *bool                    `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
-	Serverless           ServerlessConfig         `json:"serverless,omitempty"`
-	HTTP2                *HTTP2Config             `json:"http2,omitempty"`
-	UserQueries          *bool                    `json:"user_queries,omitempty"            help:"Feature flag for user N1QL/JS queries"`
-	UseXattrConfig       *bool                    `json:"use_xattr_config,omitempty"        help:"Store database configurations in system xattrs"`
-	AllowDbConfigEnvVars *bool                    `json:"allow_dbconfig_env_vars,omitempty" help:"Can be set to false to skip environment variable expansion in database configs"`
-	DiagnosticInterface  string                   `json:"diagnostic_interface,omitempty"    help:"Network interface to bind diagnostic API to"`
-	AuditInfoProvider    *AuditInfoProviderConfig `json:"audit_info_provider,omitempty"     help:"Configuration for audit info provider"`
+	StatsLogFrequency       *base.ConfigDuration     `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
+	UseStdlibJSON           *bool                    `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
+	Serverless              ServerlessConfig         `json:"serverless,omitempty"`
+	HTTP2                   *HTTP2Config             `json:"http2,omitempty"`
+	UserQueries             *bool                    `json:"user_queries,omitempty"            help:"Feature flag for user N1QL/JS queries"`
+	UseXattrConfig          *bool                    `json:"use_xattr_config,omitempty"        help:"Store database configurations in system xattrs"`
+	AllowDbConfigEnvVars    *bool                    `json:"allow_dbconfig_env_vars,omitempty" help:"Can be set to false to skip environment variable expansion in database configs"`
+	DiagnosticInterface     string                   `json:"diagnostic_interface,omitempty"    help:"Network interface to bind diagnostic API to"`
+	EffectiveUserHeaderName *string                  `json:"effective_user_header_name,omitempty" help:"HTTP header name to get effective user id from"`
+	AuditInfoProvider       *AuditInfoProviderConfig `json:"audit_info_provider,omitempty"     help:"Configuration for audit info provider"`
 }
 
 type AuditInfoProviderConfig struct {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -318,6 +318,19 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 		}
 	}
 
+	if h.server.Config.Unsupported.EffectiveUserHeaderName != nil {
+		effectiveUserFields := h.rq.Header.Get(*h.server.Config.Unsupported.EffectiveUserHeaderName)
+		if effectiveUserFields != "" {
+			var fields base.EffectiveUserPair
+			err := base.JSONUnmarshal([]byte(effectiveUserFields), &fields)
+			if err != nil {
+				base.WarnfCtx(h.ctx(), "Error unmarshalling effective user header fields: %v", err)
+			} else {
+				h.rqCtx = base.EffectiveUserIDLogCtx(h.rqCtx, fields.Domain, fields.UserID)
+			}
+		}
+	}
+
 	switch h.rq.Header.Get("Content-Encoding") {
 	case "":
 		h.requestBody = NewReaderCounter(h.rq.Body)


### PR DESCRIPTION
CBG-4064

- Stamp effective user id from headers into audit context 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2593/
