### PR TITLE
Add h.user nil check in checkPublicAuth when getting username

### DIFF
--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -669,7 +669,7 @@ func (h *handler) handleDelLocalDoc() error {
 
 // isGuest returns true if the current user is a guest
 func (h *handler) isGuest() bool {
-	return h.user == nil || h.user.Name() == ""
+	return h.user != nil && h.user.Name() == ""
 }
 
 // helper for read only check

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -669,7 +669,7 @@ func (h *handler) handleDelLocalDoc() error {
 
 // isGuest returns true if the current user is a guest
 func (h *handler) isGuest() bool {
-	return h.user == nil && h.user.Name() == ""
+	return h.user == nil || h.user.Name() == ""
 }
 
 // helper for read only check

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -669,7 +669,7 @@ func (h *handler) handleDelLocalDoc() error {
 
 // isGuest returns true if the current user is a guest
 func (h *handler) isGuest() bool {
-	return h.user != nil && h.user.Name() == ""
+	return h.user == nil && h.user.Name() == ""
 }
 
 // helper for read only check

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -890,8 +890,10 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 		} else {
 			dbCtx.DbStats.Security().AuthSuccessCount.Add(1)
 
-			username := base.GuestUsername
-			if !h.isGuest() {
+			username := ""
+			if h.isGuest() {
+				username = base.GuestUsername
+			} else if h.user != nil {
 				username = h.user.Name()
 			}
 			roleNames := getSGUserRolesForAudit(dbCtx, h.user)

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -50,7 +50,7 @@ func (h *handler) handleSessionPOST() error {
 
 	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkPublicAuth calls out into AuthenticateUntrustedJWT.
 	// Therefore, if by this point `h.user` is guest, this isn't creating a session from OIDC.
-	if h.db.Options.DisablePasswordAuthentication && h.isGuest() {
+	if h.db.Options.DisablePasswordAuthentication && (h.user == nil || h.user.Name() == "") {
 		return ErrLoginRequired
 	}
 	user, err := h.getUserFromSessionRequestBody()


### PR DESCRIPTION
`checkPublicAuth` was relying on incorrect logic from `isGuest` to determine request username resulting in a (rare?) panic in CI for some reason.

Restored handleSessionPOST back to old code, and used "correct" `isGuest` with guard against nil user when I need to grab username for audit.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
