### PR TITLE
CBG-4121 improve logging for jwts

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -418,7 +418,7 @@ func getJWTUsername(provider JWTConfigCommon, identity *Identity) (username stri
 	if provider.UsernameClaim != "" {
 		value, ok := identity.Claims[provider.UsernameClaim]
 		if !ok {
-			return "", base.RedactErrorf("jwt: specified claim %q not found in id_token, identity: %+v", base.UD(provider.UsernameClaim), base.UD(identity))
+			return "", base.RedactErrorf("jwt: specified claim %q not found in id_token, identity: %+v", provider.UsernameClaim, base.UD(identity))
 		}
 		if username, err = formatUsername(value); err != nil {
 			return "", err

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -418,7 +418,7 @@ func getJWTUsername(provider JWTConfigCommon, identity *Identity) (username stri
 	if provider.UsernameClaim != "" {
 		value, ok := identity.Claims[provider.UsernameClaim]
 		if !ok {
-			return "", fmt.Errorf("jwt: specified claim %q not found in id_token, identity: %v", provider.UsernameClaim, identity)
+			return "", base.RedactErrorf("jwt: specified claim %q not found in id_token, identity: %+v", base.UD(provider.UsernameClaim), base.UD(identity))
 		}
 		if username, err = formatUsername(value); err != nil {
 			return "", err
@@ -626,13 +626,13 @@ func (op *OIDCProvider) verifyToken(ctx context.Context, token string, callbackU
 	// Verify claims and signature on the JWT; ensure that it's been signed by the provider.
 	idToken, err := client.verifyJWT(ctx, token)
 	if err != nil {
-		base.InfofCtx(ctx, base.KeyAuth, "Client %v could not verify JWT. Error: %v", base.UD(client), err)
+		base.InfofCtx(ctx, base.KeyAuth, "Client %v could not verify JWT. Error: %v", base.UD(op.Name), err)
 		return nil, err
 	}
 
 	identity, ok, err := getIdentity(idToken)
 	if err != nil {
-		base.InfofCtx(ctx, base.KeyAuth, "Error getting identity from token (Identity: %v, Error: %v)", base.UD(identity), err)
+		base.InfofCtx(ctx, base.KeyAuth, "Error getting identity from token (Identity: %+v, Error: %v)", base.UD(identity), err)
 	}
 	if !ok {
 		return nil, err
@@ -654,7 +654,7 @@ func getIssuerWithAudience(token *jwt.JSONWebToken) (issuer string, audiences []
 		return issuer, audiences, pkgerrors.Wrapf(err, "failed to parse JWT claims")
 	}
 	if claims.Issuer == "" {
-		return issuer, audiences, fmt.Errorf("malformed JWT %v, issuer claim doesn't exist", token)
+		return issuer, audiences, fmt.Errorf("malformed JWT, issuer claim doesn't exist")
 	}
 	return claims.Issuer, claims.Audience, err
 }


### PR DESCRIPTION
- log client name if there is a validation error instead of %v
- don't log token in the case of error
- log identity with UD(%+v) which shows the values of the keys

Verified by eye in unit tests.
