### PR TITLE
CBG-4094: Audit REST API /_local/doc CRUD

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -1007,9 +1007,6 @@ var AuditEvents = events{
 			fieldGroupDatabase,
 			fieldGroupKeyspace,
 		},
-		OptionalFields: AuditFields{
-			AuditFieldChannels: []string{"list", "of", "channels"},
-		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
 		EventType:          eventTypeData,
@@ -1041,9 +1038,6 @@ var AuditEvents = events{
 			fieldGroupAuthenticated,
 			fieldGroupDatabase,
 			fieldGroupKeyspace,
-		},
-		OptionalFields: AuditFields{
-			AuditFieldChannels: []string{"list", "of", "channels"},
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,

--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -1001,12 +1001,14 @@ var AuditEvents = events{
 		MandatoryFields: AuditFields{
 			AuditFieldDocID:      "document id",
 			AuditFieldDocVersion: "revision ID",
-			AuditFieldChannels:   []string{"list", "of", "channels"},
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupAuthenticated,
 			fieldGroupDatabase,
 			fieldGroupKeyspace,
+		},
+		OptionalFields: AuditFields{
+			AuditFieldChannels: []string{"list", "of", "channels"},
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,
@@ -1034,12 +1036,14 @@ var AuditEvents = events{
 		MandatoryFields: AuditFields{
 			AuditFieldDocID:      "document id",
 			AuditFieldDocVersion: "revision ID",
-			AuditFieldChannels:   []string{"list", "of", "channels"},
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupAuthenticated,
 			fieldGroupDatabase,
 			fieldGroupKeyspace,
+		},
+		OptionalFields: AuditFields{
+			AuditFieldChannels: []string{"list", "of", "channels"},
 		},
 		EnabledByDefault:   false,
 		FilteringPermitted: true,

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -528,7 +528,7 @@ func (c *Checkpointer) getLocalCheckpoint() (checkpoint *replicationCheckpoint, 
 }
 
 func (c *Checkpointer) setLocalCheckpoint(checkpoint *replicationCheckpoint) (newRev string, err error) {
-	newRev, err = putSpecial(c.collectionDataStore, DocTypeLocal, CheckpointDocIDPrefix+c.clientID, checkpoint.Rev, checkpoint.AsBody(), c.localDocExpirySecs)
+	newRev, _, err = putSpecial(c.collectionDataStore, DocTypeLocal, CheckpointDocIDPrefix+c.clientID, checkpoint.Rev, checkpoint.AsBody(), c.localDocExpirySecs)
 	if err != nil {
 		base.TracefCtx(c.ctx, base.KeyReplicate, "Error setting local checkpoint(%v): %v", checkpoint, err)
 		return "", err

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -432,7 +432,7 @@ func setLocalStatus(ctx context.Context, metadataStore base.DataStore, statusKey
 		Status: status,
 	}
 
-	_, err = putDocWithRevision(metadataStore, statusKey, revID, newStatus.AsBody(), localDocExpirySecs)
+	_, _, err = putDocWithRevision(metadataStore, statusKey, revID, newStatus.AsBody(), localDocExpirySecs)
 	return err
 }
 
@@ -451,6 +451,6 @@ func removeLocalStatus(ctx context.Context, metadataStore base.DataStore, status
 		return nil
 	}
 
-	_, err = putDocWithRevision(metadataStore, statusKey, currentStatus.Rev, nil, 0)
+	_, _, err = putDocWithRevision(metadataStore, statusKey, currentStatus.Rev, nil, 0)
 	return err
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -244,7 +244,7 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 	if revID := checkpointMessage.rev(); revID != "" {
 		checkpoint[BodyRev] = revID
 	}
-	revID, err := bh.collection.PutSpecial(DocTypeLocal, CheckpointDocIDPrefix+checkpointMessage.client(), checkpoint)
+	revID, _, err := bh.collection.PutSpecial(DocTypeLocal, CheckpointDocIDPrefix+checkpointMessage.client(), checkpoint)
 	if err != nil {
 		return err
 	}

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -44,7 +44,7 @@ func TestBlipGetCollections(t *testing.T) {
 		checkpoint1Body := db.Body{"seq": "123"}
 		collection, _ := btc.rt.GetSingleTestDatabaseCollection()
 		scopeAndCollection := fmt.Sprintf("%s.%s", collection.ScopeName, collection.Name)
-		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
+		revID, _, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 		require.NoError(t, err)
 		checkpoint1RevID := "0-1"
 		require.Equal(t, checkpoint1RevID, revID)
@@ -164,7 +164,7 @@ func TestBlipReplicationNoDefaultCollection(t *testing.T) {
 		checkpointID1 := "checkpoint1"
 		checkpoint1Body := db.Body{"seq": "123"}
 		collection, _ := btc.rt.GetSingleTestDatabaseCollection()
-		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
+		revID, _, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 		require.NoError(t, err)
 		checkpoint1RevID := "0-1"
 		require.Equal(t, checkpoint1RevID, revID)
@@ -197,7 +197,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 		checkpointID1 := "checkpoint1"
 		checkpoint1Body := db.Body{"seq": "123"}
 		collection, _ := btc.rt.GetSingleTestDatabaseCollection()
-		revID, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
+		revID, _, err := collection.PutSpecial(db.DocTypeLocal, db.CheckpointDocIDPrefix+checkpointID1, checkpoint1Body)
 		require.NoError(t, err)
 		checkpoint1RevID := "0-1"
 		require.Equal(t, checkpoint1RevID, revID)


### PR DESCRIPTION
CBG-4094

- Make channels audit field optional on document create/update events (local docs don't have channels)
- Wire up audit events for /_local/doc REST APIs
  - Required minor refactoring to determine whether an update was a newly created document or not

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
