### PR TITLE
CBG-4135: new stat for rev cache capacity

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -1323,7 +1323,7 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.RevisionCacheNumItems, err = NewIntStat(SubsystemCacheKey, "revision_cache_num_items", StatUnitNoUnits, RevCacheNumItemsDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.RevisionCacheNumItems, err = NewIntStat(SubsystemCacheKey, "revision_cache_num_items", StatUnitNoUnits, RevCacheNumItemsDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -85,6 +85,7 @@ const (
 	StatAddedVersion3dot1dot3dot1 = "3.1.3.1"
 	StatAddedVersion3dot1dot4     = "3.1.4"
 	StatAddedVersion3dot2dot0     = "3.2.0"
+	StatAddedVersion3dot2dot1     = "3.2.1"
 	StatAddedVersion3dot3dot0     = "3.3.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
@@ -425,6 +426,8 @@ type CacheStats struct {
 	NumSkippedSeqs *SgwIntStat `json:"num_skipped_seqs"`
 	// The total number of pending sequences. These are out-of-sequence entries waiting to be cached.
 	PendingSeqLen *SgwIntStat `json:"pending_seq_len"`
+	// Total number of items in the rev cache
+	RevisionCacheNumItems *SgwIntStat `json:"revision_cache_num_items"`
 	// The total number of revision cache bypass operations performed.
 	RevisionCacheBypass *SgwIntStat `json:"rev_cache_bypass"`
 	// The total number of revision cache hits.
@@ -1320,6 +1323,10 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.RevisionCacheNumItems, err = NewIntStat(SubsystemCacheKey, "revision_cache_num_items", StatUnitNoUnits, RevCacheNumItemsDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.RevisionCacheBypass, err = NewIntStat(SubsystemCacheKey, "rev_cache_bypass", StatUnitNoUnits, RevCacheBypassDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
@@ -1377,6 +1384,7 @@ func (d *DbStats) unregisterCacheStats() {
 	prometheus.Unregister(d.CacheStats.SkippedSeqCap)
 	prometheus.Unregister(d.CacheStats.NumCurrentSeqsSkipped)
 	prometheus.Unregister(d.CacheStats.PendingSeqLen)
+	prometheus.Unregister(d.CacheStats.RevisionCacheNumItems)
 	prometheus.Unregister(d.CacheStats.RevisionCacheBypass)
 	prometheus.Unregister(d.CacheStats.RevisionCacheHits)
 	prometheus.Unregister(d.CacheStats.RevisionCacheMisses)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -119,6 +119,8 @@ const (
 
 	PendingSeqLengthDesc = "The total number of pending sequences. These are out-of-sequence entries waiting to be cached."
 
+	RevCacheNumItemsDesc = "The total number of items in the revision cache."
+
 	RevCacheBypassDesc = "The total number of revision cache bypass operations performed."
 
 	RevCacheHitsDesc = "The total number of revision cache hits. This metric can be used to calculate the ratio of revision cache hits: " +

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -402,8 +402,8 @@ func TestGetRemovedAsUser(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter)
+	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -754,8 +754,8 @@ func TestGetRemoved(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter)
+	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -823,8 +823,8 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter)
+	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -28,7 +28,6 @@ const (
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
 	// Get returns the given revision, and stores if not already cached.
-	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
 	Get(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
 
@@ -77,12 +76,13 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 
 	cacheHitStat := cacheStats.RevisionCacheHits
 	cacheMissStat := cacheStats.RevisionCacheMisses
+	cacheNumItemsStat := cacheStats.RevisionCacheNumItems
 
 	if cacheOptions.ShardCount > 1 {
-		return NewShardedLRURevisionCache(cacheOptions.ShardCount, cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat)
+		return NewShardedLRURevisionCache(cacheOptions.ShardCount, cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat)
 	}
 
-	return NewLRURevisionCache(cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat)
+	return NewLRURevisionCache(cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat)
 }
 
 type RevisionCacheOptions struct {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -32,7 +32,6 @@ type RevisionCache interface {
 	Get(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
-	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
 
 	// Peek returns the given revision if present in the cache

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -623,12 +623,13 @@ func TestRevCacheCapacityStat(t *testing.T) {
 	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
 
 	// test not found doc, assert that the stat isn't incremented
-	cache.Get(ctx, "badDoc", "1-abc", testCollectionID, false)
+	docRev, err := cache.Get(ctx, "badDoc", "1-abc", testCollectionID, false)
+	require.Error(t, err)
 	assert.Equal(t, int64(1), cacheNumItems.Value())
 	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
 
 	// Get on a doc that doesn't exist in cache, assert num items increments
-	docRev, err := cache.Get(ctx, "doc2", "1-abc", testCollectionID, false)
+	docRev, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, false)
 	require.NoError(t, err)
 	assert.Equal(t, "doc2", docRev.DocID)
 	assert.Equal(t, int64(2), cacheNumItems.Value())

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -623,13 +623,13 @@ func TestRevCacheCapacityStat(t *testing.T) {
 	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
 
 	// test not found doc, assert that the stat isn't incremented
-	docRev, err := cache.Get(ctx, "badDoc", "1-abc", testCollectionID, false)
+	_, err := cache.Get(ctx, "badDoc", "1-abc", testCollectionID, false)
 	require.Error(t, err)
 	assert.Equal(t, int64(1), cacheNumItems.Value())
 	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
 
 	// Get on a doc that doesn't exist in cache, assert num items increments
-	docRev, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, false)
+	docRev, err := cache.Get(ctx, "doc2", "1-abc", testCollectionID, false)
 	require.NoError(t, err)
 	assert.Equal(t, "doc2", docRev.DocID)
 	assert.Equal(t, int64(2), cacheNumItems.Value())

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -89,9 +89,9 @@ func CreateTestSingleBackingStoreMap(backingStore RevisionCacheBackingStore, col
 
 // Tests the eviction from the LRURevisionCache
 func TestLRURevisionCacheEviction(t *testing.T) {
-	cacheHitCounter, cacheMissCounter := base.SgwIntStat{}, base.SgwIntStat{}
+	cacheHitCounter, cacheMissCounter, cacheNumItems := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID)
-	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
+	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems)
 
 	ctx := base.TestCtx(t)
 
@@ -143,9 +143,9 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 
 func TestBackingStore(t *testing.T) {
 
-	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"Peter"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
-	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
+	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
 	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
@@ -395,9 +395,9 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 
 // Ensure subsequent updates to delta don't mutate previously retrieved deltas
 func TestRevisionImmutableDelta(t *testing.T) {
-	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
-	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
+	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems)
 
 	firstDelta := []byte("delta")
 	secondDelta := []byte("modified delta")
@@ -431,9 +431,9 @@ func TestRevisionImmutableDelta(t *testing.T) {
 
 // Ensure subsequent updates to delta don't mutate previously retrieved deltas
 func TestSingleLoad(t *testing.T) {
-	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
-	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
+	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", History: Revisions{"start": 1}}, testCollectionID)
 	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
@@ -442,9 +442,9 @@ func TestSingleLoad(t *testing.T) {
 
 // Ensure subsequent updates to delta don't mutate previously retrieved deltas
 func TestConcurrentLoad(t *testing.T) {
-	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
-	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
+	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", History: Revisions{"start": 1}}, testCollectionID)
 
@@ -608,12 +608,93 @@ func TestRevCacheHitMultiCollectionLoadFromBucket(t *testing.T) {
 	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
 }
 
+func TestRevCacheCapacityStat(t *testing.T) {
+	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
+	cache := NewLRURevisionCache(4, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems)
+	ctx := base.TestCtx(t)
+
+	assert.Equal(t, int64(0), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Create a new doc + asert num items increments
+	cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", History: Revisions{"start": 1}}, testCollectionID)
+	assert.Equal(t, int64(1), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Get on a doc that doesn't exist in cache, assert num items increments
+	docRev, err := cache.Get(ctx, "doc2", "1-abc", testCollectionID, false)
+	require.NoError(t, err)
+	assert.Equal(t, "doc2", docRev.DocID)
+	assert.Equal(t, int64(2), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Get on item in cache, assert num items remains the same
+	docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, false)
+	require.NoError(t, err)
+	assert.Equal(t, "doc1", docRev.DocID)
+	assert.Equal(t, int64(2), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Get Active on doc not in cache, assert num items increments
+	docRev, err = cache.GetActive(ctx, "doc3", testCollectionID)
+	require.NoError(t, err)
+	assert.Equal(t, "doc3", docRev.DocID)
+	assert.Equal(t, int64(3), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Get Active on doc in the cache, assert that the num items stat remains unchanged
+	docRev, err = cache.GetActive(ctx, "doc1", testCollectionID)
+	require.NoError(t, err)
+	assert.Equal(t, "doc1", docRev.DocID)
+	assert.Equal(t, int64(3), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Upsert a doc resident in cache, assert stat is unchanged
+	cache.Upsert(ctx, DocumentRevision{BodyBytes: []byte(`{"test":"12345"}`), DocID: "doc1", RevID: "1-abc", History: Revisions{"start": 1}}, testCollectionID)
+	assert.Equal(t, int64(3), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Upsert new doc, assert the num items stat increments
+	cache.Upsert(ctx, DocumentRevision{BodyBytes: []byte(`{"test":"1234}`), DocID: "doc4", RevID: "1-abc", History: Revisions{"start": 1}}, testCollectionID)
+	assert.Equal(t, int64(4), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Peek a doc that is resident in cache, assert stat is unchanged
+	docRev, ok := cache.Peek(ctx, "doc4", "1-abc", testCollectionID)
+	require.True(t, ok)
+	assert.Equal(t, "doc4", docRev.DocID)
+	assert.Equal(t, int64(4), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Peek a doc that is not resident in cache, assert stat is unchanged
+	docRev, ok = cache.Peek(ctx, "doc5", "1-abc", testCollectionID)
+	require.False(t, ok)
+	assert.Equal(t, int64(4), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Eviction situation and assert stat doesn't go over the capacity set
+	cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc5", RevID: "1-abc", History: Revisions{"start": 1}}, testCollectionID)
+	assert.Equal(t, int64(4), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+
+	// Empty cache
+	cache.Remove("doc1", "1-abc", testCollectionID)
+	cache.Remove("doc3", "1-abc", testCollectionID)
+	cache.Remove("doc4", "1-abc", testCollectionID)
+	cache.Remove("doc5", "1-abc", testCollectionID)
+
+	// Assert num items goes back to 0
+	assert.Equal(t, int64(0), cacheNumItems.Value())
+	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+}
+
 func BenchmarkRevisionCacheRead(b *testing.B) {
 	base.SetUpBenchmarkLogging(b, base.LevelDebug, base.KeyAll)
 
-	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
-	cache := NewLRURevisionCache(5000, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
+	cache := NewLRURevisionCache(5000, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems)
 
 	ctx := base.TestCtx(b)
 


### PR DESCRIPTION
CBG-4135

- Adding a new stat called `RevisionCacheNumItems` for number of items in the cache

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2655/
