### PR TITLE
CBG-3993: use md5 hash for sourceID in HLV

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -14,6 +14,7 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -1015,6 +1016,16 @@ func HexCasToUint64(cas string) uint64 {
 	}
 
 	return binary.LittleEndian.Uint64(casBytes[0:8])
+}
+
+func HexToBase64(s string) ([]byte, error) {
+	decoded := make([]byte, hex.DecodedLen(len(s)))
+	if _, err := hex.Decode(decoded, []byte(s)); err != nil {
+		return nil, err
+	}
+	encoded := make([]byte, base64.RawStdEncoding.EncodedLen(len(decoded)))
+	base64.RawStdEncoding.Encode(encoded, decoded)
+	return encoded, nil
 }
 
 func CasToString(cas uint64) string {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -291,7 +291,7 @@ func TestCVPopulationOnChangeEntry(t *testing.T) {
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	collectionID := collection.GetCollectionID()
-	bucketUUID := db.EncodedBucketUUID
+	bucketUUID := db.EncodedSourceID
 
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
@@ -564,7 +564,7 @@ func TestCurrentVersionPopulationOnChannelCache(t *testing.T) {
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	collectionID := collection.GetCollectionID()
-	bucketUUID := db.EncodedBucketUUID
+	bucketUUID := db.EncodedSourceID
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 
 	// Make channel active

--- a/db/crud.go
+++ b/db/crud.go
@@ -901,7 +901,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 		} else {
 			// Otherwise this is an SDK mutation made by the local cluster that should be added to HLV.
 			newVVEntry := Version{}
-			newVVEntry.SourceID = db.dbCtx.EncodedBucketUUID
+			newVVEntry.SourceID = db.dbCtx.EncodedSourceID
 			newVVEntry.Value = hlvExpandMacroCASValue
 			err := d.SyncData.HLV.AddVersion(newVVEntry)
 			if err != nil {
@@ -914,7 +914,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(d *Document, docUpdateEvent DocU
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
 		newVVEntry := Version{}
-		newVVEntry.SourceID = db.dbCtx.EncodedBucketUUID
+		newVVEntry.SourceID = db.dbCtx.EncodedSourceID
 		newVVEntry.Value = hlvExpandMacroCASValue
 		err := d.SyncData.HLV.AddVersion(newVVEntry)
 		if err != nil {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1778,7 +1778,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	bucketUUID := db.EncodedBucketUUID
+	bucketUUID := db.EncodedSourceID
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	// create a new doc
@@ -1879,7 +1879,7 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	bucketUUID := db.EncodedBucketUUID
+	bucketUUID := db.EncodedSourceID
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	// create a new doc

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1193,7 +1193,7 @@ func TestConflicts(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-	bucketUUID := db.EncodedBucketUUID
+	bucketUUID := db.EncodedSourceID
 
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)
 

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -9,7 +9,9 @@
 package db
 
 import (
+	"crypto/md5"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -585,4 +587,15 @@ func EncodeValue(value uint64) string {
 // EncodeValueStr converts a simplified number ("1") to a hex-encoded string
 func EncodeValueStr(value string) (string, error) {
 	return base.StringDecimalToLittleEndianHex(strings.TrimSpace(value))
+}
+
+// CreateEncodedSourceID will hash the bucket UUID and cluster UUID using md5 hash function then will base64 encode it
+func CreateEncodedSourceID(bucketUUID, clusterUUID string) (string, error) {
+	md5Hash := md5.Sum([]byte(bucketUUID + clusterUUID))
+	hexStr := hex.EncodeToString(md5Hash[:])
+	source, err := base.HexToBase64(hexStr)
+	if err != nil {
+		return "", err
+	}
+	return string(source), nil
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -590,6 +590,7 @@ func EncodeValueStr(value string) (string, error) {
 }
 
 // CreateEncodedSourceID will hash the bucket UUID and cluster UUID using md5 hash function then will base64 encode it
+// This function is in sync with xdcr implementation of UUIDstoDocumentSource https://github.com/couchbase/goxdcr/blob/dfba7a5b4251d93db46e2b0b4b55ea014218931b/hlv/hlv.go#L51
 func CreateEncodedSourceID(bucketUUID, clusterUUID string) (string, error) {
 	md5Hash := md5.Sum([]byte(bucketUUID + clusterUUID))
 	hexStr := hex.EncodeToString(md5Hash[:])

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -272,7 +272,7 @@ func TestHLVImport(t *testing.T) {
 	defer db.Close(ctx)
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-	localSource := db.EncodedBucketUUID
+	localSource := db.EncodedSourceID
 
 	// 1. Test standard import of an SDK write
 	standardImportKey := "standardImport_" + t.Name()

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -913,7 +913,7 @@ func TestGetActive(t *testing.T) {
 	syncCAS := string(base.Uint64CASToLittleEndianHex(doc.Cas))
 
 	expectedCV := Version{
-		SourceID: db.EncodedBucketUUID,
+		SourceID: db.EncodedSourceID,
 		Value:    syncCAS,
 	}
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2809,7 +2809,7 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	bucketUUID := rt.GetDatabase().EncodedBucketUUID
+	bucketUUID := rt.GetDatabase().EncodedSourceID
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"key": "value"}`)
 	RequireStatus(t, resp, http.StatusCreated)
@@ -2861,7 +2861,7 @@ func TestHLVOnPutWithImportRejection(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	bucketUUID := rt.GetDatabase().EncodedBucketUUID
+	bucketUUID := rt.GetDatabase().EncodedSourceID
 
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"type": "mobile"}`)
 	RequireStatus(t, resp, http.StatusCreated)

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -415,7 +415,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	bucketUUID := rt.GetDatabase().EncodedBucketUUID
+	bucketUUID := rt.GetDatabase().EncodedSourceID
 	const DocID = "doc1"
 
 	// activate channel cache
@@ -446,7 +446,7 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	bucketUUID := rt.GetDatabase().EncodedBucketUUID
+	bucketUUID := rt.GetDatabase().EncodedSourceID
 	const DocID = "doc1"
 
 	// activate channel cache

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8568,8 +8568,8 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	defer teardown()
 
 	// Grab the bucket UUIDs for both rest testers
-	activeBucketUUID := activeRT.GetDatabase().EncodedBucketUUID
-	passiveBucketUUID := passiveRT.GetDatabase().EncodedBucketUUID
+	activeBucketUUID := activeRT.GetDatabase().EncodedSourceID
+	passiveBucketUUID := passiveRT.GetDatabase().EncodedSourceID
 
 	const rep = "replication"
 


### PR DESCRIPTION
CBG-3993

- Copied the implementation of the `UUIDstoDocumentSource` in xdcr code base for the md5 hash then base64 encoding.
- Assigned this calculation to the db context representation of the sourceID (updated the naming to reflect this).

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2658/
