### PR TITLE
CBG-3026: Use `DatabaseInitManager` in all GSI cases

### DIFF
--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -50,7 +50,7 @@ func TestBootstrapRefCounting(t *testing.T) {
 	tlsSkipVerify := BoolPtr(TestTLSSkipVerify())
 	var perBucketCredentialsConfig map[string]*CredentialsConfig
 	ctx := TestCtx(t)
-	cluster, err := NewCouchbaseCluster(ctx, UnitTestUrl(), TestClusterUsername(), TestClusterPassword(), x509CertPath, x509KeyPath, caCertPath, forcePerBucketAuth, perBucketCredentialsConfig, tlsSkipVerify, BoolPtr(TestUseXattrs()), CachedClusterConnections)
+	cluster, err := NewCouchbaseCluster(ctx, UnitTestUrl(), TestClusterUsername(), TestClusterPassword(), x509CertPath, x509KeyPath, caCertPath, forcePerBucketAuth, perBucketCredentialsConfig, tlsSkipVerify, TestUseXattrs(), CachedClusterConnections)
 	require.NoError(t, err)
 	defer cluster.Close()
 	require.NotNil(t, cluster)

--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -56,6 +56,10 @@ func NewClusterOnlyN1QLStore(cluster *gocb.Cluster, bucketName, scopeName, colle
 
 }
 
+func (cl *ClusterOnlyN1QLStore) Close() error {
+	return cl.cluster.Close(nil)
+}
+
 func (cl *ClusterOnlyN1QLStore) GetName() string {
 	return cl.bucketName
 }

--- a/base/cluster_n1ql.go
+++ b/base/cluster_n1ql.go
@@ -56,10 +56,6 @@ func NewClusterOnlyN1QLStore(cluster *gocb.Cluster, bucketName, scopeName, colle
 
 }
 
-func (cl *ClusterOnlyN1QLStore) Close() error {
-	return cl.cluster.Close(nil)
-}
-
 func (cl *ClusterOnlyN1QLStore) GetName() string {
 	return cl.bucketName
 }

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -171,7 +171,3 @@ func (c *RosmarCluster) Close() {
 }
 
 func (c *RosmarCluster) SetConnectionStringServerless() error { return nil }
-
-func (c *RosmarCluster) GetClusterN1QLStore(bucketName, scopeName, collectionName string) (*ClusterOnlyN1QLStore, error) {
-	return nil, errors.New("rosmar doesn't support a N1QL store")
-}

--- a/db/database.go
+++ b/db/database.go
@@ -135,6 +135,7 @@ type DatabaseContext struct {
 	RequireResync                base.ScopeAndCollectionNames   // Collections requiring resync before database can go online
 	CORS                         *auth.CORSConfig               // CORS configuration
 	EnableMou                    bool                           // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
+	WasInitializedSynchronously  bool                           // true if the database was initialized synchronously
 }
 
 type Scope struct {

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -75,7 +75,7 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 
 	base.InfofCtx(ctx, base.KeyAll, "Starting new initialization for database %s ...",
 		base.MD(dbConfig.Name))
-	couchbaseCluster, err := CreateBootstrapConnectionFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
+	couchbaseCluster, err := createBootstrapConnectionWithCredentials(ctx, startupConfig, dbConfig.Username, dbConfig.Password, base.PerUseClusterConnections)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +85,7 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 		bucketName = *dbConfig.Bucket
 	}
 
-	// Initialize ClusterN1QLStore for the bucket.  Scope and collection name are set
-	// per-operation
+	// Initialize ClusterN1QLStore for the bucket.  Scope and collection name are set per-operation
 	n1qlStore, err := couchbaseCluster.GetClusterN1QLStore(bucketName, "", "")
 	if err != nil {
 		return nil, err

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -100,6 +100,7 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 
 	// Start a goroutine to perform the initialization
 	go func() {
+		defer n1qlStore.Close()
 		defer couchbaseCluster.Close()
 		// worker.Run blocks until completion, and returns any error on doneChan.
 		worker.Run()

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -100,7 +100,7 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 
 	// Start a goroutine to perform the initialization
 	go func() {
-		defer n1qlStore.Close()
+		defer func() { _ = n1qlStore.Close() }()
 		defer couchbaseCluster.Close()
 		// worker.Run blocks until completion, and returns any error on doneChan.
 		worker.Run()

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -73,7 +73,7 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 		delete(m.workers, dbConfig.Name)
 	}
 
-	base.InfofCtx(ctx, base.KeyAll, "Starting new async initialization for database %s ...",
+	base.InfofCtx(ctx, base.KeyAll, "Starting new initialization for database %s ...",
 		base.MD(dbConfig.Name))
 	couchbaseCluster, err := CreateBootstrapConnectionFromStartupConfig(ctx, startupConfig, base.PerUseClusterConnections)
 	if err != nil {

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -117,7 +117,6 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 
 func (m *DatabaseInitManager) HasActiveInitialization(dbName string) bool {
 	if m == nil {
-		// When not using persistent config, DatabaseInitManager will be nil
 		return false
 	}
 	m.workersLock.Lock()

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -38,6 +38,7 @@ func TestDatabaseInitManager(t *testing.T) {
 		scopesConfig = GetCollectionsConfig(t, tb, 1)
 	}
 	dbConfig := makeDbConfig(tb.GetName(), dbName, scopesConfig)
+	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Drop indexes
 	dropAllNonPrimaryIndexes(t, tb.GetSingleDataStore())
@@ -102,6 +103,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 
 	dbName := "dbName"
 	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, blocks after first collection
 	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
@@ -187,6 +189,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 
 	dbName := "dbName"
 	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
 	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
@@ -197,6 +200,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 
 	// Make a call to initialize database for the same db name, different collections
 	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
+	require.NoError(t, modifiedDbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 
@@ -268,9 +272,11 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 
 	db1Name := "db1Name"
 	db1Config := makeDbConfig(tb.GetName(), db1Name, collection1and2ScopesConfig)
+	require.NoError(t, db1Config.setup(ctx, db1Name, sc.Config.Bootstrap, nil, nil, false))
 
 	db2Name := "db2Name"
 	db2Config := makeDbConfig(tb.GetName(), db2Name, collection3ScopesConfig)
+	require.NoError(t, db2Config.setup(ctx, db2Name, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
 	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig())
@@ -356,9 +362,11 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 
 	db1Name := "db1Name"
 	db1Config := makeDbConfig(tb1.GetName(), db1Name, collection1and2ScopesConfig)
+	require.NoError(t, db1Config.setup(ctx, db1Name, sc.Config.Bootstrap, nil, nil, false))
 
 	db2Name := "db2Name"
 	db2Config := makeDbConfig(tb2.GetName(), db2Name, collection1and2ScopesConfig)
+	require.NoError(t, db2Config.setup(ctx, db2Name, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
 	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig())

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -433,6 +433,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	}
 	dbName := "dbName"
 	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
+	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -46,7 +46,7 @@ func TestDatabaseInitManager(t *testing.T) {
 	dropAllNonPrimaryIndexes(t, tb.GetSingleDataStore())
 
 	// Async index creation
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), dbConfig.ToDatabaseConfig())
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	select {
@@ -108,14 +108,14 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, blocks after first collection
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), dbConfig.ToDatabaseConfig())
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	WaitForChannel(t, singleCollectionInitChannel, "first collection init")
 
 	// Make a duplicate call to initialize database, should reuse the existing agent
-	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), dbConfig.ToDatabaseConfig())
+	duplicateDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	// Unblock collection callback to process all remaining collections
@@ -132,7 +132,7 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	waitForWorkerDone(t, initMgr, "dbName")
 
 	// Rerun init, should start a new worker for the database and re-verify init for each collection
-	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), dbConfig.ToDatabaseConfig())
+	rerunDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 	WaitForChannel(t, rerunDoneChan, "repeated init done chan")
 	totalCount = atomic.LoadInt64(&collectionCount)
@@ -194,7 +194,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	require.NoError(t, dbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
-	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), dbConfig.ToDatabaseConfig())
+	doneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
@@ -203,7 +203,7 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 	// Make a call to initialize database for the same db name, different collections
 	modifiedDbConfig := makeDbConfig(tb.GetName(), dbName, collection1and3ScopesConfig)
 	require.NoError(t, modifiedDbConfig.setup(ctx, dbName, sc.Config.Bootstrap, nil, nil, false))
-	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), modifiedDbConfig.ToDatabaseConfig())
+	modifiedDoneChan, err := initMgr.InitializeDatabase(ctx, sc.Config, modifiedDbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel
@@ -281,14 +281,14 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 	require.NoError(t, db2Config.setup(ctx, db2Name, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), db1Config.ToDatabaseConfig())
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Start second async index creation for db2 while first is still running
-	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), db2Config.ToDatabaseConfig())
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel
@@ -371,14 +371,14 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 	require.NoError(t, db2Config.setup(ctx, db2Name, sc.Config.Bootstrap, nil, nil, false))
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), db1Config.ToDatabaseConfig())
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, db1Config.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	// Wait for first collection to be initialized
 	WaitForChannel(t, firstCollectionInitChannel, "first collection init")
 
 	// Start second async index creation for db2 while first is still running
