### PR TITLE
CBG-4068: alter enabled by default/filterable values

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -431,8 +431,10 @@ var AuditEvents = events{
 	AuditIDDatabaseAllRead: {
 		Name:        "Read all databases",
 		Description: "All databases were viewed",
+		MandatoryFields: AuditFields{
+			AuditFieldDBNames: []string{"list", "of", "db", "names"},
+		},
 		mandatoryFieldGroups: []fieldGroup{
-			fieldGroupDatabase,
 			fieldGroupRequest,
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -200,7 +200,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeUser,
 	},
 	AuditIDAdminHTTPAPIRequest: {
@@ -218,7 +218,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDMetricsHTTPAPIRequest: {
@@ -235,8 +235,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
-		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		EnabledByDefault:   false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDPublicUserAuthenticated: {
@@ -317,7 +317,7 @@ var AuditEvents = events{
 		Name:               "sgcollect_info status",
 		Description:        "sgcollect_info status was viewed",
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		MandatoryFields:    AuditFields{},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
@@ -329,7 +329,7 @@ var AuditEvents = events{
 		Name:               "sgcollect_info start",
 		Description:        "sgcollect_info was started",
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		MandatoryFields: AuditFields{
 			"output_dir":   "output_directory",
 			"upload_host":  "upload_host",
@@ -348,7 +348,7 @@ var AuditEvents = events{
 		Name:               "sgcollect_info stop",
 		Description:        "sgcollect_info was stopped",
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		MandatoryFields:    AuditFields{},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
@@ -380,7 +380,7 @@ var AuditEvents = events{
 			AuditFieldFileName: "filename",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDClusterInfoRead: {
@@ -508,7 +508,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseCompactStop: {
@@ -523,7 +523,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseCompactStatus: {
@@ -538,7 +538,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseResyncStatus: {

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -33,7 +33,6 @@ const (
 	AuditIDPublicHTTPAPIRequest  AuditID = 53270
 	AuditIDAdminHTTPAPIRequest   AuditID = 53271
 	AuditIDMetricsHTTPAPIRequest AuditID = 53272
-	//AuditIDBLIPMessage           AuditID = 0 // TODO: Is this required? What info should the event contain?
 
 	// Auth (public) events
 	AuditIDPublicUserAuthenticated        AuditID = 53280
@@ -82,13 +81,13 @@ const (
 	AuditIDUserRead   AuditID = 54101
 	AuditIDUserUpdate AuditID = 54102
 	AuditIDUserDelete AuditID = 54103
-	AuditIDUsersAll           = 54110
+	AuditIDUsersAll           = 54104
 	// Role principal events
 	AuditIDRoleCreate AuditID = 54110
 	AuditIDRoleRead   AuditID = 54111
 	AuditIDRoleUpdate AuditID = 54112
 	AuditIDRoleDelete AuditID = 54113
-	AuditIDRolesAll           = 54120
+	AuditIDRolesAll           = 54114
 
 	// Changes feeds events
 	AuditIDChangesFeedStarted AuditID = 54200
@@ -199,7 +198,7 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
-		EnabledByDefault:   true,
+		EnabledByDefault:   false,
 		FilteringPermitted: true,
 		EventType:          eventTypeUser,
 	},
@@ -217,7 +216,7 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
-		EnabledByDefault:   true,
+		EnabledByDefault:   false,
 		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
@@ -249,7 +248,7 @@ var AuditEvents = events{
 			"oidc_issuer": "issuer",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeUser,
 	},
 	AuditIDPublicUserAuthenticationFailed: {
@@ -262,7 +261,7 @@ var AuditEvents = events{
 			"username": "username",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeUser,
 	},
 	AuditIDPublicUserSessionCreated: {
@@ -290,7 +289,7 @@ var AuditEvents = events{
 		Description:        "Admin API user successfully authenticated",
 		MandatoryFields:    AuditFields{},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDAdminUserAuthenticationFailed: {
@@ -300,7 +299,7 @@ var AuditEvents = events{
 			"username": "username",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDAdminUserAuthorizationFailed: {
@@ -310,7 +309,7 @@ var AuditEvents = events{
 			"username": "username",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDSyncGatewayCollectInfoStatus: {
@@ -359,8 +358,8 @@ var AuditEvents = events{
 	AuditIDSyncGatewayStats: {
 		Name:               "stats requested",
 		Description:        "stats were requested",
-		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		EnabledByDefault:   false, // because low value high volume
+		FilteringPermitted: true,
 		MandatoryFields: AuditFields{
 			AuditFieldStatsFormat: "expvar, prometheus, etc.",
 		},
@@ -387,7 +386,7 @@ var AuditEvents = events{
 		Name:               "Sync Gateway cluster info read",
 		Description:        "Sync Gateway cluster info was viewed",
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDCreateDatabase: {
@@ -402,7 +401,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDReadDatabase: {
@@ -413,8 +412,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
-		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		EnabledByDefault:   false, // because high volume (Capella UI)
+		FilteringPermitted: true,
 		EventType:          eventTypeUser,
 	},
 	AuditIDDeleteDatabase: {
@@ -426,7 +425,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseAllRead: {
@@ -437,8 +436,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
-		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		EnabledByDefault:   false, // because high volume (Capella UI)
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDReadDatabaseConfig: {
@@ -450,7 +449,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDUpdateDatabaseConfig: {
@@ -465,7 +464,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseOffline: {
@@ -477,7 +476,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseOnline: {
@@ -489,7 +488,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseCompactStart: {
@@ -549,8 +548,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
-		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		EnabledByDefault:   false, // because low value high volume (Capella UI)
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseResyncStart: {
@@ -567,7 +566,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseResyncStop: {
@@ -579,7 +578,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDPostUpgrade: {
@@ -593,7 +592,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseRepair: {
@@ -605,7 +604,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDDatabaseFlush: {
@@ -617,7 +616,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDUserCreate: {
@@ -630,7 +629,7 @@ var AuditEvents = events{
 			"channels": map[string]map[string][]string{"scopeName": {"collectionName": {"list", "of", "channels"}}},
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDUserRead: {
@@ -641,7 +640,7 @@ var AuditEvents = events{
 			"db":       "database name",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDUserUpdate: {
@@ -654,7 +653,7 @@ var AuditEvents = events{
 			"channels": map[string]map[string][]string{"scopeName": {"collectionName": {"list", "of", "channels"}}},
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDUserDelete: {
@@ -665,7 +664,18 @@ var AuditEvents = events{
 			"db":       "database name",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDUsersAll: {
+		Name:        "Read all users",
+		Description: "All users were viewed",
+		MandatoryFields: AuditFields{
+			"db":        "database name",
+			"usernames": []string{"list", "of", "usernames"},
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDRoleCreate: {
@@ -677,7 +687,7 @@ var AuditEvents = events{
 			"admin_channels": map[string]map[string][]string{"scopeName": {"collectionName": {"list", "of", "channels"}}},
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDRoleRead: {
@@ -689,20 +699,19 @@ var AuditEvents = events{
 			"db":   "database name",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDRoleUpdate: {
 		Name:        "Update role",
 		Description: "Role was updated",
-
 		MandatoryFields: AuditFields{
 			"role":           "role_name",
 			"db":             "database name",
 			"admin_channels": map[string]map[string][]string{"scopeName": {"collectionName": {"list", "of", "channels"}}},
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDRoleDelete: {
@@ -713,7 +722,18 @@ var AuditEvents = events{
 			"db":   "database name",
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
+	},
+	AuditIDRolesAll: {
+		Name:        "Read all roles",
+		Description: "All roles were viewed",
+		MandatoryFields: AuditFields{
+			"db":    "database name",
+			"roles": []string{"list", "of", "roles"},
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDChangesFeedStarted: {
@@ -780,7 +800,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRRead: {
@@ -795,7 +815,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRUpdate: {
@@ -811,7 +831,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 	},
 	AuditIDISGRDelete: {
 		Name:        "Delete Inter-Sync Gateway Replication",
@@ -825,7 +845,7 @@ var AuditEvents = events{
 			// fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		EnabledByDefault:   true,
-		FilteringPermitted: false,
+		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRStatus: {

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -1100,7 +1100,7 @@ func init() {
 
 func (e events) expandMandatoryFieldGroups() {
 	for _, descriptor := range e {
-		descriptor.MandatoryFields.expandMandatoryFieldGroups(descriptor.mandatoryFieldGroups)
+		descriptor.expandMandatoryFieldGroups(descriptor.mandatoryFieldGroups)
 	}
 }
 

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -1097,6 +1097,17 @@ func (e events) expandMandatoryFieldGroups() {
 	}
 }
 
+// AllAuditEventIDs is a list of all audit event IDs.
+var AllAuditeventIDs = buildAllAuditIDList(AuditEvents)
+
+func buildAllAuditIDList(e events) (ids []uint) {
+	ids = make([]uint, 0, len(e))
+	for k := range e {
+		ids = append(ids, uint(k))
+	}
+	return ids
+}
+
 // DefaultAuditEventIDs is a list of audit event IDs that are enabled by default.
 var DefaultAuditEventIDs = buildDefaultAuditIDList(AuditEvents)
 

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -81,13 +81,13 @@ const (
 	AuditIDUserRead   AuditID = 54101
 	AuditIDUserUpdate AuditID = 54102
 	AuditIDUserDelete AuditID = 54103
-	AuditIDUsersAll           = 54104
+	AuditIDUsersAll   AuditID = 54104
 	// Role principal events
 	AuditIDRoleCreate AuditID = 54110
 	AuditIDRoleRead   AuditID = 54111
 	AuditIDRoleUpdate AuditID = 54112
 	AuditIDRoleDelete AuditID = 54113
-	AuditIDRolesAll           = 54114
+	AuditIDRolesAll   AuditID = 54114
 
 	// Changes feeds events
 	AuditIDChangesFeedStarted AuditID = 54200
@@ -832,6 +832,7 @@ var AuditEvents = events{
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRDelete: {
 		Name:        "Delete Inter-Sync Gateway Replication",
@@ -861,6 +862,7 @@ var AuditEvents = events{
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRStart: {
 		Name:        "Inter-Sync Gateway Replication start",
@@ -875,6 +877,7 @@ var AuditEvents = events{
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRStop: {
 		Name:        "Inter-Sync Gateway Replication stop",
@@ -889,6 +892,7 @@ var AuditEvents = events{
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRReset: {
 		Name:        "Inter-Sync Gateway Replication reset",
@@ -903,6 +907,7 @@ var AuditEvents = events{
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRAllStatus: {
 		Name:        "All Inter-Sync Gateway Replication status",
@@ -914,6 +919,7 @@ var AuditEvents = events{
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
 	},
 	AuditIDISGRAllRead: {
 		Name:        "Read all Inter-Sync Gateway Replications",
@@ -925,6 +931,7 @@ var AuditEvents = events{
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
+		EventType:          eventTypeAdmin,
 	},
 	AuditIDDocumentCreate: {
 		Name:        "Create document",

--- a/base/audit_events_fields.go
+++ b/base/audit_events_fields.go
@@ -33,6 +33,7 @@ const (
 	AuditEffectiveUserID = "effective_userid"
 	AuditFieldAuditScope = "audit_scope"
 	AuditFieldFileName   = "filename"
+	AuditFieldDBNames    = "db_names"
 
 	// AuditIDSyncGatewayStartup AuditID = 53260
 	AuditFieldSGVersion                      = "sg_version"

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -27,7 +27,7 @@ func ParseAuditID(s string) (AuditID, error) {
 }
 
 // events is a map of audit event IDs to event descriptors.
-type events map[AuditID]EventDescriptor
+type events map[AuditID]*EventDescriptor
 
 // EventDescriptor is an audit event. The fields closely (but not exactly) follows kv_engine's auditd descriptor implementation.
 type EventDescriptor struct {
@@ -111,22 +111,22 @@ type eventType string
 type AuditFields map[string]any
 
 // expandMandatoryFields adds fields that must be present on events, of the types determined by eventFieldTypes.
-func (f AuditFields) expandMandatoryFieldGroups(groups []fieldGroup) {
-	if f == nil {
-		f = make(AuditFields)
+func (ed *EventDescriptor) expandMandatoryFieldGroups(groups []fieldGroup) {
+	if ed.MandatoryFields == nil {
+		ed.MandatoryFields = make(AuditFields)
 	}
 
 	// common global fields
 	fields := mandatoryFieldsByGroup[fieldGroupGlobal]
 	for k, v := range fields {
-		f[k] = v
+		ed.MandatoryFields[k] = v
 	}
 
 	// event-specific field groups
 	for _, group := range groups {
 		groupFields := mandatoryFieldsByGroup[group]
 		for k, v := range groupFields {
-			f[k] = v
+			ed.MandatoryFields[k] = v
 		}
 	}
 }

--- a/base/auditd_descriptor.go
+++ b/base/auditd_descriptor.go
@@ -23,7 +23,7 @@ const (
 func generateAuditdModuleDescriptor(e events) ([]byte, error) {
 	auditEvents := make([]auditdEventDescriptor, 0, len(e))
 	for id, event := range e {
-		auditEvents = append(auditEvents, toAuditdEventDescriptor(id, event))
+		auditEvents = append(auditEvents, toAuditdEventDescriptor(id, *event))
 	}
 	m := auditdModuleDescriptor{
 		Version: auditdFormatVersion,

--- a/rest/api.go
+++ b/rest/api.go
@@ -80,12 +80,19 @@ func (h *handler) handlePing() error {
 }
 
 func (h *handler) handleAllDbs() error {
-	base.Audit(h.ctx(), base.AuditIDDatabaseAllRead, nil)
-	if h.getBoolQuery("verbose") {
-		h.writeJSON(h.server.allDatabaseSummaries())
-		return nil
+	verbose := h.getBoolQuery("verbose")
+	var dbNames []string
+	if verbose {
+		summaries := h.server.allDatabaseSummaries()
+		for _, summary := range summaries {
+			dbNames = append(dbNames, summary.DBName)
+		}
+		h.writeJSON(summaries)
+	} else {
+		dbNames = h.server.AllDatabaseNames()
+		h.writeJSON(dbNames)
 	}
-	h.writeJSON(h.server.AllDatabaseNames())
+	base.Audit(h.ctx(), base.AuditIDDatabaseAllRead, base.AuditFields{base.AuditFieldDBNames: dbNames, "verbose": verbose})
 	return nil
 }
 

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -71,7 +71,8 @@ func TestAuditLoggingFields(t *testing.T) {
 	dbConfig := rt.NewDbConfig()
 	dbConfig.Logging = &DbLoggingConfig{
 		Audit: &DbAuditLoggingConfig{
-			Enabled: base.BoolPtr(true),
+			Enabled:       base.BoolPtr(true),
+			EnabledEvents: base.AllAuditeventIDs, // enable everything for testing
 			DisabledUsers: []base.AuditLoggingPrincipal{
 				{Name: filteredPublicUsername, Domain: string(base.UserDomainSyncGateway)},
 				{Name: filteredAdminUsername, Domain: string(base.UserDomainCBServer)},


### PR DESCRIPTION
CBG-4068

- Finalise filterable and enabled by default audit events based on Spreadsheet review
- Enable all events in `TestAuditLoggingFields` to allow existing assertions after default event changes, and to maximise coverage
- Populate missing admin event type for ISGR events
- Allow mandatory field groups to instantiate the MandatoryFields map 
  - fixes empty Mandatory Fields in Database events that have no other mandatory fields present.
- Correct handleAllDbs audit fields

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2599/
