### PR TITLE
CBG-4187: Add stat to track number of assertion failures

### DIFF
--- a/base/devmode.go
+++ b/base/devmode.go
@@ -27,5 +27,6 @@ var DevModeAssertionFailures atomic.Uint32
 // AssertfCtx panics when compiled with the `cb_sg_devmode` build tag, and just warns otherwise.
 // Callers must be aware that they are responsible for handling returns to cover the non-devmode warn case.
 func AssertfCtx(ctx context.Context, format string, args ...any) {
+	SyncGatewayStats.GlobalStats.ResourceUtilization.AssertionFailCount.Add(1)
 	assertLogFn(ctx, format, args...)
 }

--- a/base/devmode_off.go
+++ b/base/devmode_off.go
@@ -13,4 +13,4 @@ package base
 
 const cbSGDevModeBuildTagSet = false
 
-var assertLogFn logFn = WarnfCtx
+var assertLogFn logFn = ErrorfCtx

--- a/base/devmode_on.go
+++ b/base/devmode_on.go
@@ -11,13 +11,6 @@
 
 package base
 
-import (
-	"context"
-)
-
 const cbSGDevModeBuildTagSet = true
 
-var assertLogFn logFn = func(ctx context.Context, format string, args ...any) {
-	DevModeAssertionFailures.Add(1)
-	PanicfCtx(ctx, format, args...)
-}
+var assertLogFn logFn = PanicfCtx

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -674,8 +674,8 @@ func TestBucketPoolMain(ctx context.Context, m *testing.M, bucketReadierFunc TBP
 	teardownFuncs = append(teardownFuncs, func() { GTestBucketPool.Close(ctx) })
 
 	teardownFuncs = append(teardownFuncs, func() {
-		if DevModeAssertionFailures.Load() > 0 {
-			panic("Test harness failed due to failures from -tag cb_sg_devmode. Look at logs for panic statements.")
+		if numAssertionFails := SyncGatewayStats.GlobalStats.ResourceUtilizationStats().AssertionFailCount.Value(); numAssertionFails > 0 {
+			panic(fmt.Sprintf("Test harness failed due to %d assertion failures. Search logs for %q", numAssertionFails, assertionFailedPrefix))
 		}
 	})
 	// must be the last teardown function added to the list to correctly detect leaked goroutines

--- a/base/stats.go
+++ b/base/stats.go
@@ -89,6 +89,7 @@ const (
 	StatAddedVersion3dot2dot1     = "3.2.1"
 	StatAddedVersion3dot2dot2     = "3.2.2"
 	StatAddedVersion3dot2dot3     = "3.2.3"
+	StatAddedVersion3dot2dot4     = "3.2.4"
 	StatAddedVersion3dot3dot0     = "3.3.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
@@ -301,7 +302,7 @@ func (g *GlobalStat) initResourceUtilizationStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.AssertionFailCount, err = NewIntStat(ResourceUtilizationSubsystem, "assertion_fail_count", StatUnitNoUnits, AssertionFailCountDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	resUtil.AssertionFailCount, err = NewIntStat(ResourceUtilizationSubsystem, "assertion_fail_count", StatUnitNoUnits, AssertionFailCountDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -390,7 +391,7 @@ type ResourceUtilization struct {
 	SystemMemoryTotal *SgwIntStat `json:"system_memory_total"`
 	// The total number of warnings logged.
 	WarnCount *SgwIntStat `json:"warn_count"`
-	// The total number of assertion failures logged.
+	// The total number of assertion failures logged. This is a good indicator of a bug and should be reported.
 	AssertionFailCount *SgwIntStat `json:"assertion_fail_count"`
 	// The total uptime.
 	Uptime *SgwDurStat `json:"uptime"`

--- a/base/stats.go
+++ b/base/stats.go
@@ -301,6 +301,10 @@ func (g *GlobalStat) initResourceUtilizationStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.AssertionFailCount, err = NewIntStat(ResourceUtilizationSubsystem, "assertion_fail_count", StatUnitNoUnits, AssertionFailCountDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.CpuPercentUtil, err = NewFloatStat(ResourceUtilizationSubsystem, "process_cpu_percent_utilization", StatUnitPercent, ProcessCPUPercentUtilDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersion3dot2dot0, StatStabilityCommitted, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
@@ -386,6 +390,8 @@ type ResourceUtilization struct {
 	SystemMemoryTotal *SgwIntStat `json:"system_memory_total"`
 	// The total number of warnings logged.
 	WarnCount *SgwIntStat `json:"warn_count"`
+	// The total number of assertion failures logged.
+	AssertionFailCount *SgwIntStat `json:"assertion_fail_count"`
 	// The total uptime.
 	Uptime *SgwDurStat `json:"uptime"`
 }

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -65,7 +65,7 @@ const (
 	SystemMemoryTotalDesc = "The total memory available on the system in bytes."
 
 	WarnCountDesc          = "The total number of warnings logged."
-	AssertionFailCountDesc = "The total number of assertion failures logged."
+	AssertionFailCountDesc = "The total number of assertion failures logged. This is a good indicator of a bug and should be reported."
 
 	UptimeDesc = "The total uptime."
 )

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -64,7 +64,8 @@ const (
 
 	SystemMemoryTotalDesc = "The total memory available on the system in bytes."
 
-	WarnCountDesc = "The total number of warnings logged."
+	WarnCountDesc          = "The total number of warnings logged."
+	AssertionFailCountDesc = "The total number of assertion failures logged."
 
 	UptimeDesc = "The total uptime."
 )


### PR DESCRIPTION
CBG-4187

Add stat to track number of assertion failures. Plus more Assertion enhancements:
- Enforced 'Assertion failure:' message prefix for searchability.
- Swapped warn to error for dev-mode, since we're asking for failures to be reported and want longer-term visibility in collected logs.
- Replace dev-mode only stat with the new global stat.
- Improve description with instruction for what to do if observed.
- Improve godoc comments for AssertfCtx to make it more obvious that it does not do control flow and is up to the caller to do so.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3001/