### PR TITLE
CBG-3818 Create and use GetChanges consistently (part 1)

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2556,7 +2556,6 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 
 		// Track last sequence for next changes feed
 		var changes ChangesResults
-		changes.Last_Seq = "0"
 
 		for i, test := range testCases {
 			rt.Run(test.name, func(t *testing.T) {
@@ -3135,7 +3134,8 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 
 				// Issue a changes request for the channel before updating the document, to ensure the valid revision is
 				// resident in the channel cache (query results may be unreliable in the case of the 'invalid json' update)
-				RequireStatus(t, rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels="+testCase.channel, ""), 200)
+				changes := rt.PostChangesAdmin("/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels="+testCase.channel, "{}")
+				require.Len(t, changes.Results, 1)
 
 				err := rt.GetSingleDataStore().SetRaw(docID, 0, nil, testCase.updatedBody)
 				require.NoError(t, err)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -9,7 +9,6 @@
 package changestest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -61,39 +60,21 @@ func TestReproduce2383(t *testing.T) {
 	collection, _ := rt.GetSingleTestDatabaseCollection()
 	assert.NoError(t, collection.FlushChannelCache(ctx))
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.TestBucket.GetSingleDataStore())
 	require.True(t, ok)
 
 	// Force a partial error for the first ViewCustom call we make to initialize an invalid cache.
 	leakyDataStore.SetFirstTimeViewCustomPartialError(true)
 
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben")
 
 	// In the first changes request since cache flush, we're forcing a nil cache with no error. Thereforce we'd expect to see zero results.
 	require.Len(t, changes.Results, 0)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-
+	changes = rt.PostChanges("/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben")
 	// Now we should expect 3 results, as the invalid cache was not persisted.
 	// The second call to ViewCustom will succeed and properly create the channel cache.
 	require.Len(t, changes.Results, 3)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 
 	// if we create another doc, the cache will get updated with the latest doc.
 	cacheWaiter.Add(1)
@@ -102,16 +83,8 @@ func TestReproduce2383(t *testing.T) {
 
 	cacheWaiter.Wait()
 
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-
+	changes = rt.PostChanges("/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben")
 	require.Len(t, changes.Results, 4)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
-
 }
 
 func TestDocDeletionFromChannel(t *testing.T) {
@@ -139,12 +112,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 
 	// Check the _changes feed:
 	require.NoError(t, rt.WaitForPendingChanges())
-	var changes struct {
-		Results []db.ChangeEntry
-	}
-	response = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "alice")
-	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes := rt.GetChanges("/{{.keyspace}}/_changes", "alice")
 	require.Len(t, changes.Results, 1)
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
@@ -157,11 +125,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 
 	// Get the updates from the _changes feed:
 	_ = rt.WaitForPendingChanges()
-	response = rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", since),
-		"", "alice")
-	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	changes.Results = nil
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.GetChanges("/{{.keyspace}}/_changes?since="+since.String(), "alice")
 	require.Len(t, changes.Results, 1)
 
 	assert.Equal(t, "alpha", changes.Results[0].ID)
@@ -312,22 +276,8 @@ func TestPostChangesUserTiming(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		var changes struct {
-			Results  []db.ChangeEntry
-			Last_Seq string
-		}
 		changesJSON := `{"style":"all_docs", "timeout":6000, "feed":"longpoll", "limit":50, "since":"0"}`
-		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-		// Validate that the user receives backfill plus the new doc
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
-
-		if len(changes.Results) != 3 {
-			log.Printf("len(changes.Results) != 3, dumping changes response for diagnosis")
-			log.Printf("changes: %+v", changes)
-			log.Printf("changesResponse status code: %v.  Headers: %+v", changesResponse.Code, changesResponse.Header())
-			log.Printf("changesResponse raw body: %s", changesResponse.Body.String())
-		}
+		changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 		require.Len(t, changes.Results, 3)
 	}()
 
@@ -372,29 +322,14 @@ func TestPostChangesWithQueryString(t *testing.T) {
 
 	_ = rt.WaitForPendingChanges()
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq db.SequenceID
-	}
-
 	// Test basic properties
 	changesJSON := `{"heartbeat":50, "feed":"normal", "limit":1, "since":"3"}`
-	changesResponse := rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes?feed=longpoll&limit=10&since=0&heartbeat=50000", changesJSON)
-
-	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChangesAdmin("/{{.keyspace}}/_changes?feed=longpoll&limit=10&since=0&heartbeat=50000", changesJSON)
 	require.Len(t, changes.Results, 4)
 
 	// Test channel filter
-	var filteredChanges struct {
-		Results  []db.ChangeEntry
-		Last_Seq db.SequenceID
-	}
-	changesJSON = `{"feed":"longpoll"}`
-	changesResponse = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes?feed=longpoll&filter=sync_gateway/bychannel&channels=ABC", changesJSON)
-
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &filteredChanges)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changesJSON = `{"longpoll":true}`
+	filteredChanges := rt.PostChangesAdmin("/{{.keyspace}}/_changes?feed=longpoll&filter=sync_gateway/bychannel&channels=ABC", changesJSON)
 	require.Len(t, filteredChanges.Results, 1)
 }
 
@@ -417,16 +352,8 @@ func postChangesSince(t *testing.T, rt *rest.RestTester) {
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(5)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 	changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-
-	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	log.Printf("Changes:%s", changesResponse.Body.Bytes())
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
 
 	// Put several more documents, some to the same vbuckets
@@ -441,12 +368,8 @@ func postChangesSince(t *testing.T, rt *rest.RestTester) {
 	cacheWaiter.AddAndWait(4)
 
 	changesJSON = fmt.Sprintf(`{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"%s"}`, changes.Last_Seq)
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	log.Printf("Changes:%s", changesResponse.Body.Bytes())
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 3)
-
 }
 
 func TestPostChangesChannelFilterInteger(t *testing.T) {
@@ -483,16 +406,8 @@ func postChangesChannelFilter(t *testing.T, rt *rest.RestTester) {
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(5)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	changesJSON := `{"filter":"` + base.ByChannelFilter + `", "channels":"PBS"}`
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 4)
 
 	// Put several more documents, some to the same vbuckets
@@ -505,14 +420,8 @@ func postChangesChannelFilter(t *testing.T, rt *rest.RestTester) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs4", `{"value":4, "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(4)
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	for _, result := range changes.Results {
-		log.Printf("changes result:%+v", result)
-	}
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 7)
-
 }
 
 func TestPostChangesAdminChannelGrant(t *testing.T) {
@@ -547,37 +456,16 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(5)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Issue simple changes request
-	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
-	rest.RequireStatus(t, changesResponse, 200)
-
-	log.Printf("Response:%+v", changesResponse.Body)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 	require.Len(t, changes.Results, 1)
 
 	// Update the user doc to grant access to PBS
 	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", rest.GetUserPayload(t, "", "", "", rt.GetSingleDataStore(), []string{"ABC", "PBS"}, nil))
 	rest.RequireStatus(t, response, 200)
 
-	time.Sleep(500 * time.Millisecond)
-
 	// Issue a new changes request with since=last_seq ensure that user receives all records for channel PBS
-	changesResponse = rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq),
-		"", "bernard")
-	rest.RequireStatus(t, changesResponse, 200)
-
-	log.Printf("Response:%+v", changesResponse.Body)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
+	changes = rt.GetChanges(fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "bernard")
 	require.Len(t, changes.Results, 5) // 4 PBS docs, plus the updated user doc
 
 	// Write a few more docs
