### PR TITLE
CBG-4271: re enable attachment tests for v4 protocol

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2254,7 +2254,7 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 }
 
 // TestUpdateViaBlipMigrateAttachment:
-//   - Tests document update through blip to a doc with attachment metadata deined in sync data
+//   - Tests document update through blip to a doc with attachment metadata defined in sync data
 //   - Assert that the c doc update this way will migrate the attachment metadata from sync data to global sync data
 func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
 	rtConfig := &RestTesterConfig{
@@ -2262,7 +2262,6 @@ func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
 	const (
 		doc1ID = "doc1"
 	)
@@ -2276,7 +2275,7 @@ func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
 		ds := rt.GetSingleDataStore()
 		ctx := base.TestCtx(t)
 
-		initialVersion := btc.rt.PutDoc(doc1ID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		initialVersion := btc.rt.PutDocDirectly(doc1ID, JsonToMap(t, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`))
 		btc.rt.WaitForPendingChanges()
 		btcRunner.StartOneshotPull(btc.id)
 		btcRunner.WaitForVersion(btc.id, doc1ID, initialVersion)
@@ -2438,8 +2437,6 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // CBG-4166
-
 	const docID = "doc"
 
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
@@ -2450,7 +2447,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
 		defer btc.Close()
 		// Push an initial rev with attachment data
-		initialVersion := btc.rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		initialVersion := btc.rt.PutDocDirectly(docID, JsonToMap(t, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`))
 		btc.rt.WaitForPendingChanges()
 
 		// Replicate data to client and ensure doc arrives
@@ -2480,8 +2477,6 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // CBG-4166
-
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
@@ -2492,7 +2487,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		// Create rev 1 with the hello.txt attachment
 		const docID = "doc"
 
-		version := btc.rt.PutDoc(docID, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
+		version := btc.rt.PutDocDirectly(docID, JsonToMap(t, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`))
 		btc.rt.WaitForPendingChanges()
 
 		// Pull rev and attachment down to client
@@ -2661,7 +2656,6 @@ func TestCBLRevposHandling(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // CBG-4166
 	const (
 		doc1ID = "doc1"
 		doc2ID = "doc2"
@@ -2675,8 +2669,8 @@ func TestCBLRevposHandling(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
 		defer btc.Close()
 
-		doc1Version := btc.rt.PutDoc(doc1ID, `{}`)
-		doc2Version := btc.rt.PutDoc(doc2ID, `{}`)
+		doc1Version := btc.rt.PutDocDirectly(doc1ID, JsonToMap(t, `{}`))
+		doc2Version := btc.rt.PutDocDirectly(doc2ID, JsonToMap(t, `{}`))
 		btc.rt.WaitForPendingChanges()
 
 		btc.rt.WaitForPendingChanges()

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2275,7 +2275,7 @@ func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
 		ds := rt.GetSingleDataStore()
 		ctx := base.TestCtx(t)
 
-		initialVersion := btc.rt.PutDocDirectly(doc1ID, JsonToMap(t, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`))
+		initialVersion := btc.rt.PutDocWithAttachment(doc1ID, "{}", "hello.txt", "aGVsbG8gd29ybGQ=")
 		btc.rt.WaitForPendingChanges()
 		btcRunner.StartOneshotPull(btc.id)
 		btcRunner.WaitForVersion(btc.id, doc1ID, initialVersion)
@@ -2669,9 +2669,9 @@ func TestCBLRevposHandling(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
 		defer btc.Close()
 
-		doc1Version := btc.rt.PutDocDirectly(doc1ID, JsonToMap(t, `{}`))
-		doc2Version := btc.rt.PutDocDirectly(doc2ID, JsonToMap(t, `{}`))
-		btc.rt.WaitForPendingChanges()
+		startingBody := db.Body{"foo": "bar"}
+		doc1Version := btc.rt.PutDocDirectly(doc1ID, startingBody)
+		doc2Version := btc.rt.PutDocDirectly(doc2ID, startingBody)
 
 		btc.rt.WaitForPendingChanges()
 		btcRunner.StartOneshotPull(btc.id)

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2447,7 +2447,7 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
 		defer btc.Close()
 		// Push an initial rev with attachment data
-		initialVersion := btc.rt.PutDocDirectly(docID, JsonToMap(t, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`))
+		initialVersion := btc.rt.PutDocWithAttachment(docID, "{}", "hello.txt", "aGVsbG8gd29ybGQ=")
 		btc.rt.WaitForPendingChanges()
 
 		// Replicate data to client and ensure doc arrives
@@ -2487,7 +2487,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		// Create rev 1 with the hello.txt attachment
 		const docID = "doc"
 
-		version := btc.rt.PutDocDirectly(docID, JsonToMap(t, `{"val": "val", "_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`))
+		version := btc.rt.PutDocWithAttachment(docID, `{"val": "val"}`, "hello.txt", "aGVsbG8gd29ybGQ=")
 		btc.rt.WaitForPendingChanges()
 
 		// Pull rev and attachment down to client

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1462,7 +1462,6 @@ func createAuditLoggingRestTester(t *testing.T) *RestTester {
 
 func TestAuditBlipCRUD(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // attachments not yet replicated in V4 protocol
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 
 		rt := createAuditLoggingRestTester(t)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2859,10 +2859,3 @@ func SafeDatabaseName(t *testing.T, name string) string {
 	}
 	return dbName
 }
-
-func JsonToMap(t *testing.T, jsonStr string) map[string]interface{} {
-	result := make(map[string]interface{})
-	err := json.Unmarshal([]byte(jsonStr), &result)
-	require.NoError(t, err)
-	return result
-}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2859,3 +2859,10 @@ func SafeDatabaseName(t *testing.T, name string) string {
 	}
 	return dbName
 }
+
+func JsonToMap(t *testing.T, jsonStr string) map[string]interface{} {
+	result := make(map[string]interface{})
+	err := json.Unmarshal([]byte(jsonStr), &result)
+	require.NoError(t, err)
+	return result
+}

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -449,3 +449,17 @@ func (rt *RestTester) PutDocDirectlyInCollection(collection *db.DatabaseCollecti
 	require.NoError(rt.TB(), err)
 	return DocVersion{RevTreeID: rev, CV: db.Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version}}
 }
+
+// PutDocWithAttachment will upsert the document with a given contents and attachments.
+func (rt *RestTester) PutDocWithAttachment(docID string, body string, attachmentName, attachmentBody string) DocVersion {
+	// create new body with a 1.x style inline attachment body like `{"_attachments": {"camera.txt": {"data": "Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`.
+	require.NotEmpty(rt.TB(), attachmentName)
+	require.NotEmpty(rt.TB(), attachmentBody)
+	var rawBody db.Body
+	require.NoError(rt.TB(), base.JSONUnmarshal([]byte(body), &rawBody))
+	require.NotContains(rt.TB(), rawBody, db.BodyAttachments)
+	rawBody[db.BodyAttachments] = map[string]any{
+		attachmentName: map[string]any{"data": attachmentBody},
+	}
+	return rt.PutDocDirectly(docID, rawBody)
+}


### PR DESCRIPTION
CBG-4271

- simple PR to re enable attachment tests and use helper methods to return cv version where necessary 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2737/
