### PR TITLE
CBG-4098: Audit document revocation

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -118,6 +118,7 @@ const (
 	AuditIDDocumentMetadataRead AuditID = 55004
 	AuditIDDocumentImport       AuditID = 55005
 	AuditIDDocumentResync       AuditID = 55006
+	AuditIDDocumentRevoke       AuditID = 55007
 	// Document attachments events
 	AuditIDAttachmentCreate AuditID = 55010
 	AuditIDAttachmentRead   AuditID = 55011
@@ -1107,7 +1108,20 @@ var AuditEvents = events{
 		FilteringPermitted: true,
 		EventType:          eventTypeData,
 	},
-
+	AuditIDDocumentRevoke: {
+		Name:        "Revoke document",
+		Description: "A document revocation request was sent to a client",
+		MandatoryFields: AuditFields{
+			AuditFieldDocID:      "document id",
+			AuditFieldDocVersion: "revision ID",
+		},
+		mandatoryFieldGroups: []fieldGroup{
+			fieldGroupKeyspace,
+		},
+		EnabledByDefault:   false,
+		FilteringPermitted: true,
+		EventType:          eventTypeData,
+	},
 	AuditIDAttachmentCreate: {
 		Name:        "Create attachment",
 		Description: "A new attachment was created",

--- a/db/changes.go
+++ b/db/changes.go
@@ -299,6 +299,10 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 					return
 
 				case feed <- &change:
+					base.Audit(ctx, base.AuditIDDocumentRevoke, base.AuditFields{
+						base.AuditFieldDocID:      logEntry.DocID,
+						base.AuditFieldDocVersion: logEntry.RevID,
+					})
 					sentChanges++
 				}
 			}


### PR DESCRIPTION
CBG-4098: Audit document revocation

Manually verified with `TestRevocationWithAdminChannels`

![Screenshot 2024-07-23 at 18 43 29](https://github.com/user-attachments/assets/9494475c-a012-46bf-a6a4-a65493cbdf58)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
