### PR TITLE
CBG-4293 recognize alma/rocky and other rhel variants

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           go-version: 1.22.5
       - name: "Build Sync Gateway"
-        run: env SG_EDITON=EE ./build.sh
+        run: go build -o ./bin/sync_gateway ./...
       - name: "Run test scripts"
         run: ./integration-test/service-install-tests.sh

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           go-version: 1.22.5
       - name: "Build Sync Gateway"
-        run: go build -o ./bin/sync_gateway ./...
+        run: mkdir -p ./bin && go build -o ./bin/sync_gateway ./...
       - name: "Run test scripts"
         run: ./integration-test/service-install-tests.sh

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           go-version: 1.22.5
       - name: "Build Sync Gateway"
-        run: mkdir -p ./bin && go build -o ./bin/sync_gateway ./...
+        run: mkdir -p ./bin && go build -o ./bin ./...
       - name: "Run test scripts"
         run: ./integration-test/service-install-tests.sh

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -1,0 +1,41 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
+name: openapi
+
+on:
+  push:
+    # Only run when we modify service files
+    paths:
+      - 'service/**'
+      - 'integration-test/**'
+    branches:
+      - 'main'
+      - 'release/*'
+      - 'feature/*'
+      - 'beryllium'
+      - 'CBG*'
+      - 'ci-*'
+      - 'api-ci-*'
+  pull_request:
+    # Only run when we modify service files
+    paths:
+      - 'service/**'
+      - 'integration-test/**'
+    branches:
+      - 'main'
+      - 'release/*'
+
+jobs:
+  scripts:
+    runs-on: ubuntu-latest
+    name: Verify service script installation.
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Run test scripts"
+        run: ./integration-test/service-install-tests.sh

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -6,7 +6,7 @@
 # will be governed by the Apache License, Version 2.0, included in the file
 # licenses/APL2.txt.
 
-name: openapi
+name: service
 
 on:
   push:

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -37,5 +37,11 @@ jobs:
     name: Verify service script installation.
     steps:
       - uses: actions/checkout@v4
+      # build sync gateway since the executable is needed for service installation
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.5
+      - name: "Build Sync Gateway"
+        run: env SG_EDITON=EE ./build.sh
       - name: "Run test scripts"
         run: ./integration-test/service-install-tests.sh

--- a/integration-test/service-install-tests.sh
+++ b/integration-test/service-install-tests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+IMAGES=(
+    #"almalinux:9"
+    "amazonlinux:2"
+    "amazonlinux:2023"
+    "debian:10"
+    "debian:11"
+    "debian:12"
+    "redhat/ubi8"
+    "redhat/ubi9"
+    #"rockylinux:9"
+    "ubuntu:20.04"
+    "ubuntu:22.04"
+    "ubuntu:24.04"
+
+    # not technically supported
+    "oraclelinux:9"
+)
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+SYNC_GATEWAY_DIR=$(realpath ${SCRIPT_DIR}/..)
+
+if [ "$(uname)" == "Darwin" ]; then
+    sudo ${SYNC_GATEWAY_DIR}/integration-test/service-test.sh
+fi
+
+for IMAGE in "${IMAGES[@]}"; do
+    echo "Running tests for ${IMAGE}"
+    docker run --mount src=${SYNC_GATEWAY_DIR},target=/sync_gateway,type=bind ${IMAGE} /bin/bash -c "/sync_gateway/integration-test/service-test.sh"
+done

--- a/integration-test/service-install-tests.sh
+++ b/integration-test/service-install-tests.sh
@@ -7,11 +7,12 @@
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
 
