### PR TITLE
CBG-4045 Implement audit events

### DIFF
--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -38,7 +38,7 @@ func TestCreateSession(t *testing.T) {
 	require.NoError(t, auth.Save(user))
 
 	// Create session with a username and valid TTL of 2 hours.
-	session, err := auth.CreateSession(user, 2*time.Hour)
+	session, err := auth.CreateSession(ctx, user, 2*time.Hour)
 	require.NoError(t, err)
 
 	assert.Equal(t, username, session.Username)
@@ -57,13 +57,13 @@ func TestCreateSession(t *testing.T) {
 	assert.NotEmpty(t, session.Expiration)
 
 	// Session must not be created with zero TTL; it's illegal.
-	session, err = auth.CreateSession(user, time.Duration(0))
+	session, err = auth.CreateSession(ctx, user, time.Duration(0))
 	assert.Nil(t, session)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), invalidSessionTTLError)
 
 	// Session must not be created with negative TTL; it's illegal.
-	session, err = auth.CreateSession(user, time.Duration(-1))
+	session, err = auth.CreateSession(ctx, user, time.Duration(-1))
 	assert.Nil(t, session)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), invalidSessionTTLError)
@@ -89,7 +89,7 @@ func TestDeleteSession(t *testing.T) {
 	}
 	const noSessionExpiry = 0
 	assert.NoError(t, dataStore.Set(auth.DocIDForSession(mockSession.ID), noSessionExpiry, nil, mockSession))
-	assert.NoError(t, auth.DeleteSession(mockSession.ID))
+	assert.NoError(t, auth.DeleteSession(ctx, mockSession.ID, ""))
 
 	// Just to verify the session has been deleted gracefully.
 	session, err := auth.GetSession(mockSession.ID)
@@ -183,7 +183,7 @@ func TestDeleteSessionForCookie(t *testing.T) {
 	}
 
 	request.AddCookie(cookie)
-	newCookie := auth.DeleteSessionForCookie(request)
+	newCookie := auth.DeleteSessionForCookie(ctx, request)
 
 	assert.NotEmpty(t, newCookie.Name)
 	assert.Empty(t, newCookie.Value)
@@ -199,7 +199,7 @@ func TestDeleteSessionForCookie(t *testing.T) {
 	}
 
 	request.AddCookie(cookie)
-	newCookie = auth.DeleteSessionForCookie(request)
+	newCookie = auth.DeleteSessionForCookie(ctx, request)
 	assert.Nil(t, newCookie)
 }
 
