### PR TITLE
CBG-3861 support updating vv on xdcr

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -788,6 +788,11 @@ func RequireDocNotFoundError(t testing.TB, e error) {
 	require.True(t, IsDocNotFoundError(e), fmt.Sprintf("Expected error to be a doc not found error, but was: %v", e))
 }
 
+// RequireXattrNotFoundError asserts that the given error represents an xattr not found error.
+func RequireXattrNotFoundError(t testing.TB, e error) {
+	require.True(t, IsXattrNotFoundError(e), fmt.Sprintf("Expected error to be an xattr not found error, but was: %v", e))
+}
+
 func requireCasMismatchError(t testing.TB, err error) {
 	require.Error(t, err, "Expected an error of type IsCasMismatch %+v\n", err)
 	require.True(t, IsCasMismatch(err), "Expected error of type IsCasMismatch but got %+v\n", err)

--- a/db/database.go
+++ b/db/database.go
@@ -349,8 +349,8 @@ func ConnectToBucket(ctx context.Context, spec base.BucketSpec, failFast bool) (
 	return ibucket.(base.Bucket), nil
 }
 
-// Returns Couchbase Server Cluster UUID on a timeout. If running against walrus, do return an empty string.
-func getServerUUID(ctx context.Context, bucket base.Bucket) (string, error) {
+// GetServerUUID returns Couchbase Server Cluster UUID on a timeout. If running against rosmar, do return an empty string.
+func GetServerUUID(ctx context.Context, bucket base.Bucket) (string, error) {
 	gocbV2Bucket, err := base.AsGocbV2Bucket(bucket)
 	if err != nil {
 		return "", nil
@@ -393,7 +393,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
-	serverUUID, err := getServerUUID(ctx, bucket)
+	serverUUID, err := GetServerUUID(ctx, bucket)
 	if err != nil {
 		return nil, err
 	}

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -307,7 +307,7 @@ func TestHLVImport(t *testing.T) {
 	require.NoError(t, err)
 	encodedCAS = EncodeValue(cas)
 
-	docxattr, _ := existingXattrs[base.VirtualXattrRevSeqNo]
+	docxattr := existingXattrs[base.VirtualXattrRevSeqNo]
 	revSeqNo := RetrieveDocRevSeqNo(t, docxattr)
 
 	importOpts = importDocOptions{
@@ -466,7 +466,7 @@ func TestExtractHLVFromChangesMessage(t *testing.T) {
 
 			// TODO: When CBG-3662 is done, should be able to simplify base64 handling to treat source as a string
 			//       that may represent a base64 encoding
-			base64EncodedHlvString := cblEncodeTestSources(test.hlvString)
+			base64EncodedHlvString := EncodeTestHistory(test.hlvString)
 			hlv, err := extractHLVFromBlipMessage(base64EncodedHlvString)
 			require.NoError(t, err)
 
@@ -490,30 +490,4 @@ func BenchmarkExtractHLVFromBlipMessage(b *testing.B) {
 			}
 		})
 	}
-}
-
-// cblEncodeTestSources converts the simplified versions in test data to CBL-style encoding
-func cblEncodeTestSources(hlvString string) (base64HLVString string) {
-
-	vectorFields := strings.Split(hlvString, ";")
-	vectorLength := len(vectorFields)
-	if vectorLength == 0 {
-		return hlvString
-	}
-
-	// first vector field is single vector, cv
-	base64HLVString += EncodeTestVersion(vectorFields[0])
-	for _, field := range vectorFields[1:] {
-		base64HLVString += ";"
-		versions := strings.Split(field, ",")
-		if len(versions) == 0 {
-			continue
-		}
-		base64HLVString += EncodeTestVersion(versions[0])
-		for _, version := range versions[1:] {
-			base64HLVString += ","
-			base64HLVString += EncodeTestVersion(version)
-		}
-	}
-	return base64HLVString
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20240606153601-d152b90edccb
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78
+	github.com/couchbaselabs/rosmar v0.0.0-20240924211003-933f0fd5bba0
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.4
 	github.com/go-jose/go-jose/v4 v4.0.2
@@ -71,7 +71,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/klauspost/compress v1.17.3 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/mattn/go-sqlite3 v1.14.23 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28 h1:lh
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
 github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78 h1:pdMO4naNb0W68OisY0Y7LEE6xOXlrlZow5IWmwow2Wc=
 github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78/go.mod h1:BZgg7zjF7c8e7BR5/JBuSXZ+PLIHgyrNKwE0eLFeglw=
+github.com/couchbaselabs/rosmar v0.0.0-20240924211003-933f0fd5bba0 h1:CQil6oxiHYhJBITdKTlxEUOetPdcgN6bk8wOZd4maDM=
+github.com/couchbaselabs/rosmar v0.0.0-20240924211003-933f0fd5bba0/go.mod h1:Abf5EPwi/7j5caDy2OPmo+L36I02H7sp9dkgek5t4bM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -166,6 +168,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.23 h1:gbShiuAP1W5j9UOksQ06aiiqPMxYecovVGwmTxWtuw0=
+github.com/mattn/go-sqlite3 v1.14.23/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/xdcr/cbs_xdcr.go
+++ b/xdcr/cbs_xdcr.go
@@ -10,6 +10,7 @@ package xdcr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -20,11 +21,14 @@ import (
 )
 
 const (
-	cbsRemoteClustersEndpoint = "/pools/default/remoteClusters"
-	xdcrClusterName           = "sync_gateway_xdcr"
-	totalDocsFilteredStat     = "xdcr_docs_filtered_total"
-	totalDocsWrittenStat      = "xdcr_docs_written_total"
+	cbsRemoteClustersEndpoint           = "/pools/default/remoteClusters"
+	xdcrClusterName                     = "sync_gateway_xdcr" // this is a hardcoded name for the local XDCR cluster
+	totalMobileDocsFiltered             = "xdcr_mobile_docs_filtered_total"
+	totalDocsWrittenStat                = "xdcr_docs_written_total"
+	totalDocsConflictResolutionRejected = "xdcr_docs_failed_cr_source_total"
 )
+
+var errNoXDCRMetrics = errors.New("No metric found")
 
 // couchbaseServerManager implements a XDCR setup cluster on Couchbase Server.
 type couchbaseServerManager struct {
@@ -188,15 +192,27 @@ func (x *couchbaseServerManager) Stats(ctx context.Context) (*Stats, error) {
 		return nil, err
 	}
 	stats := &Stats{}
-	stats.DocsFiltered, err = x.getValue(mf[totalDocsFilteredStat])
-	if err != nil {
-		return stats, err
+
+	statMap := map[string]*uint64{
+		totalMobileDocsFiltered:             &stats.MobileDocsFiltered,
+		totalDocsWrittenStat:                &stats.DocsWritten,
+		totalDocsConflictResolutionRejected: &stats.TargetNewerDocs,
 	}
-	stats.DocsWritten, err = x.getValue(mf[totalDocsWrittenStat])
-	if err != nil {
-		return stats, err
+	var errs *base.MultiError
+	for metricName, stat := range statMap {
+		metricFamily, ok := mf[metricName]
+		if !ok {
+			errs = errs.Append(fmt.Errorf("Could not find %s metric: %+v", metricName, mf))
+			continue
+		}
+		var err error
+		*stat, err = x.getValue(metricFamily)
+		if err != nil {
+			errs = errs.Append(err)
+		}
 	}
-	return stats, nil
+	stats.DocsProcessed = stats.DocsWritten + stats.MobileDocsFiltered + stats.TargetNewerDocs
+	return stats, errs.ErrorOrNil()
 }
 
 func (x *couchbaseServerManager) getValue(metrics *dto.MetricFamily) (uint64, error) {
@@ -222,7 +238,7 @@ outer:
 			return 0, fmt.Errorf("Do not have a relevant type for %v", metrics.Type)
 		}
 	}
-	return 0, fmt.Errorf("Could not find relevant value for metrics %v", metrics)
+	return 0, errNoXDCRMetrics
 }
 
 var _ Manager = &couchbaseServerManager{}

--- a/xdcr/replication.go
+++ b/xdcr/replication.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/rosmar"
 )
 
@@ -74,4 +75,17 @@ func NewXDCR(ctx context.Context, fromBucket, toBucket base.Bucket, opts XDCROpt
 		return nil, fmt.Errorf("toBucket must be a *base.GocbV2Bucket since fromBucket was a gocbBucket, got %T", toBucket)
 	}
 	return newCouchbaseServerManager(ctx, gocbFromBucket, gocbToBucket, opts)
+}
+
+// getSourceID returns the source ID for a bucket.
+func getSourceID(ctx context.Context, bucket base.Bucket) (string, error) {
+	serverUUID, err := db.GetServerUUID(ctx, bucket)
+	if err != nil {
+		return "", err
+	}
+	bucketUUID, err := bucket.UUID()
+	if err != nil {
+		return "", err
+	}
+	return db.CreateEncodedSourceID(bucketUUID, serverUUID)
 }

--- a/xdcr/stats.go
+++ b/xdcr/stats.go
@@ -10,10 +10,12 @@ package xdcr
 
 // Stats represents the stats of a replication.
 type Stats struct {
-	// DocsFiltered is the number of documents that have been filtered out and have not been replicated to the target cluster.
-	DocsFiltered uint64
+	// MobileDocsFiltered is the number of documents that have been filtered out and have not been replicated to the target cluster.
+	MobileDocsFiltered uint64
 	// DocsWritten is the number of documents written to the destination cluster, since the start or resumption of the current replication.
 	DocsWritten uint64
+	// DocsProcessed is the number of documents that have been processed by the replication.
+	DocsProcessed uint64
 	// ErrorCount is the number of errors that have occurred during the replication.
 	ErrorCount uint64
 

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -13,7 +13,9 @@ import (
 	"testing"
 	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,74 +52,299 @@ func TestMobileXDCRNoSyncDataCopied(t *testing.T) {
 		attachmentDoc = "_sync:att2:foo"
 		normalDoc     = "doc2"
 		exp           = 0
-		body          = `{"key":"value"}`
-		version       = "ver"
-		source        = "src"
-		curCAS        = "cvCas"
+		startingBody  = `{"key":"value"}`
 	)
 	dataStores := map[base.DataStore]base.DataStore{
 		fromBucket.DefaultDataStore(): toBucket.DefaultDataStore(),
 	}
+	var fromDs base.DataStore
+	var toDs base.DataStore
 	if base.TestsUseNamedCollections() {
-		fromDs, err := fromBucket.GetNamedDataStore(0)
+		fromDs, err = fromBucket.GetNamedDataStore(0)
 		require.NoError(t, err)
-		toDs, err := toBucket.GetNamedDataStore(0)
+		toDs, err = toBucket.GetNamedDataStore(0)
 		require.NoError(t, err)
 		dataStores[fromDs] = toDs
+	} else {
+		fromDs = fromBucket.DefaultDataStore()
+		toDs = toBucket.DefaultDataStore()
 	}
-	var totalDocsWritten uint64
-	var totalDocsFiltered uint64
-	for fromDs, toDs := range dataStores {
-		for _, doc := range []string{syncDoc, attachmentDoc, normalDoc} {
-			_, err = fromDs.Add(doc, exp, body)
-			require.NoError(t, err)
-		}
+	fromBucketSourceID, err := getSourceID(ctx, fromBucket)
+	require.NoError(t, err)
+	docCas := make(map[string]uint64)
+	for _, doc := range []string{syncDoc, attachmentDoc, normalDoc} {
+		var inputCas uint64
+		var err error
+		docCas[doc], err = fromDs.WriteCas(doc, exp, inputCas, []byte(startingBody), 0)
+		require.NoError(t, err)
+		_, _, err = fromDs.GetXattrs(ctx, doc, []string{base.VvXattrName})
+		// make sure that the doc does not have a version vector
+		base.RequireXattrNotFoundError(t, err)
+	}
 
-		// make sure attachments are copied
-		for _, doc := range []string{normalDoc, attachmentDoc} {
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				var value string
-				_, err = toDs.Get(doc, &value)
-				assert.NoError(c, err, "Could not get doc %s", doc)
-				assert.Equal(c, body, value)
-			}, time.Second*5, time.Millisecond*100)
-		}
-
-		var value any
-		_, err = toDs.Get(syncDoc, &value)
-		base.RequireDocNotFoundError(t, err)
-
-		// stats are not updated in real time, so we need to wait a bit
+	// make sure attachments are copied
+	for _, doc := range []string{normalDoc, attachmentDoc} {
+		var body []byte
+		var xattrs map[string][]byte
+		var cas uint64
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			stats, err := xdcr.Stats(ctx)
-			assert.NoError(t, err)
-			assert.Equal(c, totalDocsFiltered+1, stats.DocsFiltered)
-			assert.Equal(c, totalDocsWritten+2, stats.DocsWritten)
-
+			var err error
+			body, xattrs, cas, err = toDs.GetWithXattrs(ctx, doc, []string{base.VvXattrName, base.MouXattrName})
+			assert.NoError(c, err, "Could not get doc %s", doc)
 		}, time.Second*5, time.Millisecond*100)
-		totalDocsWritten += 2
-		totalDocsFiltered++
-		if base.UnitTestUrlIsWalrus() {
-			// TODO: CBG-3861 implement _vv support in rosmar
+		require.Equal(t, docCas[doc], cas)
+		require.JSONEq(t, startingBody, string(body))
+		require.NotContains(t, xattrs, base.MouXattrName)
+		if !base.TestSupportsMobileXDCR() {
+			require.Len(t, xattrs, 0)
 			continue
 		}
-		// in mobile xdcr mode a version vector will be written
-		if base.TestSupportsMobileXDCR() {
-			// verify VV is written to docs that are replicated
-			for _, doc := range []string{normalDoc, attachmentDoc} {
-				require.EventuallyWithT(t, func(c *assert.CollectT) {
-					xattrs, _, err := toDs.GetXattrs(ctx, doc, []string{"_vv"})
-					assert.NoError(c, err, "Could not get doc %s", doc)
-					vvXattrBytes, ok := xattrs["_vv"]
-					require.True(t, ok)
-					var vvXattrVal map[string]any
-					require.NoError(t, base.JSONUnmarshal(vvXattrBytes, &vvXattrVal))
-					assert.NotNil(c, vvXattrVal[version])
-					assert.NotNil(c, vvXattrVal[source])
-					assert.NotNil(c, vvXattrVal[curCAS])
-
-				}, time.Second*5, time.Millisecond*100)
-			}
-		}
+		require.Contains(t, xattrs, base.VvXattrName)
+		casString := string(base.Uint64CASToLittleEndianHex(cas))
+		var vv *db.HybridLogicalVector
+		require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &vv))
+		require.Equal(t, &db.HybridLogicalVector{
+			CurrentVersionCAS: casString,
+			SourceID:          fromBucketSourceID,
+			Version:           casString,
+		}, vv)
 	}
