### PR TITLE
CBG-4069 Restore default nil for loggers

### DIFF
--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -74,12 +74,12 @@ func InitLogging(ctx context.Context, logFilePath string,
 		ConsolefCtx(ctx, LevelError, KeyNone, ErrUnsetLogFilePath.Error())
 
 		// nil out other loggers
-		errorLogger = &FileLogger{}
-		warnLogger = &FileLogger{}
-		infoLogger = &FileLogger{}
-		debugLogger = &FileLogger{}
-		traceLogger = &FileLogger{}
-		statsLogger = &FileLogger{}
+		errorLogger = nil
+		warnLogger = nil
+		infoLogger = nil
+		debugLogger = nil
+		traceLogger = nil
+		statsLogger = nil
 		auditLogger = &AuditLogger{}
 
 		return nil


### PR DESCRIPTION
Restoring the previously to support existing nil check handling for non-audit loggers.

In addition to unit tests, verified the following scenarios work as expected:
- Sync Gateway with no log_file_path defined (original issue)
- Sync Gateway emitting stats and audit logging

CBG-4069

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2597/
