### PR TITLE
[3.2.1 Backport] CBG-4176: Improved Auth Failed Logging

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -773,9 +773,17 @@ func (auth *Authenticator) AuthenticateUser(username string, password string) (U
 		return nil, err
 	}
 
-	if user == nil || !user.Authenticate(password) {
+	if user == nil {
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "HTTP auth failed for username=%q: user not found", base.UD(username))
 		return nil, nil
 	}
+
+	authenticated, reason := user.AuthenticateWithReason(password)
+	if !authenticated {
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "HTTP auth failed for username=%q: %s", base.UD(username), reason)
+		return nil, nil
+	}
+
 	return user, nil
 }
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -805,18 +805,18 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(rawToken string, oidcProvide
 		authenticator = single
 	}
 	if authenticator == nil {
-		for _, provider := range oidcProviders {
+		for providerName, provider := range oidcProviders {
 			if provider.ValidFor(auth.LogCtx, issuer, audiences) {
-				base.TracefCtx(auth.LogCtx, base.KeyAuth, "Using OIDC provider %v", base.UD(provider.Issuer))
+				base.TracefCtx(auth.LogCtx, base.KeyAuth, "Using OIDC provider %q", providerName)
 				authenticator = provider
 				break
 			}
 		}
 	}
 	if authenticator == nil {
-		for _, provider := range localJWT {
+		for providerName, provider := range localJWT {
 			if provider.ValidFor(auth.LogCtx, issuer, audiences) {
-				base.TracefCtx(auth.LogCtx, base.KeyAuth, "Using local JWT provider %v", base.UD(provider.Issuer))
+				base.TracefCtx(auth.LogCtx, base.KeyAuth, "Using local JWT provider %q", providerName)
 				authenticator = provider
 				break
 			}
@@ -830,11 +830,11 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(rawToken string, oidcProvide
 	var identity *Identity
 	identity, err = authenticator.verifyToken(auth.LogCtx, rawToken, callbackURLFunc)
 	if err != nil {
-		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "JWT invalid: %v", err)
+		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "JWT invalid for provider %q: %v", err, authenticator.GetName())
 		return nil, PrincipalConfig{}, base.HTTPErrorf(http.StatusUnauthorized, "Invalid JWT")
 	}
 
-	user, updates, _, err := auth.authenticateJWTIdentity(identity, authenticator.common())
+	user, updates, _, err := auth.authenticateJWTIdentity(identity, authenticator)
 	return user, updates, err
 }
 
@@ -862,36 +862,37 @@ func (auth *Authenticator) AuthenticateTrustedJWT(token string, provider *OIDCPr
 		}
 	}
 
-	return auth.authenticateJWTIdentity(identity, provider.JWTConfigCommon)
+	return auth.authenticateJWTIdentity(identity, provider)
 }
 
 // authenticateOIDCIdentity obtains a Sync Gateway User for the JWT. Expects that the JWT has already been verified for OIDC compliance.
 // TODO: possibly move this function to oidc.go
