### PR TITLE
CBG-4097: Filter global audit events from GET /db/_config/audit API response

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -758,7 +758,8 @@ func (h *handler) handleGetDbAuditConfig() error {
 
 	events := make(map[string]any, len(base.AuditEvents))
 	for id, descriptor := range base.AuditEvents {
-		if showOnlyFilterable && !descriptor.FilteringPermitted {
+		// skip global and non-filterable events
+		if descriptor.IsGlobalEvent || (showOnlyFilterable && !descriptor.FilteringPermitted) {
 			continue
 		}
 

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4280,6 +4280,8 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	assert.Equal(t, false, responseBody["enabled"].(bool))
 	// check we got the verbose output
 	assert.NotEmpty(t, responseBody["events"].(map[string]interface{})[base.AuditIDPublicUserAuthenticated.String()].(map[string]interface{})["description"].(string), "expected verbose output (event description, etc.)")
+	// check that global event IDs were not present
+	assert.Nil(t, responseBody["events"].(map[string]interface{})[base.AuditIDSyncGatewayCollectInfoStart.String()], "expected global event ID to not be present")
 
 	// enable auditing on the database (upsert)
 	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config/audit", `{"enabled":true}`)


### PR DESCRIPTION
CBG-4097

Filter global audit events from GET /db/_config/audit API response

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
