### PR TITLE
[3.2.1 Backport] CBG-4201: missing logging for ChangesOptions for Changes requests

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -1338,7 +1338,7 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 
 func (options ChangesOptions) String() string {
 	return fmt.Sprintf(
-		`{Since: %s, Limit: %d, Conflicts: %t, IncludeDocs: %t, Wait: %t, Continuous: %t, HeartbeatMs: %d, TimeoutMs: %d, ActiveOnly: %t, RequestPlusSeq: %d}`,
+		`{Since: %s, Limit: %d, Conflicts: %t, IncludeDocs: %t, Wait: %t, Continuous: %t, HeartbeatMs: %d, TimeoutMs: %d, ActiveOnly: %t, Revocations: %t, RequestPlusSeq: %d}`,
 		options.Since,
 		options.Limit,
 		options.Conflicts,
@@ -1348,6 +1348,7 @@ func (options ChangesOptions) String() string {
 		options.HeartbeatMs,
 		options.TimeoutMs,
 		options.ActiveOnly,
+		options.Revocations,
 		options.RequestPlusSeq,
 	)
 }

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -80,7 +80,7 @@ func TestSubChangesSince(t *testing.T) {
 	rq := blip.NewRequest()
 	rq.Properties["since"] = `"1"`
 
-	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, nil, db.ParseJSONSequenceID)
+	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, nil, rt.GetDatabase().Options.ChangesRequestPlus)
 	require.NoError(t, err)
 
 	seqID := subChangesParams.Since()
@@ -102,7 +102,7 @@ func TestSubChangesFuture(t *testing.T) {
 	rq.Properties["future"] = "true"
 	rq.Properties["since"] = `"1"`
 
-	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, db.SequenceID{}, latestSeq, db.ParseJSONSequenceID)
+	subChangesParams, err := db.NewSubChangesParams(base.TestCtx(t), rq, latestSeq, rt.GetDatabase().Options.ChangesRequestPlus)
 	require.NoError(t, err)
 
 	seqID := subChangesParams.Since()


### PR DESCRIPTION
CBG-4201

Clean-cherry pick to backport #7095 to 3.2.1 (CBG-4167) 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2720/
