### PR TITLE
CBG-4323: fix for per shard memory based eviction

### DIFF
--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -34,7 +34,7 @@ func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingSt
 	revCacheOptions.MaxItemCount = uint32(perCacheCapacity)
 	var perCacheMemoryCapacity float32
 	if revCacheOptions.MaxBytes > 0 {
-		perCacheMemoryCapacity = 1.1 * float32(revCacheOptions.MaxBytes) / float32(revCacheOptions.ShardCount)
+		perCacheMemoryCapacity = float32(revCacheOptions.MaxBytes) / float32(revCacheOptions.ShardCount)
 		revCacheOptions.MaxBytes = int64(perCacheMemoryCapacity)
 	}
 
@@ -89,10 +89,10 @@ type LRURevisionCache struct {
 	cacheMisses          *base.SgwIntStat
 	cacheNumItems        *base.SgwIntStat
 	lock                 sync.Mutex
-	capacity             uint32
-	MaxMemoryCapacity    int64
-	currMemoryCapacity   base.AtomicInt
-	cacheMemoryBytesStat *base.SgwIntStat
+	capacity             uint32           // Max number of items capacity of LRURevisionCache
+	MaxMemoryCapacity    int64            // Max memory capacity of LRURevisionCache
+	currMemoryCapacity   base.AtomicInt   // count of number of bytes used currently in the LRURevisionCache
+	cacheMemoryBytesStat *base.SgwIntStat // stat for overall cache memory usage in bytes
 }
 
 // The cache payload data. Stored as the Value of a list Element.

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -753,7 +753,6 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 	docRev, err := collection.GetRev(ctx, "doc1", rev, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
-	assert.Equal(t, int64(64), docRev.MemoryBytes)
 	assert.NotNil(t, docRev.BodyBytes)
 
 	// assert rev cache is still empty

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -694,12 +694,12 @@ func TestShardedMemoryEviction(t *testing.T) {
 	// grab this particular shard + assert that the shard memory usage is as expected
 	shardedCache := db.revisionCache.(*ShardedLRURevisionCache)
 	doc1Shard := shardedCache.getShard("doc1")
-	assert.Equal(t, int64(size), doc1Shard.currMemoryCapacity.Value())
+	assert.Equal(t, int64(size), doc1Shard.currMemoryUsage.Value())
 
 	// add new doc in diff shard + assert that the shard memory usage is as expected
 	size, _ = createDocAndReturnSizeAndRev(t, ctx, "doc2", collection, docBody)
 	doc2Shard := shardedCache.getShard("doc2")
-	assert.Equal(t, int64(size), doc2Shard.currMemoryCapacity.Value())
+	assert.Equal(t, int64(size), doc2Shard.currMemoryUsage.Value())
 	// overall mem usage should be combination oif the two added docs
 	assert.Equal(t, int64(size*2), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -713,7 +713,7 @@ func TestShardedMemoryEviction(t *testing.T) {
 	// add new doc to trigger eviction and assert stats are as expected
 	newDocSize, _ := createDocAndReturnSizeAndRev(t, ctx, "doc3", collection, docBody)
 	doc3Shard := shardedCache.getShard("doc3")
-	assert.Equal(t, int64(newDocSize), doc3Shard.currMemoryCapacity.Value())
+	assert.Equal(t, int64(newDocSize), doc3Shard.currMemoryUsage.Value())
 	assert.Equal(t, int64(2), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(size+newDocSize), cacheStats.RevisionCacheTotalMemory.Value())
 }
@@ -745,7 +745,7 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 
 	// assert that doc was not added to cache as it's too large
 	doc1Shard := shardedCache.getShard("doc1")
-	assert.Equal(t, int64(0), doc1Shard.currMemoryCapacity.Value())
+	assert.Equal(t, int64(0), doc1Shard.currMemoryUsage.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -756,7 +756,7 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 	assert.NotNil(t, docRev.BodyBytes)
 
 	// assert rev cache is still empty
-	assert.Equal(t, int64(0), doc1Shard.currMemoryCapacity.Value())
+	assert.Equal(t, int64(0), doc1Shard.currMemoryUsage.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -657,6 +657,90 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 	assert.Equal(t, int64(0), cacheNumItems.Value())
 }
 
+// TestShardedMemoryEviction:
+//   - Test adding a doc to each shard in the test
+//   - Assert that each shard has individual count for memory usage as expected
+//   - Add new doc that will take over the shard memory capacity and assert that that eviction takes place and
+//     all stats are as expected
+func TestShardedMemoryEviction(t *testing.T) {
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxBytes:     150,
+			MaxItemCount: 10,
+			ShardCount:   2,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	cacheStats := db.DbStats.Cache()
+
+	docBody := Body{
+		"channels": "_default",
+	}
+
+	// add doc that will be added to one shard
+	size, _ := createDocAndReturnSizeAndRev(t, ctx, "doc1", collection, docBody)
+	assert.Equal(t, int64(size), cacheStats.RevisionCacheTotalMemory.Value())
+	// grab this particular shard + assert that the shard memory usage is as expected
+	shardedCache := db.revisionCache.(*ShardedLRURevisionCache)
+	doc1Shard := shardedCache.getShard("doc1")
+	assert.Equal(t, int64(size), doc1Shard.currMemoryCapacity.Value())
+
+	// add new doc in diff shard + assert that the shard memory usage is as expected
+	size, _ = createDocAndReturnSizeAndRev(t, ctx, "doc2", collection, docBody)
+	doc2Shard := shardedCache.getShard("doc2")
+	assert.Equal(t, int64(size), doc2Shard.currMemoryCapacity.Value())
+	// overall mem usage should be combination oif the two added docs
+	assert.Equal(t, int64(size*2), cacheStats.RevisionCacheTotalMemory.Value())
+
+	// two docs should reside in cache at this time
+	assert.Equal(t, int64(2), cacheStats.RevisionCacheNumItems.Value())
+
+	docBody = Body{
+		"channels": "_default",
+		"some":     "field",
+	}
+	// add new doc to trigger eviction and assert stats are as expected
+	newDocSize, _ := createDocAndReturnSizeAndRev(t, ctx, "doc3", collection, docBody)
+	doc3Shard := shardedCache.getShard("doc3")
+	assert.Equal(t, int64(newDocSize), doc3Shard.currMemoryCapacity.Value())
+	assert.Equal(t, int64(2), cacheStats.RevisionCacheNumItems.Value())
+	assert.Equal(t, int64(size+newDocSize), cacheStats.RevisionCacheTotalMemory.Value())
+}
+
+// TestShardedMemoryEvictionWhenShardEmpty:
+//   - Test adding a doc to sharded revision cache that will immediately be evicted due to size
+//   - Assert that stats look as expected
+func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxBytes:     100,
+			MaxItemCount: 10,
+			ShardCount:   2,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	cacheStats := db.DbStats.Cache()
+
+	docBody := Body{
+		"channels": "_default",
+	}
+
+	// add doc that will be added to one shard
+	_, _, err := collection.Put(ctx, "doc1", docBody)
+	require.NoError(t, err)
+	shardedCache := db.revisionCache.(*ShardedLRURevisionCache)
+
+	// assert that doc was not added to cache as it's too large
+	doc1Shard := shardedCache.getShard("doc1")
+	assert.Equal(t, int64(0), doc1Shard.currMemoryCapacity.Value())
+	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
+	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
+}
+
 func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1307,6 +1307,7 @@ Database:
             max_memory_count_mb:
               description: |-
                 The maximum amount of memory the revision cache should take up in MB, setting to 0 will disable any eviction based on memory at rev cache.
+                There is a minimum value of 50 (50MB) for this config option.
                 When set this memory limit will work in in hand with revision cache size parameter. So you will potentially get eviction at revision cache both based off memory footprint and number of items in the cache.
                 **This is an Enterprise Edition feature only**
               type: integer

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1059,6 +1059,10 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 				revCacheOptions.MaxItemCount = *config.CacheConfig.RevCacheConfig.MaxItemCount
 			}
 			if config.CacheConfig.RevCacheConfig.MaxMemoryCountMB != nil {
+				maxMemoryConfigValue := *config.CacheConfig.RevCacheConfig.MaxMemoryCountMB
+				if maxMemoryConfigValue != uint32(0) && maxMemoryConfigValue < uint32(50) {
+					return db.DatabaseContextOptions{}, fmt.Errorf("maximum rev cache memory size cannot be lower than 50 MB")
+				}
 				revCacheOptions.MaxBytes = int64(*config.CacheConfig.RevCacheConfig.MaxMemoryCountMB * 1024 * 1024) // Convert MB input to bytes
 			}
 			if config.CacheConfig.RevCacheConfig.ShardCount != nil {


### PR DESCRIPTION
CBG-4323

- Hit a panic in 3.2.1 testing that was due to using the overall memory stat for memory based eviction when using sharded rev cache, this panic was from trying to evict from empty rev cache shard. As I was using the overall stat for rev cache memory usage when I hit a point where memory based eviction was needed (as overall memory exceeded the parameter), per chance I hit this point when trying to add a new doc that was going to empty shard. When adding this doc eviction as hit and then we tried to evict from the current shard but to was empty. 
- Fix is to keep separate count for memory usage per shard and evict per shard aligning with what we do for num items eviction 
- Had to do this through another atomic as we don't always hold rev cache lock when incrementing/decrementing memory and reacquiring lock will probably be more expensive
- Have minimum of 50MB for cache config 
- Removed 10% buffer per shard 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2764/