-	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), db2Config.ToDatabaseConfig())
+	doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, db2Config.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	// Unblock the first InitializeDatabase, should cancel
@@ -446,7 +446,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 		if currentCount == 0 {
 			defer wg.Done()
 			log.Printf("invoking InitializeDatabase again during teardown")
-			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), dbConfig.ToDatabaseConfig())
+			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 			require.NoError(t, err)
 			WaitForChannel(t, doneChan2, "done chan 2")
 		}
@@ -455,7 +455,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	}
 
 	// Start first async index creation, should block after first collection
-	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config.IsServerless(), dbConfig.ToDatabaseConfig())
+	doneChan1, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig())
 	require.NoError(t, err)
 
 	WaitForChannel(t, doneChan1, "done chan 1")

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -596,6 +596,7 @@ func TestSyncOnline(t *testing.T) {
 	waitAndRequireDBState(t, sc, dbName, db.DBOnline)
 
 	// Verify no collections were initialized asynchronously
+	// FIXME: Since DatabaseInitManager is now used for async and sync we can't rely on this callback to assert that async was used
 	totalCount := atomic.LoadInt64(&collectionCount)
 	require.Equal(t, int64(0), totalCount)
 

--- a/rest/main.go
+++ b/rest/main.go
@@ -369,6 +369,10 @@ func backupCurrentConfigFile(sourcePath string) (string, error) {
 }
 
 func CreateBootstrapConnectionFromStartupConfig(ctx context.Context, config *StartupConfig, bucketConnectionMode base.BucketConnectionMode) (base.BootstrapConnection, error) {
+	return createBootstrapConnectionWithCredentials(ctx, config, config.Bootstrap.Username, config.Bootstrap.Password, bucketConnectionMode)
+}
+
+func createBootstrapConnectionWithCredentials(ctx context.Context, config *StartupConfig, username, password string, bucketConnectionMode base.BucketConnectionMode) (base.BootstrapConnection, error) {
 	if base.ServerIsWalrus(config.Bootstrap.Server) {
 		cluster := base.NewRosmarCluster(config.Bootstrap.Server)
 		return cluster, nil
@@ -384,7 +388,7 @@ func CreateBootstrapConnectionFromStartupConfig(ctx context.Context, config *Sta
 	if err != nil {
 		return nil, err
 	}
-	cluster, err := base.NewCouchbaseCluster(ctx, server, config.Bootstrap.Username, config.Bootstrap.Password,
+	cluster, err := base.NewCouchbaseCluster(ctx, server, username, password,
 		config.Bootstrap.X509CertPath, config.Bootstrap.X509KeyPath, config.Bootstrap.CACertPath,
 		config.IsServerless(), config.BucketCredentials, config.Bootstrap.ServerTLSSkipVerify, config.Unsupported.UseXattrConfig, bucketConnectionMode)
 	if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -901,6 +901,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	// If asyncOnline wasn't specified, block until db init is completed, then start online processes
 	if !options.asyncOnline || !isAsync {
+		dbcontext.WasInitializedSynchronously = true
 		base.InfofCtx(ctx, base.KeyAll, "Waiting for database init to complete...")
 		if dbInitDoneChan != nil {
 			initError := <-dbInitDoneChan

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -727,7 +727,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		isAsync = startOffline || sc.DatabaseInitManager.HasActiveInitialization(dbName)
 
 		// Initialize indexes using DatabaseInitManager.
-		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config)
+		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config.IsServerless(), &config)
 		if err != nil {
 			return nil, err
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -668,6 +668,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 					return nil, fmt.Errorf("error attempting to create/update database: %w", err)
 				}
 
+				// Init views now. If we're using GSI we'll use DatabaseInitManager to handle creation later.
 				if useViews {
 					if err := db.InitializeViews(ctx, dataStore); err != nil {
 						return nil, err
@@ -719,6 +720,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 		if sc.DatabaseInitManager == nil {
 			base.AssertfCtx(ctx, "DatabaseInitManager should always be initialized")
+			return nil, errors.New("DatabaseInitManager not initialized")
 		}
 
 		// If database has been requested to start offline, or there's an active async initialization, use async initialization

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -727,7 +727,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		isAsync = startOffline || sc.DatabaseInitManager.HasActiveInitialization(dbName)
 
 		// Initialize indexes using DatabaseInitManager.
-		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config.IsServerless(), &config)
+		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
CBG-3026

Rework database initialization code to reuse `DatabaseInitManager` in all GSI cases (including persistent config) to centralize and de-duplicate index creation code.\

Pre-req for CBG-2838 to rearrange per-collection/system:indexes iteration logic to minimise collection overhead when building/waiting for indexes.

## Depends on
- [x] #7120 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2751