### PR TITLE
[3.2.0 Test Fix] Flush loggers before switching logger output to ensure only the audit…

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -422,6 +422,10 @@ func AuditLogContents(t testing.TB, f func(t testing.TB)) []byte {
 	// Temporarily override logger output
 	b := &bytes.Buffer{}
 	mw := io.MultiWriter(b, os.Stderr)
+
+	FlushLogBuffers()
+	auditLogger.FlushBufferToLog()
+
 	auditLogger.logger.SetOutput(mw)
 	defer func() { auditLogger.logger.SetOutput(os.Stderr) }()
 


### PR DESCRIPTION
CBG-4171

Flush loggers before switching logger output to ensure only the auditable action function is responsible for the logs we see.

Avoids `TestAuditLoggingFields/public_silent_request` flake from collated/buffered test setup interference.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
