### PR TITLE
[3.2.1 Backport] CBG-4190: Add audit logging metrics

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -147,6 +147,7 @@ func Audit(ctx context.Context, id AuditID, additionalData AuditFields) {
 	}
 
 	logger.logf(fieldsJSON)
+	SyncGatewayStats.GlobalStats.AuditStat.NumAuditsLogged.Add(1)
 }
 
 // IsAuditEnabled checks if auditing is enabled for the SG node
@@ -285,6 +286,7 @@ func shouldLogAuditEventForUserAndRole(logCtx *LogContext) bool {
 			Domain: string(logCtx.UserDomain),
 			Name:   logCtx.Username,
 		}]; isDisabled {
+			SyncGatewayStats.GlobalStats.AuditStat.NumAuditsFilteredByUser.Add(1)
 			return false
 		}
 	}
@@ -295,6 +297,7 @@ func shouldLogAuditEventForUserAndRole(logCtx *LogContext) bool {
 			Domain: string(logCtx.UserDomain),
 			Name:   role,
 		}]; isDisabled {
+			SyncGatewayStats.GlobalStats.AuditStat.NumAuditsFilteredByRole.Add(1)
 			return false
 		}
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -32,6 +32,7 @@ const (
 	NamespaceKey                 = "sgw"
 	ResourceUtilizationSubsystem = "resource_utilization"
 	ConfigSubsystem              = "config"
+	AuditSubsystem               = "audit"
 
 	SubsystemCacheKey           = "cache"
 	SubsystemDatabaseKey        = "database"
@@ -167,6 +168,7 @@ func (s *SgwStats) String() string {
 type GlobalStat struct {
 	ResourceUtilization *ResourceUtilization `json:"resource_utilization"`
 	ConfigStat          *ConfigStat          `json:"config"`
+	AuditStat           *AuditStat           `json:"audit"`
 }
 
 func newGlobalStat() (*GlobalStat, error) {
@@ -176,6 +178,10 @@ func newGlobalStat() (*GlobalStat, error) {
 		return nil, err
 	}
 	err = g.initConfigStats()
+	if err != nil {
+		return nil, err
+	}
+	err = g.initAuditStats()
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +200,25 @@ func (g *GlobalStat) initConfigStats() error {
 		return err
 	}
 	g.ConfigStat = configStat
+	return nil
+}
+
+func (g *GlobalStat) initAuditStats() error {
+	auditStat := &AuditStat{}
+	var err error
+	auditStat.NumAuditsLogged, err = NewIntStat(AuditSubsystem, "num_audits_logged", StatUnitNoUnits, NumAuditsLoggedDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	auditStat.NumAuditsFilteredByUser, err = NewIntStat(AuditSubsystem, "num_audits_filtered_by_user", StatUnitNoUnits, NumAuditsFilteredByUserDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	auditStat.NumAuditsFilteredByRole, err = NewIntStat(AuditSubsystem, "num_audits_filtered_by_role", StatUnitNoUnits, NumAuditsFilteredByRoleDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	g.AuditStat = auditStat
 	return nil
 }
 
@@ -362,6 +387,15 @@ type ConfigStat struct {
 	DatabaseBucketMismatches *SgwIntStat `json:"database_config_bucket_mismatches"`
 	// The number of times the config was rolled back to an invalid state (conflicting collections)
 	DatabaseRollbackCollectionCollisions *SgwIntStat `json:"database_config_rollback_collection_collisions"`
+}
+
+type AuditStat struct {
+	// The number of times an audit event was created/emitted/logged.
+	NumAuditsLogged *SgwIntStat `json:"num_audits_logged"`
+	// The number of times an audit event was filtered by username.
+	NumAuditsFilteredByUser *SgwIntStat `json:"num_audits_filtered_by_user"`
+	// The number of times an audit event was filtered by role.
+	NumAuditsFilteredByRole *SgwIntStat `json:"num_audits_filtered_by_role"`
 }
 
 type DbStats struct {

--- a/base/stats.go
+++ b/base/stats.go
@@ -86,6 +86,7 @@ const (
 	StatAddedVersion3dot1dot3dot1 = "3.1.3.1"
 	StatAddedVersion3dot1dot4     = "3.1.4"
 	StatAddedVersion3dot2dot0     = "3.2.0"
+	StatAddedVersion3dot2dot1     = "3.2.1"
 	StatAddedVersion3dot3dot0     = "3.3.0"
 
 	StatDeprecatedVersionNotDeprecated = ""

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -75,6 +75,13 @@ const (
 	DatabaseCollectionConflictDesc = "The total number of times a database config is rolled back to an invalid state (collection conflicts)."
 )
 
+// audit stat
+const (
+	NumAuditsLoggedDesc         = "The total number of audit events logged."
+	NumAuditsFilteredByUserDesc = "The total number of audit events filtered by user."
+	NumAuditsFilteredByRoleDesc = "The total number of audit events filtered by role."
+)
+
 // cache stats descriptions
 const (
 	AbandonedSequencesDesc = "The total number of skipped sequences that were not found after 60 minutes and were abandoned."


### PR DESCRIPTION
CBG-4190

Clean cherry-pick to backport #7083 to 3.2.1 (CBG-4188)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2721/
