### PR TITLE
CBG-4140: Cheaply clone additionalFields when producing audit event - avoids un…

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -11,6 +11,7 @@ package base
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"strings"
 	"time"
@@ -28,7 +29,7 @@ const (
 func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, additionalData AuditFields) AuditFields {
 	var fields AuditFields
 	if additionalData != nil {
-		fields = additionalData
+		fields = maps.Clone(additionalData)
 	} else {
 		fields = make(AuditFields)
 	}

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -104,7 +104,7 @@ func (f *AuditFields) merge(ctx context.Context, overwrites AuditFields) {
 	for k, v := range overwrites {
 		_, ok := (*f)[k]
 		if ok {
-			duplicateFields = append(duplicateFields, fmt.Sprintf("%q=%q", k, v))
+			duplicateFields = append(duplicateFields, fmt.Sprintf("%q='%v'", k, v))
 			continue
 		}
 		(*f)[k] = v

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -277,3 +277,14 @@ func TestAuditFieldsMerge(t *testing.T) {
 	}
 
 }
+
+func Test_expandFieldsAdditionalDataReadOnly(t *testing.T) {
+	additionalData := AuditFields{"foo": "bar"}
+	for i := 0; i < 5; i++ {
+		fields := expandFields(AuditIDDocumentRead, TestCtx(t), AuditFields{"global": true}, additionalData)
+		// id, name, description, timestamp, global, foo
+		assert.Len(t, fields, 6)
+	}
+	// additionalData should not be modified
+	assert.Len(t, additionalData, 1)
+}


### PR DESCRIPTION
CBG-4140

- Clone `additionalFields` when producing audit event
  - Avoids unintentional mutation by callers if additionalFields is shared for multiple audit invocations (not a super realistic scenario, but came up in benchmarking)
  - Test coverage for read-only `additionalFields`
  - Bench for `maps.Clone` - it's very cheap even compared to a pre-allocated `maps.Copy` thanks to Go runtime optimisations:
```
BenchmarkAdditionalFieldsCopy/make_empty-10         	122409171	         9.697 ns/op
BenchmarkAdditionalFieldsCopy/make_and_copy_100-10  	 1936924	       599.6 ns/op
BenchmarkAdditionalFieldsCopy/clone_100-10          	36813062	        32.65 ns/op
```
- Fix malformed warning message format for non-string types

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