+# This file is used by github CI or locally and runs a subset of test scripts to validate the service installation done by the package managers. This is intended to be run from Linux or Mac.
 
 set -eux -o pipefail
 
 IMAGES=(
-    #"almalinux:9"
+    "almalinux:9"
     "amazonlinux:2"
     "amazonlinux:2023"
     "debian:10"
@@ -19,7 +20,7 @@ IMAGES=(
     "debian:12"
     "redhat/ubi8"
     "redhat/ubi9"
-    #"rockylinux:9"
+    "rockylinux:9"
     "ubuntu:20.04"
     "ubuntu:22.04"
     "ubuntu:24.04"

--- a/integration-test/service-install-tests.sh
+++ b/integration-test/service-install-tests.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# Copyright 2024-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 
 set -eux -o pipefail
 

--- a/integration-test/service-test.sh
+++ b/integration-test/service-test.sh
@@ -1,0 +1,54 @@
+#/bin/sh
+
+set -eux -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+cd ${SCRIPT_DIR}/../service
+
+./sync_gateway_service_install.sh --servicecmd
+
+# /etc/os-release doesn't exist on Darwin
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case ${ID} in
+        amzn)
+            yum install -y shadow-utils systemd
+            ;;
+    esac
+
+    groupadd -r sync_gateway
+    useradd -g sync_gateway sync_gateway
+
+    # bash would support export -f for a systemctl wrapper, but dash does not support exporting aliases or functions
+
+    mkdir -p /tmp/systemctl_wrapper
+
+    cat << 'EOF' > /tmp/systemctl_wrapper/systemctl
+#!/bin/bash
+
+set -eu -o pipefail
+
+case ${1:-} in
+start)
+    echo "No-op systemctl start in docker, since we're not running systemd"
+    ;;
+stop)
+    echo "No-op systemctl stop in docker, since we're not running systemd"
+    ;;
+*)
+    echo "Running systemctl $@"
+    command /usr/bin/systemctl "$@"
+    ;;
+esac
+EOF
+
+    chmod +x /tmp/systemctl_wrapper/systemctl
+
+    export PATH=/tmp/systemctl_wrapper:$PATH
+fi
+./sync_gateway_service_install.sh
+./sync_gateway_service_upgrade.sh
+./sync_gateway_service_uninstall.sh
+
+echo "Successful service test"

--- a/integration-test/service-test.sh
+++ b/integration-test/service-test.sh
@@ -1,3 +1,11 @@
+# Copyright 2024-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 #/bin/sh
 
 set -eux -o pipefail

--- a/integration-test/service-test.sh
+++ b/integration-test/service-test.sh
@@ -1,3 +1,5 @@
+#/bin/sh
+
 # Copyright 2024-Present Couchbase, Inc.
 #
 # Use of this software is governed by the Business Source License included
@@ -6,7 +8,7 @@
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
 
-#/bin/sh
+# This code is intneded to be run from within a docker container of a specific platform and runs a subset of the service scripts. The full service can not be validated since systemd does not work in docker contains. This is intended to run in /bin/sh to test dash environments on debian systems.
 
 set -eux -o pipefail
 
@@ -55,7 +57,13 @@ EOF
 
     export PATH=/tmp/systemctl_wrapper:$PATH
 fi
+
 ./sync_gateway_service_install.sh
+./sync_gateway_service_upgrade.sh
+./sync_gateway_service_uninstall.sh
+
+# test again with runas option
+./sync_gateway_service_install.sh --runas=root
 ./sync_gateway_service_upgrade.sh
 ./sync_gateway_service_uninstall.sh
 

--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-set -x
 # Copyright 2014-Present Couchbase, Inc.
 #
 # Use of this software is governed by the Business Source License included in
@@ -10,6 +9,8 @@ set -x
 # licenses/APL2.txt.
 
 # Set default values
+OS=""
+VER=""
 SERVICE_NAME="sync_gateway"
 # Determine the absolute path of the installation directory
 # $( dirname "$0" ) get the directory containing this script
@@ -29,10 +30,9 @@ GATEWAY_TEMPLATE_VAR=${INSTALL_DIR}/bin/sync_gateway
 CONFIG_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/sync_gateway.json
 LOGS_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/logs
 SERVICE_CMD_ONLY=false
