### PR TITLE
CBG-4308 fix test race condition

### DIFF
--- a/base/logging_context_test.go
+++ b/base/logging_context_test.go
@@ -32,8 +32,7 @@ func requireLogIs(t testing.TB, s string, f func()) {
 	timestampLength := len(time.Now().Format(ISO8601Format) + " ")
 
 	// Temporarily override logger output for the given function call
-	oldLogger := consoleLogger.Load()
-	consoleLogger.Load()
+	oldLogger := consoleLogger.Swap(tempLogger)
 	defer func() {
 		consoleLogger.Store(oldLogger)
 	}()

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1570,7 +1570,7 @@ func TestTerminateAndWaitForClose(t *testing.T) {
 				InfofCtx(ctx, KeySGTest, "got t closing d")
 				close(d)
 			},
-			timeout: time.Second * 3,
+			timeout: time.Millisecond * 100,
 			wantErr: false,
 		},
 		{
@@ -1581,7 +1581,7 @@ func TestTerminateAndWaitForClose(t *testing.T) {
 				<-t
 				InfofCtx(ctx, KeySGTest, "got t waiting to close d")
 				select {
-				case <-time.After(time.Second * 3):
+				case <-time.After(time.Millisecond * 100):
 					InfofCtx(ctx, KeySGTest, "closing d")
 					close(d)
 				case <-ctx.Done():
@@ -1606,7 +1606,7 @@ func TestTerminateAndWaitForClose(t *testing.T) {
 					InfofCtx(ctx, KeySGTest, "test context done")
 				}
 			},
-			timeout: time.Second * 3,
+			timeout: time.Millisecond * 100,
 			wantErr: true,
 		},
 		{
@@ -1618,7 +1618,7 @@ func TestTerminateAndWaitForClose(t *testing.T) {
 				<-t
 				InfofCtx(ctx, KeySGTest, "got t not closing d")
 			},
-			timeout: time.Second * 3,
+			timeout: time.Millisecond * 100,
 			wantErr: true,
 		},
 		{
@@ -1631,7 +1631,7 @@ func TestTerminateAndWaitForClose(t *testing.T) {
 				<-ctx.Done()
 				InfofCtx(ctx, KeySGTest, "test context done")
 			},
-			timeout: time.Second * 3,
+			timeout: time.Millisecond * 100,
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
- requireLogIs was modifying ColorEnabled on an activeLogger, create the logger and replace atomically
- lower the Sleep time for TerminateAndWaitForClose tests, used for reproducing issue. This shaves 12 secs off test time

Fixes race condition:

```
2024-10-15T01:43:20.9143732Z ==================
2024-10-15T01:43:20.9144120Z WARNING: DATA RACE
2024-10-15T01:43:20.9144570Z Write at 0x00c000188560 by goroutine 66:
2024-10-15T01:43:20.9145248Z   github.com/couchbase/sync_gateway/base.requireLogIs()
2024-10-15T01:43:20.9146396Z       /home/runner/work/sync_gateway/sync_gateway/base/logging_context_test.go:32 +0x12d
2024-10-15T01:43:20.9147482Z   github.com/couchbase/sync_gateway/base.RequireLogMessage()
2024-10-15T01:43:20.9148592Z       /home/runner/work/sync_gateway/sync_gateway/base/logging_context_test.go:61 +0xb1
2024-10-15T01:43:20.9149674Z   github.com/couchbase/sync_gateway/base.TestLogFormat.func1()
2024-10-15T01:43:20.9150935Z       /home/runner/work/sync_gateway/sync_gateway/base/logging_context_test.go:224 +0x26
2024-10-15T01:43:20.9151721Z   testing.tRunner()
2024-10-15T01:43:20.9152557Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
2024-10-15T01:43:20.9153291Z   testing.(*T).Run.gowrap1()
2024-10-15T01:43:20.9154147Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x44
2024-10-15T01:43:20.9154748Z 
2024-10-15T01:43:20.9154995Z Previous read at 0x00c000188560 by goroutine 53:
2024-10-15T01:43:20.9155816Z   github.com/couchbase/sync_gateway/base.colorEnabled()
2024-10-15T01:43:20.9157147Z       /home/runner/work/sync_gateway/sync_gateway/base/logging.go:350 +0x52
2024-10-15T01:43:20.9158240Z   github.com/couchbase/sync_gateway/base.color()
2024-10-15T01:43:20.9159308Z       /home/runner/work/sync_gateway/sync_gateway/base/logging.go:323 +0x79
2024-10-15T01:43:20.9160208Z   github.com/couchbase/sync_gateway/base.logTo()
2024-10-15T01:43:20.9161242Z       /home/runner/work/sync_gateway/sync_gateway/base/logging.go:236 +0x5b4
2024-10-15T01:43:20.9162175Z   github.com/couchbase/sync_gateway/base.InfofCtx()
2024-10-15T01:43:20.9163118Z       /home/runner/work/sync_gateway/sync_gateway/base/logging.go:168 +0x9c
2024-10-15T01:43:20.9164218Z   github.com/couchbase/sync_gateway/base.TestTerminateAndWaitForClose.func5()
2024-10-15T01:43:20.9165481Z       /home/runner/work/sync_gateway/sync_gateway/base/util_test.go:1632 +0x6d
2024-10-15T01:43:20.9166709Z   github.com/couchbase/sync_gateway/base.TestTerminateAndWaitForClose.func6.gowrap1()
2024-10-15T01:43:20.9167999Z       /home/runner/work/sync_gateway/sync_gateway/base/util_test.go:1640 +0x6e
2024-10-15T01:43:20.9168677Z 
2024-10-15T01:43:20.9168851Z Goroutine 66 (running) created at:
2024-10-15T01:43:20.9169423Z   testing.(*T).Run()
2024-10-15T01:43:20.9170227Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x825
2024-10-15T01:43:20.9171161Z   github.com/couchbase/sync_gateway/base.TestLogFormat()
2024-10-15T01:43:20.9172285Z       /home/runner/work/sync_gateway/sync_gateway/base/logging_context_test.go:222 +0x1476
2024-10-15T01:43:20.9173170Z   testing.tRunner()
2024-10-15T01:43:20.9174041Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
2024-10-15T01:43:20.9174846Z   testing.(*T).Run.gowrap1()
2024-10-15T01:43:20.9175737Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x44
2024-10-15T01:43:20.9176397Z 
2024-10-15T01:43:20.9176603Z Goroutine 53 (finished) created at:
2024-10-15T01:43:20.9177661Z   github.com/couchbase/sync_gateway/base.TestTerminateAndWaitForClose.func6()
2024-10-15T01:43:20.9179002Z       /home/runner/work/sync_gateway/sync_gateway/base/util_test.go:1640 +0x191
2024-10-15T01:43:20.9179791Z   testing.tRunner()
2024-10-15T01:43:20.9180646Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1689 +0x21e
2024-10-15T01:43:20.9181432Z   testing.(*T).Run.gowrap1()
2024-10-15T01:43:20.9182315Z       /opt/hostedtoolcache/go/1.22.5/x64/src/testing/testing.go:1742 +0x44
2024-10-15T01:43:20.9183050Z ==================
2024-10-15T01:43:20.9183668Z     testing.go:1398: race detected during execution of test
```