@@ -589,12 +477,7 @@ func TestPostChangesAdminChannelGrant(t *testing.T) {
 	cacheWaiter.AddAndWait(2)
 
 	// Issue another changes request - ensure we don't backfill again
-	changesResponse = rt.SendUserRequest("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq),
-		"", "bernard")
-	rest.RequireStatus(t, changesResponse, 200)
-	log.Printf("Response:%+v", changesResponse.Body)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.GetChanges("/{{.keyspace}}/_changes?since="+changes.Last_Seq.String(), "bernard")
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -1012,7 +895,7 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 			c, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 			require.NoError(t, err)
 
-			lastSeq := c.Last_Seq.(string)
+			lastSeq := c.Last_Seq.String()
 
 			resp = sendRequestFn(rt, test.username, http.MethodGet, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&feed=%s&timeout=100", lastSeq, test.feedType), "")
 			rest.RequireStatus(t, resp, http.StatusOK)
@@ -1076,13 +959,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 6))
 
 	// Check the _changes feed:
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq db.SequenceID
-	}
-	response := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
-	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 	require.Len(t, changes.Results, 4)
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
@@ -1091,9 +968,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	// Send another changes request before any changes, with the last_seq received from the last changes ("2::6")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 0)
 
 	// Send a missing doc - low sequence should move to 3
@@ -1105,9 +980,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 3)
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
@@ -1117,11 +990,8 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 1)
-
 }
 
 // Test low sequence handling of late arriving sequences to a one-shot changes feed, ensuring that
@@ -1165,17 +1035,11 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq string
-	}
-	response := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
-	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	require.Len(t, changes.Results, 5) // Includes user doc
+	changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
+	require.Len(t, changes.Results, 5)
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	// Skip sequence 6, write docs 7-10
 	WriteDirect(t, []string{"PBS"}, 7, collection)
@@ -1187,11 +1051,9 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 4)
-	assert.Equal(t, "5::10", changes.Last_Seq)
+	assert.Equal(t, "5::10", changes.Last_Seq.String())
 
 	// Write a few more docs
 	WriteDirect(t, []string{"PBS"}, 11, collection)
@@ -1201,11 +1063,9 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 2)
-	assert.Equal(t, "5::12", changes.Last_Seq)
+	assert.Equal(t, "5::12", changes.Last_Seq.String())
 
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
 	WriteDirect(t, []string{"PBS"}, 13, collection)
@@ -1214,9 +1074,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	log.Printf("_changes 4 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 
 	// Valid results here under race conditions should be:
 	//    receive sequences 6-13, last seq 13
@@ -1231,9 +1089,9 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	//    receives sequence 6, last seq 13
 	switch len(changes.Results) {
 	case 0:
-		assert.Equal(t, "5::12", changes.Last_Seq)
+		assert.Equal(t, "5::12", changes.Last_Seq.String())
 	case 1:
-		switch changes.Last_Seq {
+		switch changes.Last_Seq.String() {
 		case "5::13":
 			assert.Equal(t, uint64(13), changes.Results[0].Seq.Seq)
 		case "6":
@@ -1246,9 +1104,9 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 			t.Errorf("invalid response.  Last_Seq: %v  changes: %v", changes.Last_Seq, changes.Results[0])
 		}
 	case 7:
-		assert.Equal(t, "12", changes.Last_Seq)
+		assert.Equal(t, "12", changes.Last_Seq.String())
 	case 8:
-		assert.Equal(t, "13", changes.Last_Seq)
+		assert.Equal(t, "13", changes.Last_Seq.String())
 	default:
 		t.Errorf("Unexpected number of changes results.  Last_Seq: %v  len(changes): %v", changes.Last_Seq, len(changes.Results))
 	}
@@ -1283,6 +1141,9 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
+
+	const user = "alice"
+	rt.CreateUser(user, []string{"PBS"})
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 
 	// Simulate 5 non-skipped writes (seq 1,2,3,4,5)
@@ -1293,17 +1154,11 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(t, []string{"PBS"}, 5, collection)
 	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 5))
 	// Check the _changes feed:
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq string
-	}
-	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes", "")
-	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes := rt.GetChanges("/{{.keyspace}}/_changes", user)
 	require.Len(t, changes.Results, 5)
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	// Skip sequence 6, write docs 7-10
 	WriteDirect(t, []string{"PBS"}, 7, collection)
@@ -1315,11 +1170,9 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes", changesJSON)
-	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChangesAdmin("/{{.keyspace}}/_changes", changesJSON)
 	require.Len(t, changes.Results, 4)
-	assert.Equal(t, "5::10", changes.Last_Seq)
+	assert.Equal(t, "5::10", changes.Last_Seq.String())
 
 	// Write a few more docs
 	WriteDirect(t, []string{"PBS"}, 11, collection)
@@ -1329,11 +1182,9 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes", changesJSON)
-	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChangesAdmin("/{{.keyspace}}/_changes", changesJSON)
 	require.Len(t, changes.Results, 2)
-	assert.Equal(t, "5::12", changes.Last_Seq)
+	assert.Equal(t, "5::12", changes.Last_Seq.String())
 
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
 	WriteDirect(t, []string{"PBS"}, 13, collection)
@@ -1342,9 +1193,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes", changesJSON)
-	log.Printf("_changes 4 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChangesAdmin("/{{.keyspace}}/_changes", changesJSON)
 
 	// Valid results here under race conditions should be:
 	//    receive sequences 6-13, last seq 13
@@ -1361,7 +1210,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	case 0:
 		assert.Equal(t, "5::12", changes.Last_Seq)
 	case 1:
-		switch changes.Last_Seq {
+		switch changes.Last_Seq.String() {
 		case "5::13":
 			assert.Equal(t, uint64(13), changes.Results[0].Seq.Seq)
 		case "6":
@@ -1374,9 +1223,9 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 			t.Errorf("invalid response.  Last_Seq: %v  changes: %v", changes.Last_Seq, changes.Results[0])
 		}
 	case 7:
-		assert.Equal(t, "12", changes.Last_Seq)
+		assert.Equal(t, "12", changes.Last_Seq.String())
 	case 8:
-		assert.Equal(t, "13", changes.Last_Seq)
+		assert.Equal(t, "13", changes.Last_Seq.String())
 	default:
 		t.Errorf("Unexpected number of changes results.  Last_Seq: %v  len(changes): %v", changes.Last_Seq, len(changes.Results))
 	}
@@ -1425,17 +1274,11 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 5))
 
 	// Check the _changes feed:
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq string
-	}
-	response := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
-	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	require.Len(t, changes.Results, 5) // Includes user doc
+	changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
+	require.Len(t, changes.Results, 5)
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	// Skip sequence 6, write docs 7-10
 	WriteDirect(t, []string{"PBS"}, 7, collection)
@@ -1447,11 +1290,9 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 4)
-	assert.Equal(t, "5::10", changes.Last_Seq)
+	assert.Equal(t, "5::10", changes.Last_Seq.String())
 
 	// Write a few more docs
 	WriteDirect(t, []string{"PBS"}, 11, collection)
@@ -1461,11 +1302,9 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 2)
-	assert.Equal(t, "5::12", changes.Last_Seq)
+	assert.Equal(t, "5::12", changes.Last_Seq.String())
 
 	caughtUpCount := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
 	// Issue a longpoll changes request.  Will block.
@@ -1475,12 +1314,10 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 		defer longpollWg.Done()
 		longpollChangesJSON := fmt.Sprintf(`{"since":"%s", "feed":"longpoll"}`, changes.Last_Seq)
 		log.Printf("starting longpoll changes w/ JSON: %s", longpollChangesJSON)