-PLATFORM="$(uname)"
 
 usage() {
-  echo "This script creates a systemd or launchctl service to run a sync_gateway instance."
+  echo "This script creates a service to run a sync_gateway instance."
   echo "If you want to install more than one service instance"
   echo "create additional services with different names."
   echo ""
@@ -46,7 +46,33 @@ usage() {
   echo ""
 }
 
-PLATFORM=$(uname)
+ostype() {
+  if [ -x "$(command -v lsb_release)" ]; then
+    OS=$(lsb_release -si)
+    VER=$(lsb_release -sr)
+  elif [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS=$(echo "${ID}")
+    if [ "${OS}" = "debian" ]; then
+      VER=$(cat /etc/debian_version)
+    else
+      VER=$VERSION_ID
+    fi
+  elif [ -f /etc/redhat-release ]; then
+    OS=rhel
+    VER=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//)
+  elif [ -f /etc/system-release ]; then
+    OS=rhel
+    VER=5.0
+  else
+    OS=$(uname -s)
+    VER=$(uname -r)
+  fi
+
+  OS=$(echo "${OS}" | tr "[:upper:]" "[:lower:]")
+  OS_MAJOR_VERSION=$(echo $VER | sed 's/\..*$//')
+  OS_MINOR_VERSION=$(echo $VER | sed s/[0-9]*\.//)
+}
 
 # expand template variables + preserve formatting
 render_template() {
@@ -64,7 +90,7 @@ setup_output_dirs() {
 # Run pre installation actions
 pre_install_actions() {
   # Check that runtime user account exists
-  if [ "$PLATFORM" != "Darwin" ] && [ -z $(id -u $RUNAS_TEMPLATE_VAR 2>/dev/null) ]; then
+  if [ "$OS" != "darwin" ] && [ -z $(id -u $RUNAS_TEMPLATE_VAR 2>/dev/null) ]; then
     echo "The sync_gateway runtime user account does not exist \"$RUNAS_TEMPLATE_VAR\"." >/dev/stderr
     exit 1
   fi
@@ -113,9 +139,10 @@ pre_install_actions() {
 #
 
 #Figure out the OS type of the current system
+ostype
 
 #If the OS is MAC OSX, set the default user account home path to /Users/sync_gateway
-if [ "$PLATFORM" = "Darwin" ]; then
+if [ "$OS" = "darwin" ]; then
   RUNBASE_TEMPLATE_VAR=/Users/sync_gateway
   CONFIG_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/sync_gateway.json
   LOGS_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/logs
@@ -138,7 +165,7 @@ while [ "$1" != "" ]; do
     ;;
   --runas)
     RUNAS_TEMPLATE_VAR=$VALUE
-    if [ "$PLATFORM" != "Darwin" ]; then
+    if [ "$OS" != "darwin" ]; then
       RUNBASE_TEMPLATE_VAR=$(getent passwd "$VALUE" | cut -d: -f 6)
     else
       RUNBASE_TEMPLATE_VAR=$(eval "echo ~$VALUE")
@@ -171,19 +198,89 @@ while [ "$1" != "" ]; do
 done
 
 #Install the service for the specific platform
-case ${PLATFORM} in
-Linux*)
+case $OS in
+debian)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 8))*)
     if [ "$SERVICE_CMD_ONLY" = true ]; then
       echo "systemctl start ${SERVICE_NAME}"
     else
       pre_install_actions
       mkdir -p /usr/lib/systemd/system
+      render_template script_templates/systemd_debian_sync_gateway.tpl >/usr/lib/systemd/system/${SERVICE_NAME}.service
+      systemctl enable ${SERVICE_NAME}
+      systemctl start ${SERVICE_NAME}
+    fi
+    ;;
+  esac
+  ;;
+ubuntu)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 16))*)
+    if [ "$SERVICE_CMD_ONLY" = true ]; then
+      echo "systemctl start ${SERVICE_NAME}"
+    else
+      pre_install_actions
+      render_template script_templates/systemd_debian_sync_gateway.tpl >/lib/systemd/system/${SERVICE_NAME}.service
+      systemctl enable ${SERVICE_NAME}
+      systemctl start ${SERVICE_NAME}
+    fi
+    ;;
+  $((OS_MAJOR_VERSION >= 12))*)
+    if [ "$SERVICE_CMD_ONLY" = true ]; then
+      echo "service ${SERVICE_NAME} start"
+    else
+      pre_install_actions
+      render_template script_templates/upstart_ubuntu_sync_gateway.tpl >/etc/init/${SERVICE_NAME}.conf
+      service ${SERVICE_NAME} start
+    fi
+    ;;
+  *)
+    echo "ERROR: Unsupported Ubuntu Version \"$VER\""
+    usage
+    exit 1
+    ;;
+  esac
+  ;;
+redhat* | rhel* | centos | ol | rocky | almalinux )
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 7))*)
+    if [ "$SERVICE_CMD_ONLY" = true ]; then
+      echo "systemctl start ${SERVICE_NAME}"
+    else
+      pre_install_actions
       render_template script_templates/systemd_sync_gateway.tpl >/usr/lib/systemd/system/${SERVICE_NAME}.service
       systemctl enable ${SERVICE_NAME}
       systemctl start ${SERVICE_NAME}
     fi
     ;;
