### PR TITLE
CBG-4242: TestReleaseSequenceOnDocWriteFailure flake

### DIFF
--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1701,10 +1701,8 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	var db *Database
 	var forceDocConflict bool
 
-	const (
-		conflictDoc = "doc1"
-		timeoutDoc  = "doc"
-	)
+	conflictDoc := t.Name() + "_conflict"
+	timeoutDoc := t.Name() + "_timeout"
 
 	// call back to create a conflict mid write and force a non timeout error upon write attempt
 	writeUpdateCallback := func(key string) {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1691,9 +1691,6 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 //   - Write new doc with conflict error
 //   - Assert we release a sequence for this
 func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("skipping for CBS pending CBG-4242")
-	}
 	defer SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 


### PR DESCRIPTION
CBG-4242

- Test seemed to fail for me locally when subdocGetBodyAndXattrs inside WriteUpdateWithXattrs from the first Put in the test seems to find a server tombstone for the document. Seems to suggest the test harness not properly purging docs from the bucket in between tests. To fix for now, I had the doc id's unique from other tests 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2761/
