### PR TITLE
CBG-4088: If we error in removeCorruptConfigIfExists we don't unload/remove database

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -126,6 +126,9 @@ func (h *handler) handleCreateDB() error {
 		// if it used to be corrupt we need to remove it from the invalid database map on server context and remove the old corrupt config from the bucket
 		err = h.removeCorruptConfigIfExists(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName)
 		if err != nil {
+			// we cannot continue on with database creation with possibility of the corrupt database config in the bucket for this db
+			// thus we need to unload the requested database config to prevent the cluster being in an inconsistent state
+			h.server._removeDatabase(contextNoCancel.Ctx, dbName)
 			return err
 		}
 		cas, err := h.server.BootstrapContext.InsertConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, &persistedConfig)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3048,6 +3048,10 @@ func TestNotFoundOnInvalidDatabase(t *testing.T) {
 		assert.Equal(c, 1, len(invalidDatabases))
 	}, time.Second*10, time.Millisecond*100)
 
+	resp := rt.SendAdminRequest(http.MethodGet, "/db1/", "")
+	RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, resp.Body.String(), "You must update database config immediately")
+
 	// delete the invalid db config to force the not found error
 	rt.DeleteDbConfigInBucket(dbConfig.Name, realBucketName)
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -704,7 +704,7 @@ func (h *handler) removeCorruptConfigIfExists(ctx context.Context, bucket, confi
 	}
 	// remove the bad config from the bucket
 	err := h.server.BootstrapContext.DeleteConfig(ctx, bucket, configGroupID, dbName)
-	if err != nil {
+	if err != nil && !base.IsDocNotFoundError(err) {
 		return err
 	}
 	// delete the database name form the invalid database map on server context


### PR DESCRIPTION
CBG-4088

- add not found check in `removeCorruptConfigIfExists`, if doc not found error, we should continue on remove the invalid db config and carry on with db creation 
- in error scenarios (not doc not found errors) we need to unload the database before exiting create db function

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2618/ 