-		longPollResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", longpollChangesJSON, "bernard")
-		log.Printf("longpoll changes looks like: %s", longPollResponse.Body.Bytes())
-		assert.NoError(t, base.JSONUnmarshal(longPollResponse.Body.Bytes(), &changes))
+		changes := rt.PostChanges("/{{.keyspace}}/_changes", longpollChangesJSON, "bernard")
 		// Expect to get 6 through 12
 		require.Len(t, changes.Results, 7)
-		assert.Equal(t, "12", changes.Last_Seq)
+		assert.Equal(t, "12", changes.Last_Seq.String())
 	}()
 
 	// Wait for longpoll to get into wait mode
@@ -1715,17 +1552,10 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictActive"}], "new_edits":false}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
 	err = rt.WaitForCondition(func() bool {
-		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
+		changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 		return len(changes.Results) == 5
 	})
 	assert.NoError(t, err)
@@ -1744,10 +1574,9 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
+	var changes rest.ChangesResults
 	err = rt.WaitForCondition(func() bool {
-		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
+		changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 		return len(changes.Results) == 5
 	})
 	assert.NoError(t, err)
@@ -1760,13 +1589,11 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 
 	// Active only, POST
 	changesJSON = `{"style":"all_docs", "active_only":true}`
-	changes.Results = nil
 	err = rt.WaitForCondition(func() bool {
-		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
+		changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 		return len(changes.Results) == 3
 	})
+	require.NoError(t, err)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
@@ -1776,13 +1603,11 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 	}
 
 	// Active only, GET
-	changes.Results = nil
 	err = rt.WaitForCondition(func() bool {
-		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs&active_only=true", "", "bernard")
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
+		changes = rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs&active_only=true", "bernard")
 		return len(changes.Results) == 3
 	})
+	require.NoError(t, err)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
@@ -1828,96 +1653,67 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	// Create struct to hold changes response
-	var changes struct {
-		Results []db.ChangeEntry
-	}
-
 	// User has access to single channel
 	body := `{"filter":"_doc_ids", "doc_ids":["doc4", "doc1", "docA", "b0gus"]}`
-	response := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user1")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", body, "user1")
 	require.Len(t, changes.Results, 2)
 	assert.Equal(t, "doc4", changes.Results[1].ID)
 
 	// User has access to different single channel
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "docB", "docD", "doc1"]}`
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user2")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", body, "user2")
 	require.Len(t, changes.Results, 3)
 	assert.Equal(t, "docD", changes.Results[2].ID)
 
 	// User has access to multiple channels
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"]}`
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user3")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", body, "user3")
 	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "docD", changes.Results[3].ID)
 
 	// User has no channel access
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"]}`
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user4")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", body, "user4")
 	require.Len(t, changes.Results, 0)
 
 	// User has "*" channel access
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1", "docA"]}`
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user5")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", body, "user5")
 	require.Len(t, changes.Results, 5)
 
 	// User has "*" channel access, override POST with GET params
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1", "docA"]}`
-	response = rt.SendUserRequest("POST", `/{{.keyspace}}/_changes?doc_ids=["docC","doc1"]`, body, "user5")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges(`/{{.keyspace}}/_changes?doc_ids=["docC","doc1"]`, body, "user5")
 	require.Len(t, changes.Results, 2)
 
 	// User has "*" channel access, use GET
-	response = rt.SendUserRequest("GET", `/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=["docC","doc1","docD"]`, "", "user5")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.GetChanges(`/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=["docC","doc1","docD"]`, "user5")
 	require.Len(t, changes.Results, 3)
 
 	// User has "*" channel access, use GET with doc_ids plain comma separated list
-	response = rt.SendUserRequest("GET", `/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=docC,doc1,doc2,docD`, "", "user5")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.GetChanges(`/{{.keyspace}}/_changes?filter=_doc_ids&doc_ids=docC,doc1,doc2,docD`, "user5")
 	require.Len(t, changes.Results, 4)
 
 	// Admin User
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "docA"]}`
-	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_changes", body)
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChangesAdmin("/{{.keyspace}}/_changes", body)
 	require.Len(t, changes.Results, 4)
 
 	// Use since value to restrict results
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "since":6}`
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user3")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", body, "user3")
 	require.Len(t, changes.Results, 3)
 	assert.Equal(t, "docD", changes.Results[2].ID)
 
 	// Use since value and limit value to restrict results
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "since":6, "limit":1}`
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user3")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", body, "user3")
 	require.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc4", changes.Results[0].ID)
 
 	// test parameter include_docs=true
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "include_docs":true }`
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user3")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", body, "user3")
 	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "docD", changes.Results[3].ID)
 	var docBody db.Body
