### PR TITLE
CBG-4157: disable audit events bug/panic and fix

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4310,8 +4310,8 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	eventsJSON, err := json.Marshal(eventsMap)
 	require.NoError(t, err)
 
-	// CBG-4111: Try to disable all events on top of the default (nil) set... either PUT or POST where *all* of the given IDs are set to false. Bug results in a no-op.
-	// CBG-????: Ensure ALL specified events were actually disabled. QE reported that some stay true!
+	// CBG-4111: Try to disable events on top of the default (nil) set... either PUT or POST where *all* of the given IDs are set to false. Bug results in a no-op.
+	// CBG-4157: Ensure ALL specified events were actually disabled. Bug results in some events remaining 'true', and sometimes panicking by going out-of-bounds in a slice.
 	resp = rt.SendAdminRequest(http.MethodPost, "/db/_config/audit", fmt.Sprintf(`{"enabled":true,"events":%s}`, eventsJSON))
 	rest.RequireStatus(t, resp, http.StatusOK)
 	// check all events were actually disabled

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4320,7 +4320,6 @@ func TestDatabaseConfigAuditAPI(t *testing.T) {
 	resp.DumpBody()
 	responseBody = nil
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &responseBody))
-	eventsMap = nil
 	eventsMap, ok = responseBody["events"].(map[string]interface{})
 	require.True(t, ok)
 	for id, val := range eventsMap {


### PR DESCRIPTION
CBG-4157

- Repro QE bug for disabling all events via POST and produce panic
- Fix POST db audit events logic when most of the events are set to 'false'

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2640/
