### PR TITLE
Add SPDX identifiers to LICENSE file for reliable license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: Apache-2.0 AND BUSL-1.1
+
 Source code in this repository is licensed under various licenses. The
 Business Source License 1.1 (BSL) is one such license. Each file indicates in
 a section at the beginning of the file the name of the license that applies to


### PR DESCRIPTION
This change adds SPDX license idenfiers for the licenses we use, which https://pkg.go.dev should be able to use to reliably identify the license information and properly build the module documentation. This will help with development as it allows us to use a pretty standard resource, instead of requiring local go doc parsers or worse, going without.

https://spdx.dev/learn/handling-license-info/

The ` AND ` is conjunctive and signals that BOTH licenses must be complied with. ` OR ` would misleadingly lead people to believe they can choose which license applies, which is not our current policy.

https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/#conjunctive-and-operator

---

![Screenshot 2024-09-11 at 16 03 27](https://github.com/user-attachments/assets/14a4ad40-2f14-4dc4-9255-d51b3caf8924)

https://pkg.go.dev/license-policy

> If we are not able to detect one of the licenses below, only limited package and module information will be made available.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a