### PR TITLE
[3.2.0 Backport] CBG-4139: 3.2.0 Cherry-pick: CBG-4138: Enable log collation by default for audit logging

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -180,6 +180,10 @@ func NewAuditLogger(ctx context.Context, config *AuditLoggerConfig, logFilePath 
 		config.FileLoggerConfig.Enabled = BoolPtr(defaultAuditEnabled)
 	}
 
+	if config.CollationBufferSize == nil {
+		config.CollationBufferSize = IntPtr(defaultFileLoggerCollateBufferSize)
+	}
+
 	fl, err := NewFileLogger(ctx, &config.FileLoggerConfig, LevelNone, auditLogName, logFilePath, minAge, buffer)
 	if err != nil {
 		return nil, err

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -762,6 +762,12 @@ func TestEffectiveUserID(t *testing.T) {
 	events := jsonLines(t, output)
 
 	for _, event := range events {
+		eventID := base.AuditID(event[base.AuditFieldID].(float64))
+		// ignore events that don't have user info ()
+		if eventID != base.AuditIDPublicUserAuthenticated && eventID != base.AuditIDReadDatabase {
+			continue
+		}
+
 		effective := event[base.AuditEffectiveUserID].(map[string]any)
 		assert.Equal(t, cnfDomain, effective[base.AuditFieldEffectiveUserIDDomain])
 		assert.Equal(t, cnfUser, effective[base.AuditFieldEffectiveUserIDUser])


### PR DESCRIPTION
CBG-4139

Backports #7019 to 3.2.0
- CBG-4138: Enable log collation by default for audit logging

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
