### PR TITLE
CBG-4096: add mandatory fields to AuditIDChangesFeedStarted event

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -802,6 +802,8 @@ var AuditEvents = events{
 			AuditFieldSince: "since",
 		},
 		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupDatabase,
+			fieldGroupKeyspace,
 			fieldGroupRequest,
 			fieldGroupAuthenticated,
 		},

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -802,7 +802,6 @@ var AuditEvents = events{
 			AuditFieldSince: "since",
 		},
 		mandatoryFieldGroups: []fieldGroup{
-			fieldGroupDatabase,
 			fieldGroupKeyspace,
 			fieldGroupRequest,
 			fieldGroupAuthenticated,


### PR DESCRIPTION
CBG-4096

- Missing mandatory fields added 

```
{"cid":"#001","db":"db1","description":"Changes feed was started","feed_type":"normal","id":54200,"ks":"db1._default._default","local":{"ip":"127.0.0.1","port":"4985"},"name":"Changes feed started","real_userid":{"domain":"cbs","user":"couchbase"},"remote":{"ip":"127.0.0.1","port":"55965"},"since":"0","timestamp":"2024-07-23T15:21:01.242867+01:00"}
```

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
