### PR TITLE
CBG-4160: Replace base.WaitForStat with Assert/Require and fix missing stat incr

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -736,22 +736,33 @@ func DirExists(filename string) bool {
 	return info.IsDir()
 }
 
-// WaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.
-func WaitForStat(t testing.TB, getStatFunc func() int64, expected int64) (int64, bool) {
+// _waitForStat is the internal implementation of AssertWaitForStat and RequireWaitForStat. Use those instead.
+func _waitForStat(t testing.TB, getStatFunc func() int64, expected int64) (int64, bool) {
 	workerFunc := func() (shouldRetry bool, err error, val interface{}) {
 		val = getStatFunc()
 		return val != expected, nil, val
 	}
 	// wait for up to 20 seconds for the stat to meet the expected value
 	err, val := RetryLoop(TestCtx(t), "waitForStat retry loop", workerFunc, CreateSleeperFunc(200, 100))
-	valInt64, ok := val.(int64)
+	require.NoError(t, err)
 
-	return valInt64, err == nil && ok
+	valInt64, ok := val.(int64)
+	require.True(t, ok)
+
+	return valInt64, expected == valInt64
+}
+
+// AssertWaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.
+func AssertWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) (val int64) {
+	val, ok := _waitForStat(t, getStatFunc, expected)
+	require.True(t, ok)
+	assert.Equal(t, expected, val)
+	return val
 }
 
 // RequireWaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.
 func RequireWaitForStat(t testing.TB, getStatFunc func() int64, expected int64) {
-	val, ok := WaitForStat(t, getStatFunc, expected)
+	val, ok := _waitForStat(t, getStatFunc, expected)
 	require.True(t, ok)
 	require.Equal(t, expected, val)
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -721,6 +721,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 			if err != nil {
 				base.WarnfCtx(bh.loggingCtx, "Failed to purge document: %v", err)
 			}
+			bh.replicationStats.HandleRevDocsPurgedCount.Add(1)
 
 			// Fall into skip sending case
 			missing = nil

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1971,8 +1971,8 @@ func TestSendReplacementRevision(t *testing.T) {
 					require.True(t, ok)
 					assert.Equal(t, msg1, msg2)
 
-					base.WaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 1)
-					base.WaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 0)
+					base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 1)
+					base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 0)
 				} else {
 					// requested revision (or any alternative) did not get replicated
 					data := btcRunner.SingleCollection(btc.id).WaitForVersion(docID, version1)
@@ -1987,8 +1987,8 @@ func TestSendReplacementRevision(t *testing.T) {
 					require.True(t, ok)
 					assert.Equal(t, db.MessageNoRev, msg.Profile())
 
-					base.WaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 1)
-					base.WaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 0)
+					base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 1)
+					base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 0)
 				}
 			})
 		}

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1429,7 +1429,7 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
-	dbBucketMismatch, _ = base.WaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
+	dbBucketMismatch = base.AssertWaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
 
 	// Move config docs from original bucket to b2 and force a fetch/load (simulate backup/restore or XDCR to different bucket)
 	base.MoveDocument(t, base.SGRegistryKey, b2.GetMetadataStore(), b1.GetMetadataStore())
@@ -1448,7 +1448,7 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
-	dbBucketMismatch, _ = base.WaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
+	dbBucketMismatch = base.AssertWaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
 
 	// repair config
 	dbConfig.Bucket = &b2Name
@@ -1465,7 +1465,7 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
-	_, _ = base.WaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
+	base.RequireWaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
 }
 
 // startBootstrapServerWithoutConfigPolling starts a server with config polling disabled, and returns the server context.

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1429,7 +1429,7 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
-	dbBucketMismatch = base.AssertWaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
+	dbBucketMismatch = base.RequireWaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
 
 	// Move config docs from original bucket to b2 and force a fetch/load (simulate backup/restore or XDCR to different bucket)
 	base.MoveDocument(t, base.SGRegistryKey, b2.GetMetadataStore(), b1.GetMetadataStore())
@@ -1448,7 +1448,7 @@ func TestPersistentConfigNoBucketField(t *testing.T) {
 	count, err = rt.ServerContext().fetchAndLoadConfigs(base.TestCtx(t), false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
-	dbBucketMismatch = base.AssertWaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
+	dbBucketMismatch = base.RequireWaitForStat(t, base.SyncGatewayStats.GlobalStats.ConfigStat.DatabaseBucketMismatches.Value, dbBucketMismatch+1)
 
 	// repair config
 	dbConfig.Bucket = &b2Name

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -5753,13 +5753,14 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 						// wait for an arbitrary number of reconnect attempts
 						require.EventuallyWithT(t, func(c *assert.CollectT) {
 							assert.Greaterf(c, ar.Push.GetStats().NumConnectAttempts.Value(), int64(2), "Expecting NumConnectAttempts > 2")
-						}, time.Second*5, timeoutVal+time.Millisecond*100)
+						}, time.Second*5, time.Millisecond*100)
 
 						time.Sleep(timeoutVal + time.Millisecond*250)
+
 						// wait for the retry loop to hit the TotalReconnectTimeout and give up retrying
 						require.EventuallyWithT(t, func(c *assert.CollectT) {
 							assert.Greaterf(c, ar.Push.GetStats().NumReconnectsAborted.Value(), int64(0), "Expecting NumReconnectsAborted > 0")
-						}, time.Second*5, timeoutVal+time.Millisecond*100)
+						}, time.Second*5, time.Millisecond*100)
 					}
 				})
 			}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2381,20 +2381,6 @@ func NewHTTPTestServerOnListener(h http.Handler, l net.Listener) *httptest.Serve
 	return s
 }
 
-func WaitAndRequireCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...interface{}) {
-	t.Helper()
-	t.Log("starting waitAndRequireCondition")
-	for i := 0; i <= 20; i++ {
-		if i == 20 {
-			require.Fail(t, "Condition failed to be satisfied", failureMsgAndArgs...)
-		}
-		if fn() {
-			break
-		}
-		time.Sleep(time.Millisecond * 250)
-	}
-}
-
 func WaitAndAssertCondition(t testing.TB, fn func() bool, failureMsgAndArgs ...interface{}) {
 	t.Helper()
 	t.Log("starting WaitAndAssertCondition")


### PR DESCRIPTION
CBG-4160

- Replace `base.WaitForStat` with `require.EventuallyWithT` variants due to misuse and silently failing tests.
- Add missing `HandleRevDocsPurgedCount` stat increment in non-rev removal case (caught by one of the silently failing tests)
- Fix silently failing assertion in `TestActiveReplicatorPushAndPullConflict` which didn't take into account conflict count, and caused flakyness in the test

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2662/
