### PR TITLE
CBG-4247: refactor in memory format for hlv

### DIFF
--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -44,7 +44,7 @@ type LogEntry struct {
 	IsPrincipal  bool       // Whether the log-entry is a tracking entry for a principal doc
 	CollectionID uint32     // Collection ID
 	SourceID     string     // SourceID allocated to the doc's Current Version on the HLV
-	Version      string     // Version allocated to the doc's Current Version on the HLV
+	Version      uint64     // Version allocated to the doc's Current Version on the HLV
 }
 
 func (l LogEntry) String() string {

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -49,7 +49,7 @@ type LogEntry struct {
 
 func (l LogEntry) String() string {
 	return fmt.Sprintf(
-		"seq: %d docid: %s revid: %s collectionID: %d source: %s version: %s",
+		"seq: %d docid: %s revid: %s collectionID: %d source: %s version: %d",
 		l.Sequence,
 		l.DocID,
 		l.RevID,

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -94,7 +94,7 @@ func (channelMap ChannelMap) KeySet() []string {
 type RevAndVersion struct {
 	RevTreeID      string `json:"rev,omitempty"`
 	CurrentSource  string `json:"src,omitempty"`
-	CurrentVersion string `json:"ver,omitempty"` // String representation of version
+	CurrentVersion string `json:"ver,omitempty"` // Version needs to be hex string here to support macro expansion when writing to _sync.rev
 }
 
 // RevAndVersionJSON aliases RevAndVersion to support conditional unmarshalling from either string (revTreeID) or

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -130,7 +130,7 @@ func (entry *LogEntry) SetRevAndVersion(rv channels.RevAndVersion) {
 	entry.RevID = rv.RevTreeID
 	if rv.CurrentSource != "" {
 		entry.SourceID = rv.CurrentSource
-		entry.Version = rv.CurrentVersion
+		entry.Version = base.HexCasToUint64(rv.CurrentVersion)
 	}
 }
 
@@ -494,7 +494,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 					change.DocID = docID
 					change.RevID = atRev.RevTreeID
 					change.SourceID = atRev.CurrentSource
-					change.Version = atRev.CurrentVersion
+					change.Version = base.HexCasToUint64(atRev.CurrentVersion)
 					change.Channels = channelRemovals
 				}
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -81,7 +81,7 @@ func testLogEntryWithCV(seq uint64, docid string, revid string, channelNames []s
 		TimeReceived: time.Now(),
 		CollectionID: collectionID,
 		SourceID:     sourceID,
-		Version:      string(base.Uint64CASToLittleEndianHex(version)),
+		Version:      version,
 	}
 	channelMap := make(channels.ChannelMap)
 	for _, channelName := range channelNames {

--- a/db/changes.go
+++ b/db/changes.go
@@ -489,7 +489,7 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channel channels.ID) 
 	// populate CurrentVersion entry if log entry has sourceID and Version populated
 	// This allows current version to be nil in event of CV not being populated on log entry
 	// allowing omitempty to work as expected
-	if logEntry.SourceID != "" && logEntry.Version != "" {
+	if logEntry.SourceID != "" && logEntry.Version != 0 {
 		change.CurrentVersion = &Version{SourceID: logEntry.SourceID, Value: logEntry.Version}
 	}
 	if logEntry.Flags&channels.Removed != 0 {

--- a/db/changes.go
+++ b/db/changes.go
@@ -489,7 +489,7 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channel channels.ID) 
 	// populate CurrentVersion entry if log entry has sourceID and Version populated
 	// This allows current version to be nil in event of CV not being populated on log entry
 	// allowing omitempty to work as expected
-	if logEntry.SourceID != "" && logEntry.Version != 0 {
+	if logEntry.SourceID != "" {
 		change.CurrentVersion = &Version{SourceID: logEntry.SourceID, Value: logEntry.Version}
 	}
 	if logEntry.Flags&channels.Removed != 0 {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -314,10 +314,9 @@ func TestCVPopulationOnChangeEntry(t *testing.T) {
 	changes, err := collection.GetChanges(ctx, base.SetOf("A"), getChangesOptionsWithZeroSeq(t))
 	require.NoError(t, err)
 
-	encodedCAS := string(base.Uint64CASToLittleEndianHex(doc.Cas))
 	assert.Equal(t, doc.ID, changes[0].ID)
 	assert.Equal(t, bucketUUID, changes[0].CurrentVersion.SourceID)
-	assert.Equal(t, encodedCAS, changes[0].CurrentVersion.Value)
+	assert.Equal(t, doc.Cas, changes[0].CurrentVersion.Value)
 }
 
 func TestDocDeletionFromChannelCoalesced(t *testing.T) {
@@ -587,7 +586,7 @@ func TestCurrentVersionPopulationOnChannelCache(t *testing.T) {
 
 	// assert that the source and version has been populated with the channel cache entry for the doc
 	assert.Equal(t, "doc1", entries[0].DocID)
-	assert.Equal(t, syncData.Cas, entries[0].Version)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), entries[0].Version)
 	assert.Equal(t, bucketUUID, entries[0].SourceID)
 	assert.Equal(t, syncData.HLV.SourceID, entries[0].SourceID)
 	assert.Equal(t, syncData.HLV.Version, entries[0].Version)

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -69,7 +69,7 @@ func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIter
 
 	if queryRow.RemovalRev != nil {
 		entry.RevID = queryRow.RemovalRev.RevTreeID
-		entry.Version = queryRow.RemovalRev.CurrentVersion
+		entry.Version = base.HexCasToUint64(queryRow.RemovalRev.CurrentVersion)
 		entry.SourceID = queryRow.RemovalRev.CurrentSource
 		if queryRow.RemovalDel {
 			entry.SetDeleted()

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -961,8 +961,7 @@ func verifyCVEntries(entries []*LogEntry, cvs []cvValues) bool {
 		if entries[index].SourceID != cv.source {
 			return false
 		}
-		encdedVrs := string(base.Uint64CASToLittleEndianHex(cv.version))
-		if entries[index].Version != encdedVrs {
+		if entries[index].Version != cv.version {
 			return false
 		}
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -940,7 +940,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 				doc.updateChannelHistory(channel, curSequence, false)
 				changed = append(changed, channel)
 				// If the current version requires macro expansion, new removal in channel map will also require macro expansion
-				if doc.HLV != nil && doc.HLV.Version == hlvExpandMacroCASValue {
+				if doc.HLV != nil && doc.HLV.Version == expandMacroCASValueUint64 {
 					revokedChannelsRequiringExpansion = append(revokedChannelsRequiringExpansion, channel)
 				}
 			}
@@ -1297,7 +1297,7 @@ func computeMetadataOnlyUpdate(currentCas uint64, revNo uint64, currentMou *Meta
 	}
 
 	metadataOnlyUpdate := &MetadataOnlyUpdate{
-		CAS:              expandMacroCASValue, // when non-empty, this is replaced with cas macro expansion
+		CAS:              expandMacroCASValueString, // when non-empty, this is replaced with cas macro expansion
 		PreviousCAS:      prevCas,
 		PreviousRevSeqNo: revNo,
 	}
@@ -1362,7 +1362,7 @@ func (s *SyncData) GetRevAndVersion() (rav channels.RevAndVersion) {
 	rav.RevTreeID = s.CurrentRev
 	if s.HLV != nil {
 		rav.CurrentSource = s.HLV.SourceID
-		rav.CurrentVersion = s.HLV.Version
+		rav.CurrentVersion = string(base.Uint64CASToLittleEndianHex(s.HLV.Version))
 	}
 	return rav
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -58,7 +58,7 @@ func ParseVersion(versionString string) (version Version, err error) {
 
 // String returns a version/sourceID pair in CBL string format
 func (v Version) String() string {
-	return fmt.Sprintf("%x@%s", v.Value, v.SourceID)
+	return strconv.FormatUint(v.Value, 16) + "@" + v.SourceID
 }
 
 // ExtractCurrentVersionFromHLV will take the current version form the HLV struct and return it in the Version struct

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -13,59 +13,25 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
 
-// hlvExpandMacroCASValue causes the field to be populated by CAS value by macro expansion
-const hlvExpandMacroCASValue = "expand"
-
-// HybridLogicalVectorInterface is an interface to contain methods that will operate on both a decoded HLV and encoded HLV
-type HybridLogicalVectorInterface interface {
-	GetValue(sourceID string) (uint64, bool)
-}
-
-var _ HybridLogicalVectorInterface = &HybridLogicalVector{}
-var _ HybridLogicalVectorInterface = &DecodedHybridLogicalVector{}
-
-// DecodedHybridLogicalVector (HLV) is a type that represents a decoded vector of Hybrid Logical Clocks.
-type DecodedHybridLogicalVector struct {
-	CurrentVersionCAS uint64            // current version cas (or cvCAS) stores the current CAS in uint64 type at the time of replication
-	ImportCAS         uint64            // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
-	SourceID          string            // source bucket uuid in (base64 encoded format) of where this entry originated from
-	Version           uint64            // current cas in uint64 format of the current version on the version vector
-	MergeVersions     map[string]uint64 // map of merge versions for fast efficient lookup
-	PreviousVersions  map[string]uint64 // map of previous versions for fast efficient lookup
-}
+type HLVVersions map[string]uint64 // map of source ID to version uint64 version value
 
 // Version is representative of a single entry in a HybridLogicalVector.
 type Version struct {
 	// SourceID is an ID representing the source of the value (e.g. Couchbase Lite ID)
 	SourceID string `json:"source_id"`
 	// Value is a Hybrid Logical Clock value (In Couchbase Server, CAS is a HLC)
-	Value string `json:"version"`
-}
-
-// DecodedVersion is a sourceID and version pair in string/uint64 format for use in conflict detection
-type DecodedVersion struct {
-	// SourceID is an ID representing the source of the value (e.g. Couchbase Lite ID)
-	SourceID string `json:"source_id"`
-	// Value is a Hybrid Logical Clock value (In Couchbase Server, CAS is a HLC)
 	Value uint64 `json:"version"`
 }
 
-// CreateDecodedVersion creates a sourceID and version pair in string/uint64 format
-func CreateDecodedVersion(source string, version uint64) DecodedVersion {
-	return DecodedVersion{
-		SourceID: source,
-		Value:    version,
-	}
-}
-
 // CreateVersion creates an encoded sourceID and version pair
-func CreateVersion(source, version string) Version {
+func CreateVersion(source string, version uint64) Version {
 	return Version{
 		SourceID: source,
 		Value:    version,
@@ -78,30 +44,21 @@ func ParseVersion(versionString string) (version Version, err error) {
 		return version, fmt.Errorf("Malformed version string %s, delimiter not found", versionString)
 	}
 	version.SourceID = sourceBase64
-	version.Value = timestampString
-	return version, nil
-}
-
-func ParseDecodedVersion(versionString string) (version DecodedVersion, err error) {
-	timestampString, sourceBase64, found := strings.Cut(versionString, "@")
-	if !found {
-		return version, fmt.Errorf("Malformed version string %s, delimiter not found", versionString)
+	// remove any leading whitespace, this should be addressed in CBG-3662
+	if len(timestampString) > 0 && timestampString[0] == ' ' {
+		timestampString = timestampString[1:]
 	}
-	version.SourceID = sourceBase64
-	version.Value = base.HexCasToUint64(timestampString)
+	vrs, err := strconv.ParseUint(timestampString, 16, 64)
+	if err != nil {
+		return version, err
+	}
+	version.Value = vrs
 	return version, nil
-}
-
-// String returns a Couchbase Lite-compatible string representation of the version.
-func (v DecodedVersion) String() string {
-	timestamp := string(base.Uint64CASToLittleEndianHex(v.Value))
-	source := base64.StdEncoding.EncodeToString([]byte(v.SourceID))
-	return timestamp + "@" + source
 }
 
 // String returns a version/sourceID pair in CBL string format
 func (v Version) String() string {
-	return v.Value + "@" + v.SourceID
+	return fmt.Sprintf("%x@%s", v.Value, v.SourceID)
 }
 
 // ExtractCurrentVersionFromHLV will take the current version form the HLV struct and return it in the Version struct
@@ -114,24 +71,33 @@ func (hlv *HybridLogicalVector) ExtractCurrentVersionFromHLV() *Version {
 // PersistedHybridLogicalVector is the marshalled format of HybridLogicalVector.
 // This representation needs to be kept in sync with XDCR.
 type HybridLogicalVector struct {
-	CurrentVersionCAS string            `json:"cvCas,omitempty"`     // current version cas (or cvCAS) stores the current CAS in little endian hex format at the time of replication
-	ImportCAS         string            `json:"importCAS,omitempty"` // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
-	SourceID          string            `json:"src"`                 // source bucket uuid in (base64 encoded format) of where this entry originated from
-	Version           string            `json:"ver"`                 // current cas in little endian hex format of the current version on the version vector
-	MergeVersions     map[string]string `json:"mv,omitempty"`        // map of merge versions for fast efficient lookup
-	PreviousVersions  map[string]string `json:"pv,omitempty"`        // map of previous versions for fast efficient lookup
+	CurrentVersionCAS uint64      // current version cas (or cvCAS) stores the current CAS in little endian hex format at the time of replication
+	ImportCAS         uint64      // Set when an import modifies the document CAS but preserves the HLV (import of a version replicated by XDCR)
+	SourceID          string      // source bucket uuid in (base64 encoded format) of where this entry originated from
+	Version           uint64      // current cas in little endian hex format of the current version on the version vector
+	MergeVersions     HLVVersions // map of merge versions for fast efficient lookup
+	PreviousVersions  HLVVersions // map of previous versions for fast efficient lookup
+}
+
+type BucketVector struct {
+	CurrentVersionCAS string            `json:"cvCas,omitempty"`
+	ImportCAS         string            `json:"importCAS,omitempty"`
+	SourceID          string            `json:"src"`
+	Version           string            `json:"ver"`
+	MergeVersions     map[string]string `json:"mv,omitempty"`
+	PreviousVersions  map[string]string `json:"pv,omitempty"`
 }
 
 // NewHybridLogicalVector returns an initialised HybridLogicalVector.
 func NewHybridLogicalVector() HybridLogicalVector {
 	return HybridLogicalVector{
-		PreviousVersions: make(map[string]string),
-		MergeVersions:    make(map[string]string),
+		PreviousVersions: make(HLVVersions),
+		MergeVersions:    make(HLVVersions),
 	}
 }
 
 // GetCurrentVersion returns the current version from the HLV in memory.
-func (hlv *HybridLogicalVector) GetCurrentVersion() (string, string) {
+func (hlv *HybridLogicalVector) GetCurrentVersion() (string, uint64) {
 	return hlv.SourceID, hlv.Version
 }
 
@@ -147,15 +113,6 @@ func (hlv *HybridLogicalVector) GetCurrentVersionString() string {
 	return version.String()
 }
 
-// IsVersionInConflict tests to see if a given version would be in conflict with the in memory HLV.
-func (hlv *HybridLogicalVector) IsVersionInConflict(version Version) bool {
-	v1 := Version{hlv.SourceID, hlv.Version}
-	if v1.isVersionDominating(version) || version.isVersionDominating(v1) {
-		return false
-	}
-	return true
-}
-
 // IsVersionKnown checks to see whether the HLV already contains a Version for the provided
 // source with a matching or newer value
 func (hlv *HybridLogicalVector) DominatesSource(version Version) bool {
@@ -163,16 +120,16 @@ func (hlv *HybridLogicalVector) DominatesSource(version Version) bool {
 	if !found {
 		return false
 	}
-	return existingValueForSource >= base.HexCasToUint64(version.Value)
+	return existingValueForSource >= version.Value
 
 }
 
 // AddVersion adds newVersion to the in memory representation of the HLV.
 func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	var newVersionCAS uint64
-	hlvVersionCAS := base.HexCasToUint64(hlv.Version)
-	if newVersion.Value != hlvExpandMacroCASValue {
-		newVersionCAS = base.HexCasToUint64(newVersion.Value)
+	hlvVersionCAS := hlv.Version
+	if newVersion.Value != expandMacroCASValueUint64 {
+		newVersionCAS = newVersion.Value
 	}
 	// check if this is the first time we're adding a source - version pair
 	if hlv.SourceID == "" {
@@ -182,25 +139,25 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	}
 	// if new entry has the same source we simple just update the version
 	if newVersion.SourceID == hlv.SourceID {
-		if newVersion.Value != hlvExpandMacroCASValue && newVersionCAS < hlvVersionCAS {
-			return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value for the same source. Current cas: %s new cas %s", hlv.Version, newVersion.Value)
+		if newVersion.Value != expandMacroCASValueUint64 && newVersionCAS < hlvVersionCAS {
+			return fmt.Errorf("attempting to add new version vector entry with a CAS that is less than the current version CAS value for the same source. Current cas: %d new cas %d", hlv.Version, newVersion.Value)
 		}
 		hlv.Version = newVersion.Value
 		return nil
 	}
 	// if we get here this is a new version from a different sourceID thus need to move current sourceID to previous versions and update current version
 	if hlv.PreviousVersions == nil {
-		hlv.PreviousVersions = make(map[string]string)
+		hlv.PreviousVersions = make(HLVVersions)
 	}
 	// we need to check if source ID already exists in PV, if so we need to ensure we are only updating with the
 	// sourceID-version pair if incoming version is greater than version already there
 	if currPVVersion, ok := hlv.PreviousVersions[hlv.SourceID]; ok {
 		// if we get here source ID exists in PV, only replace version if it is less than the incoming version
-		currPVVersionCAS := base.HexCasToUint64(currPVVersion)
+		currPVVersionCAS := currPVVersion
 		if currPVVersionCAS < hlvVersionCAS {
 			hlv.PreviousVersions[hlv.SourceID] = hlv.Version
 		} else {
-			return fmt.Errorf("local hlv has current source in previous version with version greater than current version. Current CAS: %s, PV CAS %s", hlv.Version, currPVVersion)
+			return fmt.Errorf("local hlv has current source in previous version with version greater than current version. Current CAS: %d, PV CAS %d", hlv.Version, currPVVersion)
 		}
 	} else {
 		// source doesn't exist in PV so add
@@ -215,7 +172,7 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 // TODO: Does this need to remove source from current version as well? Merge Versions?
 func (hlv *HybridLogicalVector) Remove(source string) error {
 	// if entry is not found in previous versions we return error
-	if hlv.PreviousVersions[source] == "" {
+	if hlv.PreviousVersions[source] == 0 {
 		return base.ErrNotFound
 	}
 	delete(hlv.PreviousVersions, source)
@@ -230,88 +187,6 @@ func (hlv *HybridLogicalVector) isDominating(otherVector HybridLogicalVector) bo
 	return hlv.DominatesSource(Version{otherVector.SourceID, otherVector.Version})
 }
 
-// isVersionDominating tests if v2 is dominating v1
-func (v1 *Version) isVersionDominating(v2 Version) bool {
-	if v1.SourceID != v2.SourceID {
-		return false
-	}
-	if v1.Value > v2.Value {
-		return true
-	}
-	return false
-}
-
-// isEqual tests if in memory HLV is equal to another
-func (hlv *DecodedHybridLogicalVector) isEqual(otherVector DecodedHybridLogicalVector) bool {
-	// if in HLV(A) sourceID the same as HLV(B) sourceID and HLV(A) CAS is equal to HLV(B) CAS then the two HLV's are equal
-	if hlv.SourceID == otherVector.SourceID && hlv.Version == otherVector.Version {
-		return true
-	}
-	// if the HLV(A) merge versions isn't empty and HLV(B) merge versions isn't empty AND if
-	// merge versions between the two HLV's are the same, they are equal
-	if len(hlv.MergeVersions) != 0 && len(otherVector.MergeVersions) != 0 {
-		if hlv.equalMergeVectors(otherVector) {
-			return true
-		}
-	}
-	if len(hlv.PreviousVersions) != 0 && len(otherVector.PreviousVersions) != 0 {
-		if hlv.equalPreviousVectors(otherVector) {
-			return true
-		}
-	}
-	// they aren't equal
-	return false
-}
-
-// equalMergeVectors tests if two merge vectors between HLV's are equal or not
-func (hlv *DecodedHybridLogicalVector) equalMergeVectors(otherVector DecodedHybridLogicalVector) bool {
-	if len(hlv.MergeVersions) != len(otherVector.MergeVersions) {
-		return false
-	}
-	for k, v := range hlv.MergeVersions {
-		if v != otherVector.MergeVersions[k] {
-			return false
-		}
-	}
-	return true
-}
-
-// equalPreviousVectors tests if two previous versions vectors between two HLV's are equal or not
-func (hlv *DecodedHybridLogicalVector) equalPreviousVectors(otherVector DecodedHybridLogicalVector) bool {
-	if len(hlv.PreviousVersions) != len(otherVector.PreviousVersions) {
-		return false
-	}
-	for k, v := range hlv.PreviousVersions {
-		if v != otherVector.PreviousVersions[k] {
-			return false
-		}
-	}
-	return true
-}
-
-// GetValue returns the latest CAS value in the HLV for a given sourceID along with boolean value to
-// indicate if sourceID is found in the HLV, if the sourceID is not present in the HLV it will return 0 CAS value and false
-func (hlv *DecodedHybridLogicalVector) GetValue(sourceID string) (uint64, bool) {
-	if sourceID == "" {
-		return 0, false
-	}
-	var latestVersion uint64
-	if sourceID == hlv.SourceID {
-		latestVersion = hlv.Version
-	}
-	if pvEntry := hlv.PreviousVersions[sourceID]; pvEntry > latestVersion {
-		latestVersion = pvEntry
-	}
-	if mvEntry := hlv.MergeVersions[sourceID]; mvEntry > latestVersion {
-		latestVersion = mvEntry
-	}
-	// if we have 0 cas value, there is no entry for this source ID in the HLV
-	if latestVersion == 0 {
-		return latestVersion, false
-	}
-	return latestVersion, true
-}
-
 // GetVersion returns the latest decoded CAS value in the HLV for a given sourceID
 func (hlv *HybridLogicalVector) GetValue(sourceID string) (uint64, bool) {
 	if sourceID == "" {
@@ -319,16 +194,16 @@ func (hlv *HybridLogicalVector) GetValue(sourceID string) (uint64, bool) {
 	}
 	var latestVersion uint64
 	if sourceID == hlv.SourceID {
-		latestVersion = base.HexCasToUint64(hlv.Version)
+		latestVersion = hlv.Version
 	}
 	if pvEntry, ok := hlv.PreviousVersions[sourceID]; ok {
-		entry := base.HexCasToUint64(pvEntry)
+		entry := pvEntry
 		if entry > latestVersion {
 			latestVersion = entry
 		}
 	}
 	if mvEntry, ok := hlv.MergeVersions[sourceID]; ok {
-		entry := base.HexCasToUint64(mvEntry)
+		entry := mvEntry
 		if entry > latestVersion {
 			latestVersion = entry
 		}
@@ -356,12 +231,12 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 		// Iterate through incoming vector previous versions, update with the version from other vector
 		// for source if the local version for that source is lower
 		for i, v := range otherVector.PreviousVersions {
-			if hlv.PreviousVersions[i] == "" {
+			if hlv.PreviousVersions[i] == 0 {
 				hlv.setPreviousVersion(i, v)
 			} else {
 				// if we get here then there is entry for this source in PV so we must check if its newer or not
-				otherHLVPVValue := base.HexCasToUint64(v)
-				localHLVPVValue := base.HexCasToUint64(hlv.PreviousVersions[i])
+				otherHLVPVValue := v
+				localHLVPVValue := hlv.PreviousVersions[i]
 				if localHLVPVValue < otherHLVPVValue {
 					hlv.setPreviousVersion(i, v)
 				}
@@ -378,14 +253,14 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector HybridLogicalVector
 // computeMacroExpansions returns the mutate in spec needed for the document update based off the outcome in updateHLV
 func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansionSpec {
 	var outputSpec []sgbucket.MacroExpansionSpec
-	if hlv.Version == hlvExpandMacroCASValue {
+	if hlv.Version == expandMacroCASValueUint64 {
 		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionPath(base.VvXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, spec)
 		// If version is being expanded, we need to also specify the macro expansion for the expanded rev property
 		currentRevSpec := sgbucket.NewMacroExpansionSpec(xattrCurrentRevVersionPath(base.SyncXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, currentRevSpec)
 	}
-	if hlv.CurrentVersionCAS == hlvExpandMacroCASValue {
+	if hlv.CurrentVersionCAS == expandMacroCASValueUint64 {
 		spec := sgbucket.NewMacroExpansionSpec(xattrCurrentVersionCASPath(base.VvXattrName), sgbucket.MacroCas)
 		outputSpec = append(outputSpec, spec)
 	}
@@ -393,9 +268,9 @@ func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansi
 }
 
 // setPreviousVersion will take a source/version pair and add it to the HLV previous versions map
-func (hlv *HybridLogicalVector) setPreviousVersion(source string, version string) {
+func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64) {
 	if hlv.PreviousVersions == nil {
-		hlv.PreviousVersions = make(map[string]string)
+		hlv.PreviousVersions = make(HLVVersions)
 	}
 	hlv.PreviousVersions[source] = version
 }
@@ -405,7 +280,7 @@ func (hlv *HybridLogicalVector) IsVersionKnown(otherVersion Version) bool {
 	if !found {
 		return false
 	}
-	return value >= base.HexCasToUint64(otherVersion.Value)
+	return value >= otherVersion.Value
 }
 
 // toHistoryForHLV formats blip History property for V4 replication and above
@@ -444,36 +319,6 @@ func (hlv *HybridLogicalVector) ToHistoryForHLV() string {
 	return s.String()
 }
 
-// ToDecodedHybridLogicalVector converts the little endian hex values of a HLV to uint64 values
-func (hlv *HybridLogicalVector) ToDecodedHybridLogicalVector() DecodedHybridLogicalVector {
-	var decodedVersion, decodedCVCAS, decodedImportCAS uint64
-	if hlv.Version != "" {
-		decodedVersion = base.HexCasToUint64(hlv.Version)
-	}
-	if hlv.ImportCAS != "" {
-		decodedImportCAS = base.HexCasToUint64(hlv.ImportCAS)
-	}
-	if hlv.CurrentVersionCAS != "" {
-		decodedCVCAS = base.HexCasToUint64(hlv.CurrentVersionCAS)
-	}
-	decodedHLV := DecodedHybridLogicalVector{
-		CurrentVersionCAS: decodedCVCAS,
-		Version:           decodedVersion,
-		ImportCAS:         decodedImportCAS,
-		SourceID:          hlv.SourceID,
-		PreviousVersions:  make(map[string]uint64, len(hlv.PreviousVersions)),
-		MergeVersions:     make(map[string]uint64, len(hlv.MergeVersions)),
-	}
-
-	for i, v := range hlv.PreviousVersions {
-		decodedHLV.PreviousVersions[i] = base.HexCasToUint64(v)
-	}
-	for i, v := range hlv.MergeVersions {
-		decodedHLV.MergeVersions[i] = base.HexCasToUint64(v)
-	}
-	return decodedHLV
-}
-
 // appendRevocationMacroExpansions adds macro expansions for the channel map.  Not strictly an HLV operation
 // but putting the function here as it's required when the HLV's current version is being macro expanded
 func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, channelNames []string) (updatedSpec []sgbucket.MacroExpansionSpec) {
@@ -508,7 +353,11 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 		return HybridLogicalVector{}, fmt.Errorf("invalid version in changes message received")
 	}
 
-	err := hlv.AddVersion(Version{SourceID: version[1], Value: version[0]})
+	vrs, err := strconv.ParseUint(version[0], 16, 64)
+	if err != nil {
+		return HybridLogicalVector{}, err
+	}
+	err = hlv.AddVersion(Version{SourceID: version[1], Value: vrs})
 	if err != nil {
 		return HybridLogicalVector{}, err
 	}
@@ -523,7 +372,7 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 		if err != nil {
 			return HybridLogicalVector{}, err
 		}
-		hlv.PreviousVersions = make(map[string]string)
+		hlv.PreviousVersions = make(HLVVersions)
 		for _, v := range sourceVersionListPV {
 			hlv.PreviousVersions[v.SourceID] = v.Value
 		}
@@ -531,7 +380,7 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 	case 3:
 		// cv, mv and pv present
 		sourceVersionListPV, err := parseVectorValues(vectorFields[2])
-		hlv.PreviousVersions = make(map[string]string)
+		hlv.PreviousVersions = make(HLVVersions)
 		if err != nil {
 			return HybridLogicalVector{}, err
 		}
@@ -540,7 +389,7 @@ func extractHLVFromBlipMessage(versionVectorStr string) (HybridLogicalVector, er
 		}
 
 		sourceVersionListMV, err := parseVectorValues(vectorFields[1])
-		hlv.MergeVersions = make(map[string]string)
+		hlv.MergeVersions = make(HLVVersions)
 		if err != nil {
 			return HybridLogicalVector{}, err
 		}
@@ -580,10 +429,6 @@ func EncodeSource(source string) string {
 	return base64.StdEncoding.EncodeToString([]byte(source))
 }
 
-func EncodeValue(value uint64) string {
-	return base.CasToString(value)
-}
-
 // EncodeValueStr converts a simplified number ("1") to a hex-encoded string
 func EncodeValueStr(value string) (string, error) {
 	return base.StringDecimalToLittleEndianHex(strings.TrimSpace(value))
@@ -599,4 +444,94 @@ func CreateEncodedSourceID(bucketUUID, clusterUUID string) (string, error) {
 		return "", err
 	}
 	return string(source), nil
+}
+
+func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
+	var cvCasByteArray []byte
+	var importCASBytes []byte
+	var vrsCasByteArray []byte
+	if hlv.CurrentVersionCAS != 0 {
+		cvCasByteArray = base.Uint64CASToLittleEndianHex(hlv.CurrentVersionCAS)
+	}
+	if hlv.ImportCAS != 0 {
+		importCASBytes = base.Uint64CASToLittleEndianHex(hlv.ImportCAS)
+	}
+	if hlv.Version != 0 {
+		vrsCasByteArray = base.Uint64CASToLittleEndianHex(hlv.Version)
+	}
+
+	pvPersistedFormat, err := convertMapToPersistedFormat(hlv.PreviousVersions)
+	if err != nil {
+		return nil, err
+	}
+	mvPersistedFormat, err := convertMapToPersistedFormat(hlv.MergeVersions)
+	if err != nil {
+		return nil, err
+	}
+
+	bucketVector := BucketVector{
+		CurrentVersionCAS: string(cvCasByteArray),
+		ImportCAS:         string(importCASBytes),
+		Version:           string(vrsCasByteArray),
+		SourceID:          hlv.SourceID,
+		MergeVersions:     mvPersistedFormat,
+		PreviousVersions:  pvPersistedFormat,
+	}
+
+	return base.JSONMarshal(&bucketVector)
+}
+
+func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
+	persistedJSON := BucketVector{}
+	err := base.JSONUnmarshal(inputjson, &persistedJSON)
+	if err != nil {
+		return err
+	}
+	// convert the data to in memory format
+	hlv.convertPersistedHLVToInMemoryHLV(persistedJSON)
+	return nil
+}
+
+func (hlv *HybridLogicalVector) convertPersistedHLVToInMemoryHLV(persistedJSON BucketVector) {
+	hlv.CurrentVersionCAS = base.HexCasToUint64(persistedJSON.CurrentVersionCAS)
+	if persistedJSON.ImportCAS != "" {
+		hlv.ImportCAS = base.HexCasToUint64(persistedJSON.ImportCAS)
+	}
+	hlv.SourceID = persistedJSON.SourceID
+	// convert the hex cas to uint64 cas
+	hlv.Version = base.HexCasToUint64(persistedJSON.Version)
+	// convert the maps form persisted format to the in memory format
+	hlv.PreviousVersions = convertMapToInMemoryFormat(persistedJSON.PreviousVersions)
+	hlv.MergeVersions = convertMapToInMemoryFormat(persistedJSON.MergeVersions)
+}
+
+// convertMapToPersistedFormat will convert in memory map of previous versions or merge versions into the persisted format map
+func convertMapToPersistedFormat(memoryMap map[string]uint64) (map[string]string, error) {
+	if memoryMap == nil {
+		return nil, nil
+	}
+	returnedMap := make(map[string]string)
+	var persistedCAS string
+	for source, cas := range memoryMap {
+		casByteArray := base.Uint64CASToLittleEndianHex(cas)
+		persistedCAS = string(casByteArray)
+		// remove the leading '0x' from the CAS value
+		persistedCAS = persistedCAS[2:]
+		returnedMap[source] = persistedCAS
+	}
+	return returnedMap, nil
+}
+
+// convertMapToInMemoryFormat will convert the persisted format map to an in memory format of that map.
+// Used for previous versions and merge versions maps on HLV
+func convertMapToInMemoryFormat(persistedMap map[string]string) map[string]uint64 {
+	if persistedMap == nil {
+		return nil
+	}
+	returnedMap := make(map[string]uint64)
+	// convert each CAS entry from little endian hex to Uint64
+	for key, value := range persistedMap {
+		returnedMap[key] = base.HexCasToUint64(value)
+	}
+	return returnedMap
 }

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -240,8 +240,8 @@ func TestMigrateMetadataWithHLV(t *testing.T) {
 	assert.NoError(t, err, "Error unmarshalling body")
 
 	hlv := &HybridLogicalVector{}
-	require.NoError(t, hlv.AddVersion(CreateVersion("source123", base.CasToString(100))))
-	hlv.CurrentVersionCAS = base.CasToString(100)
+	require.NoError(t, hlv.AddVersion(CreateVersion("source123", 100)))
+	hlv.CurrentVersionCAS = 100
 	hlvBytes := base.MustJSONMarshal(t, hlv)
 	xattrBytes := map[string][]byte{
 		base.VvXattrName: hlvBytes,

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -333,7 +333,7 @@ type IDAndRev struct {
 
 type IDandCV struct {
 	DocID        string
-	Version      string
+	Version      uint64
 	Source       string
 	CollectionID uint32
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -53,7 +53,7 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 
 	doc.HLV = &HybridLogicalVector{
 		SourceID: "test",
-		Version:  "123",
+		Version:  123,
 	}
 	_, _, err = doc.updateChannels(ctx, base.SetOf("*"))
 	if err != nil {
@@ -125,7 +125,8 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
+		vrs := uint64(docID)
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 	}
 
 	// Get them back out
@@ -142,7 +143,8 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 	// Add 3 more docs to the now full revcache
 	for i := 10; i < 13; i++ {
 		docID := strconv.Itoa(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: docID, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
+		vrs := uint64(i)
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 	}
 
 	// Check that the first 3 docs were evicted
@@ -186,7 +188,8 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Fill up the rev cache with the first 10 docs
 	for docID := 0; docID < 10; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
+		vrs := uint64(docID)
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 	}
 
 	// assert that the list has 10 elements along with both lookup maps
@@ -197,7 +200,8 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	// Add 3 more docs to the now full rev cache to trigger eviction
 	for docID := 10; docID < 13; docID++ {
 		id := strconv.Itoa(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: id, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
+		vrs := uint64(docID)
+		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 	}
 	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
 	assert.Equal(t, 10, len(cache.hlvCache))
@@ -208,7 +212,8 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 	prevCacheHitCount := cacheHitCounter.Value()
 	for i := 0; i < 10; i++ {
 		id := strconv.Itoa(i + 3)
-		cv := Version{Value: id, SourceID: "test"}
+		vrs := uint64(i + 3)
+		cv := Version{Value: vrs, SourceID: "test"}
 		docRev, err := cache.GetWithCV(ctx, id, &cv, testCollectionID, RevCacheOmitDelta)
 
 		assert.NoError(t, err)
@@ -290,13 +295,13 @@ func TestBackingStoreCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	cv := Version{SourceID: "test", Value: "123"}
+	cv := Version{SourceID: "test", Value: 123}
 	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, "123", docRev.CV.Value)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
@@ -307,14 +312,14 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, "123", docRev.CV.Value)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, int64(1), getDocumentCounter.Value())
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	cv = Version{SourceID: "test11", Value: "100"}
+	cv = Version{SourceID: "test11", Value: 100}
 	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta)
 
 	assertHTTPError(t, err, 404)
@@ -581,7 +586,7 @@ func TestSingleLoad(t *testing.T) {
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
 	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: "123", SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
 
 	assert.NoError(t, err)
@@ -593,7 +598,7 @@ func TestConcurrentLoad(t *testing.T) {
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
 	cache := NewLRURevisionCache(10, backingStoreMap, &cacheHitCounter, &cacheMissCounter)
 
-	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: "1234", SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
+	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: 1234, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 
 	// Trigger load into cache
 	var wg sync.WaitGroup
@@ -769,7 +774,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cache := NewLRURevisionCache(10, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), &cacheHitCounter, &cacheMissCounter)
 
-	cv := Version{SourceID: "test", Value: "123"}
+	cv := Version{SourceID: "test", Value: 123}
 	documentRevision := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -785,7 +790,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, "123", docRev.CV.Value)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
@@ -798,7 +803,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
 	assert.Equal(t, "test", docRev.CV.SourceID)
-	assert.Equal(t, "123", docRev.CV.Value)
+	assert.Equal(t, uint64(123), docRev.CV.Value)
 	assert.Equal(t, []byte(`{"test":"12345"}`), docRev.BodyBytes)
 	assert.Equal(t, int64(2), cacheHitCounter.Value())
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
@@ -843,7 +848,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	cache := NewLRURevisionCache(10, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), &cacheHitCounter, &cacheMissCounter)
 
 	// create cv with incorrect version to the one stored in backing store
-	cv := Version{SourceID: "test", Value: "1234"}
+	cv := Version{SourceID: "test", Value: 1234}
 
 	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta)
 	require.Error(t, err)
@@ -873,7 +878,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := Version{SourceID: "test", Value: "123"}
+	cv := Version{SourceID: "test", Value: 123}
 	go func() {
 		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 		require.NoError(t, err)
@@ -889,7 +894,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	wg.Wait()
 
 	revElement := cache.cache[IDAndRev{RevID: "1-abc", DocID: "doc1"}]
-	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: "123"}]
+	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123}]
 	assert.Equal(t, 1, cache.lruList.Len())
 	assert.Equal(t, 1, len(cache.cache))
 	assert.Equal(t, 1, len(cache.hlvCache))
@@ -910,11 +915,10 @@ func TestGetActive(t *testing.T) {
 
 	rev1id, doc, err := collection.Put(ctx, "doc", Body{"val": 123})
 	require.NoError(t, err)
-	syncCAS := string(base.Uint64CASToLittleEndianHex(doc.Cas))
 
 	expectedCV := Version{
 		SourceID: db.EncodedSourceID,
-		Value:    syncCAS,
+		Value:    doc.Cas,
 	}
 
 	// remove the entry form the rev cache to force the cache to not have the active version in it
@@ -940,7 +944,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	cv := Version{SourceID: "test", Value: "123"}
+	cv := Version{SourceID: "test", Value: 123}
 	docRev := DocumentRevision{
 		DocID:     "doc1",
 		RevID:     "1-abc",
@@ -964,7 +968,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	wg.Wait()
 
 	revElement := cache.cache[IDAndRev{RevID: "1-abc", DocID: "doc1"}]
-	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: "123"}]
+	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123}]
 
 	assert.Equal(t, 1, cache.lruList.Len())
 	assert.Equal(t, 1, len(cache.cache))

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -854,7 +854,7 @@ func createTestDocument(docID string, revID string, body Body, deleted bool, exp
 }
 
 // requireCurrentVersion fetches the document by key, and validates that cv matches.
-func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, source string, version string) {
+func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, source string, version uint64) {
 	ctx := base.TestCtx(t)
 	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)
@@ -869,12 +869,12 @@ func (c *DatabaseCollection) RequireCurrentVersion(t *testing.T, key string, sou
 }
 
 // GetDocumentCurrentVersion fetches the document by key and returns the current version
-func (c *DatabaseCollection) GetDocumentCurrentVersion(t testing.TB, key string) (source string, version string) {
+func (c *DatabaseCollection) GetDocumentCurrentVersion(t testing.TB, key string) (source string, version uint64) {
 	ctx := base.TestCtx(t)
 	doc, err := c.GetDocument(ctx, key, DocUnmarshalSync)
 	require.NoError(t, err)
 	if doc.HLV == nil {
-		return "", ""
+		return "", 0
 	}
 	return doc.HLV.SourceID, doc.HLV.Version
 }

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -44,9 +45,9 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 // a different, non-SGW HLV-aware peer)
 func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64) {
 	hlv := &HybridLogicalVector{}
-	err := hlv.AddVersion(CreateVersion(h.Source, hlvExpandMacroCASValue))
+	err := hlv.AddVersion(CreateVersion(h.Source, expandMacroCASValueUint64))
 	require.NoError(h.t, err)
-	hlv.CurrentVersionCAS = hlvExpandMacroCASValue
+	hlv.CurrentVersionCAS = expandMacroCASValueUint64
 
 	vvDataBytes := base.MustJSONMarshal(h.t, hlv)
 	mutateInOpts := &sgbucket.MutateInOptions{
@@ -64,16 +65,20 @@ func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64
 }
 
 // EncodeTestVersion converts a simplified string version of the form 1@abc to a hex-encoded version and base64 encoded
-// source, like 0x0100000000000000@YWJj.  Allows use of simplified versions in tests for readability, ease of use.
+// source, like 169a05acd705ffc0@YWJj.  Allows use of simplified versions in tests for readability, ease of use.
 func EncodeTestVersion(versionString string) (encodedString string) {
 	timestampString, source, found := strings.Cut(versionString, "@")
 	if !found {
 		return versionString
 	}
-	hexTimestamp, err := EncodeValueStr(timestampString)
-	if err != nil {
-		panic(fmt.Sprintf("unable to encode timestampString %v", timestampString))
+	if len(timestampString) > 0 && timestampString[0] == ' ' {
+		timestampString = timestampString[1:]
 	}
+	timestampUint, err := strconv.ParseUint(timestampString, 10, 64)
+	if err != nil {
+		return ""
+	}
+	hexTimestamp := fmt.Sprintf("%x", timestampUint)
 	base64Source := EncodeSource(source)
 	return hexTimestamp + "@" + base64Source
 }
@@ -106,11 +111,11 @@ func EncodeTestHistory(historyString string) (encodedString string) {
 
 // ParseTestHistory takes a string test history in the form 1@abc,2@def;3@ghi,4@jkl and formats this
 // as pv and mv maps keyed by encoded source, with encoded values
-func ParseTestHistory(t *testing.T, historyString string) (pv map[string]string, mv map[string]string) {
+func ParseTestHistory(t *testing.T, historyString string) (pv HLVVersions, mv HLVVersions) {
 	versionSets := strings.Split(historyString, ";")
 
-	pv = make(map[string]string)
-	mv = make(map[string]string)
+	pv = make(HLVVersions)
+	mv = make(HLVVersions)
 
 	var pvString, mvString string
 	switch len(versionSets) {
@@ -127,9 +132,7 @@ func ParseTestHistory(t *testing.T, historyString string) (pv map[string]string,
 	for _, versionStr := range strings.Split(pvString, ",") {
 		version, err := ParseVersion(versionStr)
 		require.NoError(t, err)
-		encodedValue, err := EncodeValueStr(version.Value)
-		require.NoError(t, err)
-		pv[EncodeSource(version.SourceID)] = encodedValue
+		pv[EncodeSource(version.SourceID)] = version.Value
 	}
 
 	// mv
@@ -137,9 +140,7 @@ func ParseTestHistory(t *testing.T, historyString string) (pv map[string]string,
 		for _, versionStr := range strings.Split(mvString, ",") {
 			version, err := ParseVersion(versionStr)
 			require.NoError(t, err)
-			encodedValue, err := EncodeValueStr(version.Value)
-			require.NoError(t, err)
-			mv[EncodeSource(version.SourceID)] = encodedValue
+			mv[EncodeSource(version.SourceID)] = version.Value
 		}
 	}
 	return pv, mv
@@ -150,7 +151,5 @@ func RequireCVEqual(t *testing.T, hlv *HybridLogicalVector, expectedCV string) {
 	testVersion, err := ParseVersion(expectedCV)
 	require.NoError(t, err)
 	require.Equal(t, EncodeSource(testVersion.SourceID), hlv.SourceID)
-	encodedValue, err := EncodeValueStr(testVersion.Value)
-	require.NoError(t, err)
-	require.Equal(t, encodedValue, hlv.Version)
+	require.Equal(t, testVersion.Value, hlv.Version)
 }

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -78,7 +77,7 @@ func EncodeTestVersion(versionString string) (encodedString string) {
 	if err != nil {
 		return ""
 	}
-	hexTimestamp := fmt.Sprintf("%x", timestampUint)
+	hexTimestamp := strconv.FormatUint(timestampUint, 16)
 	base64Source := EncodeSource(source)
 	return hexTimestamp + "@" + base64Source
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2819,8 +2819,8 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
-	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.Version)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.CurrentVersionCAS)
 
 	// Put a new revision of this doc and assert that the version vector SourceID and Version is updated
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, `{"key1": "value1"}`)
@@ -2830,8 +2830,8 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
-	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.Version)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.CurrentVersionCAS)
 
 	// Delete doc and assert that the version vector SourceID and Version is updated
 	resp = rt.SendAdminRequest(http.MethodDelete, "/{{.keyspace}}/doc1?rev="+syncData.CurrentRev, "")
@@ -2841,8 +2841,8 @@ func TestPutDocUpdateVersionVector(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
-	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.Version)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.CurrentVersionCAS)
 }
 
 // TestHLVOnPutWithImportRejection:
@@ -2871,8 +2871,8 @@ func TestHLVOnPutWithImportRejection(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
-	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.Version)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.CurrentVersionCAS)
 
 	// Put a doc that will be rejected by the import filter on the attempt to perform on demand import for write
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{"type": "not-mobile"}`)
@@ -2883,8 +2883,8 @@ func TestHLVOnPutWithImportRejection(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, bucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
-	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.Version)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.CurrentVersionCAS)
 }
 
 func TestTombstoneCompactionAPI(t *testing.T) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1752,7 +1752,7 @@ func TestPutRevV4(t *testing.T) {
 	require.NoError(t, err)
 	pv, _ := db.ParseTestHistory(t, history)
 	db.RequireCVEqual(t, doc.HLV, "3@efg")
-	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.Equal(t, doc.Cas, doc.HLV.CurrentVersionCAS)
 	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
 
 	// 2. Update the document with a non-conflicting revision, where only cv is updated
@@ -1765,7 +1765,7 @@ func TestPutRevV4(t *testing.T) {
 	doc, _, err = collection.GetDocWithXattrs(base.TestCtx(t), docID, db.DocUnmarshalNoHistory)
 	require.NoError(t, err)
 	db.RequireCVEqual(t, doc.HLV, "4@efg")
-	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.Equal(t, doc.Cas, doc.HLV.CurrentVersionCAS)
 	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
 
 	// 3. Update the document again with a non-conflicting revision from a different source (previous cv moved to pv)
@@ -1780,7 +1780,7 @@ func TestPutRevV4(t *testing.T) {
 	require.NoError(t, err)
 	pv, _ = db.ParseTestHistory(t, updatedHistory)
 	db.RequireCVEqual(t, doc.HLV, "1@jkl")
-	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.Equal(t, doc.Cas, doc.HLV.CurrentVersionCAS)
 	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
 
 	// 4. Update the document again with a non-conflicting revision from a different source, and additional sources in history (previous cv moved to pv, and pv expanded)
@@ -1795,7 +1795,7 @@ func TestPutRevV4(t *testing.T) {
 	require.NoError(t, err)
 	pv, _ = db.ParseTestHistory(t, updatedHistory)
 	db.RequireCVEqual(t, doc.HLV, "1@nnn")
-	assert.Equal(t, db.EncodeValue(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.Equal(t, doc.Cas, doc.HLV.CurrentVersionCAS)
 	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
 
 	// 5. Attempt to update the document again with a conflicting revision from a different source (previous cv not in pv), expect conflict
@@ -1818,7 +1818,7 @@ func TestPutRevV4(t *testing.T) {
 
 	pv, mv := db.ParseTestHistory(t, mvHistory)
 	db.RequireCVEqual(t, doc.HLV, "3@efg")
-	assert.Equal(t, base.CasToString(doc.Cas), doc.HLV.CurrentVersionCAS)
+	assert.Equal(t, doc.Cas, doc.HLV.CurrentVersionCAS)
 	assert.True(t, reflect.DeepEqual(pv, doc.HLV.PreviousVersions))
 	assert.True(t, reflect.DeepEqual(mv, doc.HLV.MergeVersions))
 }
@@ -2185,7 +2185,7 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 			RevTreeID: bucketDoc.CurrentRev,
 			CV: db.Version{
 				SourceID: hlvHelper.Source,
-				Value:    string(base.Uint64CASToLittleEndianHex(cas)),
+				Value:    cas,
 			},
 		}
 
@@ -3315,4 +3315,26 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestPutRevBlip(t *testing.T) {
+	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{GuestEnabled: true, blipProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()}})
+	require.NoError(t, err, "Error creating BlipTester")
+	defer bt.Close()
+
+	_, _, _, err = bt.SendRev(
+		"foo",
+		"2@stZPWD8vS/O3nsx9yb2Brw",
+		[]byte(`{"key": "val"}`),
+		blip.Properties{},
+	)
+	require.NoError(t, err)
+
+	_, _, _, err = bt.SendRev(
+		"foo",
+		"fa1@stZPWD8vS/O3nsx9yb2Brw",
+		[]byte(`{"key": "val2"}`),
+		blip.Properties{},
+	)
+	require.NoError(t, err)
 }

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -816,7 +816,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	expectedResults = []string{
 		`{"seq":"8:2","id":"hbo-1","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":8,"id":"grant-1","changes":[{"rev":"1-c5098bb14d12d647c901850ff6a6292a"}]}`,
-		fmt.Sprintf(`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}], "current_version":{"source_id": "%s", "version": "%s"}}`, mixSource, mixVersion),
+		fmt.Sprintf(`{"seq":9,"id":"mix-1","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}], "current_version":{"source_id": "%s", "version": "%d"}}`, mixSource, mixVersion),
 	}
 
 	rt.Run("grant via existing channel", func(t *testing.T) {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8582,8 +8582,8 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, activeBucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
-	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.Version)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.CurrentVersionCAS)
 
 	// create the replication to push the doc to the passive node and wait for the doc to be replicated
 	activeRT.CreateReplication(rep, remoteURL, db.ActiveReplicatorTypePush, nil, false, db.ConflictResolverDefault)
@@ -8597,6 +8597,6 @@ func TestReplicatorUpdateHLVOnPut(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, passiveBucketUUID, syncData.HLV.SourceID)
-	assert.Equal(t, syncData.Cas, syncData.HLV.CurrentVersionCAS)
-	assert.Equal(t, syncData.Cas, syncData.HLV.Version)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.CurrentVersionCAS)
+	assert.Equal(t, base.HexCasToUint64(syncData.Cas), syncData.HLV.Version)
 }

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -966,11 +966,11 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev strin
 		//  - revisionHistory is just previous cv (parentRev) for changes response
 		startValue := uint64(0)
 		if parentRev != "" {
-			parentVersion, _ := db.ParseDecodedVersion(parentRev)
+			parentVersion, _ := db.ParseVersion(parentRev)
 			startValue = parentVersion.Value
 			revisionHistory = append(revisionHistory, parentRev)
 		}
-		newVersion := db.DecodedVersion{SourceID: btc.parent.SourceID, Value: startValue + uint64(revCount)}
+		newVersion := db.Version{SourceID: btc.parent.SourceID, Value: startValue + uint64(revCount)}
 		newRevID = newVersion.String()
 
 	} else {

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -970,7 +970,7 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID, parentRev strin
 			startValue = parentVersion.Value
 			revisionHistory = append(revisionHistory, parentRev)
 		}
-		newVersion := db.Version{SourceID: btc.parent.SourceID, Value: startValue + uint64(revCount)}
+		newVersion := db.Version{SourceID: db.EncodeSource(btc.parent.SourceID), Value: startValue + uint64(revCount)}
 		newRevID = newVersion.String()
 
 	} else {

--- a/xdcr/rosmar_xdcr.go
+++ b/xdcr/rosmar_xdcr.go
@@ -222,10 +222,9 @@ func opWithMeta(ctx context.Context, collection *rosmar.Collection, sourceID str
 	// TODO: clear _mou when appropriate CBG-4251
 
 	// update new cv with new source/cas
-	casBytes := string(base.Uint64CASToLittleEndianHex(event.Cas))
 	vv.SourceID = sourceID
-	vv.CurrentVersionCAS = casBytes
-	vv.Version = casBytes
+	vv.CurrentVersionCAS = event.Cas
+	vv.Version = event.Cas
 
 	var err error
 	xattrs[base.VvXattrName], err = json.Marshal(vv)

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -321,12 +321,11 @@ func requireWaitForXDCRDocsProcessed(t *testing.T, xdcr Manager, expectedDocsPro
 
 // requireCV requires tests that a given hlv from server has a sourceID and cas matching the version. This is strict and will fail if _pv is populated (TODO: CBG-4250).
 func requireCV(t *testing.T, vvBytes []byte, sourceID string, cas uint64) {
-	casString := string(base.Uint64CASToLittleEndianHex(cas))
 	var vv *db.HybridLogicalVector
 	require.NoError(t, base.JSONUnmarshal(vvBytes, &vv))
 	require.Equal(t, &db.HybridLogicalVector{
-		CurrentVersionCAS: casString,
+		CurrentVersionCAS: cas,
 		SourceID:          sourceID,
-		Version:           casString,
+		Version:           cas,
 	}, vv)
 }


### PR DESCRIPTION
CBG-4247

- Change in memory format for cas from string to uint64
- Remove decoded hlv 
- Updated logging in conflict check 
- removed any unused code I saw 
- Change blip format to encode version to hex encoding
- Json unmarshal/marshal functions. These may well be optimised in the delatas PR 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2734/ (test flake)
