### PR TITLE
Reset global loggers in a function that modifies global loggers

### DIFF
--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1424,6 +1424,7 @@ func deleteTempFile(t *testing.T, file *os.File) {
 }
 
 func TestDefaultLogging(t *testing.T) {
+	base.ResetGlobalTestLogging(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	config := DefaultStartupConfig("")
 	assert.Equal(t, base.RedactPartial, config.Logging.RedactionLevel)


### PR DESCRIPTION
Allows `TestHTTPLogging` to be run after `TestDefaultLogging` if `SG_TEST_USE_LOG_LEVEL` is set. In the case where `SG_TEST_USE_LOG_LEVEL` `SetUpTestLogging` will reset the loggers, but if `SG_TEST_USE_LOG_LEVEL` is set then `SetUpTestLogging` is a no-op.