### PR TITLE
README.md: Replace coverage card with combined integration test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Sync Gateway Documentation](https://img.shields.io/badge/documentation-current-blue.svg)][SG_DOCS]
 [![GoDoc](https://godoc.org/github.com/couchbase/sync_gateway?status.svg)](https://godoc.org/github.com/couchbase/sync_gateway)
 [![Go Report Card](https://goreportcard.com/badge/github.com/couchbase/sync_gateway)](https://goreportcard.com/report/github.com/couchbase/sync_gateway)
-[![Code Coverage](https://img.shields.io/coveralls/github/couchbase/sync_gateway.svg)](https://coveralls.io/github/couchbase/sync_gateway)
+![Code Coverage](https://jenkins.sgwdev.com/buildStatus/icon?job=MasterIntegration&subject=coverage&status=${lineCoverage}&color=${colorLineCoverage})
 [![License](https://img.shields.io/badge/license-BSL%201.1-lightgrey)](https://github.com/couchbase/sync_gateway/blob/main/LICENSE)
 
 Sync Gateway is a horizontally scalable web server that securely manages the access control and


### PR DESCRIPTION
Replace CE unit test coverage with the full combined coverage stats from the latest `main` run on our Jenkins instance: ![Code Coverage](https://jenkins.sgwdev.com/buildStatus/icon?job=MasterIntegration&subject=coverage&status=${lineCoverage}&color=${colorLineCoverage})

![Screenshot 2024-08-13 at 15 56 35](https://github.com/user-attachments/assets/8026df8d-40e3-491d-8340-3a78f578588b)


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a