### PR TITLE
CBG-4067 Only skip releasing sequences for timeouts

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -257,6 +257,18 @@ func IsTemporaryKvError(err error) bool {
 	return false
 }
 
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, gocb.ErrTimeout) || errors.Is(err, ErrTimeout) {
+		return true
+	}
+
+	return false
+}
+
 func IsXattrNotFoundError(err error) bool {
 	if unwrappedErr := pkgerrors.Cause(err); unwrappedErr == nil {
 		return false

--- a/db/crud.go
+++ b/db/crud.go
@@ -2094,7 +2094,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 	// If the WriteUpdate didn't succeed, check whether there are unused, allocated sequences that need to be accounted for
 	if err != nil {
-		if !base.IsTemporaryKvError(err) {
+		// For timeout errors, the write may or may not have succeeded so we cannot release the sequence as unused
+		if !base.IsTimeoutError(err) {
 			if docSequence > 0 {
 				if seqErr := db.sequences().releaseSequence(ctx, docSequence); seqErr != nil {
 					base.WarnfCtx(ctx, "Error returned when releasing sequence %d. Falling back to skipped sequence handling.  Error:%v", docSequence, seqErr)


### PR DESCRIPTION
Ensure we release sequences in scenarios where we are sure the write associated with the allocated sequence did not occur.

CBG-4067
## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2642/