+
+	_, err = toDs.Get(syncDoc, nil)
+	base.RequireDocNotFoundError(t, err)
+
+	var totalDocsWritten uint64
+	var totalDocsFiltered uint64
+
+	// stats are not updated in real time, so we need to wait a bit
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		stats, err := xdcr.Stats(ctx)
+		assert.NoError(t, err)
+		assert.Equal(c, totalDocsFiltered+1, stats.DocsFiltered)
+		assert.Equal(c, totalDocsWritten+2, stats.DocsWritten)
+
+	}, time.Second*5, time.Millisecond*100)
+}
+
+// getTwoBucketDataStores creates two data stores in separate buckets to run xdcr within. Returns a named collection or a default collection based on the global test configuration.
+func getTwoBucketDataStores(t *testing.T) (base.Bucket, sgbucket.DataStore, base.Bucket, sgbucket.DataStore) {
+	ctx := base.TestCtx(t)
+	base.RequireNumTestBuckets(t, 2)
+	fromBucket := base.GetTestBucket(t)
+	t.Cleanup(func() {
+		fromBucket.Close(ctx)
+	})
+	toBucket := base.GetTestBucket(t)
+	t.Cleanup(func() {
+		toBucket.Close(ctx)
+	})
+	var fromDs base.DataStore
+	var toDs base.DataStore
+	if base.TestsUseNamedCollections() {
+		var err error
+		fromDs, err = fromBucket.GetNamedDataStore(0)
+		require.NoError(t, err)
+		toDs, err = toBucket.GetNamedDataStore(0)
+		require.NoError(t, err)
+	} else {
+		fromDs = fromBucket.DefaultDataStore()
+		toDs = toBucket.DefaultDataStore()
+	}
+	return fromBucket, fromDs, toBucket, toDs
+}
+
+func TestReplicateVV(t *testing.T) {
+	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
+	ctx := base.TestCtx(t)
+	fromBucketSourceID, err := getSourceID(ctx, fromBucket)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name        string
+		docID       string
+		body        string
+		preXDCRFunc func(t *testing.T, docID string) uint64
+	}{
+		{
+			name:  "normal doc",
+			docID: "doc1",
+			body:  `{"key":"value"}`,
+			preXDCRFunc: func(t *testing.T, docID string) uint64 {
+				cas, err := fromDs.WriteCas(docID, 0, 0, []byte(`{"key":"value"}`), 0)
+				require.NoError(t, err)
+				return cas
+			},
+		},
+		{
+			name:  "dest doc older, expect overwrite",
+			docID: "doc2",
+			body:  `{"datastore":"fromDs"}`,
+			preXDCRFunc: func(t *testing.T, docID string) uint64 {
+				_, err := toDs.WriteCas(docID, 0, 0, []byte(`{"datastore":"toDs"}`), 0)
+				require.NoError(t, err)
+				cas, err := fromDs.WriteCas(docID, 0, 0, []byte(`{"datastore":"fromDs"}`), 0)
+				require.NoError(t, err)
+				return cas
+			},
+		},
+		{
+			name:  "dest doc newer, expect keep old version",
+			docID: "doc3",
+			body:  `{"datastore":"fromDs"}`,
+			preXDCRFunc: func(t *testing.T, docID string) uint64 {
+				_, err := toDs.WriteCas(docID, 0, 0, []byte(`{"datastore":"toDs"}`), 0)
+				require.NoError(t, err)
+				cas, err := fromDs.WriteCas(docID, 0, 0, []byte(`{"datastore":"fromDs"}`), 0)
+				require.NoError(t, err)
+				return cas
+			},
+		},
+	}
+	// tests write a document
+	// start xdcr
+	// verify result
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fromCAS := testCase.preXDCRFunc(t, testCase.docID)
+
+			xdcr := startXDCR(t, fromBucket, toBucket, XDCROptions{Mobile: MobileOn})
+			defer func() {
+				assert.NoError(t, xdcr.Stop(ctx))
+			}()
+			requireWaitForXDCRDocsWritten(t, xdcr, 1)
+
+			body, xattrs, destCas, err := toDs.GetWithXattrs(ctx, testCase.docID, []string{base.VvXattrName, base.MouXattrName})
+			require.NoError(t, err, "Could not get doc %s", testCase.docID)
+			require.Equal(t, fromCAS, destCas)
+			require.JSONEq(t, testCase.body, string(body))
+			require.NotContains(t, xattrs, base.MouXattrName)
+			require.Contains(t, xattrs, base.VvXattrName)
+			casString := string(base.Uint64CASToLittleEndianHex(fromCAS))
+			var vv *db.HybridLogicalVector
+			require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &vv))
+			require.Equal(t, &db.HybridLogicalVector{
+				CurrentVersionCAS: casString,
+				SourceID:          fromBucketSourceID,
+				Version:           casString,
+			}, vv)
+
+		})
+	}
+}
+
+func TestVVWriteTwice(t *testing.T) {
+	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
+	ctx := base.TestCtx(t)
+	fromBucketSourceID, err := getSourceID(ctx, fromBucket)
+	require.NoError(t, err)
+
+	docID := "doc1"
+	ver1Body := `{"ver":1}`
+	fromCAS, err := fromDs.WriteCas(docID, 0, 0, []byte(ver1Body), 0)
+	require.NoError(t, err)
+	xdcr := startXDCR(t, fromBucket, toBucket, XDCROptions{Mobile: MobileOn})
+	defer func() {
+		assert.NoError(t, xdcr.Stop(ctx))
+	}()
+	requireWaitForXDCRDocsWritten(t, xdcr, 1)
+
+	body, xattrs, destCas, err := toDs.GetWithXattrs(ctx, docID, []string{base.VvXattrName, base.MouXattrName})
+	require.NoError(t, err)
+	require.Equal(t, fromCAS, destCas)
+	require.JSONEq(t, ver1Body, string(body))
+	require.Contains(t, xattrs, base.VvXattrName)
+	casString := string(base.Uint64CASToLittleEndianHex(fromCAS))
+	var vv *db.HybridLogicalVector
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &vv))
+	require.Equal(t, &db.HybridLogicalVector{
+		CurrentVersionCAS: casString,
+		SourceID:          fromBucketSourceID,
+		Version:           casString,
+	}, vv)
+
+	fromCAS2, err := fromDs.WriteCas(docID, 0, fromCAS, []byte(`{"ver":2}`), 0)
+	require.NoError(t, err)
+	requireWaitForXDCRDocsWritten(t, xdcr, 2)
+
+	body, xattrs, destCas, err = toDs.GetWithXattrs(ctx, docID, []string{base.VvXattrName, base.MouXattrName})
+	require.NoError(t, err)
+	require.Equal(t, fromCAS2, destCas)
+	require.JSONEq(t, `{"ver":2}`, string(body))
+	require.Contains(t, xattrs, base.VvXattrName)
+	casString = string(base.Uint64CASToLittleEndianHex(fromCAS2))
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &vv))
+	require.Equal(t, &db.HybridLogicalVector{
+		CurrentVersionCAS: casString,
+		SourceID:          fromBucketSourceID,
+		Version:           casString,
+	}, vv)
+}
+
+func TestVVWriteOnDestAfterInitialReplication(t *testing.T) {
+	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
+	ctx := base.TestCtx(t)
+	fromBucketSourceID, err := getSourceID(ctx, fromBucket)
+	require.NoError(t, err)
+
+	docID := "doc1"
+	ver1Body := `{"ver":1}`
+	fromCAS, err := fromDs.WriteCas(docID, 0, 0, []byte(ver1Body), 0)
+	require.NoError(t, err)
+	xdcr := startXDCR(t, fromBucket, toBucket, XDCROptions{Mobile: MobileOn})
+	defer func() {
+		assert.NoError(t, xdcr.Stop(ctx))
+	}()
+	requireWaitForXDCRDocsWritten(t, xdcr, 1)
+
+	body, xattrs, destCas, err := toDs.GetWithXattrs(ctx, docID, []string{base.VvXattrName, base.MouXattrName})
+	require.NoError(t, err)
+	require.Equal(t, fromCAS, destCas)
+	require.JSONEq(t, ver1Body, string(body))
+	require.Contains(t, xattrs, base.VvXattrName)
+	casString := string(base.Uint64CASToLittleEndianHex(fromCAS))
+	fmt.Printf("vv after write1: %+v\n", string(xattrs[base.VvXattrName]))
+	var vv *db.HybridLogicalVector
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &vv))
+	require.Equal(t, &db.HybridLogicalVector{
+		CurrentVersionCAS: casString,
+		SourceID:          fromBucketSourceID,
+		Version:           casString,
+	}, vv)
+
+	// write to dest bucket again
+	toCas2, err := toDs.WriteCas(docID, 0, fromCAS, []byte(`{"ver":3}`), 0)
+	require.NoError(t, err)
+	fmt.Printf("toCas2: %d\n", toCas2)
+
+	body, xattrs, destCas, err = toDs.GetWithXattrs(ctx, docID, []string{base.VvXattrName, base.MouXattrName})
+	require.NoError(t, err)
+	require.Equal(t, toCas2, destCas)
+	require.JSONEq(t, `{"ver":3}`, string(body))
+	require.Contains(t, xattrs, base.VvXattrName)
+	casString = string(base.Uint64CASToLittleEndianHex(fromCAS))
+	fmt.Printf("vv after write2: %+v\n", string(xattrs[base.VvXattrName]))
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &vv))
+	require.Equal(t, &db.HybridLogicalVector{
+		CurrentVersionCAS: casString,
+		SourceID:          fromBucketSourceID,
+		Version:           casString,
+	}, vv)
+}
+
+func startXDCR(t *testing.T, fromBucket base.Bucket, toBucket base.Bucket, opts XDCROptions) Manager {
+	ctx := base.TestCtx(t)
+	xdcr, err := NewXDCR(ctx, fromBucket, toBucket, opts)
+	require.NoError(t, err)
+	err = xdcr.Start(ctx)
+	require.NoError(t, err)
+	return xdcr
+}
+
+func requireWaitForXDCRDocsWritten(t *testing.T, xdcr Manager, expectedDocsWritten uint64) {
+	ctx := base.TestCtx(t)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		stats, err := xdcr.Stats(ctx)
+		assert.NoError(t, err)
+		assert.Equal(c, expectedDocsWritten, stats.DocsWritten)
+	}, time.Second*5, time.Millisecond*100)
 }


