### PR TITLE
CBG-3692: Improved logging for failed basic auth login

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -773,9 +773,17 @@ func (auth *Authenticator) AuthenticateUser(username string, password string) (U
 		return nil, err
 	}
 
-	if user == nil || !user.Authenticate(password) {
+	if user == nil {
+		base.WarnfCtx(auth.LogCtx, "Authentication failed for username %q: user not found", base.UD(username))
 		return nil, nil
 	}
+
+	authenticated, reason := user.AuthenticateWithReason(password)
+	if !authenticated {
+		base.WarnfCtx(auth.LogCtx, "Authentication failed for username %q: %s", base.UD(username), reason)
+		return nil, nil
+	}
+
 	return user, nil
 }
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -774,13 +774,13 @@ func (auth *Authenticator) AuthenticateUser(username string, password string) (U
 	}
 
 	if user == nil {
-		base.WarnfCtx(auth.LogCtx, "Authentication failed for username %q: user not found", base.UD(username))
+		base.WarnfCtx(auth.LogCtx, "HTTP auth failed for username=%q: user not found", base.UD(username))
 		return nil, nil
 	}
 
 	authenticated, reason := user.AuthenticateWithReason(password)
 	if !authenticated {
-		base.WarnfCtx(auth.LogCtx, "Authentication failed for username %q: %s", base.UD(username), reason)
+		base.WarnfCtx(auth.LogCtx, "HTTP auth failed for username=%q: %s", base.UD(username), reason)
 		return nil, nil
 	}
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -774,13 +774,13 @@ func (auth *Authenticator) AuthenticateUser(username string, password string) (U
 	}
 
 	if user == nil {
-		base.WarnfCtx(auth.LogCtx, "HTTP auth failed for username=%q: user not found", base.UD(username))
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "HTTP auth failed for username=%q: user not found", base.UD(username))
 		return nil, nil
 	}
 
 	authenticated, reason := user.AuthenticateWithReason(password)
 	if !authenticated {
-		base.WarnfCtx(auth.LogCtx, "HTTP auth failed for username=%q: %s", base.UD(username), reason)
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "HTTP auth failed for username=%q: %s", base.UD(username), reason)
 		return nil, nil
 	}
 

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -85,6 +85,9 @@ type User interface {
 	// Authenticates the user's password.
 	Authenticate(password string) bool
 
+	// AuthenticateWithReason is the same as Authenticate, except it provides the reason for failure.
+	AuthenticateWithReason(password string) (bool, string)
+
 	// GetSessionUUID returns the UUID that a session to match to be a valid session.
 	GetSessionUUID() string
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -499,6 +499,7 @@ func (user *userImpl) Authenticate(password string) bool {
 	return ok
 }
 
+// AuthenticateWithReason returns true if the user exists, is not disabled, and has a valid password. If authentication fails, a user readable string for logging will be returned.
 func (user *userImpl) AuthenticateWithReason(password string) (ok bool, reason string) {
 	if user == nil {
 		return false, "User not found"

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -969,7 +969,6 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 				return err
 			}
 			if h.user == nil {
-				base.InfofCtx(h.ctx(), base.KeyAll, "HTTP auth failed for username=%q", base.UD(userName))
 				auditFields["username"] = userName
 				if dbCtx.Options.SendWWWAuthenticateHeader == nil || *dbCtx.Options.SendWWWAuthenticateHeader {
 					h.response.Header().Set("WWW-Authenticate", wwwAuthenticateHeader)

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1640,13 +1640,16 @@ func TestDisabledUser(t *testing.T) {
 	const username = "alice"
 	rt.CreateUser(username, nil)
 
-	response := rt.SendUserRequest("GET", "/{{.db}}/", "", username)
+	response := rt.SendUserRequest(http.MethodGet, "/{{.db}}/", "", username)
 	RequireStatus(t, response, http.StatusOK)
+
+	response = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.db}}/", "", nil, username, "incorrectpassword")
+	RequireStatus(t, response, http.StatusUnauthorized)
 
 	// disable user
-	response = rt.SendAdminRequest("PUT", "/{{.db}}/_user/"+username, `{"disabled":true}`)
+	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_user/"+username, `{"disabled":true}`)
 	RequireStatus(t, response, http.StatusOK)
 
-	response = rt.SendUserRequest("GET", "/{{.db}}/", "", username)
+	response = rt.SendUserRequest(http.MethodGet, "/{{.db}}/", "", username)
 	RequireStatus(t, response, http.StatusUnauthorized)
 }


### PR DESCRIPTION
CBG-3692

Uses existing info log message when failing to authenticate, but now also provides a reason for the auth failure, one of:
- "User not found"
- "Account disabled"
- "User account still has pre-beta password hash; need to reset password"
- "Incorrect password"

```
2024-08-16T15:06:06.573+01:00 [INF] HTTP: c:#002 db:db GET http://localhost/db/ (as <ud>alice</ud>)
2024-08-16T15:06:06.574+01:00 [WRN] c:#003 db:db HTTP auth failed for username="<ud>alice</ud>": Incorrect password -- auth.(*Authenticator).AuthenticateUser() at auth.go:783
2024-08-16T15:06:06.574+01:00 [INF] HTTP: c:#003 db:db GET http://localhost/db/
2024-08-16T15:06:06.575+01:00 [INF] HTTP: c:#003 db:db #003:     --> 401 Invalid login  (1.7 ms)
2024-08-16T15:06:06.575+01:00 [INF] HTTP: c:#004 db:db PUT http://localhost/db/_user/<ud>alice</ud> (as ADMIN)
2024-08-16T15:06:06.575+01:00 [WRN] c:#005 db:db HTTP auth failed for username="<ud>alice</ud>": Account disabled -- auth.(*Authenticator).AuthenticateUser() at auth.go:783
2024-08-16T15:06:06.575+01:00 [INF] HTTP: c:#005 db:db GET http://localhost/db/
2024-08-16T15:06:06.575+01:00 [INF] HTTP: c:#005 db:db #005:     --> 401 Invalid login  (0.0 ms)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a