### PR TITLE
[3.2.1 Backport] CBG-4151: Memory-based rev cache size

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -85,6 +85,7 @@ const (
 	StatAddedVersion3dot1dot3dot1 = "3.1.3.1"
 	StatAddedVersion3dot1dot4     = "3.1.4"
 	StatAddedVersion3dot2dot0     = "3.2.0"
+	StatAddedVersion3dot2dot1     = "3.2.1"
 	StatAddedVersion3dot3dot0     = "3.3.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
@@ -425,6 +426,8 @@ type CacheStats struct {
 	NumSkippedSeqs *SgwIntStat `json:"num_skipped_seqs"`
 	// The total number of pending sequences. These are out-of-sequence entries waiting to be cached.
 	PendingSeqLen *SgwIntStat `json:"pending_seq_len"`
+	// Total number of items in the rev cache
+	RevisionCacheNumItems *SgwIntStat `json:"revision_cache_num_items"`
 	// The total number of revision cache bypass operations performed.
 	RevisionCacheBypass *SgwIntStat `json:"rev_cache_bypass"`
 	// The total number of revision cache hits.
@@ -1320,6 +1323,10 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.RevisionCacheNumItems, err = NewIntStat(SubsystemCacheKey, "revision_cache_num_items", StatUnitNoUnits, RevCacheNumItemsDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.RevisionCacheBypass, err = NewIntStat(SubsystemCacheKey, "rev_cache_bypass", StatUnitNoUnits, RevCacheBypassDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
@@ -1377,6 +1384,7 @@ func (d *DbStats) unregisterCacheStats() {
 	prometheus.Unregister(d.CacheStats.SkippedSeqCap)
 	prometheus.Unregister(d.CacheStats.NumCurrentSeqsSkipped)
 	prometheus.Unregister(d.CacheStats.PendingSeqLen)
+	prometheus.Unregister(d.CacheStats.RevisionCacheNumItems)
 	prometheus.Unregister(d.CacheStats.RevisionCacheBypass)
 	prometheus.Unregister(d.CacheStats.RevisionCacheHits)
 	prometheus.Unregister(d.CacheStats.RevisionCacheMisses)

--- a/base/stats.go
+++ b/base/stats.go
@@ -434,6 +434,8 @@ type CacheStats struct {
 	RevisionCacheHits *SgwIntStat `json:"rev_cache_hits"`
 	// The total number of revision cache misses.
 	RevisionCacheMisses *SgwIntStat `json:"rev_cache_misses"`
+	// Total memory used by the rev cache
+	RevisionCacheTotalMemory *SgwIntStat `json:"revision_cache_total_memory"`
 	// The current length of the pending skipped sequence slice.
 	SkippedSeqLen *SgwIntStat `json:"skipped_seq_len"`
 	// The current capacity of the skipped sequence slice
@@ -1339,6 +1341,10 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.RevisionCacheTotalMemory, err = NewIntStat(SubsystemCacheKey, "revision_cache_total_memory", StatUnitNoUnits, RevCacheMemoryDesc, StatAddedVersion3dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.SkippedSeqLen, err = NewIntStat(SubsystemCacheKey, "skipped_seq_len", StatUnitNoUnits, SkippedSeqLengthDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
@@ -1388,6 +1394,7 @@ func (d *DbStats) unregisterCacheStats() {
 	prometheus.Unregister(d.CacheStats.RevisionCacheBypass)
 	prometheus.Unregister(d.CacheStats.RevisionCacheHits)
 	prometheus.Unregister(d.CacheStats.RevisionCacheMisses)
+	prometheus.Unregister(d.CacheStats.RevisionCacheTotalMemory)
 	prometheus.Unregister(d.CacheStats.SkippedSeqLen)
 	prometheus.Unregister(d.CacheStats.ViewQueries)
 }

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -119,6 +119,8 @@ const (
 
 	PendingSeqLengthDesc = "The total number of pending sequences. These are out-of-sequence entries waiting to be cached."
 
+	RevCacheNumItemsDesc = "The total number of items in the revision cache."
+
 	RevCacheBypassDesc = "The total number of revision cache bypass operations performed."
 
 	RevCacheHitsDesc = "The total number of revision cache hits. This metric can be used to calculate the ratio of revision cache hits: " +

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -129,6 +129,8 @@ const (
 	RevCacheMissesDesc = "The total number of revision cache misses. This metric can be used to calculate the ratio of revision cache misses: " +
 		"Rev Cache Miss Ratio = rev_cache_misses / (rev_cache_hits + rev_cache_misses)"
 
+	RevCacheMemoryDesc = "The approximation of total memory taken up by rev cache for documents. This is measured by the raw document body, the channels allocated to a document and its revision history."
+
 	SkippedSeqLengthDesc = "The current length of the pending skipped sequence slice."
 
 	SkippedSeqCapDesc = "The current capacity of the skipped sequence slice."

--- a/db/changes.go
+++ b/db/changes.go
@@ -137,7 +137,7 @@ func (db *DatabaseCollectionWithUser) addDocToChangeEntry(ctx context.Context, e
 }
 
 func (db *DatabaseCollectionWithUser) AddDocToChangeEntryUsingRevCache(ctx context.Context, entry *ChangeEntry, revID string) (err error) {
-	rev, err := db.getRev(ctx, entry.ID, revID, 0, nil, RevCacheIncludeBody)
+	rev, err := db.getRev(ctx, entry.ID, revID, 0, nil)
 	if err != nil {
 		return err
 	}
@@ -325,7 +325,7 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 
 // UserHasDocAccess checks whether the user has access to the active revision of the document
 func UserHasDocAccess(ctx context.Context, collection *DatabaseCollectionWithUser, docID string) (bool, error) {
-	currentRev, err := collection.revisionCache.GetActive(ctx, docID, false)
+	currentRev, err := collection.revisionCache.GetActive(ctx, docID)
 	if err != nil {
 		if base.IsDocNotFoundError(err) {
 			return false, nil

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -402,8 +402,13 @@ func TestGetRemovedAsUser(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
+	cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStat := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems, db.DatabaseContext.DbStats.Cache().RevisionCacheTotalMemory
+	cacheOptions := &RevisionCacheOptions{
+		MaxBytes:     0,
+		MaxItemCount: DefaultRevisionCacheSize,
+		ShardCount:   DefaultRevisionCacheShardCount,
+	}
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStat)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -754,8 +759,13 @@ func TestGetRemoved(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
+	cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStat := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems, db.DatabaseContext.DbStats.Cache().RevisionCacheTotalMemory
+	cacheOptions := &RevisionCacheOptions{
+		MaxBytes:     0,
+		MaxItemCount: DefaultRevisionCacheSize,
+		ShardCount:   DefaultRevisionCacheShardCount,
+	}
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStat)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -823,8 +833,13 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
+	cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStats := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems, db.DatabaseContext.DbStats.Cache().RevisionCacheTotalMemory
+	cacheOptions := &RevisionCacheOptions{
+		MaxBytes:     0,
+		MaxItemCount: DefaultRevisionCacheSize,
+		ShardCount:   DefaultRevisionCacheShardCount,
+	}
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStats)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -514,9 +514,11 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	_, rev1Digest := ParseRevID(ctx, rev1ID)
 	_, rev2Digest := ParseRevID(ctx, rev2ID)
 
+	var interfaceListChannels []interface{}
+	interfaceListChannels = append(interfaceListChannels, "ABC")
 	bodyExpected := Body{
 		"k2":       "v2",
-		"channels": []string{"ABC"},
+		"channels": interfaceListChannels,
 		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2Digest, rev1Digest},
@@ -3320,4 +3322,61 @@ func TestBadDCPStart(t *testing.T) {
 	require.Error(t, err)
 
 	dbCtx.Close(ctx)
+}
+
+func TestInject1xBodyProperties(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	rev1ID, _, err := collection.Put(ctx, "doc", Body{"test": "doc"})
+	require.NoError(t, err)
+	var rev2Body Body
+	rev2Data := `{"key":"value", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
+	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
+	_, rev2ID, err := collection.PutExistingRevWithBody(ctx, "doc", rev2Body, []string{"2-abc", rev1ID}, true)
+	require.NoError(t, err)
+
+	docRev, err := collection.GetRev(ctx, "doc", rev2ID, true, nil)
+	require.NoError(t, err)
+
+	// mock expiry on doc
+	exp := time.Now()
+	docRev.Expiry = &exp
+
+	newDoc, err := docRev.Inject1xBodyProperties(ctx, collection, docRev.History, nil, true)
+	require.NoError(t, err)
+	var resBody Body
+	require.NoError(t, resBody.Unmarshal(newDoc))
+
+	// cast to map of interface given we have injected the properties runtime has no concept of the AttachmentMeta and Revisions types
+	revs := resBody[BodyRevisions].(map[string]interface{})
+	atts := resBody[BodyAttachments].(map[string]interface{})
+
+	assert.NotNil(t, atts)
+	assert.NotNil(t, revs)
+	assert.Equal(t, "doc", resBody[BodyId])
+	assert.Equal(t, "2-abc", resBody[BodyRev])
+	assert.Equal(t, exp.Format(time.RFC3339), resBody[BodyExpiry])
+	assert.Equal(t, "value", resBody["key"])
+
+	// mock doc deleted
+	docRev.Deleted = true
+
+	newDoc, err = docRev.Inject1xBodyProperties(ctx, collection, docRev.History, []string{"2-abc"}, true)
+	require.NoError(t, err)
+	require.NoError(t, resBody.Unmarshal(newDoc))
+
+	// cast to map of interface given we have injected the properties runtime has no concept of the AttachmentMeta and Revisions types
+	revs = resBody[BodyRevisions].(map[string]interface{})
+	atts = resBody[BodyAttachments].(map[string]interface{})
+
+	assert.NotNil(t, atts)
+	assert.NotNil(t, revs)
+	assert.Equal(t, "doc", resBody[BodyId])
+	assert.Equal(t, "2-abc", resBody[BodyRev])
+	assert.Equal(t, exp.Format(time.RFC3339), resBody[BodyExpiry])
+	assert.Equal(t, "value", resBody["key"])
+	assert.True(t, resBody[BodyDeleted].(bool))
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -402,8 +402,8 @@ func TestGetRemovedAsUser(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter)
+	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -754,8 +754,8 @@ func TestGetRemoved(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter)
+	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -823,8 +823,8 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter)
+	cacheHitCounter, cacheMissCounter, cacheNumItems := db.DatabaseContext.DbStats.Cache().RevisionCacheHits, db.DatabaseContext.DbStats.Cache().RevisionCacheMisses, db.DatabaseContext.DbStats.Cache().RevisionCacheNumItems
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -31,13 +31,9 @@ func NewBypassRevisionCache(backingStores map[uint32]RevisionCacheBackingStore, 
 }
 
 // Get fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, collectionID uint32, includeBody, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
 
-	unmarshalLevel := DocUnmarshalSync
-	if includeBody {
-		unmarshalLevel = DocUnmarshalAll
-	}
-	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, unmarshalLevel)
+	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -45,7 +41,7 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, col
 	docRev = DocumentRevision{
 		RevID: revID,
 	}
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, revID)
+	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, revID)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -56,13 +52,9 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, col
 }
 
 // GetActive fetches the active revision for the given docID immediately from the bucket.
-func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32, includeBody bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
 
-	unmarshalLevel := DocUnmarshalSync
-	if includeBody {
-		unmarshalLevel = DocUnmarshalAll
-	}
-	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, unmarshalLevel)
+	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -71,7 +63,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 		RevID: doc.CurrentRev,
 	}
 
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.CurrentRev)
+	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -31,11 +30,11 @@ type RevisionCache interface {
 	// Get returns the given revision, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	Get(ctx context.Context, docID, revID string, collectionID uint32, includeBody, includeDelta bool) (DocumentRevision, error)
+	Get(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
-	GetActive(ctx context.Context, docID string, collectionID uint32, includeBody bool) (docRev DocumentRevision, err error)
+	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
 
 	// Peek returns the given revision if present in the cache
 	Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool)
@@ -54,8 +53,6 @@ type RevisionCache interface {
 }
 
 const (
-	RevCacheIncludeBody  = true
-	RevCacheOmitBody     = false
 	RevCacheIncludeDelta = true
 	RevCacheOmitDelta    = false
 )
@@ -103,7 +100,7 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 // RevisionCacheBackingStore is the interface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.
 type RevisionCacheBackingStore interface {
 	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
-	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error)
+	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error)
 }
 
 // collectionRevisionCache is a view of a revision cache for a collection.
@@ -121,13 +118,13 @@ func newCollectionRevisionCache(revCache *RevisionCache, collectionID uint32) co
 }
 
 // Get is for per collection access to Get method
-func (c *collectionRevisionCache) Get(ctx context.Context, docID, revID string, includeBody, includeDelta bool) (DocumentRevision, error) {
-	return (*c.revCache).Get(ctx, docID, revID, c.collectionID, includeBody, includeDelta)
+func (c *collectionRevisionCache) Get(ctx context.Context, docID, revID string, includeDelta bool) (DocumentRevision, error) {
+	return (*c.revCache).Get(ctx, docID, revID, c.collectionID, includeDelta)
 }
 
 // GetActive is for per collection access to GetActive method
-func (c *collectionRevisionCache) GetActive(ctx context.Context, docID string, includeBody bool) (DocumentRevision, error) {
-	return (*c.revCache).GetActive(ctx, docID, c.collectionID, includeBody)
+func (c *collectionRevisionCache) GetActive(ctx context.Context, docID string) (DocumentRevision, error) {
+	return (*c.revCache).GetActive(ctx, docID, c.collectionID)
 }
 
 // Peek is for per collection access to Peek method
@@ -168,8 +165,6 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
-
-	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
 
 // MutableBody returns a deep copy of the given document revision as a plain body (without any special properties)
@@ -186,19 +181,62 @@ func (rev *DocumentRevision) MutableBody() (b Body, err error) {
 // If an unmarshalled copy is not available in the document revision, it makes a copy from the raw body
 // bytes and stores it in document revision itself before returning the body.
 func (rev *DocumentRevision) Body() (b Body, err error) {
-	// if we already have an unmarshalled body, take a copy and return it
-	if rev._shallowCopyBody != nil {
-		return rev._shallowCopyBody, nil
-	}
 
 	if err := b.Unmarshal(rev.BodyBytes); err != nil {
 		return nil, err
 	}
 
-	// store a copy of the unmarshalled body for next time we need it
-	rev._shallowCopyBody = b
-
 	return b, nil
+}
+
+// Inject1xBodyProperties will inject special properties (_rev etc) into document body avoiding unnecessary marshal work
+func (rev *DocumentRevision) Inject1xBodyProperties(ctx context.Context, db *DatabaseCollectionWithUser, requestedHistory Revisions, attachmentsSince []string, showExp bool) ([]byte, error) {
+
+	kvPairs := []base.KVPair{
+		{Key: BodyId, Val: rev.DocID},
+		{Key: BodyRev, Val: rev.RevID},
+	}
+
+	if requestedHistory != nil {
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyRevisions, Val: requestedHistory})
+	}
+
+	if showExp && rev.Expiry != nil && !rev.Expiry.IsZero() {
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyExpiry, Val: rev.Expiry.Format(time.RFC3339)})
+	}
+
+	if rev.Deleted {
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyDeleted, Val: rev.Deleted})
+	}
+
+	if attachmentsSince != nil {
+		if len(rev.Attachments) > 0 {
+			minRevpos := 1
+			if len(attachmentsSince) > 0 {
+				ancestor := rev.History.findAncestor(attachmentsSince)
+				if ancestor != "" {
+					minRevpos, _ = ParseRevID(ctx, ancestor)
+					minRevpos++
+				}
+			}
+			bodyAtts, err := db.loadAttachmentsData(rev.Attachments, minRevpos, rev.DocID)
+			if err != nil {
+				return nil, err
+			}
+			DeleteAttachmentVersion(bodyAtts)
+			kvPairs = append(kvPairs, base.KVPair{Key: BodyAttachments, Val: bodyAtts})
+		}
+	} else if rev.Attachments != nil {
+		// Stamp attachment metadata back into the body
+		DeleteAttachmentVersion(rev.Attachments)
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyAttachments, Val: rev.Attachments})
+	}
+
+	newBytes, err := base.InjectJSONProperties(rev.BodyBytes, kvPairs...)
+	if err != nil {
+		return nil, err
+	}
+	return newBytes, nil
 }
 
 // Mutable1xBody returns a copy of the given document revision as a 1.x style body (with special properties)
@@ -257,14 +295,13 @@ func (rev *DocumentRevision) Mutable1xBody(ctx context.Context, db *DatabaseColl
 
 // As1xBytes returns a byte slice representing the 1.x style body, containing special properties (i.e. _id, _rev, _attachments, etc.)
 func (rev *DocumentRevision) As1xBytes(ctx context.Context, db *DatabaseCollectionWithUser, requestedHistory Revisions, attachmentsSince []string, showExp bool) (b []byte, err error) {
-	// unmarshal
-	body1x, err := rev.Mutable1xBody(ctx, db, requestedHistory, attachmentsSince, showExp)
+	// inject the special properties
+	body1x, err := rev.Inject1xBodyProperties(ctx, db, requestedHistory, attachmentsSince, showExp)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: We could avoid the unmarshal -> marshal work here by injecting properties into the original body bytes directly.
-	return json.Marshal(body1x)
+	return body1x, nil
 }
 
 type IDAndRev struct {
@@ -296,44 +333,40 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore, id IDAndRev) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
 	var doc *Document
-	unmarshalLevel := DocUnmarshalSync
-	if unmarshalBody {
-		unmarshalLevel = DocUnmarshalAll
-	}
-	if doc, err = backingStore.GetDocument(ctx, id.DocID, unmarshalLevel); doc == nil {
-		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, err
+	if doc, err = backingStore.GetDocument(ctx, id.DocID, DocUnmarshalSync); doc == nil {
+		return bodyBytes, history, channels, removed, attachments, deleted, expiry, err
 	}
 
 	return revCacheLoaderForDocument(ctx, backingStore, doc, id.RevID)
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
-	if bodyBytes, body, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
+func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+	if bodyBytes, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
 		if isRemovalErr != nil {
-			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
+			return bodyBytes, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
 		}
 
 		if isRemoval {
-			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
+			return removalBodyBytes, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
-			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, err
+			return bodyBytes, history, channels, removed, nil, isDelete, nil, err
 		}
 	}
 	deleted = doc.History[revid].Deleted
 
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
-		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
+		return bodyBytes, history, channels, removed, nil, deleted, nil, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
 	channels = doc.History[revid].Channels
 
-	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err
+	return bodyBytes, history, channels, removed, attachments, deleted, doc.Expiry, err
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -28,12 +28,10 @@ const (
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
 	// Get returns the given revision, and stores if not already cached.
-	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
 	Get(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
-	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
 
 	// Peek returns the given revision if present in the cache
@@ -77,12 +75,13 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 
 	cacheHitStat := cacheStats.RevisionCacheHits
 	cacheMissStat := cacheStats.RevisionCacheMisses
+	cacheNumItemsStat := cacheStats.RevisionCacheNumItems
 
 	if cacheOptions.ShardCount > 1 {
-		return NewShardedLRURevisionCache(cacheOptions.ShardCount, cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat)
+		return NewShardedLRURevisionCache(cacheOptions.ShardCount, cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat)
 	}
 
-	return NewLRURevisionCache(cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat)
+	return NewLRURevisionCache(cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat)
 }
 
 type RevisionCacheOptions struct {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -77,6 +77,12 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 	cacheMissStat := cacheStats.RevisionCacheMisses
 	cacheNumItemsStat := cacheStats.RevisionCacheNumItems
 	cacheMemoryStat := cacheStats.RevisionCacheTotalMemory
+	if cacheNumItemsStat.Value() != 0 {
+		cacheNumItemsStat.Set(0)
+	}
+	if cacheMemoryStat.Value() != 0 {
+		cacheMemoryStat.Set(0)
+	}
 
 	if cacheOptions.ShardCount > 1 {
 		return NewShardedLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -68,7 +68,7 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 		cacheOptions = DefaultRevisionCacheOptions()
 	}
 
-	if cacheOptions.Size == 0 {
+	if cacheOptions.MaxItemCount == 0 {
 		bypassStat := cacheStats.RevisionCacheBypass
 		return NewBypassRevisionCache(backingStores, bypassStat)
 	}
@@ -76,23 +76,25 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 	cacheHitStat := cacheStats.RevisionCacheHits
 	cacheMissStat := cacheStats.RevisionCacheMisses
 	cacheNumItemsStat := cacheStats.RevisionCacheNumItems
+	cacheMemoryStat := cacheStats.RevisionCacheTotalMemory
 
 	if cacheOptions.ShardCount > 1 {
-		return NewShardedLRURevisionCache(cacheOptions.ShardCount, cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat)
+		return NewShardedLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
 	}
 
-	return NewLRURevisionCache(cacheOptions.Size, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat)
+	return NewLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
 }
 
 type RevisionCacheOptions struct {
-	Size       uint32
-	ShardCount uint16
+	MaxItemCount uint32
+	MaxBytes     int64
+	ShardCount   uint16
 }
 
 func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 	return &RevisionCacheOptions{
-		Size:       DefaultRevisionCacheSize,
-		ShardCount: DefaultRevisionCacheShardCount,
+		MaxItemCount: DefaultRevisionCacheSize,
+		ShardCount:   DefaultRevisionCacheShardCount,
 	}
 }
 
@@ -163,7 +165,8 @@ type DocumentRevision struct {
 	Attachments AttachmentsMeta
 	Delta       *RevisionDelta
 	Deleted     bool
-	Removed     bool // True if the revision is a removal.
+	Removed     bool  // True if the revision is a removal.
+	MemoryBytes int64 // storage of the doc rev bytes measurement, includes size of delta when present too
 }
 
 // MutableBody returns a deep copy of the given document revision as a plain body (without any special properties)
@@ -317,10 +320,11 @@ type RevisionDelta struct {
 	ToChannels            base.Set                // Full list of channels for the to revision
 	RevisionHistory       []string                // Revision history from parent of ToRevID to source revID, in descending order
 	ToDeleted             bool                    // Flag if ToRevID is a tombstone
+	totalDeltaBytes       int64                   // totalDeltaBytes is the total bytes for channels, revisions and body on the delta itself
 }
 
 func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {
-	return RevisionDelta{
+	revDelta := RevisionDelta{
 		ToRevID:               toRevision.RevID,
 		DeltaBytes:            deltaBytes,
 		AttachmentStorageMeta: toRevAttStorageMeta,
@@ -328,6 +332,8 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 		RevisionHistory:       toRevision.History.parseAncestorRevisions(fromRevID),
 		ToDeleted:             deleted,
 	}
+	revDelta.CalculateDeltaBytes()
+	return revDelta
 }
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -26,18 +26,25 @@ type ShardedLRURevisionCache struct {
 }
 
 // Creates a sharded revision cache with the given capacity and an optional loader function.
-func NewShardedLRURevisionCache(shardCount uint16, capacity uint32, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat, cacheMissStat, cacheNumItemsStat *base.SgwIntStat) *ShardedLRURevisionCache {
+func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat *base.SgwIntStat) *ShardedLRURevisionCache {
 
-	caches := make([]*LRURevisionCache, shardCount)
+	caches := make([]*LRURevisionCache, revCacheOptions.ShardCount)
 	// Add 10% to per-shared cache capacity to ensure overall capacity is reached under non-ideal shard hashing
-	perCacheCapacity := 1.1 * float32(capacity) / float32(shardCount)
-	for i := 0; i < int(shardCount); i++ {
-		caches[i] = NewLRURevisionCache(uint32(perCacheCapacity+0.5), backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat)
+	perCacheCapacity := 1.1 * float32(revCacheOptions.MaxItemCount) / float32(revCacheOptions.ShardCount)
+	revCacheOptions.MaxItemCount = uint32(perCacheCapacity)
+	var perCacheMemoryCapacity float32
+	if revCacheOptions.MaxBytes > 0 {
+		perCacheMemoryCapacity = 1.1 * float32(revCacheOptions.MaxBytes) / float32(revCacheOptions.ShardCount)
+		revCacheOptions.MaxBytes = int64(perCacheMemoryCapacity)
+	}
+
+	for i := 0; i < int(revCacheOptions.ShardCount); i++ {
+		caches[i] = NewLRURevisionCache(revCacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
 	}
 
 	return &ShardedLRURevisionCache{
 		caches:    caches,
-		numShards: shardCount,
+		numShards: revCacheOptions.ShardCount,
 	}
 }
 
@@ -75,14 +82,16 @@ func (sc *ShardedLRURevisionCache) Remove(docID, revID string, collectionID uint
 
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
-	backingStores map[uint32]RevisionCacheBackingStore
-	cache         map[IDAndRev]*list.Element
-	lruList       *list.List
-	cacheHits     *base.SgwIntStat
-	cacheMisses   *base.SgwIntStat
-	cacheNumItems *base.SgwIntStat
-	lock          sync.Mutex
-	capacity      uint32
+	backingStores    map[uint32]RevisionCacheBackingStore
+	cache            map[IDAndRev]*list.Element
+	lruList          *list.List
+	cacheHits        *base.SgwIntStat
+	cacheMisses      *base.SgwIntStat
+	cacheNumItems    *base.SgwIntStat
+	lock             sync.Mutex
+	capacity         uint32
+	memoryCapacity   int64
+	cacheMemoryBytes *base.SgwIntStat
 }
 
 // The cache payload data. Stored as the Value of a list Element.
@@ -98,19 +107,22 @@ type revCacheValue struct {
 	lock        sync.RWMutex
 	deleted     bool
 	removed     bool
+	itemBytes   int64
 }
 
 // Creates a revision cache with the given capacity and an optional loader function.
-func NewLRURevisionCache(capacity uint32, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat, cacheMissStat, cacheNumItemsStat *base.SgwIntStat) *LRURevisionCache {
+func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat *base.SgwIntStat, cacheMissStat *base.SgwIntStat, cacheNumItemsStat *base.SgwIntStat, revCacheMemoryStat *base.SgwIntStat) *LRURevisionCache {
 
 	return &LRURevisionCache{
-		cache:         map[IDAndRev]*list.Element{},
-		lruList:       list.New(),
-		capacity:      capacity,
-		backingStores: backingStores,
-		cacheHits:     cacheHitStat,
-		cacheMisses:   cacheMissStat,
-		cacheNumItems: cacheNumItemsStat,
+		cache:            map[IDAndRev]*list.Element{},
+		lruList:          list.New(),
+		capacity:         revCacheOptions.MaxItemCount,
+		backingStores:    backingStores,
+		cacheHits:        cacheHitStat,
+		cacheMisses:      cacheMissStat,
+		cacheNumItems:    cacheNumItemsStat,
+		cacheMemoryBytes: revCacheMemoryStat,
+		memoryCapacity:   revCacheOptions.MaxBytes,
 	}
 }
 
@@ -137,7 +149,12 @@ func (rc *LRURevisionCache) Peek(ctx context.Context, docID, revID string, colle
 func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
 	value := rc.getValue(docID, revID, collectionID, false)
 	if value != nil {
-		value.updateDelta(toDelta)
+		outGoingBytes := value.updateDelta(toDelta)
+		if outGoingBytes != 0 {
+			rc.cacheMemoryBytes.Add(outGoingBytes)
+		}
+		// check for memory based eviction
+		rc.revCacheMemoryBasedEviction()
 	}
 }
 
@@ -150,40 +167,17 @@ func (rc *LRURevisionCache) getFromCache(ctx context.Context, docID, revID strin
 	docRev, statEvent, err := value.load(ctx, rc.backingStores[collectionID], includeDelta)
 	rc.statsRecorderFunc(statEvent)
 
+	if !statEvent && err == nil {
+		// cache miss so we had to load doc, increment memory count
+		rc.cacheMemoryBytes.Add(value.getItemBytes())
+		// check for memory based eviction
+		rc.revCacheMemoryBasedEviction()
+	}
+
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
 	return docRev, err
-}
-
-// In the event that a revision in invalid it needs to be replaced later and the revision cache value should not be
-// used. This function grabs the value directly from the bucket.
-func (rc *LRURevisionCache) LoadInvalidRevFromBackingStore(ctx context.Context, key IDAndRev, doc *Document, collectionID uint32, includeDelta bool) (DocumentRevision, error) {
-	var delta *RevisionDelta
-
-	value := revCacheValue{
-		key: key,
-	}
-
-	// If doc has been passed in use this to grab values. Otherwise run revCacheLoader which will grab the Document
-	// first
-	if doc != nil {
-		value.bodyBytes, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, key.RevID)
-	} else {
-		value.bodyBytes, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoader(ctx, rc.backingStores[collectionID], key)
-	}
-
-	if includeDelta {
-		delta = value.delta
-	}
-
-	docRev, err := value.asDocumentRevision(delta)
-
-	// Classify operation as a cache miss
-	rc.statsRecorderFunc(false)
-
-	return docRev, err
-
 }
 
 // Attempts to retrieve the active revision for a document from the cache.  Requires retrieval
@@ -209,6 +203,13 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStores[collectionID], bucketDoc)
 	rc.statsRecorderFunc(statEvent)
 
+	if !statEvent && err == nil {
+		// cache miss so we had to load doc, increment memory count
+		rc.cacheMemoryBytes.Add(value.getItemBytes())
+		// check for rev cache memory based eviction
+		rc.revCacheMemoryBasedEviction()
+	}
+
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
@@ -231,6 +232,11 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision, co
 		panic("Missing history for RevisionCache.Put")
 	}
 	value := rc.getValue(docRev.DocID, docRev.RevID, collectionID, true)
+	// increment incoming bytes
+	docRev.CalculateBytes()
+	rc.cacheMemoryBytes.Add(docRev.MemoryBytes)
+	// check for rev cache memory based eviction
+	rc.revCacheMemoryBasedEviction()
 	value.store(docRev)
 }
 
@@ -242,6 +248,9 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 	newItem := true
 	// If element exists remove from lrulist
 	if elem := rc.cache[key]; elem != nil {
+		revItem := elem.Value.(*revCacheValue)
+		// decrement item bytes by the removed item
+		rc.cacheMemoryBytes.Add(-revItem.getItemBytes())
 		rc.lruList.Remove(elem)
 		newItem = false
 	}
@@ -254,7 +263,7 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 		rc.cacheNumItems.Add(1)
 	}
 
-	// Purge oldest item if required
+	// Purge oldest item if over number capacity
 	var numItemsRemoved int
 	for len(rc.cache) > int(rc.capacity) {
 		rc.purgeOldest_()
@@ -263,6 +272,18 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 	if numItemsRemoved > 0 {
 		rc.cacheNumItems.Add(int64(-numItemsRemoved))
 	}
+
+	docRev.CalculateBytes()
+	// add new item bytes to overall count
+	rc.cacheMemoryBytes.Add(docRev.MemoryBytes)
+
+	// check we aren't over memory capacity, if so perform eviction
+	if rc.memoryCapacity > 0 {
+		for rc.cacheMemoryBytes.Value() > rc.memoryCapacity {
+			rc.purgeOldest_()
+		}
+	}
+
 	rc.lock.Unlock()
 
 	value.store(docRev)
@@ -283,6 +304,7 @@ func (rc *LRURevisionCache) getValue(docID, revID string, collectionID uint32, c
 		rc.cache[key] = rc.lruList.PushFront(value)
 		rc.cacheNumItems.Add(1)
 
+		// evict if over number capacity
 		var numItemsRemoved int
 		for len(rc.cache) > int(rc.capacity) {
 			rc.purgeOldest_()
@@ -306,6 +328,9 @@ func (rc *LRURevisionCache) Remove(docID, revID string, collectionID uint32) {
 		return
 	}
 	rc.lruList.Remove(element)
+	// decrement the overall memory bytes count
+	revItem := element.Value.(*revCacheValue)
+	rc.cacheMemoryBytes.Add(-revItem.getItemBytes())
 	delete(rc.cache, key)
 	rc.cacheNumItems.Add(-1)
 }
@@ -324,6 +349,8 @@ func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 func (rc *LRURevisionCache) purgeOldest_() {
 	value := rc.lruList.Remove(rc.lruList.Back()).(*revCacheValue)
 	delete(rc.cache, value.key)
+	// decrement memory overall size
+	rc.cacheMemoryBytes.Add(-value.getItemBytes())
 }
 
 // Gets the body etc. out of a revCacheValue. If they aren't present already, the loader func
@@ -361,9 +388,15 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	if includeDelta {
 		delta = value.delta
 	}
-	value.lock.Unlock()
 
 	docRev, err = value.asDocumentRevision(delta)
+	// if not cache hit, we loaded from bucket. Calculate doc rev size and assign to rev cache value
+	if !cacheHit {
+		docRev.CalculateBytes()
+		value.itemBytes = docRev.MemoryBytes
+	}
+	value.lock.Unlock()
+
 	return docRev, cacheHit, err
 }
 
@@ -408,8 +441,13 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 		cacheHit = false
 		value.bodyBytes, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, value.err = revCacheLoaderForDocument(ctx, backingStore, doc, value.key.RevID)
 	}
-	value.lock.Unlock()
 	docRev, err = value.asDocumentRevision(nil)
+	// if not cache hit, we loaded from bucket. Calculate doc rev size and assign to rev cache value
+	if !cacheHit {
+		docRev.CalculateBytes()
+		value.itemBytes = docRev.MemoryBytes
+	}
+	value.lock.Unlock()
 	return docRev, cacheHit, err
 }
 
@@ -425,12 +463,82 @@ func (value *revCacheValue) store(docRev DocumentRevision) {
 		value.attachments = docRev.Attachments.ShallowCopy() // Don't store attachments the caller might later mutate
 		value.deleted = docRev.Deleted
 		value.err = nil
+		value.itemBytes = docRev.MemoryBytes
 	}
 	value.lock.Unlock()
 }
 
-func (value *revCacheValue) updateDelta(toDelta RevisionDelta) {
+func (value *revCacheValue) updateDelta(toDelta RevisionDelta) (diffInBytes int64) {
 	value.lock.Lock()
+	var previousDeltaBytes int64
+	if value.delta != nil {
+		// delta exists, need to pull this to update overall memory size correctly
+		previousDeltaBytes = value.delta.totalDeltaBytes
+	}
+	diffInBytes = toDelta.totalDeltaBytes - previousDeltaBytes
 	value.delta = &toDelta
+	if diffInBytes != 0 {
+		value.itemBytes += diffInBytes
+	}
 	value.lock.Unlock()
+	return diffInBytes
+}
+
+// getItemBytes acquires read lock and retrieves the rev cache items overall memory footprint
+func (value *revCacheValue) getItemBytes() int64 {
+	value.lock.RLock()
+	defer value.lock.RUnlock()
+	return value.itemBytes
+}
+
+// CalculateBytes will calculate the bytes from revisions in the document, body and channels on the document
+func (rev *DocumentRevision) CalculateBytes() {
+	var totalBytes int
+	for v := range rev.Channels {
+		bytes := len([]byte(v))
+		totalBytes += bytes
+	}
+	// calculate history
+	digests, _ := GetStringArrayProperty(rev.History, RevisionsIds)
+	historyBytes := 32 * len(digests)
+	totalBytes += historyBytes
+	// add body bytes into calculation
+	totalBytes += len(rev.BodyBytes)
+
+	// convert the int to int64 type and assign to document revision
+	rev.MemoryBytes = int64(totalBytes)
+}
+
+// CalculateDeltaBytes will calculate bytes from delta channels, delta revisions and delta body
+func (delta *RevisionDelta) CalculateDeltaBytes() {
+	var totalBytes int
+	for v := range delta.ToChannels {
+		bytes := len([]byte(v))
+		totalBytes += bytes
+	}
+	// history calculation
+	historyBytes := 32 * len(delta.RevisionHistory)
+	totalBytes += historyBytes
+
+	// account for delta body
+	totalBytes += len(delta.DeltaBytes)
+
+	delta.totalDeltaBytes = int64(totalBytes)
+}
+
+// revCacheMemoryBasedEviction checks for rev cache eviction, if required calls performEviction which will acquire lock to evict
+func (rc *LRURevisionCache) revCacheMemoryBasedEviction() {
+	// if memory capacity is not set, don't check for eviction this way
+	if rc.memoryCapacity > 0 && rc.cacheMemoryBytes.Value() > rc.memoryCapacity {
+		rc.performEviction()
+	}
+}
+
+// performEviction will evict the oldest items in the cache till we are below the memory threshold
+func (rc *LRURevisionCache) performEviction() {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	for rc.cacheMemoryBytes.Value() > rc.memoryCapacity {
+		rc.purgeOldest_()
+	}
 }

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -235,9 +235,9 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision, co
 	// increment incoming bytes
 	docRev.CalculateBytes()
 	rc.cacheMemoryBytes.Add(docRev.MemoryBytes)
+	value.store(docRev)
 	// check for rev cache memory based eviction
 	rc.revCacheMemoryBasedEviction()
-	value.store(docRev)
 }
 
 // Upsert a revision in the cache.
@@ -276,17 +276,19 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 	docRev.CalculateBytes()
 	// add new item bytes to overall count
 	rc.cacheMemoryBytes.Add(docRev.MemoryBytes)
+	value.store(docRev)
 
 	// check we aren't over memory capacity, if so perform eviction
+	numItemsRemoved = 0
 	if rc.memoryCapacity > 0 {
 		for rc.cacheMemoryBytes.Value() > rc.memoryCapacity {
 			rc.purgeOldest_()
+			numItemsRemoved++
 		}
+		rc.cacheNumItems.Add(int64(-numItemsRemoved))
 	}
 
 	rc.lock.Unlock()
-
-	value.store(docRev)
 }
 
 func (rc *LRURevisionCache) getValue(docID, revID string, collectionID uint32, create bool) (value *revCacheValue) {
@@ -538,7 +540,10 @@ func (rc *LRURevisionCache) revCacheMemoryBasedEviction() {
 func (rc *LRURevisionCache) performEviction() {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
+	var numItemsRemoved int64
 	for rc.cacheMemoryBytes.Value() > rc.memoryCapacity {
 		rc.purgeOldest_()
+		numItemsRemoved++
 	}
+	rc.cacheNumItems.Add(-numItemsRemoved)
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -53,7 +53,7 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 	return doc, nil
 }
 
-func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error) {
+func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error) {
 	t.getRevisionCounter.Add(1)
 
 	b := Body{
@@ -63,7 +63,7 @@ func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid
 		BodyRevisions: Revisions{RevisionsStart: 1},
 	}
 	bodyBytes, err := base.JSONMarshal(b)
-	return bodyBytes, b, nil, err
+	return bodyBytes, nil, err
 }
 
 type noopBackingStore struct{}
@@ -72,8 +72,8 @@ func (*noopBackingStore) GetDocument(ctx context.Context, docid string, unmarsha
 	return nil, nil
 }
 
-func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, Body, AttachmentsMeta, error) {
-	return nil, nil, nil, nil
+func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error) {
+	return nil, nil, nil
 }
 
 // testCollectionID is a test collection ID to use for a key in the backing store map to point to a tests backing store.
@@ -104,7 +104,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Get them back out
 	for i := 0; i < 10; i++ {
 		docID := strconv.Itoa(i)
-		docRev, err := cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+		docRev, err := cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", docID)
 		assert.Equal(t, docID, docRev.DocID)
@@ -132,7 +132,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// and check we can Get up to and including the last 3 we put in
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		docRev, err := cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+		docRev, err := cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta)
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
 		assert.Equal(t, id, docRev.DocID)
@@ -148,7 +148,7 @@ func TestBackingStore(t *testing.T) {
 	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -159,7 +159,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -168,7 +168,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev is already resident, but still issue GetDocument to check for later revisions
-	docRev, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -179,7 +179,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -269,15 +269,15 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.False(t, ok)
 
 	// Get non-existing doc
-	_, err = rc.Get(ctx, "invalid", rev1, testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	_, err = rc.Get(ctx, "invalid", rev1, testCollectionID, RevCacheOmitDelta)
 	assert.True(t, base.IsDocNotFoundError(err))
 
 	// Get non-existing revision
-	_, err = rc.Get(ctx, key, "3-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	_, err = rc.Get(ctx, key, "3-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 
 	// Get specific revision
-	doc, err := rc.Get(ctx, key, rev1, testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+	doc, err := rc.Get(ctx, key, rev1, testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	require.NotNil(t, doc)
 	assert.Equal(t, `{"value":1234}`, string(doc.BodyBytes))
@@ -294,7 +294,7 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.False(t, ok)
 
 	// Get active revision
-	doc, err = rc.GetActive(ctx, key, testCollectionID, false)
+	doc, err = rc.GetActive(ctx, key, testCollectionID)
 	assert.NoError(t, err)
 	assert.Equal(t, `{"value":5678}`, string(doc.BodyBytes))
 
@@ -375,7 +375,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)
 
 	// Get the raw document directly from the revcache, validate _attachments property isn't found
-	docRevision, err := collection.revisionCache.Get(ctx, docKey, rev2id, RevCacheOmitBody, RevCacheOmitDelta)
+	docRevision, err := collection.revisionCache.Get(ctx, docKey, rev2id, RevCacheOmitDelta)
 	assert.NoError(t, err, "Unexpected error calling collection.revisionCache.Get")
 	assert.NotContains(t, docRevision.BodyBytes, BodyAttachments, "_attachments property still present in document body retrieved from rev cache: %#v", bucketBody)
 	_, ok = docRevision.Attachments["myatt"]
@@ -403,12 +403,12 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	secondDelta := []byte("modified delta")
 
 	// Trigger load into cache
-	_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheIncludeDelta)
+	_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error adding to cache")
 	cache.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevisionDelta{ToRevID: "rev2", DeltaBytes: firstDelta})
 
 	// Retrieve from cache
-	retrievedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheIncludeDelta)
+	retrievedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
@@ -419,7 +419,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Retrieve again, validate delta is correct
-	updatedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheOmitBody, RevCacheIncludeDelta)
+	updatedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev3", updatedRev.Delta.ToRevID)
 	assert.Equal(t, secondDelta, updatedRev.Delta.DeltaBytes)
@@ -436,7 +436,7 @@ func TestSingleLoad(t *testing.T) {
 	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", History: Revisions{"start": 1}}, testCollectionID)
-	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, true, false)
+	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
 	assert.NoError(t, err)
 }
 
@@ -453,7 +453,7 @@ func TestConcurrentLoad(t *testing.T) {
 	wg.Add(20)
 	for i := 0; i < 20; i++ {
 		go func() {
-			_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, true, false)
+			_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -471,19 +471,19 @@ func TestRevisionCacheRemove(t *testing.T) {
 	rev1id, _, err := collection.Put(ctx, "doc", Body{"val": 123})
 	assert.NoError(t, err)
 
-	docRev, err := collection.revisionCache.Get(ctx, "doc", rev1id, true, true)
+	docRev, err := collection.revisionCache.Get(ctx, "doc", rev1id, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheMisses.Value())
 
 	collection.revisionCache.Remove("doc", rev1id)
 
-	docRev, err = collection.revisionCache.Get(ctx, "doc", rev1id, true, true)
+	docRev, err = collection.revisionCache.Get(ctx, "doc", rev1id, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 
-	docRev, err = collection.revisionCache.GetActive(ctx, "doc", true)
+	docRev, err = collection.revisionCache.GetActive(ctx, "doc")
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
@@ -619,7 +619,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 
 	// trigger load into cache
 	for i := 0; i < 5000; i++ {
-		_, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+		_, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitDelta)
 	}
 
 	b.ResetTimer()
@@ -627,7 +627,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		// GET the document until test run has completed
 		for pb.Next() {
 			docId := fmt.Sprintf("doc%d", rand.Intn(5000))
-			_, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheOmitBody, RevCacheOmitDelta)
+			_, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheOmitDelta)
 		}
 	})
 }

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -724,12 +724,15 @@ func (tree RevTree) RenderGraphvizDot() string {
 func (tree RevTree) getHistory(revid string) ([]string, error) {
 	maxHistory := len(tree)
 
+	var totalBytesForHistory int
 	history := make([]string, 0, 5)
 	for revid != "" {
 		info, err := tree.getInfo(revid)
 		if err != nil {
 			break
 		}
+		revBytes := len([]byte(revid))
+		totalBytesForHistory += revBytes
 		history = append(history, revid)
 		if len(history) > maxHistory {
 			return history, fmt.Errorf("getHistory found cycle in revision tree, history calculated as: %v", history)

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -724,15 +724,12 @@ func (tree RevTree) RenderGraphvizDot() string {
 func (tree RevTree) getHistory(revid string) ([]string, error) {
 	maxHistory := len(tree)
 
-	var totalBytesForHistory int
 	history := make([]string, 0, 5)
 	for revid != "" {
 		info, err := tree.getInfo(revid)
 		if err != nil {
 			break
 		}
-		revBytes := len([]byte(revid))
-		totalBytesForHistory += revBytes
 		history = append(history, revid)
 		if len(history) > maxHistory {
 			return history, fmt.Errorf("getHistory found cycle in revision tree, history calculated as: %v", history)

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1294,6 +1294,13 @@ Database:
               description: The maximum number of revisions that can be stored in the revision cache.
               type: string
               default: 5000
+            max_memory_count_mb:
+              description: |-
+                The maximum amount of memory the revision cache should take up in MB, setting to 0 will disable any eviction based on memory at rev cache.
+                When set this memory limit will work in in hand with revision cache size parameter. So you will potentially get eviction at revision cache both based off memory footprint and number of items in the cache.
+                **This is an enterprise-edition feature only**
+              type: integer
+              default: 0
             shard_count:
               description: The number of shards the revision cache should be split into.
               type: string

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -313,7 +313,7 @@ func TestUserHasDocAccessDocNotFound(t *testing.T) {
 			QueryPaginationLimit: base.IntPtr(2),
 			CacheConfig: &CacheConfig{
 				RevCacheConfig: &RevCacheConfig{
-					Size: base.Uint32Ptr(0),
+					MaxItemCount: base.Uint32Ptr(0),
 				},
 				ChannelCacheConfig: &ChannelCacheConfig{
 					MaxNumber: base.IntPtr(0),

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2462,7 +2462,7 @@ func TestHandleDBConfig(t *testing.T) {
 	dbConfig := rt.NewDbConfig()
 	dbConfig.CacheConfig = &rest.CacheConfig{
 		RevCacheConfig: &rest.RevCacheConfig{
-			Size: base.Uint32Ptr(1337), ShardCount: base.Uint16Ptr(7),
+			MaxItemCount: base.Uint32Ptr(1337), ShardCount: base.Uint16Ptr(7),
 		},
 	}
 

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -127,7 +127,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
 	// Get database handle
 	rtDatabase := rt.GetDatabase()
-	revCacheSize := rtDatabase.Options.RevisionCacheOptions.Size
+	revCacheSize := rtDatabase.Options.RevisionCacheOptions.MaxItemCount
 
 	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
 	numDocs := int(revCacheSize + 1)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2757,6 +2757,11 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, body)
 	assert.Contains(t, err.Error(), "null doc body for doc")
+
+	bodyBytes, err := documentRev.Inject1xBodyProperties(rt.Context(), collection, nil, nil, false)
+	require.Error(t, err)
+	require.Nil(t, bodyBytes)
+	assert.Contains(t, err.Error(), "b is not a JSON object")
 }
 
 func TestTombstoneCompactionAPI(t *testing.T) {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -847,7 +847,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 			collection, ctx := rt.GetSingleTestDatabaseCollection()
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := collection.GetRevisionCacheForTest().Get(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitBody, db.RevCacheOmitDelta)
+			docRev, cacheErr := collection.GetRevisionCacheForTest().Get(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -69,7 +69,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Empty(t, dbConfigResp.Username)
 	assert.Empty(t, dbConfigResp.Password)
 	require.Nil(t, dbConfigResp.Sync)
-	require.Equal(t, uint32(1234), *dbConfigResp.CacheConfig.RevCacheConfig.Size)
+	require.Equal(t, uint32(1234), *dbConfigResp.CacheConfig.RevCacheConfig.MaxItemCount)
 
 	// Sanity check to use the database
 	resp = BootstrapAdminRequest(t, sc, http.MethodPut, "/db1/doc1", `{"foo":"bar"}`)
@@ -103,7 +103,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Empty(t, dbConfigResp.Username)
 	assert.Empty(t, dbConfigResp.Password)
 	require.Nil(t, dbConfigResp.Sync)
-	require.Equal(t, uint32(1234), *dbConfigResp.CacheConfig.RevCacheConfig.Size)
+	require.Equal(t, uint32(1234), *dbConfigResp.CacheConfig.RevCacheConfig.MaxItemCount)
 
 	// Ensure it's _actually_ the same bucket
 	resp = BootstrapAdminRequest(t, sc, http.MethodGet, "/db1/doc1", ``)

--- a/rest/config.go
+++ b/rest/config.go
@@ -246,8 +246,9 @@ type DeprecatedCacheConfig struct {
 }
 
 type RevCacheConfig struct {
-	Size       *uint32 `json:"size,omitempty"`        // Maximum number of revisions to store in the revision cache
-	ShardCount *uint16 `json:"shard_count,omitempty"` // Number of shards the rev cache should be split into
+	MaxItemCount     *uint32 `json:"size,omitempty"`                // Maximum number of revisions to store in the revision cache
+	MaxMemoryCountMB *uint32 `json:"max_memory_count_mb,omitempty"` // Maximum amount of memory the rev cache should consume in MB, when configured it will work in tandem with max items
+	ShardCount       *uint16 `json:"shard_count,omitempty"`         // Number of shards the rev cache should be split into
 }
 
 type ChannelCacheConfig struct {
@@ -814,10 +815,15 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 
 		if dbConfig.CacheConfig.RevCacheConfig != nil {
 			// EE: disable revcache
-			revCacheSize := dbConfig.CacheConfig.RevCacheConfig.Size
+			revCacheSize := dbConfig.CacheConfig.RevCacheConfig.MaxItemCount
 			if !isEnterpriseEdition && revCacheSize != nil && *revCacheSize == 0 {
 				base.WarnfCtx(ctx, eeOnlyWarningMsg, "cache.rev_cache.size", *revCacheSize, db.DefaultRevisionCacheSize)
-				dbConfig.CacheConfig.RevCacheConfig.Size = nil
+				dbConfig.CacheConfig.RevCacheConfig.MaxItemCount = nil
+			}
+			revCacheMemoryLimit := dbConfig.CacheConfig.RevCacheConfig.MaxMemoryCountMB
+			if !isEnterpriseEdition && revCacheMemoryLimit != nil && *revCacheMemoryLimit != 0 {
+				base.WarnfCtx(ctx, eeOnlyWarningMsg, "cache.rev_cache.max_memory_count_mb", *revCacheMemoryLimit, "no memory limit")
+				dbConfig.CacheConfig.RevCacheConfig.MaxMemoryCountMB = nil
 			}
 
 			if dbConfig.CacheConfig.RevCacheConfig.ShardCount != nil {
@@ -1116,8 +1122,8 @@ func (dbConfig *DbConfig) deprecatedConfigCacheFallback() (warnings []string) {
 	}
 
 	if dbConfig.DeprecatedRevCacheSize != nil {
-		if dbConfig.CacheConfig.RevCacheConfig.Size == nil {
-			dbConfig.CacheConfig.RevCacheConfig.Size = dbConfig.DeprecatedRevCacheSize
+		if dbConfig.CacheConfig.RevCacheConfig.MaxItemCount == nil {
+			dbConfig.CacheConfig.RevCacheConfig.MaxItemCount = dbConfig.DeprecatedRevCacheSize
 		}
 		warnings = append(warnings, fmt.Sprintf(warningMsgFmt, "rev_cache_size", "cache.rev_cache.size"))
 	}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -137,8 +137,8 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		AllowEmptyPassword: base.BoolPtr(false),
 		CacheConfig: &CacheConfig{
 			RevCacheConfig: &RevCacheConfig{
-				Size:       base.Uint32Ptr(db.DefaultRevisionCacheSize),
-				ShardCount: base.Uint16Ptr(db.DefaultRevisionCacheShardCount),
+				MaxItemCount: base.Uint32Ptr(db.DefaultRevisionCacheSize),
+				ShardCount:   base.Uint16Ptr(db.DefaultRevisionCacheShardCount),
 			},
 			ChannelCacheConfig: &ChannelCacheConfig{
 				MaxNumber:            base.IntPtr(db.DefaultChannelCacheMaxNumber),

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -190,11 +191,11 @@ func TestConfigValidationCache(t *testing.T) {
 
 	require.NotNil(t, config.Databases["db"].CacheConfig.RevCacheConfig)
 	if base.IsEnterpriseEdition() {
-		require.NotNil(t, config.Databases["db"].CacheConfig.RevCacheConfig.Size)
-		assert.Equal(t, 0, int(*config.Databases["db"].CacheConfig.RevCacheConfig.Size))
+		require.NotNil(t, config.Databases["db"].CacheConfig.RevCacheConfig.MaxItemCount)
+		assert.Equal(t, 0, int(*config.Databases["db"].CacheConfig.RevCacheConfig.MaxItemCount))
 	} else {
 		// CE disallowed - should be nil
-		assert.Nil(t, config.Databases["db"].CacheConfig.RevCacheConfig.Size)
+		assert.Nil(t, config.Databases["db"].CacheConfig.RevCacheConfig.MaxItemCount)
 	}
 
 	require.NotNil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig)
@@ -488,7 +489,7 @@ func TestDeprecatedCacheConfig(t *testing.T) {
 	require.Len(t, warnings, 8)
 
 	// Check that the deprecated values have correctly been propagated upto the new config values
-	assert.Equal(t, *dbConfig.CacheConfig.RevCacheConfig.Size, uint32(10))
+	assert.Equal(t, *dbConfig.CacheConfig.RevCacheConfig.MaxItemCount, uint32(10))
 	assert.Equal(t, *dbConfig.CacheConfig.ChannelCacheConfig.ExpirySeconds, 10)
 	assert.Equal(t, *dbConfig.CacheConfig.ChannelCacheConfig.MinLength, 10)
 	assert.Equal(t, *dbConfig.CacheConfig.ChannelCacheConfig.MaxLength, 10)
@@ -507,7 +508,7 @@ func TestDeprecatedCacheConfig(t *testing.T) {
 
 	// Set A Couple Deprecated Values AND Their New Counterparts
 	dbConfig.DeprecatedRevCacheSize = base.Uint32Ptr(10)
-	dbConfig.CacheConfig.RevCacheConfig.Size = base.Uint32Ptr(20)
+	dbConfig.CacheConfig.RevCacheConfig.MaxItemCount = base.Uint32Ptr(20)
 	dbConfig.CacheConfig.DeprecatedEnableStarChannel = base.BoolPtr(false)
 	dbConfig.CacheConfig.ChannelCacheConfig.EnableStarChannel = base.BoolPtr(true)
 
@@ -518,7 +519,7 @@ func TestDeprecatedCacheConfig(t *testing.T) {
 	require.Len(t, warnings, 2)
 
 	// Check that the deprecated value has been ignored as the new value is the priority
-	assert.Equal(t, *dbConfig.CacheConfig.RevCacheConfig.Size, uint32(20))
+	assert.Equal(t, *dbConfig.CacheConfig.RevCacheConfig.MaxItemCount, uint32(20))
 	assert.Equal(t, *dbConfig.CacheConfig.ChannelCacheConfig.EnableStarChannel, true)
 }
 
@@ -3066,4 +3067,43 @@ func TestNotFoundOnInvalidDatabase(t *testing.T) {
 		assert.Equal(c, 0, len(invalidDatabases))
 		assert.Equal(c, 1, len(rt.ServerContext().dbConfigs))
 	}, time.Second*10, time.Millisecond*100)
+}
+
+func TestRevCacheMemoryLimitConfig(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		CustomTestBucket: base.GetTestBucket(t),
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+
+	resp := rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &dbConfig))
+	assert.Nil(t, dbConfig.CacheConfig)
+
+	dbConfig.CacheConfig = &CacheConfig{}
+	dbConfig.CacheConfig.RevCacheConfig = &RevCacheConfig{
+		MaxItemCount:     base.Uint32Ptr(100),
+		MaxMemoryCountMB: base.Uint32Ptr(4),
+	}
+	RequireStatus(t, rt.UpsertDbConfig("db1", dbConfig), http.StatusCreated)
+
+	resp = rt.SendAdminRequest(http.MethodGet, "/db1/_config", "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	// empty db config struct
+	dbConfig = DbConfig{}
+	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &dbConfig))
+	assert.NotNil(t, dbConfig.CacheConfig)
+
+	assert.Equal(t, uint32(100), *dbConfig.CacheConfig.RevCacheConfig.MaxItemCount)
+	if base.IsEnterpriseEdition() {
+		assert.Equal(t, uint32(4), *dbConfig.CacheConfig.RevCacheConfig.MaxMemoryCountMB)
+	} else {
+		assert.Nil(t, dbConfig.CacheConfig.RevCacheConfig.MaxMemoryCountMB)
+	}
 }

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -60,7 +60,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
 
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, true, false)
+	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, false)
 	assert.NoError(t, err)
 	assert.Len(t, docRev.Channels.ToArray(), 0)
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
@@ -82,7 +82,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData2))
 
-	docRev2, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, true, false)
+	docRev2, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.CurrentRev, false)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.CurrentRev, docRev2.RevID)
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7487,7 +7487,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 	require.NoError(t, err)
 
 	passiveRTCollection, passiveRTCtx := passiveRT.GetSingleTestDatabaseCollection()
-	rev, err := passiveRTCollection.GetRevisionCacheForTest().GetActive(passiveRTCtx, "test", true)
+	rev, err := passiveRTCollection.GetRevisionCacheForTest().GetActive(passiveRTCtx, "test")
 	require.NoError(t, err)
 	// Making body invalid to trigger log "Unable to unmarshal mutable body for doc" in handleRev
 	// Which should give a HTTP 422

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1091,7 +1091,7 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 			QueryPaginationLimit: base.IntPtr(2),
 			CacheConfig: &CacheConfig{
 				RevCacheConfig: &RevCacheConfig{
-					Size: base.Uint32Ptr(0),
+					MaxItemCount: base.Uint32Ptr(0),
 				},
 				ChannelCacheConfig: &ChannelCacheConfig{
 					MaxNumber: base.IntPtr(0),
@@ -1180,7 +1180,7 @@ func TestRevocationsWithQueryLimitChangesLimit(t *testing.T) {
 			QueryPaginationLimit: base.IntPtr(2),
 			CacheConfig: &CacheConfig{
 				RevCacheConfig: &RevCacheConfig{
-					Size: base.Uint32Ptr(0),
+					MaxItemCount: base.Uint32Ptr(0),
 				},
 				ChannelCacheConfig: &ChannelCacheConfig{
 					MaxNumber: base.IntPtr(0),
@@ -1234,7 +1234,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 			QueryPaginationLimit: base.IntPtr(2),
 			CacheConfig: &CacheConfig{
 				RevCacheConfig: &RevCacheConfig{
-					Size: base.Uint32Ptr(0),
+					MaxItemCount: base.Uint32Ptr(0),
 				},
 				ChannelCacheConfig: &ChannelCacheConfig{
 					MaxNumber: base.IntPtr(0),

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1165,7 +1165,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 
 		if config.CacheConfig.RevCacheConfig != nil {
 			if config.CacheConfig.RevCacheConfig.Size != nil {
-				revCacheOptions.Size = *config.CacheConfig.RevCacheConfig.Size
+				revCacheOptions.MaxItemCount = *config.CacheConfig.RevCacheConfig.Size
 			}
 			if config.CacheConfig.RevCacheConfig.ShardCount != nil {
 				revCacheOptions.ShardCount = *config.CacheConfig.RevCacheConfig.ShardCount

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1164,8 +1164,11 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		}
 
 		if config.CacheConfig.RevCacheConfig != nil {
-			if config.CacheConfig.RevCacheConfig.Size != nil {
-				revCacheOptions.MaxItemCount = *config.CacheConfig.RevCacheConfig.Size
+			if config.CacheConfig.RevCacheConfig.MaxItemCount != nil {
+				revCacheOptions.MaxItemCount = *config.CacheConfig.RevCacheConfig.MaxItemCount
+			}
+			if config.CacheConfig.RevCacheConfig.MaxMemoryCountMB != nil {
+				revCacheOptions.MaxBytes = int64(*config.CacheConfig.RevCacheConfig.MaxMemoryCountMB * 1024 * 1024) // Convert MB input to bytes
 			}
 			if config.CacheConfig.RevCacheConfig.ShardCount != nil {
 				revCacheOptions.ShardCount = *config.CacheConfig.RevCacheConfig.ShardCount


### PR DESCRIPTION
CBG-4151

Clean cherry-picks for backport into 3.2.1
- CBG-4023: Removal unmarshalled body on the rev cache #7030
- CBG-4135: new stat for rev cache capacity #7049
- CBG-4032: memory based rev cache implementation #7040
- CBG-4134: link rev cache memory limit config option to rev cache #7084
- CBG-4234: clean up rev cache work #7113
- CBG-4277: Remove unused totalBytesForHistory from getHistory #7137

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2725/
