### PR TITLE
CBG-4191 Switch version numbers to only show x.y

### DIFF
--- a/docs/api/admin-capella.yaml
+++ b/docs/api/admin-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Admin API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: 3.3.0
+  version: 3.3
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/admin-capella.yaml
+++ b/docs/api/admin-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Admin API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: 3.3
+  version: '3.3'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: 3.3
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3
+  version: '3.3'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/diagnostic.yaml
+++ b/docs/api/diagnostic.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: 3.3
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/diagnostic.yaml
+++ b/docs/api/diagnostic.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3
+  version: '3.3'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric-capella.yaml
+++ b/docs/api/metric-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Metrics API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: 3.3.0
+  version: 3.3
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric-capella.yaml
+++ b/docs/api/metric-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Metrics API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: 3.3
+  version: '3.3'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: 3.3
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3
+  version: '3.3'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: 3.3
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3
+  version: '3.3'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'


### PR DESCRIPTION
since only one version of docs for a minor release are shown on public website at a time