@@ -1931,9 +1727,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "style":"all_docs"}`
-	response = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", body, "user3")
-	rest.RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", body, "user3")
 	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "docC", changes.Results[3].ID)
 	require.Len(t, changes.Results[3].Changes, 2)
@@ -2064,11 +1858,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	expectedResults[7] = `{"seq":19,"id":"doc_large_numbers","doc":{"_id":"doc_large_numbers","_rev":"1-2721633d9000e606e9c642e98f2f5ae7","channels":["alpha"],"largefloat":1234567890.1234,"largeint":1234567890,"type":"large_numbers"},"changes":[{"rev":"1-2721633d9000e606e9c642e98f2f5ae7"}]}`
 	expectedResults[8] = `{"seq":22,"id":"doc_conflict","doc":{"_id":"doc_conflict","_rev":"2-conflicting_rev","channels":["alpha"],"type":"conflict"},"changes":[{"rev":"2-conflicting_rev"}]}`
 	expectedResults[9] = `{"seq":26,"id":"doc_resolved_conflict","doc":{"_id":"doc_resolved_conflict","_rev":"2-251ba04e5889887152df5e7a350745b4","channels":["alpha"],"type":"resolved_conflict"},"changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"}]}`
-	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "", "user1")
-
-	var changes rest.ChangesResults
-	assert.NoError(t, base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes))
-	assert.Equal(t, len(expectedResults), len(changes.Results))
+	changes := rt.GetChanges("/{{.keyspace}}/_changes?include_docs=true", "user1")
 
 	for index, result := range changes.Results {
 		var expectedChange db.ChangeEntry
@@ -2099,10 +1889,8 @@ func TestChangesIncludeDocs(t *testing.T) {
 	data := collection.GetCollectionDatastore()
 	assert.NoError(t, data.Delete(base.RevPrefix+"doc_pruned:34:2-5afcb73bd3eb50615470e3ba54b80f00"))
 
-	postFlushChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "", "user1")
+	postFlushChanges := rt.GetChanges("/{{.keyspace}}/_changes?include_docs=true", "user1")
 
-	var postFlushChanges rest.ChangesResults
-	assert.NoError(t, base.JSONUnmarshal(postFlushChangesResponse.Body.Bytes(), &postFlushChanges))
 	assert.Equal(t, len(expectedResults), len(postFlushChanges.Results))
 
 	for index, result := range postFlushChanges.Results {
@@ -2141,24 +1929,16 @@ func TestChangesIncludeDocs(t *testing.T) {
 	expectedStyleAllDocs[8] = `{"seq":22,"id":"doc_conflict","changes":[{"rev":"2-conflicting_rev"},{"rev":"2-869a7167ccbad634753105568055bd61"}]}`
 	expectedStyleAllDocs[9] = `{"seq":26,"id":"doc_resolved_conflict","changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"},{"rev":"3-f25ad98ef169791adec6c1d385717b84"}]}`
 
-	styleAllDocsChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs", "", "user1")
-	var allDocsChanges struct {
-		Results []*json.RawMessage
-	}
-	err = base.JSONUnmarshal(styleAllDocsChangesResponse.Body.Bytes(), &allDocsChanges)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, len(expectedStyleAllDocs), len(allDocsChanges.Results))
+	allDocsChanges := rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs", "user1")
 	for index, result := range allDocsChanges.Results {
-		assert.Equal(t, expectedStyleAllDocs[index], fmt.Sprintf("%s", *result))
+		assert.Equal(t, expectedStyleAllDocs[index], fmt.Sprintf("%s", base.MustJSONMarshal(t, result)))
 	}
 
 	// Validate style=all_docs, include_docs=true permutations.  Only modified doc from include_docs test is doc_conflict (adds open revisions)
 	expectedResults[8] = `{"seq":22,"id":"doc_conflict","doc":{"_id":"doc_conflict","_rev":"2-conflicting_rev","channels":["alpha"],"type":"conflict"},"changes":[{"rev":"2-conflicting_rev"},{"rev":"2-869a7167ccbad634753105568055bd61"}]}`
 	expectedResults[9] = `{"seq":26,"id":"doc_resolved_conflict","doc":{"_id":"doc_resolved_conflict","_rev":"2-251ba04e5889887152df5e7a350745b4","channels":["alpha"],"type":"resolved_conflict"},"changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"},{"rev":"3-f25ad98ef169791adec6c1d385717b84"}]}`
 
-	combinedChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs&include_docs=true", "", "user1")
-	var combinedChanges rest.ChangesResults
-	assert.NoError(t, base.JSONUnmarshal(combinedChangesResponse.Body.Bytes(), &combinedChanges))
+	combinedChanges := rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs&include_docs=true", "user1")
 	assert.Equal(t, len(expectedResults), len(combinedChanges.Results))
 
 	for index, result := range combinedChanges.Results {
@@ -2223,37 +2003,20 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	// Flush the channel cache
 	assert.NoError(t, collection.FlushChannelCache(ctx))
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Initialize query count
 	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 
 	// Issue a since=0 changes request.  Validate that there is a view-based backfill
-	changes.Results = nil
 	changesJSON := `{"since":0, "limit":50}`
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 10)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there has been a view query
 	secondQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, queryCount+1, secondQueryCount)
 
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 10)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	thirdQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, secondQueryCount, thirdQueryCount)
 
@@ -2299,63 +2062,35 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	assert.NoError(t, collection.FlushChannelCache(ctx))
 
 	// Issue a since=0 changes request, with limit less than the number of PBS documents
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 
 	// Issue a since=0, limit 5 changes request.  Results shouldn't be prepended to the cache, since they aren't
 	// contiguous with the cache's validFrom.
-	changes.Results = nil
 	changesJSON := `{"since":0, "limit":5}`
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 
 	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	log.Printf("After initial changes request, query count is :%d", queryCount)
 
 	// Issue another since=0, limit 5 changes request.  Validate that there is another a view-based backfill
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there has been one more view query
 	secondQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, queryCount+1, secondQueryCount)
 
 	// Issue a since=20, limit 5 changes request.  Results should be prepended to the cache (seqs 23, 26, 29)
-	changes.Results = nil
 	changesJSON = `{"since":20, "limit":5}`
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 3)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there has been one more view query
 	thirdQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, secondQueryCount+1, thirdQueryCount)
 
 	// Issue a since=20, limit 5 changes request again.  Results should be served from the cache (seqs 23, 26, 29)
-	changes.Results = nil
 	changesJSON = `{"since":20, "limit":5}`
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 3)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there hasn't been another view query
 	fourthQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, thirdQueryCount, fourthQueryCount)
@@ -2401,46 +2136,24 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	assert.NoError(t, collection.FlushChannelCache(ctx))
 
 	// Issue a since=n changes request, where n > 0 and is a non-PBS sequence.  Validate that there's a view-based backfill
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 	changesJSON := `{"since":15, "limit":50}`
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 
 	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	log.Printf("After initial changes request, query count is :%d", queryCount)
 
 	// Issue a since=0 changes request.  Expect a second view query to retrieve the additional results
-	changes.Results = nil
 	changesJSON = `{"since":0, "limit":50}`
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 10)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there has been one more view query
 	secondQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, queryCount+1, secondQueryCount)
 
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 10)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there haven't been any more view queries
 	thirdQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, secondQueryCount, thirdQueryCount)
@@ -2502,33 +2215,17 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Issue a since=n changes request, where 0 < n < 30 (high sequence at cache init)Validate that there's a view-based backfill
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 	changesJSON := `{"since":15, "limit":50}`
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 6)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 
 	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	log.Printf("After initial changes request, query count is :%d", queryCount)
 
 	// Issue the same changes request.  Validate that there is not another a view-based backfill
-	changes.Results = nil
 	changesJSON = `{"since":15, "limit":50}`
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 6)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there has been one more view query
 	secondQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, queryCount, secondQueryCount)
@@ -2578,31 +2275,15 @@ func TestChangesViewBackfill(t *testing.T) {
 	cacheWaiter.AddAndWait(2)
 
 	// Issue a since=0 changes request.  Validate that there's a view-based backfill
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 	changesJSON := `{"since":0, "limit":50}`
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	log.Printf("After initial changes request, query count is: %d", queryCount)
 
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there haven't been any more view queries
 	assert.Equal(t, testDb.DbStats.Cache().ViewQueries.Value(), queryCount)
 
@@ -2652,14 +2333,8 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	cacheWaiter.Wait()
 
 	// Issue a since=0 changes request.  Validate that there's a view-based backfill
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 	changesJSON := `{"since":0, "limit":50}`
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
 	for index, entry := range changes.Results {
@@ -2671,10 +2346,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	log.Printf("After initial changes request, query count is: %d", queryCount)
 
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
 	for index, entry := range changes.Results {
 		// Expects docs in sequence order from 1-5
@@ -2832,15 +2504,8 @@ func TestChangesQueryBackfillWithLimit(t *testing.T) {
 			startQueryCount := testDb.GetChannelQueryCount()
 
 			// Issue a since=0 changes request.
-			var changes struct {
-				Results  []db.ChangeEntry
-				Last_Seq interface{}
-			}
 			changesJSON := fmt.Sprintf(`{"since":0, "limit":%d}`, test.requestLimit)
-			changes.Results = nil
-			changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, username)
-			err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-			assert.NoError(t, err, "Error unmarshalling changes response")
+			changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, username)
 			require.Equal(t, test.expectedResultCount, len(changes.Results))
 
 			// Validate expected number of queries
@@ -2896,15 +2561,8 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 	assert.NoError(t, collection.FlushChannelCache(ctx))
 
 	// 1. Issue a since=0 changes request, validate results
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 	changesJSON := fmt.Sprintf(`{"since":0}`)
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, username)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, username)
 	require.Len(t, changes.Results, 50)
 
 	// Verify results ordering
@@ -2914,12 +2572,8 @@ func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
 
 	// 2. Same again, but with limit on the changes request
 	assert.NoError(t, collection.FlushChannelCache(ctx))
-	changes.Results = nil
 	changesJSON = fmt.Sprintf(`{"since":0, "limit":25}`)
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, username)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, username)
 	require.Len(t, changes.Results, 25)
 
 	// Verify results ordering
@@ -2965,15 +2619,8 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 	startQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 
 	// Issue a since=0 changes request.  Validate that there's a view-based backfill
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 	changesJSON := `{"since":0, "limit":7}`
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Equal(t, len(changes.Results), 7)
 	finalQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, int64(2), finalQueryCount-startQueryCount)
@@ -3059,15 +2706,8 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	//   4. doc1 rev-1 is prepended to the cache
 	//   5. Returns 1 + 2 (doc 2, doc 1 rev-1).  This is correct (doc1 rev2 wasn't cached when the changes query was issued),
 	//      but now the cache has two versions of doc1.  Subsequent changes request will returns duplicates.
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
 	changesJSON := `{"since":0, "limit":50}`
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 2)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3078,14 +2718,8 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	leakyDataStore.SetPostQueryCallback(nil)
 
 	// Issue another since=0 changes request - cache SHOULD only have a single rev for doc1
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 2)
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
 	// Validate that there haven't been any more view queries
 	updatedQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	log.Printf("After second changes request, query count is: %d", updatedQueryCount)
@@ -3154,16 +2788,9 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(1)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
 
 	// Delete
@@ -3204,9 +2831,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3217,10 +2842,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	// Active only NO Limit, POST
 	changesJSON = `{"style":"all_docs", "active_only":true}`
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3232,10 +2854,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	// Active only with Limit, POST
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3245,10 +2864,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 		}
 	}
 	// Active only with Limit, GET
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs&active_only=true&limit=5", "", "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs&active_only=true&limit=5", "bernard")
 	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3259,10 +2875,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	// Active only with Limit set higher than number of revisions, POST
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3326,16 +2939,9 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	cacheWaiter.AddAndWait(1)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Get pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
 
 	// Delete
@@ -3366,9 +2972,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3382,10 +2986,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	assert.NoError(t, collection.FlushChannelCache(ctx))
 
 	changesJSON = `{"style":"all_docs", "active_only":true}`
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3398,10 +2999,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	// Active only with Limit, POST
 	assert.NoError(t, collection.FlushChannelCache(ctx))
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3413,10 +3011,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	// Active only with Limit, GET
 	assert.NoError(t, collection.FlushChannelCache(ctx))
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs&active_only=true&limit=5", "", "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs&active_only=true&limit=5", "bernard")
 	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3428,10 +3023,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	// Active only with Limit set higher than number of revisions, POST
 	assert.NoError(t, collection.FlushChannelCache(ctx))
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3443,10 +3035,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	// No limit active only, GET, followed by normal (https://github.com/couchbase/sync_gateway/issues/2955)
 	assert.NoError(t, collection.FlushChannelCache(ctx))
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs&active_only=true", "", "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs&active_only=true", "bernard")
 	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3455,15 +3044,8 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 		}
 	}
 
-	var updatedChanges struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &updatedChanges)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	require.Len(t, updatedChanges.Results, 10)
-
+	changes = rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
+	require.Len(t, changes.Results, 10)
 }
 
 func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
@@ -3567,10 +3149,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 
 	// Active only NO Limit, POST
 	changesJSON := `{"style":"all_docs", "active_only":true}`
-	changes.Results = nil
-	changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3582,10 +3161,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 
 	// Active only with Limit, POST
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3595,10 +3171,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 		}
 	}
 	// Active only with Limit, GET
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?style=all_docs&active_only=true&limit=5", "", "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.GetChanges("/{{.keyspace}}/_changes?style=all_docs&active_only=true&limit=5", "bernard")
 	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3609,10 +3182,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 
 	// Active only with Limit set higher than number of revisions, POST
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
-	changes.Results = nil
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", changesJSON, "bernard")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", changesJSON, "bernard")
 	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -3644,18 +3214,10 @@ func TestChangesIncludeConflicts(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/conflictedDoc?new_edits=false", `{"_revisions":{"start":2, "ids":["conflictTwo", "82214a562e80c8fa7b2361719847bc73"]}, "value":"c2", "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Get changes
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	changesResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes?style=all_docs", "")
-	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	log.Printf("changes response: %s", changesResponse.Body.Bytes())
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChangesAdmin("/{{.keyspace}}/_changes?style=all_docs", "{}")
 	require.Len(t, changes.Results, 1)
 	require.Len(t, changes.Results[0].Changes, 2)
 
@@ -3687,35 +3249,28 @@ func TestChangesLargeSequences(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
+	const user = "alice"
+
+	rt.CreateUser(user, []string{"PBS"})
+
 	// Create document
 	response := rt.SendAdminRequest("PUT", "/db/largeSeqDocForChanges", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Get changes
 	require.NoError(t, rt.WaitForPendingChanges())
 
-	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775800", "")
-	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.GetChanges("/{{.keyspace}/_changes?since=9223372036854775800", user)
 	require.Len(t, changes.Results, 1)
 	assert.Equal(t, uint64(9223372036854775808), changes.Results[0].Seq.Seq)
 	assert.Equal(t, "9223372036854775808", changes.Last_Seq)
 
 	// Validate incoming since value isn't being truncated
-	changesResponse = rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775808", "")
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.GetChanges("/{{.keyspace}}/_changes?since=9223372036854775808", user)
 	require.Len(t, changes.Results, 0)
 
 	// Validate incoming since value isn't being truncated
-	changesResponse = rt.SendAdminRequest("POST", "/db/_changes", `{"since":9223372036854775808}`)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes = rt.PostChangesAdmin("/{{.keyspace}}/_changes", `{"since":9223372036854775808}`)
 	require.Len(t, changes.Results, 0)
 
 }
@@ -3746,28 +3301,15 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 
 	cacheWaiter.AddAndWait(3)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Get as admin
-	changes.Results = nil
-	changesResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "")
-	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	log.Printf("admin response: %s", changesResponse.Body.Bytes())
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	changes := rt.PostChangesAdmin("/{{.keyspace}}/_changes?include_docs=true", "{}")
 	// Expect three docs, no user docs
 	require.Len(t, changes.Results, 3)
 
 	// Get as user
-	changes.Results = nil
-	userChangesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?include_docs=true", "", "includeDocsUser")
-	err = base.JSONUnmarshal(userChangesResponse.Body.Bytes(), &changes)
-	log.Printf("userChangesResponse: %s", userChangesResponse.Body.Bytes())
-	assert.NoError(t, err, "Error unmarshalling changes response")
+	userChanges := rt.GetChanges("/{{.keyspace}}/_changes?include_docs=true", "includeDocsUser")
 	// Expect three docs and the authenticated user's user doc
-	require.Len(t, changes.Results, 4)
+	require.Len(t, userChanges.Results, 4)
 
 }
 
