### PR TITLE
Update docs for 3.2.1

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -15,24 +15,55 @@ apis:
       remove-x-internal: on
   admin-internal:
     root: "./docs/api/admin.yaml"
+  admin-capella:
+    root: "./docs/api/admin-capella.yaml"
+    decorators:
+      filter-out:
+        property: x-capella
+        value: false
+      remove-x-internal: on
   public:
     root: "./docs/api/public.yaml"
     decorators:
       remove-x-internal: on
   public-internal:
     root: "./docs/api/public.yaml"
+  public-capella:
+    root: "./docs/api/public.yaml"
+    decorators:
+      filter-out:
+        property: x-capella
+        value: false
+      info-override:
+        description: "App Services manages access and synchronization between Couchbase Lite and Couchbase Capella"
+      plugin/replace-description-capella: on
+      plugin/replace-server-capella:
+        serverUrl: 'https://{hostname}:4984'
+      remove-x-internal: on
   metric:
     root: "./docs/api/metric.yaml"
     decorators:
       remove-x-internal: on
   metric-internal:
     root: "./docs/api/metric.yaml"
+  metric-capella:
+    root: "./docs/api/metric-capella.yaml"
+    decorators:
+      filter-out:
+        property: x-capella
+        value: false
+      plugin/excise-rbac-capella: on
+      plugin/replace-description-capella: on
+      remove-x-internal: on
   diagnostic:
     root: "./docs/api/diagnostic.yaml"
     decorators:
       remove-x-internal: on
   diagnostic-internal:
     root: "./docs/api/diagnostic.yaml"
+
+plugins:
+  - './docs/api/plugins/plugin.js'
 
 extends:
   - minimal

--- a/docs/api/admin-capella.yaml
+++ b/docs/api/admin-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Admin API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/admin-capella.yaml
+++ b/docs/api/admin-capella.yaml
@@ -1,0 +1,42 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
+openapi: 3.0.3
+info:
+  title: App Services Admin API
+  description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
+  version: 3.3.0
+  license:
+    name: Business Source License 1.1 (BSL)
+    url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'
+servers:
+  - url: 'https://{hostname}:4985'
+    description: Admin API
+    variables:
+      hostname:
+        description: The hostname to use
+        default: localhost
+paths:
+  '/{db}/_session':
+    $ref: './paths/admin/db-_session.yaml'
+  '/{db}/_session/{sessionid}':
+    $ref: './paths/admin/db-_session-sessionid.yaml'
+  '/{db}/_user/{name}':
+    $ref: './paths/admin/db-_user-name.yaml'
+  '/{db}/_user/{name}/_session':
+    $ref: './paths/admin/db-_user-name-_session.yaml'
+  '/{db}/_user/{name}/_session/{sessionid}':
+    $ref: './paths/admin/db-_user-name-_session-sessionid.yaml'
+  '/{db}/_role/':
+    $ref: './paths/admin/db-_role-.yaml'
+  '/{db}/_role/{name}':
+    $ref: './paths/admin/db-_role-name.yaml'
+
+externalDocs:
+  description: Manage App Services for Mobile and Edge | Couchbase Docs
+  url: 'https://docs.couchbase.com/cloud/app-services/index.html'

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1201,6 +1201,16 @@ Database:
       additionalProperties:
         x-additionalPropertiesName: scopename
         $ref: '#/Scopes'
+      maxProperties: 1
+      example:
+        scopename:
+          collections:
+            collectionname1:
+              sync: 'function(doc){channel("collection name");}'
+              import_filter: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
+            collectionname2:
+              sync: 'function(doc){channel("collection name");}'
+              import_filter: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
     name:
       description: The name of the database.
       type: string
@@ -2218,37 +2228,7 @@ Startup-config:
     logging:
       description: The configuration settings for modifying Sync Gateway logging.
       type: object
-      properties:
-        log_file_path:
-          description: Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
-          type: string
-          readOnly: true
-        redaction_level:
-          description: Redaction level to apply to log output.
-          type: string
-          default: partial
-          enum:
-            - none
-            - partial
-            - full
-            - unset
-          readOnly: true
-        console:
-          $ref: '#/Console-logging-config'
-        error:
-          $ref: '#/File-logging-config'
-        warn:
-          $ref: '#/File-logging-config'
-        info:
-          $ref: '#/File-logging-config'
-        debug:
-          $ref: '#/File-logging-config'
-        trace:
-          $ref: '#/File-logging-config'
-        stats:
-          $ref: '#/File-logging-config'
-        audit:
-          $ref: '#/Audit-logging-config'
+      $ref: '#/Logging-config'
     auth:
       type: object
       properties:
@@ -2369,65 +2349,171 @@ Runtime-config:
   type: object
   properties:
     logging:
