### PR TITLE
Fix redocly plugins

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -18,6 +18,7 @@ apis:
   admin-capella:
     root: "./docs/api/admin-capella.yaml"
     decorators:
+      plugin/excise-rbac-capella: on
       filter-out:
         property: x-capella
         value: false
@@ -36,6 +37,7 @@ apis:
         value: false
       info-override:
         description: "App Services manages access and synchronization between Couchbase Lite and Couchbase Capella"
+      plugin/excise-rbac-capella: on
       plugin/replace-description-capella: on
       plugin/replace-server-capella:
         serverUrl: 'https://{hostname}:4984'

--- a/docs/api/plugins/decorators/excise-rbac-capella.js
+++ b/docs/api/plugins/decorators/excise-rbac-capella.js
@@ -23,7 +23,7 @@ function ExciseRBACCapella() {
     Operation: {
       leave(Operation) {
         // remove all text after first regex match
-        idx = Operation.description.search(re);
+        idx = (Operation.description || '').search(re);
         if (idx > 0) {
           Operation.description = Operation.description.substr(0, idx);
         }

--- a/docs/api/plugins/decorators/replace-description-capella.js
+++ b/docs/api/plugins/decorators/replace-description-capella.js
@@ -20,10 +20,12 @@ function ReplaceDescriptionCapella() {
   return {
     Operation: {
       leave(Operation) {
-        Operation.description = Operation.description.replace(
-          "Sync Gateway",
-          "App Services",
-        );
+        if (Operation.description) {
+            Operation.description = Operation.description.replace(
+              "Sync Gateway",
+              "App Services",
+            );
+        }
       },
     },
   };


### PR DESCRIPTION
These crashed when description was missing, so add defaulting/logic to fix.
Enable the excise-rbac for the other APIs for the *-capella targets.

Ping @torcolvin to review - I don't think this checklist applies to this PR?
I can create a CBG if required.

CBG-0000

Describe your PR here...
- Use bullet points if there's more than one thing changed

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
