### PR TITLE
[3.2.1 Backport] CBG-4179 check early for context cancellation (#7079)

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -476,7 +476,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 
 	}
 
-	_, forceClose := generateBlipSyncChanges(bh.loggingCtx, changesDb, channelSet, options, opts.docIDs, func(changes []*ChangeEntry) error {
+	forceClose := generateBlipSyncChanges(bh.loggingCtx, changesDb, channelSet, options, opts.docIDs, func(changes []*ChangeEntry) error {
 		base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Sending %d changes", len(changes))
 		for _, change := range changes {
 			if !strings.HasPrefix(change.ID, "_") {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -509,9 +509,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 	collectionWithUser, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	collectionWithUser.user, err = authenticator.GetUser("naomi")
 	require.NoError(t, err)
-	changes, err := collectionWithUser.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
-	assert.NoError(t, err, "Couldn't GetChanges")
-	assert.Len(t, changes, 4)
+	changes := getChanges(t, collectionWithUser, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 
 	collectionID := collection.GetCollectionID()
 
@@ -547,8 +545,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 
 	// verify changes has three entries (needs to resend all since previous LowSeq, which
 	// will be the late arriver (3) along with 5, 6)
-	changes, err = collectionWithUser.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
-	require.NoError(t, err)
+	changes = getChanges(t, collectionWithUser, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
 	assert.Len(t, changes, 3)
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 3, LowSeq: 3},
@@ -939,8 +936,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 		options.Continuous = false
 		options.Wait = false
 		options.Limit = 2 // Avoid prepending results in cache, as we don't want second changes to serve results from cache
-		_, err := collection.GetChanges(ctx, base.SetOf("ABC"), options)
-		assert.NoError(t, err, "Expect no error for first changes request")
+		_ = getChanges(t, collection, base.SetOf("ABC"), options)
 	}()
 
 	// Wait for queryBlocked=true - ensures the first goroutine has acquired view lock
@@ -964,8 +960,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 		options.Continuous = false
 		options.Limit = 2
 		options.Wait = false
-		_, err := collection.GetChanges(ctx, base.SetOf("ABC"), options)
-		assert.Error(t, err, "Expected error for second changes")
+		_ = getChanges(t, collection, base.SetOf("ABC"), options)
 	}()
 
 	// wait for second goroutine to be queued for the view lock (based on expvar)
@@ -1244,8 +1239,7 @@ func TestChannelCacheSize(t *testing.T) {
 	collectionWithUser, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	collectionWithUser.user, err = authenticator.GetUser("naomi")
 	require.NoError(t, err)
-	changes, err := collectionWithUser.GetChanges(ctx, base.SetOf("ABC"), getChangesOptionsWithZeroSeq(t))
-	assert.NoError(t, err, "Couldn't GetChanges")
+	changes := getChanges(t, collectionWithUser, base.SetOf("ABC"), getChangesOptionsWithZeroSeq(t))
 	assert.Len(t, changes, 750)
 
 	// Validate that cache stores the expected number of values
@@ -1532,8 +1526,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 	}
 
 	// Issue getChanges for empty channel
-	changes, err := collection.GetChanges(ctx, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly(t))
-	assert.NoError(t, err, "Couldn't GetChanges")
+	changes := getChanges(t, collection, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly(t))
 	changesCount := len(changes)
 	assert.Equal(t, 0, changesCount)
 
@@ -1550,10 +1543,8 @@ func TestInitializeEmptyCache(t *testing.T) {
 	cacheWaiter.Add(docCount)
 	cacheWaiter.Wait()
 
-	changes, err = collection.GetChanges(ctx, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly(t))
-	assert.NoError(t, err, "Couldn't GetChanges")
-	changesCount = len(changes)
-	assert.Equal(t, 10, changesCount)
+	changes = getChanges(t, collection, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly(t))
+	assert.Len(t, changes, 10)
 }
 
 // Trigger initialization of the channel cache under load via getChanges.  Ensures validFrom handling correctly
@@ -1597,8 +1588,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 
 	// Wait for writes to be in progress, then getChanges for channel zero
 	writesInProgress.Wait()
-	changes, err := collection.GetChanges(ctx, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly(t))
-	require.NoError(t, err, "Couldn't GetChanges")
+	changes := getChanges(t, collection, channels.BaseSetOf(t, "zero"), getChangesOptionsWithCtxOnly(t))
 	firstChangesCount := len(changes)
 	var lastSeq SequenceID
 	if firstChangesCount > 0 {
@@ -1608,8 +1598,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	// Wait for all writes to be cached, then getChanges again
 	cacheWaiter.Wait()
 
-	changes, err = collection.GetChanges(ctx, channels.BaseSetOf(t, "zero"), getChangesOptionsWithSeq(t, lastSeq))
-	require.NoError(t, err, "Couldn't GetChanges")
+	changes = getChanges(t, collection, channels.BaseSetOf(t, "zero"), getChangesOptionsWithSeq(t, lastSeq))
 	secondChangesCount := len(changes)
 	assert.Equal(t, docCount, firstChangesCount+secondChangesCount)
 
@@ -2860,6 +2849,20 @@ func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) 
 		dbContext.UpdateCalculatedStats(ctx)
 		assert.Equal(c, int64(19), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
+}
+
+// getChanges is a synchronous convenience function that returns all changes as a simple array. This will fail the test if an error is returned.
+func getChanges(t *testing.T, collection *DatabaseCollectionWithUser, channels base.Set, options ChangesOptions) []*ChangeEntry {
+	require.NotNil(t, options.ChangesCtx)
+	feed, err := collection.MultiChangesFeed(options.ChangesCtx, channels, options)
+
+	require.NoError(t, err)
+	require.NotNil(t, feed)
+	var changes = make([]*ChangeEntry, 0, 50)
+	for entry := range feed {
+		changes = append(changes, entry)
+	}
+	return changes
 }
 
 // TestAddPendingLogs:

--- a/db/changes.go
+++ b/db/changes.go
@@ -219,6 +219,11 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 		//   3. An error is returned when calling singleChannelCache.GetChanges
 		//   4. An error is returned when calling wasDocInChannelPriorToRevocation
 		for {
+			if options.ChangesCtx.Err() != nil {
+				base.DebugfCtx(ctx, base.KeyChanges, "Terminating revocation channel feed %s", base.UD(to))
+				return
+			}
+
 			if requestLimit == 0 {
 				paginationOptions.Limit = queryLimit
 			} else {
@@ -241,6 +246,11 @@ func (db *DatabaseCollectionWithUser) buildRevokedFeed(ctx context.Context, ch c
 
 			sentChanges := 0
 			for _, logEntry := range changes {
+				if options.ChangesCtx.Err() != nil {
+					base.DebugfCtx(ctx, base.KeyChanges, "Terminating revocation channel feed %s", base.UD(to))
+					return
+				}
+
 				seqID := SequenceID{
 					Seq:         logEntry.Sequence,
 					TriggeredBy: revokedAt,
@@ -409,6 +419,10 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 		//   2. A limit is specified on the incoming ChangesOptions, and that limit is reached
 		//   3. An error is returned when calling singleChannelCache.GetChanges
 		for {
+			if options.ChangesCtx.Err() != nil {
+				base.DebugfCtx(ctx, base.KeyChanges, "Terminating channel feed %s", base.UD(to))
+				return
+			}
 			// Calculate limit for this iteration
 			if requestLimit == 0 {
 				paginationOptions.Limit = queryLimit
@@ -432,6 +446,10 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 			// Now write each log entry to the 'feed' channel in turn:
 			sentChanges := 0
 			for _, logEntry := range changes {
+				if options.ChangesCtx.Err() != nil {
+					base.DebugfCtx(ctx, base.KeyChanges, "Terminating channel feed %s", base.UD(to))
+					return
+				}
 				if logEntry.Sequence >= options.Since.TriggeredBy {
 					options.Since.TriggeredBy = 0
 				}
@@ -758,7 +776,10 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 				if err != nil {
 					base.WarnfCtx(ctx, "Unable to obtain channel cache for %s, terminating feed", base.UD(chanName))
 					change := makeErrorEntry("Channel cache unavailable, terminating feed")
-					output <- &change
+					select {
+					case output <- &change:
+					case <-options.ChangesCtx.Done():
+					}
 					return
 				}
 
@@ -769,7 +790,7 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 				if useLateSequenceFeeds {
 					lateSequenceFeedHandler := lateSequenceFeeds[chanID]
 					if lateSequenceFeedHandler != nil {
-						latefeed, err := col.getLateFeed(lateSequenceFeedHandler, singleChannelCache)
+						latefeed, err := col.getLateFeed(options.ChangesCtx, lateSequenceFeedHandler, singleChannelCache)
 						if err != nil {
 							base.WarnfCtx(ctx, "MultiChangesFeed got error reading late sequence feed %q, rolling back channel changes feed to last sent low sequence #%d.", base.UD(chanName), lastSentLowSeq)
 							chanOpts.Since.LowSeq = lastSentLowSeq
@@ -889,7 +910,10 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 							// On feed error, send the error and exit changes processing
 							if current[i].Err == base.ErrChannelFeed {
 								base.WarnfCtx(ctx, "MultiChangesFeed got error reading changes feed: %v", current[i].Err)
-								output <- current[i]
+								select {
+								case <-options.ChangesCtx.Done():
+								case output <- current[i]:
+								}
 								return
 							}
 						}
@@ -967,6 +991,9 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 				// Send the entry, and repeat the loop:
 				base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed sending %+v %s", base.UD(minEntry), base.UD(to))
 
+				if options.ChangesCtx.Err() != nil {
+					return
+				}
 				select {
 				case <-options.ChangesCtx.Done():
 					return
@@ -1001,7 +1028,11 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 			// If nothing found, and in wait mode: wait for the db to change, then run again.
 			// First notify the reader that we're waiting by sending a nil.
 			base.DebugfCtx(ctx, base.KeyChanges, "MultiChangesFeed waiting... %s", base.UD(to))
-			output <- nil
+			select {
+			case <-options.ChangesCtx.Done():
+				return
+			case output <- nil:
+			}
 
 			// If this is an initial replication using CBL 2.x (active only), flip activeOnly now the client has caught up.
 			if options.clientType == clientTypeCBL2 && options.ActiveOnly {
@@ -1027,22 +1058,12 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 				waitResponse := changeWaiter.Wait(ctx)
 				col.dbStats().CBLReplicationPull().NumPullReplCaughtUp.Add(-1)
 
-				if waitResponse == WaiterClosed {
+				if options.ChangesCtx.Err() != nil {
+					return
+				} else if waitResponse == WaiterClosed {
 					break outer
 				} else if waitResponse == WaiterHasChanges {
-					select {
-					case <-options.ChangesCtx.Done():
-						return
-					default:
-						break waitForChanges
-					}
-				} else if waitResponse == WaiterCheckTerminated {
-					// Check whether I was terminated while waiting for a change.  If not, resume wait.
-					select {
-					case <-options.ChangesCtx.Done():
-						return
-					default:
-					}
+					break waitForChanges
 				}
 			}
 			// Update the current max cached sequence for the next changes iteration
@@ -1054,7 +1075,10 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 			if err != nil {
 				change := makeErrorEntry("User not found during reload - terminating changes feed")
 				base.DebugfCtx(ctx, base.KeyChanges, "User not found during reload - terminating changes feed with entry %+v", base.UD(change))
-				output <- &change
+				select {
+				case <-options.ChangesCtx.Done():
+				case output <- &change:
+				}
 				return
 			}
 			if userChanged && col.user != nil {
@@ -1097,28 +1121,6 @@ func (col *DatabaseCollectionWithUser) waitForCacheUpdate(ctx context.Context, c
 		}
 	}
 	return false
-}
-
-// FOR TEST USE ONLY: Synchronous convenience function that returns all changes as a simple array,
-// Returns error if initial feed creation fails, or if an error is returned with the changes entries
-func (db *DatabaseCollectionWithUser) GetChanges(ctx context.Context, channels base.Set, options ChangesOptions) ([]*ChangeEntry, error) {
-	if options.ChangesCtx == nil {
-		changesCtx, changesCtxCancel := context.WithCancel(context.Background())
-		options.ChangesCtx = changesCtx
-		defer changesCtxCancel()
-	}
-
-	var changes = make([]*ChangeEntry, 0, 50)
-	feed, err := db.MultiChangesFeed(ctx, channels, options)
-	if err == nil && feed != nil {
-		for entry := range feed {
-			if entry.Err != nil {
-				err = entry.Err
-			}
-			changes = append(changes, entry)
-		}
-	}
-	return changes, err
 }
 
 // Returns the set of cached log entries for a given channel
@@ -1177,7 +1179,7 @@ func (db *DatabaseCollectionWithUser) newLateSequenceFeed(singleChannelCache Sin
 
 // Feed to process late sequences for the channel.  Updates lastSequence as it works the feed.  Error indicates
 // previous position in late sequence feed isn't available, and caller should reset to low sequence.
-func (db *DatabaseCollectionWithUser) getLateFeed(feedHandler *lateSequenceFeed, singleChannelCache SingleChannelCache) (<-chan *ChangeEntry, error) {
+func (db *DatabaseCollectionWithUser) getLateFeed(ctx context.Context, feedHandler *lateSequenceFeed, singleChannelCache SingleChannelCache) (<-chan *ChangeEntry, error) {
 
 	if !singleChannelCache.SupportsLateFeed() {
 		return nil, errors.New("Cache doesn't support late feeds")
@@ -1217,7 +1219,12 @@ func (db *DatabaseCollectionWithUser) getLateFeed(feedHandler *lateSequenceFeed,
 				Seq: logEntry.Sequence,
 			}
 			change := makeChangeEntry(logEntry, seqID, singleChannelCache.ChannelID())
-			feed <- &change
+			select {
+			case <-ctx.Done():
+				return
+
+			case feed <- &change:
+			}
 		}
 	}()
 
@@ -1354,14 +1361,15 @@ func (options ChangesOptions) String() string {
 }
 
 // Used by BLIP connections for changes.  Supports both one-shot and continuous changes.
-func generateBlipSyncChanges(ctx context.Context, database *DatabaseCollectionWithUser, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
+func generateBlipSyncChanges(ctx context.Context, database *DatabaseCollectionWithUser, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (forceClose bool) {
 
 	// Store one-shot here to protect
 	isOneShot := !options.Continuous
-	err, forceClose = GenerateChanges(ctx, options.ChangesCtx, database, inChannels, options, docIDFilter, send)
+	err, forceClose := GenerateChanges(ctx, database, inChannels, options, docIDFilter, send)
 
 	if _, ok := err.(*ChangesSendErr); ok {
-		return nil, forceClose // error is probably because the client closed the connection
+		// If there was already an error in a send function, do not send last one shot changes message, since it probably will not work anyway.
+		return forceClose // error is probably because the client closed the connection
 	}
 
 	// For one-shot changes, invoke the callback w/ nil to trigger the 'caught up' changes message.  (For continuous changes, this
@@ -1369,7 +1377,7 @@ func generateBlipSyncChanges(ctx context.Context, database *DatabaseCollectionWi
 	if isOneShot {
 		_ = send(nil)
 	}
-	return err, forceClose
+	return forceClose
 }
 
 type ChangesSendErr struct{ error }
@@ -1377,7 +1385,7 @@ type ChangesSendErr struct{ error }
 // Shell of the continuous changes feed -- calls out to a `send` function to deliver the change.
 // This is called from BLIP connections as well as HTTP handlers, which is why this is not a
 // method on `handler`.
-func GenerateChanges(ctx context.Context, cancelCtx context.Context, database *DatabaseCollectionWithUser, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
+func GenerateChanges(ctx context.Context, database *DatabaseCollectionWithUser, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (err error, forceClose bool) {
 	// Set up heartbeat/timeout
 	var timeoutInterval time.Duration
 	var timer *time.Timer
@@ -1508,7 +1516,7 @@ loop:
 		case <-database.exitChanges():
 			forceClose = true
 			break loop
-		case <-cancelCtx.Done():
+		case <-options.ChangesCtx.Done():
 			forceClose = true
 			break loop
 		}
@@ -1516,6 +1524,11 @@ loop:
 			forceClose = true
 			return &ChangesSendErr{sendErr}, forceClose
 		}
+	}
+
+	// if the ChangesCtx is done, the connection was force closed. This could actually happen and send a ChangeEntry.Err. Instead of checking each place in this function, set the forceClose flag here.
+	if options.ChangesCtx.Err() != nil {
+		forceClose = true
 	}
 
 	return nil, forceClose

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -76,7 +76,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 			collection.user, err = auth.GetUser("test")
 			require.NoError(t, err)
 
-			ch, err := collection.GetChanges(ctx, testCase.accessChans, getChangesOptionsWithZeroSeq(t))
+			ch := getChanges(t, collection, testCase.accessChans, getChangesOptionsWithZeroSeq(t))
 			require.NoError(t, err)
 			require.Len(t, ch, len(testCase.expectedDocsReturned))
 
@@ -127,9 +127,9 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check the _changes feed:
-	collection.user, _ = authenticator.GetUser("naomi")
-	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
-	assert.NoError(t, err, "Couldn't GetChanges")
+	collection.user, err = authenticator.GetUser("naomi")
+	require.NoError(t, err)
+	changes := getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 	printChanges(changes)
 	require.Len(t, changes, 3)
 
@@ -156,7 +156,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 2 (the user doc) and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
-	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
+	changes = getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
@@ -165,8 +165,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	assert.Equal(t, []ChangeRev{{"rev": revid}}, changes[0].Changes)
 
 	// validate from zero
-	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
-	assert.NoError(t, err, "Couldn't GetChanges")
+	changes = getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 	printChanges(changes)
 
 }
@@ -226,9 +225,9 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
-	collection.user, _ = authenticator.GetUser("alice")
-	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
-	require.NoError(t, err, "Couldn't GetChanges")
+	collection.user, err = authenticator.GetUser("alice")
+	require.NoError(t, err)
+	changes := getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 	printChanges(changes)
 	assert.Len(t, changes, 1)
 	collectionID := collection.GetCollectionID()
@@ -272,9 +271,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 3 and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
-	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
-
-	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
+	changes = getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
 
 	assert.Len(t, changes, 1)
 	assert.Equal(t, &ChangeEntry{
@@ -312,9 +309,9 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
-	collection.user, _ = authenticator.GetUser("alice")
-	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
-	assert.NoError(t, err, "Couldn't GetChanges")
+	collection.user, err = authenticator.GetUser("alice")
+	require.NoError(t, err)
+	changes := getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 	printChanges(changes)
 
 	collectionID := collection.GetCollectionID()
@@ -356,9 +353,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	// sequence 3 (the modified document) and isn't stuck waiting for it.
 	cacheWaiter.AddAndWait(1)
 
-	changes, err = collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
-
-	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
+	changes = getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithSeq(t, lastSeq))
 
 	assert.Len(t, changes, 1)
 	require.Equal(t, &ChangeEntry{
@@ -406,8 +401,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	initQueryCount := db.DbStats.Cache().ViewQueries.Value()
 
 	// Get changes with active_only=true
-	activeChanges, err := collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
-	require.NoError(t, err, "Error getting changes with active_only true")
+	activeChanges := getChanges(t, collection, base.SetOf("*"), changesOptions)
 	require.Len(t, activeChanges, 5)
 
 	// Ensure the test is triggering a query, and not serving from DCP-generated cache
@@ -416,8 +410,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 	// Get changes with active_only=false, validate that triggers a new query
 	changesOptions.ActiveOnly = false
-	allChanges, err := collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
-	require.NoError(t, err, "Error getting changes with active_only true")
+	allChanges := getChanges(t, collection, base.SetOf("*"), changesOptions)
 	require.Len(t, allChanges, 10)
 
 	postChangesQueryCount = db.DbStats.Cache().ViewQueries.Value()
@@ -425,8 +418,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 	// Get changes with active_only=false again, verify results are served from the cache
 	changesOptions.ActiveOnly = false
-	allChanges, err = collection.GetChanges(ctx, base.SetOf("*"), changesOptions)
-	require.NoError(t, err, "Error getting changes with active_only true")
+	allChanges = getChanges(t, collection, base.SetOf("*"), changesOptions)
 	require.Len(t, allChanges, 10)
 
 	postChangesQueryCount = db.DbStats.Cache().ViewQueries.Value()

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1725,14 +1725,13 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 
 	// init channel cache, this will make changes call after timeout doc is written below fail pre changes made in CBG-4067,
 	// due to duplicate sequence at the cache with an unused sequence. See steps in ticket CBG-4067 as example.
-	_, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
-	require.NoError(t, err)
+	_ = getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 
 	assert.Equal(t, int64(0), db.DbStats.Database().SequenceReleasedCount.Value())
 
 	// write doc that will return timeout but will actually be persisted successfully on server
 	// this mimics what was seen before
-	_, _, err = collection.Put(ctx, timeoutDoc, Body{"test": "doc"})
+	_, _, err := collection.Put(ctx, timeoutDoc, Body{"test": "doc"})
 	require.Error(t, err)
 
 	// wait for changes
@@ -1746,8 +1745,7 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	}, time.Second*10, time.Millisecond*100)
 
 	// get cached changes + assert the document is present
-	changes, err := collection.GetChanges(ctx, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
-	require.NoError(t, err)
+	changes := getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 	require.Len(t, changes, 1)
 	assert.Equal(t, timeoutDoc, changes[0].ID)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -951,8 +951,7 @@ func TestAllDocsOnly(t *testing.T) {
 	changesCtx, changesCtxCancel := context.WithCancel(base.TestCtx(t))
 	options.ChangesCtx = changesCtx
 	defer changesCtxCancel()
-	changes, err := collection.GetChanges(ctx, channels.BaseSetOf(t, "all"), options)
-	assert.NoError(t, err, "Couldn't GetChanges")
+	changes := getChanges(t, collection, channels.BaseSetOf(t, "all"), options)
 	require.Len(t, changes, 100)
 
 	for i, change := range changes {
@@ -979,8 +978,7 @@ func TestAllDocsOnly(t *testing.T) {
 	assert.True(t, sortedSeqAsc(changes), "Sequences should be ascending for all entries in the changes response")
 
 	options.IncludeDocs = true
-	changes, err = collection.GetChanges(ctx, channels.BaseSetOf(t, "KFJC"), options)
-	assert.NoError(t, err, "Couldn't GetChanges")
+	changes = getChanges(t, collection, channels.BaseSetOf(t, "KFJC"), options)
 	assert.Len(t, changes, 10)
 	for i, change := range changes {
 		assert.Equal(t, ids[10*i].DocID, change.ID)
@@ -1145,8 +1143,7 @@ func TestConflicts(t *testing.T) {
 		Conflicts:  true,
 		ChangesCtx: base.TestCtx(t),
 	}
-	changes, err := collection.GetChanges(ctx, channels.BaseSetOf(t, "all"), options)
-	assert.NoError(t, err, "Couldn't GetChanges")
+	changes := getChanges(t, collection, channels.BaseSetOf(t, "all"), options)
 	assert.Len(t, changes, 1)
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 3},
@@ -1180,8 +1177,7 @@ func TestConflicts(t *testing.T) {
 	cacheWaiter.AddAndWait(1)
 
 	// Verify the _changes feed:
-	changes, err = collection.GetChanges(ctx, channels.BaseSetOf(t, "all"), options)
-	assert.NoError(t, err, "Couldn't GetChanges")
+	changes = getChanges(t, collection, channels.BaseSetOf(t, "all"), options)
 	assert.Len(t, changes, 1)
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 4},


### PR DESCRIPTION
CBG-4196

Backports #7079 to 3.2.1

(also test-only changes in #7031 that this cherry-pick depended on)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2743/
