### PR TITLE
CBG-4261 have simple topologies working

### DIFF
--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -282,10 +282,10 @@ var simpleTopologies = []Topology{
 				},
 			},
 			{
-				activePeer:  "cbs2",
-				passivePeer: "cbs1",
+				activePeer:  "cbs1",
+				passivePeer: "cbs2",
 				config: PeerReplicationConfig{
-					direction: PeerReplicationDirectionPush,
+					direction: PeerReplicationDirectionPull,
 				},
 			},
 		},

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -265,9 +265,9 @@ var simpleTopologies = []Topology{
 	{
 
 		/*
-			+------+     +------+
-			| cbs1 | --> | cbs2 |
-			+------+     +------+
+			+------+      +------+
+			| cbs1 | <--> | cbs2 |
+			+------+      +------+
 		*/
 		description: "Couchbase Server -> Couchbase Server",
 		peers: map[string]PeerOptions{
@@ -277,6 +277,13 @@ var simpleTopologies = []Topology{
 			{
 				activePeer:  "cbs1",
 				passivePeer: "cbs2",
+				config: PeerReplicationConfig{
+					direction: PeerReplicationDirectionPush,
+				},
+			},
+			{
+				activePeer:  "cbs2",
+				passivePeer: "cbs1",
 				config: PeerReplicationConfig{
 					direction: PeerReplicationDirectionPush,
 				},
@@ -307,6 +314,13 @@ var simpleTopologies = []Topology{
 				passivePeer: "cbs2",
 				config: PeerReplicationConfig{
 					direction: PeerReplicationDirectionPush,
+				},
+			},
+			{
+				activePeer:  "cbs1",
+				passivePeer: "cbs2",
+				config: PeerReplicationConfig{
+					direction: PeerReplicationDirectionPull,
 				},
 			},
 		},


### PR DESCRIPTION
All the topologies defined in the test document are implemented. `simpleTopologies` are not used automatically but can be useful for testing. 

All other topologies are correctly defined.
