### PR TITLE
CBG-4117: Add type checking to mandatory audit fields during event validation

### DIFF
--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -74,7 +74,7 @@ const (
 var fieldsByGroup = map[fieldGroup]map[string]any{
 	fieldGroupGlobal: {
 		AuditFieldTimestamp:   "timestamp",
-		AuditFieldID:          uint(123),
+		AuditFieldID:          uint32(123),
 		AuditFieldName:        "event name",
 		AuditFieldDescription: "event description",
 	},

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -31,7 +31,7 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	}
 
 	// static event data
-	fields[AuditFieldID] = uint64(id)
+	fields[AuditFieldID] = uint(id)
 	fields[AuditFieldName] = AuditEvents[id].Name
 	fields[AuditFieldDescription] = AuditEvents[id].Description
 
@@ -86,7 +86,7 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 		}
 	}
 
-	fields[AuditFieldTimestamp] = time.Now()
+	fields[AuditFieldTimestamp] = time.Now().Format(time.RFC3339)
 
 	fields.merge(ctx, globalFields)
 	fields.merge(ctx, logCtx.RequestAdditionalAuditFields)

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -31,7 +31,7 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	}
 
 	// static event data
-	fields[AuditFieldID] = uint(id)
+	fields[AuditFieldID] = uint32(id)
 	fields[AuditFieldName] = AuditEvents[id].Name
 	fields[AuditFieldDescription] = AuditEvents[id].Description
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -2062,7 +2062,7 @@ func (h *handler) putReplication() error {
 	if err != nil {
 		return err
 	}
-	auditFields := base.AuditFields{base.AuditFieldReplicationID: replicationConfig.ID, base.AuditFieldPayload: body}
+	auditFields := base.AuditFields{base.AuditFieldReplicationID: replicationConfig.ID, base.AuditFieldPayload: string(body)}
 	if created {
 		h.writeStatus(http.StatusCreated, "Created")
 		base.Audit(h.ctx(), base.AuditIDISGRCreate, auditFields)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -793,9 +793,14 @@ func (h *handler) handleGetDbAuditConfig() error {
 // PUT/POST audit config for database
 func (h *handler) handlePutDbAuditConfig() error {
 
-	var body HandleDbAuditConfigBody
+	var bodyRaw []byte
 	err := h.mutateDbConfig(func(config *DbConfig) error {
-		if err := h.readJSONInto(&body); err != nil {
+		bodyRaw, err := h.readBody()
+		if err != nil {
+			return err
+		}
+		var body HandleDbAuditConfigBody
+		if err := base.JSONUnmarshal(bodyRaw, &body); err != nil {
 			return err
 		}
 
@@ -860,7 +865,7 @@ func (h *handler) handlePutDbAuditConfig() error {
 	}
 	base.Audit(h.ctx(), base.AuditIDAuditConfigChanged, base.AuditFields{
 		base.AuditFieldAuditScope: "db",
-		base.AuditFieldPayload:    body,
+		base.AuditFieldPayload:    string(bodyRaw),
 	})
 	return nil
 }

--- a/rest/api.go
+++ b/rest/api.go
@@ -324,6 +324,8 @@ func (h *handler) handlePostResync() error {
 
 	action := h.getQuery("action")
 	regenerateSequences, _ := h.getOptBoolQuery("regenerate_sequences", false)
+	reset := h.getBoolQuery("reset")
+
 	body, err := h.readBody()
 	if err != nil {
 		return err
@@ -353,7 +355,7 @@ func (h *handler) handlePostResync() error {
 				"database":            h.db,
 				"regenerateSequences": regenerateSequences,
 				"collections":         resyncPostReqBody.Scope,
-				"reset":               h.getBoolQuery("reset"),
+				"reset":               reset,
 			})
 			if err != nil {
 				return err
@@ -367,7 +369,7 @@ func (h *handler) handlePostResync() error {
 			base.Audit(h.ctx(), base.AuditIDDatabaseResyncStart, base.AuditFields{
 				"collections":          resyncPostReqBody.Scope,
 				"regenerate_sequences": regenerateSequences,
-				"reset":                h.getQuery("reset"),
+				"reset":                reset,
 			})
 		} else {
 			dbState := atomic.LoadUint32(&h.db.State)


### PR DESCRIPTION
CBG-4117

Previously #6987 

Ensures that the type for the field in the event declaration matches the one actually being passed (when validating during devmode)

Caught a few instances of fields not matching their definitions and potential bugs as a result:
- `AuditFieldPayload` in some cases was taking either `[]byte` or a struct, instead of `string`
  - This will affect audit output (`[]byte` will be a base64 encoded string in JSON)
  - `handlePutDbAuditConfig` was printing the resulting config, rather than the request payload.
- Resync "reset" param: `string` vs. `bool` for a minor difference in output.
- Benign changes (don't affect audit output):
  - `AuditFieldID` switched to `uint32` in all places
    - Was a mixture of implicit `int` and `uint64` types, but 32bit uints are plenty to represent audit IDs
  - `AuditFieldTimestamp` `time.Time`->`string` 
    - `expandFields` now writes a `RFC3339` formatted timestamp directly, instead of relying on the underlying JSON marshalling of `time.Time`. Gives us better control of format.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2614/
