### PR TITLE
CBG-4339 avoid panic if change listener is stopped before close

### DIFF
--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -159,7 +159,7 @@ func (listener *changeListener) Stop(ctx context.Context) {
 
 	base.DebugfCtx(ctx, base.KeyChanges, "changeListener.Stop() called")
 
-	if !listener.started.IsTrue() {
+	if !listener.started.CompareAndSwap(true, false) {
 		// not started, nothing to do
 		return
 	}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3391,3 +3391,13 @@ func TestInject1xBodyProperties(t *testing.T) {
 	assert.Equal(t, "value", resBody["key"])
 	assert.True(t, resBody[BodyDeleted].(bool))
 }
+
+func TestDatabaseCloseIdempotent(t *testing.T) {
+	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
+	defer db.Close(ctx)
+
+	// simulate a stop from StartOnlineProcesses, if the import feed does not work
+	db.BucketLock.Lock()
+	defer db.BucketLock.Unlock()
+	db._stopOnlineProcesses(ctx)
+}


### PR DESCRIPTION
fixes CBG-4339.

Reproduced failure with not checked in code from CBG-4317.
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2777/
