### PR TITLE
CBG-4116 skip successful auth on silent handlers

### DIFF
--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -27,10 +27,6 @@ import (
 )
 
 func TestAuditLoggingFields(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("This test can panic with gocb logging CBG-4076")
-	}
-
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Audit logging only works in EE")
 	}
@@ -56,9 +52,10 @@ func TestAuditLoggingFields(t *testing.T) {
 	)
 
 	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled:                 true,
-		AdminInterfaceAuthentication: !base.UnitTestUrlIsWalrus(), // disable admin auth for walrus so we can get coverage of both subtests
-		PersistentConfig:             true,
+		GuestEnabled:                   true,
+		AdminInterfaceAuthentication:   !base.UnitTestUrlIsWalrus(), // disable admin auth for walrus so we can get coverage of both subtests
+		metricsInterfaceAuthentication: true,
+		PersistentConfig:               true,
 		MutateStartupConfig: func(config *StartupConfig) {
 			config.Unsupported.AuditInfoProvider = &AuditInfoProviderConfig{
 				RequestInfoHeaderName: base.StringPtr(requestInfoHeaderName),
@@ -147,6 +144,45 @@ func TestAuditLoggingFields(t *testing.T) {
 			name: "public silent request",
 			auditableAction: func(t testing.TB) {
 				RequireStatus(t, rt.SendRequest(http.MethodGet, "/_ping", ""), http.StatusOK)
+			},
+		},
+		{
+			name: "admin silent request, admin authentication enabled",
+			auditableAction: func(t testing.TB) {
+				if !rt.AdminInterfaceAuthentication {
+					t.Skip("Skipping subtest that requires admin auth to be enabled")
+				}
+				RequireStatus(t, rt.SendAdminRequest(http.MethodGet, "/_expvar", ""), http.StatusUnauthorized)
+			},
+			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
+				base.AuditIDAdminUserAuthenticationFailed: {
+					base.AuditFieldUserName: "",
+				},
+			},
+		},
+		{
+			name: "admin silent request authenticated",
+			auditableAction: func(t testing.TB) {
+				RequireStatus(t, rt.SendAdminRequestWithAuth(http.MethodGet, "/_expvar", "", base.TestClusterUsername(), base.TestClusterPassword()), http.StatusOK)
+			},
+			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
+				base.AuditIDSyncGatewayStats: {
+					base.AuditFieldStatsFormat: "expvar",
+				},
+			},
+		},
+		{
+			name: "admin silent request bad creds",
+			auditableAction: func(t testing.TB) {
+				if !rt.AdminInterfaceAuthentication {
+					t.Skip("Skipping subtest that requires admin auth to be enabled")
+				}
+				RequireStatus(t, rt.SendAdminRequestWithAuth(http.MethodGet, "/_expvar", "", "not a real user", base.TestClusterPassword()), http.StatusUnauthorized)
+			},
+			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
+				base.AuditIDAdminUserAuthenticationFailed: {
+					base.AuditFieldUserName: "not a real user",
+				},
 			},
 		},
 		{
@@ -247,7 +283,7 @@ func TestAuditLoggingFields(t *testing.T) {
 			},
 		},
 		{
-			name: "anon admin request",
+			name: "anon admin request, admin authentication disabled",
 			auditableAction: func(t testing.TB) {
 				if rt.AdminInterfaceAuthentication {
 					t.Skip("Skipping subtest that requires admin auth to be disabled")
@@ -265,6 +301,24 @@ func TestAuditLoggingFields(t *testing.T) {
 			},
 		},
 		{
+			name: "anon admin request, rejected",
+			auditableAction: func(t testing.TB) {
+				if !rt.AdminInterfaceAuthentication {
+					t.Skip("Skipping subtest that requires admin auth to be enabled")
+				}
+				RequireStatus(t, rt.SendAdminRequest(http.MethodGet, "/db/", ""), http.StatusUnauthorized)
+			},
+			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
+				base.AuditIDAdminHTTPAPIRequest: {
+					base.AuditFieldHTTPMethod: http.MethodGet,
+					base.AuditFieldHTTPPath:   "/db/",
+				},
+				base.AuditIDAdminUserAuthenticationFailed: {
+					base.AuditFieldUserName: "",
+				},
+			},
+		},
+		{
 			name: "authed admin request",
 			auditableAction: func(t testing.TB) {
 				if !rt.AdminInterfaceAuthentication {
@@ -275,7 +329,7 @@ func TestAuditLoggingFields(t *testing.T) {
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDAdminUserAuthenticated: {
 					base.AuditFieldCorrelationID: auditFieldValueIgnored,
-					//	base.AuditFieldRealUserID:    map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
+					base.AuditFieldRealUserID:    map[string]any{"domain": "cbs", "user": base.TestClusterUsername()},
 				},
 				base.AuditIDReadDatabase: {
 					base.AuditFieldCorrelationID: auditFieldValueIgnored,
@@ -371,7 +425,7 @@ func TestAuditLoggingFields(t *testing.T) {
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDAdminUserAuthenticated: {
 					base.AuditFieldCorrelationID: auditFieldValueIgnored,
-					//	base.AuditFieldRealUserID:    map[string]any{"domain": "cbs", "user": unfilteredAdminRoleUsername},
+					base.AuditFieldRealUserID:    map[string]any{"domain": "cbs", "user": unfilteredAdminRoleUsername},
 				},
 				base.AuditIDReadDatabase: {
 					base.AuditFieldCorrelationID: auditFieldValueIgnored,
@@ -380,6 +434,51 @@ func TestAuditLoggingFields(t *testing.T) {
 				base.AuditIDAdminHTTPAPIRequest: {
 					base.AuditFieldHTTPMethod: http.MethodGet,
 					base.AuditFieldHTTPPath:   "/db/",
+				},
+			},
+		},
+		{
+			name: "metrics request authenticated",
+			auditableAction: func(t testing.TB) {
+				headers := map[string]string{
+					"Authorization": getBasicAuthHeader(base.TestClusterUsername(), base.TestClusterPassword()),
+				}
+				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", headers), http.StatusOK)
+			},
+			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
+				base.AuditIDSyncGatewayStats: {
+					base.AuditFieldStatsFormat: "prometheus",
+				},
+			},
+		},
+		{
+			name: "metrics request no authentication",
+			auditableAction: func(t testing.TB) {
+				if !rt.AdminInterfaceAuthentication {
+					t.Skip("Skipping subtest that requires admin auth to be enabled")
+				}
+				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", nil), http.StatusUnauthorized)
+			},
+			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
+				base.AuditIDAdminUserAuthenticationFailed: {
+					base.AuditFieldUserName: "",
+				},
+			},
+		},
+		{
+			name: "metrics request bad credentials",
+			auditableAction: func(t testing.TB) {
+				if !rt.AdminInterfaceAuthentication {
+					t.Skip("Skipping subtest that requires admin auth to be enabled")
+				}
+				headers := map[string]string{
+					"Authorization": getBasicAuthHeader("notauser", base.TestClusterPassword()),
+				}
+				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", headers), http.StatusUnauthorized)
+			},
+			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
+				base.AuditIDAdminUserAuthenticationFailed: {
+					base.AuditFieldUserName: "notauser",
 				},
 			},
 		},
@@ -413,8 +512,9 @@ func TestAuditLoggingFields(t *testing.T) {
 							}
 						}
 					}
+
 				}
-				assert.Truef(t, eventFound, "expected event %v not found in set of events", expectedAuditID)
+				assert.Truef(t, eventFound, "expected event %s:%v not found in set of events", base.AuditEvents[expectedAuditID].Name, expectedAuditID)
 			}
 
 		})
