### PR TITLE
Add missing WaitForPendingChanges to fix flake

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3142,6 +3142,8 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 
 				markerDocBody := fmt.Sprintf(`{"channel":%q}`, testCase.channel)
 				_ = rt.PutDoc(markerDoc, markerDocBody)
+				// Wait for changed doc to be in cache before one shot pull
+				require.NoError(t, rt.WaitForPendingChanges())
 
 				rt.GetDatabase().FlushRevisionCacheForTest()
 


### PR DESCRIPTION
There's a true fix on main in https://github.com/couchbase/sync_gateway/commit/cbd8c23255af9621206450d7182524a4a85e864f but this change is too big for 3.2.0