@@ -3796,11 +3338,6 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	caughtUpCount := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
 
 	// Issue longpoll changes request
@@ -3809,9 +3346,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 	go func() {
 		defer longpollWg.Done()
 		longpollChangesJSON := `{"since":0, "feed":"longpoll"}`
-		longPollResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", longpollChangesJSON, "bernard")
-		log.Printf("longpoll changes response looks like: %s", longPollResponse.Body.Bytes())
-		assert.NoError(t, base.JSONUnmarshal(longPollResponse.Body.Bytes(), &changes))
+		changes := rt.PostChanges("/{{.keyspace}}/_changes", longpollChangesJSON, "bernard")
 		// Expect to get 4 docs plus user doc
 		require.Len(t, changes.Results, 5)
 	}()
@@ -3857,14 +3392,9 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 		longpollWg.Add(1)
 		go func(i int) {
 			defer longpollWg.Done()
-			var changes struct {
-				Results  []db.ChangeEntry
-				Last_Seq interface{}
-			}
 			channelName := fmt.Sprintf("chan_%d", i)
 			changesURL := fmt.Sprintf(changesURLPattern, channelName)
-			changesResponse := rt.SendAdminRequest("GET", changesURL, "")
-			assert.NoError(t, base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes))
+			changes := rt.PostChangesAdmin(changesURL, "{}")
 			// Expect to get 1 doc
 			require.Len(t, changes.Results, 1)
 		}(i)
