### PR TITLE
CBG-4093 Add audit events for all roles, users

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -701,10 +701,15 @@ var AuditEvents = events{
 	},
 	AuditIDUsersAll: {
 		Name:        "Read all users",
-		Description: "All users were viewed",
+		Description: "List of all users was viewed",
 		MandatoryFields: AuditFields{
-			"db":        "database name",
-			"usernames": []string{"list", "of", "usernames"},
+			AuditFieldNameOnly: true,
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+		},
+		OptionalFields: AuditFields{
+			AuditFieldLimit: 100,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,
@@ -759,10 +764,15 @@ var AuditEvents = events{
 	},
 	AuditIDRolesAll: {
 		Name:        "Read all roles",
-		Description: "All roles were viewed",
+		Description: "List of all roles was viewed",
 		MandatoryFields: AuditFields{
-			"db":    "database name",
-			"roles": []string{"list", "of", "roles"},
+			AuditFieldIncludeDeleted: true,
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+		},
+		OptionalFields: AuditFields{
+			AuditFieldLimit: 100,
 		},
 		EnabledByDefault:   true,
 		FilteringPermitted: true,

--- a/base/audit_events_fields.go
+++ b/base/audit_events_fields.go
@@ -73,6 +73,11 @@ const (
 	// Session events 53282, 53283
 	AuditFieldSessionID = "session_id"
 
+	// User and role events
+	AuditFieldNameOnly       = "name_only"
+	AuditFieldLimit          = "limit"
+	AuditFieldIncludeDeleted = "include_deleted"
+
 	// AuditIDChangesFeedStarted AuditID = 54200
 	AuditFieldSince       = "since"
 	AuditFieldFilter      = "filter"

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1894,6 +1894,15 @@ func (h *handler) getUsers() error {
 	if marshalErr != nil {
 		return marshalErr
 	}
+
+	auditFields := base.AuditFields{
+		base.AuditFieldNameOnly: nameOnly,
+	}
+	if limit > 0 {
+		auditFields[base.AuditFieldLimit] = limit
+	}
+	base.Audit(h.ctx(), base.AuditIDUsersAll, auditFields)
+
 	h.writeRawJSON(bytes)
 	return nil
 }
@@ -1908,6 +1917,8 @@ func (h *handler) getRoles() error {
 	}
 
 	bytes, err := base.JSONMarshal(roles)
+
+	base.Audit(h.ctx(), base.AuditIDRolesAll, base.AuditFields{base.AuditFieldIncludeDeleted: includeDeleted})
 	h.writeRawJSON(bytes)
 	return err
 }


### PR DESCRIPTION
CBG-4093

Add new audit events for the all users and all roles endpoints, with event fields for optional parameters.  

