### PR TITLE
CBG-4236: Create SG log files on startup with 0644 permission bits set

### DIFF
--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -248,7 +248,12 @@ func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name stri
 
 	var rotationDoneChan chan struct{}
 	if lfc.Output == nil {
-		rotationDoneChan = lfc.initLumberjack(ctx, name, filepath.Join(filepath.FromSlash(logFilePath), logFilePrefix+name+".log"))
+		logFileName := logFilePrefix + name + ".log"
+		logFileOutput := filepath.Join(filepath.FromSlash(logFilePath), logFileName)
+		if err := validateLogFileOutput(logFileOutput); err != nil {
+			return nil, err
+		}
+		rotationDoneChan = lfc.initLumberjack(ctx, name, logFileOutput)
 	}
 
 	if lfc.CollationBufferSize == nil {

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -41,6 +41,9 @@ const (
 	fileLoggerCollateFlushTimeout    = 10 * time.Millisecond
 
 	rotatedLogDeletionInterval = time.Hour // not configurable
+
+	logFilePermission            = 0644              // rw-r--r--
+	logFileDirWriteCheckFilename = ".SG_write_check" // filename used when writing a write-check test file in the log directory
 )
 
 // ErrUnsetLogFilePath is returned when no log_file_path, or --defaultLogFilePath fallback can be used.
@@ -319,8 +322,8 @@ func validateLogFilePath(logFilePath string) error {
 	}
 
 	// Make temporary empty file to check if the log file path is writable
-	writeCheckFilePath := filepath.Join(logFilePath, ".SG_write_check")
-	err = os.WriteFile(writeCheckFilePath, nil, 0666)
+	writeCheckFilePath := filepath.Join(logFilePath, logFileDirWriteCheckFilename)
+	err = os.WriteFile(writeCheckFilePath, nil, logFilePermission) //nolint:gosec
 	if err != nil {
 		return errors.Wrap(err, ErrUnwritableLogFilePath.Error())
 	}
@@ -344,7 +347,7 @@ func validateLogFileOutput(logFileOutput string) error {
 	}
 
 	// Validate given file is writeable
-	file, err := os.OpenFile(logFileOutput, os.O_WRONLY|os.O_CREATE, 0666)
+	file, err := os.OpenFile(logFileOutput, os.O_WRONLY|os.O_CREATE, logFilePermission)
 	if err != nil {
 		if os.IsPermission(err) {
 			return errors.Wrap(err, "invalid file output")

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -317,7 +317,9 @@ func validateLogFileOutput(logFileOutput string) error {
 		return errors.Wrap(ErrInvalidLogFilePath, "not a directory")
 	}
 
-	// Validate given file is writeable
+	// Validate given file is writeable by touching it.
+	// If the file does not exist, this will open a zero sized log file intentionally to set permissions.
+	// The permissions will then be used by lumberjack. Otherwise, lumberjack will use 0600 permissions.
 	file, err := os.OpenFile(logFileOutput, os.O_WRONLY|os.O_CREATE, logFilePermission)
 	if err != nil {
 		if os.IsPermission(err) {

--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -64,7 +64,8 @@ func TestLogFilePathWritable(t *testing.T) {
 			err := os.Mkdir(logFilePath, test.logFilePathPerms)
 			require.NoError(t, err)
 
-			err = validateLogFilePath(logFilePath)
+			// The write-check is done inside validateLogFileOutput now.
+			err = validateLogFileOutput(filepath.Join(logFilePath, test.name+".log"))
 			if test.error {
 				assert.Error(t, err)
 				return

--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -31,6 +31,18 @@ func TestValidateLogFileOutput(t *testing.T) {
 	assert.NoError(t, err, "log file output path should be validated")
 }
 
+func TestValidateLogFileOutputNonDirectory(t *testing.T) {
+	tmpdir := t.TempDir()
+	file1 := filepath.Join(tmpdir, "1.log")
+	_, err := os.Create(file1)
+	require.NoError(t, err)
+
+	invalidFilePath := filepath.Join(file1, "2.log")
+	err = validateLogFileOutput(invalidFilePath)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not a directory")
+}
+
 // CBG-1760: Error upfront when the configured logFilePath is not writable
 func TestLogFilePathWritable(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -34,13 +34,19 @@ func TestValidateLogFileOutput(t *testing.T) {
 func TestValidateLogFileOutputNonDirectory(t *testing.T) {
 	tmpdir := t.TempDir()
 	file1 := filepath.Join(tmpdir, "1.log")
-	_, err := os.Create(file1)
+	f, err := os.Create(file1)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
 
 	invalidFilePath := filepath.Join(file1, "2.log")
 	err = validateLogFileOutput(invalidFilePath)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "not a directory")
+	assert.ErrorContains(t, err, "invalid log file path: mkdir")
+	if runtime.GOOS == "windows" {
+		assert.ErrorContains(t, err, "The system cannot find the path specified")
+	} else {
+		assert.ErrorContains(t, err, "not a directory")
+	}
 }
 
 // CBG-1760: Error upfront when the configured logFilePath is not writable


### PR DESCRIPTION
CBG-4236

Creates log files on startup with `0644` permission bits set.
- This restores pre-3.2.0 file permission behaviour. Existing files will retain their existing permission bits.
- New behaviour with this PR: SG creates empty log files at startup time, rather than creating on-demand when the log file needs to be written to.
- Removes now redundant '.SG_write_check' logic that ensures a given log_file_path directory is writable. We now use the log files directly, rather than this proxy.
- 
## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
