### PR TITLE
[3.2.0 Backport] CBG-4142: Ensure expandFields does not mutate additionalData AuditFields

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -11,6 +11,7 @@ package base
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"strings"
 	"time"
@@ -28,7 +29,7 @@ const (
 func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, additionalData AuditFields) AuditFields {
 	var fields AuditFields
 	if additionalData != nil {
-		fields = additionalData
+		fields = maps.Clone(additionalData)
 	} else {
 		fields = make(AuditFields)
 	}
@@ -103,7 +104,7 @@ func (f *AuditFields) merge(ctx context.Context, overwrites AuditFields) {
 	for k, v := range overwrites {
 		_, ok := (*f)[k]
 		if ok {
-			duplicateFields = append(duplicateFields, fmt.Sprintf("%q=%q", k, v))
+			duplicateFields = append(duplicateFields, fmt.Sprintf("%q='%v'", k, v))
 			continue
 		}
 		(*f)[k] = v

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -274,3 +274,14 @@ func TestAuditFieldsMerge(t *testing.T) {
 	}
 
 }
+
+func Test_expandFieldsAdditionalDataReadOnly(t *testing.T) {
+	additionalData := AuditFields{"foo": "bar"}
+	for i := 0; i < 5; i++ {
+		fields := expandFields(AuditIDDocumentRead, TestCtx(t), AuditFields{"global": true}, additionalData)
+		// id, name, description, timestamp, global, foo
+		assert.Len(t, fields, 6)
+	}
+	// additionalData should not be modified
+	assert.Len(t, additionalData, 1)
+}


### PR DESCRIPTION
CBG-4142

Backports #7019 (CBG-4140) to 3.2.0

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a