### PR TITLE
CBG-4101 avoid test flake

### DIFF
--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1355,6 +1355,8 @@ func TestAuditChangesFeedStart(t *testing.T) {
 			rt.Run(testCase.name, func(t *testing.T) {
 				docID := strings.ReplaceAll(testCase.name, " ", "_")
 				docVersion := rt.PutDoc(docID, `{"channels": "A"}`)
+				// wait for changes before starting one shot changes feeds
+				require.NoError(t, rt.WaitForPendingChanges())
 				output := base.AuditLogContents(t, func(t testing.TB) {
 					testCase.auditableCode(t, docID, docVersion)
 				})


### PR DESCRIPTION
Wait for the change cache to receive this document before starting a continuous:false changes feed.