### PR TITLE
Fix version numbers for 3.2 openapi documentation

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1201,6 +1201,16 @@ Database:
       additionalProperties:
         x-additionalPropertiesName: scopename
         $ref: '#/Scopes'
+      maxProperties: 1
+      example:
+        scopename:
+          collections:
+            collectionname1:
+              sync: 'function(doc){channel("collection name");}'
+              import_filter: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
+            collectionname2:
+              sync: 'function(doc){channel("collection name");}'
+              import_filter: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
     name:
       description: The name of the database.
       type: string

--- a/docs/api/diagnostic.yaml
+++ b/docs/api/diagnostic.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric-capella.yaml
+++ b/docs/api/metric-capella.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: App Services Metrics API
   description: 'App Services manages access and synchronization between Couchbase Lite and Couchbase Capella'
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -10,7 +10,7 @@ openapi: 3.0.3
 info:
   title: Sync Gateway
   description: Sync Gateway manages access and synchronization between Couchbase Lite and Couchbase Server
-  version: 3.3.0
+  version: '3.2'
   license:
     name: Business Source License 1.1 (BSL)
     url: 'https://github.com/couchbase/sync_gateway/blob/master/LICENSE'


### PR DESCRIPTION
I'm not sure how these never got updated even though initial 3.2 docs were deployed to capella correctly. I think this must have been on a private branch and I didn't correctly do https://github.com/couchbase/sync_gateway/pull/7090 correctly.

Pulled in https://github.com/couchbase/sync_gateway/commit/8aa0c899a0c40c62efaffcfd823b3af292cc055d after doing a `git diff origin/main docs` which seems useful.