### PR TITLE
CBG-3713 nil non console loggers in ResetGlobalLogging

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -114,6 +114,7 @@ func init() {
 
 // initializeLoggers should be called once per program in init. This is also called to reset logging in a test context.
 func initializeLoggers(ctx context.Context) {
+	nilAllNonConsoleLoggers()
 	// We'll initilise a default consoleLogger so we can still log stuff before/during parsing logging configs.
 	// This maintains consistent formatting (timestamps, levels, etc) in the output,
 	// and allows a single set of logging functions to be used, rather than fmt.Printf()

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -74,16 +74,7 @@ func InitLogging(ctx context.Context, logFilePath string,
 		ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Files disabled")
 		// Explicitly log this error to console
 		ConsolefCtx(ctx, LevelError, KeyNone, ErrUnsetLogFilePath.Error())
-
-		// nil out other loggers
-		errorLogger.Store(nil)
-		warnLogger.Store(nil)
-		infoLogger.Store(nil)
-		debugLogger.Store(nil)
-		traceLogger.Store(nil)
-		statsLogger.Store(nil)
-		auditLogger.Store(nil)
-
+		nilAllNonConsoleLoggers()
 		return nil
 	}
 
@@ -361,4 +352,15 @@ func validateLogFileOutput(logFileOutput string) error {
 	}
 
 	return file.Close()
+}
+
+// nilAllNonConsoleLoggers will nil out all loggers except the console logger.
+func nilAllNonConsoleLoggers() {
+	errorLogger.Store(nil)
+	warnLogger.Store(nil)
+	infoLogger.Store(nil)
+	debugLogger.Store(nil)
+	traceLogger.Store(nil)
+	statsLogger.Store(nil)
+	auditLogger.Store(nil)
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -657,7 +657,9 @@ func setTestLogging(logLevel LogLevel, caller string, logKeys ...LogKey) (teardo
 		*logger.LogKeyMask != *initialLogKey {
 		panic(fmt.Sprintf("Logging is in an unexpected state! Did a previous test forget to call the teardownFn of SetUpTestLogging?, LogLevel=%s, expected=%s; LogKeyMask=%s, expected=%s", logger.LogLevel, initialLogLevel, logger.LogKeyMask, initialLogKey))
 	}
-
+	if errorLogger.Load() != nil {
+		panic("Logging is in an expected state, an earlier test possibly needed to call ResetGlobalTestLogging")
+	}
 	logger.LogLevel.Set(logLevel)
 	logger.LogKeyMask.Set(logKeyMask(logKeys...))
 	updateExternalLoggers()

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -163,6 +163,7 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 }
 
 func TestLoggingKeys(t *testing.T) {
+	base.ResetGlobalTestLogging(t)
 	if base.GlobalTestLoggingSet.IsTrue() {
 		t.Skip("Test does not work when a global test log level is set")
 	}
@@ -2924,6 +2925,7 @@ func TestConfigEndpoint(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
+			base.ResetGlobalTestLogging(t)
 			base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 			base.InitializeMemoryLoggers()
@@ -3025,6 +3027,7 @@ func TestInitialStartupConfig(t *testing.T) {
 }
 
 func TestIncludeRuntimeStartupConfig(t *testing.T) {
+	base.ResetGlobalTestLogging(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	base.InitializeMemoryLoggers()
@@ -3275,6 +3278,7 @@ func TestNotExistentDBRequest(t *testing.T) {
 }
 
 func TestConfigsIncludeDefaults(t *testing.T) {
+	base.ResetGlobalTestLogging(t)
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 


### PR DESCRIPTION
`ResetGlobalTestLogging` would reset the state of the console logger and close the files of the open loggers, but it wouldn't nil the loggers. Running tests in succession would cause you to see a problem:

```
2024-08-05T14:34:15.4578445Z WARNING: DATA RACE
2024-08-05T14:34:15.4578597Z Write at 0x00c0026b5b68 by goroutine 204213:
2024-08-05T14:34:15.4578713Z   runtime.racewrite()
2024-08-05T14:34:15.4578919Z       <autogenerated>:1 +0x1e
2024-08-05T14:34:15.4579213Z   github.com/couchbase/sync_gateway/base.FlushLogBuffers()
2024-08-05T14:34:15.4579624Z       /home/runner/work/sync_gateway/sync_gateway/base/logger.go:53 +0x144
2024-08-05T14:34:15.4579877Z   github.com/couchbase/sync_gateway/base.AssertLogContains()
2024-08-05T14:34:15.4580232Z       /home/runner/work/sync_gateway/sync_gateway/base/logging.go:401 +0x436
2024-08-05T14:34:15.4580506Z   github.com/couchbase/sync_gateway/rest.TestBadCORSValuesConfig()
2024-08-05T14:34:15.4580862Z       /home/runner/work/sync_gateway/sync_gateway/rest/cors_test.go:552 +0x364
2024-08-05T14:34:15.4580976Z   testing.tRunner()
2024-08-05T14:34:15.4581362Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
2024-08-05T14:34:15.4581489Z   testing.(*T).Run.gowrap1()
2024-08-05T14:34:15.4581832Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x44
2024-08-05T14:34:15.4581843Z 
2024-08-05T14:34:15.4582023Z Previous read at 0x00c0026b5b68 by goroutine 204295:
2024-08-05T14:34:15.4582146Z   runtime.raceread()
2024-08-05T14:34:15.4582286Z       <autogenerated>:1 +0x1e
2024-08-05T14:34:15.4582519Z   github.com/couchbase/sync_gateway/base.(*FileLogger).logf()
2024-08-05T14:34:15.4582889Z       /home/runner/work/sync_gateway/sync_gateway/base/logger_file.go:179 +0xae
2024-08-05T14:34:15.4583065Z   github.com/couchbase/sync_gateway/base.logTo()
2024-08-05T14:34:15.4583418Z       /home/runner/work/sync_gateway/sync_gateway/base/logging.go:244 +0x6cc
2024-08-05T14:34:15.4583602Z   github.com/couchbase/sync_gateway/base.InfofCtx()
2024-08-05T14:34:15.4583947Z       /home/runner/work/sync_gateway/sync_gateway/base/logging.go:167 +0xa4
2024-08-05T14:34:15.4584297Z   github.com/couchbase/sync_gateway/db.(*sgReplicateManager).RefreshReplicationCfg()
2024-08-05T14:34:15.4584679Z       /home/runner/work/sync_gateway/sync_gateway/db/sg_replicate_cfg.go:745 +0x4e
2024-08-05T14:34:15.4585005Z   github.com/couchbase/sync_gateway/db.(*sgReplicateManager).SubscribeCfgChanges()
2024-08-05T14:34:15.4585384Z       /home/runner/work/sync_gateway/sync_gateway/db/sg_replicate_cfg.go:836 +0x1c5
2024-08-05T14:34:15.4585715Z   github.com/couchbase/sync_gateway/db.(*sgReplicateManager).StartReplications()
2024-08-05T14:34:15.4586094Z       /home/runner/work/sync_gateway/sync_gateway/db/sg_replicate_cfg.go:549 +0x948
2024-08-05T14:34:15.4586439Z   github.com/couchbase/sync_gateway/db.(*DatabaseContext).startReplications.func1()
2024-08-05T14:34:15.4586805Z       /home/runner/work/sync_gateway/sync_gateway/db/sg_replicate_cfg.go:470 +0x4d1
2024-08-05T14:34:15.4586811Z 
2024-08-05T14:34:15.4586944Z Goroutine 204213 (running) created at:
2024-08-05T14:34:15.4587050Z   testing.(*T).Run()
2024-08-05T14:34:15.4587396Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x825
2024-08-05T14:34:15.4587527Z   testing.runTests.func1()
2024-08-05T14:34:15.4587866Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:2161 +0x85
2024-08-05T14:34:15.4587980Z   testing.tRunner()
2024-08-05T14:34:15.4588320Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
2024-08-05T14:34:15.4588437Z   testing.runTests()
2024-08-05T14:34:15.4588767Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:2159 +0x8be
2024-08-05T14:34:15.4588873Z   testing.(*M).Run()
2024-08-05T14:34:15.4589206Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:2027 +0xf17
2024-08-05T14:34:15.4589447Z   github.com/couchbase/sync_gateway/base.TestBucketPoolMain()
2024-08-05T14:34:15.4589872Z       /home/runner/work/sync_gateway/sync_gateway/base/main_test_bucket_pool.go:736 +0x4e4
2024-08-05T14:34:15.4590140Z   github.com/couchbase/sync_gateway/db.TestBucketPoolWithIndexes()
2024-08-05T14:34:15.4590499Z       /home/runner/work/sync_gateway/sync_gateway/db/util_testing.go:611 +0x74
2024-08-05T14:34:15.4590774Z   github.com/couchbase/sync_gateway/rest.TestMain()
2024-08-05T14:34:15.4591121Z       /home/runner/work/sync_gateway/sync_gateway/rest/main_test.go:26 +0x1d
2024-08-05T14:34:15.4591335Z   main.main()
2024-08-05T14:34:15.4591495Z       _testmain.go:1225 +0x2d4
2024-08-05T14:34:15.4591577Z 
2024-08-05T14:34:15.4591714Z Goroutine 204295 (finished) created at:
2024-08-05T14:34:15.4592029Z   github.com/couchbase/sync_gateway/db.(*DatabaseContext).startReplications()
2024-08-05T14:34:15.4592419Z       /home/runner/work/sync_gateway/sync_gateway/db/sg_replicate_cfg.go:454 +0x1e7
2024-08-05T14:34:15.4592744Z   github.com/couchbase/sync_gateway/db.(*DatabaseContext).StartOnlineProcesses()
2024-08-05T14:34:15.4593095Z       /home/runner/work/sync_gateway/sync_gateway/db/database.go:2472 +0x34c4
2024-08-05T14:34:15.4593461Z   github.com/couchbase/sync_gateway/rest.(*ServerContext)._getOrAddDatabaseFromConfig()
2024-08-05T14:34:15.4593858Z       /home/runner/work/sync_gateway/sync_gateway/rest/server_context.go:1024 +0x4eab
2024-08-05T14:34:15.4594205Z   github.com/couchbase/sync_gateway/rest.(*ServerContext)._reloadDatabaseWithConfig()
2024-08-05T14:34:15.4594586Z       /home/runner/work/sync_gateway/sync_gateway/rest/server_context.go:501 +0x173
2024-08-05T14:34:15.4594876Z   github.com/couchbase/sync_gateway/rest.(*ServerContext)._applyConfig()
2024-08-05T14:34:15.4595221Z       /home/runner/work/sync_gateway/sync_gateway/rest/config.go:2065 +0x797
2024-08-05T14:34:15.4595495Z   github.com/couchbase/sync_gateway/rest.(*handler).handleCreateDB()
2024-08-05T14:34:15.4595853Z       /home/runner/work/sync_gateway/sync_gateway/rest/admin_api.go:120 +0x1392
2024-08-05T14:34:15.4596078Z   github.com/couchbase/sync_gateway/rest.(*handler).invoke()
2024-08-05T14:34:15.4596426Z       /home/runner/work/sync_gateway/sync_gateway/rest/handler.go:282 +0x32f
2024-08-05T14:34:15.4597032Z   github.com/couchbase/sync_gateway/rest.CreateAdminRouter.makeHandlerSpecificAuthScope.makeHandlerWithOptions.func77()
2024-08-05T14:34:15.4597385Z       /home/runner/work/sync_gateway/sync_gateway/rest/handler.go:127 +0x15d
2024-08-05T14:34:15.4597527Z   net/http.HandlerFunc.ServeHTTP()
2024-08-05T14:34:15.4597880Z       /opt/hostedtoolcache/go/1.22.5/x64/src/net/http/server.go:2171 +0x47
2024-08-05T14:34:15.4598191Z   github.com/couchbase/sync_gateway/rest.NewRouter.withServerType.func1.1()
2024-08-05T14:34:15.4598532Z       /home/runner/work/sync_gateway/sync_gateway/rest/routing.go:367 +0x97
2024-08-05T14:34:15.4598675Z   net/http.HandlerFunc.ServeHTTP()
2024-08-05T14:34:15.4599016Z       /opt/hostedtoolcache/go/1.22.5/x64/src/net/http/server.go:2171 +0x47
2024-08-05T14:34:15.4599188Z   github.com/gorilla/mux.(*Router).ServeHTTP()
2024-08-05T14:34:15.4599562Z       /home/runner/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x371
2024-08-05T14:34:15.4599902Z   github.com/couchbase/sync_gateway/rest.CreateAdminHandler.wrapRouter.func1()
2024-08-05T14:34:15.4600249Z       /home/runner/work/sync_gateway/sync_gateway/rest/routing.go:418 +0x27b
2024-08-05T14:34:15.4600387Z   net/http.HandlerFunc.ServeHTTP()
2024-08-05T14:34:15.4600725Z       /opt/hostedtoolcache/go/1.22.5/x64/src/net/http/server.go:2171 +0x47
2024-08-05T14:34:15.4601018Z   github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest()
2024-08-05T14:34:15.4601423Z       /home/runner/work/sync_gateway/sync_gateway/rest/utilities_testing.go:955 +0x2d9
2024-08-05T14:34:15.4601703Z   github.com/couchbase/sync_gateway/rest.(*RestTester).CreateDatabase()
2024-08-05T14:34:15.4602103Z       /home/runner/work/sync_gateway/sync_gateway/rest/utilities_testing.go:474 +0x375
2024-08-05T14:34:15.4602569Z   github.com/couchbase/sync_gateway/rest.TestBadCORSValuesConfig.func1()
2024-08-05T14:34:15.4602923Z       /home/runner/work/sync_gateway/sync_gateway/rest/cors_test.go:553 +0xb0
2024-08-05T14:34:15.4603163Z   github.com/couchbase/sync_gateway/base.AssertLogContains()
2024-08-05T14:34:15.4603510Z       /home/runner/work/sync_gateway/sync_gateway/base/logging.go:399 +0x431
2024-08-05T14:34:15.4603880Z   github.com/couchbase/sync_gateway/rest.TestBadCORSValuesConfig()
2024-08-05T14:34:15.4604300Z       /home/runner/work/sync_gateway/sync_gateway/rest/cors_test.go:552 +0x364
2024-08-05T14:34:15.4604478Z   testing.tRunner()
2024-08-05T14:34:15.4604907Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
2024-08-05T14:34:15.4605033Z   testing.(*T).Run.gowrap1()
2024-08-05T14:34:15.4605372Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x44
```

This problem is _not_ fixed by this PR, which causes a data race if you have collation enabled. In this case `logf` can be called at the same time as `FlushLogBuffers`. This is exceeding unlikely that I do not believe it is worth fixing. In production, the only time this would occur is when Sync Gateway is panicking and you might lose a bit of logging in a different go routine while it is panicking, which is a risk anyway.

Regardless, this code should be present to clean up test state. To see an example of failures, run `(TestAuditLogConfig|TestBadCors)`
