### PR TITLE
CBG-3694: Improved logging for failed session auth

### DIFF
--- a/auth/session.go
+++ b/auth/session.go
@@ -40,7 +40,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	_, err := auth.datastore.Get(auth.DocIDForSession(cookie.Value), &session)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
-			base.WarnfCtx(auth.LogCtx, "Session not found: %s", base.UD(cookie.Value))
+			base.InfofCtx(auth.LogCtx, base.KeyAuth, "Session not found: %s", base.UD(cookie.Value))
 			return nil, base.HTTPErrorf(http.StatusUnauthorized, "Session Invalid")
 		}
 		return nil, err
@@ -73,7 +73,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	}
 
 	if session.SessionUUID != user.GetSessionUUID() {
-		base.WarnfCtx(auth.LogCtx, "Session no longer valid for user %s", base.UD(session.Username))
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Session no longer valid for user %s", base.UD(session.Username))
 		return nil, base.HTTPErrorf(http.StatusUnauthorized, "Session no longer valid for user")
 	}
 	return user, err

--- a/auth/session.go
+++ b/auth/session.go
@@ -40,6 +40,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	_, err := auth.datastore.Get(auth.DocIDForSession(cookie.Value), &session)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
+			base.WarnfCtx(auth.LogCtx, "Session not found: %s", base.UD(cookie.Value))
 			return nil, base.HTTPErrorf(http.StatusUnauthorized, "Session Invalid")
 		}
 		return nil, err
@@ -72,6 +73,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	}
 
 	if session.SessionUUID != user.GetSessionUUID() {
+		base.WarnfCtx(auth.LogCtx, "Session no longer valid for user %s", base.UD(session.Username))
 		return nil, base.HTTPErrorf(http.StatusUnauthorized, "Session no longer valid for user")
 	}
 	return user, err

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -85,13 +85,13 @@ func (h *handler) getUserFromSessionRequestBody() (auth.User, error) {
 	}
 
 	if user == nil {
-		base.WarnfCtx(h.ctx(), "Couldn't create session for user %q: not found", base.UD(params.Name))
+		base.InfofCtx(h.ctx(), base.KeyAuth, "Couldn't create session for user %q: not found", base.UD(params.Name))
 		return nil, nil
 	}
 
 	authenticated, reason := user.AuthenticateWithReason(params.Password)
 	if !authenticated {
-		base.WarnfCtx(h.ctx(), "Couldn't create session for user %q: %s", base.UD(params.Name), reason)
+		base.InfofCtx(h.ctx(), base.KeyAuth, "Couldn't create session for user %q: %s", base.UD(params.Name), reason)
 		return nil, nil
 	}
 

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -84,10 +84,18 @@ func (h *handler) getUserFromSessionRequestBody() (auth.User, error) {
 		return nil, err
 	}
 
-	if user != nil && !user.Authenticate(params.Password) {
-		user = nil
+	if user == nil {
+		base.WarnfCtx(h.ctx(), "Couldn't create session for user %q: not found", base.UD(params.Name))
+		return nil, nil
 	}
-	return user, err
+
+	authenticated, reason := user.AuthenticateWithReason(params.Password)
+	if !authenticated {
+		base.WarnfCtx(h.ctx(), "Couldn't create session for user %q: %s", base.UD(params.Name), reason)
+		return nil, nil
+	}
+
+	return user, nil
 }
 
 // DELETE /_session logs out the current session

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -243,7 +243,7 @@ func TestSessionLogin(t *testing.T) {
 
 	// invalid cookie (no username available)
 	headers = map[string]string{
-		"Cookie": "invalidcookie",
+		"Cookie": "SyncGatewaySession=123456abcdef; Path=/db; Expires=Sat, 17 Aug 2024 15:20:52 GMT",
 	}
 	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/", "", headers, "", "")
 	RequireStatus(t, resp, http.StatusUnauthorized)


### PR DESCRIPTION
CBG-3694

```
2024-08-16T16:33:10.880+01:00 [INF] HTTP: c:#006 db:db POST http://localhost/db/_session (as GUEST)
2024-08-16T16:33:10.882+01:00 [WRN] c:#006 db:db Couldn't create session for user "<ud>pupshaw</ud>": Incorrect password -- rest.(*handler).getUserFromSessionRequestBody() at session_api.go:94
2024-08-16T16:33:10.882+01:00 [INF] HTTP: c:#006 db:db #006:     --> 401 Invalid login  (1.6 ms)
    session_test.go:241: Set-Cookie: 
2024-08-16T16:33:10.882+01:00 [WRN] c:#007 db:db Session not found: <ud>123456abcdef</ud> -- auth.(*Authenticator).AuthenticateCookie() at session.go:43
2024-08-16T16:33:10.882+01:00 [INF] HTTP: c:#007 db:db GET http://localhost/db/
2024-08-16T16:33:10.882+01:00 [INF] HTTP: c:#007 db:db #007:     --> 401 Session Invalid  (0.1 ms)
```

- [x] Depends on #7080 for `user.AuthenticateWithReason()`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a