### PR TITLE
CBG-4254 implement Couchbase Server peer

### DIFF
--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -9,6 +9,7 @@
 package topologytest
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -131,9 +132,19 @@ func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, config PeerReplicat
 	return replication
 }
 
-// SourceID returns the source ID for the peer used in <val>@sourceID.
+// SourceID returns the source ID for the peer used in <val>@<sourceID>.
 func (r *CouchbaseLiteMockPeer) SourceID() string {
 	return r.name
+}
+
+// Context returns the context for the peer.
+func (p *CouchbaseLiteMockPeer) Context() context.Context {
+	return base.TestCtx(p.TB())
+}
+
+// TB returns the testing.TB for the peer.
+func (p *CouchbaseLiteMockPeer) TB() testing.TB {
+	return p.t
 }
 
 // GetBackingBucket returns the backing bucket for the peer. This is always nil.

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -232,6 +232,7 @@ var Topologies = []Topology{
 				case "cbl1", "cbl2":
 					t.Skip("CBG-4257, docs don't get CV when set from CBL")
 				}
+				t.Skip("CBG-4281 doesn't skip or preserve _sync xattr")
 			}
 		},
 	},

--- a/xdcr/cbs_xdcr.go
+++ b/xdcr/cbs_xdcr.go
@@ -154,6 +154,10 @@ func (x *couchbaseServerManager) Start(ctx context.Context) error {
 
 // Stop starts the XDCR replication and deletes the replication from Couchbase Server.
 func (x *couchbaseServerManager) Stop(ctx context.Context) error {
+	// replication is not started
+	if x.replicationID == "" {
+		return nil
+	}
 	method := http.MethodDelete
 	url := "/controller/cancelXDCR/" + url.PathEscape(x.replicationID)
 	output, statusCode, err := x.fromBucket.MgmtRequest(ctx, method, url, "application/x-www-form-urlencoded", nil)


### PR DESCRIPTION
- Skipped tests in https://docs.google.com/spreadsheets/d/1U2FxFlMo5vT-tk9mmDgw68zONX1JCPsy9gxzH7uWk6E/edit?gid=0#gid=0 in future tickets.
- Implement Write and Delete functions to always overwrite with the latest update. The Delete will technically be able to delete something that has already been deleted, but I actually think that is desired.
- Read the hlv implicitly out the xattrs to construct a DocVersion, there is a concept of a CV without a _vv, that is just implicitly sourceID@cas (when a document is written directly to couchbase server and not replicated by XDCR).
