### PR TITLE
CBG-3693: Improved logging for no-user/no auto-register case in JWT auth

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -799,18 +799,18 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(rawToken string, oidcProvide
 		authenticator = single
 	}
 	if authenticator == nil {
-		for _, provider := range oidcProviders {
+		for providerName, provider := range oidcProviders {
 			if provider.ValidFor(auth.LogCtx, issuer, audiences) {
-				base.TracefCtx(auth.LogCtx, base.KeyAuth, "Using OIDC provider %v", base.UD(provider.Issuer))
+				base.TracefCtx(auth.LogCtx, base.KeyAuth, "Using OIDC provider %q", providerName)
 				authenticator = provider
 				break
 			}
 		}
 	}
 	if authenticator == nil {
-		for _, provider := range localJWT {
+		for providerName, provider := range localJWT {
 			if provider.ValidFor(auth.LogCtx, issuer, audiences) {
-				base.TracefCtx(auth.LogCtx, base.KeyAuth, "Using local JWT provider %v", base.UD(provider.Issuer))
+				base.TracefCtx(auth.LogCtx, base.KeyAuth, "Using local JWT provider %q", providerName)
 				authenticator = provider
 				break
 			}
@@ -824,11 +824,11 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(rawToken string, oidcProvide
 	var identity *Identity
 	identity, err = authenticator.verifyToken(auth.LogCtx, rawToken, callbackURLFunc)
 	if err != nil {
-		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "JWT invalid: %v", err)
+		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "JWT invalid for provider %q: %v", err, authenticator.GetName())
 		return nil, PrincipalConfig{}, base.HTTPErrorf(http.StatusUnauthorized, "Invalid JWT")
 	}
 
-	user, updates, _, err := auth.authenticateJWTIdentity(identity, authenticator.common())
+	user, updates, _, err := auth.authenticateJWTIdentity(identity, authenticator)
 	return user, updates, err
 }
 
@@ -856,36 +856,37 @@ func (auth *Authenticator) AuthenticateTrustedJWT(token string, provider *OIDCPr
 		}
 	}
 
-	return auth.authenticateJWTIdentity(identity, provider.JWTConfigCommon)
+	return auth.authenticateJWTIdentity(identity, provider)
 }
 
 // authenticateOIDCIdentity obtains a Sync Gateway User for the JWT. Expects that the JWT has already been verified for OIDC compliance.
 // TODO: possibly move this function to oidc.go
