### PR TITLE
CBG-4090 Enable fieldGroupAuthenticated

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -165,7 +165,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EventType: eventTypeAdmin,
 	},
@@ -192,13 +192,17 @@ var AuditEvents = events{
 		MandatoryFields: AuditFields{
 			AuditFieldHTTPMethod: "GET, POST, etc.",
 			AuditFieldHTTPPath:   "request_path",
+			AuditFieldHTTPStatus: 200,
 		},
 		OptionalFields: AuditFields{
 			AuditFieldRequestBody: "request_body",
+			AuditFieldRealUserID: map[string]any{
+				AuditFieldRealUserIDDomain: "user domain",
+				AuditFieldRealUserIDUser:   "user name",
+			},
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
@@ -210,13 +214,17 @@ var AuditEvents = events{
 		MandatoryFields: AuditFields{
 			AuditFieldHTTPMethod: "GET, POST, etc.",
 			AuditFieldHTTPPath:   "request_path",
+			AuditFieldHTTPStatus: 200,
 		},
 		OptionalFields: AuditFields{
 			AuditFieldRequestBody: "request_body",
+			AuditFieldRealUserID: map[string]any{
+				AuditFieldRealUserIDDomain: "user domain",
+				AuditFieldRealUserIDUser:   "user name",
+			},
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
@@ -228,13 +236,17 @@ var AuditEvents = events{
 		MandatoryFields: AuditFields{
 			AuditFieldHTTPMethod: "GET, POST, etc.",
 			AuditFieldHTTPPath:   "request_path",
+			AuditFieldHTTPStatus: 200,
 		},
 		OptionalFields: AuditFields{
 			AuditFieldRequestBody: "request_body",
+			AuditFieldRealUserID: map[string]any{
+				AuditFieldRealUserIDDomain: "user domain",
+				AuditFieldRealUserIDUser:   "user name",
+			},
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
@@ -338,7 +350,7 @@ var AuditEvents = events{
 		MandatoryFields:    AuditFields{},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EventType: eventTypeAdmin,
 	},
@@ -357,7 +369,7 @@ var AuditEvents = events{
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EventType: eventTypeAdmin,
 	},
@@ -369,7 +381,7 @@ var AuditEvents = events{
 		MandatoryFields:    AuditFields{},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EventType: eventTypeAdmin,
 	},
@@ -383,7 +395,7 @@ var AuditEvents = events{
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EventType: eventTypeAdmin,
 	},
@@ -416,7 +428,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -428,7 +440,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   false, // because high volume (Capella UI)
 		FilteringPermitted: true,
@@ -440,7 +452,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -454,7 +466,7 @@ var AuditEvents = events{
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   false, // because high volume (Capella UI)
 		FilteringPermitted: true,
@@ -466,7 +478,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -481,7 +493,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -493,7 +505,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -505,7 +517,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -524,7 +536,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -539,7 +551,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -554,7 +566,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -566,7 +578,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   false, // because low value high volume (Capella UI)
 		FilteringPermitted: true,
@@ -583,7 +595,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -595,7 +607,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -609,7 +621,7 @@ var AuditEvents = events{
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -621,7 +633,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -633,7 +645,7 @@ var AuditEvents = events{
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,
 			fieldGroupRequest,
-			// fieldGroupAuthenticated, // FIXME: CBG-3973,
+			fieldGroupAuthenticated,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,

--- a/base/audit_events_fields.go
+++ b/base/audit_events_fields.go
@@ -11,18 +11,21 @@ package base
 const (
 
 	// Commonly used audit event fields
-	AuditFieldID            = "id"
-	AuditFieldTimestamp     = "timestamp"
-	AuditFieldName          = "name"
-	AuditFieldDescription   = "description"
-	AuditFieldRealUserID    = "real_userid"
-	AuditFieldLocal         = "local"
-	AuditFieldRemote        = "remote"
-	AuditFieldDatabase      = "db"
-	AuditFieldCorrelationID = "cid" // FIXME: how to distinguish between this field (http) and blip id below
-	AuditFieldKeyspace      = "ks"
-	AuditFieldAuthMethod    = "auth_method"
-	AuditFieldUserName      = "username" // Name of a Sync Gateway user, not necessarily the same as real_userid
+
+	AuditFieldID               = "id"
+	AuditFieldTimestamp        = "timestamp"
+	AuditFieldName             = "name"
+	AuditFieldDescription      = "description"
+	AuditFieldRealUserID       = "real_userid"
+	AuditFieldRealUserIDDomain = "domain"
+	AuditFieldRealUserIDUser   = "user"
+	AuditFieldLocal            = "local"
+	AuditFieldRemote           = "remote"
+	AuditFieldDatabase         = "db"
+	AuditFieldCorrelationID    = "cid" // FIXME: how to distinguish between this field (http) and blip id below
+	AuditFieldKeyspace         = "ks"
+	AuditFieldAuthMethod       = "auth_method"
+	AuditFieldUserName         = "username"
 
 	AuditFieldReplicationID      = "replication_id"
 	AuditFieldPayload            = "payload"
@@ -31,10 +34,12 @@ const (
 	AuditFieldCompactionReset    = "reset"
 	AuditFieldPostUpgradePreview = "preview"
 
-	AuditEffectiveUserID = "effective_userid"
-	AuditFieldAuditScope = "audit_scope"
-	AuditFieldFileName   = "filename"
-	AuditFieldDBNames    = "db_names"
+	AuditEffectiveUserID            = "effective_userid"
+	AuditFieldEffectiveUserIDDomain = "domain"
+	AuditFieldEffectiveUserIDUser   = "user"
+	AuditFieldAuditScope            = "audit_scope"
+	AuditFieldFileName              = "filename"
+	AuditFieldDBNames               = "db_names"
 
 	// AuditIDSyncGatewayStartup AuditID = 53260
 	AuditFieldSGVersion                      = "sg_version"
@@ -55,6 +60,7 @@ const (
 	// API events  AuditID = 53270, 53271, 53272
 	AuditFieldHTTPMethod  = "http_method"
 	AuditFieldHTTPPath    = "http_path"
+	AuditFieldHTTPStatus  = "http_status"
 	AuditFieldRequestBody = "request_body"
 
 	// CRUD events

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -85,8 +85,8 @@ var mandatoryFieldsByGroup = map[fieldGroup]map[string]any{
 	},
 	fieldGroupAuthenticated: {
 		AuditFieldRealUserID: map[string]any{
-			"domain": "user domain",
-			"name":   "user name",
+			AuditFieldRealUserIDDomain: "user domain",
+			AuditFieldRealUserIDUser:   "user name",
 		},
 	},
 	fieldGroupDatabase: {

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -50,16 +50,16 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	userName := logCtx.Username
 	if userDomain != "" || userName != "" {
 		fields[AuditFieldRealUserID] = map[string]any{
-			"domain": userDomain,
-			"user":   userName,
+			AuditFieldRealUserIDDomain: userDomain,
+			AuditFieldRealUserIDUser:   userName,
 		}
 	}
 	effectiveDomain := logCtx.EffectiveDomain
 	effectiveUser := logCtx.EffectiveUserID
 	if effectiveDomain != "" || effectiveUser != "" {
 		fields[AuditEffectiveUserID] = map[string]any{
-			"domain": effectiveDomain,
-			"user":   effectiveUser,
+			AuditFieldEffectiveUserIDDomain: effectiveDomain,
+			AuditFieldEffectiveUserIDUser:   effectiveUser,
 		}
 	}
 	if logCtx.RequestHost != "" {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -267,10 +267,13 @@ type EffectiveUserPair struct {
 type UserIDDomain string
 
 const (
-	UserDomainSyncGateway UserIDDomain = "sgw"
-	UserDomainCBServer    UserIDDomain = "cbs"
-	UserDomainBuiltin                  = "builtin" // internal users (e.g. SG bootstrap user)
+	UserDomainSyncGateway      UserIDDomain = "sgw"
+	UserDomainCBServer         UserIDDomain = "cbs"
+	UserDomainSyncGatewayAdmin UserIDDomain = "sgw_admin" // domain for SGW admin API when admin auth disabled
+	UserDomainBuiltin                       = "builtin"   // internal users (e.g. SG bootstrap user)
 )
+
+const UserSyncGatewayAdmin = "admin_noauth" // real_userid for admin API requests when admin auth is disabled
 
 func UserLogCtx(parent context.Context, username string, domain UserIDDomain, roles []string) context.Context {
 	newCtx := getLogCtx(parent)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2672,7 +2672,7 @@ func TestMetricsHandler(t *testing.T) {
 		base.SkipPrometheusStatsRegistration = true
 	}()
 
-	// Create and remove a database
+	// Create and remove a databaseion
 	// This ensures that creation and removal of a DB is possible without a re-registration issue ( the below rest tester will re-register "db")
 	ctx := base.TestCtx(t)
 	tBucket := base.GetTestBucket(t)

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -619,15 +619,15 @@ func TestEffectiveUserID(t *testing.T) {
 	base.ResetGlobalTestLogging(t)
 	base.InitializeMemoryLoggers()
 	const (
-		user       = "user"
-		domain     = "domain"
-		cnfDomain  = "myDomain"
-		cnfUser    = "bob"
-		realUser   = "alice"
-		realDomain = "sgw"
+		headerUser   = "user"
+		headerDomain = "domain"
+		cnfDomain    = "myDomain"
+		cnfUser      = "bob"
+		realUser     = "alice"
+		realDomain   = "sgw"
 	)
 	reqHeaders := map[string]string{
-		"user_header":   fmt.Sprintf(`{"%s": "%s", "%s":"%s"}`, domain, cnfDomain, user, cnfUser),
+		"user_header":   fmt.Sprintf(`{"%s": "%s", "%s":"%s"}`, headerDomain, cnfDomain, headerUser, cnfUser),
 		"Authorization": getBasicAuthHeader(realUser, RestTesterDefaultUserPassword),
 	}
 
@@ -659,11 +659,11 @@ func TestEffectiveUserID(t *testing.T) {
 
 	for _, event := range events {
 		effective := event[base.AuditEffectiveUserID].(map[string]any)
-		assert.Equal(t, cnfDomain, effective[domain])
-		assert.Equal(t, cnfUser, effective[user])
+		assert.Equal(t, cnfDomain, effective[base.AuditFieldEffectiveUserIDDomain])
+		assert.Equal(t, cnfUser, effective[base.AuditFieldEffectiveUserIDUser])
 		realUserEvent := event[base.AuditFieldRealUserID].(map[string]any)
-		assert.Equal(t, realDomain, realUserEvent[domain])
-		assert.Equal(t, realUser, realUserEvent[user])
+		assert.Equal(t, realDomain, realUserEvent[base.AuditFieldRealUserIDDomain])
+		assert.Equal(t, realUser, realUserEvent[base.AuditFieldRealUserIDUser])
 	}
 }
 


### PR DESCRIPTION
CBG-4090

For HTTPRequest audit events, makes AuditFieldRealUserID an optional field, to handle non-authenticated endpoints and use cases.  Adds status as a required field to those endpoints to reliably identify authenticated vs. non-authenticated calls.

Standardizes on "user" for property name in real and effective user ID, switches to event field constants for this use cases.

Adds a hardcoded real userid for cases where auth is disabled on admin or metrics port - in that case uses (user,domain) of ("admin_noauth", "sgw_admin").  Open to naming suggestions if there's something more appropriate.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2602/