### PR DESCRIPTION
- this code will only update cv when appropriate, does not yet support changing pv or mv (not supported in mobile xdcr anyway)
- stubs out some kinds of tests we can write
- Creates a `SourceID` for rosmar that is just bucketUUID (clusterUUID is always empty string), but this will be unique since rosmar is only in memory
- replace `cblEncodeTestSources` with `EncodeTestHistory` since these were duplicate functions and I was about to write a third.

Parts of this PR I'm particularly interested in are whether the test code is easily readable. I gave some limited thought to how to parameterize `TestVVWriteOnDestAfterInitialReplication` and `TestVVWriteTwice` like `TestReplicateVV`, but I couldn't think of something that wasn't like:

- test.preXDCRFunc1
- run xdcr
- test.assertVV1
- test.preXDCRFunc2
- test.assertVV2

I didn't feel like this was more readable and generalizable enough. I am imagining that we have a different set of test cases for the future when we implement `pv` support that doesn't take a datastore, but rather has two `DatabaseContext` instances which would allow us to use the crud operations on `DatabaseContext` and also creating imports. When implementing this, I was going to debate if a structure like above was appropriate.

Ultimately, I just decided to stop working on this to be able to get some code in place and be able to break tasks up into smaller pieces. I do think it's worthwhile to get this in good shape and any significant improvements, I'll break into separate tickets.