### PR TITLE
CBG-4161 log the source of metadata ID

### DIFF
--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -768,7 +768,7 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 	for _, cg := range registry.ConfigGroups {
 		for dbName, db := range cg.Databases {
 			if dbName == config.Name {
-				base.DebugfCtx(ctx, base.KeyConfig, "Using metadata ID=%q from registry for db %q", base.MD(db.MetadataID), base.MD(dbName))
+				base.InfofCtx(ctx, base.KeyConfig, "Using metadata ID=%q from registry for db %q", base.MD(db.MetadataID), base.MD(dbName))
 				return db.MetadataID
 			}
 			if db.MetadataID == defaultMetadataID {
@@ -793,7 +793,7 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 			}
 		}
 		if !defaultFound {
-			base.DebugfCtx(ctx, base.KeyConfig, "Using metadata ID %q for db %q since _default._default collection is not a collection targeted by this db", base.MD(standardMetadataID), base.MD(config.Name))
+			base.InfofCtx(ctx, base.KeyConfig, "Using metadata ID %q for db %q since _default._default collection is not a collection targeted by this db", base.MD(standardMetadataID), base.MD(config.Name))
 			return standardMetadataID
 		}
 	}
@@ -808,11 +808,11 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 	}
 
 	if exists && syncInfo.MetadataID != defaultMetadataID {
-		base.DebugfCtx(ctx, base.KeyConfig, "Using metadata ID %q for db %q because db uses the default collection, and _sync:syncInfo in the default collection specifies the non-default metadata ID %q", base.MD(standardMetadataID), base.MD(config.Name), base.MD(syncInfo.MetadataID))
+		base.InfofCtx(ctx, base.KeyConfig, "Using metadata ID %q for db %q because db uses the default collection, and _sync:syncInfo in the default collection specifies the non-default metadata ID %q", base.MD(standardMetadataID), base.MD(config.Name), base.MD(syncInfo.MetadataID))
 		return standardMetadataID
 	}
 
-	base.DebugfCtx(ctx, base.KeyConfig, "Using default metadata ID %q for db %q", base.MD(defaultMetadataID), base.MD(config.Name))
+	base.InfofCtx(ctx, base.KeyConfig, "Using default metadata ID %q for db %q", base.MD(defaultMetadataID), base.MD(config.Name))
 	return defaultMetadataID
 }
 

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -764,7 +764,7 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 	standardMetadataID := b.standardMetadataID(config.Name)
 
 	// If there's already a metadataID assigned to this database in the registry (including other config groups), use that
-	defaultMetadataIDInUse := false
+	defaultMetadataIDDb := ""
 	for _, cg := range registry.ConfigGroups {
 		for dbName, db := range cg.Databases {
 			if dbName == config.Name {
@@ -773,13 +773,14 @@ func (b *bootstrapContext) computeMetadataID(ctx context.Context, registry *Gate
 			}
 			if db.MetadataID == defaultMetadataID {
 				// do not return standardMetadataID here in case there was a different metadata ID assigned to this database
-				defaultMetadataIDInUse = true
+				defaultMetadataIDDb = config.Name
 			}
 		}
 	}
 
 	// If the default metadata ID is already in use in the registry by a different database, use standard ID.
-	if defaultMetadataIDInUse {
+	if defaultMetadataIDDb != "" {
+		base.InfofCtx(ctx, base.KeyConfig, "Using metadata ID %q for db %q since the default metadata ID is already in use by db %q", base.MD(standardMetadataID), base.MD(config.Name), base.MD(defaultMetadataIDDb))
 		return standardMetadataID
 	}
 	// If the database config doesn't include _default._default, use standard ID


### PR DESCRIPTION
I implemented this with a subfunction rather than declaring `var logMessage` at the top of the function and using a defer because I thought it would prevent us from missing a place that we log by requiring a specific return. The only weird part is that we'll double log, once on WRN and once on DBG, if we have an error other than `IsDocNotFound` getting `_sync:syncInfo`.

I am not worried about this function getting called on each config because it is only called when creating a new db, or when main or initial bootstrap polling finds a legacy config.

```mermaid
flowchart TD
    InsertConfig --> computeMetadataID
    ComputeMetadataIDForConfig --> computeMetadataID
    handleCreateDb --> ComputeMetadataIDForConfig
    main --> automaticConfigUpgrade
    automaticConfigUpgrade --> InsertConfig
    handleCreateDb --> computeMetadataID
    migrateV30Configs --> InsertConfig
    initializeBootstrapConnection --> migrateV30Configs
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

