### PR TITLE
Cancel in-progress GH actions jobs when the PR or ref has been superseded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ on:
       - 'release/*'
       - 'beryllium'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
 jobs:
   build:

--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -19,6 +19,10 @@ on:
       - 'release/*'
       - 'beryllium'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   redocly_preview_links:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi-pr.yml
+++ b/.github/workflows/openapi-pr.yml
@@ -21,7 +21,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
 jobs:
   redocly_preview_links:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -32,6 +32,10 @@ on:
       - 'release/*'
       - 'beryllium'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   api_validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -34,7 +34,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
 jobs:
   api_validation:

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -33,7 +33,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
 
 jobs:
   scripts:

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -31,6 +31,10 @@ on:
       - 'main'
       - 'release/*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scripts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't need the old runs to continue to completion for PRs or refs that are being re-run.
Cancel them to save unnessesary CI work. Thanks @snej!

https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions 