### PR TITLE
CBG-4017 Move to go-oidc v3.11.0, go-jose v4.0.2

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"github.com/go-jose/go-jose/v4/jwt"
 	pkgerrors "github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // Authenticator manages user authentication for a database.
@@ -780,7 +780,9 @@ func (auth *Authenticator) AuthenticateUser(username string, password string) (U
 }
 
 func (auth *Authenticator) AuthenticateUntrustedJWT(rawToken string, oidcProviders OIDCProviderMap, localJWT LocalJWTProviderMap, callbackURLFunc OIDCCallbackURLFunc) (User, PrincipalConfig, error) {
-	token, err := jwt.ParseSigned(rawToken)
+
+	// Parse using the full list of supported algorithms, algorithm checking done during verify
+	token, err := jwt.ParseSigned(rawToken, SupportedAlgorithmsSlice)
 	if err != nil {
 		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Error parsing JWT in AuthenticateUntrustedJWT: %v", err)
 		return nil, PrincipalConfig{}, err

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -21,10 +21,10 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func NewTestAuthenticator(t testing.TB, dataStore sgbucket.DataStore, channelComputer ChannelComputer, opts AuthenticatorOptions) *Authenticator {
@@ -837,7 +837,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 	t.Run("token with issuer but no clientID config", func(t *testing.T) {
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerGoogleAccounts})
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		provider := oidcProviderForTest(t, &OIDCProvider{
 			Name: providerGoogle.Name,
@@ -876,7 +876,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 		wantUsername, err := getJWTUsername(provider.common(), &Identity{Subject: claims.Subject})
 		assert.NoError(t, err, "Error retrieving OpenID Connect username")
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.NoError(t, err, "Error authenticating with trusted JWT")
@@ -905,7 +905,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Expiry:   jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		}
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.Error(t, err, "Error verifying issuer claim from token")
@@ -934,7 +934,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Expiry:   jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		}
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.Error(t, err, "Error verifying audience claim from token")
@@ -962,7 +962,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Expiry:   jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		}
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.Error(t, err, "Error verifying audience claim from token")
@@ -991,7 +991,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Expiry:   jwt.NewNumericDate(time.Now().Add(-1 * time.Minute)),
 		}
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.Error(t, err, "Can't authenticate with expired token")
@@ -1024,7 +1024,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 		wantUsername, err := getJWTUsername(provider.common(), &Identity{Subject: claims.Subject})
 		assert.NoError(t, err, "Error retrieving OpenID Connect username")
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.NoError(t, err, "Error authenticating with trusted token")
@@ -1054,7 +1054,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			NotBefore: jwt.NewNumericDate(time.Now().Add(2 * time.Minute)),
 		}
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.Error(t, err, "Token with expired nbf (not before) time")
@@ -1082,7 +1082,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Expiry:   jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		}
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.Error(t, err, "Token must contain valid subject claim")
@@ -1121,7 +1121,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 		claimEmail := map[string]interface{}{"email": wantUserEmail}
 		builder := jwt.Signed(signer).Claims(claims).Claims(claimEmail)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.NoError(t, err, "Error authenticating with trusted JWT")
@@ -1162,7 +1162,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 		claimEmail := map[string]interface{}{"email": "emily@"}
 		builder := jwt.Signed(signer).Claims(claims).Claims(claimEmail)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.NoError(t, err, "Error authenticating with trusted JWT")
@@ -1197,7 +1197,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 
 		claimEmail := map[string]interface{}{"email": "layla@"}
 		builder := jwt.Signed(signer).Claims(claims).Claims(claimEmail)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, expiry, err := auth.AuthenticateTrustedJWT(token, provider, callbackURLFunc)
 		assert.NoError(t, err, "Error authenticating with trusted JWT")