@@ -857,7 +957,7 @@ func TestAuditAttachmentEvents(t *testing.T) {
 	}{
 		{
 			name: "add attachment",
-			setupCode: func(t testing.TB, docID string) DocVersion {
+			setupCode: func(_ testing.TB, docID string) DocVersion {
 				return rt.CreateTestDoc(docID)
 			},
 			auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
@@ -867,7 +967,7 @@ func TestAuditAttachmentEvents(t *testing.T) {
 		},
 		{
 			name: "add inline attachment",
-			setupCode: func(t testing.TB, docID string) DocVersion {
+			setupCode: func(_ testing.TB, docID string) DocVersion {
 				return rt.CreateTestDoc(docID)
 			},
 			auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
@@ -909,7 +1009,7 @@ func TestAuditAttachmentEvents(t *testing.T) {
 		},
 		{
 			name: "all_docs attachment with rev",
-			setupCode: func(t testing.TB, docID string) DocVersion {
+			setupCode: func(_ testing.TB, docID string) DocVersion {
 				return rt.CreateTestDoc(docID)
 			},
 			auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
@@ -1011,7 +1111,7 @@ func TestAuditDocumentCreateUpdateEvents(t *testing.T) {
 		},
 		{
 			name: "update doc",
-			setupCode: func(t testing.TB, docID string) DocVersion {
+			setupCode: func(_ testing.TB, docID string) DocVersion {
 				return rt.CreateTestDoc(docID)
 			},
 			auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {


### PR DESCRIPTION
- Report an authentication failed event if no credentials are specified on the admin port
- `/_ping` endpoint uses `publicPrivs` so it doesn't log auth event anyway.

Tentatively removing 

```
if !base.UnitTestUrlIsWalrus() {
		t.Skip("This test can panic with gocb logging CBG-4076")
}
```	

but I should possibly pull that out into a separate commit. Without removing this, the test doesn't work! I'm not sure that we have a way to use rosmar with admin auth. I'm trying to reproduce CBG-4076 again.

I have a separate commit that makes all loggers work on an atomic.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2619/
