### PR TITLE
CBG-4177: remove no xattr CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,25 +131,6 @@ jobs:
         with:
           test-results: test.json
 
-  test-no-xattrs:
-    runs-on: ubuntu-latest
-    env:
-      GOPRIVATE: github.com/couchbaselabs
-      SG_TEST_USE_XATTRS: false
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: 1.22.5
-      - name: Run Tests
-        run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
-        shell: bash
-      - name: Annotate Failures
-        if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
-        with:
-          test-results: test.json
-
   python-format:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
CBG-4177

Xattrs will not be supported on this branch. Tests will always fail on this CI run. 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