@@ -1352,7 +1352,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 	t.Run("multiple providers token with no issuer no audience", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
 		builder := jwt.Signed(signer).Claims(jwt.Claims{})
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "Error getting issuer and audience from token")
@@ -1362,7 +1362,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 	t.Run("multiple providers token with issuer no audience", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerGoogleAccounts})
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "Error getting issuer and audience from token")
@@ -1372,7 +1372,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 	t.Run("multiple providers token with issuer empty audience", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerGoogleAccounts, Audience: jwt.Audience{}})
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "Error getting issuer and audience from token")
@@ -1382,7 +1382,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 	t.Run("multiple providers token with audience no issuer", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Audience: jwt.Audience{"aud1", "aud2", "aud3"}})
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "Error getting issuer and audience from token")
@@ -1392,7 +1392,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 	t.Run("multiple providers token with issuer mismatch", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerAmazonAccounts, Audience: jwt.Audience{"aud1"}})
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "No provider found against the configured issuer")
@@ -1402,7 +1402,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 	t.Run("multiple providers token with audience mismatch", func(t *testing.T) {
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
 		builder := jwt.Signed(signer).Claims(jwt.Claims{Issuer: issuerGoogleAccounts, Audience: jwt.Audience{"aud2"}})
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		require.Error(t, err, "No provider found against the configured issuer")
@@ -1431,7 +1431,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 			Expiry:   jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		}
 		builder := jwt.Signed(signer).Claims(claims)
-		token, err := builder.CompactSerialize()
+		token, err := builder.Serialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
 		user, _, err := auth.AuthenticateUntrustedJWT(token, providers, LocalJWTProviderMap{}, callbackURLFunc)
 		assert.Error(t, err, "Error authenticating with trusted JWT")

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -17,9 +17,9 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
 )
 
 func dummyCallbackURL(_ string, _ bool) string {
@@ -185,9 +185,9 @@ func TestJWTVerifyToken(t *testing.T) {
 	}), anyError))
 
 	// header: alg=none
-	t.Run("valid JWT with alg none", test(baseProvider, `eyJhbGciOiJub25lIn0.eyJhdWQiOlsidGVzdEF1ZCJdLCJpc3MiOiJ0ZXN0SXNzdWVyIn0.`, "id token signed with unsupported algorithm"))
+	t.Run("valid JWT with alg none", test(baseProvider, `eyJhbGciOiJub25lIn0.eyJhdWQiOlsidGVzdEF1ZCJdLCJpc3MiOiJ0ZXN0SXNzdWVyIn0.`, "unexpected signature algorithm"))
 	// header: alg=HS256
-	t.Run("valid JWT with alg HS256", test(baseProvider, `eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsidGVzdEF1ZCJdLCJpc3MiOiJ0ZXN0SXNzdWVyIn0.aPSuXUVKN1FNS53mw0Xw3a-SU2GVS98gHWEVrzTnQYM`, "id token signed with unsupported algorithm"))
+	t.Run("valid JWT with alg HS256", test(baseProvider, `eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsidGVzdEF1ZCJdLCJpc3MiOiJ0ZXN0SXNzdWVyIn0.aPSuXUVKN1FNS53mw0Xw3a-SU2GVS98gHWEVrzTnQYM`, "unexpected signature algorithm"))
 	// header: alg=RS256, kid=rsa
 	t.Run("valid JWT with no signature", test(baseProvider, `eyJhbGciOiJSUzI1NiIsImtpZCI6InJzYSJ9.eyJhdWQiOlsidGVzdEF1ZCJdLCJpc3MiOiJ0ZXN0SXNzdWVyIn0.`, "failed to verify signature"))
 

--- a/auth/jwt_test_utils.go
+++ b/auth/jwt_test_utils.go
@@ -11,9 +11,9 @@ package auth
 import (
 	"testing"
 
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // These are not in jwt_test.go to allow use in tests from other packages.
@@ -37,7 +37,7 @@ func CreateTestJWT(t *testing.T, alg jose.SignatureAlgorithm, key interface{}, h
 	}, signerOpts)
 	require.NoError(t, err, "failed to create signer")
 