@@ -4070,11 +3600,6 @@ func TestOneShotGrantTiming(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs-4", `{"channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	var changes struct {
-		Results  []db.ChangeEntry
-		Last_Seq interface{}
-	}
-
 	// Allocate a sequence but do not write a doc for it - will block DCP buffering until sequence is skipped
 	slowSequence, seqErr := db.AllocateTestSequence(database)
 	require.NoError(t, seqErr)
@@ -4086,13 +3611,7 @@ func TestOneShotGrantTiming(t *testing.T) {
 
 	// Issue normal one-shot changes request.  Expect no results as granting document hasn't been buffered (blocked by
 	// slowSequence)
-	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
-	rest.RequireStatus(t, changesResponse, 200)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
+	changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 	require.Len(t, changes.Results, 0)
 
 	// Release the slow sequence and wait for it to be processed over DCP
@@ -4101,15 +3620,8 @@ func TestOneShotGrantTiming(t *testing.T) {
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Issue normal one-shot changes request.  Expect results as granting document buffering is unblocked
-	changesResponse = rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
-	rest.RequireStatus(t, changesResponse, 200)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
+	changes = rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 	require.Len(t, changes.Results, 4)
-
 }
 
 // TestOneShotGrantRequestPlus simulates a one-shot changes feed being made before a previously issued grant has been
@@ -4164,14 +3676,7 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
-		var changes rest.ChangesResults
-		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?request_plus=true", "", "bernard")
-		rest.RequireStatus(t, changesResponse, 200)
-		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
-		for _, entry := range changes.Results {
-			log.Printf("Entry:%+v", entry)
-		}
+		changes := rt.GetChanges("/{{.keyspace}}/_changes?request_plus=true", "bernard")
 		require.Len(t, changes.Results, 4)
 	}()
 
@@ -4179,14 +3684,7 @@ func TestOneShotGrantRequestPlus(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
-		var changes rest.ChangesResults
-		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{"request_plus":true}`, "bernard")
-		rest.RequireStatus(t, changesResponse, 200)
-		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
-		for _, entry := range changes.Results {
-			log.Printf("Entry:%+v", entry)
-		}
+		changes := rt.PostChanges("/{{.keyspace}}/_changes", `{"request_plus":true}`, "bernard")
 		require.Len(t, changes.Results, 4)
 	}()
 
@@ -4254,25 +3752,12 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 
 	// Issue one-shot GET changes request explicitly setting request_plus=false (should override config value).
 	// Expect no results as granting document hasn't been buffered (blocked by slowSequence)
-	changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes?request_plus=false", "", "bernard")
-	rest.RequireStatus(t, changesResponse, 200)
-	var changes rest.ChangesResults
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
+	changes := rt.GetChanges("/{{.keyspace}}/_changes?request_plus=false", "bernard")
 	require.Len(t, changes.Results, 0)
 
 	// Issue one-shot POST changes request explicitly setting request_plus=false (should override config value).
 	// Expect no results as granting document hasn't been buffered (blocked by slowSequence)
-	changesResponse = rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{"request_plus":false}`, "bernard")
-	rest.RequireStatus(t, changesResponse, 200)
-	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-	assert.NoError(t, err, "Error unmarshalling changes response")
-	for _, entry := range changes.Results {
-		log.Printf("Entry:%+v", entry)
-	}
+	changes = rt.PostChanges("/{{.keyspace}}/_changes", `{"request_plus":false}`, "bernard")
 	require.Len(t, changes.Results, 0)
 
 	caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
@@ -4282,14 +3767,7 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
-		var changes rest.ChangesResults
-		changesResponse := rt.SendUserRequest("GET", "/{{.keyspace}}/_changes", "", "bernard")
-		rest.RequireStatus(t, changesResponse, 200)
-		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
-		for _, entry := range changes.Results {
-			log.Printf("Entry:%+v", entry)
-		}
+		changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 		require.Len(t, changes.Results, 4)
 	}()
 
