### PR TITLE
CBG-4067: do not release doc sequence upon timeout error

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -237,7 +237,7 @@ func IsDocNotFoundError(err error) bool {
 	}
 }
 
-func IsTimeoutError(err error) bool {
+func IsTemporaryKvError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -250,6 +250,16 @@ func IsTimeoutError(err error) bool {
 	if errors.Is(err, gocb.ErrUnambiguousTimeout) {
 		return true
 	}
+	if errors.Is(err, gocb.ErrOverload) {
+		return true
+	}
+	if errors.Is(err, gocb.ErrTemporaryFailure) {
+		return true
+	}
+	if errors.Is(err, gocb.ErrCircuitBreakerOpen) {
+		return true
+	}
+
 	return false
 }
 

--- a/base/error.go
+++ b/base/error.go
@@ -237,27 +237,21 @@ func IsDocNotFoundError(err error) bool {
 	}
 }
 
+// IsTemporaryKvError returns true if a kv operation has an error that is likely to be ephemeral. This represents
+// situations where Couchbase Server is under load and would be expected to return a success or failure in a future call.
 func IsTemporaryKvError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, ErrTimeout) {
-		return true
-	}
-	if errors.Is(err, gocb.ErrAmbiguousTimeout) {
-		return true
-	}
-	if errors.Is(err, gocb.ErrUnambiguousTimeout) {
-		return true
-	}
-	if errors.Is(err, gocb.ErrOverload) {
-		return true
-	}
-	if errors.Is(err, gocb.ErrTemporaryFailure) {
-		return true
-	}
-	if errors.Is(err, gocb.ErrCircuitBreakerOpen) {
-		return true
+	// define list of temporary errors
+	temporaryKVError := []error{ErrTimeout, gocb.ErrAmbiguousTimeout, gocb.ErrUnambiguousTimeout,
+		gocb.ErrOverload, gocb.ErrTemporaryFailure, gocb.ErrCircuitBreakerOpen}
+
+	// iterate through to check incoming error is one of them
+	for _, tempKVErr := range temporaryKVError {
+		if errors.Is(err, tempKVErr) {
+			return true
+		}
 	}
 
 	return false

--- a/base/error.go
+++ b/base/error.go
@@ -237,6 +237,22 @@ func IsDocNotFoundError(err error) bool {
 	}
 }
 
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrTimeout) {
+		return true
+	}
+	if errors.Is(err, gocb.ErrAmbiguousTimeout) {
+		return true
+	}
+	if errors.Is(err, gocb.ErrUnambiguousTimeout) {
+		return true
+	}
+	return false
+}
+
 func IsXattrNotFoundError(err error) bool {
 	if unwrappedErr := pkgerrors.Cause(err); unwrappedErr == nil {
 		return false

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -121,6 +121,8 @@ type LeakyBucketConfig struct {
 
 	ForceErrorSetRawKeys []string // Issuing a SetRaw call with a specified key will return an error
 
+	ForceTimeoutErrorOnUpdateKeys []string // Specified keys will return timeout error AFTER write is sent to server
+
 	// Returns a partial error the first time ViewCustom is called
 	FirstTimeViewCustomPartialError bool
 	PostQueryCallback               func(ddoc, viewName string, params map[string]interface{}) // Issues callback after issuing query when bucket.ViewQuery is called

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -154,10 +155,8 @@ func (lds *LeakyDataStore) Update(k string, exp uint32, callback sgbucket.Update
 			return updated, expiry, isDelete, err
 		}
 		casOut, err = lds.dataStore.Update(k, exp, wrapperCallback)
-		for _, errorKey := range lds.config.ForceTimeoutErrorOnUpdateKeys {
-			if k == errorKey {
-				return 0, ErrTimeout
-			}
+		if slices.Contains(lds.config.ForceTimeoutErrorOnUpdateKeys, k) {
+			return 0, ErrTimeout
 		}
 		return casOut, err
 	}
@@ -274,10 +273,8 @@ func (lds *LeakyDataStore) WriteUpdateWithXattrs(ctx context.Context, k string, 
 			return updatedDoc, err
 		}
 		casOut, err = lds.dataStore.WriteUpdateWithXattrs(ctx, k, xattrKeys, exp, previous, opts, wrapperCallback)
-		for _, errorKey := range lds.config.ForceTimeoutErrorOnUpdateKeys {
-			if k == errorKey {
-				return 0, ErrTimeout
-			}
+		if slices.Contains(lds.config.ForceTimeoutErrorOnUpdateKeys, k) {
+			return 0, ErrTimeout
 		}
 		return casOut, err
 	}

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -267,7 +267,13 @@ func (lds *LeakyDataStore) WriteUpdateWithXattrs(ctx context.Context, k string, 
 			lds.config.UpdateCallback(k)
 			return updatedDoc, err
 		}
-		return lds.dataStore.WriteUpdateWithXattrs(ctx, k, xattrKeys, exp, previous, opts, wrapperCallback)
+		casOut, err = lds.dataStore.WriteUpdateWithXattrs(ctx, k, xattrKeys, exp, previous, opts, wrapperCallback)
+		for _, errorKey := range lds.config.ForceTimeoutErrorOnUpdateKeys {
+			if k == errorKey {
+				return 0, ErrTimeout
+			}
+		}
+		return casOut, err
 	}
 	return lds.dataStore.WriteUpdateWithXattrs(ctx, k, xattrKeys, exp, previous, opts, callback)
 }

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -153,7 +153,13 @@ func (lds *LeakyDataStore) Update(k string, exp uint32, callback sgbucket.Update
 			lds.config.UpdateCallback(k)
 			return updated, expiry, isDelete, err
 		}
-		return lds.dataStore.Update(k, exp, wrapperCallback)
+		casOut, err = lds.dataStore.Update(k, exp, wrapperCallback)
+		for _, errorKey := range lds.config.ForceTimeoutErrorOnUpdateKeys {
+			if k == errorKey {
+				return 0, ErrTimeout
+			}
+		}
+		return casOut, err
 	}
 
 	casOut, err = lds.dataStore.Update(k, exp, callback)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2096,15 +2096,17 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 	// If the WriteUpdate didn't succeed, check whether there are unused, allocated sequences that need to be accounted for
 	if err != nil {
-		if docSequence > 0 {
-			if seqErr := db.sequences().releaseSequence(ctx, docSequence); seqErr != nil {
-				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)
-			}
+		if !base.IsTimeoutError(err) {
+			if docSequence > 0 {
+				if seqErr := db.sequences().releaseSequence(ctx, docSequence); seqErr != nil {
+					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)
+				}
 
-		}
-		for _, sequence := range unusedSequences {
-			if seqErr := db.sequences().releaseSequence(ctx, sequence); seqErr != nil {
-				base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", sequence, seqErr)
+			}
+			for _, sequence := range unusedSequences {
+				if seqErr := db.sequences().releaseSequence(ctx, sequence); seqErr != nil {
+					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", sequence, seqErr)
+				}
 			}
 		}
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -2096,7 +2096,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 	// If the WriteUpdate didn't succeed, check whether there are unused, allocated sequences that need to be accounted for
 	if err != nil {
-		if !base.IsTimeoutError(err) {
+		if !base.IsTemporaryKvError(err) {
 			if docSequence > 0 {
 				if seqErr := db.sequences().releaseSequence(ctx, docSequence); seqErr != nil {
 					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1690,7 +1690,7 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 //   - Assert we don;t release a sequence for it + we hav eit in changes
 //   - Write new doc with conflict error
 //   - Assert we release a sequence for this
-func TestReleaseSequenceOnDocWrite(t *testing.T) {
+func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	defer SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1714,7 +1714,6 @@ func TestReleaseSequenceOnDocWrite(t *testing.T) {
 		}
 	}
 
-	// Use leaky bucket to inject callback in query invocation
 	callbackConfig := base.LeakyBucketConfig{
 		UpdateCallback:                writeUpdateCallback,
 		ForceTimeoutErrorOnUpdateKeys: []string{timeoutDoc},
@@ -1748,7 +1747,7 @@ func TestReleaseSequenceOnDocWrite(t *testing.T) {
 	// get cached changes + assert the document is present
 	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 	require.NoError(t, err)
-	assert.Len(t, changes, 1)
+	require.Len(t, changes, 1)
 	assert.Equal(t, timeoutDoc, changes[0].ID)
 
 	// write doc that will have a conflict error, we should expect the document sequence to be released

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1730,7 +1730,7 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	assert.Equal(t, int64(0), db.DbStats.Database().SequenceReleasedCount.Value())
 
 	// write doc that will return timeout but will actually be persisted successfully on server
-	// this mimics what was seen in CBSE-17458
+	// this mimics what was seen before
 	_, _, err = collection.Put(ctx, timeoutDoc, Body{"test": "doc"})
 	require.Error(t, err)
 


### PR DESCRIPTION
CBG-4067

- Added check to only release doc sequences when a write error is **not** a timeout error. 
- Added some functionality to leaky bucket to force return a timeout error upon a successful write (open to ideas of better forcing a timeout here) 
- Test also covers us correctly releasing a doc sequence upon a different et error at write time by casuing conflict uszing leaky bucket functionality 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2617/