-	tok, err := jwt.Signed(signer).Claims(claims).CompactSerialize()
+	tok, err := jwt.Signed(signer).Claims(claims).Serialize()
 	require.NoError(t, err, "failed to serialize JWT")
 	return tok
 }

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -38,12 +38,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	pkgerrors "github.com/pkg/errors"
 	"golang.org/x/oauth2"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 const (

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -24,13 +24,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // oidcProviderForTest automatically stops the provider once the test has stopped.
@@ -453,10 +453,10 @@ func TestGetJWTIssuer(t *testing.T) {
 
 	claims := jwt.Claims{Issuer: wantIssuer, Audience: wantAudience}
 	builder := jwt.Signed(signer).Claims(claims)
-	token, err := builder.CompactSerialize()
+	token, err := builder.Serialize()
 	require.NoError(t, err, "Failed to serialize JSON Web Token")
 
-	jwt, err := jwt.ParseSigned(token)
+	jwt, err := jwt.ParseSigned(token, SupportedAlgorithmsSlice)
 	require.NoError(t, err, "Failed to decode raw JSON Web Token")
 	issuer, audiences, err := getIssuerWithAudience(jwt)
 	require.NoError(t, err)

--- a/auth/oidc_verify.go
+++ b/auth/oidc_verify.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-oidc"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-jose/go-jose/v4/jwt"
 
 	"github.com/couchbase/sync_gateway/base"
 	pkgerrors "github.com/pkg/errors"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 require (
 	dario.cat/mergo v1.0.0
 	github.com/KimMachineGun/automemlimit v0.6.1
-	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/couchbase/cbgt v1.3.9
 	github.com/couchbase/clog v0.1.0
 	github.com/couchbase/go-blip v0.0.0-20231212195435-3490e96d30e3
@@ -19,6 +19,7 @@ require (
 	github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.4
+	github.com/go-jose/go-jose/v4 v4.0.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/json-iterator/go v1.1.12
@@ -38,7 +39,6 @@ require (
 	golang.org/x/net v0.27.0
 	golang.org/x/oauth2 v0.21.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
-	gopkg.in/square/go-jose.v2 v2.6.0
 )
 
 require (
@@ -79,7 +79,6 @@ require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/pquerna/cachecontrol v0.2.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups/v3 v3.0.1 h1:4hfGvu8rfGIwVIDd+nLzn/B9ZXx4BcCjzt5ToenJRaE=
 github.com/containerd/cgroups/v3 v3.0.1/go.mod h1:/vtwk1VXrtoa5AaZLkypuOJgA/6DyPMZHJPGQNtlHnw=
-github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
-github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
+github.com/coreos/go-oidc/v3 v3.11.0 h1:Ia3MxdwpSw702YW0xgfmP1GVCMA9aEFWu12XUZ3/OtI=
+github.com/coreos/go-oidc/v3 v3.11.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDhf0r5lltWI0=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/couchbase/blance v0.1.5 h1:kNSAwhb8FXSJpicJ8R8Kk7+0V1+MyTcY1MOHIDbU79w=
@@ -97,6 +97,8 @@ github.com/felixge/fgprof v0.9.4 h1:ocDNwMFlnA0NU0zSB3I52xkO4sFXk80VK9lXjLClu88=
 github.com/felixge/fgprof v0.9.4/go.mod h1:yKl+ERSa++RYOs32d8K6WEXCB4uXdLls4ZaZPpayhMM=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
+github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
+github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -184,8 +186,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/pquerna/cachecontrol v0.2.0 h1:vBXSNuE5MYP9IJ5kjsdo8uq+w41jSPgvba2DEnkRx9k=
-github.com/pquerna/cachecontrol v0.2.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
 github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=
 github.com/prometheus/client_golang v1.16.0/go.mod h1:Zsulrv/L9oM40tJ7T815tM89lFEugiJ9HzIqaAx4LKc=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -227,7 +227,6 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -378,8 +377,6 @@ gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYs
 gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbRxng+XOj5ITVgY24WcbNnQopyfKoYQ=
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
-gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
-gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/rest/config.go
+++ b/rest/config.go
@@ -30,8 +30,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/square/go-jose.v2"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -32,8 +32,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/square/go-jose.v2"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
 )
 
 func TestLocalJWTAuthenticationE2E(t *testing.T) {

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -31,11 +31,11 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // A forceError is being used when you want to force an error of type 'forceErrorType'
@@ -336,7 +336,7 @@ func (s *mockAuthServer) makeToken(claimSet claimSet) (string, error) {
 		primaryClaims.Issuer = s.options.issuer
 	}
 	builder := jwt.Signed(s.signer).Claims(primaryClaims).Claims(secondaryClaims)
-	token, err := builder.CompactSerialize()
+	token, err := builder.Serialize()
 	if err != nil {
 		return "", err
 	}

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1549,7 +1549,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 
 	t.Run("new user authentication with future time nbf claim", func(t *testing.T) {
 		claimSet := claimsAuthentic()
-		claimSet.primaryClaims.NotBefore = jwt.NewNumericDate(time.Now().Add(5 * time.Minute))
+		claimSet.primaryClaims.NotBefore = jwt.NewNumericDate(time.Now().Add(10 * time.Minute))
 		runBadAuthTest(claimSet)
 	})
 
@@ -1570,7 +1570,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 	t.Run("registered user authentication with future time nbf claim", func(t *testing.T) {
 		createUser(t, restTester, username)
 		claimSet := claimsAuthentic()
-		claimSet.primaryClaims.NotBefore = jwt.NewNumericDate(time.Now().Add(5 * time.Minute))
+		claimSet.primaryClaims.NotBefore = jwt.NewNumericDate(time.Now().Add(10 * time.Minute))
 		runBadAuthTest(claimSet)
 		deleteUser(t, restTester, username)
 	})

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 // This is the private RSA Key that will be used to sign all tokens
@@ -433,7 +433,7 @@ func createJWTWithExtraClaims(subject, issuerUrl string, authState AuthState, ex
 		Audience: jwt.Audience{testProviderAud},
 	}
 
-	token, err = jwt.Signed(signer).Claims(claims).Claims(extraClaims).CompactSerialize()
+	token, err = jwt.Signed(signer).Claims(claims).Claims(extraClaims).Serialize()
 	if err != nil {
 		return "", err
 	}

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -25,13 +25,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func TestCreateJWTToken(t *testing.T) {
@@ -86,7 +86,7 @@ func TestCreateJWTToken(t *testing.T) {
 			rawToken, err := createJWT(subject, issueURL, authState)
 			assert.NoError(t, err, "Couldn't to create JSON Web Token")
 			assert.NotEmpty(t, rawToken, "Empty token received")
-			token, err := jwt.ParseSigned(rawToken)
+			token, err := jwt.ParseSigned(rawToken, auth.SupportedAlgorithmsSlice)
 			require.NoError(t, err, "Error parsing signed token")
 			claims := &jwt.Claims{}
 			customClaims := &CustomClaims{}
@@ -360,7 +360,7 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 			assert.NotEmpty(t, authResponseActual.RefreshToken, "refresh_token mismatch")
 
 			// Check token header
-			token, err := jwt.ParseSigned(authResponseActual.IDToken)
+			token, err := jwt.ParseSigned(authResponseActual.IDToken, auth.SupportedAlgorithmsSlice)
 			require.NoError(t, err, "Error parsing signed token")
 			claims := &jwt.Claims{}
 			customClaims := &CustomClaims{}


### PR DESCRIPTION
CBG-4017

Includes uptake of change to jwt.ParseSigned API, following the approach used by go-oidc.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
