### PR TITLE
[3.2.1 Backport] CBG-4243: Create SG log files on startup with 0644 permission bits set

### DIFF
--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -248,7 +248,12 @@ func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name stri
 
 	var rotationDoneChan chan struct{}
 	if lfc.Output == nil {
-		rotationDoneChan = lfc.initLumberjack(ctx, name, filepath.Join(filepath.FromSlash(logFilePath), logFilePrefix+name+".log"))
+		logFileName := logFilePrefix + name + ".log"
+		logFileOutput := filepath.Join(filepath.FromSlash(logFilePath), logFileName)
+		if err := validateLogFileOutput(logFileOutput); err != nil {
+			return nil, err
+		}
+		rotationDoneChan = lfc.initLumberjack(ctx, name, logFileOutput)
 	}
 
 	if lfc.CollationBufferSize == nil {


### PR DESCRIPTION
CBG-4243

Clean cherry pick to backport #7128 to 3.2.1

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
