### PR TITLE
[3.2.0 backport] CBG-4113: Differentiate between nil set and empty set of enabled db audit events

### DIFF
--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -80,7 +80,7 @@ func TestAuditLoggingFields(t *testing.T) {
 	dbConfig.Logging = &DbLoggingConfig{
 		Audit: &DbAuditLoggingConfig{
 			Enabled:       base.BoolPtr(true),
-			EnabledEvents: base.AllDbAuditeventIDs, // enable everything for testing
+			EnabledEvents: &base.AllDbAuditeventIDs, // enable everything for testing
 			DisabledUsers: []base.AuditLoggingPrincipal{
 				{Name: filteredPublicUsername, Domain: string(base.UserDomainSyncGateway)},
 				{Name: filteredAdminUsername, Domain: string(base.UserDomainCBServer)},

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -101,7 +101,7 @@ func DefaultPerDBLogging(bootstrapLoggingCnf base.LoggingConfig) *DbLoggingConfi
 	}
 	dblc.Audit = &DbAuditLoggingConfig{
 		Enabled:       base.BoolPtr(base.DefaultDbAuditEnabled),
-		EnabledEvents: base.DefaultDbAuditEventIDs,
+		EnabledEvents: &base.DefaultDbAuditEventIDs,
 	}
 	return dblc
 }


### PR DESCRIPTION
cherry-pick of https://github.com/couchbase/sync_gateway/commit/b7ad16265943f07754528648360e017e7528c8e3