-Darwin*)
+  *)
+    echo "ERROR: Unsupported RedHat/CentOS/Rocky/Alma Version \"$VER\""
+    usage
+    exit 1
+    ;;
+  esac
+  ;;
+amzn*)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 2))*)
+  if [ "$SERVICE_CMD_ONLY" = true ]; then
+      echo "systemctl start ${SERVICE_NAME}"
+    else
+      pre_install_actions
+      render_template script_templates/systemd_sync_gateway.tpl >/usr/lib/systemd/system/${SERVICE_NAME}.service
+      systemctl enable ${SERVICE_NAME}
+      systemctl start ${SERVICE_NAME}
+    fi
+    ;;
+  *)
+    echo "ERROR: Unsupported Amazon Linux Version \"$VER\""
+    usage
+    exit 1
+    ;;
+  esac
+  ;;
+darwin)
   if [ "$SERVICE_CMD_ONLY" = true ]; then
     echo "launchctl start /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist"
   else
@@ -193,7 +290,7 @@ Darwin*)
   fi
   ;;
 *)
-  echo "ERROR: unknown platform \"$PLATFORM\""
+  echo "ERROR: unknown OS \"$OS\""
   usage
   exit 1
   ;;

--- a/service/sync_gateway_service_uninstall.sh
+++ b/service/sync_gateway_service_uninstall.sh
@@ -9,8 +9,6 @@
 # licenses/APL2.txt.
 
 # Set default values
-OS=""
-VER=""
 SERVICE_NAME="sync_gateway"
 # Determine the absolute path of the installation directory
 # $( dirname "$0" ) get the directory containing this script
@@ -30,42 +28,18 @@ GATEWAY_TEMPLATE_VAR=${INSTALL_DIR}/bin/sync_gateway
 CONFIG_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/sync_gateway.json
 LOGS_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/logs
 SERVICE_CMD_ONLY=false
+PLATFORM="$(uname)"
 
 usage() {
   echo "This script removes a systemd or launchctl service to run a sync_gateway instance."
-}
-
-ostype() {
-  if [ -f /etc/os-release ]; then
-    . /etc/os-release
-    if [ "${ID_LIKE##*rhel*}" != "${ID_LIKE}" ]; then
-      OS=rhel
-    else
-      OS=$(echo "${ID}")
-    fi
-    VER=${VERSION_ID}
-  elif [ -x "$(command -v lsb_release)" ]; then
-    OS=$(lsb_release -si)
-    VER=$(lsb_release -sr)
-  else
-    OS=$(uname -s)
-    VER=$(uname -r)
-  fi
-
-  OS=$(echo "${OS}" | tr "[:upper:]" "[:lower:]")
-  OS_MAJOR_VERSION=$(echo $VER | sed 's/\..*$//')
-  OS_MINOR_VERSION=$(echo $VER | sed s/[0-9]*\.//)
 }
 
 #
 #script starts here
 #
 
-#Figure out the OS type of the current system
-ostype
-
 #If the OS is MAC OSX, set the default user account home path to /Users/sync_gateway
-if [ "$OS" = "darwin" ]; then
+if [ "$PLATFORM" = "Darwin" ]; then
   RUNBASE_TEMPLATE_VAR=/Users/sync_gateway
   CONFIG_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/sync_gateway.json
   LOGS_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/logs
@@ -78,10 +52,8 @@ if [ $(id -u) != 0 ]; then
 fi
 
 #Install the service for the specific platform
-case $OS in
-debian)
-  case 1:${OS_MAJOR_VERSION:--} in
-  $((OS_MAJOR_VERSION >= 8))*)
+case $PLATFORM in
+Linux)
     systemctl stop ${SERVICE_NAME}
     systemctl disable ${SERVICE_NAME}
 
