### PR TITLE
CBG-4110: Flip defaultDbAuditEnabled

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -17,8 +17,11 @@ import (
 )
 
 const (
-	auditLogName        = "audit"
+	auditLogName = "audit"
+	// DefaultAuditEnabled is the default value for whether auditing is enabled globally.
 	defaultAuditEnabled = false
+	// DefaultDbAuditEnabled is the default value for whether database-level auditing is enabled.
+	DefaultDbAuditEnabled = false
 )
 
 // expandFields populates data with information from the id, context and additionalData.

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -69,7 +69,7 @@ type LogContext struct {
 	EffectiveDomain string
 }
 
-const defaultDbAuditEnabled = true
+const defaultDbAuditEnabled = false
 
 // DbLogConfig can be used to customise the logging for logs associated with this database.
 type DbLogConfig struct {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -69,8 +69,6 @@ type LogContext struct {
 	EffectiveDomain string
 }
 
-const DefaultDbAuditEnabled = false
-
 // DbLogConfig can be used to customise the logging for logs associated with this database.
 type DbLogConfig struct {
 	Console *DbConsoleLogConfig

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -69,7 +69,7 @@ type LogContext struct {
 	EffectiveDomain string
 }
 
-const defaultDbAuditEnabled = false
+const DefaultDbAuditEnabled = false
 
 // DbLogConfig can be used to customise the logging for logs associated with this database.
 type DbLogConfig struct {
@@ -81,7 +81,7 @@ func (dlc *DbLogConfig) DbAuditEnabled() bool {
 	if dlc != nil && dlc.Audit != nil {
 		return dlc.Audit.Enabled
 	}
-	return defaultDbAuditEnabled
+	return DefaultDbAuditEnabled
 }
 
 // DbConsoleLogConfig can be used to customise the console logging for logs associated with this database.

--- a/rest/config.go
+++ b/rest/config.go
@@ -2297,7 +2297,7 @@ func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 		}
 
 		aud = &base.DbAuditLogConfig{
-			Enabled:       base.BoolDefault(l.Audit.Enabled, false),
+			Enabled:       base.BoolDefault(l.Audit.Enabled, base.DefaultDbAuditEnabled),
 			EnabledEvents: enabledEvents,
 			DisabledUsers: disabledUsers,
 			DisabledRoles: disabledRoles,

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -100,7 +100,7 @@ func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfi
 		}
 	}
 	dblc.Audit = &DbAuditLoggingConfig{
-		Enabled:       base.BoolPtr(false),
+		Enabled:       base.BoolPtr(base.DefaultDbAuditEnabled),
 		EnabledEvents: base.DefaultDbAuditEventIDs,
 	}
 	return dblc


### PR DESCRIPTION
CBG-4110

Flip value of `defaultDbAuditEnabled` to be correct (false). This change only affects output of the `AuditIDAuditEnabled` event when db auditing is _not_ enabled via `DbAuditEnabled()`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a