### PR TITLE
CBG-4125 use a non cancellable context for OIDC metadata

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -692,6 +692,7 @@ func (op *OIDCProvider) startDiscoverySync(ctx context.Context, discoveryURL str
 		return err
 	}
 	go func() {
+		ctx := base.NewNonCancelCtxForDatabase(ctx).Ctx
 		for {
 			select {
 			case <-time.After(duration):

--- a/base/util.go
+++ b/base/util.go
@@ -62,12 +62,14 @@ func NewNonCancelCtx() NonCancellableContext {
 }
 
 // NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
-func NewNonCancelCtxForDatabase(dbName string, dbLogConfig *DbLogConfig) NonCancellableContext {
-	dbLogContext := DatabaseLogCtx(context.Background(), dbName, dbLogConfig)
-	ctxStruct := NonCancellableContext{
+func NewNonCancelCtxForDatabase(parentContext context.Context) NonCancellableContext {
+	ctx := getLogCtx(parentContext)
+
+	dbLogContext := DatabaseLogCtx(context.Background(), ctx.Database, ctx.DbLogConfig)
+
+	return NonCancellableContext{
 		Ctx: dbLogContext,
 	}
-	return ctxStruct
 }
 
 // RedactBasicAuthURLUserAndPassword returns the given string, with a redacted HTTP basic auth component.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1031,7 +1031,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// If asyncOnline is requested, set state to Starting and spawn a separate goroutine to wait for init completion
 		// before going online
 		base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete asynchonously...")
-		nonCancelCtx := base.NewNonCancelCtxForDatabase(dbName, dbcontext.Options.LoggingConfig)
+		nonCancelCtx := base.NewNonCancelCtxForDatabase(ctx)
 		go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
 		return dbcontext, nil
 	}


### PR DESCRIPTION
Create the non cancellable context from inside the goroutine, since the other code is request mediated and can actually pass an error back out to a request.

I'm not sure about a good way to regression test this, are there examples of where we have access to a request context and then cancel it?