@@ -89,47 +61,14 @@ debian)
       rm /usr/lib/systemd/system/${SERVICE_NAME}.service
     fi
     ;;
-  esac
-  ;;
-ubuntu)
-  case 1:${OS_MAJOR_VERSION:--} in
-  $((OS_MAJOR_VERSION >= 16))*)
-    systemctl stop ${SERVICE_NAME}
-    systemctl disable ${SERVICE_NAME}
-
-    if [ -f /lib/systemd/system/${SERVICE_NAME}.service ]; then
-      rm /lib/systemd/system/${SERVICE_NAME}.service
-    fi
-    ;;
-  $((OS_MAJOR_VERSION >= 12))*)
-    service ${SERVICE_NAME} stop
-    if [ -f /etc/init/${SERVICE_NAME}.conf ]; then
-      rm /etc/init/${SERVICE_NAME}.conf
-    fi
-    ;;
-  *)
-    echo "ERROR: Unsupported Ubuntu Version \"$VER\""
-    usage
-    exit 1
-    ;;
-  esac
-  ;;
-rhel*|amzn*) # RHEL, Alma, Rocky, Amazon Linux and any derivatives
-  systemctl stop ${SERVICE_NAME}
-  systemctl disable ${SERVICE_NAME}
-
-  if [ -f /usr/lib/systemd/system/${SERVICE_NAME}.service ]; then
-    rm /usr/lib/systemd/system/${SERVICE_NAME}.service
-  fi
-  ;;
-darwin)
+Darwin)
   launchctl unload /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist
   if [ -f /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist ]; then
     rm /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist
   fi
   ;;
 *)
-  echo "ERROR: unknown OS \"$OS\""
+  echo "ERROR: unknown platform \"$PLATFORM\""
   usage
   exit 1
   ;;

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -9,6 +9,8 @@
 # licenses/APL2.txt.
 
 # Set default values
+OS=""
+VER=""
 SERVICE_NAME="sync_gateway"
 # Determine the absolute path of the installation directory
 # $( dirname "$0" ) get the directory containing this script
@@ -28,18 +30,48 @@ GATEWAY_TEMPLATE_VAR=${INSTALL_DIR}/bin/sync_gateway
 CONFIG_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/sync_gateway.json
 LOGS_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/logs
 SERVICE_CMD_ONLY=false
-PLATFORM="$(uname)"
 
 usage() {
-  echo "This script upgrades systemd or launchctl service to run a sync_gateway instance."
+  echo "This script upgrades a service to run a sync_gateway instance."
+}
+
+ostype() {
+  if [ -x "$(command -v lsb_release)" ]; then
+    OS=$(lsb_release -si)
+    VER=$(lsb_release -sr)
+  elif [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS=$(echo "${ID}")
+    if [ "${OS}" = "debian" ]; then
+      VER=$(cat /etc/debian_version)
+    else
+      VER=$VERSION_ID
+    fi
+  elif [ -f /etc/redhat-release ]; then
+    OS=rhel
+    VER=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//)
+  elif [ -f /etc/system-release ]; then
+    OS=rhel
+    VER=5.0
+  else
+    OS=$(uname -s)
+    VER=$(uname -r)
+  fi
+
+  OS=$(echo "${OS}" | tr "[:upper:]" "[:lower:]")
+  OS_MAJOR_VERSION=$(echo $VER | sed 's/\..*$//')
+  OS_MINOR_VERSION=$(echo $VER | sed s/[0-9]*\.//)
 }
 
 #
 #script starts here
 #
 
+#Figure out the OS type of the current system
+ostype
+
 #If the OS is MAC OSX, set the default user account home path to /Users/sync_gateway
-if [ "$PLATFORM" = "Darwin" ]; then
+if [ "$OS" = "darwin" ]; then
   RUNBASE_TEMPLATE_VAR=/Users/sync_gateway
   CONFIG_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/sync_gateway.json
   LOGS_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/logs
@@ -51,18 +83,65 @@ if [ $(id -u) != 0 ]; then
   exit 1
 fi
 
-#Restart the service for the specific platform
-case $PLATFORM in
-Linux)
+#Install the service for the specific platform
+case $OS in
+debian)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 8))*)
     systemctl stop ${SERVICE_NAME}
     systemctl start ${SERVICE_NAME}