-      description: The configuration settings for modifying Sync Gateway logging.
-      type: object
-      properties:
-        log_file_path:
-          description: Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
-          type: string
-          readOnly: true
-        redaction_level:
-          description: Redaction level to apply to log output.
-          type: string
-          default: partial
-          enum:
-            - none
-            - partial
-            - full
-            - unset
-          readOnly: true
-        console:
-          $ref: '#/Console-logging-config'
-        error:
-          $ref: '#/File-logging-config'
-        warn:
-          $ref: '#/File-logging-config'
-        info:
-          $ref: '#/File-logging-config'
-        debug:
-          $ref: '#/File-logging-config'
-        trace:
-          $ref: '#/File-logging-config'
-        stats:
-          $ref: '#/File-logging-config'
-        audit:
-          $ref: '#/Audit-logging-config'
+      $ref: "#/Logging-config"
     max_concurrent_replications:
       description: Maximum number of concurrent replication connections allowed. If set to 0 this limit will be ignored.
       type: integer
       default: 0
   title: Runtime-config
-File-logging-config:
+Logging-config:
+  type: object
+  properties:
+    log_file_path:
+      description: Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
+      type: string
+      readOnly: true
+    redaction_level:
+      description: Redaction level to apply to log output.
+      type: string
+      default: partial
+      enum:
+        - none
+        - partial
+        - full
+        - unset
+      readOnly: true
+    console:
+      $ref: '#/Console-logging-config'
+    error:
+      allOf:
+        - $ref: '#/File-logging-config-base'
+        - type: object
+          properties:
+            rotation:
+              allOf:
+                - $ref: '#/Log-rotation-base'
+                - type: object
+                  properties:
+                    max_age:
+                      description: The maximum number of days to retain old log files.
+                      default: 360
+                      type: integer
+            collation_buffer_size:
+              description: The size of the log collation buffer.
+              default: 10
+              type: integer
+              readOnly: true
+    warn:
+      allOf:
+        - $ref: '#/File-logging-config-base'
+        - type: object
+          properties:
+            rotation:
+              allOf:
+                - $ref: '#/Log-rotation-base'
+                - type: object
+                  properties:
+                    max_age:
+                      description: The maximum number of days to retain old log files.
+                      default: 180
+                      type: integer
+            collation_buffer_size:
+              description: The size of the log collation buffer
+              default: 1000
+              type: integer
+              readOnly: true
+    info:
+      allOf:
+        - $ref: '#/File-logging-config-base'
+        - type: object
+          properties:
+            rotation:
+              allOf:
+                - $ref: '#/Log-rotation-base'
+                - type: object
+                  properties:
+                    max_age:
+                      description: The maximum number of days to retain old log files.
+                      default: 6
+                      type: integer
+            collation_buffer_size:
+              description: The size of the log collation buffer
+              default: 1000
+              type: integer
+              readOnly: true
+    debug:
+      allOf:
+        - $ref: '#/File-logging-config-base'
+        - type: object
+          properties:
+            rotation:
+              allOf:
+                - $ref: '#/Log-rotation-base'
+                - type: object
+                  properties:
+                    max_age:
+                      description: The maximum number of days to retain old log files.
+                      default: 2
+                      type: integer
+            collation_buffer_size:
+              description: The size of the log collation buffer
+              default: 0
+              type: integer
+              readOnly: true
+    trace:
+      allOf:
+        - $ref: '#/File-logging-config-base'
+        - type: object
+          properties:
+            rotation:
+              allOf:
+                - $ref: '#/Log-rotation-base'
+                - type: object
+                  properties:
+                    max_age:
+                      description: The maximum number of days to retain old log files.
+                      default: 2
+                      type: integer
+            collation_buffer_size:
+              description: The size of the log collation buffer
+              default: 0
+              type: integer
+              readOnly: true
+    stats:
+      allOf:
+        - $ref: '#/File-logging-config-base'
+        - type: object
+          properties:
+            rotation:
+              allOf:
+                - $ref: '#/Log-rotation-base'
+                - type: object
+                  properties:
+                    max_age:
+                      description: The maximum number of days to retain old log files.
+                      default: 6
+                      type: integer
+            collation_buffer_size:
+              description: The size of the log collation buffer
+              default: 0
+              type: integer
+              readOnly: true
+    audit:
+      $ref: '#/Audit-logging-config'
+File-logging-config-base:
   type: object
   properties:
     enabled:
       description: Toggle for this log output
       type: boolean
-    rotation:
-      $ref: '#/Log-rotation-config-readonly'
-    collation_buffer_size:
-      description: The size of the log collation buffer
-      type: integer
-      readOnly: true
+      default: false
   title: File-logging-config
 Audit-logging-config:
+  allOf:
+    - $ref: '#/File-logging-config-base'
+    - type: object
+      properties:
+        rotation:
+          allOf:
+            - $ref: '#/Log-rotation-base'
+            - type: object
+              properties:
+                max_age:
+                  description: The maximum number of days to retain old log files. By default, there is no rotation, max_age=0.
+                  default: 0
+                  type: integer
   type: object
   properties:
-    enabled:
-      description: Toggle for this log output
-      type: boolean
-    rotation:
-      $ref: '#/Log-rotation-config-readonly'
     audit_log_file_path:
       description: The path to write audit log files to
       type: string
@@ -2439,21 +2525,14 @@ Audit-logging-config:
         type: number
       example: [1234, 5678]
       readOnly: true
-    collation_buffer_size:
-      description: The size of the log collation buffer
-      type: integer
-      readOnly: true
   title: Audit-logging-config
-Log-rotation-config-readonly:
+Log-rotation-base:
   type: object
   properties:
     max_size:
       description: The maximum size in MB of the log file before it gets rotated.
       type: integer
       default: 100
-    max_age:
-      description: The maximum number of days to retain old log files. The defaults for this value are 360 days for error, 180 days for warn, 6 days for info, 2 days for debug, and 2 days for trace logs.
-      type: integer
     localtime:
       description: 'If true, it uses the computer''s local time to format the backup timestamp.'
       type: boolean
@@ -2471,13 +2550,16 @@ Log-rotation-config-readonly:
       default: 0
   readOnly: true
   title: Log-rotation-config
+Log-rotation-config:
+  allOf:
+    - $ref: '#/Log-rotation-base'
 Console-logging-config:
   type: object
   properties:
     log_level:
       description: Log Level for the console output
       type: string
-      default: none
+      default: info
       enum:
         - none
         - error
@@ -2493,6 +2575,7 @@ Console-logging-config:
     color_enabled:
       description: Log with color for the console output
       type: boolean
+      default: false
       readOnly: true
     file_output:
       description: 'Override the default stderr output, and write to the file specified instead'
@@ -2501,12 +2584,21 @@ Console-logging-config:
     enabled:
       description: Toggle for this log output
       type: boolean
+      default: false
       readOnly: true
     rotation:
-      $ref: '#/Log-rotation-config-readonly'
+      allOf:
+        - $ref: '#/Log-rotation-base'
+        - type: object
+          properties:
+            max_age:
+              description: The maximum number of days to retain old log files. By default, there is no rotation, max_age=0.
+              default: 0
+              type: integer
     collation_buffer_size:
-      description: The size of the log collation buffer.
+      description: The size of the log collation buffer. The default is 10 if the output is stderr, or 1000 if to a file.
       type: integer
+      default: 10
       readOnly: true
   title: Console-logging-config
 Log-update-enabled:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2509,8 +2509,8 @@ Audit-logging-config:
             - type: object
               properties:
                 max_age:
-                  description: The maximum number of days to retain old log files. By default, there is no rotation, max_age=0.
-                  default: 0
+                  description: The maximum number of days to retain old log files.
+                  default: 6
                   type: integer
   type: object
   properties:

--- a/docs/api/diagnostic.yaml
+++ b/docs/api/diagnostic.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric-capella.yaml
+++ b/docs/api/metric-capella.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
+openapi: 3.0.3
+info:
+  title: App Services Metrics API
+  description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
+  version: 3.3.0
+  license:
+    name: Business Source License 1.1 (BSL)
+    url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'
+servers:
+  - url: 'https://{hostname}:4988'
+    description: Metrics API
+    variables:
+      hostname:
+        description: The hostname to use
+        default: localhost
+paths:
+  /metrics:
+    $ref: ./paths/metric/metrics.yaml
+tags:
+  - name: Prometheus
+    description: Endpoints for use with Prometheus
+externalDocs:
+  description: Manage App Services for Mobile and Edge | Couchbase Docs
+  url: 'https://docs.couchbase.com/cloud/app-services/index.html'

--- a/docs/api/metric-capella.yaml
+++ b/docs/api/metric-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Metrics API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/plugins/decorators/excise-rbac-capella.js
+++ b/docs/api/plugins/decorators/excise-rbac-capella.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2024-Present Couchbase, Inc.
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ * in that file, in accordance with the Business Source License, use of this
+ * software will be governed by the Apache License, Version 2.0, included in
+ * the file licenses/APL2.txt.
+ */
+
+/**
+ * Removes the RBAC roles from capella API docs. This expects the RBAC information to be at the end of the documentation string. This is not a robust way of doing this.
+ * @module ExciseRBACCapella
+ */
+
+module.exports = ExciseRBACCapella;
+
+const re = new RegExp("Required Sync Gateway RBAC roles");
+
+/** @type {import('@redocly/cli').OasDecorator} */
+function ExciseRBACCapella() {
+  return {
+    Operation: {
+      leave(Operation) {
+        // remove all text after first regex match
+        idx = Operation.description.search(re);
+        if (idx > 0) {
+          Operation.description = Operation.description.substr(0, idx);
+        }
+      },
+    },
+  };
+}

