### PR TITLE
CBG-4335 update to go 1.23, and minor versions for 3.1/3.2 branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - name: go-build
         run: go build "./..."
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - name: Run Tests
         run: go test -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - name: Run Tests
         run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - name: Run Tests
         run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -191,7 +191,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.2
       - name: go-build
         run: go build "./..."
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.2
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -54,12 +54,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
-          cache: false
+          go-version: 1.23.2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.59.0
+          version: v1.61.0
           args: --config=.golangci-strict.yml
 
   test:
@@ -82,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.2
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -90,7 +89,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.7.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json
 
@@ -102,13 +101,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.2
       - name: Run Tests
         run: go test -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json
 
@@ -121,13 +120,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.2
       - name: Run Tests
         run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json
 
@@ -140,13 +139,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.2
       - name: Run Tests
         run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.8.0
         with:
           test-results: test.json
 
@@ -192,7 +191,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.2
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -40,7 +40,7 @@ jobs:
       # build sync gateway since the executable is needed for service installation
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.3
       - name: "Build Sync Gateway"
         run: mkdir -p ./bin && go build -o ./bin ./...
       - name: "Run test scripts"

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -40,7 +40,7 @@ jobs:
       # build sync gateway since the executable is needed for service installation
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.5
+          go-version: 1.23.2
       - name: "Build Sync Gateway"
         run: mkdir -p ./bin && go build -o ./bin ./...
       - name: "Run test scripts"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
 
     tools {
-        go '1.22.5'
+        go '1.23.2'
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     }
 
     tools {
-        go '1.23.2'
+        go '1.23.3'
     }
 
     stages {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.22
+go 1.23
 
 require (
 	dario.cat/mergo v1.0.0

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -57,7 +57,10 @@ if [ "${USE_GO_MODULES:-}" == "false" ]; then
     go get -u -v github.com/AlekSi/gocov-xml
 else
     # Install tools to use after job has completed
-    go install -v github.com/tebeka/go2xunit@latest
+    # go2xunit will fail with 1.23 with name mismatch (try disabling parallel mode), but without any t.Parallel()
+    go install golang.org/dl/go1.22.8@latest
+    ~/go/bin/go1.22.8 download
+    ~/go/bin/go1.22.8 install -v github.com/tebeka/go2xunit@latest
     go install -v github.com/axw/gocov/gocov@latest
     go install -v github.com/AlekSi/gocov-xml@latest
 fi

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.23.2",
+            "go_version": "1.23.3",
             "trigger_blackduck": true,
             "start_build": 11
         },
@@ -612,7 +612,7 @@
             "release_name": "Couchbase Sync Gateway 3.2.1",
             "production": true,
             "interval": 120,
-            "go_version": "1.22.8",
+            "go_version": "1.22.9",
             "trigger_blackduck": true,
             "start_build": 1
         },
@@ -621,7 +621,7 @@
             "release_name": "Couchbase Sync Gateway 4.0.0",
             "production": true,
             "interval": 30,
-            "go_version": "1.23.2",
+            "go_version": "1.23.3",
             "trigger_blackduck": true,
             "start_build": 1
         },

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.22.5",
+            "go_version": "1.23.2",
             "trigger_blackduck": true,
             "start_build": 11
         },
@@ -612,7 +612,7 @@
             "release_name": "Couchbase Sync Gateway 3.2.1",
             "production": true,
             "interval": 120,
-            "go_version": "1.22.5",
+            "go_version": "1.22.8",
             "trigger_blackduck": true,
             "start_build": 1
         },
@@ -621,7 +621,7 @@
             "release_name": "Couchbase Sync Gateway 4.0.0",
             "production": true,
             "interval": 30,
-            "go_version": "1.22.2",
+            "go_version": "1.23.2",
             "trigger_blackduck": true,
             "start_build": 1
         },


### PR DESCRIPTION
- go2xunit fails with go 1.23 on a full integration test run, so use 1.22. I tried briefly to use https://github.com/jstemmer/go-junit-report but it doesn't work as a drop in replacement. I'm not sure what the long term plan for creating xunit files would be, but I think this solution will continue to work for some time.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2774/ (go2xunit changes only)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2768/ (fails with only go2xunit)
