### PR TITLE
CBG-4138: Enable log collation by default for audit logging

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -188,6 +188,10 @@ func NewAuditLogger(ctx context.Context, config *AuditLoggerConfig, logFilePath 
 		config.FileLoggerConfig.Enabled = BoolPtr(defaultAuditEnabled)
 	}
 
+	if config.CollationBufferSize == nil {
+		config.CollationBufferSize = IntPtr(defaultFileLoggerCollateBufferSize)
+	}
+
 	fl, err := NewFileLogger(ctx, &config.FileLoggerConfig, LevelNone, auditLogName, logFilePath, minAge, buffer)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
CBG-4138

Enables log collation by default for audit logging.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2636/
