### PR TITLE
CBG-4292 compute mouMatch on the metadataOnlyUpdate before it is modified

### DIFF
--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -370,7 +370,14 @@ func TestHLVImport(t *testing.T) {
 				}
 			},
 			expectedHLV: func(output *outputData) *HybridLogicalVector {
-				return output.preImportHLV
+				return &HybridLogicalVector{
+					SourceID:          db.EncodedSourceID,
+					Version:           output.preImportCas,
+					CurrentVersionCAS: output.preImportCas,
+					PreviousVersions: map[string]uint64{
+						EncodeSource(otherSource): output.preImportHLV.CurrentVersionCAS,
+					},
+				}
 			},
 		},
 		{
@@ -450,7 +457,10 @@ func TestHLVImport(t *testing.T) {
 				postImportCas:     finalCas,
 				preImportRevSeqNo: revSeqNo,
 			}
-			require.NoError(t, base.JSONUnmarshal(xattrs[base.VvXattrName], &output.preImportHLV))
+			if existingHLV, ok := existingXattrs[base.VvXattrName]; ok {
+
+				require.NoError(t, base.JSONUnmarshal(existingHLV, &output.preImportHLV))
+			}
 
 			if testCase.expectedMou != nil {
 				require.Contains(t, xattrs, base.MouXattrName)

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -220,6 +220,7 @@ func createPeers(t *testing.T, peersOptions map[string]PeerOptions) map[string]P
 	peers := make(map[string]Peer, len(peersOptions))
 	for id, peerOptions := range peersOptions {
 		peer := NewPeer(t, id, buckets, peerOptions)
+		t.Logf("TopologyTest: created peer %s, SourceID=%+v", id, peer.SourceID())
 		t.Cleanup(func() {
 			peer.Close()
 		})

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -64,11 +64,7 @@ var Topologies = []Topology{
 				},
 			},
 		},
-		skipIf: func(t *testing.T, activePeer string, peers map[string]Peer) {
-			switch activePeer {
-			case "cbs1":
-				t.Skip("CBG-4289 imported documents get CV updated")
-			}
+		skipIf: func(t *testing.T, activePeer string, _ map[string]Peer) {
 			if base.UnitTestUrlIsWalrus() {
 				switch activePeer {
 				case "cbl1":
@@ -136,13 +132,11 @@ var Topologies = []Topology{
 				},
 			},
 		},
-		skipIf: func(t *testing.T, activePeer string, peers map[string]Peer) {
+		skipIf: func(t *testing.T, activePeer string, _ map[string]Peer) {
 			if base.UnitTestUrlIsWalrus() {
 				switch activePeer {
-				case "cbs1", "cbs2":
-					t.Skip("CBG-4289 imported documents get CV updated")
-				case "cbl1":
-					t.Skip("CBG-4257, docs don't get CV when set from CBL")
+				case "cbs1", "cbs2", "cbl1":
+					t.Skip("CBG-4300 rosmar XDCR is working correctly")
 				}
 			}
 		},
@@ -222,17 +216,9 @@ var Topologies = []Topology{
 				},
 			},
 		},
-		skipIf: func(t *testing.T, activePeer string, peers map[string]Peer) {
-			switch activePeer {
-			case "cbs1", "cbs2":
-				t.Skip("CBG-4289 imported documents get CV updated")
-			}
+		skipIf: func(t *testing.T, _ string, _ map[string]Peer) {
 			if base.UnitTestUrlIsWalrus() {
-				switch activePeer {
-				case "cbl1", "cbl2":
-					t.Skip("CBG-4257, docs don't get CV when set from CBL")
-				}
-				t.Skip("CBG-4281 doesn't skip or preserve _sync xattr")
+				t.Skip("CBG-4300 rosmar XDCR is working correctly")
 			}
 		},
 	},
@@ -346,11 +332,6 @@ var simpleTopologies = []Topology{
 				},
 			},
 		},
-		skipIf: func(t *testing.T, activePeer string, peers map[string]Peer) {
-			if base.UnitTestUrlIsWalrus() {
-				t.Skip("CBG-4300, need to construct a _vv on source if none is present, to then call setWithMeta")
-			}
-		},
 	},
 	{
 		/*
@@ -386,13 +367,11 @@ var simpleTopologies = []Topology{
 				},
 			},
 		},
-		skipIf: func(t *testing.T, activePeer string, peers map[string]Peer) {
+		skipIf: func(t *testing.T, activePeer string, _ map[string]Peer) {
 			if base.UnitTestUrlIsWalrus() {
 				switch activePeer {
-				case "cbs1":
-					t.Skip("CBG-4289 imported documents get CV updated")
-				case "cbs2":
-					t.Skip("CBG-4300, need to construct a _vv on source if none is present, to then call setWithMeta")
+				case "cbs1", "cbs2":
+					t.Skip("CBG-4300 rosmar XDCR is working correctly")
 				}
 			}
 		},


### PR DESCRIPTION
Before this PR, `doc.metadataOnlyUpdate.CAS` was always equal to `expand` in the callback from `updateAndReturnDoc` in `importDoc`.

The test assertions in https://github.com/couchbase/sync_gateway/commit/f72474954bbd0506a573b32e10110b4ed6e2c6df were wrong in two ways:

`output.preImportHLV` was accidentally set to final HLV, and in one test case we expected the HLV to actually add to the PV.

Couchbase Server topology tests now pass, but rosmar XDCR tests are still failing for reasons I think are unrelated to the import issue. It's possible the rosmar tests hit race conditions that CBS tests don't yet hit.