### PR TITLE
[3.1.10 backport] CBG-4127 use a non cancellable context for OIDC metadata

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -692,8 +692,7 @@ func (op *OIDCProvider) startDiscoverySync(ctx context.Context, discoveryURL str
 		return err
 	}
 	go func() {
-		// use DbConsoleLogConfig as nil in 3.1 branch only. This is stored on database in >= 3.2
-		ctx := base.NewNonCancelCtxForDatabase(ctx, nil).Ctx
+		ctx := base.NewNonCancelCtxForDatabase(ctx).Ctx
 		for {
 			select {
 			case <-time.After(duration):

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -692,6 +692,8 @@ func (op *OIDCProvider) startDiscoverySync(ctx context.Context, discoveryURL str
 		return err
 	}
 	go func() {
+		// use DbConsoleLogConfig as nil in 3.1 branch only. This is stored on database in >= 3.2
+		ctx := base.NewNonCancelCtxForDatabase(ctx, nil).Ctx
 		for {
 			select {
 			case <-time.After(duration):

--- a/base/util.go
+++ b/base/util.go
@@ -64,12 +64,14 @@ func NewNonCancelCtx() NonCancellableContext {
 }
 
 // NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
-func NewNonCancelCtxForDatabase(dbName string, dbConsoleLogConfig *DbConsoleLogConfig) NonCancellableContext {
-	dbLogContext := DatabaseLogCtx(context.Background(), dbName, dbConsoleLogConfig)
-	ctxStruct := NonCancellableContext{
+func NewNonCancelCtxForDatabase(parentCtx context.Context, dbConsoleLogConfig *DbConsoleLogConfig) NonCancellableContext {
+	ctx := getLogCtx(parentCtx)
+
+	dbLogContext := DatabaseLogCtx(context.Background(), ctx.Database, dbConsoleLogConfig)
+
+	return NonCancellableContext{
 		Ctx: dbLogContext,
 	}
-	return ctxStruct
 }
 
 // RedactBasicAuthURLUserAndPassword returns the given string, with a redacted HTTP basic auth component.

--- a/base/util.go
+++ b/base/util.go
@@ -63,11 +63,11 @@ func NewNonCancelCtx() NonCancellableContext {
 	return ctxStruct
 }
 
-// NewNonCancelCtx creates a new background context struct for operations that require a fresh context, with database logging context added
-func NewNonCancelCtxForDatabase(parentCtx context.Context, dbConsoleLogConfig *DbConsoleLogConfig) NonCancellableContext {
+// NewNonCancelCtxForDatabase creates a new background context struct for operations that require a fresh context, with database logging context added
+func NewNonCancelCtxForDatabase(parentCtx context.Context) NonCancellableContext {
 	ctx := getLogCtx(parentCtx)
 
-	dbLogContext := DatabaseLogCtx(context.Background(), ctx.Database, dbConsoleLogConfig)
+	dbLogContext := DatabaseLogCtx(context.Background(), ctx.Database, ctx.DbConsoleLogConfig)
 
 	return NonCancellableContext{
 		Ctx: dbLogContext,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -948,7 +948,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// before going online
 		base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete asynchonously...")
 		atomic.StoreUint32(&dbcontext.State, db.DBStarting)
-		nonCancelCtx := base.NewNonCancelCtxForDatabase(ctx, dbcontext.Options.LoggingConfig.Console)
+		nonCancelCtx := base.NewNonCancelCtxForDatabase(ctx)
 		go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
 		return dbcontext, nil
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -948,7 +948,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// before going online
 		base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete asynchonously...")
 		atomic.StoreUint32(&dbcontext.State, db.DBStarting)
-		nonCancelCtx := base.NewNonCancelCtxForDatabase(dbName, dbcontext.Options.LoggingConfig.Console)
+		nonCancelCtx := base.NewNonCancelCtxForDatabase(ctx, dbcontext.Options.LoggingConfig.Console)
 		go sc.asyncDatabaseOnline(nonCancelCtx, dbcontext, dbInitDoneChan, config.Version)
 		return dbcontext, nil
 	}


### PR DESCRIPTION
Backports https://github.com/couchbase/sync_gateway/commit/5db7dbed861ff0b10d0d7ac803fe5518dfeaf9da

This was not a clean cherry-pick, I split the difference on `NewNonCancelCtxForDatabase` to pull some of the dbname from the context but otherwise use nil db console logging config in auth package since it not on the `LoggingContext` in 3.1 branch.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2650/