-func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider JWTConfigCommon) (user User, updates PrincipalConfig, tokenExpiry time.Time, err error) {
+func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider jwtAuthenticator) (user User, updates PrincipalConfig, tokenExpiry time.Time, err error) {
 	// Note: any errors returned from this function will be converted to 403s with a generic message, so we need to
 	// separately log them to ensure they're preserved for debugging.
 	if identity == nil || identity.Subject == "" {
 		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Empty subject found in OIDC identity: %v", base.UD(identity))
 		return nil, PrincipalConfig{}, time.Time{}, errors.New("subject not found in OIDC identity")
 	}
-	username, err := getJWTUsername(provider, identity)
+	common := provider.common()
+	username, err := getJWTUsername(common, identity)
 	if err != nil {
-		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Error retrieving OIDCUsername: %v", err)
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Error retrieving OIDCUsername for provider %q: %v", provider.GetName(), err)
 		return nil, PrincipalConfig{}, time.Time{}, err
 	}
-	base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Got username %q from JWT", base.UD(username))
+	base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Got username %q from JWT for provider %q", base.UD(username), provider.GetName())
 
 	var jwtRoles, jwtChannels base.Set
-	if provider.RolesClaim != "" {
-		jwtRoles, err = getJWTClaimAsSet(identity, provider.RolesClaim)
+	if common.RolesClaim != "" {
+		jwtRoles, err = getJWTClaimAsSet(identity, common.RolesClaim)
 		if err != nil {
 			return nil, PrincipalConfig{}, time.Time{}, fmt.Errorf("failed to find JWT roles: %w", err)
 		}
 	} else {
 		jwtRoles = base.Set{}
 	}
-	if provider.ChannelsClaim != "" {
-		jwtChannels, err = getJWTClaimAsSet(identity, provider.ChannelsClaim)
+	if common.ChannelsClaim != "" {
+		jwtChannels, err = getJWTClaimAsSet(identity, common.ChannelsClaim)
 		if err != nil {
 			return nil, PrincipalConfig{}, time.Time{}, fmt.Errorf("failed to find JWT channels: %w", err)
 		}
@@ -902,7 +903,7 @@ func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider 
 	updates = PrincipalConfig{
 		Name:        base.StringPtr(username),
 		Email:       &identity.Email,
-		JWTIssuer:   &provider.Issuer,
+		JWTIssuer:   &common.Issuer,
 		JWTRoles:    jwtRoles,
 		JWTChannels: jwtChannels,
 	}
@@ -913,7 +914,7 @@ func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider 
 
 	// Auto-registration. This will normally be done when token is originally returned
 	// to client by oidc callback, but also needed here to handle clients obtaining their own tokens.
-	if provider.Register {
+	if common.Register {
 		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Registering new user: %v with email: %v", base.UD(username), base.UD(identity.Email))
 		user, err := auth.RegisterNewUser(username, identity.Email)
 		if err != nil && !base.IsCasMismatch(err) {
@@ -923,7 +924,7 @@ func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider 
 		return user, updates, identity.Expiry, nil
 	}
 
-	base.InfofCtx(auth.LogCtx, base.KeyAuth, "User not found for OIDC username: %v", base.UD(username))
+	base.InfofCtx(auth.LogCtx, base.KeyAuth, "User %q not found and provider %q does not have Register enabled", base.UD(username), provider.GetName())
 	return nil, PrincipalConfig{}, time.Time{}, nil
 }
 

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -22,6 +22,7 @@ import (
 type jwtAuthenticator interface {
 	verifyToken(ctx context.Context, token string, callbackURLFunc OIDCCallbackURLFunc) (*Identity, error)
 	common() JWTConfigCommon
+	GetName() string
 }
 
 // SupportedAlgorithms is list of signing algorithms explicitly supported
@@ -188,6 +189,10 @@ type LocalJWTAuthProvider struct {
 	name string
 	// keySet has the keys for this config, either in-memory or from oidc.NewRemoteKeySet.
 	keySet oidc.KeySet
+}
+
+func (l *LocalJWTAuthProvider) GetName() string {
+	return l.name
 }
 
 func (l *LocalJWTAuthProvider) verifyToken(ctx context.Context, token string, _ OIDCCallbackURLFunc) (*Identity, error) {

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -239,6 +239,10 @@ func (opm OIDCProviderMap) Stop() {
 	}
 }
 
+func (op *OIDCProvider) GetName() string {
+	return op.Name
+}
+
 // GetClient initializes the client on first successful request.
 func (op *OIDCProvider) GetClient(ctx context.Context, buildCallbackURLFunc OIDCCallbackURLFunc) (*OIDCClient, error) {
 	// If the callback URL isn't defined for the provider, uses buildCallbackURLFunc to construct (based on current request)

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1235,7 +1235,7 @@ func TestJWTRolesChannels(t *testing.T) {
 					Claims:  login.claims,
 				}
 				var updates PrincipalConfig
-				user, updates, _, err = auth.authenticateJWTIdentity(identity, provider.common())
+				user, updates, _, err = auth.authenticateJWTIdentity(identity, provider)
 				require.NoError(t, err, "error on authenticateOIDCIdentity")
 				require.NotNil(t, user, "nil user")
 				user.SetJWTChannels(ch.AtSequence(updates.JWTChannels, user.Sequence()), user.Sequence())

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1398,6 +1398,8 @@ func checkGoodAuthResponse(t *testing.T, rt *RestTester, response *http.Response
 
 // E2E test that checks OpenID Connect Implicit Flow edge cases.
 func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAuth, base.KeyHTTP)
+
 	const emailClaim = "email"
 	var username = "foo_noah"
 	providers := auth.OIDCProviderMap{


### PR DESCRIPTION
CBG-3693

- Logs when a valid token is used with an incorrect or unknown username in the claims, and we don't have auto-register set for the provider.
- Covered by existing test `TestOpenIDConnectImplicitFlowEdgeCases/unsuccessful user auth when username_claim is set with different value in token`

```
2024-08-19T17:58:59.182+01:00 [INF] Auth: c:#003 db:db Fetching provider config from explicitly defined discovery endpoint: <ud>http://127.0.0.1:55719/foo/.well-known/openid-configuration</ud>
2024-08-19T17:58:59.184+01:00 [INF] Auth: c:#003 db:db No change in discovery config detected at this time, next sync will be after 24h0m0s
2024-08-19T17:58:59.185+01:00 [INF] Auth: c:#003 db:db User "<ud>bar_alice</ud>" not found and provider "foo" does not have Register enabled
2024-08-19T17:58:59.185+01:00 [INF] HTTP: c:#003 db:db POST /db/_session
2024-08-19T17:58:59.185+01:00 [INF] HTTP: c:#003 db:db #003:     --> 401 Invalid login  (3.3 ms)
```


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a