### PR TITLE
CBG-4115 add WaitForPendingChanges to test

### DIFF
--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1361,6 +1361,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 			rt.Run(testCase.name, func(t *testing.T) {
 				docID := strings.ReplaceAll(testCase.name, " ", "_")
 				docVersion := rt.PutDoc(docID, `{"channels": "A"}`)
+				require.NoError(t, rt.WaitForPendingChanges())
 				output := base.AuditLogContents(t, func(t testing.TB) {
 					testCase.auditableCode(t, docID, docVersion)
 				})


### PR DESCRIPTION
The fix in main is in a big broad fixup https://github.com/couchbase/sync_gateway/commit/cbd8c23255af9621206450d7182524a4a85e864f but this is a narrow fix for a test flake. We need the document to be present from the mutation DCP feed before querying for changes.