-func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider JWTConfigCommon) (user User, updates PrincipalConfig, tokenExpiry time.Time, err error) {
+func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider jwtAuthenticator) (user User, updates PrincipalConfig, tokenExpiry time.Time, err error) {
 	// Note: any errors returned from this function will be converted to 403s with a generic message, so we need to
 	// separately log them to ensure they're preserved for debugging.
 	if identity == nil || identity.Subject == "" {
 		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Empty subject found in OIDC identity: %v", base.UD(identity))
 		return nil, PrincipalConfig{}, time.Time{}, errors.New("subject not found in OIDC identity")
 	}
-	username, err := getJWTUsername(provider, identity)
+	common := provider.common()
+	username, err := getJWTUsername(common, identity)
 	if err != nil {
-		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Error retrieving OIDCUsername: %v", err)
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Error retrieving OIDCUsername for provider %q: %v", provider.GetName(), err)
 		return nil, PrincipalConfig{}, time.Time{}, err
 	}
-	base.DebugfCtx(auth.LogCtx, base.KeyAuth, "OIDCUsername: %v", base.UD(username))
+	base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Got username %q from JWT for provider %q", base.UD(username), provider.GetName())
 
 	var jwtRoles, jwtChannels base.Set
-	if provider.RolesClaim != "" {
-		jwtRoles, err = getJWTClaimAsSet(identity, provider.RolesClaim)
+	if common.RolesClaim != "" {
+		jwtRoles, err = getJWTClaimAsSet(identity, common.RolesClaim)
 		if err != nil {
 			return nil, PrincipalConfig{}, time.Time{}, fmt.Errorf("failed to find JWT roles: %w", err)
 		}
 	} else {
 		jwtRoles = base.Set{}
 	}
-	if provider.ChannelsClaim != "" {
-		jwtChannels, err = getJWTClaimAsSet(identity, provider.ChannelsClaim)
+	if common.ChannelsClaim != "" {
+		jwtChannels, err = getJWTClaimAsSet(identity, common.ChannelsClaim)
 		if err != nil {
 			return nil, PrincipalConfig{}, time.Time{}, fmt.Errorf("failed to find JWT channels: %w", err)
 		}
@@ -905,29 +906,32 @@ func (auth *Authenticator) authenticateJWTIdentity(identity *Identity, provider 
 		return nil, PrincipalConfig{}, time.Time{}, err
 	}
 
+	updates = PrincipalConfig{
+		Name:        base.StringPtr(username),
+		Email:       &identity.Email,
+		JWTIssuer:   &common.Issuer,
+		JWTRoles:    jwtRoles,
+		JWTChannels: jwtChannels,
+	}
+
+	if user != nil {
+		return user, updates, identity.Expiry, nil
+	}
+
 	// Auto-registration. This will normally be done when token is originally returned
 	// to client by oidc callback, but also needed here to handle clients obtaining their own tokens.
-	if user == nil && provider.Register {
+	if common.Register {
 		base.DebugfCtx(auth.LogCtx, base.KeyAuth, "Registering new user: %v with email: %v", base.UD(username), base.UD(identity.Email))
-		var err error
-		user, err = auth.RegisterNewUser(username, identity.Email)
+		user, err := auth.RegisterNewUser(username, identity.Email)
 		if err != nil && !base.IsCasMismatch(err) {
 			base.InfofCtx(auth.LogCtx, base.KeyAuth, "Error registering new user: %v", err)
 			return nil, PrincipalConfig{}, time.Time{}, err
 		}
+		return user, updates, identity.Expiry, nil
 	}
 
-	if user != nil {
-		updates = PrincipalConfig{
-			Name:        base.StringPtr(user.Name()),
-			Email:       &identity.Email,
-			JWTIssuer:   &provider.Issuer,
-			JWTRoles:    jwtRoles,
-			JWTChannels: jwtChannels,
-		}
-	}
-
-	return user, updates, identity.Expiry, nil
+	base.InfofCtx(auth.LogCtx, base.KeyAuth, "User %q not found and provider %q does not have Register enabled", base.UD(username), provider.GetName())
+	return nil, PrincipalConfig{}, time.Time{}, nil
 }
 
 // Registers a new user account based on the given verified username and optional email address.

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -22,6 +22,7 @@ import (
 type jwtAuthenticator interface {
 	verifyToken(ctx context.Context, token string, callbackURLFunc OIDCCallbackURLFunc) (*Identity, error)
 	common() JWTConfigCommon
+	GetName() string
 }
 
 // SupportedAlgorithms is list of signing algorithms explicitly supported
@@ -173,6 +174,10 @@ type LocalJWTAuthProvider struct {
 	name string
 	// keySet has the keys for this config, either in-memory or from oidc.NewRemoteKeySet.
 	keySet oidc.KeySet
+}
+
+func (l *LocalJWTAuthProvider) GetName() string {
+	return l.name
 }
 
 func (l *LocalJWTAuthProvider) verifyToken(ctx context.Context, token string, _ OIDCCallbackURLFunc) (*Identity, error) {

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -239,6 +239,10 @@ func (opm OIDCProviderMap) Stop() {
 	}
 }
 
+func (op *OIDCProvider) GetName() string {
+	return op.Name
+}
+
 // GetClient initializes the client on first successful request.
 func (op *OIDCProvider) GetClient(ctx context.Context, buildCallbackURLFunc OIDCCallbackURLFunc) (*OIDCClient, error) {
 	// If the callback URL isn't defined for the provider, uses buildCallbackURLFunc to construct (based on current request)

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1235,7 +1235,7 @@ func TestJWTRolesChannels(t *testing.T) {
 					Claims:  login.claims,
 				}
 				var updates PrincipalConfig
-				user, updates, _, err = auth.authenticateJWTIdentity(identity, provider.common())
+				user, updates, _, err = auth.authenticateJWTIdentity(identity, provider)
 				require.NoError(t, err, "error on authenticateOIDCIdentity")
 				require.NotNil(t, user, "nil user")
 				user.SetJWTChannels(ch.AtSequence(updates.JWTChannels, user.Sequence()), user.Sequence())

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -85,6 +85,9 @@ type User interface {
 	// Authenticates the user's password.
 	Authenticate(password string) bool
 
+	// AuthenticateWithReason is the same as Authenticate, except it provides the reason for failure.
+	AuthenticateWithReason(password string) (bool, string)
+
 	// GetSessionUUID returns the UUID that a session to match to be a valid session.
 	GetSessionUUID() string
 

--- a/auth/session.go
+++ b/auth/session.go
@@ -40,6 +40,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	_, err := auth.datastore.Get(auth.DocIDForSession(cookie.Value), &session)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
+			base.InfofCtx(auth.LogCtx, base.KeyAuth, "Session not found: %s", base.UD(cookie.Value))
 			return nil, base.HTTPErrorf(http.StatusUnauthorized, "Session Invalid")
 		}
 		return nil, err
@@ -72,6 +73,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 	}
 
 	if session.SessionUUID != user.GetSessionUUID() {
+		base.InfofCtx(auth.LogCtx, base.KeyAuth, "Session no longer valid for user %s", base.UD(session.Username))
 		return nil, base.HTTPErrorf(http.StatusUnauthorized, "Session no longer valid for user")
 	}
 	return user, err

--- a/auth/user.go
+++ b/auth/user.go
@@ -495,26 +495,33 @@ func (user *userImpl) CollectionChannelGrantedPeriods(scope, collection, chanNam
 
 // Returns true if the given password is correct for this user, and the account isn't disabled.
 func (user *userImpl) Authenticate(password string) bool {
+	ok, _ := user.AuthenticateWithReason(password)
+	return ok
+}
+
+// AuthenticateWithReason returns true if the user exists, is not disabled, and has a valid password. If authentication fails, a user readable string for logging will be returned.
+func (user *userImpl) AuthenticateWithReason(password string) (ok bool, reason string) {
 	if user == nil {
-		return false
+		return false, "User not found"
 	}
 
 	// exit early for disabled user accounts
 	if user.Disabled_ {
-		return false
+		return false, "Account disabled"
 	}
 
 	// exit early if old hash is present
 	if user.OldPasswordHash_ != nil {
+		// Password must be reset to use new (bcrypt) password hash
 		base.WarnfCtx(user.auth.LogCtx, "User account %q still has pre-beta password hash; need to reset password", base.UD(user.Name_))
-		return false // Password must be reset to use new (bcrypt) password hash
+		return false, "User account still has pre-beta password hash; need to reset password"
 	}
 
 	// bcrypt hash present
 	if user.PasswordHash_ != nil {
 		if !compareHashAndPassword(cachedHashes, user.PasswordHash_, []byte(password)) {
 			// incorrect password
-			return false
+			return false, "Incorrect password"
 		}
 
 		// password was correct, we'll rehash the password if required
@@ -526,11 +533,11 @@ func (user *userImpl) Authenticate(password string) bool {
 	} else {
 		// no hash, but (incorrect) password provided
 		if password != "" {
-			return false
+			return false, "Incorrect password"
 		}
 	}
 
-	return true
+	return true, ""
 }
 
 // GetSessionUUID returns the UUID that a session to match to be a valid session.

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -969,7 +969,6 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 				return err
 			}
 			if h.user == nil {
-				base.InfofCtx(h.ctx(), base.KeyAll, "HTTP auth failed for username=%q", base.UD(userName))
 				auditFields["username"] = userName
 				if dbCtx.Options.SendWWWAuthenticateHeader == nil || *dbCtx.Options.SendWWWAuthenticateHeader {
 					h.response.Header().Set("WWW-Authenticate", wwwAuthenticateHeader)

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1398,6 +1398,8 @@ func checkGoodAuthResponse(t *testing.T, rt *RestTester, response *http.Response
 
 // E2E test that checks OpenID Connect Implicit Flow edge cases.
 func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAuth, base.KeyHTTP)
+
 	const emailClaim = "email"
 	var username = "foo_noah"
 	providers := auth.OIDCProviderMap{

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -84,10 +84,18 @@ func (h *handler) getUserFromSessionRequestBody() (auth.User, error) {
 		return nil, err
 	}
 
-	if user != nil && !user.Authenticate(params.Password) {
-		user = nil
+	if user == nil {
+		base.InfofCtx(h.ctx(), base.KeyAuth, "Couldn't create session for user %q: not found", base.UD(params.Name))
+		return nil, nil
 	}
-	return user, err
+
+	authenticated, reason := user.AuthenticateWithReason(params.Password)
+	if !authenticated {
+		base.InfofCtx(h.ctx(), base.KeyAuth, "Couldn't create session for user %q: %s", base.UD(params.Name), reason)
+		return nil, nil
+	}
+
+	return user, nil
 }
 
 // DELETE /_session logs out the current session

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -210,35 +210,45 @@ func TestSessionFail(t *testing.T) {
 	RequireStatus(t, response, http.StatusOK)
 }
 
-func TestLogin(t *testing.T) {
-	rt := NewRestTester(t, nil)
+func TestSessionLogin(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: false})
 	defer rt.Close()
 
-	a := auth.NewAuthenticator(rt.MetadataStore(), nil, rt.GetDatabase().AuthenticatorOptions(rt.Context()))
-	user, err := a.GetUser("")
-	assert.NoError(t, err)
-	user.SetDisabled(true)
-	err = a.Save(user)
-	assert.NoError(t, err)
+	// ensure guest is actually disabled
+	resp := rt.SendRequest(http.MethodPut, "/db/doc", `{"hi": "there"}`)
+	RequireStatus(t, resp, http.StatusUnauthorized)
 
-	user, err = a.GetUser("")
-	assert.NoError(t, err)
-	assert.True(t, user.Disabled())
+	rt.CreateUser("pupshaw", []string{"*"})
 
-	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
-	RequireStatus(t, response, 401)
+	resp = rt.SendRequest(http.MethodGet, "/db/_session", "")
+	RequireStatus(t, resp, http.StatusOK)
 
-	user, err = a.NewUser("pupshaw", "letmein", channels.BaseSetOf(t, "*"))
-	require.NoError(t, err)
-	assert.NoError(t, a.Save(user))
+	resp = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"pupshaw", "password":"letmein"}`)
+	RequireStatus(t, resp, http.StatusOK)
+	cookie := resp.Header().Get("Set-Cookie")
+	require.NotEmptyf(t, cookie, "Set-Cookie header not found in response: %v", resp)
+	t.Logf("Set-Cookie: %s", cookie)
 
-	RequireStatus(t, rt.SendRequest("GET", "/db/_session", ""), 200)
+	headers := map[string]string{
+		"Cookie": cookie,
+	}
+	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/", "", headers, "", "")
+	RequireStatus(t, resp, http.StatusOK)
 
-	response = rt.SendRequest("POST", "/db/_session", `{"name":"pupshaw", "password":"letmein"}`)
-	RequireStatus(t, response, 200)
-	log.Printf("Set-Cookie: %s", response.Header().Get("Set-Cookie"))
-	assert.True(t, response.Header().Get("Set-Cookie") != "")
+	// invalid password
+	resp = rt.SendRequest(http.MethodPost, "/db/_session", `{"name":"pupshaw", "password":"incorrectpassword"}`)
+	RequireStatus(t, resp, http.StatusUnauthorized)
+	t.Logf("Set-Cookie: %s", resp.Header().Get("Set-Cookie"))
+	require.Emptyf(t, resp.Header().Get("Set-Cookie"), "Set-Cookie header should not be set in response: %v", resp)
+
+	// invalid cookie (no username available)
+	headers = map[string]string{
+		"Cookie": "SyncGatewaySession=123456abcdef; Path=/db; Expires=Sat, 17 Aug 2024 15:20:52 GMT",
+	}
+	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/db/", "", headers, "", "")
+	RequireStatus(t, resp, http.StatusUnauthorized)
 }
+
 func TestCustomCookieName(t *testing.T) {
 
 	customCookieName := "TestCustomCookieName"


### PR DESCRIPTION
CBG-4176

Clean cherry-picks of #7080 #7082 #7081 for 3.2.1 (CBG-3692 CBG-3693 CBG-3694)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2722/
