### PR TITLE
CBG3026 prereq: More low-risk cleanup/refactoring

### DIFF
--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -344,9 +344,9 @@ func stripSyncProperty(row *sgbucket.ViewRow) {
 }
 
 func InitializeViews(ctx context.Context, ds sgbucket.DataStore) error {
-	collection, ok := ds.(*base.Collection)
-	if ok && !collection.IsDefaultScopeCollection() {
-		return fmt.Errorf("Can not initialize views on a non default collection")
+	collection, isCBServerCollection := ds.(*base.Collection)
+	if isCBServerCollection && !collection.IsDefaultScopeCollection() {
+		return fmt.Errorf("Can not initialize views on a non-default Couchbase Server collection")
 	}
 
 	viewStore, ok := ds.(sgbucket.ViewStore)

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -384,6 +384,7 @@ func InitializeIndexes(ctx context.Context, n1QLStore base.N1QLStore, options In
 	deferredIndexes := make([]string, 0)
 	for _, sgIndex := range sgIndexes {
 
+		// TODO CBG-2838: build list of indexes to create (with one GetIndexMeta call)
 		if !sgIndex.shouldCreate(options) {
 			base.DebugfCtx(ctx, base.KeyAll, "Skipping index: %s ...", sgIndex.simpleName)
 			continue

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -80,7 +80,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 	}
 
 	// tests sg_users index
-	t.Run("testUserQueries", func(t *testing.T) {
+	rt.Run("testUserQueries", func(t *testing.T) {
 		users := []string{"alice", "bob"}
 
 		for _, user := range users {
@@ -96,7 +96,7 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 	})
 
 	// tests sg_roles index
-	t.Run("testRoleQueries", func(t *testing.T) {
+	rt.Run("testRoleQueries", func(t *testing.T) {
 		roles := []string{"roleA", "roleB"}
 
 		for _, role := range roles {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -588,6 +588,14 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		dbName = spec.BucketName
 	}
 
+	// Generate database context options from config and server context
+	contextOptions, err := dbcOptionsFromConfig(ctx, sc, &config.DbConfig, dbName)
+	if err != nil {
+		return nil, err
+	}
+	// set this early so we have dbName available in db-init related logging, before we have an actual database
+	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig)
+
 	defer func() {
 		if returnedError == nil {
 			return
@@ -776,14 +784,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	if err != nil {
 		return nil, err
 	}
-
-	// Generate database context options from config and server context
-	contextOptions, err := dbcOptionsFromConfig(ctx, sc, &config.DbConfig, dbName)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig)
 
 	contextOptions.UseViews = useViews
 


### PR DESCRIPTION
This PR contains the changes unrelated to `DatabaseInitManager` that are in the upcoming CBG-3026 PR just to completely isolate those changes given the complexity.

- Move `DatabaseLogCtx` earlier in `_getOrAddDatabaseFromConfig` so we can identify which database init-related logging is for
- `t.Run`->`rt.Run` fixes (prevents panics with failing subtests)
- Minor rename and TODO comment for upcoming work

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2694/
