### PR TITLE
remove use of primary index in tests

### DIFF
--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -249,7 +249,7 @@ func setupN1QLStore(t *testing.T, bucket base.Bucket, isServerless bool) {
 	testBucket, ok := bucket.(*base.TestBucket)
 	require.True(t, ok)
 
-	hasOnlyDefaultDataStore := len(testBucket.GetNonDefaultDatastoreNames()) > 0
+	hasOnlyDefaultDataStore := len(testBucket.GetNonDefaultDatastoreNames()) == 0
 
 	defaultDataStore := bucket.DefaultDataStore()
 	defaultN1QLStore, ok := base.AsN1QLStore(defaultDataStore)


### PR DESCRIPTION
This makes the tests faster and prevents us from accidentally utilizing the primary index in 7.2 CBS. On 7.6, the primary index seems to be created implicitly, and so this passes. This also seems to speed up the tests by a good bit.

- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2695/ (db/indextest fails)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2698/ (db/indextest only)