### PR TITLE
CBD-6003, build repo SHA changes to pickup GOPROXY change.

### DIFF
--- a/manifest/3.1.xml
+++ b/manifest/3.1.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
+  <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
     <annotation name="VERSION" value="3.1.10"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>

--- a/manifest/3.2.xml
+++ b/manifest/3.2.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
-    <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
+    <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
         <annotation name="VERSION" value="3.2.0"     keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>

--- a/manifest/4.0.xml
+++ b/manifest/4.0.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
+  <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
     <annotation name="VERSION" value="4.0.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -17,7 +17,7 @@ licenses/APL2.txt.
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
+  <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
     <annotation name="VERSION" value="3.3.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
CBD-6003

Advance build repo SHA to pickup GOPROXY change.  This add proxy.golang.org to GOPROXY in the build script.
Due to recent ownership change of nhooyr.io.  goproxy.build.couchbase.com is unable to cache its older packages, returns 404, and results in a build failure.  Public proxy is more forgiving.  Hence, proxy.golang.org is added to the proxy list to serve as a fallback. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
