### PR TITLE
CBG-4212: Trigger attachment migration job upon db startup

### DIFF
--- a/base/constants_syncdocs.go
+++ b/base/constants_syncdocs.go
@@ -479,23 +479,15 @@ func SerializeIfLonger(name string, length int) string {
 // CompareMetadataVersion Will build comparable build version for comparison with meta version defined in syncInfo, then
 // will return true if we require attachment migration, false if not.
 func CompareMetadataVersion(ctx context.Context, metaVersion string) (bool, error) {
-	var syncInfoVersion *ComparableBuildVersion
-	var requiresAttachmentMigration bool
-	var err error
-	if metaVersion != "" {
-		syncInfoVersion, err = NewComparableBuildVersionFromString(metaVersion)
-		if err != nil {
-			return true, err
-		}
-		requiresAttachmentMigration, err = CheckRequireAttachmentMigration(ctx, syncInfoVersion)
-		if err != nil {
-			return true, err
-		}
-	} else {
+	if metaVersion == "" {
 		// no meta version passed in, thus attachment migration should take place
-		requiresAttachmentMigration = true
+		return true, nil
 	}
-	return requiresAttachmentMigration, nil
+	syncInfoVersion, err := NewComparableBuildVersionFromString(metaVersion)
+	if err != nil {
+		return true, err
+	}
+	return CheckRequireAttachmentMigration(ctx, syncInfoVersion)
 }
 
 // CheckRequireAttachmentMigration will return true if current metaVersion < 4.0.0, else false

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -195,7 +195,7 @@ func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string
 		// set sync info metadata version
 		for _, collectionID := range currCollectionIDs {
 			dbc := db.CollectionByID[collectionID]
-			if err := base.SetSyncInfoMetaVersion(dbc.dataStore, base.ProductAPIVersion); err != nil {
+			if err := base.SetSyncInfoMetaVersion(dbc.dataStore, base.ProductVersion.String()); err != nil {
 				base.WarnfCtx(ctx, "[%s] Completed attachment migration, but unable to update syncInfo for collection %s: %v", migrationLoggingID, dbc.Name, err)
 				return err
 			}
@@ -348,7 +348,7 @@ func getCollectionIDsForMigration(db *DatabaseContext) ([]uint32, error) {
 	// if all collections are included in RequireAttachmentMigration then we need to run against all collections,
 	// if no collections are specified in RequireAttachmentMigration, run against all collections. This is to support job
 	// being triggered by rest api (even after job was previously completed)
-	if len(db.CollectionByID) == len(db.RequireAttachmentMigration) || len(db.RequireAttachmentMigration) == 0 {
+	if len(db.RequireAttachmentMigration) == 0 {
 		// get all collection IDs
 		collectionIDs = db.GetCollectionIDs()
 	} else {
@@ -356,7 +356,7 @@ func getCollectionIDsForMigration(db *DatabaseContext) ([]uint32, error) {
 		for _, v := range db.RequireAttachmentMigration {
 			collection, err := db.GetDatabaseCollection(v.ScopeName(), v.CollectionName())
 			if err != nil {
-				return nil, fmt.Errorf("failed to find ID for collection %s.%s", base.MD(v.ScopeName()).Redact(), base.MD(v.CollectionName()).Redact())
+				return nil, base.RedactErrorf("failed to find ID for collection %s.%s", base.MD(v.ScopeName()), base.MD(v.CollectionName()))
 			}
 			collectionIDs = append(collectionIDs, collection.GetCollectionID())
 		}

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -31,6 +31,8 @@ type AttachmentMigrationManager struct {
 
 var _ BackgroundManagerProcessI = &AttachmentMigrationManager{}
 
+const MetaVersionValue = "4.0.0" // Meta version to set in syncInfo document upon completion of attachment migration for collection
+
 func NewAttachmentMigrationManager(database *DatabaseContext) *BackgroundManager {
 	metadataStore := database.MetadataStore
 	metaKeys := database.MetadataKeys
@@ -195,7 +197,7 @@ func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string
 		// set sync info metadata version
 		for _, collectionID := range currCollectionIDs {
 			dbc := db.CollectionByID[collectionID]
-			if err := base.SetSyncInfoMetaVersion(dbc.dataStore, base.ProductVersion.String()); err != nil {
+			if err := base.SetSyncInfoMetaVersion(dbc.dataStore, MetaVersionValue); err != nil {
 				base.WarnfCtx(ctx, "[%s] Completed attachment migration, but unable to update syncInfo for collection %s: %v", migrationLoggingID, dbc.Name, err)
 				return err
 			}

--- a/db/database.go
+++ b/db/database.go
@@ -2495,6 +2495,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 		if err != nil {
 			base.WarnfCtx(ctx, "Error trying to migrate attachments for %s with error: %v", db.Name, err)
 		}
+		base.InfofCtx(ctx, base.KeyAll, "Migrating attachment metadata automatically to Sync Gateway 4.0+ for collections %v", db.RequireAttachmentMigration)
 	}
 
 	if err := base.RequireNoBucketTTL(ctx, db.Bucket); err != nil {

--- a/db/database.go
+++ b/db/database.go
@@ -2495,7 +2495,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 		if err != nil {
 			base.WarnfCtx(ctx, "Error trying to migrate attachments for %s with error: %v", db.Name, err)
 		}
-		base.InfofCtx(ctx, base.KeyAll, "Migrating attachment metadata automatically to Sync Gateway 4.0+ for collections %v", db.RequireAttachmentMigration)
+		base.DebugfCtx(ctx, base.KeyAll, "Migrating attachment metadata automatically to Sync Gateway 4.0+ for collections %v", db.RequireAttachmentMigration)
 	}
 
 	if err := base.RequireNoBucketTTL(ctx, db.Bucket); err != nil {

--- a/db/database.go
+++ b/db/database.go
@@ -146,6 +146,7 @@ type DatabaseContext struct {
 	CollectionNames              map[string]map[string]struct{} // Map of scope, collection names
 	MetadataKeys                 *base.MetadataKeys             // Factory to generate metadata document keys
 	RequireResync                base.ScopeAndCollectionNames   // Collections requiring resync before database can go online
+	RequireAttachmentMigration   base.ScopeAndCollectionNames   // Collections that require the attachment migration background task to run against
 	CORS                         *auth.CORSConfig               // CORS configuration
 	EnableMou                    bool                           // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
 }
@@ -668,6 +669,14 @@ func (context *DatabaseContext) stopBackgroundManagers() []*BackgroundManager {
 		if !isBackgroundManagerStopped(context.TombstoneCompactionManager.GetRunState()) {
 			if err := context.TombstoneCompactionManager.Stop(); err == nil {
 				bgManagers = append(bgManagers, context.TombstoneCompactionManager)
+			}
+		}
+	}
+
+	if context.AttachmentMigrationManager != nil {
+		if !isBackgroundManagerStopped(context.AttachmentMigrationManager.GetRunState()) {
+			if err := context.AttachmentMigrationManager.Stop(); err == nil {
+				bgManagers = append(bgManagers, context.AttachmentMigrationManager)
 			}
 		}
 	}
@@ -2478,6 +2487,15 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 		return err
 	}
 	db.backgroundTasks = append(db.backgroundTasks, bgtSyncTime)
+
+	db.AttachmentMigrationManager = NewAttachmentMigrationManager(db)
+	// if we have collections requiring migration, run the job
+	if len(db.RequireAttachmentMigration) > 0 && !db.BucketSpec.IsWalrusBucket() {
+		err := db.AttachmentMigrationManager.Start(ctx, nil)
+		if err != nil {
+			base.WarnfCtx(ctx, "Error trying to migrate attachments for %s with error: %v", db.Name, err)
+		}
+	}
 
 	if err := base.RequireNoBucketTTL(ctx, db.Bucket); err != nil {
 		return err

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3716,13 +3716,17 @@ func TestSettingSyncInfo(t *testing.T) {
 
 }
 
+// TestRequireMigration:
+//   - Purpose is to test code pathways inside the InitSyncInfo function will return requires attachment migration
+//     as expected.
+//   - Have a test case for meta version being 4.0 in the bucket and assert it returns false in that scenario
 func TestRequireMigration(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection, _ := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	ds := collection.GetCollectionDatastore()
 
-	// test no sync info in bucket returns requireMigration
+	// test no sync info in bucket and set metadataID, returns requireMigration
 	_, requireMigration, err := base.InitSyncInfo(ds, "someID")
 	require.NoError(t, err)
 	assert.True(t, requireMigration)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3775,7 +3775,7 @@ func TestRequireMigration(t *testing.T) {
 				require.NoError(t, base.SetSyncInfoMetaVersion(ds, testcase.metaVersion))
 			}
 
-			_, requireMigration, err := base.InitSyncInfo(ds, testcase.newMetadataID)
+			_, requireMigration, err := base.InitSyncInfo(ctx, ds, testcase.newMetadataID)
 			require.NoError(t, err)
 			if testcase.requireMigration {
 				assert.True(t, requireMigration)
@@ -3800,13 +3800,13 @@ func TestInitSyncInfoRequireMigrationEmptyBucket(t *testing.T) {
 	ds := tb.GetSingleDataStore()
 
 	// test no sync info in bucket and set metadataID, returns requireMigration
-	_, requireMigration, err := base.InitSyncInfo(ds, "someID")
+	_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID")
 	require.NoError(t, err)
 	assert.True(t, requireMigration)
 
 	// delete the doc, test no sync info in bucket returns requireMigration
 	require.NoError(t, ds.Delete(base.SGSyncInfo))
-	_, requireMigration, err = base.InitSyncInfo(ds, "")
+	_, requireMigration, err = base.InitSyncInfo(ctx, ds, "")
 	require.NoError(t, err)
 	assert.True(t, requireMigration)
 }
@@ -3856,12 +3856,12 @@ func TestInitSyncInfoMetaVersionComparison(t *testing.T) {
 			require.NoError(t, base.SetSyncInfoMetadataID(ds, testcase.metadataID))
 
 			if testcase.metaVersion == "" {
-				_, requireMigration, err := base.InitSyncInfo(ds, "someID")
+				_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID")
 				require.NoError(t, err)
 				assert.True(t, requireMigration)
 			} else {
 				require.NoError(t, base.SetSyncInfoMetaVersion(ds, testcase.metaVersion))
-				_, requireMigration, err := base.InitSyncInfo(ds, "someID")
+				_, requireMigration, err := base.InitSyncInfo(ctx, ds, "someID")
 				require.NoError(t, err)
 				assert.False(t, requireMigration)
 			}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -933,5 +933,5 @@ func AssertSyncInfoMetaVersion(t *testing.T, ds base.DataStore) {
 	var syncInfo base.SyncInfo
 	_, err := ds.Get(base.SGSyncInfo, &syncInfo)
 	require.NoError(t, err)
-	assert.Equal(t, base.ProductVersion.String(), syncInfo.MetaDataVersion)
+	assert.Equal(t, "4.0.0", syncInfo.MetaDataVersion)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -922,8 +922,16 @@ func RequireBackgroundManagerState(t *testing.T, ctx context.Context, mgr *Backg
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		var status BackgroundManagerStatus
 		rawStatus, err := mgr.GetStatus(ctx)
-		require.NoError(c, err)
-		require.NoError(c, base.JSONUnmarshal(rawStatus, &status))
+		assert.NoError(c, err)
+		assert.NoError(c, base.JSONUnmarshal(rawStatus, &status))
 		assert.Equal(c, expState, status.State)
 	}, time.Second*10, time.Millisecond*100)
+}
+
+// AssertSyncInfoMetaVersion will assert that meta version is equal to current product version
+func AssertSyncInfoMetaVersion(t *testing.T, ds base.DataStore) {
+	var syncInfo base.SyncInfo
+	_, err := ds.Get(base.SGSyncInfo, &syncInfo)
+	require.NoError(t, err)
+	assert.Equal(t, base.ProductVersion.String(), syncInfo.MetaDataVersion)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -917,3 +917,13 @@ func MoveAttachmentXattrFromGlobalToSync(t *testing.T, ctx context.Context, docI
 	_, err = dataStore.WriteWithXattrs(ctx, docID, 0, cas, value, map[string][]byte{base.SyncXattrName: newSync}, []string{base.GlobalXattrName}, opts)
 	require.NoError(t, err)
 }
+
+func RequireBackgroundManagerState(t *testing.T, ctx context.Context, mgr *BackgroundManager, expState BackgroundProcessState) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var status BackgroundManagerStatus
+		rawStatus, err := mgr.GetStatus(ctx)
+		require.NoError(c, err)
+		require.NoError(c, base.JSONUnmarshal(rawStatus, &status))
+		assert.Equal(c, expState, status.State)
+	}, time.Second*10, time.Millisecond*100)
+}

--- a/rest/attachment_migration_test.go
+++ b/rest/attachment_migration_test.go
@@ -1,0 +1,415 @@
+//  Copyright 2024-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrationJobStartOnDbStart(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+
+	ds := rt.GetSingleDataStore()
+	dbCtx := rt.GetDatabase()
+
+	mgr := dbCtx.AttachmentMigrationManager
+
+	// wait for migration job to finish
+	db.RequireBackgroundManagerState(t, ctx, mgr, db.BackgroundProcessStateCompleted)
+
+	// assert that sync info with metadata version written to the collection
+	syncInf := base.SyncInfo{}
+	_, err := ds.Get(base.SGSyncInfo, &syncInf)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0", syncInf.MetaDataVersion)
+
+}
+
+func TestChangeDbCollectionsRestartMigrationJob(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+	base.TestRequiresCollections(t)
+	base.RequireNumTestDataStores(t, 2)
+	base.LongRunningTest(t)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	tb := base.GetTestBucket(t)
+	rtConfig := &RestTesterConfig{
+		CustomTestBucket: tb,
+		PersistentConfig: true,
+	}
+
+	rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	_ = rt.Bucket()
+
+	const (
+		dbName         = "db1"
+		totalDocsAdded = 8000
+	)
+
+	ds0, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	ds1, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+	opts := &sgbucket.MutateInOptions{}
+
+	// add some docs (with xattr so they won't be ignored in the background job) to both collections
+	bodyBytes := []byte(`{"some": "body"}`)
+	for i := 0; i < 4000; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		xattrsInput := map[string][]byte{
+			"_xattr": []byte(`{"some":"xattr"}`),
+		}
+		_, writeErr := ds0.WriteWithXattrs(ctx, key, 0, 0, bodyBytes, xattrsInput, nil, opts)
+		require.NoError(t, writeErr)
+	}
+	for i := 0; i < 4000; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name()+"greg", i)
+		xattrsInput := map[string][]byte{
+			"_xattr": []byte(`{"some":"xattr"}`),
+		}
+		_, writeErr := ds1.WriteWithXattrs(ctx, key, 0, 0, bodyBytes, xattrsInput, nil, opts)
+		require.NoError(t, writeErr)
+	}
+
+	scopesConfigC1Only := GetCollectionsConfig(t, tb, 2)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfigC1Only)
+	scope := dataStoreNames[0].ScopeName()
+	collection2 := dataStoreNames[1].CollectionName()
+	delete(scopesConfigC1Only[scope].Collections, collection2)
+
+	scopesConfigBothCollection := GetCollectionsConfig(t, tb, 2)
+
+	// Create a db1 with one collection initially
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AutoImport = false
+	dbConfig.Scopes = scopesConfigC1Only
+
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	dbCtx := rt.GetDatabase()
+	mgr := dbCtx.AttachmentMigrationManager
+	assert.Len(t, dbCtx.RequireAttachmentMigration, 1)
+	// wait for migration job to start
+	db.RequireBackgroundManagerState(t, ctx, mgr, db.BackgroundProcessStateRunning)
+
+	// update db config to include second collection
+	dbConfig = rt.NewDbConfig()
+	dbConfig.AutoImport = false
+	dbConfig.Scopes = scopesConfigBothCollection
+	resp = rt.UpsertDbConfig(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// wait for attachment migration job to start and finish
+	dbCtx = rt.GetDatabase()
+	mgr = dbCtx.AttachmentMigrationManager
+	assert.Len(t, dbCtx.RequireAttachmentMigration, 2)
+	db.RequireBackgroundManagerState(t, ctx, mgr, db.BackgroundProcessStateRunning)
+
+	db.RequireBackgroundManagerState(t, ctx, mgr, db.BackgroundProcessStateCompleted)
+
+	var mgrStatus db.AttachmentMigrationManagerResponse
+	stat, err := mgr.GetStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, base.JSONUnmarshal(stat, &mgrStatus))
+	// assert that number of docs precessed is greater than the total docs added, this will be because when updating
+	// the db config to include a new collection this should force reset of DCP checkpoints and start DCP feed from 0 again
+	assert.Greater(t, mgrStatus.DocsProcessed, int64(totalDocsAdded))
+
+	// assert that sync info with metadata version written to both collections
+	syncInf := base.SyncInfo{}
+	_, err = ds0.Get(base.SGSyncInfo, &syncInf)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0", syncInf.MetaDataVersion)
+	syncInf = base.SyncInfo{}
+	_, err = ds1.Get(base.SGSyncInfo, &syncInf)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0", syncInf.MetaDataVersion)
+}
+
+func TestMigrationNewCollectionToDbNoRestart(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+	base.TestRequiresCollections(t)
+	base.RequireNumTestDataStores(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	tb := base.GetTestBucket(t)
+	rtConfig := &RestTesterConfig{
+		CustomTestBucket: tb,
+		PersistentConfig: true,
+	}
+
+	rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	_ = rt.Bucket()
+
+	const (
+		dbName                = "db1"
+		totalDocsAddedCollOne = 10
+		totalDocsAddedCollTwo = 10
+	)
+
+	ds0, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	ds1, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+	opts := &sgbucket.MutateInOptions{}
+
+	// add some docs (with xattr so they won't be ignored in the background job) to both collections
+	bodyBytes := []byte(`{"some": "body"}`)
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		xattrsInput := map[string][]byte{
+			"_xattr": []byte(`{"some":"xattr"}`),
+		}
+		_, writeErr := ds0.WriteWithXattrs(ctx, key, 0, 0, bodyBytes, xattrsInput, nil, opts)
+		require.NoError(t, writeErr)
+	}
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%s_%d", "greg", i)
+		xattrsInput := map[string][]byte{
+			"_xattr": []byte(`{"some":"xattr"}`),
+		}
+		_, writeErr := ds1.WriteWithXattrs(ctx, key, 0, 0, bodyBytes, xattrsInput, nil, opts)
+		require.NoError(t, writeErr)
+	}
+
+	scopesConfigC1Only := GetCollectionsConfig(t, tb, 2)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfigC1Only)
+	scope := dataStoreNames[0].ScopeName()
+	collection2 := dataStoreNames[1].CollectionName()
+	delete(scopesConfigC1Only[scope].Collections, collection2)
+
+	// Create a db1 with one collection initially
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AutoImport = false
+	dbConfig.Scopes = scopesConfigC1Only
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	dbCtx := rt.GetDatabase()
+	mgr := dbCtx.AttachmentMigrationManager
+	assert.Len(t, dbCtx.RequireAttachmentMigration, 1)
+	// wait for migration job to finish on single collection
+	db.RequireBackgroundManagerState(t, ctx, mgr, db.BackgroundProcessStateCompleted)
+
+	var mgrStatus db.AttachmentMigrationManagerResponse
+	stat, err := mgr.GetStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, base.JSONUnmarshal(stat, &mgrStatus))
+	// assert that number of docs precessed is equal to docs in collection 1
+	assert.Equal(t, int64(totalDocsAddedCollOne), mgrStatus.DocsProcessed)
+
+	// assert sync info meta version exists for this collection
+	syncInf := base.SyncInfo{}
+	_, err = ds0.Get(base.SGSyncInfo, &syncInf)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0", syncInf.MetaDataVersion)
+
+	// create db with second collection, background job should only run on new collection added given
+	// existent of sync info meta version on collection 1
+	scopesConfigBothCollection := GetCollectionsConfig(t, tb, 2)
+	dbConfig = rt.NewDbConfig()
+	dbConfig.AutoImport = false
+	dbConfig.Scopes = scopesConfigBothCollection
+	resp = rt.UpsertDbConfig(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	dbCtx = rt.GetDatabase()
+	mgr = dbCtx.AttachmentMigrationManager
+	assert.Len(t, dbCtx.RequireAttachmentMigration, 1)
+	// wait for migration job to finish on the new collection
+	db.RequireBackgroundManagerState(t, ctx, mgr, db.BackgroundProcessStateCompleted)
+
+	mgrStatus = db.AttachmentMigrationManagerResponse{}
+	stat, err = mgr.GetStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, base.JSONUnmarshal(stat, &mgrStatus))
+	// assert that number of docs precessed is equal to docs in collection 2 (not the total number of docs added across
+	// the collections, as we'd expect if the process had reset)
+	assert.Equal(t, int64(totalDocsAddedCollTwo), mgrStatus.DocsProcessed)
+
+	// assert that sync info with metadata version written to both collections
+	syncInf = base.SyncInfo{}
+	_, err = ds0.Get(base.SGSyncInfo, &syncInf)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0", syncInf.MetaDataVersion)
+	syncInf = base.SyncInfo{}
+	_, err = ds1.Get(base.SGSyncInfo, &syncInf)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0", syncInf.MetaDataVersion)
+}
+
+func TestMigrationNoReRunStartStopDb(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+	base.TestRequiresCollections(t)
+	base.RequireNumTestDataStores(t, 2)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	tb := base.GetTestBucket(t)
+	rtConfig := &RestTesterConfig{
+		CustomTestBucket: tb,
+		PersistentConfig: true,
+	}
+
+	rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	_ = rt.Bucket()
+
+	const (
+		dbName         = "db1"
+		totalDocsAdded = 20
+	)
+
+	ds0, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	ds1, err := tb.GetNamedDataStore(1)
+	require.NoError(t, err)
+	opts := &sgbucket.MutateInOptions{}
+
+	// add some docs (with xattr so they won't be ignored in the background job) to both collections
+	bodyBytes := []byte(`{"some": "body"}`)
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		xattrsInput := map[string][]byte{
+			"_xattr": []byte(`{"some":"xattr"}`),
+		}
+		_, writeErr := ds0.WriteWithXattrs(ctx, key, 0, 0, bodyBytes, xattrsInput, nil, opts)
+		require.NoError(t, writeErr)
+	}
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%s_%d", "greg", i)
+		xattrsInput := map[string][]byte{
+			"_xattr": []byte(`{"some":"xattr"}`),
+		}
+		_, writeErr := ds1.WriteWithXattrs(ctx, key, 0, 0, bodyBytes, xattrsInput, nil, opts)
+		require.NoError(t, writeErr)
+	}
+
+	scopesConfigBothCollection := GetCollectionsConfig(t, tb, 2)
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AutoImport = false
+	dbConfig.Scopes = scopesConfigBothCollection
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	dbCtx := rt.GetDatabase()
+	assert.Len(t, dbCtx.RequireAttachmentMigration, 2)
+	mgr := dbCtx.AttachmentMigrationManager
+	// wait for migration job to finish on both collections
+	db.RequireBackgroundManagerState(t, ctx, mgr, db.BackgroundProcessStateCompleted)
+
+	var mgrStatus db.AttachmentMigrationManagerResponse
+	stat, err := mgr.GetStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, base.JSONUnmarshal(stat, &mgrStatus))
+	// assert that number of docs precessed is equal to docs in collection 1
+	assert.Equal(t, int64(totalDocsAdded), mgrStatus.DocsProcessed)
+
+	// assert that sync info with metadata version written to both collections
+	syncInf := base.SyncInfo{}
+	_, err = ds0.Get(base.SGSyncInfo, &syncInf)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0", syncInf.MetaDataVersion)
+	syncInf = base.SyncInfo{}
+	_, err = ds1.Get(base.SGSyncInfo, &syncInf)
+	require.NoError(t, err)
+	assert.Equal(t, "4.0", syncInf.MetaDataVersion)
+
+	// reload db config with a config change
+	dbConfig = rt.NewDbConfig()
+	dbConfig.AutoImport = true
+	dbConfig.Scopes = scopesConfigBothCollection
+	resp = rt.UpsertDbConfig(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	dbCtx = rt.GetDatabase()
+	mgr = dbCtx.AttachmentMigrationManager
+	// assert that the job remains in completed state (not restarted)
+	mgrStatus = db.AttachmentMigrationManagerResponse{}
+	stat, err = mgr.GetStatus(ctx)
+	require.NoError(t, err)
+	require.NoError(t, base.JSONUnmarshal(stat, &mgrStatus))
+	assert.Equal(t, db.BackgroundProcessStateCompleted, mgrStatus.State)
+	assert.Equal(t, int64(totalDocsAdded), mgrStatus.DocsProcessed)
+	assert.Len(t, dbCtx.RequireAttachmentMigration, 0)
+}
+
+func TestStartMigrationAlreadyRunningProcess(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+	base.TestRequiresCollections(t)
+	base.RequireNumTestDataStores(t, 1)
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	tb := base.GetTestBucket(t)
+	rtConfig := &RestTesterConfig{
+		CustomTestBucket: tb,
+		PersistentConfig: true,
+	}
+
+	rt := NewRestTester(t, rtConfig)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	_ = rt.Bucket()
+
+	const (
+		dbName = "db1"
+	)
+
+	ds0, err := tb.GetNamedDataStore(0)
+	require.NoError(t, err)
+	opts := &sgbucket.MutateInOptions{}
+
+	// add some docs (with xattr so they won't be ignored in the background job) to both collections
+	bodyBytes := []byte(`{"some": "body"}`)
+	for i := 0; i < 2000; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		xattrsInput := map[string][]byte{
+			"_xattr": []byte(`{"some":"xattr"}`),
+		}
+		_, writeErr := ds0.WriteWithXattrs(ctx, key, 0, 0, bodyBytes, xattrsInput, nil, opts)
+		require.NoError(t, writeErr)
+	}
+
+	scopesConfig := GetCollectionsConfig(t, tb, 1)
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AutoImport = false
+	dbConfig.Scopes = scopesConfig
+	resp := rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+	dbCtx := rt.GetDatabase()
+	nodeMgr := dbCtx.AttachmentMigrationManager
+	// wait for migration job to start
+	db.RequireBackgroundManagerState(t, ctx, nodeMgr, db.BackgroundProcessStateRunning)
+
+	err = nodeMgr.Start(ctx, nil)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "Process already running")
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -710,7 +710,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				}
 
 				// Verify whether the collection is associated with a different database's metadataID - if so, add to set requiring resync
