### PR TITLE
[3.2.1 Backport] CBG-4089: Do not remove loaded database on transient fetch error

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -244,8 +244,12 @@ func IsTemporaryKvError(err error) bool {
 		return false
 	}
 	// define list of temporary errors
-	temporaryKVError := []error{ErrTimeout, gocb.ErrAmbiguousTimeout, gocb.ErrUnambiguousTimeout,
-		gocb.ErrOverload, gocb.ErrTemporaryFailure, gocb.ErrCircuitBreakerOpen}
+	temporaryKVError := []error{
+		ErrTimeout,                 // Sync Gateway client-side timeout
+		gocb.ErrTimeout,            // SDK op timeout.  Wrapped by gocb.ErrAmbiguousTimeout, gocb.ErrUnambiguousTimeout,
+		gocb.ErrOverload,           // SDK client-side pipeline queue full, request was not submitted to server
+		gocb.ErrTemporaryFailure,   // Couchbase Server returned temporary failure error
+		gocb.ErrCircuitBreakerOpen} // SDK client-side circuit breaker blocked request
 
 	// iterate through to check incoming error is one of them
 	for _, tempKVErr := range temporaryKVError {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -76,6 +76,7 @@ type RestTesterConfig struct {
 	syncGatewayVersion              *base.ComparableBuildVersion // alternate version of Sync Gateway to use on startup
 	allowDbConfigEnvVars            *bool
 	maxConcurrentRevs               *int
+	UseXattrConfig                  bool
 }
 
 type collectionConfiguration uint8
@@ -234,6 +235,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.Bootstrap.ServerTLSSkipVerify = base.BoolPtr(base.TestTLSSkipVerify())
 	sc.Unsupported.Serverless.Enabled = &rt.serverless
 	sc.Unsupported.AllowDbConfigEnvVars = rt.RestTesterConfig.allowDbConfigEnvVars
+	sc.Unsupported.UseXattrConfig = &rt.UseXattrConfig
 	sc.Replicator.MaxConcurrentRevs = rt.RestTesterConfig.maxConcurrentRevs
 	if rt.serverless {
 		if !rt.PersistentConfig {


### PR DESCRIPTION
CBG-4089

Backports #7035 to 3.2.1

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2741/
