### PR TITLE
CBG-3818 Create and use GetChanges consistently (part 2)

### DIFF
--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -965,8 +965,9 @@ func TestAccessOnTombstone(t *testing.T) {
 	RequireStatus(t, response, 201)
 	version := DocVersionFromPutResponse(t, response)
 
-	// Validate the user gets the doc on the _changes feed
 	rt.WaitForPendingChanges()
+
+	// Validate the user gets the doc on the _changes feed
 	changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 	require.Len(t, changes.Results, 1)
 	require.Equal(t, "alpha", changes.Results[0].ID)
@@ -980,6 +981,7 @@ func TestAccessOnTombstone(t *testing.T) {
 
 	// Wait for change caching to complete
 	rt.WaitForPendingChanges()
+
 	// Check user access again:
 	changes = rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 	require.Len(t, changes.Results, 1)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -965,9 +965,8 @@ func TestAccessOnTombstone(t *testing.T) {
 	RequireStatus(t, response, 201)
 	version := DocVersionFromPutResponse(t, response)
 
-	assert.NoError(t, rt.WaitForPendingChanges())
-
 	// Validate the user gets the doc on the _changes feed
+	rt.WaitForPendingChanges()
 	changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 	require.Len(t, changes.Results, 1)
 	require.Equal(t, "alpha", changes.Results[0].ID)
@@ -980,8 +979,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	RequireStatus(t, response, 404)
 
 	// Wait for change caching to complete
-	assert.NoError(t, rt.WaitForPendingChanges())
-
+	rt.WaitForPendingChanges()
 	// Check user access again:
 	changes = rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
 	require.Len(t, changes.Results, 1)

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -252,7 +252,7 @@ func TestMultiCollectionDCP(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	for _, ks := range rt.GetKeyspaces() {
 		_, err = rt.WaitForChanges(1, fmt.Sprintf("/%s/_changes", ks), "", true)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1824,8 +1824,9 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?rev="+docRevID2, `{"channels": ["B"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
-	// Changes call, one user, one doc
 	rt.WaitForPendingChanges()
+
+	// Changes call, one user, one doc
 	changes := rt.GetChanges("/{{.keyspace}}/_changes", "jacques")
 	require.Len(t, changes.Results, 2)
 	assert.Equal(t, changes.Results[1].Deleted, false)
@@ -1854,6 +1855,7 @@ func TestChanCacheActiveRevsStat(t *testing.T) {
 	RequireStatus(t, response, http.StatusCreated)
 
 	rt.WaitForPendingChanges()
+
 	changes := rt.PostChangesAdmin("/{{.keyspace}}/_changes?active_only=true&include_docs=true&filter=sync_gateway/bychannel&channels=a&feed=normal&since=0&heartbeat=0&timeout=300000", "{}")
 	assert.Equal(t, 2, len(changes.Results))
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1700,6 +1700,9 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// Put a document to increment the counter for the * channel
 	rt.PutDoc("lost", `{"channel":["ABC"]}`)
 
+	// make sure docs are written to change cache
+	rt.WaitForPendingChanges()
+
 	// Previous bug: changeWaiter was treating the implicit '*' wildcard in the _changes request as the '*' channel, so the wait counter
 	// was being initialized to 1 (the previous PUT).  Later the wildcard was resolved to actual channels (PBS, _sync:user:bernard), which
 	// has a wait counter of zero (no documents writted since the listener was restarted).
@@ -1821,9 +1824,8 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1?rev="+docRevID2, `{"channels": ["B"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
-	require.NoError(t, rt.WaitForPendingChanges())
-
 	// Changes call, one user, one doc
+	rt.WaitForPendingChanges()
 	changes := rt.GetChanges("/{{.keyspace}}/_changes", "jacques")
 	require.Len(t, changes.Results, 2)
 	assert.Equal(t, changes.Results[1].Deleted, false)
@@ -1851,9 +1853,7 @@ func TestChanCacheActiveRevsStat(t *testing.T) {
 	rev2 := fmt.Sprint(responseBody["rev"])
 	RequireStatus(t, response, http.StatusCreated)
 
-	err = rt.WaitForPendingChanges()
-	assert.NoError(t, err)
-
+	rt.WaitForPendingChanges()
 	changes := rt.PostChangesAdmin("/{{.keyspace}}/_changes?active_only=true&include_docs=true&filter=sync_gateway/bychannel&channels=a&feed=normal&since=0&heartbeat=0&timeout=300000", "{}")
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -1863,8 +1863,7 @@ func TestChanCacheActiveRevsStat(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/testdoc2?new_edits=true&rev="+rev2, `{"value":"a value", "channels":[]}`)
 	RequireStatus(t, response, http.StatusCreated)
 
-	err = rt.WaitForPendingChanges()
-	assert.NoError(t, err)
+	rt.WaitForPendingChanges()
 
 	assert.Equal(t, 0, int(rt.GetDatabase().DbStats.Cache().ChannelCacheRevsActive.Value()))
 
@@ -2626,30 +2625,6 @@ func TestChannelHistoryLegacyDoc(t *testing.T) {
 
 type ChannelsTemp struct {
 	Channels map[string][]string `json:"channels"`
-}
-
-func (rt *RestTester) CreateDocReturnRev(t *testing.T, docID string, revID string, bodyIn interface{}) string {
-	bodyJSON, err := base.JSONMarshal(bodyIn)
-	assert.NoError(t, err)
-
-	url := "/{{.keyspace}}/" + docID
-	if revID != "" {
-		url += "?rev=" + revID
-	}
-
-	resp := rt.SendAdminRequest("PUT", url, string(bodyJSON))
-	RequireStatus(t, resp, http.StatusCreated)
-
-	var body db.Body
-	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
-	assert.Equal(t, true, body["ok"])
-	revID = body["rev"].(string)
-	if revID == "" {
-		t.Fatalf("No revID in response for PUT doc")
-	}
-
-	require.NoError(t, rt.WaitForPendingChanges())
-	return revID
 }
 
 func TestMetricsHandler(t *testing.T) {

--- a/rest/api_test_helpers.go
+++ b/rest/api_test_helpers.go
@@ -67,7 +67,7 @@ func (rt *RestTester) PutNewEditsFalse(docID string, newVersion DocVersion, pare
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID+"?new_edits=false", string(requestBytes))
 	RequireStatus(rt.TB(), resp, 201)
 
-	require.NoError(rt.TB(), rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	return DocVersionFromPutResponse(rt.TB(), resp)
 }

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2246,8 +2246,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 	// Otherwise attachment will not be purged
 	_, _, err = dataStore.GetRaw(att2Key)
 	if base.TestUseXattrs() {
-		assert.Error(t, err)
-		assert.True(t, base.IsDocNotFoundError(err))
+		base.RequireDocNotFoundError(t, err)
 	} else {
 		assert.NoError(t, err)
 	}
@@ -2473,6 +2472,8 @@ func TestProveAttachmentNotFound(t *testing.T) {
 	sent, _, _, err := bt.SendRev("doc1", "1-abc", []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentDataEncoded+`"}}}`), blip.Properties{})
 	require.True(t, sent)
 	require.NoError(t, err)
+
+	rt.WaitForPendingChanges()
 
 	// Should log:
 	// "Peer sent prove attachment error 404 attachment not found, falling back to getAttachment for proof in doc <ud>doc1</ud> (digest sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=)"

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2099,8 +2099,6 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 
 	// Create doc rev 2 with attachment
 	version = rt.UpdateDoc(docID, version, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-	err := rt.WaitForPendingChanges()
-	assert.NoError(t, err)
 
 	// Create doc rev 3 referencing previous attachment
 	losingVersion3 := rt.UpdateDoc(docID, version, `{"_attachments": {"hello.txt": {"revpos":2,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`)
@@ -2120,7 +2118,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 	resp := rt.SendAdminRequestWithHeaders("GET", "/{{.keyspace}}/doc?attachments=true&rev="+losingVersion3.RevID, "", map[string]string{"Accept": "application/json"})
 	RequireStatus(t, resp, http.StatusOK)
 
-	err = base.JSONUnmarshal(resp.BodyBytes(), &doc1)
+	err := base.JSONUnmarshal(resp.BodyBytes(), &doc1)
 	assert.NoError(t, err)
 	require.Contains(t, doc1.Attachments, "hello.txt")
 	attachmentData, ok := doc1.Attachments["hello.txt"].(map[string]interface{})
@@ -2194,15 +2192,13 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 	// Create doc with attachment
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+t.Name(), `{"_attachments": {"hello": {"data": "aGVsbG8gd29ybGQ="}}}`)
 	RequireStatus(t, resp, http.StatusCreated)
-	err := rt.WaitForPendingChanges()
-	assert.NoError(t, err)
 
 	// Ensure attachment is uploaded and key the attachment doc key
 	resp = rt.SendAdminRequest("GET", "/{{.keyspace}}/"+t.Name()+"/hello?meta=true", "")
 	RequireStatus(t, resp, http.StatusOK)
 
 	var body db.Body
-	err = base.JSONUnmarshal(resp.BodyBytes(), &body)
+	err := base.JSONUnmarshal(resp.BodyBytes(), &body)
 	require.NoError(t, err)
 
 	key, ok := body["key"].(string)
@@ -2232,12 +2228,10 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 	// Create doc with attachment and expiry
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}, "_exp": 2}`)
 	RequireStatus(t, resp, http.StatusCreated)
-	err := rt.WaitForPendingChanges()
-	assert.NoError(t, err)
 
 	// Wait for document to be expired - this bucket get should also trigger the expiry purge interval
-	err = rt.WaitForCondition(func() bool {
-		_, _, err = dataStore.GetRaw(t.Name())
+	err := rt.WaitForCondition(func() bool {
+		_, _, err := dataStore.GetRaw(t.Name())
 		return base.IsDocNotFoundError(err)
 	})
 	assert.NoError(t, err)
@@ -2281,17 +2275,15 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		doc1Version := rt.PutDoc(doc1ID, `{}`)
 		doc2Version := rt.PutDoc(doc2ID, `{}`)
 
-		require.NoError(t, rt.WaitForPendingChanges())
-
-		err := btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
 		btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 		btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
 
 		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
 		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
 
-		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+		doc1Version, err := btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
 		require.NoError(t, err)
 		doc2Version, err = btcRunner.PushRev(btc.id, doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
 		require.NoError(t, err)
@@ -2339,10 +2331,8 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 		// Add doc1 and doc2
 		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
 
-		require.NoError(t, btc.rt.WaitForPendingChanges())
-
-		err := btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		btc.rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
 
 		btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 
@@ -2388,12 +2378,10 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		defer btc.Close()
 		// Push an initial rev with attachment data
 		initialVersion := btc.rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-		err := btc.rt.WaitForPendingChanges()
-		assert.NoError(t, err)
 
 		// Replicate data to client and ensure doc arrives
-		err = btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		btc.rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
 		btcRunner.WaitForVersion(btc.id, docID, initialVersion)
 
 		// Push a revision with a bunch of history simulating doc updated on mobile device
@@ -2429,12 +2417,11 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		// Create rev 1 with the hello.txt attachment
 		const docID = "doc"
 		version := btc.rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
-		err := btc.rt.WaitForPendingChanges()
-		assert.NoError(t, err)
 
 		// Pull rev and attachment down to client
-		err = btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		btc.rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
+
 		btcRunner.WaitForVersion(btc.id, docID, version)
 
 		// Add an attachment to client
@@ -2443,7 +2430,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		btcRunner.AttachmentsLock(btc.id).Unlock()
 
 		// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
-		_, err = btcRunner.PushRevWithHistory(btc.id, docID, version.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
+		_, err := btcRunner.PushRevWithHistory(btc.id, docID, version.RevID, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
 		require.NoError(t, err)
 
 		// Ensure message and attachment is pushed up
@@ -2487,9 +2474,6 @@ func TestProveAttachmentNotFound(t *testing.T) {
 	require.True(t, sent)
 	require.NoError(t, err)
 
-	err = rt.WaitForPendingChanges()
-	require.NoError(t, err)
-
 	// Should log:
 	// "Peer sent prove attachment error 404 attachment not found, falling back to getAttachment for proof in doc <ud>doc1</ud> (digest sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=)"
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
@@ -2500,8 +2484,7 @@ func TestProveAttachmentNotFound(t *testing.T) {
 	require.True(t, sent)
 	require.NoError(t, err)
 
-	err = rt.WaitForPendingChanges()
-	require.NoError(t, err)
+	rt.WaitForPendingChanges()
 	// Check attachment is on the document
 	body := rt.GetDocBody("doc1")
 	assert.Equal(t, "2-abc", body.ExtractRev())
@@ -2614,17 +2597,16 @@ func TestCBLRevposHandling(t *testing.T) {
 
 		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
 		doc2Version := btc.rt.PutDoc(doc2ID, `{}`)
-		require.NoError(t, btc.rt.WaitForPendingChanges())
 
-		err := btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		btc.rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
 		btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 		btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
 
 		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
 		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
 
-		doc1Version, err = btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+		doc1Version, err := btcRunner.PushRev(btc.id, doc1ID, doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
 		require.NoError(t, err)
 		doc2Version, err = btcRunner.PushRev(btc.id, doc2ID, doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
 		require.NoError(t, err)

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1220,7 +1220,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 			{
 				name: "blip changes continuous",
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
-					require.NoError(t, btcRunner.StartPull(btc.id))
+					btcRunner.StartPull(btc.id)
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
 					_, err := btcRunner.UnsubPullChanges(btc.id)
 					require.NoError(t, err)
@@ -1233,7 +1233,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 			{
 				name: "blip changes one shot",
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
-					require.NoError(t, btcRunner.StartOneshotPull(btc.id))
+					btcRunner.StartOneshotPull(btc.id)
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
 					_, err := btcRunner.UnsubPullChanges(btc.id)
 					require.NoError(t, err)
@@ -1246,7 +1246,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 			{
 				name: "blip changes with channels",
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
-					require.NoError(t, btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", Channels: "A,B"}))
+					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", Channels: "A,B"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
 					_, err := btcRunner.UnsubPullChanges(btc.id)
 					require.NoError(t, err)
@@ -1261,7 +1261,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 			{
 				name: "blip changes with docids",
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
-					require.NoError(t, btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", DocIDs: []string{docID, "non_existent"}}))
+					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", DocIDs: []string{docID, "non_existent"}})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
 					_, err := btcRunner.UnsubPullChanges(btc.id)
 					require.NoError(t, err)
@@ -1277,7 +1277,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				// invalid specification, this would ignore channel filter and only use docids filter
 				name: "blip changes with docids and channels",
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
-					require.NoError(t, btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", DocIDs: []string{docID, "non_existent"}, Channels: "A,B"}))
+					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", DocIDs: []string{docID, "non_existent"}, Channels: "A,B"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
 					_, err := btcRunner.UnsubPullChanges(btc.id)
 					require.NoError(t, err)
@@ -1293,7 +1293,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 			{
 				name: "blip changes with compound since",
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
-					require.NoError(t, btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "1:10"}))
+					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "1:10"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
 					_, err := btcRunner.UnsubPullChanges(btc.id)
 					require.NoError(t, err)
@@ -1308,8 +1308,8 @@ func TestAuditChangesFeedStart(t *testing.T) {
 			rt.Run(testCase.name, func(t *testing.T) {
 				docID := strings.ReplaceAll(testCase.name, " ", "_")
 				docVersion := rt.PutDoc(docID, `{"channels": "A"}`)
-				// wait for changes before starting one shot changes feeds
-				require.NoError(t, rt.WaitForPendingChanges())
+				// the auditable code is using changes requests, which can fail if document isn't present yet
+				rt.WaitForPendingChanges()
 				output := base.AuditLogContents(t, func(t testing.TB) {
 					testCase.auditableCode(t, docID, docVersion)
 				})

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -59,8 +59,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 
-		err := btcRunner.StartPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(btc.id)
 
 		// Create doc revision with attachment on SG.
 		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
@@ -72,7 +71,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 
 		// Update the replicated doc at client along with keeping the same attachment stub.
 		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-		version, err = btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
+		version, err := btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
 		require.NoError(t, err)
 
 		// Wait for the document to be replicated at SG
@@ -130,8 +129,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 
-		err := btcRunner.StartPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(btc.id)
 
 		// Create doc revision with attachment on SG.
 		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
@@ -143,7 +141,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 
 		// Update the replicated doc at client along with keeping the same attachment stub.
 		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-		version, err = btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
+		version, err := btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
 		require.NoError(t, err)
 
 		// Wait for the document to be replicated at SG
@@ -203,8 +201,7 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 		})
 		defer btc.Close()
 
-		err := btcRunner.StartPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(btc.id)
 
 		// Create two docs with the same attachment data on SG - v2 attachments intentionally result in two copies,
 		// CBL will still de-dupe attachments based on digest, so will still try proveAttachmnet for the 2nd.
@@ -300,12 +297,11 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 
-		err := btcRunner.StartPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(btc.id)
 
 		// CBL creates revisions 1-abc,2-abc on the client, with an attachment associated with rev 2.
 		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-		err = btcRunner.StoreRevOnClient(btc.id, docID, "2-abc", []byte(bodyText))
+		err := btcRunner.StoreRevOnClient(btc.id, docID, "2-abc", []byte(bodyText))
 		require.NoError(t, err)
 
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
@@ -373,14 +369,13 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
-		err := btcRunner.StartPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(btc.id)
 
 		// CBL creates revisions 1-abc, 2-abc, 3-abc, 4-abc on the client, with an attachment associated with rev 2.
 		// rev tree pruning on the CBL side, so 1-abc no longer exists.
 		// CBL replicates, sends to client as 4-abc history:[4-abc, 3-abc, 2-abc], attachment has revpos=2
 		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
-		err = btcRunner.StoreRevOnClient(btc.id, docID, "2-abc", []byte(bodyText))
+		err := btcRunner.StoreRevOnClient(btc.id, docID, "2-abc", []byte(bodyText))
 		require.NoError(t, err)
 
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -259,14 +259,11 @@ func TestCollectionsReplication(t *testing.T) {
 		defer btc.Close()
 
 		version := btc.rt.PutDoc(docID, "{}")
-		require.NoError(t, btc.rt.WaitForPendingChanges())
 
-		btcCollection := btcRunner.SingleCollection(btc.id)
+		btc.rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
 
-		err := btcCollection.StartOneshotPull()
-		require.NoError(t, err)
-
-		btcCollection.WaitForVersion(docID, version)
+		btcRunner.WaitForVersion(btc.id, docID, version)
 	})
 }
 
@@ -292,11 +289,11 @@ func TestBlipReplicationMultipleCollections(t *testing.T) {
 			RequireStatus(t, resp, http.StatusCreated)
 			versions = append(versions, DocVersionFromPutResponse(t, resp))
 		}
-		require.NoError(t, btc.rt.WaitForPendingChanges())
+		btc.rt.WaitForPendingChanges()
 
 		// start all the clients first
 		for _, collectionClient := range btc.collectionClients {
-			require.NoError(t, collectionClient.StartPull())
+			collectionClient.StartOneshotPull()
 		}
 
 		for i, collectionClient := range btc.collectionClients {
@@ -346,11 +343,11 @@ func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
 				collectionDocIDs[blipName] = append(collectionDocIDs[blipName], docName)
 			}
 		}
-		require.NoError(t, btc.rt.WaitForPendingChanges())
+		btc.rt.WaitForPendingChanges()
 
 		// start all the clients first
 		for _, collectionClient := range btc.collectionClients {
-			require.NoError(t, collectionClient.StartOneshotPull())
+			collectionClient.StartOneshotPull()
 		}
 
 		for _, collectionClient := range btc.collectionClients {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2266,8 +2266,8 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
-		// At this point changes should send revocation, as document isn't in any of the user's channels
 		rt.WaitForPendingChanges()
+		// At this point changes should send revocation, as document isn't in any of the user's channels
 		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
 		require.NoError(t, err)
 		assert.Len(t, changes.Results, 1)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -993,7 +993,7 @@ function(doc, oldDoc) {
 	revsFinishedWg.Add(1)
 	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/grantDoc", `{"accessUser":"user1", "accessChannel":"ABC", "channels":["ABC"]}`)
 	RequireStatus(t, response, 201)
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	// Wait until all expected changes are received by change handler
 	timeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*5)
@@ -1773,7 +1773,8 @@ func TestGetRemovedDoc(t *testing.T) {
 	require.NoError(t, err)                        // no error
 	assert.Empty(t, resp.Properties["Error-Code"]) // no error
 
-	require.NoError(t, rt.WaitForPendingChanges())
+	// wait for rev 2 to arrive to cache cache
+	rt.WaitForPendingChanges()
 
 	// Try to get rev 2 via BLIP API and assert that _removed == false
 	resultDoc, err := bt.GetDocAtRev("foo", "2-bcd")
@@ -1794,7 +1795,7 @@ func TestGetRemovedDoc(t *testing.T) {
 	assert.NoError(t, err)                         // no error
 	assert.Empty(t, resp.Properties["Error-Code"]) // no error
 
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	// Flush rev cache in case this prevents the bug from showing up (didn't make a difference)
 	rt.GetDatabase().FlushRevisionCacheForTest()
@@ -1947,8 +1948,8 @@ func TestSendReplacementRevision(t *testing.T) {
 				defer btc.Close()
 
 				// one shot or else we'll carry on to send rev 2-... normally, and we can't assert correctly on the final state of the client
-				err := btcRunner.StartOneshotPullFiltered(btc.id, replicationChannels)
-				require.NoError(t, err)
+				rt.WaitForPendingChanges()
+				btcRunner.StartOneshotPullFiltered(btc.id, replicationChannels)
 
 				// block until we've written the update and got the new version to use in assertions
 				version2 := <-updatedVersion
@@ -2019,8 +2020,7 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 		defer client.Close()
 		client.ClientDeltas = true
 
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 
 		const docID = "doc1"
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
@@ -2060,7 +2060,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 		version := rt.PutDoc(docID, `{"test":true}`)
 
 		// start an initial pull
-		require.NoError(t, btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: true, Since: "0", ActiveOnly: true}))
+		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: true, Since: "0", ActiveOnly: true})
 		rev := btcRunner.WaitForVersion(btc.id, docID, version)
 		assert.Equal(t, `{"test":true}`, string(rev))
 
@@ -2156,8 +2156,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		assert.Equal(t, "doc", changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
-		err = btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		version = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
@@ -2168,8 +2167,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
-		err = btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		version = rt.UpdateDoc(docID, version, `{"channels": []}`)
@@ -2188,8 +2186,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
 		assert.False(t, changes.Results[1].Revoked)
 
-		err = btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docMarker, docMarkerVersion)
 
 		messages := btc.pullReplication.GetMessages()
@@ -2265,27 +2262,25 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
-		err = btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
-		require.NoError(t, rt.WaitForPendingChanges())
 		// At this point changes should send revocation, as document isn't in any of the user's channels
+		rt.WaitForPendingChanges()
 		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
 		require.NoError(t, err)
 		assert.Len(t, changes.Results, 1)
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
-		err = btcRunner.StartOneshotPullFiltered(btc.id, "A")
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPullFiltered(btc.id, "A")
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		_ = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
 		markerID := "docmarker"
 		markerVersion := rt.PutDoc(markerID, `{"channels": ["A"]}`)
-		require.NoError(t, rt.WaitForPendingChanges())
+		rt.WaitForPendingChanges()
 
 		// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
 		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
@@ -2294,8 +2289,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		assert.Equal(t, "doc", changes.Results[0].ID)
 		assert.Equal(t, markerID, changes.Results[1].ID)
 
-		err = btcRunner.StartOneshotPullFiltered(btc.id, "A")
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPullFiltered(btc.id, "A")
 		_ = btcRunner.WaitForVersion(btc.id, markerID, markerVersion)
 
 		messages := btc.pullReplication.GetMessages()
@@ -2572,8 +2566,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Wait for rev to be received on RT
-				err = rt.WaitForPendingChanges()
-				require.NoError(t, err)
+				rt.WaitForPendingChanges()
 				changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "", true)
 				require.NoError(t, err)
 
@@ -2633,8 +2626,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	assert.NoError(t, ar.Start(activeCtx))
 	defer func() { require.NoError(t, ar.Stop()) }()
 
-	err = activeRT.WaitForPendingChanges()
-	require.NoError(t, err)
+	activeRT.WaitForPendingChanges()
 	err = activeRT.WaitForVersion(docID, version)
 	require.NoError(t, err)
 
@@ -2762,8 +2754,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 				// Flush cache so document has to be retrieved from the leaky bucket
 				rt.GetDatabase().FlushRevisionCacheForTest()
 
-				err := btcRunner.StartPull(btc.id)
-				require.NoError(t, err)
+				btcRunner.StartPull(btc.id)
 
 				// Wait 3 seconds for noRev to be received
 				select {
@@ -2810,8 +2801,7 @@ func TestUnsubChanges(t *testing.T) {
 		assert.Empty(t, response)
 
 		// Sub changes
-		err = btcRunner.StartPull(btc.id)
-		require.NoError(t, err)
+		btcRunner.StartPull(btc.id)
 
 		doc1Version := rt.PutDoc(doc1ID, `{"key":"val1"}`)
 		_ = btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
@@ -2840,8 +2830,7 @@ func TestUnsubChanges(t *testing.T) {
 		assert.Empty(t, response)
 
 		// Confirm the pull replication can be restarted and it syncs doc2
-		err = btcRunner.StartPull(btc.id)
-		require.NoError(t, err)
+		btcRunner.StartPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
 	})
 }
@@ -2888,8 +2877,7 @@ func TestRequestPlusPull(t *testing.T) {
 		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 
 		// Start a regular one-shot pull
-		err := btcRunner.StartOneshotPullRequestPlus(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPullRequestPlus(client.id)
 
 		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
 		require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
@@ -2952,8 +2940,7 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 
 		// Start a regular one-shot pull
-		err := btcRunner.StartOneshotPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(client.id)
 
 		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
 		require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))
@@ -3008,8 +2995,7 @@ func TestBlipRefreshUser(t *testing.T) {
 		version := rt.PutDoc(docID, `{"channels":["chan1"]}`)
 
 		// Start a regular one-shot pull
-		err := btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: true, Since: "0"})
-		require.NoError(t, err)
+		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: true, Since: "0"})
 
 		_ = btcRunner.WaitForDoc(btc.id, docID)
 
@@ -3020,14 +3006,14 @@ func TestBlipRefreshUser(t *testing.T) {
 		response := rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/_user/"+username, "")
 		RequireStatus(t, response, http.StatusOK)
 
-		require.NoError(t, rt.WaitForPendingChanges())
+		rt.WaitForPendingChanges()
 
 		// further requests will 500, but shouldn't panic
 		unsubChangesRequest := blip.NewRequest()
 		unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
 		btc.addCollectionProperty(unsubChangesRequest)
 
-		err = btc.pullReplication.sendMsg(unsubChangesRequest)
+		err := btc.pullReplication.sendMsg(unsubChangesRequest)
 		require.NoError(t, err)
 
 		testResponse := unsubChangesRequest.Response()
@@ -3130,7 +3116,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 				revID := rt.PutDoc(docID, validBody)
 
 				// Wait for initial revision to arrive over DCP before mutating
-				require.NoError(t, rt.WaitForPendingChanges())
+				rt.WaitForPendingChanges()
 
 				// Issue a changes request for the channel before updating the document, to ensure the valid revision is
 				// resident in the channel cache (query results may be unreliable in the case of the 'invalid json' update)
@@ -3142,7 +3128,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 
 				markerDocBody := fmt.Sprintf(`{"channel":%q}`, testCase.channel)
 				_ = rt.PutDoc(markerDoc, markerDocBody)
-
+				rt.WaitForPendingChanges()
 				rt.GetDatabase().FlushRevisionCacheForTest()
 
 				btc2 := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
@@ -3152,7 +3138,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 				})
 				defer btc2.Close()
 
-				require.NoError(t, btcRunner.StartOneshotPull(btc2.id))
+				btcRunner.StartOneshotPull(btc2.id)
 
 				btcRunner.WaitForDoc(btc2.id, markerDoc)
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -121,8 +121,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 		defer btc.Close()
 
 		btc.ClientDeltas = true
-		err := btcRunner.StartPull(btc.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(btc.id)
 		const docID = "doc1"
 
 		// Create doc1 rev 1-77d9041e49931ceef58a1eef5fd032e8 on SG with an attachment
@@ -135,7 +134,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 
 		// Update the replicated doc at client by adding another attachment.
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="},"world.txt":{"data":"bGVsbG8gd29ybGQ="}}}`
-		version, err = btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
+		version, err := btcRunner.PushRev(btc.id, docID, version, []byte(bodyText))
 		require.NoError(t, err)
 
 		// Wait for the document to be replicated at SG
@@ -193,8 +192,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		defer client.Close()
 
 		client.ClientDeltas = true
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		version := rt.PutDoc(doc1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -292,8 +290,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		defer client.Close()
 
 		client.ClientDeltas = true
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -373,8 +370,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		client.rejectDeltasForSrcRev = docVersion1.RevID
 
 		client.ClientDeltas = true
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 		data := btcRunner.WaitForVersion(client.id, docID, docVersion1)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
@@ -439,8 +435,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		})
 		defer client.Close()
 
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-1513b53e2738671e634d9dd111f48de0
 		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
@@ -514,8 +509,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		})
 		defer client.Close()
 
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 
 		const docID = "doc1"
 		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
@@ -617,8 +611,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		})
 		defer client2.Close()
 
-		err := btcRunner.StartPull(client1.id)
-		require.NoError(t, err)
+		btcRunner.StartPull(client1.id)
 
 		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
 		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
@@ -628,8 +621,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
 		// Have client2 get only rev-1 and then stop replicating
-		err = btcRunner.StartOneshotPull(client2.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(client2.id)
 		data = btcRunner.WaitForVersion(client2.id, docID, version)
 		assert.Contains(t, string(data), `"channels":["public"]`)
 		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
@@ -657,8 +649,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		}
 
 		// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
-		err = btcRunner.StartOneshotPull(client2.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(client2.id)
 		data = btcRunner.WaitForVersion(client2.id, docID, version)
 		assert.Equal(t, `{}`, string(data))
 		msg = btcRunner.WaitForBlipRevMessage(client2.id, docID, version)
@@ -736,8 +727,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		defer client.Close()
 
 		client.ClientDeltas = true
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -750,8 +740,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		defer client2.Close()
 
 		client2.ClientDeltas = true
-		err = btcRunner.StartOneshotPull(client2.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(client2.id)
 		data = btcRunner.WaitForVersion(client2.id, docID, version1)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
@@ -775,8 +764,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 		// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
 		client2.ClientDeltas = true
-		err = btcRunner.StartOneshotPull(client2.id)
-		assert.NoError(t, err)
+		btcRunner.StartOneshotPull(client2.id)
 		msg2 := btcRunner.WaitForBlipRevMessage(client2.id, docID, version2)
 
 		// Check the request was sent with the correct deltaSrc property
@@ -822,8 +810,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		defer client.Close()
 		client.ClientDeltas = true
 
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -929,8 +916,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		defer client.Close()
 
 		client.ClientDeltas = false
-		err := btcRunner.StartPull(client.id)
-		assert.NoError(t, err)
+		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -74,7 +74,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 					lastPushRevErr.Store(err)
 				}
 			}
-			_ = rt.WaitForPendingChanges()
+			rt.WaitForPendingChanges()
 			wg.Done()
 		}()
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -751,20 +751,20 @@ func (btcRunner *BlipTestClientRunner) Collection(clientID uint32, collectionNam
 }
 
 // StartPull will begin a continuous pull replication since 0 between the client and server
-func (btcc *BlipTesterCollectionClient) StartPull() (err error) {
-	return btcc.StartPullSince(BlipTesterPullOptions{Continuous: true, Since: "0"})
+func (btcc *BlipTesterCollectionClient) StartPull() {
+	btcc.StartPullSince(BlipTesterPullOptions{Continuous: true, Since: "0"})
 }
 
-func (btcc *BlipTesterCollectionClient) StartOneshotPull() (err error) {
-	return btcc.StartPullSince(BlipTesterPullOptions{Continuous: false, Since: "0"})
+func (btcc *BlipTesterCollectionClient) StartOneshotPull() {
+	btcc.StartPullSince(BlipTesterPullOptions{Continuous: false, Since: "0"})
 }
 
-func (btcc *BlipTesterCollectionClient) StartOneshotPullFiltered(channels string) (err error) {
-	return btcc.StartPullSince(BlipTesterPullOptions{Continuous: false, Since: "0", Channels: channels})
+func (btcc *BlipTesterCollectionClient) StartOneshotPullFiltered(channels string) {
+	btcc.StartPullSince(BlipTesterPullOptions{Continuous: false, Since: "0", Channels: channels})
 }
 
-func (btcc *BlipTesterCollectionClient) StartOneshotPullRequestPlus() (err error) {
-	return btcc.StartPullSince(BlipTesterPullOptions{Continuous: false, Since: "0", RequestPlus: true})
+func (btcc *BlipTesterCollectionClient) StartOneshotPullRequestPlus() {
+	btcc.StartPullSince(BlipTesterPullOptions{Continuous: false, Since: "0", RequestPlus: true})
 }
 
 // BlipTesterPullOptions represents options passed to StartPull (SubChanges) functions
@@ -778,7 +778,7 @@ type BlipTesterPullOptions struct {
 }
 
 // StartPullSince will begin a pull replication between the client and server with the given params.
-func (btc *BlipTesterCollectionClient) StartPullSince(options BlipTesterPullOptions) (err error) {
+func (btc *BlipTesterCollectionClient) StartPullSince(options BlipTesterPullOptions) {
 	subChangesRequest := blip.NewRequest()
 	subChangesRequest.SetProfile(db.MessageSubChanges)
 	subChangesRequest.Properties[db.SubChangesContinuous] = fmt.Sprintf("%t", options.Continuous)
@@ -808,11 +808,7 @@ func (btc *BlipTesterCollectionClient) StartPullSince(options BlipTesterPullOpti
 			},
 		))
 	}
-	if err := btc.sendPullMsg(subChangesRequest); err != nil {
-		return err
-	}
-
-	return nil
+	require.NoError(btc.TB(), btc.sendPullMsg(subChangesRequest))
 }
 
 func (btc *BlipTesterCollectionClient) UnsubPullChanges() (response []byte, err error) {
@@ -1180,8 +1176,8 @@ func (btc *BlipTesterCollectionClient) GetBlipRevMessage(docID, revID string) (m
 	return nil, false
 }
 
-func (btcRunner *BlipTestClientRunner) StartPull(clientID uint32) error {
-	return btcRunner.SingleCollection(clientID).StartPull()
+func (btcRunner *BlipTestClientRunner) StartPull(clientID uint32) {
+	btcRunner.SingleCollection(clientID).StartPull()
 }
 
 // WaitForVersion blocks until the given document version has been stored by the client, and returns the data when found or fails test if document is not found after 10 seconds.
@@ -1199,24 +1195,24 @@ func (btcRunner *BlipTestClientRunner) WaitForBlipRevMessage(clientID uint32, do
 	return btcRunner.SingleCollection(clientID).WaitForBlipRevMessage(docID, docVersion)
 }
 
-func (btcRunner *BlipTestClientRunner) StartOneshotPull(clientID uint32) error {
-	return btcRunner.SingleCollection(clientID).StartOneshotPull()
+func (btcRunner *BlipTestClientRunner) StartOneshotPull(clientID uint32) {
+	btcRunner.SingleCollection(clientID).StartOneshotPull()
 }
 
-func (btcRunner *BlipTestClientRunner) StartOneshotPullFiltered(clientID uint32, channels string) error {
-	return btcRunner.SingleCollection(clientID).StartOneshotPullFiltered(channels)
+func (btcRunner *BlipTestClientRunner) StartOneshotPullFiltered(clientID uint32, channels string) {
+	btcRunner.SingleCollection(clientID).StartOneshotPullFiltered(channels)
 }
 
-func (btcRunner *BlipTestClientRunner) StartOneshotPullRequestPlus(clientID uint32) error {
-	return btcRunner.SingleCollection(clientID).StartOneshotPullRequestPlus()
+func (btcRunner *BlipTestClientRunner) StartOneshotPullRequestPlus(clientID uint32) {
+	btcRunner.SingleCollection(clientID).StartOneshotPullRequestPlus()
 }
 
 func (btcRunner *BlipTestClientRunner) PushRev(clientID uint32, docID string, version DocVersion, body []byte) (DocVersion, error) {
 	return btcRunner.SingleCollection(clientID).PushRev(docID, version, body)
 }
 
-func (btcRunner *BlipTestClientRunner) StartPullSince(clientID uint32, options BlipTesterPullOptions) error {
-	return btcRunner.SingleCollection(clientID).StartPullSince(options)
+func (btcRunner *BlipTestClientRunner) StartPullSince(clientID uint32, options BlipTesterPullOptions) {
+	btcRunner.SingleCollection(clientID).StartPullSince(options)
 }
 
 func (btcRunner *BlipTestClientRunner) GetVersion(clientID uint32, docID string, docVersion DocVersion) ([]byte, bool) {

--- a/rest/changes_request_plus_test.go
+++ b/rest/changes_request_plus_test.go
@@ -40,7 +40,7 @@ func TestRequestPlusSkippedSequence(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 	docSeq := rt.GetDocumentSequence("doc1")
 
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	// add an unused sequence
 	unusedSeq, err := db.AllocateTestSequence(rt.GetDatabase())

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -38,7 +38,8 @@ func TestMultiCollectionChangesAdmin(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/abc1", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	_ = rt.WaitForPendingChanges()
+	// requireAdminChangesCount will issue a changes request, wait for docs to be written
+	rt.WaitForPendingChanges()
 
 	// Issue changes request.  Will initialize cache for channels, and return docs via query
 	requireAdminChangesCount(rt, "{{.keyspace1}}", 1)
@@ -49,7 +50,8 @@ func TestMultiCollectionChangesAdmin(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/abc2", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	// requireAdminChangesCount will issue a changes request, wait for docs to be written
+	rt.WaitForPendingChanges()
 
 	requireAdminChangesCount(rt, "{{.keyspace1}}", 2)
 	requireAdminChangesCount(rt, "{{.keyspace2}}", 2)
@@ -69,7 +71,8 @@ func TestMultiCollectionChangesAdminSameChannelName(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/pbs1_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	// requireAdminChangesCount will issue a changes request, wait for docs to be written
+	rt.WaitForPendingChanges()
 
 	// Issue changes request.  Will initialize cache for channels, and return docs via query
 	requireAdminChangesCount(rt, "{{.keyspace1}}", 1)
@@ -80,7 +83,8 @@ func TestMultiCollectionChangesAdminSameChannelName(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/pbs2_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	// requireAdminChangesCount will issue a changes request, wait for docs to be written
+	rt.WaitForPendingChanges()
 
 	requireAdminChangesCount(rt, "{{.keyspace1}}", 2)
 	requireAdminChangesCount(rt, "{{.keyspace2}}", 2)
@@ -107,9 +111,9 @@ func TestMultiCollectionChangesUser(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/pbs1_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
 
 	// Issue changes request.  Will initialize cache for channels, and return docs via query
+	rt.WaitForPendingChanges()
 	changes := rt.GetChanges("/{{.keyspace1}}/_changes", "bernard")
 	require.Len(t, changes.Results, 1)
 	changes = rt.GetChanges("/{{.keyspace2}}/_changes", "bernard")
@@ -120,7 +124,7 @@ func TestMultiCollectionChangesUser(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/pbs2_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	rt.WaitForPendingChanges()
 
 	changes = rt.GetChanges("/{{.keyspace1}}/_changes", "bernard")
 	require.Len(t, changes.Results, 2)
@@ -160,7 +164,7 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/chr1_c1", `{"channels":["CHR"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	rt.WaitForPendingChanges()
 
 	// Issue changes request.  Will initialize cache for channels, and return docs via queries
 	changes := rt.GetChanges("/{{.keyspace1}}/_changes", "bernard")
@@ -176,14 +180,14 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/chr2_c2", `{"value":1, "channels":["CHR"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	rt.WaitForPendingChanges()
 
 	changes = rt.GetChanges("/{{.keyspace1}}/_changes", "bernard")
 	require.Len(t, changes.Results, 2)
 
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/brn3_c1", `{"value":1, "channels":["BRN"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	rt.WaitForPendingChanges()
 
 	changes = rt.GetChanges("/{{.keyspace1}}/_changes", "charlie")
 	require.Len(t, changes.Results, 2)
@@ -197,7 +201,7 @@ func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/chr3_c1", `{"value":1, "channels":["CHR"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	rt.WaitForPendingChanges()
 
 	changes = rt.GetChanges("/{{.keyspace1}}/_changes", "bernard")
 	require.Len(t, changes.Results, 4)
@@ -241,7 +245,7 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/abc1_c2", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	// Issue changes request.  Will initialize cache for channels, and return docs via query
 	changes := rt.GetChanges("/{{.keyspace1}}/_changes", "bernard")
@@ -253,7 +257,7 @@ func TestMultiCollectionChangesUserDynamicGrant(t *testing.T) {
 	// Grant user access to channel ABC in collection 1
 	err = rt.SetAdminChannels("bernard", rt.GetKeyspaces()[0], "ABC", "PBS")
 	require.NoError(t, err)
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	// confirm that change from c1 is sent, along with user doc
 	changes = rt.GetChanges("/{{.keyspace1}}/_changes?since="+lastSeq, "bernard")
@@ -290,7 +294,7 @@ func TestMultiCollectionChangesUserDynamicGrantDCP(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/abc1_c2", `{"value":1, "channels":["ABC"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	rt.WaitForPendingChanges()
 
 	// Issue changes request.  Will initialize cache for user channel (PBS), and return docs via query
 	changes := rt.GetChanges("/{{.keyspace1}}/_changes", "bernard")
@@ -319,7 +323,7 @@ func TestMultiCollectionChangesUserDynamicGrantDCP(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/pbs2_c2", `{"value":1, "channels":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	rt.WaitForPendingChanges()
 
 	// Expect 4 documents in collection with ABC grant:
 	//  - backfill of 1 ABC doc written prior to lastSeq
@@ -383,7 +387,7 @@ func TestMultiCollectionChangesCustomSyncFunctions(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/publicDoc", `{"value":1, "public":true}`)
 	rest.RequireStatus(t, response, 201)
-	_ = rt.WaitForPendingChanges()
+	rt.WaitForPendingChanges()
 
 	// Issue changes request.  Will initialize cache for channels, and return docs via query
 	changes := rt.GetChanges("/{{.keyspace1}}/_changes", "bernard")

--- a/rest/changestest/logging_test.go
+++ b/rest/changestest/logging_test.go
@@ -29,7 +29,7 @@ func TestDocChangedLogging(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusCreated)
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace2}}/doc1", `{"foo":"bar"}`)
 	rest.RequireStatus(t, response, http.StatusCreated)
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	base.AssertLogContains(t, "Ignoring non-metadata mutation for doc", func() {
 		err := rt.GetDatabase().MetadataStore.Set("doc1", 0, nil, db.Body{"foo": "bar"})
@@ -38,6 +38,6 @@ func TestDocChangedLogging(t *testing.T) {
 		// no other way of synchronising this no-op as no stats to wait on
 		response = rt.SendAdminRequest("PUT", "/{{.keyspace1}}/doc2", `{"foo":"bar"}`)
 		rest.RequireStatus(t, response, http.StatusCreated)
-		require.NoError(t, rt.WaitForPendingChanges())
+		rt.WaitForPendingChanges()
 	})
 }

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1392,7 +1392,7 @@ func TestDbConfigEnvVarsToggle(t *testing.T) {
 			docID := "doc"
 			_ = rt.PutDoc(docID, `{"foo":"bar"}`)
 
-			require.NoError(t, rt.WaitForPendingChanges())
+			rt.WaitForPendingChanges()
 
 			// ensure doc is in expected channel and is not in the unexpected channels
 			changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels="+test.expectedChannel, "", true)

--- a/rest/importuserxattrtest/rawdoc_test.go
+++ b/rest/importuserxattrtest/rawdoc_test.go
@@ -35,6 +35,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, "{}")
 	rest.RequireStatus(t, resp, http.StatusCreated)
+	rt.WaitForPendingChanges()
 
 	cas, err := rt.GetSingleDataStore().Get(docKey, nil)
 	require.NoError(t, err)

--- a/rest/importuserxattrtest/rawdoc_test.go
+++ b/rest/importuserxattrtest/rawdoc_test.go
@@ -35,7 +35,6 @@ func TestUserXattrsRawGet(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, "{}")
 	rest.RequireStatus(t, resp, http.StatusCreated)
-	require.NoError(t, rt.WaitForPendingChanges())
 
 	cas, err := rt.GetSingleDataStore().Get(docKey, nil)
 	require.NoError(t, err)

--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -73,7 +73,6 @@ func TestUserXattrRevCache(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
-	require.NoError(t, rt.WaitForPendingChanges())
 
 	cas, err := rt.GetSingleDataStore().Get(docKey, nil)
 	require.NoError(t, err)
@@ -159,7 +158,6 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
-	require.NoError(t, rt.WaitForPendingChanges())
 
 	cas, err := rt.GetSingleDataStore().Get(docKey, nil)
 	require.NoError(t, err)

--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -73,6 +73,7 @@ func TestUserXattrRevCache(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
+	rt.WaitForPendingChanges()
 
 	cas, err := rt.GetSingleDataStore().Get(docKey, nil)
 	require.NoError(t, err)
@@ -158,6 +159,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
+	rt.WaitForPendingChanges()
 
 	cas, err := rt.GetSingleDataStore().Get(docKey, nil)
 	require.NoError(t, err)

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -50,6 +50,8 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
+	rt.WaitForPendingChanges()
+
 	// Get current sync data
 	var syncData db.SyncData
 	xattrs, cas, err := dataStore.GetXattrs(rt.Context(), docKey, []string{base.SyncXattrName})

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -50,8 +50,6 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+docKey, `{}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
-	require.NoError(t, rt.WaitForPendingChanges())
-
 	// Get current sync data
 	var syncData db.SyncData
 	xattrs, cas, err := dataStore.GetXattrs(rt.Context(), docKey, []string{base.SyncXattrName})

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1159,7 +1159,7 @@ func TestOpenIDConnectImplicitFlowReuseToken(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 	docSeq := restTester.GetDocumentSequence("doc1")
 
-	require.NoError(t, restTester.WaitForPendingChanges())
+	restTester.WaitForPendingChanges()
 
 	ctx := base.DatabaseLogCtx(base.TestCtx(t), restTester.GetDatabase().Name, nil)
 	u, err := restTester.GetDatabase().Authenticator(ctx).GetUser("foo_noah")

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -115,8 +115,8 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, rt1.WaitForPendingChanges())
-	require.NoError(t, rt2.WaitForPendingChanges())
+	rt1.WaitForPendingChanges()
+	rt2.WaitForPendingChanges()
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestAdminHandler())
@@ -234,8 +234,8 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 		rest.RequireStatus(t, resp, http.StatusCreated)
 	}
 
-	require.NoError(t, rt1.WaitForPendingChanges())
-	require.NoError(t, rt2.WaitForPendingChanges())
+	rt1.WaitForPendingChanges()
+	rt2.WaitForPendingChanges()
 
 	err = ar.Start(ctx1)
 	require.NoError(t, err)
@@ -488,7 +488,7 @@ func TestReplicatorMissingCollections(t *testing.T) {
 				rest.RequireStatus(t, resp, http.StatusCreated)
 
 			}
-			require.NoError(t, activeRT.WaitForPendingChanges())
+			activeRT.WaitForPendingChanges()
 			// use string since omitempty will occur for max_backoff_time, rendering test useless
 			replicationID := strings.ReplaceAll(t.Name(), "/", "_")
 			replicationConfig := `{

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -91,7 +91,7 @@ func requireErrorKeyNotFound(t *testing.T, rt *rest.RestTester, docID string) {
 // waitForTombstone waits until the specified tombstone revision is available
 // in the bucket backed by the specified RestTester instance.
 func waitForTombstone(t *testing.T, rt *rest.RestTester, docID string) {
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 	require.NoError(t, rt.WaitForCondition(func() bool {
 		doc, _ := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
@@ -103,7 +103,8 @@ func waitForTombstone(t *testing.T, rt *rest.RestTester, docID string) {
 func createDoc(rt *rest.RestTester, docID string, bodyValue string) rest.DocVersion {
 	body := fmt.Sprintf(`{"key":%q,"channels":["alice"]}`, bodyValue)
 	updatedVersion := rt.PutDoc(docID, body)
-	require.NoError(rt.TB(), rt.WaitForPendingChanges())
+	// make sure doc is available to changes feed
+	rt.WaitForPendingChanges()
 	return updatedVersion
 }
 
@@ -111,7 +112,8 @@ func createDoc(rt *rest.RestTester, docID string, bodyValue string) rest.DocVers
 func updateDoc(rt *rest.RestTester, docID string, version rest.DocVersion, bodyValue string) rest.DocVersion {
 	body := fmt.Sprintf(`{"key":%q,"channels":["alice"]}`, bodyValue)
 	updatedVersion := rt.UpdateDoc(docID, version, body)
-	require.NoError(rt.TB(), rt.WaitForPendingChanges())
+	// make sure doc is available to changes feed
+	rt.WaitForPendingChanges()
 	return updatedVersion
 }
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2339,13 +2339,13 @@ func TestRevocationNoRev(t *testing.T) {
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
 		version := rt.PutDoc(docID, `{"channels": "A"}`)
+		firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
 		// OneShot pull to grab doc
 		rt.WaitForPendingChanges()
 		btcRunner.StartOneshotPull(btc.id)
 
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
-		firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -132,18 +132,13 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expected
 	var changes ChangesResults
 
 	// Ensure any previous mutations have caught up before issuing changes request
-	err := tester.restTester.WaitForPendingChanges()
-	assert.NoError(tester.test, err)
+	tester.restTester.WaitForPendingChanges()
 
-	err = tester.restTester.WaitForCondition(func() bool {
+	err := tester.restTester.WaitForCondition(func() bool {
 		changes = tester.restTester.GetChanges(fmt.Sprintf("/{{.keyspace}}/_changes?since=%v&revocations=true", sinceSeq), "user")
 		return len(changes.Results) == expectedLength
 	})
 	require.NoError(tester.test, err, fmt.Sprintf("Unexpected: %d. Expected %d", len(changes.Results), expectedLength))
-
-	err = tester.restTester.WaitForPendingChanges()
-	assert.NoError(tester.test, err)
-
 	return changes
 }
 
@@ -838,8 +833,7 @@ func TestEnsureRevocationAfterDocMutation(t *testing.T) {
 	// Skip to seq 19 and then update doc foo
 	revocationTester.fillToSeq(19)
 	_ = rt.UpdateDoc(docID, version, `{"channels": "A"}`)
-	err := rt.WaitForPendingChanges()
-	require.NoError(t, err)
+	rt.WaitForPendingChanges()
 
 	// Get changes and ensure doc is revoked through ID-only revocation
 	changes = revocationTester.getChanges(10, 1)
@@ -1198,6 +1192,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 
 	revocationTester.removeRole("user", "foo")
 
+	rt.WaitForPendingChanges()
 	waitForUserChangesWithLimit := func(sinceVal interface{}, limit int) ChangesResults {
 		var changesRes ChangesResults
 		err := rt.WaitForCondition(func() bool {
@@ -1246,7 +1241,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	assert.Len(t, changes.Results, 2)
 
 	revocationTester.removeRoleChannel("foo", "A")
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.GetSingleDataStore())
 	require.True(t, ok)
@@ -1743,7 +1738,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	revocationTester.addRole(revocationTestUser, revocationTestRole)
-	require.NoError(t, rt2.WaitForPendingChanges())
+	rt2.WaitForPendingChanges()
 
 	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -1786,7 +1781,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	// Revoke C and ensure docC gets purged from local
 	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A", "B"}))
 	RequireStatus(t, resp, http.StatusOK)
-	require.NoError(t, rt2.WaitForPendingChanges())
+	rt2.WaitForPendingChanges()
 
 	err = rt1.WaitForCondition(func() bool {
 		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docC", "")
@@ -1958,7 +1953,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	_ = rt2.PutDoc("docA", `{"channels": ["ABC"]}`)
-	require.NoError(t, rt2.WaitForPendingChanges())
+	rt2.WaitForPendingChanges()
 
 	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -2041,7 +2036,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	_ = rt2.PutDoc("docB", `{"channels": ["B"]}`)
 	_ = rt2.PutDoc("docABC", `{"channels": ["A","B", "C"]}`)
 	_ = rt2.PutDoc("docC", `{"channels": ["C"]}`)
-	require.NoError(t, rt2.WaitForPendingChanges())
+	rt2.WaitForPendingChanges()
 
 	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
 		ID:          t.Name(),
@@ -2235,11 +2230,9 @@ func TestRevocationMessage(t *testing.T) {
 		revocationTester.fillToSeq(4)
 		version := rt.PutDoc("doc", `{"channels": "A"}`)
 
-		require.NoError(t, rt.WaitForPendingChanges())
-
 		// Start pull
-		err := btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
 
 		// Wait for doc revision to come over
 		_ = btcRunner.WaitForBlipRevMessage(btc.id, "doc", version)
@@ -2253,11 +2246,9 @@ func TestRevocationMessage(t *testing.T) {
 		revocationTester.fillToSeq(10)
 		version = rt.UpdateDoc(doc1ID, version, "{}")
 
-		require.NoError(t, rt.WaitForPendingChanges())
-
 		// Start a pull since 5 to receive revocation and removal
-		err = btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: false, Since: "5"})
-		assert.NoError(t, err)
+		rt.WaitForPendingChanges()
+		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: false, Since: "5"})
 
 		// Wait for doc1 rev2 - This is the last rev we expect so we can be sure replication is complete here
 		_ = btcRunner.WaitForVersion(btc.id, doc1ID, version)
@@ -2287,7 +2278,7 @@ func TestRevocationMessage(t *testing.T) {
 				for _, msg := range messages {
 					if msg.Properties[db.BlipProfile] == db.MessageChanges {
 						var changesMessages [][]interface{}
-						err = msg.ReadJSONBody(&changesMessages)
+						err := msg.ReadJSONBody(&changesMessages)
 						if err != nil {
 							continue
 						}
@@ -2318,7 +2309,6 @@ func TestRevocationMessage(t *testing.T) {
 			})
 		}
 
-		assert.NoError(t, err)
 	})
 }
 
@@ -2350,14 +2340,12 @@ func TestRevocationNoRev(t *testing.T) {
 		revocationTester.fillToSeq(4)
 		version := rt.PutDoc(docID, `{"channels": "A"}`)
 
-		require.NoError(t, rt.WaitForPendingChanges())
-		firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
-
 		// OneShot pull to grab doc
-		err := btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
+		rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
 
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
+		firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
@@ -2365,11 +2353,9 @@ func TestRevocationNoRev(t *testing.T) {
 		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
 		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
-		require.NoError(t, rt.WaitForPendingChanges())
-
+		rt.WaitForPendingChanges()
 		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
-		err = btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: false, Since: lastSeqStr})
-		assert.NoError(t, err)
+		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: false, Since: lastSeqStr})
 
 		_ = btcRunner.WaitForVersion(btc.id, waitMarkerID, waitMarkerVersion)
 
@@ -2390,7 +2376,7 @@ func TestRevocationNoRev(t *testing.T) {
 		}
 
 		var messageBody []interface{}
-		err = highestSeqMsg.ReadJSONBody(&messageBody)
+		err := highestSeqMsg.ReadJSONBody(&messageBody)
 		require.NoError(t, err)
 		require.Len(t, messageBody, 2)
 		require.Len(t, messageBody[0], 4)
@@ -2446,12 +2432,12 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		revocationTester.fillToSeq(4)
 		version := rt.PutDoc(docID, `{"channels": "A"}}`)
 
-		require.NoError(t, rt.WaitForPendingChanges())
+		// OneShot pull to grab doc
+		rt.WaitForPendingChanges()
+		btcRunner.StartOneshotPull(btc.id)
+
 		firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
-		// OneShot pull to grab doc
-		err := btcRunner.StartOneshotPull(btc.id)
-		assert.NoError(t, err)
 		throw = true
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
@@ -2461,11 +2447,10 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
 		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
-		require.NoError(t, rt.WaitForPendingChanges())
 
+		rt.WaitForPendingChanges()
 		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
-		err = btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: false, Since: lastSeqStr})
-		assert.NoError(t, err)
+		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: false, Since: lastSeqStr})
 
 		_ = btcRunner.WaitForVersion(btc.id, waitMarkerID, waitMarkerVersion)
 	})
@@ -2507,7 +2492,7 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 		})
 		defer bt.Close()
 
-		require.NoError(t, btcRunner.StartPull(bt.id))
+		btcRunner.StartPull(bt.id)
 
 		// in the failing case we'll panic before hitting this
 		base.RequireWaitForStat(t, func() int64 {
@@ -2574,8 +2559,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 		_ = rt2.PutDoc(fmt.Sprintf("docB%d", i), `{"channels": ["B"]}`)
 	}
 
-	err = rt2.WaitForPendingChanges()
-	require.NoError(t, err)
+	rt2.WaitForPendingChanges()
 
 	require.NoError(t, ar.Start(ctx1))
 
@@ -2597,8 +2581,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 		_ = rt2.PutDoc(fmt.Sprintf("docB%d", i), `{"channels": ["B"]}`)
 	}
 
-	err = rt2.WaitForPendingChanges()
-	assert.NoError(t, err)
+	rt2.WaitForPendingChanges()
 
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
@@ -2635,8 +2618,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
 
 	// Validate none of the documents are purged after flipping option
-	err = rt2.WaitForPendingChanges()
-	assert.NoError(t, err)
+	rt2.WaitForPendingChanges()
 
 	changesResults, err = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
 	assert.NoError(t, err)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -886,7 +886,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	RequireStatus(t, response, http.StatusCreated)
 
 	// Let everything catch up before opening changes feed
-	require.NoError(t, rt.WaitForPendingChanges())
+	rt.WaitForPendingChanges()
 
 	changesRespContains := func(changesResp ChangesResults, docid string) bool {
 		for _, resp := range changesResp.Results {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -584,14 +584,11 @@ func (rt *RestTester) WaitForSequence(seq uint64) error {
 	return collection.WaitForSequence(ctx, seq)
 }
 
-func (rt *RestTester) WaitForPendingChanges() error {
+func (rt *RestTester) WaitForPendingChanges() {
+	ctx := rt.Context()
 	for _, collection := range rt.GetDbCollections() {
-		err := collection.WaitForPendingChanges(base.TestCtx(rt.TB()))
-		if err != nil {
-			return err
-		}
+		require.NoError(rt.TB(), collection.WaitForPendingChanges(ctx))
 	}
-	return nil
 }
 
 func (rt *RestTester) SetAdminParty(partyTime bool) error {


### PR DESCRIPTION
- changes `WaitForPendingChanges` to do its own assertions to make it easier to use. Not all places actually stopped if changes did not come.
- change `StartPull*` blip tester code to not do external assertions, and do its assertions inside the function

Analyze all `GetChanges` and `StartPull` code to see if they needed `rt.WaitForPendingChanges`. 

There are many places where `rt.WaitForPendingChanges`:

1. `WaitForChanges` will wait for that number of changes by doing a backoff. This could be generally be replaced `WaitForChanges` followed by a single changes request.
2. `WaitForSequence` will wait for a particular sequence number.

This change is on top of https://github.com/couchbase/sync_gateway/pull/7033 and this PR should be merged into part 1's branch and then both PRs could go in as a single commit to main.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2631/
