### PR TITLE
CBG-4209: Add test for blip doc update attachment metadata migration

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2255,7 +2255,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 // TestUpdateViaBlipMigrateAttachment:
 //   - Tests document update through blip to a doc with attachment metadata deined in sync data
-//   - Assert that teh doc update this way will migrate the attachment metadata from sync data to global sync data
+//   - Assert that the c doc update this way will migrate the attachment metadata from sync data to global sync data
 func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,


### PR DESCRIPTION
CBG-4209

- Small PR to add a test coverage of doc update migrating attachment metadata via blip 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2692/