@@ -4297,14 +3775,7 @@ func TestOneShotGrantRequestPlusDbConfig(t *testing.T) {
 	oneShotComplete.Add(1)
 	go func() {
 		defer oneShotComplete.Done()
-		var changes rest.ChangesResults
-		changesResponse := rt.SendUserRequest("POST", "/{{.keyspace}}/_changes", `{}`, "bernard")
-		rest.RequireStatus(t, changesResponse, 200)
-		err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.NoError(t, err, "Error unmarshalling changes response")
-		for _, entry := range changes.Results {
-			log.Printf("Entry:%+v", entry)
-		}
+		changes := rt.PostChanges("/{{.keyspace}}/_changes", `{}`, "bernard")
 		require.Len(t, changes.Results, 4)
 	}()
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2264,8 +2264,7 @@ func TestImportRollback(t *testing.T) {
 			// wait for doc to be imported
 			changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 			require.NoError(t, err)
-			lastSeq, ok := changes.Last_Seq.(string)
-			require.True(t, ok)
+			lastSeq := changes.Last_Seq.String()
 
 			// Close db while we mess with checkpoints
 			db := rt.GetDatabase()

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -494,7 +494,7 @@ func TestPushReplicationAPI(t *testing.T) {
 	_ = rt2.PutDoc(docID2, `{"source":"rt1","channels":["alice"]}`)
 
 	// wait for doc2 to arrive at rt2
-	changesResults = rt2.RequireWaitChanges(1, changesResults.Last_Seq.(string))
+	changesResults = rt2.RequireWaitChanges(1, changesResults.Last_Seq.String())
 	assert.Equal(t, docID2, changesResults.Results[0].ID)
 
 	// Validate doc2 contents
@@ -537,7 +537,7 @@ func TestPullReplicationAPI(t *testing.T) {
 	_ = rt2.PutDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
 
 	// wait for new document to arrive at rt1
-	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.(string))
+	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.String())
 	changesResults.RequireDocIDs(t, []string{docID2})
 
 	// Validate doc2 contents
@@ -735,7 +735,7 @@ func TestReplicationStatusActions(t *testing.T) {
 	_ = rt2.PutDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
 
 	// wait for new document to arrive at rt1
-	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.(string))
+	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.String())
 	changesResults.RequireDocIDs(t, []string{docID2})
 
 	// Validate doc2 contents
@@ -861,7 +861,7 @@ func TestReplicationRebalancePull(t *testing.T) {
 	_ = remoteRT.PutDoc(docDEF2, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at activeRT
-	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.(string))
+	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.String())
 	changesResults.RequireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents
@@ -966,7 +966,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 	_ = activeRT.PutDoc(docDEF2, `{"source":"activeRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at remote
-	changesResults = remoteRT.RequireWaitChanges(2, changesResults.Last_Seq.(string))
+	changesResults = remoteRT.RequireWaitChanges(2, changesResults.Last_Seq.String())
 	changesResults.RequireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents
@@ -1789,7 +1789,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	_ = remoteRT.PutDoc(docDEF2, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at activeRT
-	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.(string))
+	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.String())
 	changesResults.RequireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents via both active nodes
@@ -1827,7 +1827,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	docDEF3 := t.Name() + "DEF3"
 	_ = remoteRT.PutDoc(docDEF3, `{"source":"remoteRT","channels":["DEF"]}`)
 
-	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.(string))
+	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.String())
 	changesResults.RequireDocIDs(t, []string{docABC3, docDEF3})
 
 	// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
@@ -2828,7 +2828,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			lastSeq := changesResults.Last_Seq.(string)
+			lastSeq := changesResults.Last_Seq.String()
 
 			resp := rt1.SendAdminRequest(http.MethodPut, "/{{.db}}/_replicationStatus/repl1?action=stop", "")
 			rest.RequireStatus(t, resp, http.StatusOK)
@@ -2842,7 +2842,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			lastSeq = changesResults.Last_Seq.(string)
+			lastSeq = changesResults.Last_Seq.String()
 
 			resp = rt2.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID+"?rev="+version1.RevID, test.remoteConflictingRevBody)
 			rest.RequireStatus(t, resp, http.StatusCreated)
@@ -2856,7 +2856,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, changesResults.Results, 1)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			_ = changesResults.Last_Seq.(string)
+			_ = changesResults.Last_Seq.String()
 
 			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
 			doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
@@ -5131,7 +5131,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
-	lastSeq := changesResults.Last_Seq.(string)
+	lastSeq := changesResults.Last_Seq.String()
 
 	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
 	doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -136,11 +136,7 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 	assert.NoError(tester.test, err)
 
 	err = tester.restTester.WaitForCondition(func() bool {
-		resp := tester.restTester.SendUserRequestWithHeaders("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%v&revocations=true", sinceSeq), "", nil, "user", RestTesterDefaultUserPassword)
-		require.Equal(tester.test, http.StatusOK, resp.Code)
-		err := json.Unmarshal(resp.BodyBytes(), &changes)
-		require.NoError(tester.test, err)
-
+		changes = tester.restTester.GetChanges(fmt.Sprintf("/{{.keyspace}}/_changes?since=%v&revocations=true", sinceSeq), "user")
 		return len(changes.Results) == expectedLength
 	})
 	require.NoError(tester.test, err, fmt.Sprintf("Unexpected: %d. Expected %d", len(changes.Results), expectedLength))
@@ -211,19 +207,19 @@ func TestRevocationScenario1(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "20:3", changes.Last_Seq)
+	assert.Equal(t, "20:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(40)
 
 	changes = revocationTester.getChanges(25, 0)
-	assert.Equal(t, "25", changes.Last_Seq)
+	assert.Equal(t, "25", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(44)
 	revocationTester.removeRole("user", "foo")
@@ -236,7 +232,7 @@ func TestRevocationScenario1(t *testing.T) {
 	revocationTester.fillToSeq(80)
 
 	changes = revocationTester.getChanges(40, 1)
-	assert.Equal(t, "75:3", changes.Last_Seq)
+	assert.Equal(t, "75:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
@@ -245,7 +241,7 @@ func TestRevocationScenario1(t *testing.T) {
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
-	assert.Equal(t, "85:3", changes.Last_Seq)
+	assert.Equal(t, "85:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -262,21 +258,21 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "20:3", changes.Last_Seq)
+	assert.Equal(t, "20:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(44)
 	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(50)
 	changes = revocationTester.getChanges(25, 1)
-	assert.Equal(t, "45:3", changes.Last_Seq)
+	assert.Equal(t, "45:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(54)
@@ -288,7 +284,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.fillToSeq(80)
 
 	changes = revocationTester.getChanges(50, 1)
-	assert.Equal(t, "75:3", changes.Last_Seq)
+	assert.Equal(t, "75:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
@@ -297,7 +293,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
-	assert.Equal(t, "85:3", changes.Last_Seq)
+	assert.Equal(t, "85:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -314,14 +310,14 @@ func TestRevocationScenario3(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "20:3", changes.Last_Seq)
+	assert.Equal(t, "20:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(44)
 	revocationTester.removeRole("user", "foo")
@@ -330,7 +326,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	revocationTester.fillToSeq(60)
 	changes = revocationTester.getChanges(25, 1)
-	assert.Equal(t, "45:3", changes.Last_Seq)
+	assert.Equal(t, "45:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(64)
@@ -340,7 +336,7 @@ func TestRevocationScenario3(t *testing.T) {
 	revocationTester.fillToSeq(80)
 
 	changes = revocationTester.getChanges(50, 1)
-	assert.Equal(t, "75:3", changes.Last_Seq)
+	assert.Equal(t, "75:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
@@ -349,7 +345,7 @@ func TestRevocationScenario3(t *testing.T) {
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
-	assert.Equal(t, "85:3", changes.Last_Seq)
+	assert.Equal(t, "85:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -366,14 +362,14 @@ func TestRevocationScenario4(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "20:3", changes.Last_Seq)
+	assert.Equal(t, "20:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(44)
 	revocationTester.removeRole("user", "foo")
@@ -384,7 +380,7 @@ func TestRevocationScenario4(t *testing.T) {
 
 	revocationTester.fillToSeq(70)
 	changes = revocationTester.getChanges(25, 1)
-	assert.Equal(t, "55:3", changes.Last_Seq)
+	assert.Equal(t, "55:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(74)
@@ -392,7 +388,7 @@ func TestRevocationScenario4(t *testing.T) {
 	revocationTester.fillToSeq(80)
 
 	changes = revocationTester.getChanges(50, 1)
-	assert.Equal(t, "75:3", changes.Last_Seq)
+	assert.Equal(t, "75:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
@@ -401,7 +397,7 @@ func TestRevocationScenario4(t *testing.T) {
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
-	assert.Equal(t, "85:3", changes.Last_Seq)
+	assert.Equal(t, "85:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -418,14 +414,14 @@ func TestRevocationScenario5(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "20:3", changes.Last_Seq)
+	assert.Equal(t, "20:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(44)
 	revocationTester.removeRole("user", "foo")
@@ -438,7 +434,7 @@ func TestRevocationScenario5(t *testing.T) {
 	revocationTester.fillToSeq(80)
 
 	changes = revocationTester.getChanges(25, 1)
-	assert.Equal(t, "75:3", changes.Last_Seq)
+	assert.Equal(t, "75:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
@@ -447,7 +443,7 @@ func TestRevocationScenario5(t *testing.T) {
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(80, 1)
-	assert.Equal(t, "85:3", changes.Last_Seq)
+	assert.Equal(t, "85:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -464,14 +460,14 @@ func TestRevocationScenario6(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "20:3", changes.Last_Seq)
+	assert.Equal(t, "20:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(44)
 	revocationTester.removeRole("user", "foo")
@@ -487,7 +483,7 @@ func TestRevocationScenario6(t *testing.T) {
 	revocationTester.fillToSeq(90)
 
 	changes = revocationTester.getChanges(25, 1)
-	assert.Equal(t, "55:3", changes.Last_Seq)
+	assert.Equal(t, "55:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(94)
@@ -495,7 +491,7 @@ func TestRevocationScenario6(t *testing.T) {
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(90, 0)
-	assert.Equal(t, "90", changes.Last_Seq)
+	assert.Equal(t, "90", changes.Last_Seq.String())
 }
 
 func TestRevocationScenario7(t *testing.T) {
@@ -511,14 +507,14 @@ func TestRevocationScenario7(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
 	revocationTester.fillToSeq(25)
 
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "20:3", changes.Last_Seq)
+	assert.Equal(t, "20:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(44)
 	revocationTester.removeRole("user", "foo")
@@ -536,13 +532,13 @@ func TestRevocationScenario7(t *testing.T) {
 	revocationTester.fillToSeq(100)
 
 	changes = revocationTester.getChanges(25, 1)
-	assert.Equal(t, "45:3", changes.Last_Seq)
+	assert.Equal(t, "45:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.fillToSeq(110)
 
 	changes = revocationTester.getChanges(100, 0)
-	assert.Equal(t, "100", changes.Last_Seq)
+	assert.Equal(t, "100", changes.Last_Seq.String())
 }
 
 func TestRevocationScenario8(t *testing.T) {
@@ -558,7 +554,7 @@ func TestRevocationScenario8(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
@@ -567,7 +563,7 @@ func TestRevocationScenario8(t *testing.T) {
 
 	revocationTester.fillToSeq(50)
 	changes = revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(54)
 	revocationTester.removeRoleChannel("foo", "ch1")
@@ -582,7 +578,7 @@ func TestRevocationScenario8(t *testing.T) {
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(50, 0)
-	assert.Equal(t, "50", changes.Last_Seq)
+	assert.Equal(t, "50", changes.Last_Seq.String())
 }
 
 func TestRevocationScenario9(t *testing.T) {
@@ -598,7 +594,7 @@ func TestRevocationScenario9(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
@@ -609,7 +605,7 @@ func TestRevocationScenario9(t *testing.T) {
 
 	revocationTester.fillToSeq(60)
 	changes = revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(64)
 	revocationTester.addRole("user", "foo")
@@ -622,7 +618,7 @@ func TestRevocationScenario9(t *testing.T) {
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(60, 0)
-	assert.Equal(t, "60", changes.Last_Seq)
+	assert.Equal(t, "60", changes.Last_Seq.String())
 }
 
 func TestRevocationScenario10(t *testing.T) {
@@ -638,7 +634,7 @@ func TestRevocationScenario10(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
@@ -651,7 +647,7 @@ func TestRevocationScenario10(t *testing.T) {
 
 	revocationTester.fillToSeq(70)
 	changes = revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(74)
 	revocationTester.addRoleChannel("foo", "ch1")
@@ -662,7 +658,7 @@ func TestRevocationScenario10(t *testing.T) {
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(70, 0)
-	assert.Equal(t, "70", changes.Last_Seq)
+	assert.Equal(t, "70", changes.Last_Seq.String())
 }
 
 func TestRevocationScenario11(t *testing.T) {
@@ -678,7 +674,7 @@ func TestRevocationScenario11(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
@@ -693,7 +689,7 @@ func TestRevocationScenario11(t *testing.T) {
 
 	revocationTester.fillToSeq(80)
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "75:3", changes.Last_Seq)
+	assert.Equal(t, "75:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(84)
 	revocationTester.removeRoleChannel("foo", "ch1")
@@ -702,7 +698,7 @@ func TestRevocationScenario11(t *testing.T) {
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(80, 1)
-	assert.Equal(t, "85:3", changes.Last_Seq)
+	assert.Equal(t, "85:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -719,7 +715,7 @@ func TestRevocationScenario12(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
@@ -736,14 +732,14 @@ func TestRevocationScenario12(t *testing.T) {
 
 	revocationTester.fillToSeq(90)
 	changes = revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(94)
 	revocationTester.removeRole("user", "foo")
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(90, 0)
-	assert.Equal(t, "90", changes.Last_Seq)
+	assert.Equal(t, "90", changes.Last_Seq.String())
 }
 
 func TestRevocationScenario13(t *testing.T) {
@@ -759,7 +755,7 @@ func TestRevocationScenario13(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
@@ -778,11 +774,11 @@ func TestRevocationScenario13(t *testing.T) {
 
 	revocationTester.fillToSeq(100)
 	changes = revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(110)
 	changes = revocationTester.getChanges(100, 0)
-	assert.Equal(t, "100", changes.Last_Seq)
+	assert.Equal(t, "100", changes.Last_Seq.String())
 }
 
 func TestRevocationScenario14(t *testing.T) {
@@ -798,20 +794,20 @@ func TestRevocationScenario14(t *testing.T) {
 	revocationTester.addRoleChannel("foo", "ch1")
 
 	changes := revocationTester.getChanges(5, 0)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(19)
 	revocationTester.addRole("user", "foo")
 
 	revocationTester.fillToSeq(25)
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "20:3", changes.Last_Seq)
+	assert.Equal(t, "20:3", changes.Last_Seq.String())
 
 	revocationTester.fillToSeq(44)
 	revocationTester.removeRole("user", "foo")
 
 	changes = revocationTester.getChanges(25, 1)
-	assert.Equal(t, "45:3", changes.Last_Seq)
+	assert.Equal(t, "45:3", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -833,7 +829,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 	// Skip to seq 10 then do pull since 4 to get doc
 	revocationTester.fillToSeq(10)
 	changes := revocationTester.getChanges(4, 1)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	// Skip to seq 14 then revoke role from user
 	revocationTester.fillToSeq(14)
@@ -847,7 +843,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 
 	// Get changes and ensure doc is revoked through ID-only revocation
 	changes = revocationTester.getChanges(10, 1)
-	assert.Equal(t, "15:20", changes.Last_Seq)
+	assert.Equal(t, "15:20", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -868,7 +864,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 
 	// Do pull to get doc
 	changes := revocationTester.getChanges(4, 1)
-	assert.Equal(t, "5", changes.Last_Seq)
+	assert.Equal(t, "5", changes.Last_Seq.String())
 
 	// Revoke channel from role at seq 8
 	revocationTester.fillToSeq(7)
@@ -879,7 +875,7 @@ func TestEnsureRevocationUsingDocHistory(t *testing.T) {
 	_ = rt.UpdateDoc(docID, version, `{"channels": "A"}`)
 
 	changes = revocationTester.getChanges(5, 1)
-	assert.Equal(t, "8:10", changes.Last_Seq)
+	assert.Equal(t, "8:10", changes.Last_Seq.String())
 	assert.True(t, changes.Results[0].Revoked)
 }
 
@@ -1205,11 +1201,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 	waitForUserChangesWithLimit := func(sinceVal interface{}, limit int) ChangesResults {
 		var changesRes ChangesResults
 		err := rt.WaitForCondition(func() bool {
-			resp := rt.SendUserRequestWithHeaders("GET", fmt.Sprintf("/{{.keyspace}}/_changes?since=%v&revocations=true&limit=%d", sinceVal, limit), "", nil, "user", RestTesterDefaultUserPassword)
-			require.Equal(t, http.StatusOK, resp.Code)
-			err := json.Unmarshal(resp.BodyBytes(), &changesRes)
-			require.NoError(t, err)
-
+			changesRes = rt.GetChanges(fmt.Sprintf("/{{.keyspace}}/_changes?since=%v&revocations=true&limit=%d", sinceVal, limit), "user")
 			return len(changesRes.Results) == limit
 		})
 		assert.NoError(t, err)

--- a/rest/xattr_upgrade_test.go
+++ b/rest/xattr_upgrade_test.go
@@ -225,9 +225,8 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	require.NoError(t, rt.WaitForSequence(1))
 
 	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
-	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/_changes", "")
-	assert.Equal(t, 200, response.Code)
-	log.Printf("response:%s", response.Body.Bytes())
+	changes := rt.PostChangesAdmin("/{{.keyspace}}/_changes", "{}")
+	require.Len(t, changes.Results, 1)
 
 	// Validate non-xattr document doesn't get processed on attempted feed read
 	nonMobileKey := "TestUpgradeNoXattr"


### PR DESCRIPTION
Create helper functions for managing _changes requests. This has a few advantages:

1.  Allows recognition of when a changes feed is called so we can call `rt.WaitForPendingChanges`.
2. Removes boilerplate from declaring and unmarshaling changes. This is done in a way where the `ChangesResult` structure was reused and `Last_Seq` was not always cleared. In practice, this didn't cause a problem but having a separate structure is less error prone.

There's a secondary PR handles the changes to `WaitForPendingChanges` that will go on top of this one. It was intentionally omitted to make it easier to read. I recommend merging part 2 into part 1 after reviewing this.
