### PR TITLE
CBG-4058: Globally configurable audit events

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -1154,13 +1154,18 @@ func (e events) expandMandatoryFieldGroups() {
 	}
 }
 
-// AllAuditEventIDs is a list of all audit event IDs.
-var AllAuditeventIDs = buildAllAuditIDList(AuditEvents)
+// AllDbAuditeventIDs is a list of all audit event IDs that are available for the db config.
+var AllDbAuditeventIDs = buildAllAuditIDList(AuditEvents, false)
 
-func buildAllAuditIDList(e events) (ids []uint) {
+// AllGlobalAuditeventIDs is a list of all audit event IDs that are available for the bootstrap config.
+var AllGlobalAuditeventIDs = buildAllAuditIDList(AuditEvents, true)
+
+func buildAllAuditIDList(e events, globalEvents bool) (ids []uint) {
 	ids = make([]uint, 0, len(e))
-	for k := range e {
-		ids = append(ids, uint(k))
+	for k, v := range e {
+		if globalEvents == v.IsGlobalEvent {
+			ids = append(ids, uint(k))
+		}
 	}
 	return ids
 }

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -141,7 +141,8 @@ var AuditEvents = events{
 		OptionalFields: AuditFields{
 			"db": "database name",
 		},
-		EventType: eventTypeAdmin,
+		EventType:     eventTypeAdmin,
+		IsGlobalEvent: true,
 	},
 	AuditIDAuditDisabled: {
 		Name:               "Auditing disabled",
@@ -151,7 +152,8 @@ var AuditEvents = events{
 		MandatoryFields: AuditFields{
 			"audit_scope": "global or db",
 		},
-		EventType: eventTypeAdmin,
+		EventType:     eventTypeAdmin,
+		IsGlobalEvent: true,
 	},
 	AuditIDAuditConfigChanged: {
 		Name:               "Auditing configuration changed",
@@ -167,7 +169,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			fieldGroupAuthenticated,
 		},
-		EventType: eventTypeAdmin,
+		EventType:     eventTypeAdmin,
+		IsGlobalEvent: true,
 	},
 	AuditIDSyncGatewayStartup: {
 		Name:               "Sync Gateway startup",
@@ -184,7 +187,8 @@ var AuditEvents = events{
 			AuditFieldBcryptCost:                     10,
 			AuditFieldDisablePersistentConfig:        false,
 		},
-		EventType: eventTypeAdmin,
+		EventType:     eventTypeAdmin,
+		IsGlobalEvent: true,
 	},
 	AuditIDPublicHTTPAPIRequest: {
 		Name:        "Public HTTP API request",
@@ -207,6 +211,7 @@ var AuditEvents = events{
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
 		EventType:          eventTypeUser,
+		IsGlobalEvent:      true,
 	},
 	AuditIDAdminHTTPAPIRequest: {
 		Name:        "Admin HTTP API request",
@@ -229,6 +234,7 @@ var AuditEvents = events{
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
+		IsGlobalEvent:      true,
 	},
 	AuditIDMetricsHTTPAPIRequest: {
 		Name:        "Metrics HTTP API request",
@@ -251,6 +257,7 @@ var AuditEvents = events{
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
+		IsGlobalEvent:      true,
 	},
 	AuditIDPublicUserAuthenticated: {
 		Name:        "Public API user authenticated",
@@ -352,7 +359,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			fieldGroupAuthenticated,
 		},
-		EventType: eventTypeAdmin,
+		EventType:     eventTypeAdmin,
+		IsGlobalEvent: true,
 	},
 	AuditIDSyncGatewayCollectInfoStart: {
 		Name:               "sgcollect_info start",
@@ -371,7 +379,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			fieldGroupAuthenticated,
 		},
-		EventType: eventTypeAdmin,
+		EventType:     eventTypeAdmin,
+		IsGlobalEvent: true,
 	},
 	AuditIDSyncGatewayCollectInfoStop: {
 		Name:               "sgcollect_info stop",
@@ -383,7 +392,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			fieldGroupAuthenticated,
 		},
-		EventType: eventTypeAdmin,
+		EventType:     eventTypeAdmin,
+		IsGlobalEvent: true,
 	},
 	AuditIDSyncGatewayStats: {
 		Name:               "stats requested",
@@ -397,7 +407,8 @@ var AuditEvents = events{
 			fieldGroupRequest,
 			fieldGroupAuthenticated,
 		},
-		EventType: eventTypeAdmin,
+		EventType:     eventTypeAdmin,
+		IsGlobalEvent: true,
 	},
 	AuditIDSyncGatewayProfiling: {
 		Name:        "profiling requested",
@@ -411,6 +422,7 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
+		IsGlobalEvent:      true,
 	},
 	AuditIDClusterInfoRead: {
 		Name:               "Sync Gateway cluster info read",
@@ -418,6 +430,7 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
+		IsGlobalEvent:      true,
 	},
 	AuditIDCreateDatabase: {
 		Name:        "Create database",
@@ -471,6 +484,7 @@ var AuditEvents = events{
 		EnabledByDefault:   false, // because high volume (Capella UI)
 		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
+		IsGlobalEvent:      true,
 	},
 	AuditIDReadDatabaseConfig: {
 		Name:        "Read database config",
@@ -626,6 +640,7 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
 		EventType:          eventTypeAdmin,
+		IsGlobalEvent:      true,
 	},
 	AuditIDDatabaseRepair: {
 		Name:        "Database repair",

--- a/base/audit_events_fields.go
+++ b/base/audit_events_fields.go
@@ -38,6 +38,7 @@ const (
 	AuditFieldEffectiveUserIDDomain = "domain"
 	AuditFieldEffectiveUserIDUser   = "user"
 	AuditFieldAuditScope            = "audit_scope"
+	AuditFieldEnabledEvents         = "enabled_events"
 	AuditFieldFileName              = "filename"
 	AuditFieldDBNames               = "db_names"
 

--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -50,9 +50,10 @@ type EventDescriptor struct {
 	// EventType represents a type of event
 	EventType eventType
 
-	// isDatabaseEvent indicates whether the event is a database event or a global (SG) event
-	// this controls where this event can be configured (startup config (false) vs. db config (true))
-	//isDatabaseEvent bool
+	// IsGlobalEvent indicates where the event can be enabled
+	//  - true  = only via the bootstrap config
+	//  - false = only via the database config
+	IsGlobalEvent bool
 }
 
 type fieldGroup string

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -147,8 +147,9 @@ type AuditLogger struct {
 	FileLogger
 
 	// AuditLoggerConfig stores the initial config used to instantiate AuditLogger
-	config       AuditLoggerConfig
-	globalFields map[string]any
+	config        AuditLoggerConfig
+	globalFields  map[string]any
+	enabledEvents map[AuditID]struct{}
 }
 
 func (l *AuditLogger) getAuditLoggerConfig() *AuditLoggerConfig {
@@ -178,10 +179,12 @@ func NewAuditLogger(ctx context.Context, config *AuditLoggerConfig, logFilePath 
 		return nil, err
 	}
 
+	enabledEvents := make(map[AuditID]struct{})
 	logger := &AuditLogger{
-		FileLogger:   *fl,
-		config:       *config,
-		globalFields: globalFields,
+		FileLogger:    *fl,
+		config:        *config,
+		globalFields:  globalFields,
+		enabledEvents: enabledEvents,
 	}
 
 	if *config.FileLoggerConfig.Enabled {

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -211,7 +211,7 @@ func NewAuditLogger(ctx context.Context, config *AuditLoggerConfig, logFilePath 
 	}
 
 	if *config.FileLoggerConfig.Enabled {
-		Audit(ctx, AuditIDAuditEnabled, AuditFields{"audit_scope": "global"})
+		Audit(ctx, AuditIDAuditEnabled, AuditFields{AuditFieldAuditScope: "global", AuditFieldEnabledEvents: config.EnabledEvents})
 	}
 
 	return logger, nil

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -233,7 +233,6 @@ func EnableAuditLogger(ctx context.Context, enabled bool) {
 			Audit(ctx, AuditIDAuditEnabled, AuditFields{AuditFieldAuditScope: "global"})
 		}
 	}
-
 }
 
 // === Used by tests only ===

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -277,6 +277,7 @@ type LoggingConfig struct {
 type AuditLoggerConfig struct {
 	FileLoggerConfig
 	AuditLogFilePath *string `json:"audit_log_file_path,omitempty"` // If set, overrides the output path for the audit log files
+	EnabledEvents    []uint  `json:"enabled_events,omitempty"`
 }
 
 func BuildLoggingConfigFromLoggers(originalConfig LoggingConfig) *LoggingConfig {

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1844,7 +1844,7 @@ Database:
               type: boolean
               default: false
             enabled_events:
-              description: List of enabled audit events
+              description: List of enabled audit events for this database.
               type: array
               items:
                 type: number
@@ -2248,7 +2248,7 @@ Startup-config:
         stats:
           $ref: '#/File-logging-config'
         audit:
-          $ref: '#/File-logging-config'
+          $ref: '#/Audit-logging-config'
     auth:
       type: object
       properties:
@@ -2432,11 +2432,18 @@ Audit-logging-config:
       description: The path to write audit log files to
       type: string
       readOnly: true
+    enabled_events:
+      description: List of enabled global audit events.
+      type: array
+      items:
+        type: number
+      example: [1234, 5678]
+      readOnly: true
     collation_buffer_size:
       description: The size of the log collation buffer
       type: integer
       readOnly: true
-  title: File-logging-config
+  title: Audit-logging-config
 Log-rotation-config-readonly:
   type: object
   properties:

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -67,6 +67,7 @@ func TestAuditLoggingFields(t *testing.T) {
 					FileLoggerConfig: base.FileLoggerConfig{
 						Enabled: base.BoolPtr(true),
 					},
+					EnabledEvents: base.AllGlobalAuditeventIDs, // enable everything for testing
 				},
 			}
 			require.NoError(t, config.SetupAndValidateLogging(base.TestCtx(t)))
@@ -80,7 +81,7 @@ func TestAuditLoggingFields(t *testing.T) {
 	dbConfig.Logging = &DbLoggingConfig{
 		Audit: &DbAuditLoggingConfig{
 			Enabled:       base.BoolPtr(true),
-			EnabledEvents: base.AllAuditeventIDs, // enable everything for testing
+			EnabledEvents: base.AllDbAuditeventIDs, // enable everything for testing
 			DisabledUsers: []base.AuditLoggingPrincipal{
 				{Name: filteredPublicUsername, Domain: string(base.UserDomainSyncGateway)},
 				{Name: filteredAdminUsername, Domain: string(base.UserDomainCBServer)},

--- a/rest/config.go
+++ b/rest/config.go
@@ -1070,8 +1070,10 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 			}
 			for _, id := range dbConfig.Logging.Audit.EnabledEvents {
 				id := base.AuditID(id)
-				if _, ok := base.AuditEvents[id]; !ok {
+				if e, ok := base.AuditEvents[id]; !ok {
 					multiError = multiError.Append(fmt.Errorf("unknown audit event ID %q", id))
+				} else if e.IsGlobalEvent {
+					multiError = multiError.Append(fmt.Errorf("event %q is not configurable at the database level", id))
 				}
 			}
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -2273,15 +2273,15 @@ func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 		enabledEvents := make(map[base.AuditID]struct{}, len(l.Audit.EnabledEvents))
 		events := l.Audit.EnabledEvents
 		if events == nil {
-			events = base.DefaultAuditEventIDs
+			events = base.DefaultDbAuditEventIDs
 		}
-		// always enable the non-filterable events
-		for id := range base.NonFilterableEvents {
-			enabledEvents[id] = struct{}{}
-		}
-		// enable the events specified in the config
 		for _, event := range events {
 			enabledEvents[base.AuditID(event)] = struct{}{}
+		}
+
+		// always enable the non-filterable events... since by definition they cannot be disabled
+		for id := range base.NonFilterableAuditEventsForDb {
+			enabledEvents[id] = struct{}{}
 		}
 
 		// user/role filtering

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -101,7 +101,7 @@ func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfi
 	}
 	dblc.Audit = &DbAuditLoggingConfig{
 		Enabled:       base.BoolPtr(false),
-		EnabledEvents: base.DefaultAuditEventIDs,
+		EnabledEvents: base.DefaultDbAuditEventIDs,
 	}
 	return dblc
 }

--- a/rest/config_flags_test.go
+++ b/rest/config_flags_test.go
@@ -48,6 +48,8 @@ func TestAllConfigFlags(t *testing.T) {
 				val = `{"db1":{"password":"foo"}}`
 			case *base.PerBucketCredentialsConfig:
 				val = `{"bucket":{"password":"foo"}}`
+			case *[]uint:
+				val = `123,456,789`
 			}
 			flags = append(flags, "-"+name, val)
 		case bool:

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -850,9 +850,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// previous state.
 	if base.IsAuditEnabled() {
 		if contextOptions.LoggingConfig.DbAuditEnabled() {
-			base.Audit(ctx, base.AuditIDAuditEnabled, base.AuditFields{"audit_scope": "db", "db": dbName})
+			base.Audit(ctx, base.AuditIDAuditEnabled, base.AuditFields{base.AuditFieldAuditScope: "db", base.AuditFieldDatabase: dbName})
 		} else {
-			base.Audit(ctx, base.AuditIDAuditDisabled, base.AuditFields{"audit_scope": "db", "db": dbName})
+			base.Audit(ctx, base.AuditIDAuditDisabled, base.AuditFields{base.AuditFieldAuditScope: "db", base.AuditFieldDatabase: dbName})
 		}
 	}
 


### PR DESCRIPTION
CBG-4058

Makes a small subset of events globally configurable in the startup config, because they're not associated with any one database where we can hang the configuration from.

These events are not allowed to be defined on the database's `enabled_events` configuration, and likewise, database-scoped events are not allowed to be defined in the startup config. This avoids inherietance/override complications, and there's no (current) case that a single event is always applicable to both (and filterable).

It's possible this could change in the future (e.g. the log streaming allows database console log level/key settings to override the global one if set, maybe that approach could apply here too in future?)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2605/
