### PR TITLE
CBG-4147: Improve Audit performance (JSON marshalling / expandFields)

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -10,6 +10,7 @@ package base
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net"
@@ -57,28 +58,25 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 	userDomain := logCtx.UserDomain
 	userName := logCtx.Username
 	if userDomain != "" || userName != "" {
-		fields[AuditFieldRealUserID] = map[string]any{
-			AuditFieldRealUserIDDomain: userDomain,
-			AuditFieldRealUserIDUser:   userName,
-		}
+		fields[AuditFieldRealUserID] = json.RawMessage(`{"` +
+			AuditFieldRealUserIDDomain + `":"` + string(userDomain) + `","` +
+			AuditFieldRealUserIDUser + `":"` + userName +
+			`"}`)
 	}
 	effectiveDomain := logCtx.EffectiveDomain
 	effectiveUser := logCtx.EffectiveUserID
 	if effectiveDomain != "" || effectiveUser != "" {
-		fields[AuditEffectiveUserID] = map[string]any{
-			AuditFieldEffectiveUserIDDomain: effectiveDomain,
-			AuditFieldEffectiveUserIDUser:   effectiveUser,
-		}
+		fields[AuditEffectiveUserID] = json.RawMessage(`{"` +
+			AuditFieldEffectiveUserIDDomain + `":"` + effectiveDomain + `","` +
+			AuditFieldEffectiveUserIDUser + `":"` + effectiveUser +
+			`"}`)
 	}
 	if logCtx.RequestHost != "" {
 		host, port, err := net.SplitHostPort(logCtx.RequestHost)
 		if err != nil {
 			AssertfCtx(ctx, "couldn't parse request host %q: %v", logCtx.RequestHost, err)
 		} else {
-			fields[AuditFieldLocal] = map[string]any{
-				"ip":   host,
-				"port": port,
-			}
+			fields[AuditFieldLocal] = json.RawMessage(`{"ip":"` + host + `","port":"` + port + `"}`)
 		}
 	}
 
@@ -87,10 +85,7 @@ func expandFields(id AuditID, ctx context.Context, globalFields AuditFields, add
 		if err != nil {
 			AssertfCtx(ctx, "couldn't parse request remote addr %q: %v", logCtx.RequestRemoteAddr, err)
 		} else {
-			fields[AuditFieldRemote] = map[string]any{
-				"ip":   host,
-				"port": port,
-			}
+			fields[AuditFieldRemote] = json.RawMessage(`{"ip":"` + host + `","port":"` + port + `"}`)
 		}
 	}
 

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -16,6 +16,8 @@ import (
 	"net"
 	"strings"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 const (
@@ -137,12 +139,14 @@ func Audit(ctx context.Context, id AuditID, additionalData AuditFields) {
 	if fields == nil {
 		fields = expandFields(id, ctx, logger.globalFields, additionalData)
 	}
-	fieldsJSON, err := JSONMarshalCanonical(fields)
+
+	fieldsJSON, err := jsoniter.MarshalToString(fields)
 	if err != nil {
 		AssertfCtx(ctx, "failed to marshal audit fields: %v", err)
 		return
 	}
-	logger.logf(string(fieldsJSON))
+
+	logger.logf(fieldsJSON)
 }
 
 // IsAuditEnabled checks if auditing is enabled for the SG node

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -175,11 +175,20 @@ func (l *FileLogger) logf(format string, args ...interface{}) {
 	if l == nil {
 		return
 	}
+	doPrintf := len(args) > 0
 	if l.collateBuffer != nil {
 		l.collateBufferWg.Add(1)
-		l.collateBuffer <- fmt.Sprintf(format, args...)
+		if doPrintf {
+			l.collateBuffer <- fmt.Sprintf(format, args...)
+		} else {
+			l.collateBuffer <- format
+		}
 	} else {
-		l.logger.Printf(format, args...)
+		if doPrintf {
+			l.logger.Printf(format, args...)
+		} else {
+			l.logger.Print(format)
+		}
 	}
 }
 


### PR DESCRIPTION
CBG-4147

## benchstat before/after

```
$ benchstat base-stdlib.txt cbg-4147.txt
goos: darwin
goarch: arm64
pkg: github.com/couchbase/sync_gateway/base
                                    │ base-stdlib.txt │            cbg-4147.txt             │
                                    │     sec/op      │   sec/op     vs base                │
AuditFieldwork/additional_fields-10       5.370µ ± 2%   2.456µ ± 2%  -54.26% (p=0.000 n=10)

                                    │ base-stdlib.txt │             cbg-4147.txt             │
                                    │      B/op       │     B/op      vs base                │
AuditFieldwork/additional_fields-10      5.422Ki ± 0%   2.117Ki ± 0%  -60.96% (p=0.000 n=10)

                                    │ base-stdlib.txt │            cbg-4147.txt            │
                                    │    allocs/op    │ allocs/op   vs base                │
AuditFieldwork/additional_fields-10        71.00 ± 0%   24.00 ± 0%  -66.20% (p=0.000 n=10)
```

## Changes (ordered by improvement)
- Swap to `jsoniter` for marshalling audit event fields **(~2x speedup)**
- Build common nested audit objects as `json.RawMessage` manually to avoid marshal overhead
- Pre-allocate audit fields for marshalling at correct size (elimiates map growth - reduces `expandFields` to 1 alloc)
- Optimise `merge` method to avoid map growth/re-allocs
- Use `MarshalToString` and avoid `[]byte`->`string` conversion
- Conditional `Printf`/`Print` for FileLogger based on `len(args)`

## Profiling (with benchmark enhancements on `main`)

`base.Audit`

![Screenshot 2024-08-12 at 17 34 35](https://github.com/user-attachments/assets/3cf69f2b-5656-47ad-a096-582ed6eebdee)

`expandFields`

![Screenshot 2024-08-12 at 17 35 46](https://github.com/user-attachments/assets/bf30a448-3736-4b14-a583-a13616ef809d)



## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2646/
