### PR TITLE
CBG-4207: Attachment metadata migration on import 

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -193,9 +193,9 @@ type AttachmentsMetaMap struct {
 	Attachments map[string]AttachmentsMeta `json:"_attachments"`
 }
 
-// AttachmentCompactionData struct to unmarshal a document sync data into in order to process attachments during mark
+// AttachmentCompactionSyncData struct to unmarshal a document sync data into in order to process attachments during mark
 // phase. Contains only what is necessary
-type AttachmentCompactionData struct {
+type AttachmentCompactionSyncData struct {
 	Attachments map[string]AttachmentsMeta `json:"attachments"`
 	Flags       uint8                      `json:"flags"`
 	History     struct {
@@ -204,29 +204,43 @@ type AttachmentCompactionData struct {
 	} `json:"history"`
 }
 
-// getAttachmentSyncData takes the data type and data from the DCP feed and will return a AttachmentCompactionData
+// AttachmentCompactionGlobalSyncData is to unmarshal a documents global xattr in order to process attachments during mark phase.
+type AttachmentCompactionGlobalSyncData struct {
+	Attachments map[string]AttachmentsMeta `json:"attachments_meta"`
+}
+
+// getAttachmentSyncData takes the data type and data from the DCP feed and will return a AttachmentCompactionSyncData
 // struct containing data needed to process attachments on a document.
-func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionData, error) {
-	var attachmentData *AttachmentCompactionData
+func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionSyncData, error) {
+	var attachmentSyncData *AttachmentCompactionSyncData
+	var attachmentGlobalSyncData AttachmentCompactionGlobalSyncData
 	var documentBody []byte
 
 	if dataType&base.MemcachedDataTypeXattr != 0 {
-		body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{base.SyncXattrName}, data)
+		body, xattrs, err := sgbucket.DecodeValueWithXattrs([]string{base.SyncXattrName, base.GlobalXattrName}, data)
 		if err != nil {
 			if errors.Is(err, sgbucket.ErrXattrInvalidLen) {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("Could not parse DCP attachment sync data: %w", err)
 		}
-		err = base.JSONUnmarshal(xattrs[base.SyncXattrName], &attachmentData)
+		err = base.JSONUnmarshal(xattrs[base.SyncXattrName], &attachmentSyncData)
 		if err != nil {
 			return nil, err
+		}
+		if xattrs[base.GlobalXattrName] != nil && attachmentSyncData.Attachments == nil {
+			fmt.Println("inside global unmarshal ytihng ")
+			err = base.JSONUnmarshal(xattrs[base.GlobalXattrName], &attachmentGlobalSyncData)
+			if err != nil {
+				return nil, err
+			}
+			attachmentSyncData.Attachments = attachmentGlobalSyncData.Attachments
 		}
 		documentBody = body
 
 	} else {
 		type AttachmentDataSync struct {
-			AttachmentData AttachmentCompactionData `json:"_sync"`
+			AttachmentData AttachmentCompactionSyncData `json:"_sync"`
 		}
 		var attachmentDataSync AttachmentDataSync
 		err := base.JSONUnmarshal(data, &attachmentDataSync)
@@ -235,21 +249,21 @@ func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionDa
 		}
 
 		documentBody = data
-		attachmentData = &attachmentDataSync.AttachmentData
+		attachmentSyncData = &attachmentDataSync.AttachmentData
 	}
 
 	// If we've not yet found any attachments have a last effort attempt to grab it from the body for pre-2.5 documents
-	if len(attachmentData.Attachments) == 0 {
+	if len(attachmentSyncData.Attachments) == 0 {
 		attachmentMetaMap, err := checkForInlineAttachments(documentBody)
 		if err != nil {
 			return nil, err
 		}
 		if attachmentMetaMap != nil {
-			attachmentData.Attachments = attachmentMetaMap.Attachments
+			attachmentSyncData.Attachments = attachmentMetaMap.Attachments
 		}
 	}
 
-	return attachmentData, nil
+	return attachmentSyncData, nil
 }
 
 // checkForInlineAttachments will scan a body for "_attachments" for pre-2.5 attachments and will return any attachments

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -229,7 +229,6 @@ func getAttachmentSyncData(dataType uint8, data []byte) (*AttachmentCompactionSy
 			return nil, err
 		}
 		if xattrs[base.GlobalXattrName] != nil && attachmentSyncData.Attachments == nil {
-			fmt.Println("inside global unmarshal ytihng ")
 			err = base.JSONUnmarshal(xattrs[base.GlobalXattrName], &attachmentGlobalSyncData)
 			if err != nil {
 				return nil, err

--- a/db/import.go
+++ b/db/import.go
@@ -97,7 +97,7 @@ func (db *DatabaseCollectionWithUser) ImportDoc(ctx context.Context, docid strin
 				existingBucketDoc.Xattrs[base.MouXattrName], err = base.JSONMarshal(existingDoc.metadataOnlyUpdate)
 			}
 		} else {
-			existingBucketDoc.Body, existingBucketDoc.Xattrs[base.SyncXattrName], existingBucketDoc.Xattrs[base.VvXattrName], existingBucketDoc.Xattrs[base.MouXattrName], _, err = existingDoc.MarshalWithXattrs()
+			existingBucketDoc.Body, existingBucketDoc.Xattrs[base.SyncXattrName], existingBucketDoc.Xattrs[base.VvXattrName], existingBucketDoc.Xattrs[base.MouXattrName], existingBucketDoc.Xattrs[base.GlobalXattrName], err = existingDoc.MarshalWithXattrs()
 		}
 	}
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -220,8 +220,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 				base.DebugfCtx(ctx, base.KeyImport, "Did not import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", base.UD(docID), err)
 			}
 		}
-	}
-	if syncData != nil && syncData.Attachments != nil {
+	} else if syncData != nil && syncData.Attachments != nil {
 		base.DebugfCtx(ctx, base.KeyImport, "Attachment metadata found in sync data for doc with id %s, migrating attachment metadata", base.UD(docID))
 		// we have attachments to migrate
 		err := collection.MigrateAttachmentMetadata(ctx, docID, event.Cas, syncData)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -902,6 +902,7 @@ func MoveAttachmentXattrFromGlobalToSync(t *testing.T, ctx context.Context, docI
 	docSync.Attachments = attachments
 
 	opts := &sgbucket.MutateInOptions{}
+	// this should be true for cases we want to move the attachment metadata without causing a new import feed event
 	if macroExpand {
 		spec := macroExpandSpec(base.SyncXattrName)
 		opts.MacroExpansion = spec


### PR DESCRIPTION
CBG-4207

- Added new function `MigrateAttachmentMetadata` that will move any defined attachments from sync data into the new global sync xattr and remove it from sync data
- Two new tests that test on demand import moving the attachment metadata and the import feed moving it
- Test for import feed tests a doc that needs importing moving the metadata and a doc that is deemed as not needing to be imported migrating metadata
- Define a new function for test purposes that moved global sync data attachment metadata to sync data attachment metadata 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2691/