@@ -241,7 +241,7 @@ func TestCreateSessionChangePassword(t *testing.T) {
 			require.NoError(t, auth.Save(user))
 
 			// Create session with a username and valid TTL of 2 hours.
-			session, err := auth.CreateSession(user, 2*time.Hour)
+			session, err := auth.CreateSession(ctx, user, 2*time.Hour)
 			require.NoError(t, err)
 
 			session, err = auth.GetSession(session.ID)
@@ -297,7 +297,7 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 	require.NotNil(t, user)
 
 	// Create session with a username and valid TTL of 2 hours.
-	session, err := auth.CreateSession(user, 2*time.Hour)
+	session, err := auth.CreateSession(ctx, user, 2*time.Hour)
 	require.NoError(t, err)
 
 	session, err = auth.GetSession(session.ID)

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -40,6 +40,8 @@ const (
 	AuditIDPublicUserAuthenticationFailed AuditID = 53281
 	AuditIDPublicUserSessionCreated       AuditID = 53282
 	AuditIDPublicUserSessionDeleted       AuditID = 53283
+	AuditIDPublicUserSessionDeleteAll     AuditID = 53284
+
 	// Auth (admin) events
 	AuditIDAdminUserAuthenticated        AuditID = 53290
 	AuditIDAdminUserAuthenticationFailed AuditID = 53291
@@ -259,7 +261,7 @@ var AuditEvents = events{
 			AuditFieldAuthMethod: "basic, oidc, cookie, etc.",
 		},
 		OptionalFields: AuditFields{
-			"username": "username",
+			AuditFieldUserName: "username",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -269,7 +271,10 @@ var AuditEvents = events{
 		Name:        "Public API user session created",
 		Description: "Public API user session was created",
 		MandatoryFields: AuditFields{
-			"session_id": "session_id",
+			AuditFieldSessionID: "session_id",
+		},
+		OptionalFields: AuditFields{
+			AuditFieldUserName: "username",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -279,7 +284,20 @@ var AuditEvents = events{
 		Name:        "Public API user session deleted",
 		Description: "Public API user session was deleted",
 		MandatoryFields: AuditFields{
-			"session_id": "session_id",
+			AuditFieldSessionID: "session_id",
+		},
+		OptionalFields: AuditFields{
+			AuditFieldUserName: "username",
+		},
+		EnabledByDefault:   true,
+		FilteringPermitted: true,
+		EventType:          eventTypeUser,
+	},
+	AuditIDPublicUserSessionDeleteAll: {
+		Name:        "Public API user all sessions deleted",
+		Description: "All sessions were deleted for a Public API user",
+		MandatoryFields: AuditFields{
+			AuditFieldUserName: "username",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -297,7 +315,7 @@ var AuditEvents = events{
 		Name:        "Admin API user authentication failed",
 		Description: "Admin API user failed to authenticate",
 		MandatoryFields: AuditFields{
-			"username": "username",
+			AuditFieldUserName: "username",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -307,7 +325,7 @@ var AuditEvents = events{
 		Name:        "Admin API user authorization failed",
 		Description: "Admin API user failed to authorize",
 		MandatoryFields: AuditFields{
-			"username": "username",
+			AuditFieldUserName: "username",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -624,10 +642,10 @@ var AuditEvents = events{
 		Name:        "Create user",
 		Description: "A new user was created",
 		MandatoryFields: AuditFields{
-			"username": "username",
-			"db":       "database name",
-			"roles":    []string{"list", "of", "roles"},
-			"channels": map[string]map[string][]string{"scopeName": {"collectionName": {"list", "of", "channels"}}},
+			AuditFieldUserName: "username",
+			AuditFieldDatabase: "database name",
+			"roles":            []string{"list", "of", "roles"},
+			"channels":         map[string]map[string][]string{"scopeName": {"collectionName": {"list", "of", "channels"}}},
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -637,8 +655,8 @@ var AuditEvents = events{
 		Name:        "Read user",
 		Description: "Information about this user was viewed",
 		MandatoryFields: AuditFields{
-			"username": "username",
-			"db":       "database name",
+			AuditFieldUserName: "username",
+			AuditFieldDatabase: "database name",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -648,10 +666,10 @@ var AuditEvents = events{
 		Name:        "Update user",
 		Description: "User was updated",
 		MandatoryFields: AuditFields{
-			"username": "username",
-			"db":       "database name",
-			"roles":    []string{"list", "of", "roles"},
-			"channels": map[string]map[string][]string{"scopeName": {"collectionName": {"list", "of", "channels"}}},
+			AuditFieldUserName: "username",
+			AuditFieldDatabase: "database name",
+			"roles":            []string{"list", "of", "roles"},
+			"channels":         map[string]map[string][]string{"scopeName": {"collectionName": {"list", "of", "channels"}}},
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -661,8 +679,8 @@ var AuditEvents = events{
 		Name:        "Delete user",
 		Description: "User was deleted",
 		MandatoryFields: AuditFields{
-			"username": "username",
-			"db":       "database name",
+			AuditFieldUserName: "username",
+			AuditFieldDatabase: "database name",
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
@@ -720,15 +738,18 @@ var AuditEvents = events{
 		Name:        "Changes feed started",
 		Description: "Changes feed was started",
 		MandatoryFields: AuditFields{
-			"db":    "database name",
-			"ks":    "keyspace",
-			"since": "since",
+			AuditFieldSince: "since",
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupRequest,
+			// fieldGroupAuthenticated, // FIXME: CBG-3973
 		},
 		OptionalFields: AuditFields{
-			"filter":           "filter",
-			"doc_ids":          []string{"list", "of", "doc_ids"},
-			AuditFieldChannels: []string{"list", "of", "channels"},
-			"feed_type":        "continuous, normal, longpoll, websocket, etc.",
+			AuditFieldFilter:      "filter",
+			AuditFieldDocIDs:      []string{"list", "of", "doc_ids"},
+			AuditFieldChannels:    []string{"list", "of", "channels"},
+			AuditFieldFeedType:    "continuous, normal, longpoll, websocket, etc.",
+			AuditFieldIncludeDocs: true,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,

--- a/base/audit_events_fields.go
+++ b/base/audit_events_fields.go
@@ -22,6 +22,7 @@ const (
 	AuditFieldCorrelationID = "cid" // FIXME: how to distinguish between this field (http) and blip id below
 	AuditFieldKeyspace      = "ks"
 	AuditFieldAuthMethod    = "auth_method"
+	AuditFieldUserName      = "username" // Name of a Sync Gateway user, not necessarily the same as real_userid
 
 	AuditFieldReplicationID      = "replication_id"
 	AuditFieldPayload            = "payload"
@@ -61,4 +62,14 @@ const (
 	AuditFieldDocID        = "doc_id"
 	AuditFieldDocVersion   = "doc_version"
 	AuditFieldPurged       = "purged"
+
+	// Session events 53282, 53283
+	AuditFieldSessionID = "session_id"
+
+	// AuditIDChangesFeedStarted AuditID = 54200
+	AuditFieldSince       = "since"
+	AuditFieldFilter      = "filter"
+	AuditFieldDocIDs      = "doc_ids"
+	AuditFieldFeedType    = "feed_type"
+	AuditFieldIncludeDocs = "include_docs"
 )

--- a/base/constants.go
+++ b/base/constants.go
@@ -148,6 +148,7 @@ const (
 
 	// Replication filter constants
 	ByChannelFilter = "sync_gateway/bychannel"
+	DocIDsFilter    = "_doc_ids"
 
 	// Increase default gocbv2 op timeout to match the standard SG backoff retry timing used for gocb v1
 	DefaultGocbV2OperationTimeout = 10 * time.Second

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1994,6 +1994,7 @@ func (h *handler) getReplications() error {
 		replication.ReplicationConfig = *replication.Redacted(h.ctx())
 	}
 
+	base.Audit(h.ctx(), base.AuditIDISGRAllRead, nil)
 	h.writeJSON(replications)
 	return nil
 }
@@ -2063,7 +2064,7 @@ func (h *handler) getReplicationsStatus() error {
 	if err != nil {
 		return err
 	}
-	base.Audit(h.ctx(), base.AuditIDISGRAllRead, nil)
+	base.Audit(h.ctx(), base.AuditIDISGRAllStatus, nil)
 	h.writeJSON(replicationsStatus)
 	return nil
 }


### PR DESCRIPTION
CBG-4045

Implements:
- AuditIDPublicUserSessionCreated 
- AuditIDPublicUserSessionDeleted        
- AuditIDPublicUserSessionDeleteAll
- AuditIDAdminUserAuthenticated       
- AuditIDAdminUserAuthenticationFailed 
- AuditIDAdminUserAuthorizationFailed 
- AuditIDChangesFeedStarted 
- AuditIDISGRAllStatus 

Additional notes:
- Does not generate admin user events when admin auth is disabled
- Adds new event AuditIDPublicUserSessionDeleteAll (for all session delete on user credential change).
- Also adds an 'include_docs' AuditField to AuditIDChangesFeedStarted.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2598/
