### PR TITLE
CBG-4114 Fixes for db scoped audit enabled/disabled events

### DIFF
--- a/base/audit_events.go
+++ b/base/audit_events.go
@@ -139,10 +139,11 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		MandatoryFields: AuditFields{
-			"audit_scope": "global or db",
+			AuditFieldAuditScope: "global or db",
 		},
 		OptionalFields: AuditFields{
-			"db": "database name",
+			AuditFieldDatabase:      "database name",
+			AuditFieldEnabledEvents: "54000,54001, etc",
 		},
 		EventType:     eventTypeAdmin,
 		IsGlobalEvent: true,
@@ -153,7 +154,10 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		MandatoryFields: AuditFields{
-			"audit_scope": "global or db",
+			AuditFieldAuditScope: "global or db",
+		},
+		OptionalFields: AuditFields{
+			AuditFieldDatabase: "database name",
 		},
 		EventType:     eventTypeAdmin,
 		IsGlobalEvent: true,
@@ -164,8 +168,8 @@ var AuditEvents = events{
 		EnabledByDefault:   true,
 		FilteringPermitted: false,
 		MandatoryFields: AuditFields{
-			"audit_scope":     "global or db",
-			AuditFieldPayload: "JSON representation of new db audit config",
+			AuditFieldAuditScope: "global or db",
+			AuditFieldPayload:    "JSON representation of new db audit config",
 		},
 		mandatoryFieldGroups: []fieldGroup{
 			fieldGroupDatabase,

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -225,6 +225,10 @@ func (al *AuditLogger) shouldLog(id AuditID, ctx context.Context) bool {
 		return false
 	}
 
+	if !AuditEvents[id].FilteringPermitted {
+		return true
+	}
+
 	isGlobal := AuditEvents[id].IsGlobalEvent
 	if isGlobal {
 		if _, ok := al.enabledEvents[id]; !ok {

--- a/db/database.go
+++ b/db/database.go
@@ -71,6 +71,10 @@ var (
 	DefaultQueryPaginationLimit = 5000
 )
 
+var (
+	BypassReleasedSequenceWait atomic.Bool
+)
+
 const (
 	CompactIntervalMinDays = float32(0.04) // ~1 Hour in days
 	CompactIntervalMaxDays = float32(60)   // 60 Days in days
@@ -2340,7 +2344,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	// Unlock change cache.  Validate that any allocated sequences on other nodes have either been assigned or released
 	// before starting
-	if initialSequence > 0 {
+	if initialSequence > 0 && !BypassReleasedSequenceWait.Load() {
 		_ = db.sequences.waitForReleasedSequences(ctx, initialSequenceTime)
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -72,7 +72,7 @@ var (
 )
 
 var (
-	BypassReleasedSequenceWait atomic.Bool
+	BypassReleasedSequenceWait atomic.Bool // Used to optimize single-node testing, see DisableSequenceWaitOnDbRestart
 )
 
 const (

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -787,3 +787,13 @@ func RawDocWithInlineSyncData(_ testing.TB) string {
 }
 `
 }
+
+// DisableSequenceWaitOnDbStart disables the release sequence wait on db start.  Appropriate for tests
+// that make changes to database config after first startup, and don't assert/require on sequence correctness
+func DisableSequenceWaitOnDbRestart(tb testing.TB) {
+	//
+	BypassReleasedSequenceWait.Store(true)
+	tb.Cleanup(func() {
+		BypassReleasedSequenceWait.Store(false)
+	})
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -618,12 +618,15 @@ func (h *handler) handlePutDbConfig() (err error) {
 	}
 
 	var updatedDbConfig *DatabaseConfig
+	var previousAuditEnabled, updatedAuditEnabled bool
+	var updatedAuditEvents []uint
 	cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbConfig.Name, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 		if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 		}
 		oldBucketDbConfig := bucketDbConfig.DbConfig
 		previousCollectionMap := bucketDbConfig.Scopes.CollectionMap()
+		previousAuditEnabled, _ = oldBucketDbConfig.IsAuditLoggingEnabled()
 
 		if h.rq.Method == http.MethodPost {
 			base.TracefCtx(h.ctx(), base.KeyConfig, "merging upserted config into bucket config")
@@ -676,8 +679,10 @@ func (h *handler) handlePutDbConfig() (err error) {
 		if err != nil {
 			return nil, err
 		}
+		updatedAuditEnabled, updatedAuditEvents = bucketDbConfig.IsAuditLoggingEnabled()
 		return bucketDbConfig, nil
 	})
+
 	if err != nil {
 		base.WarnfCtx(h.ctx(), "Couldn't update config for database - rolling back: %v", err)
 		// failed to start the new database config - rollback and return the original error for the user
@@ -687,6 +692,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		}
 		return err
 	}
+	auditDbAuditEnabled(h.ctx(), dbName, previousAuditEnabled, updatedAuditEnabled, updatedAuditEvents)
 	// store the cas in the loaded config after a successful update
 	h.setEtag(updatedDbConfig.Version)
 	h.server.lock.Lock()
@@ -796,7 +802,10 @@ func (h *handler) handleGetDbAuditConfig() error {
 func (h *handler) handlePutDbAuditConfig() error {
 
 	var bodyRaw []byte
+	var previousAuditEnabled, updatedAuditEnabled bool
+	var updatedAuditEvents []uint
 	err := h.mutateDbConfig(func(config *DbConfig) error {
+		previousAuditEnabled, _ = config.IsAuditLoggingEnabled()
 		bodyRaw, err := h.readBody()
 		if err != nil {
 			return err
@@ -859,12 +868,14 @@ func (h *handler) handlePutDbAuditConfig() error {
 		}
 
 		mutateConfigFromDbAuditConfigBody(isReplace, config.Logging.Audit, &body, toChange)
-
+		updatedAuditEnabled, updatedAuditEvents = config.IsAuditLoggingEnabled()
 		return nil
 	})
 	if err != nil {
 		return err
 	}
+
+	auditDbAuditEnabled(h.ctx(), h.db.Name, previousAuditEnabled, updatedAuditEnabled, updatedAuditEvents)
 	base.Audit(h.ctx(), base.AuditIDAuditConfigChanged, base.AuditFields{
 		base.AuditFieldAuditScope: "db",
 		base.AuditFieldPayload:    string(bodyRaw),
@@ -2234,4 +2245,27 @@ func checkUserAPIReadOnlyFields(newInfo auth.PrincipalConfig, user auth.User) (a
 		newInfo.JWTChannels = nil
 	}
 	return newInfo, true
+}
+
+// auditDbAuditEnabled writes any audit events for changes in whether db auditing is enabled
+func auditDbAuditEnabled(ctx context.Context, dbName string, previousEnabled, newEnabled bool, events []uint) {
+
+	if !base.IsAuditEnabled() {
+		return
+	}
+
+	auditFields := base.AuditFields{
+		base.AuditFieldAuditScope: "db",
+		base.AuditFieldDatabase:   dbName,
+	}
+
+	if previousEnabled != newEnabled {
+		if newEnabled {
+			auditFields[base.AuditFieldEnabledEvents] = events
+			base.Audit(ctx, base.AuditIDAuditEnabled, auditFields)
+		} else {
+			base.Audit(ctx, base.AuditIDAuditDisabled, auditFields)
+		}
+	}
+
 }

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1560,3 +1560,154 @@ func TestAuditBlipCRUD(t *testing.T) {
 		}
 	})
 }
+
+// TestDatabaseAuditChanges verifies that the expect events are raised when the audit configuration is changed.
+// Note: test cases are run sequentially, and depend on ordering, as events are only raised for changes in state
+func TestDatabaseAuditChanges(t *testing.T) {
+
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Audit logging only works in EE")
+	}
+
+	db.DisableSequenceWaitOnDbRestart(t)
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
+
+	rt := createAuditLoggingRestTester(t)
+	defer rt.Close()
+
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+
+	// Create full db config payloads with audit enabled/disabled, for PUT /_config test cases
+	auditEnabledFullConfig := rt.NewDbConfig()
+	auditEnabledFullConfig.Logging = &DbLoggingConfig{
+		Audit: &DbAuditLoggingConfig{
+			Enabled: base.BoolPtr(true),
+		},
+	}
+	auditEnabledPutConfigPayload := base.MustJSONMarshal(t, auditEnabledFullConfig)
+	auditDisabledPutConfigPayload := base.MustJSONMarshal(t, rt.NewDbConfig())
+
+	type testCase struct {
+		name                     string
+		method                   string
+		path                     string
+		requestBody              string
+		expectedStatus           int
+		expectedEvents           []base.AuditID
+		expectedEnabledEventList []any
+	}
+	testCases := []testCase{
+		{
+			name:           "disable via _config POST, already disabled",
+			method:         http.MethodPost,
+			path:           "/{{.db}}/_config",
+			requestBody:    `{"logging":{"audit":{"enabled":false}}}`,
+			expectedStatus: http.StatusCreated,
+			expectedEvents: []base.AuditID{},
+		},
+		{
+			name:           "enable via _config POST",
+			method:         http.MethodPost,
+			path:           "/{{.db}}/_config",
+			requestBody:    `{"logging":{"audit":{"enabled":true}}}`,
+			expectedStatus: http.StatusCreated,
+			expectedEvents: []base.AuditID{base.AuditIDAuditEnabled},
+		},
+		{
+			name:           "enable via _config POST, already enabled",
+			method:         http.MethodPost,
+			path:           "/{{.db}}/_config",
+			requestBody:    `{"logging":{"audit":{"enabled":true}}}`,
+			expectedStatus: http.StatusCreated,
+			expectedEvents: []base.AuditID{},
+		},
+		{
+			name:           "disable via _config POST",
+			method:         http.MethodPost,
+			path:           "/{{.db}}/_config",
+			requestBody:    `{"logging":{"audit":{"enabled":false}}}`,
+			expectedStatus: http.StatusCreated,
+			expectedEvents: []base.AuditID{base.AuditIDAuditDisabled},
+		},
+		{
+			name:           "enable via _config PUT",
+			method:         http.MethodPut,
+			path:           "/{{.db}}/_config",
+			requestBody:    string(auditEnabledPutConfigPayload),
+			expectedStatus: http.StatusCreated,
+			expectedEvents: []base.AuditID{base.AuditIDAuditEnabled},
+		},
+		{
+			name:           "disable via _config PUT",
+			method:         http.MethodPut,
+			path:           "/{{.db}}/_config",
+			requestBody:    string(auditDisabledPutConfigPayload),
+			expectedStatus: http.StatusCreated,
+			expectedEvents: []base.AuditID{base.AuditIDAuditDisabled},
+		},
+		{
+			name:           "enable via _config/audit",
+			method:         http.MethodPost,
+			path:           "/{{.db}}/_config/audit",
+			requestBody:    `{"enabled":true}`,
+			expectedStatus: http.StatusOK,
+			expectedEvents: []base.AuditID{base.AuditIDAuditEnabled},
+		},
+		{
+			name:           "enable via _config/audit, already enabled",
+			method:         http.MethodPost,
+			path:           "/{{.db}}/_config/audit",
+			requestBody:    `{"enabled":true}`,
+			expectedStatus: http.StatusOK,
+			expectedEvents: []base.AuditID{},
+		},
+		{
+			name:           "disable via _config/audit",
+			method:         http.MethodPost,
+			path:           "/{{.db}}/_config/audit",
+			requestBody:    `{"enabled":false}`,
+			expectedStatus: http.StatusOK,
+			expectedEvents: []base.AuditID{base.AuditIDAuditDisabled},
+		},
+		{
+			name:           "disable via _config/audit, already disabled",
+			method:         http.MethodPost,
+			path:           "/{{.db}}/_config/audit",
+			requestBody:    `{"enabled":false}`,
+			expectedStatus: http.StatusOK,
+			expectedEvents: []base.AuditID{},
+		},
+		{
+			name:                     "enable via _config/audit with events",
+			method:                   http.MethodPost,
+			path:                     "/{{.db}}/_config/audit",
+			requestBody:              `{"enabled":true, "events":{"53282":true}}`,
+			expectedStatus:           http.StatusOK,
+			expectedEvents:           []base.AuditID{base.AuditIDAuditEnabled},
+			expectedEnabledEventList: []any{float64(base.AuditIDPublicUserSessionCreated)},
+		},
+	}
+	for _, testCase := range testCases {
+		rt.Run(testCase.name, func(t *testing.T) {
+			output := base.AuditLogContents(t, func(t testing.TB) {
+				RequireStatus(t, rt.SendAdminRequestWithAuth(testCase.method, testCase.path, testCase.requestBody, base.TestClusterUsername(), base.TestClusterPassword()), testCase.expectedStatus)
+			})
+			events := jsonLines(t, output)
+			for _, expectedEventID := range testCase.expectedEvents {
+				found := false
+				for _, event := range events {
+					eventID := base.AuditID(event[base.AuditFieldID].(float64))
+					if eventID == expectedEventID {
+						require.Equal(rt.TB(), event[base.AuditFieldDatabase], "db")
+						if testCase.expectedEnabledEventList != nil {
+							require.Equal(rt.TB(), testCase.expectedEnabledEventList, event[base.AuditFieldEnabledEvents])
+						}
+						found = true
+					}
+				}
+				require.True(t, found, fmt.Sprintf("Expected event %v not present", expectedEventID))
+			}
+		})
+	}
+}

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1679,13 +1679,30 @@ func TestDatabaseAuditChanges(t *testing.T) {
 			expectedEvents: []base.AuditID{},
 		},
 		{
-			name:                     "enable via _config/audit with events",
-			method:                   http.MethodPost,
+			name:                     "enable via _config/audit with events PUT",
+			method:                   http.MethodPut,
 			path:                     "/{{.db}}/_config/audit",
-			requestBody:              `{"enabled":true, "events":{"53282":true}}`,
+			requestBody:              `{"enabled":true, "events":{"53282":true}}`, // AuditIDPublicUserSessionCreated
 			expectedStatus:           http.StatusOK,
 			expectedEvents:           []base.AuditID{base.AuditIDAuditEnabled},
 			expectedEnabledEventList: []any{float64(base.AuditIDPublicUserSessionCreated)},
+		},
+		{
+			name:           "disable via _config/audit with events PUT",
+			method:         http.MethodPut,
+			path:           "/{{.db}}/_config/audit",
+			requestBody:    `{"enabled":false, "events":{"53282":true}}`, // AuditIDPublicUserSessionCreated
+			expectedStatus: http.StatusOK,
+			expectedEvents: []base.AuditID{base.AuditIDAuditDisabled},
+		},
+		{
+			name:                     "enable via _config/audit with events POST",
+			method:                   http.MethodPost,
+			path:                     "/{{.db}}/_config/audit",
+			requestBody:              `{"enabled":true, "events":{"53283":true}}`, // AuditIDPublicUserSessionDeleted
+			expectedStatus:           http.StatusOK,
+			expectedEvents:           []base.AuditID{base.AuditIDAuditEnabled},
+			expectedEnabledEventList: []any{float64(base.AuditIDPublicUserSessionCreated), float64(base.AuditIDPublicUserSessionDeleted)},
 		},
 	}
 	for _, testCase := range testCases {

--- a/rest/config.go
+++ b/rest/config.go
@@ -2317,7 +2317,9 @@ func (c *DbConfig) IsAuditLoggingEnabled() (enabled bool, events []uint) {
 
 	if c != nil && c.Logging != nil && c.Logging.Audit != nil && c.Logging.Audit.Enabled != nil {
 		enabled = *c.Logging.Audit.Enabled
-		events = c.Logging.Audit.EnabledEvents
+		if c.Logging.Audit.EnabledEvents != nil {
+			events = *c.Logging.Audit.EnabledEvents
+		}
 		return enabled, events
 	} else {
 		// Audit logging not defined in the config.  Use default value

--- a/rest/config.go
+++ b/rest/config.go
@@ -2311,3 +2311,16 @@ func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 		Audit:   aud,
 	}
 }
+
+// IsAuditLoggingEnabled() checks whether audit logging is enabled for the db, independent of the global setting
+func (c *DbConfig) IsAuditLoggingEnabled() (enabled bool, events []uint) {
+
+	if c != nil && c.Logging != nil && c.Logging.Audit != nil && c.Logging.Audit.Enabled != nil {
+		enabled = *c.Logging.Audit.Enabled
+		events = c.Logging.Audit.EnabledEvents
+		return enabled, events
+	} else {
+		// Audit logging not defined in the config.  Use default value
+		return base.DefaultDbAuditEnabled, nil
+	}
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -844,21 +844,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
-	/*
-		// If audit logging is enabled for the node, log the db setting.  This may not represent a change in
-		// auditing since the last time the db was running on this node, but we don't have any insight into the
-		// previous state.  These are global events (even though they have a db property, so audit these prior to
-		// adding DatabaseLogCtx to ensure db context filtering isn't applied.
-		if base.IsAuditEnabled() {
-			if contextOptions.LoggingConfig.DbAuditEnabled() {
-				base.Audit(ctx, base.AuditIDAuditEnabled, base.AuditFields{base.AuditFieldAuditScope: "db", base.AuditFieldDatabase: dbName})
-			} else {
-				base.Audit(ctx, base.AuditIDAuditDisabled, base.AuditFields{base.AuditFieldAuditScope: "db", base.AuditFieldDatabase: dbName})
-			}
-		}
-
-	*/
-
 	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig)
 
 	contextOptions.UseViews = useViews

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -607,9 +607,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		spec.Server = sc.Config.Bootstrap.Server
 	}
 
-	if sc.databases_[dbName] != nil {
+	previousDatabase := sc.databases_[dbName]
+	if previousDatabase != nil {
 		if options.useExisting {
-			return sc.databases_[dbName], nil
+			return previousDatabase, nil
 		} else {
 			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, // what CouchDB returns
 				"Duplicate database name %q", dbName)
@@ -843,18 +844,22 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, err
 	}
 
-	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig)
-
-	// If audit logging is enabled for the node, log the db setting.  This may not represent a change in
-	// auditing since the last time the db was running on this node, but we don't have any insight into the
-	// previous state.
-	if base.IsAuditEnabled() {
-		if contextOptions.LoggingConfig.DbAuditEnabled() {
-			base.Audit(ctx, base.AuditIDAuditEnabled, base.AuditFields{base.AuditFieldAuditScope: "db", base.AuditFieldDatabase: dbName})
-		} else {
-			base.Audit(ctx, base.AuditIDAuditDisabled, base.AuditFields{base.AuditFieldAuditScope: "db", base.AuditFieldDatabase: dbName})
+	/*
+		// If audit logging is enabled for the node, log the db setting.  This may not represent a change in
+		// auditing since the last time the db was running on this node, but we don't have any insight into the
+		// previous state.  These are global events (even though they have a db property, so audit these prior to
+		// adding DatabaseLogCtx to ensure db context filtering isn't applied.
+		if base.IsAuditEnabled() {
+			if contextOptions.LoggingConfig.DbAuditEnabled() {
+				base.Audit(ctx, base.AuditIDAuditEnabled, base.AuditFields{base.AuditFieldAuditScope: "db", base.AuditFieldDatabase: dbName})
+			} else {
+				base.Audit(ctx, base.AuditIDAuditDisabled, base.AuditFields{base.AuditFieldAuditScope: "db", base.AuditFieldDatabase: dbName})
+			}
 		}
-	}
+
+	*/
+
+	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig)
 
 	contextOptions.UseViews = useViews
 


### PR DESCRIPTION
CBG-4114

Only emit audit events when the audit enabled/disabled state changes for a db.

This changes handling for non-filterable events in logger_audit to skip subsequent enabled checking.  Required to emit db-level audit change events even if db auditing is disabled.  

Also added the ability to disable the 1.5s sequence wait on db restart for tests that don’t require it.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2622/
