### PR TITLE
CBG-4111: Differentiate between `nil` set and empty set of enabled db audit events

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4297,6 +4297,17 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	assert.False(t, responseBody["events"].(map[string]interface{})[base.AuditIDISGRStatus.String()].(bool), "audit enabled event should be disabled by default")
 	assert.True(t, responseBody["events"].(map[string]interface{})[base.AuditIDPublicUserAuthenticated.String()].(bool), "public user authenticated event should be enabled by default")
 
+	// CBG-4111: Try to disable events on top of the default (nil) set... either PUT or POST where *all* of the given IDs are set to false. Bug results in a no-op.
+	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config/audit", fmt.Sprintf(`{"enabled":true,"events":{"%s":false}}`, base.AuditIDPublicUserAuthenticated))
+	rest.RequireStatus(t, resp, http.StatusOK)
+	// check event we just tried to disable
+	resp = rt.SendAdminRequest(http.MethodGet, "/db/_config/audit", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	resp.DumpBody()
+	responseBody = nil
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &responseBody))
+	assert.False(t, responseBody["events"].(map[string]interface{})[base.AuditIDPublicUserAuthenticated.String()].(bool), "public user authenticated event should be disabled")
+
 	// do a PUT to completely replace the full config (events not declared here will be disabled)
 	// enable AuditEnabled event, but implicitly others
 	resp = rt.SendAdminRequest(http.MethodPut, "/db/_config/audit", fmt.Sprintf(`{"enabled":true,"events":{"%s":true}}`, base.AuditIDISGRStatus))

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4407,9 +4407,11 @@ func RequireEventCount(t *testing.T, runtimeConfig *rest.RuntimeDatabaseConfig, 
 		require.Zero(t, expectedCount)
 	}
 	actualCount := 0
-	for _, configID := range loggingConfig.Audit.EnabledEvents {
-		if configID == uint(auditID) {
-			actualCount++
+	if loggingConfig.Audit.EnabledEvents != nil {
+		for _, configID := range *loggingConfig.Audit.EnabledEvents {
+			if configID == uint(auditID) {
+				actualCount++
+			}
 		}
 	}
 	require.Equal(t, expectedCount, actualCount)

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -83,7 +83,7 @@ func TestAuditLoggingFields(t *testing.T) {
 	dbConfig.Logging = &DbLoggingConfig{
 		Audit: &DbAuditLoggingConfig{
 			Enabled:       base.BoolPtr(true),
-			EnabledEvents: base.AllDbAuditeventIDs, // enable everything for testing
+			EnabledEvents: &base.AllDbAuditeventIDs, // enable everything for testing
 			DisabledUsers: []base.AuditLoggingPrincipal{
 				{Name: filteredPublicUsername, Domain: string(base.UserDomainSyncGateway)},
 				{Name: filteredAdminUsername, Domain: string(base.UserDomainCBServer)},

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -101,7 +101,7 @@ func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfi
 	}
 	dblc.Audit = &DbAuditLoggingConfig{
 		Enabled:       base.BoolPtr(base.DefaultDbAuditEnabled),
-		EnabledEvents: base.DefaultDbAuditEventIDs,
+		EnabledEvents: &base.DefaultDbAuditEventIDs,
 	}
 	return dblc
 }


### PR DESCRIPTION
CBG-4111

Closes up a bug where we didn't correctly apply a change on top of the default set of events because we couldn't determine whether `nil` meant the default set, or none set.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2624/