--- a/docs/api/plugins/decorators/replace-description-capella.js
+++ b/docs/api/plugins/decorators/replace-description-capella.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2024-Present Couchbase, Inc.
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ * in that file, in accordance with the Business Source License, use of this
+ * software will be governed by the Apache License, Version 2.0, included in
+ * the file licenses/APL2.txt.
+ */
+
+/**
+ * Does a string replacement on all operations (GET,PUT,POST,etc) to replace Sync Gateway with App Services.
+ * @module ReplaceDescriptionCapella
+ */
+
+module.exports = ReplaceDescriptionCapella;
+
+/** @type {import('@redocly/cli').OasDecorator} */
+function ReplaceDescriptionCapella() {
+  return {
+    Operation: {
+      leave(Operation) {
+        Operation.description = Operation.description.replace(
+          "Sync Gateway",
+          "App Services",
+        );
+      },
+    },
+  };
+}

--- a/docs/api/plugins/decorators/replace-server-capella.js
+++ b/docs/api/plugins/decorators/replace-server-capella.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024-Present Couchbase, Inc.
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ * in that file, in accordance with the Business Source License, use of this
+ * software will be governed by the Apache License, Version 2.0, included in
+ * the file licenses/APL2.txt.
+ */
+
+module.exports = ReplaceServersCapella;
+
+/** @type {import('@redocly/cli').OasDecorator} */
+function ReplaceServersCapella({ serverUrl }) {
+  return {
+    Server: {
+      leave(Server) {
+        if (serverUrl) {
+          Server.url = serverUrl;
+        }
+      },
+    },
+  };
+}

--- a/docs/api/plugins/plugin.js
+++ b/docs/api/plugins/plugin.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024-Present Couchbase, Inc.
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ * in that file, in accordance with the Business Source License, use of this
+ * software will be governed by the Apache License, Version 2.0, included in
+ * the file licenses/APL2.txt.
+ */
+
+const ExciseRBACCapella = require("./decorators/excise-rbac-capella.js");
+const ReplaceDescriptionCapella = require("./decorators/replace-description-capella.js");
+const ReplaceServerCapella = require("./decorators/replace-server-capella.js");
+
+module.exports = {
+  decorators: {
+    oas3: {
+      "excise-rbac-capella": ExciseRBACCapella,
+      "replace-description-capella": ReplaceDescriptionCapella,
+      "replace-server-capella": ReplaceServerCapella,
+    },
+  },
+  id: "plugin",
+};

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -50,8 +50,10 @@ paths:
     $ref: './paths/public/keyspace-_changes.yaml'
   '/{db}/_design/{ddoc}':
     $ref: './paths/public/db-_design-ddoc.yaml'
+    x-capella: false
   '/{db}/_design/{ddoc}/_view/{view}':
     $ref: './paths/public/db-_design-ddoc-_view-view.yaml'
+    x-capella: false
   '/{db}/_ensure_full_commit':
     $ref: './paths/public/db-_ensure_full_commit.yaml'
   '/{keyspace}/_revs_diff':
@@ -101,8 +103,10 @@ tags:
     description: Create and manage document attachments
   - name: Replication
     description: Create and manage inter-Sync Gateway replications
+    x-capella: false
   - name: Unsupported
     description: Endpoints that are not supported by Sync Gateway
+    x-capella: false
 externalDocs:
   description: Sync Gateway Quickstart | Couchbase Docs
   url: 'https://docs.couchbase.com/sync-gateway/current/index.html'

--- a/docs/api/public.yaml
+++ b/docs/api/public.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/replace-servers-capella.js
+++ b/docs/api/replace-servers-capella.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024-Present Couchbase, Inc.
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+ * in that file, in accordance with the Business Source License, use of this
+ * software will be governed by the Apache License, Version 2.0, included in
+ * the file licenses/APL2.txt.
+ */
+
+module.exports = ReplaceServersCapella;
+
+/** @type {import('@redocly/cli').OasDecorator} */
+
+function ReplaceServersCapella({ serverUrl }) {
+  return {
+    Server: {
+      leave(Server) {
+        Server.url = serverUrl;
+        delete Server.protocol;
+      },
+    },
+  };
+}


### PR DESCRIPTION
Created with:

- git checkout origin/main .redocly.yaml docs
- manually edit 3.2 -> 3.3
- git cherry-pick CBG-3933-docs-fix

If I create this branch without creating a manifest, no builds will be done for this, which seems right. On the other hand if there are any more commits in 3.2.0, release/3.2.1 existing means that backports will have to be done to 3.2.0 and 3.2.1. I do not expect any more changes.