### PR TITLE
Add benchmark to get audit field overhead measurements

### DIFF
--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -9,7 +9,9 @@
 package base
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"maps"
 	"testing"
 
@@ -276,4 +278,57 @@ func TestAuditFieldsMerge(t *testing.T) {
 		})
 	}
 
+}
+
+func BenchmarkAuditFieldwork(b *testing.B) {
+	originalLogger := auditLogger.Load()
+	b.Cleanup(func() {
+		auditLogger.Store(originalLogger)
+	})
+
+	// discard audits to benchmark field expansion only
+	buf := io.Discard
+	al, err := NewAuditLogger(TestCtx(b), &AuditLoggerConfig{
+		FileLoggerConfig: FileLoggerConfig{
+			Enabled: BoolPtr(true),
+			Output:  buf,
+		},
+	}, b.TempDir(), auditMinage, nil, map[string]any{"foo": "bar", "buzz": 1234})
+	require.NoError(b, err)
+	auditLogger.Store(al)
+
+	ctx := TestCtx(b)
+	ctx = CorrelationIDLogCtx(ctx, FormatBlipContextID("a0b1c2"))
+	ctx = CollectionLogCtx(ctx, "foo", "bar")
+
+	docID, revID := "docID", "revID"
+
+	type args struct {
+		ctx            context.Context
+		id             AuditID
+		additionalData AuditFields
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "additional fields",
+			args: args{
+				ctx: ctx,
+				id:  AuditIDDocumentRead,
+				additionalData: AuditFields{
+					AuditFieldDocID:      docID,
+					AuditFieldDocVersion: revID,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				Audit(test.args.ctx, test.args.id, test.args.additionalData)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Intentionally does not benchmark logger, by writing into `io.Discard`, but aims to be a benchmark to get profiling information for the `expandFields` and marshalling required to produce an audit event.

![Screenshot 2024-08-05 at 17 34 37](https://github.com/user-attachments/assets/5a493e97-9748-41af-8aea-08906d0afaae)
