### PR TITLE
Populate fake server address/port for RestTester

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -773,10 +773,12 @@ func (rt *RestTester) TestAdminHandlerNoConflictsMode() http.Handler {
 	return rt.TestAdminHandler()
 }
 
+var fakeRestTesterIP = net.IPv4(127, 0, 0, 99)
+
 func (rt *RestTester) TestAdminHandler() http.Handler {
 	rt.adminHandlerOnce.Do(func() {
 		rt.AdminHandler = CreateAdminHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(adminServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4zero, Port: 4985}})
+		rt.ServerContext().addHTTPServer(adminServer, &serverInfo{nil, &net.TCPAddr{IP: fakeRestTesterIP, Port: 4985}})
 	})
 	return rt.AdminHandler
 }
@@ -784,7 +786,7 @@ func (rt *RestTester) TestAdminHandler() http.Handler {
 func (rt *RestTester) TestPublicHandler() http.Handler {
 	rt.publicHandlerOnce.Do(func() {
 		rt.PublicHandler = CreatePublicHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(publicServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4zero, Port: 4984}})
+		rt.ServerContext().addHTTPServer(publicServer, &serverInfo{nil, &net.TCPAddr{IP: fakeRestTesterIP, Port: 4984}})
 	})
 	return rt.PublicHandler
 }
@@ -792,7 +794,7 @@ func (rt *RestTester) TestPublicHandler() http.Handler {
 func (rt *RestTester) TestMetricsHandler() http.Handler {
 	rt.metricsHandlerOnce.Do(func() {
 		rt.MetricsHandler = CreateMetricHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(metricsServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4zero, Port: 4986}})
+		rt.ServerContext().addHTTPServer(metricsServer, &serverInfo{nil, &net.TCPAddr{IP: fakeRestTesterIP, Port: 4986}})
 	})
 	return rt.MetricsHandler
 }
@@ -801,7 +803,7 @@ func (rt *RestTester) TestMetricsHandler() http.Handler {
 func (rt *RestTester) TestDiagnosticHandler() http.Handler {
 	rt.diagnosticHandlerOnce.Do(func() {
 		rt.DiagnosticHandler = createDiagnosticHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(diagnosticServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4zero, Port: 4987}})
+		rt.ServerContext().addHTTPServer(diagnosticServer, &serverInfo{nil, &net.TCPAddr{IP: fakeRestTesterIP, Port: 4987}})
 	})
 	return rt.DiagnosticHandler
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -776,7 +776,7 @@ func (rt *RestTester) TestAdminHandlerNoConflictsMode() http.Handler {
 func (rt *RestTester) TestAdminHandler() http.Handler {
 	rt.adminHandlerOnce.Do(func() {
 		rt.AdminHandler = CreateAdminHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(adminServer, &serverInfo{nil, &net.TCPAddr{}})
+		rt.ServerContext().addHTTPServer(adminServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 94985}})
 	})
 	return rt.AdminHandler
 }
@@ -784,7 +784,7 @@ func (rt *RestTester) TestAdminHandler() http.Handler {
 func (rt *RestTester) TestPublicHandler() http.Handler {
 	rt.publicHandlerOnce.Do(func() {
 		rt.PublicHandler = CreatePublicHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(publicServer, &serverInfo{nil, &net.TCPAddr{}})
+		rt.ServerContext().addHTTPServer(publicServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 94984}})
 	})
 	return rt.PublicHandler
 }
@@ -792,7 +792,7 @@ func (rt *RestTester) TestPublicHandler() http.Handler {
 func (rt *RestTester) TestMetricsHandler() http.Handler {
 	rt.metricsHandlerOnce.Do(func() {
 		rt.MetricsHandler = CreateMetricHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(metricsServer, &serverInfo{nil, &net.TCPAddr{}})
+		rt.ServerContext().addHTTPServer(metricsServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 94986}})
 	})
 	return rt.MetricsHandler
 }
@@ -801,7 +801,7 @@ func (rt *RestTester) TestMetricsHandler() http.Handler {
 func (rt *RestTester) TestDiagnosticHandler() http.Handler {
 	rt.diagnosticHandlerOnce.Do(func() {
 		rt.DiagnosticHandler = createDiagnosticHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(diagnosticServer, &serverInfo{nil, &net.TCPAddr{}})
+		rt.ServerContext().addHTTPServer(diagnosticServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 94987}})
 	})
 	return rt.DiagnosticHandler
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -776,7 +776,7 @@ func (rt *RestTester) TestAdminHandlerNoConflictsMode() http.Handler {
 func (rt *RestTester) TestAdminHandler() http.Handler {
 	rt.adminHandlerOnce.Do(func() {
 		rt.AdminHandler = CreateAdminHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(adminServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 94985}})
+		rt.ServerContext().addHTTPServer(adminServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4zero, Port: 4985}})
 	})
 	return rt.AdminHandler
 }
@@ -784,7 +784,7 @@ func (rt *RestTester) TestAdminHandler() http.Handler {
 func (rt *RestTester) TestPublicHandler() http.Handler {
 	rt.publicHandlerOnce.Do(func() {
 		rt.PublicHandler = CreatePublicHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(publicServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 94984}})
+		rt.ServerContext().addHTTPServer(publicServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4zero, Port: 4984}})
 	})
 	return rt.PublicHandler
 }
@@ -792,7 +792,7 @@ func (rt *RestTester) TestPublicHandler() http.Handler {
 func (rt *RestTester) TestMetricsHandler() http.Handler {
 	rt.metricsHandlerOnce.Do(func() {
 		rt.MetricsHandler = CreateMetricHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(metricsServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 94986}})
+		rt.ServerContext().addHTTPServer(metricsServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4zero, Port: 4986}})
 	})
 	return rt.MetricsHandler
 }
@@ -801,7 +801,7 @@ func (rt *RestTester) TestMetricsHandler() http.Handler {
 func (rt *RestTester) TestDiagnosticHandler() http.Handler {
 	rt.diagnosticHandlerOnce.Do(func() {
 		rt.DiagnosticHandler = createDiagnosticHandler(rt.ServerContext())
-		rt.ServerContext().addHTTPServer(diagnosticServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 94987}})
+		rt.ServerContext().addHTTPServer(diagnosticServer, &serverInfo{nil, &net.TCPAddr{IP: net.IPv4zero, Port: 4987}})
 	})
 	return rt.DiagnosticHandler
 }


### PR DESCRIPTION
Populates fake server address/port for RestTester handlers so it appears in "local" field of audit events:

```json
{
...
"local":{"ip":"127.0.0.99","port":"4985"},
"remote":{"ip":"test.client.addr","port":"99999"},
...
}
```