+    ;;
+  esac
   ;;
-Darwin)
+ubuntu)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 16))*)
+    systemctl stop ${SERVICE_NAME}
+    systemctl start ${SERVICE_NAME}
+    ;;
+  $((OS_MAJOR_VERSION >= 12))*)
+    service ${SERVICE_NAME} stop
+    service ${SERVICE_NAME} start
+    ;;
+  *)
+    echo "ERROR: Unsupported Ubuntu Version \"$VER\""
+    usage
+    exit 1
+    ;;
+  esac
+  ;;
+redhat* | rhel* | centos | ol | rocky | almalinux )
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 7))*)
+    systemctl stop ${SERVICE_NAME}
+    systemctl start ${SERVICE_NAME}
+    ;;
+  *)
+    echo "ERROR: Unsupported RedHat/CentOS/Rocky/Alma Version \"$VER\""
+    usage
+    exit 1
+    ;;
+  esac
+  ;;
+amzn*)
+  case 1:${OS_MAJOR_VERSION:--} in
+  $((OS_MAJOR_VERSION >= 2))*)
+    systemctl stop ${SERVICE_NAME}
+    systemctl start ${SERVICE_NAME}
+    ;;
+  *)
+    echo "ERROR: Unsupported Amazon Linux Version \"$VER\""
+    usage
+    exit 1
+    ;;
+  esac
+  ;;
+darwin)
   launchctl unload /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist
   launchctl load /Library/LaunchDaemons/com.couchbase.mobile.sync_gateway.plist
   ;;
 *)
-  echo "ERROR: unknown platform \"$PLATFORM\""
+  echo "ERROR: unknown OS \"$OS\""
   usage
   exit 1
   ;;


### PR DESCRIPTION
Change `ostype` shell function to recognize `ID_LIKE` containing `rhel` as a red hat based linux.

An alternative fix here would be to add `alma* | rocky*` to `redhat* | rhel* | centos | ol)` line, but I worry that yet another rhel variant would come out and we'd forget to add it.

The following is the contents of `/etc/os-release`.

| OS | ID | ID_LIKE |
| ---| ---| -------- |
| Amazon Linux 2 | amzn | "centos rhel fedora" |
| Amazon Linux 2023 | amzn | "fedora" |
| Redhat 8, 9 | rhel | "fedora" |
| Centos 7, 8 (unsupported) | centos | "rhel fedora" |
| Alma 8, 9 | almalinux | "rhel centos fedora" |
| Rocky 8, 9 | rockylinux | "rhel centos fedora" |
| Debian 7-12 | debian | <unspecified> |
| Ubuntu 16.04-24.10 | ubuntu | "debian" |

This method preserve some support that already exists, like accounting for Oracle Linux (ol), even though this isn't a supported platform. I made this more general to support matching a future rhel fork that I haven't come up with.

# Scoping

This PR could be descoped to the alternative fix to just change `redhat* | rhel* | centos | ol)`  to ``redhat* | rhel* | centos | ol | alma* | rocky* )` 

Alternatively, this PR could be enhanced:

-  combine debian and ubuntu  and rhel sections now that every OS we support uses systemd. The only difference with debian, ubuntu and rhel variants is that the systemd file uses `/usr/bin/bash` on Debian-like systems and `/bin/bash` on rhel systems, but `/usr/bin/bash` and `/bin/bash` exists on all supported platforms.
- use a common file to define `ostype` between all three shell scripts to avoid duplication.

# Manual Testing:

I don't know how to build packages exactly (I think you need a toy build, which I don't know how to do).

For rhel, alma, rocky, ubuntu, debian, amazon (two versions) I downloaded existing 3.2.0 package in a docker container. Then I copied over `service/*sh` to `/opt/couchbase-sync-gateway/service/` and ran the scripts. The error behavior would be easily observable with the scripts exiting non zero.

# Possible automated regression testing (not implemented)

- Move `ostype` to common file like `service_utils.sh` that is source by other files.
- Create github action to use docker images for all supported platforms and run `./service/sync_gateway_service_install.sh --servicecmd` and validate that it returns non zero.