-				resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(dataStore, config.MetadataID)
+				resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(ctx, dataStore, config.MetadataID)
 				if err != nil {
 					return nil, err
 				}
@@ -733,7 +733,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 	} else {
 		// no scopes configured - init the default data store
-		resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(bucket.DefaultDataStore(), config.MetadataID)
+		resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(ctx, bucket.DefaultDataStore(), config.MetadataID)
 		if err != nil {
 			return nil, err
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -670,6 +670,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	collectionsRequiringResync := make([]base.ScopeAndCollectionName, 0)
+	collectionsRequiringAttachmentMigration := make([]base.ScopeAndCollectionName, 0)
 	if len(config.Scopes) > 0 {
 		if !bucket.IsSupported(sgbucket.BucketStoreFeatureCollections) {
 			return nil, errCollectionsUnsupported
@@ -709,13 +710,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				}
 
 				// Verify whether the collection is associated with a different database's metadataID - if so, add to set requiring resync
-				resyncRequired, err := base.InitSyncInfo(dataStore, config.MetadataID)
+				resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(dataStore, config.MetadataID)
 				if err != nil {
 					return nil, err
 				}
 				scName := base.ScopeAndCollectionName{Scope: scopeName, Collection: collectionName}
 				if resyncRequired {
 					collectionsRequiringResync = append(collectionsRequiringResync, scName)
+				}
+				if requiresAttachmentMigration {
+					collectionsRequiringAttachmentMigration = append(collectionsRequiringAttachmentMigration, scName)
 				}
 				if err := initDataStore(dataStore, metadataIndexOption, scName); err != nil {
 					return nil, err
@@ -729,12 +733,15 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 	} else {
 		// no scopes configured - init the default data store
-		resyncRequired, err := base.InitSyncInfo(bucket.DefaultDataStore(), config.MetadataID)
+		resyncRequired, requiresAttachmentMigration, err := base.InitSyncInfo(bucket.DefaultDataStore(), config.MetadataID)
 		if err != nil {
 			return nil, err
 		}
 		if resyncRequired {
 			collectionsRequiringResync = append(collectionsRequiringResync, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: base.DefaultCollection})
+		}
+		if requiresAttachmentMigration {
+			collectionsRequiringAttachmentMigration = append(collectionsRequiringAttachmentMigration, base.ScopeAndCollectionName{Scope: base.DefaultScope, Collection: base.DefaultCollection})
 		}
 		if err := initDataStore(bucket.DefaultDataStore(), db.IndexesAll, base.DefaultScopeAndCollectionName()); err != nil {
 			return nil, err
@@ -923,6 +930,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext.ServerContextHasStarted = sc.hasStarted
 	dbcontext.NoX509HTTPClient = sc.NoX509HTTPClient
 	dbcontext.RequireResync = collectionsRequiringResync
+	dbcontext.RequireAttachmentMigration = collectionsRequiringAttachmentMigration
 
 	if config.CORS != nil {
 		dbcontext.CORS = config.DbConfig.CORS


### PR DESCRIPTION
CBG-4212

- Changes to `InitSyncInfo` to return requires migration if the collection needs it (if sync info is missing altogether or is `metaVersion` is not equal to 4.0)
- Stores collections that require migration on the db context 
- Initiates a new Attachment migration manager upon db startup, will trigger this job based upon existence of collections that require migrating 
- Changes as purging of dcp checkpoints weren't happening as expected
- Changed to way we build collection IDs for dcp client. Changes will mean we only run dcp feeds against collections wee need for migration. This will make less overhead for updating a db to include a new collection when the other collection(s) have already been migrated. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2766/
