### PR TITLE
CBG-4136: OpenAPI Specs: Limit db scopes to 1 and provide example

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1203,7 +1203,7 @@ Database:
         $ref: '#/Scopes'
       maxProperties: 1
       example:
-        scopename1:
+        scopename:
           collections:
             collectionname1:
               sync: 'function(doc){channel("collection name");}'

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1201,6 +1201,16 @@ Database:
       additionalProperties:
         x-additionalPropertiesName: scopename
         $ref: '#/Scopes'
+      maxProperties: 1
+      example:
+        scopename1:
+          collections:
+            collectionname1:
+              sync: 'function(doc){channel("collection name");}'
+              import_filter: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
+            collectionname2:
+              sync: 'function(doc){channel("collection name");}'
+              import_filter: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
     name:
       description: The name of the database.
       type: string


### PR DESCRIPTION
CBG-4136

Limit db scopes to 1 and provide example

![Screenshot 2024-08-05 at 12 35 44](https://github.com/user-attachments/assets/0db4fb11-c951-4725-a620-9018220aa981)
![Screenshot 2024-08-05 at 12 35 48](https://github.com/user-attachments/assets/68d28533-7ab3-4aa3-aaaa-092084db1940)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a