### PR TITLE
Require CBS 7.6 to support anemone

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -137,6 +137,15 @@ func NewTestBucketPoolWithOptions(ctx context.Context, bucketReadierFunc TBPBuck
 	}
 	tbp.skipMobileXDCR = !useMobileXDCR
 
+	// at least anemone release
+	if os.Getenv(tbpEnvAllowIncompatibleServerVersion) == "" && !ProductVersion.Less(&ComparableBuildVersion{major: 4}) {
+		overrideMsg := "Set " + tbpEnvAllowIncompatibleServerVersion + "=true to override this check."
+		// this check also covers BucketStoreFeatureMultiXattrSubdocOperations, which is Couchbase Server 7.6
+		if tbp.skipMobileXDCR {
+			tbp.Fatalf(ctx, "Sync Gateway %v requires mobile XDCR support, but Couchbase Server %v does not support it. Couchbase Server %s is required. %s", ProductVersion, tbp.cluster.version, firstServerVersionToSupportMobileXDCR, overrideMsg)
+		}
+	}
+
 	tbp.verbose.Set(tbpVerbose())
 
 	// Start up an async readier worker to process dirty buckets
@@ -450,6 +459,7 @@ func (tbp *TestBucketPool) setXDCRBucketSetting(ctx context.Context, bucket Buck
 
 	tbp.Logf(ctx, "Setting crossClusterVersioningEnabled=true")
 
+	// retry for 1 minute to get this bucket setting, MB-63675
 	store, ok := AsCouchbaseBucketStore(bucket)
 	if !ok {
 		tbp.Fatalf(ctx, "unable to get server management endpoints. Underlying bucket type was not GoCBBucket")
@@ -459,12 +469,20 @@ func (tbp *TestBucketPool) setXDCRBucketSetting(ctx context.Context, bucket Buck
 	posts.Add("enableCrossClusterVersioning", "true")
 
 	url := fmt.Sprintf("/pools/default/buckets/%s", store.GetName())
-	output, statusCode, err := store.MgmtRequest(ctx, http.MethodPost, url, "application/x-www-form-urlencoded", strings.NewReader(posts.Encode()))
+	// retry for 1 minute to get this bucket setting, MB-63675
+	_, err := RetryLoop(ctx, "setXDCRBucketSetting", func() (bool, error, interface{}) {
+		output, statusCode, err := store.MgmtRequest(ctx, http.MethodPost, url, "application/x-www-form-urlencoded", strings.NewReader(posts.Encode()))
+		if err != nil {
+			tbp.Fatalf(ctx, "request to mobile XDCR bucket setting failed, status code: %d error: %w output: %s", statusCode, err, string(output))
+		}
+		if statusCode != http.StatusOK {
+			err := fmt.Errorf("request to mobile XDCR bucket setting failed with status code, %d, output: %s", statusCode, string(output))
+			return true, err, nil
+		}
+		return false, nil, nil
+	}, CreateMaxDoublingSleeperFunc(200, 500, 500))
 	if err != nil {
-		tbp.Fatalf(ctx, "request to mobile XDCR bucket setting failed, status code: %d error: %v output: %s", statusCode, err, string(output))
-	}
-	if statusCode != http.StatusOK {
-		tbp.Fatalf(ctx, "request to mobile XDCR bucket setting failed with status code, %d, output: %s", statusCode, string(output))
+		tbp.Fatalf(ctx, "Couldn't set crossClusterVersioningEnabled: %v", err)
 	}
 }
 

--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -53,6 +53,9 @@ const (
 
 	tbpEnvUseDefaultCollection = "SG_TEST_USE_DEFAULT_COLLECTION"
 
+	// tbpEnvAllowIncompatibleServerVersion allows tests to run against a server version that is not presumed compatible with version of Couchbase Server running.
+	tbpEnvAllowIncompatibleServerVersion = "SG_TEST_SKIP_SERVER_VERSION_CHECK"
+
 	// wait this long when requesting a test bucket from the pool before giving up and failing the test.
 	waitForReadyBucketTimeout = time.Minute
 

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -11,6 +11,7 @@ package base
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -18,11 +19,14 @@ import (
 )
 
 // firstServerVersionToSupportMobileXDCR this is the first server version to support Mobile XDCR feature
-var firstServerVersionToSupportMobileXDCR = &ComparableBuildVersion{
-	epoch: 0,
-	major: 7,
-	minor: 6,
-	patch: 2,
+var firstServerVersionToSupportMobileXDCR *ComparableBuildVersion
+
+func init() {
+	var err error
+	firstServerVersionToSupportMobileXDCR, err = NewComparableBuildVersionFromString("7.6.3")
+	if err != nil {
+		log.Fatalf("Couldn't parse firstServerVersionToSupportMobileXDCR: %v", err)
+	}
 }
 
 type clusterLogFunc func(ctx context.Context, format string, args ...interface{})

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -23,7 +23,7 @@ var firstServerVersionToSupportMobileXDCR *ComparableBuildVersion
 
 func init() {
 	var err error
-	firstServerVersionToSupportMobileXDCR, err = NewComparableBuildVersionFromString("7.6.3")
+	firstServerVersionToSupportMobileXDCR, err = NewComparableBuildVersionFromString("7.6.4@5004")
 	if err != nil {
 		log.Fatalf("Couldn't parse firstServerVersionToSupportMobileXDCR: %v", err)
 	}
@@ -220,9 +220,13 @@ func (c *tbpCluster) mobileXDCRCompatible(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	// take server version, server version will be the first 5 character of version string
-	// in the form of x.x.x
-	vrs := c.version[:5]
+	// string is x.y.z-aaaa-enterprise or x.y.z-aaaa-community
+	// convert to a comparable string that Sync Gateway understands x.y.z@aaaa
+	components := strings.Split(c.version, "-")
+	vrs := components[0]
+	if len(components) > 1 {
+		vrs += "@" + components[1]
+	}
 
 	// convert the above string into a comparable string
 	version, err := NewComparableBuildVersionFromString(vrs)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -211,7 +211,7 @@ func TestUseXattrs() bool {
 		panic(fmt.Sprintf("unable to parse %q value %q: %v", TestEnvSyncGatewayUseXattrs, useXattrs, err))
 	}
 	if !val {
-		panic("sync gateway requires xattrs to be enabled")
+		panic(fmt.Sprintf("sync gateway %s requires xattrs to be enabled, remove env var %s=%s", ProductVersion, TestEnvSyncGatewayUseXattrs, useXattrs))
 	}
 
 	return val


### PR DESCRIPTION
This forces the requirement so that you do not forget. `SG_TEST_SKIP_SERVER_VERSION_CHECK` can override it and the error message should tell you what to do.

Also creates a retry loop for setting crossVectorVersioning on a bucket, MB-63675 to make the test harness more robust.

The actual minimum version was increased to https://jira.issues.couchbase.com/browse/MB-62290, which is actually only in 5004 since 7.6.2-MP3 became 7.6.3. 

This version will be increased again _pv support when https://jira.issues.couchbase.com/browse/MB-63303 is merged. Pre-release builds are available in docker and can be used in jenkins. Instructions are on the `COUCHBASE_SERVER_VERSION` in the jenkins page, and in Sync Gateway Dev docs.