### PR TITLE
CBG-4023: Removal unmarshalled body on the rev cache

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -137,7 +137,7 @@ func (db *DatabaseCollectionWithUser) addDocToChangeEntry(ctx context.Context, e
 }
 
 func (db *DatabaseCollectionWithUser) AddDocToChangeEntryUsingRevCache(ctx context.Context, entry *ChangeEntry, revID string) (err error) {
-	rev, err := db.getRev(ctx, entry.ID, revID, 0, nil, RevCacheIncludeBody)
+	rev, err := db.getRev(ctx, entry.ID, revID, 0, nil)
 	if err != nil {
 		return err
 	}
@@ -325,7 +325,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 
 // UserHasDocAccess checks whether the user has access to the active revision of the document
 func UserHasDocAccess(ctx context.Context, collection *DatabaseCollectionWithUser, docID string) (bool, error) {
-	currentRev, err := collection.revisionCache.GetActive(ctx, docID, false)
+	currentRev, err := collection.revisionCache.GetActive(ctx, docID)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			return false, nil

--- a/db/crud.go
+++ b/db/crud.go
@@ -258,7 +258,7 @@ func (db *DatabaseCollectionWithUser) GetRev(ctx context.Context, docID, revID s
 	if history {
 		maxHistory = math.MaxInt32
 	}
-	return db.getRev(ctx, docID, revID, maxHistory, nil, RevCacheOmitBody)
+	return db.getRev(ctx, docID, revID, maxHistory, nil)
 }
 
 // Returns the body of the current revision of a document
@@ -278,7 +278,7 @@ func (db *DatabaseCollectionWithUser) Get1xRevBody(ctx context.Context, docid, r
 
 // Retrieves rev with request history specified as collection of revids (historyFrom)
 func (db *DatabaseCollectionWithUser) Get1xRevBodyWithHistory(ctx context.Context, docid, revid string, maxHistory int, historyFrom []string, attachmentsSince []string, showExp bool) (Body, error) {
-	rev, err := db.getRev(ctx, docid, revid, maxHistory, historyFrom, RevCacheIncludeBody)
+	rev, err := db.getRev(ctx, docid, revid, maxHistory, historyFrom)
 	if err != nil {
 		return nil, err
 	}
@@ -305,14 +305,14 @@ func (db *DatabaseCollectionWithUser) Get1xRevBodyWithHistory(ctx context.Contex
 //   - attachmentsSince is nil to return no attachment bodies, otherwise a (possibly empty) list of
 //     revisions for which the client already has attachments and doesn't need bodies. Any attachment
 //     that hasn't changed since one of those revisions will be returned as a stub.
-func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid string, maxHistory int, historyFrom []string, includeBody bool) (revision DocumentRevision, err error) {
+func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid string, maxHistory int, historyFrom []string) (revision DocumentRevision, err error) {
 	if revid != "" {
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
-		revision, err = db.revisionCache.Get(ctx, docid, revid, includeBody, RevCacheOmitDelta)
+		revision, err = db.revisionCache.Get(ctx, docid, revid, RevCacheOmitDelta)
 	} else {
 		// No rev ID given, so load active revision
-		revision, err = db.revisionCache.GetActive(ctx, docid, includeBody)
+		revision, err = db.revisionCache.GetActive(ctx, docid)
 	}
 
 	if err != nil {
@@ -373,7 +373,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		return nil, nil, nil
 	}
 
-	fromRevision, err := db.revisionCache.Get(ctx, docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+	fromRevision, err := db.revisionCache.Get(ctx, docID, fromRevID, RevCacheIncludeDelta)
 
 	// If the fromRevision is a removal cache entry (no body), but the user has access to that removal, then just
 	// return 404 missing to indicate that the body of the revision is no longer available.
@@ -413,7 +413,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		// db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheMisses, 1)
 		db.dbStats().DeltaSync().DeltaCacheMiss.Add(1)
-		toRevision, err := db.revisionCache.Get(ctx, docID, toRevID, RevCacheOmitBody, RevCacheIncludeDelta)
+		toRevision, err := db.revisionCache.Get(ctx, docID, toRevID, RevCacheIncludeDelta)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -549,38 +549,36 @@ func (col *DatabaseCollectionWithUser) authorizeDoc(doc *Document, revid string)
 
 // Gets a revision of a document. If it's obsolete it will be loaded from the database if possible.
 // inline "_attachments" properties in the body will be extracted and returned separately if present (pre-2.5 metadata, or backup revisions)
-func (c *DatabaseCollection) getRevision(ctx context.Context, doc *Document, revid string) (bodyBytes []byte, body Body, attachments AttachmentsMeta, err error) {
+func (c *DatabaseCollection) getRevision(ctx context.Context, doc *Document, revid string) (bodyBytes []byte, attachments AttachmentsMeta, err error) {
 	bodyBytes = doc.getRevisionBodyJSON(ctx, revid, c.RevisionBodyLoader)
 
 	// No inline body, so look for separate doc:
 	if bodyBytes == nil {
 		if !doc.History.contains(revid) {
-			return nil, nil, nil, ErrMissing
+			return nil, nil, ErrMissing
 		}
 
 		bodyBytes, err = c.getOldRevisionJSON(ctx, doc.ID, revid)
 		if err != nil || bodyBytes == nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 	}
 
 	// optimistically grab the doc body and to store as a pre-unmarshalled version, as well as anticipating no inline attachments.
 	if doc.CurrentRev == revid {
-		body = doc._body
 		attachments = doc.Attachments
 	}
 
 	// handle backup revision inline attachments, or pre-2.5 meta
-	if inlineAtts, cleanBodyBytes, cleanBody, err := extractInlineAttachments(bodyBytes); err != nil {
-		return nil, nil, nil, err
+	if inlineAtts, cleanBodyBytes, _, err := extractInlineAttachments(bodyBytes); err != nil {
+		return nil, nil, err
 	} else if len(inlineAtts) > 0 {
 		// we found some inline attachments, so merge them with attachments, and update the bodies
 		attachments = mergeAttachments(inlineAtts, attachments)
 		bodyBytes = cleanBodyBytes
-		body = cleanBody
 	}
 
-	return bodyBytes, body, attachments, nil
+	return bodyBytes, attachments, nil
 }
 
 // mergeAttachments copies the docAttachments map, and merges pre25Attachments into it.
@@ -705,7 +703,7 @@ func (db *DatabaseCollectionWithUser) get1xRevFromDoc(ctx context.Context, doc *
 				return nil, false, ErrDeleted
 			}
 		}
-		if bodyBytes, _, attachments, err = db.getRevision(ctx, doc, revid); err != nil {
+		if bodyBytes, attachments, err = db.getRevision(ctx, doc, revid); err != nil {
 			return nil, false, err
 		}
 	}
@@ -742,7 +740,7 @@ func (db *DatabaseCollectionWithUser) get1xRevFromDoc(ctx context.Context, doc *
 // Returns the body and rev ID of the asked-for revision or the most recent available ancestor.
 func (db *DatabaseCollectionWithUser) getAvailableRev(ctx context.Context, doc *Document, revid string) ([]byte, string, AttachmentsMeta, error) {
 	for ; revid != ""; revid = doc.History[revid].Parent {
-		if bodyBytes, _, attachments, _ := db.getRevision(ctx, doc, revid); bodyBytes != nil {
+		if bodyBytes, attachments, _ := db.getRevision(ctx, doc, revid); bodyBytes != nil {
 			return bodyBytes, revid, attachments, nil
 		}
 	}
@@ -2157,15 +2155,14 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 		revChannels := doc.History[newRevID].Channels
 		documentRevision := DocumentRevision{
-			DocID:            docid,
-			RevID:            newRevID,
-			BodyBytes:        storedDocBytes,
-			History:          encodeRevisions(ctx, docid, history),
-			Channels:         revChannels,
-			Attachments:      doc.Attachments,
-			Expiry:           doc.Expiry,
-			Deleted:          doc.History[newRevID].Deleted,
-			_shallowCopyBody: storedDoc.Body(ctx),
+			DocID:       docid,
+			RevID:       newRevID,
+			BodyBytes:   storedDocBytes,
+			History:     encodeRevisions(ctx, docid, history),
+			Channels:    revChannels,
+			Attachments: doc.Attachments,
+			Expiry:      doc.Expiry,
+			Deleted:     doc.History[newRevID].Deleted,
 		}
 
 		if createNewRevIDSkipped {
@@ -2263,7 +2260,7 @@ func getAttachmentIDsForLeafRevisions(ctx context.Context, db *DatabaseCollectio
 	})
 
 	for _, leafRevision := range documentLeafRevisions {
-		_, _, attachmentMeta, err := db.getRevision(ctx, doc, leafRevision)
+		_, attachmentMeta, err := db.getRevision(ctx, doc, leafRevision)
 		if err != nil {
 			return nil, err
 		}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -514,9 +514,11 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	_, rev1Digest := ParseRevID(ctx, rev1ID)
 	_, rev2Digest := ParseRevID(ctx, rev2ID)
 
+	var interfaceListChannels []interface{}
+	interfaceListChannels = append(interfaceListChannels, "ABC")
 	bodyExpected := Body{
 		"k2":       "v2",
-		"channels": []string{"ABC"},
+		"channels": interfaceListChannels,
 		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2Digest, rev1Digest},

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -514,9 +514,11 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	_, rev1Digest := ParseRevID(ctx, rev1ID)
 	_, rev2Digest := ParseRevID(ctx, rev2ID)
 
+	var interfaceListChannels []interface{}
+	interfaceListChannels = append(interfaceListChannels, "ABC")
 	bodyExpected := Body{
 		"k2":       "v2",
-		"channels": []string{"ABC"},
+		"channels": interfaceListChannels,
 		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2Digest, rev1Digest},
@@ -3320,4 +3322,61 @@ func TestBadDCPStart(t *testing.T) {
 	require.Error(t, err)
 
 	dbCtx.Close(ctx)
+}
+
+func TestInject1xBodyProperties(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	collection := GetSingleDatabaseCollectionWithUser(t, db)
+
+	rev1ID, _, err := collection.Put(ctx, "doc", Body{"test": "doc"})
+	require.NoError(t, err)
+	var rev2Body Body
+	rev2Data := `{"key":"value", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
+	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
+	_, rev2ID, err := collection.PutExistingRevWithBody(ctx, "doc", rev2Body, []string{"2-abc", rev1ID}, true)
+	require.NoError(t, err)
+
+	docRev, err := collection.GetRev(ctx, "doc", rev2ID, true, nil)
+	require.NoError(t, err)
+
+	// mock expiry on doc
+	exp := time.Now()
+	docRev.Expiry = &exp
+
+	newDoc, err := docRev.Inject1xBodyProperties(ctx, collection, docRev.History, nil, true)
+	require.NoError(t, err)
+	var resBody Body
+	require.NoError(t, resBody.Unmarshal(newDoc))
+
+	// cast to map of interface given we have injected the properties runtime has no concept of the AttachmentMeta and Revisions types
+	revs := resBody[BodyRevisions].(map[string]interface{})
+	atts := resBody[BodyAttachments].(map[string]interface{})
+
+	assert.NotNil(t, atts)
+	assert.NotNil(t, revs)
+	assert.Equal(t, "doc", resBody[BodyId])
+	assert.Equal(t, "2-abc", resBody[BodyRev])
+	assert.Equal(t, exp.Format(time.RFC3339), resBody[BodyExpiry])
+	assert.Equal(t, "value", resBody["key"])
+
+	// mock doc deleted
+	docRev.Deleted = true
+
+	newDoc, err = docRev.Inject1xBodyProperties(ctx, collection, docRev.History, []string{"2-abc"}, true)
+	require.NoError(t, err)
+	require.NoError(t, resBody.Unmarshal(newDoc))
+
+	// cast to map of interface given we have injected the properties runtime has no concept of the AttachmentMeta and Revisions types
+	revs = resBody[BodyRevisions].(map[string]interface{})
+	atts = resBody[BodyAttachments].(map[string]interface{})
+
+	assert.NotNil(t, atts)
+	assert.NotNil(t, revs)
+	assert.Equal(t, "doc", resBody[BodyId])
+	assert.Equal(t, "2-abc", resBody[BodyRev])
+	assert.Equal(t, exp.Format(time.RFC3339), resBody[BodyExpiry])
+	assert.Equal(t, "value", resBody["key"])
+	assert.True(t, resBody[BodyDeleted].(bool))
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -514,11 +514,9 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	_, rev1Digest := ParseRevID(ctx, rev1ID)
 	_, rev2Digest := ParseRevID(ctx, rev2ID)
 
-	var interfaceListChannels []interface{}
-	interfaceListChannels = append(interfaceListChannels, "ABC")
 	bodyExpected := Body{
 		"k2":       "v2",
-		"channels": interfaceListChannels,
+		"channels": []string{"ABC"},
 		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2Digest, rev1Digest},
@@ -3328,7 +3326,7 @@ func TestInject1xBodyProperties(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	collection := GetSingleDatabaseCollectionWithUser(t, db)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	rev1ID, _, err := collection.Put(ctx, "doc", Body{"test": "doc"})
 	require.NoError(t, err)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -31,13 +31,9 @@ func NewBypassRevisionCache(backingStores map[uint32]RevisionCacheBackingStore, 
 }
 
 // Get fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, collectionID uint32, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
 
-	unmarshalLevel := DocUnmarshalSync
-	if includeBody {
-		unmarshalLevel = DocUnmarshalAll
-	}
-	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, unmarshalLevel)
+	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -45,7 +41,7 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, col
 	docRev = DocumentRevision{
 		RevID: revID,
 	}
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, revID)
+	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, revID)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -56,13 +52,9 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, col
 }
 
 // GetActive fetches the active revision for the given docID immediately from the bucket.
-func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32, includeBody bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
 
-	unmarshalLevel := DocUnmarshalSync
-	if includeBody {
-		unmarshalLevel = DocUnmarshalAll
-	}
-	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, unmarshalLevel)
+	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -71,7 +63,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 		RevID: doc.CurrentRev,
 	}
 
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.CurrentRev)
+	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -31,11 +30,11 @@ type RevisionCache interface {
 	// Get returns the given revision, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	Get(ctx context.Context, docID, revID string, collectionID uint32, includeBody, includeDelta bool) (DocumentRevision, error)
+	Get(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
-	GetActive(ctx context.Context, docID string, collectionID uint32, includeBody bool) (docRev DocumentRevision, err error)
+	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
 
 	// Peek returns the given revision if present in the cache
 	Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool)
@@ -54,8 +53,6 @@ type RevisionCache interface {
 }
 
 const (
-	RevCacheIncludeBody  = true
-	RevCacheOmitBody     = false
 	RevCacheIncludeDelta = true
 	RevCacheOmitDelta    = false
 )
@@ -103,7 +100,7 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 // RevisionCacheBackingStore is the interface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.
 type RevisionCacheBackingStore interface {
 	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
-	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error)
+	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error)
 }
 
 // collectionRevisionCache is a view of a revision cache for a collection.
@@ -121,13 +118,13 @@ func newCollectionRevisionCache(revCache *RevisionCache, collectionID uint32) co
 }
 
 // Get is for per collection access to Get method
-func (c *collectionRevisionCache) Get(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (DocumentRevision, error) {
-	return (*c.revCache).Get(ctx, docID, revID, c.collectionID, includeBody, includeDelta)
+func (c *collectionRevisionCache) Get(ctx context.Context, docID, revID string, includeDelta bool) (DocumentRevision, error) {
+	return (*c.revCache).Get(ctx, docID, revID, c.collectionID, includeDelta)
 }
 
 // GetActive is for per collection access to GetActive method
-func (c *collectionRevisionCache) GetActive(ctx context.Context, docID string, includeBody bool) (DocumentRevision, error) {
-	return (*c.revCache).GetActive(ctx, docID, c.collectionID, includeBody)
+func (c *collectionRevisionCache) GetActive(ctx context.Context, docID string) (DocumentRevision, error) {
+	return (*c.revCache).GetActive(ctx, docID, c.collectionID)
 }
 
 // Peek is for per collection access to Peek method
@@ -168,8 +165,6 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
-
-	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
 
 // MutableBody returns a deep copy of the given document revision as a plain body (without any special properties)
@@ -186,19 +181,62 @@ func (rev *DocumentRevision) MutableBody() (b Body, err error) {
 // If an unmarshalled copy is not available in the document revision, it makes a copy from the raw body
 // bytes and stores it in document revision itself before returning the body.
 func (rev *DocumentRevision) Body() (b Body, err error) {
-	// if we already have an unmarshalled body, take a copy and return it
-	if rev._shallowCopyBody != nil {
-		return rev._shallowCopyBody, nil
-	}
 
 	if err := b.Unmarshal(rev.BodyBytes); err != nil {
 		return nil, err
 	}
 
-	// store a copy of the unmarshalled body for next time we need it
-	rev._shallowCopyBody = b
-
 	return b, nil
+}
+
+// Inject1xBodyProperties will inject special properties (_rev etc) into document body avoiding unnecessary marshal work
+func (rev *DocumentRevision) Inject1xBodyProperties(ctx context.Context, db *DatabaseCollectionWithUser, requestedHistory Revisions, attachmentsSince []string, showExp bool) ([]byte, error) {
+
+	kvPairs := []base.KVPair{
+		{Key: BodyId, Val: rev.DocID},
+		{Key: BodyRev, Val: rev.RevID},
+	}
+
+	if requestedHistory != nil {
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyRevisions, Val: requestedHistory})
+	}
+
+	if showExp && rev.Expiry != nil && !rev.Expiry.IsZero() {
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyExpiry, Val: rev.Expiry.Format(time.RFC3339)})
+	}
+
+	if rev.Deleted {
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyDeleted, Val: rev.Deleted})
+	}
+
+	if attachmentsSince != nil {
+		if len(rev.Attachments) > 0 {
+			minRevpos := 1
+			if len(attachmentsSince) > 0 {
+				ancestor := rev.History.findAncestor(attachmentsSince)
+				if ancestor != "" {
+					minRevpos, _ = ParseRevID(ctx, ancestor)
+					minRevpos++
+				}
+			}
+			bodyAtts, err := db.loadAttachmentsData(rev.Attachments, minRevpos, rev.DocID)
+			if err != nil {
+				return nil, err
+			}
+			DeleteAttachmentVersion(bodyAtts)
+			kvPairs = append(kvPairs, base.KVPair{Key: BodyAttachments, Val: bodyAtts})
+		}
+	} else if rev.Attachments != nil {
+		// Stamp attachment metadata back into the body
+		DeleteAttachmentVersion(rev.Attachments)
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyAttachments, Val: rev.Attachments})
+	}
+
+	newBytes, err := base.InjectJSONProperties(rev.BodyBytes, kvPairs...)
+	if err != nil {
+		return nil, err
+	}
+	return newBytes, nil
 }
 
 // Mutable1xBody returns a copy of the given document revision as a 1.x style body (with special properties)
@@ -257,14 +295,13 @@ func (rev *DocumentRevision) Mutable1xBody(ctx context.Context, db *DatabaseColl
 
 // As1xBytes returns a byte slice representing the 1.x style body, containing special properties (i.e. _id, _rev, _attachments, etc.)
 func (rev *DocumentRevision) As1xBytes(ctx context.Context, db *DatabaseCollectionWithUser, requestedHistory Revisions, attachmentsSince []string, showExp bool) (b []byte, err error) {
-	// unmarshal
-	body1x, err := rev.Mutable1xBody(ctx, db, requestedHistory, attachmentsSince, showExp)
+	// inject the special properties
+	body1x, err := rev.Inject1xBodyProperties(ctx, db, requestedHistory, attachmentsSince, showExp)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: We could avoid the unmarshal -> marshal work here by injecting properties into the original body bytes directly.
-	return json.Marshal(body1x)
+	return body1x, nil
 }
 
 type IDAndRev struct {
@@ -296,44 +333,40 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
 	var doc *Document
-	unmarshalLevel := DocUnmarshalSync
-	if unmarshalBody {
-		unmarshalLevel = DocUnmarshalAll
-	}
-	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
-		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, err
+	if doc, err = backingStore.GetDocument(ctx, id.DocID, DocUnmarshalSync); doc == nil {
+		return bodyBytes, history, channels, removed, attachments, deleted, expiry, err
 	}
 
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
-	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+	if bodyBytes, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
 		if isRemovalErr != nil {
-			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
+			return bodyBytes, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
 		}
 
 		if isRemoval {
-			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
+			return removalBodyBytes, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
-			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, err
+			return bodyBytes, history, channels, removed, nil, isDelete, nil, err
 		}
 	}
 	deleted = doc.History[revid].Deleted
 
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
-		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
+		return bodyBytes, history, channels, removed, nil, deleted, nil, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
 
-	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err
+	return bodyBytes, history, channels, removed, attachments, deleted, doc.Expiry, err
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -53,7 +53,7 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 	return doc, nil
 }
 
-func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error) {
+func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error) {
 	t.getRevisionCounter.Add(1)
 
 	b := Body{
@@ -63,7 +63,7 @@ func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid
 		BodyRevisions: Revisions{RevisionsStart: 1},
 	}
 	bodyBytes, err := base.JSONMarshal(b)
-	return bodyBytes, b, nil, err
+	return bodyBytes, nil, err
 }
 
 type noopBackingStore struct{}
@@ -72,8 +72,8 @@ func (*noopBackingStore) GetDocument(ctx context.Context, docid string, unmarsha
 	return nil, nil
 }
 
-func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error) {
-	return nil, nil, nil, nil
+func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error) {
+	return nil, nil, nil
 }
 
 // testCollectionID is a test collection ID to use for a key in the backing store map to point to a tests backing store.
@@ -104,7 +104,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Get them back out
 	for i := 0; i < 10; i++ {
 		docID := strconv.Itoa(i)
-		docRev, err := cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+		docRev, err := cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", docID)
 		assert.Equal(t, docID, docRev.DocID)
@@ -132,7 +132,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// and check we can Get up to and including the last 3 we put in
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		docRev, err := cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+		docRev, err := cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
 		assert.Equal(t, id, docRev.DocID)
@@ -148,7 +148,7 @@ func TestBackingStore(t *testing.T) {
 	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -159,7 +159,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -168,7 +168,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev is already resident, but still issue GetDocument to check for later revisions
-	docRev, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -179,7 +179,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -269,15 +269,15 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.False(t, ok)
 
 	// Get non-existing doc
-	_, err = rc.Get(ctx, "invalid", rev1, testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	_, err = rc.Get(ctx, "invalid", rev1, testCollectionID, RevCacheOmitDelta)
 	assert.True(t, base.IsDocNotFoundError(err))
 
 	// Get non-existing revision
-	_, err = rc.Get(ctx, key, "3-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	_, err = rc.Get(ctx, key, "3-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 
 	// Get specific revision
-	doc, err := rc.Get(ctx, key, rev1, testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	doc, err := rc.Get(ctx, key, rev1, testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	require.NotNil(t, doc)
 	assert.Equal(t, `{"value":1234}`, string(doc.BodyBytes))
@@ -294,7 +294,7 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.False(t, ok)
 
 	// Get active revision
-	doc, err = rc.GetActive(ctx, key, testCollectionID, false)
+	doc, err = rc.GetActive(ctx, key, testCollectionID)
 	assert.NoError(t, err)
 	assert.Equal(t, `{"value":5678}`, string(doc.BodyBytes))
 
@@ -375,7 +375,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)
 
 	// Get the raw document directly from the revcache, validate _attachments property isn't found
-	docRevision, err := collection.revisionCache.Get(ctx, docKey, rev2id, RevCacheOmitBody, RevCacheOmitDelta)
+	docRevision, err := collection.revisionCache.Get(ctx, docKey, rev2id, RevCacheOmitDelta)
 	assert.NoError(t, err, "Unexpected error calling collection.revisionCache.Get")
 	assert.NotContains(t, docRevision.BodyBytes, BodyAttachments, "_attachments property still present in document body retrieved from rev cache: %#v", bucketBody)
 	_, ok = docRevision.Attachments["myatt"]
@@ -403,12 +403,12 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	secondDelta := []byte("modified delta")
 
 	// Trigger load into cache
-	_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheIncludeDelta)
+	_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error adding to cache")
 	cache.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevisionDelta{ToRevID: "rev2", DeltaBytes: firstDelta})
 
 	// Retrieve from cache
-	retrievedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheIncludeDelta)
+	retrievedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
@@ -419,7 +419,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Retrieve again, validate delta is correct
-	updatedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheIncludeDelta)
+	updatedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev3", updatedRev.Delta.ToRevID)
 	assert.Equal(t, secondDelta, updatedRev.Delta.DeltaBytes)
@@ -436,7 +436,7 @@ func TestSingleLoad(t *testing.T) {
 	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", History: Revisions{"start": 1}}, testCollectionID)
-	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, true, false)
+	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
 	assert.NoError(t, err)
 }
 
@@ -453,7 +453,7 @@ func TestConcurrentLoad(t *testing.T) {
 	wg.Add(20)
 	for i := 0; i < 20; i++ {
 		go func() {
-			_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, true, false)
+			_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -471,19 +471,19 @@ func TestRevisionCacheRemove(t *testing.T) {
 	rev1id, _, err := collection.Put(ctx, "doc", Body{"val": 123})
 	assert.NoError(t, err)
 
-	docRev, err := collection.revisionCache.Get(ctx, "doc", rev1id, true, true)
+	docRev, err := collection.revisionCache.Get(ctx, "doc", rev1id, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheMisses.Value())
 
 	collection.revisionCache.Remove("doc", rev1id)
 
-	docRev, err = collection.revisionCache.Get(ctx, "doc", rev1id, true, true)
+	docRev, err = collection.revisionCache.Get(ctx, "doc", rev1id, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 
-	docRev, err = collection.revisionCache.GetActive(ctx, "doc", true)
+	docRev, err = collection.revisionCache.GetActive(ctx, "doc")
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
@@ -619,7 +619,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 
 	// trigger load into cache
 	for i := 0; i < 5000; i++ {
-		_, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+		_, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitDelta)
 	}
 
 	b.ResetTimer()
@@ -627,7 +627,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		// GET the document until test run has completed
 		for pb.Next() {
 			docId := fmt.Sprintf("doc%d", rand.Intn(5000))
-			_, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+			_, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheOmitDelta)
 		}
 	})
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2757,6 +2757,11 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, body)
 	assert.Contains(t, err.Error(), "null doc body for doc")
+
+	bodyBytes, err := documentRev.Inject1xBodyProperties(rt.Context(), collection, nil, nil, false)
+	require.Error(t, err)
+	require.Nil(t, bodyBytes)
+	assert.Contains(t, err.Error(), "b is not a JSON object")
 }
 
 func TestTombstoneCompactionAPI(t *testing.T) {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -847,7 +847,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 			collection, ctx := rt.GetSingleTestDatabaseCollection()
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta)
+			docRev, cacheErr := collection.GetRevisionCacheForTest().Get(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -847,7 +847,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 			collection, ctx := rt.GetSingleTestDatabaseCollection()
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := collection.GetRevisionCacheForTest().Get(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
+			docRev, cacheErr := rt.GetSingleTestDatabaseCollection().GetRevisionCacheForTest().Get(base.TestCtx(t), "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -60,7 +60,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
 
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, true, false)
+	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, false)
 	assert.NoError(t, err)
 	assert.Len(t, docRev.Channels.ToArray(), 0)
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
@@ -82,7 +82,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData2))
 
-	docRev2, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, true, false)
+	docRev2, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, false)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.CurrentRev, docRev2.RevID)
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7487,7 +7487,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveRTCollection, passiveRTCtx := passiveRT.GetSingleTestDatabaseCollection()
-	rev, err := passiveRTCollection.GetRevisionCacheForTest().GetActive(passiveRTCtx, "test", true)
+	rev, err := passiveRTCollection.GetRevisionCacheForTest().GetActive(passiveRTCtx, "test")
 	require.NoError(t, err)
 	// Making body invalid to trigger log "Unable to unmarshal mutable body for doc" in handleRev
 	// Which should give a HTTP 422


### PR DESCRIPTION
CBG-4044

- I lost this original commit in a rebase... mistake I made so ended up opting to cherry pick the original commit on to of rebase of the feature branch
- **NOTE TO REVIEW**: not sure how the above effects merging, not sure we still need to rebase and merge or squash and merge now? 


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2630/
