### PR TITLE
CBG-4277: Remove unused totalBytesForHistory from getHistory

### DIFF
--- a/db/revtree.go
+++ b/db/revtree.go
@@ -724,15 +724,12 @@ func (tree RevTree) RenderGraphvizDot() string {
 func (tree RevTree) getHistory(revid string) ([]string, error) {
 	maxHistory := len(tree)
 
-	var totalBytesForHistory int
 	history := make([]string, 0, 5)
 	for revid != "" {
 		info, err := tree.getInfo(revid)
 		if err != nil {
 			break
 		}
-		revBytes := len([]byte(revid))
-		totalBytesForHistory += revBytes
 		history = append(history, revid)
 		if len(history) > maxHistory {
 			return history, fmt.Errorf("getHistory found cycle in revision tree, history calculated as: %v", history)


### PR DESCRIPTION
CBG-4277

- This was missed on earlier implementation of memory based rev cache

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
