### PR TITLE
CBG-4213: add attachment migration api

### DIFF
--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -66,8 +66,8 @@ func (a *AttachmentMigrationManager) Init(ctx context.Context, options map[strin
 		var statusDoc AttachmentMigrationManagerStatusDoc
 		err := base.JSONUnmarshal(clusterStatus, &statusDoc)
 
-		reset, ok := options["reset"].(bool)
-		if reset && ok {
+		reset, _ := options["reset"].(bool)
+		if reset {
 			base.InfofCtx(ctx, base.KeyAll, "Attachment Migration: Resetting migration process. Will not resume any partially completed process")
 		}
 

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -68,7 +68,7 @@ func (a *AttachmentMigrationManager) Init(ctx context.Context, options map[strin
 
 		reset, ok := options["reset"].(bool)
 		if reset && ok {
-			base.InfofCtx(ctx, base.KeyAll, "Resync: Resetting resync process. Will not resume any partially completed process")
+			base.InfofCtx(ctx, base.KeyAll, "Attachment Migration: Resetting migration process. Will not resume any partially completed process")
 		}
 
 		// If the previous run completed, or there was an error during unmarshalling the status we will start the

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -73,7 +73,7 @@ func (a *AttachmentMigrationManager) Init(ctx context.Context, options map[strin
 
 		// If the previous run completed, or there was an error during unmarshalling the status we will start the
 		// process from scratch with a new migration ID. Otherwise, we should resume with the migration ID, stats specified in the doc.
-		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || (reset && ok) {
+		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || reset {
 			return newRunInit()
 		}
 		a.MigrationID = statusDoc.MigrationID

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -66,9 +66,14 @@ func (a *AttachmentMigrationManager) Init(ctx context.Context, options map[strin
 		var statusDoc AttachmentMigrationManagerStatusDoc
 		err := base.JSONUnmarshal(clusterStatus, &statusDoc)
 
+		reset, ok := options["reset"].(bool)
+		if reset && ok {
+			base.InfofCtx(ctx, base.KeyAll, "Resync: Resetting resync process. Will not resume any partially completed process")
+		}
+
 		// If the previous run completed, or there was an error during unmarshalling the status we will start the
 		// process from scratch with a new migration ID. Otherwise, we should resume with the migration ID, stats specified in the doc.
-		if statusDoc.State == BackgroundProcessStateCompleted || err != nil {
+		if statusDoc.State == BackgroundProcessStateCompleted || err != nil || (reset && ok) {
 			return newRunInit()
 		}
 		a.MigrationID = statusDoc.MigrationID

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -124,6 +124,8 @@ paths:
     $ref: ./paths/admin/_all_dbs.yaml
   '/{db}/_compact':
     $ref: './paths/admin/db-_compact.yaml'
+  '/{.db}/_attachment_migration':
+    $ref: './paths/admin/db-_attachment_migration.yaml'
   '/{db}/':
     $ref: './paths/admin/db-.yaml'
   '/{keyspace}/':

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -124,7 +124,7 @@ paths:
     $ref: ./paths/admin/_all_dbs.yaml
   '/{db}/_compact':
     $ref: './paths/admin/db-_compact.yaml'
-  '/{.db}/_attachment_migration':
+  '/{db}/_attachment_migration':
     $ref: './paths/admin/db-_attachment_migration.yaml'
   '/{db}/':
     $ref: './paths/admin/db-.yaml'

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1988,6 +1988,41 @@ Resync-status:
     - docs_changed
     - docs_processed
   title: Resync-status
+Attachment-Migration-status:
+  description: The status of a attachment migration operation
+  type: object
+  properties:
+    status:
+      description: The status of the current attachment migration operation.
+      type: string
+      enum:
+        - running
+        - completed
+        - stopping
+        - stopped
+        - error
+    start_time:
+      description: The ISO-8601 date and time the attachment migration operation was started.
+      type: string
+    last_error:
+      description: The last error that occurred in the attachment migration operation (if any).
+      type: string
+    migration_id:
+      description: The UUID given to the attachment migration operation.
+      type: string
+    docs_changed:
+      description: The amount of documents that have had attachment metadata migrated as a result of attachment migration operation.
+      type: integer
+    docs_processed:
+      description: The amount of docs that have been processed through the attachment migration operation.
+      type: integer
+  required:
+    - status
+    - start_time
+    - last_error
+    - docs_changed
+    - docs_processed
+  title: Attachment-Migration-status
 Compact-status:
   description: The status returned from a compaction.
   type: object

--- a/docs/api/paths/admin/db-_attachment_migration.yaml
+++ b/docs/api/paths/admin/db-_attachment_migration.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-Present Couchbase, Inc.
+# Copyright 2024-Present Couchbase, Inc.
 #
 # Use of this software is governed by the Business Source License included
 # in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
@@ -12,8 +12,8 @@ post:
   description: |-
     This allows a new attachment migration operation to be done on the database, or to stop an existing running attachment migration operation.
 
-    Attachment Migration is a single node process and can only one node can be running it at one point. 
-    
+    Attachment Migration is a single node process and can only one node can be running it at one point.
+
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Architect

--- a/docs/api/paths/admin/db-_attachment_migration.yaml
+++ b/docs/api/paths/admin/db-_attachment_migration.yaml
@@ -1,0 +1,73 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+parameters:
+  - $ref: ../../components/parameters.yaml#/db
+post:
+  summary: Manage a attachment migration operation
+  description: |-
+    This allows a new attachment migration operation to be done on the database, or to stop an existing running attachment migration operation.
+
+    Attachment Migration is a single node process and can only one node can be running it at one point. 
+    
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Architect
+  parameters:
+    - name: action
+      in: query
+      description: Defines whether the an attachment migration operation is being started or stopped.
+      schema:
+        type: string
+        default: start
+        enum:
+          - start
+          - stop
+    - name: reset
+      in: query
+      description: |-
+        This forces a fresh attachment migration start instead of trying to resume the previous failed migration operation.
+      schema:
+        type: boolean
+  responses:
+    '200':
+      description: Started or stopped compact operation successfully
+    '400':
+      $ref: ../../components/responses.yaml#/request-problem
+    '404':
+      $ref: ../../components/responses.yaml#/Not-found
+    '503':
+      description: Cannot start attachment migration due to another migration operation still running.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/HTTP-Error
+  tags:
+    - Database Management
+  operationId: post_db-_attachment_migration
+get:
+  summary: Get the status of the most recent attachment migration operation
+  description: |-
+    This will retrieve the current status of the most recent attachment migration operation.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Architect
+  responses:
+    '200':
+      description: Attachment migration status retrieved successfully
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/Attachment-Migration-status
+    '400':
+      $ref: ../../components/responses.yaml#/request-problem
+    '404':
+      $ref: ../../components/responses.yaml#/Not-found
+  tags:
+    - Database Management
+  operationId: get_db-_attachment_migration

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -59,7 +59,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
 
-	// Wait for run to complete
+	// Wait for run to completes
 	err = rt.WaitForCondition(func() bool {
 		time.Sleep(1 * time.Second)
 

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -59,7 +59,7 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment", "")
 	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
 
-	// Wait for run to completes
+	// Wait for run to complete
 	err = rt.WaitForCondition(func() bool {
 		time.Sleep(1 * time.Second)
 

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2024-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package attachmentmigrationtest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachmentMigrationAPI(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // turn off import feed to stop the feed migrating attachments
+		}},
+	})
+	defer rt.Close()
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+	// Perform GET as automatic migration kicks in upon db start
+	resp := rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	var migrationStatus db.AttachmentMigrationManagerResponse
+	err := base.JSONUnmarshal(resp.BodyBytes(), &migrationStatus)
+	require.NoError(t, err)
+	require.Equal(t, db.BackgroundProcessStateRunning, migrationStatus.State)
+	assert.Equal(t, int64(0), migrationStatus.DocsChanged)
+	assert.Equal(t, int64(0), migrationStatus.DocsProcessed)
+	assert.Empty(t, migrationStatus.LastErrorMessage)
+
+	// Wait for run on startup to complete
+	_ = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+
+	// add some docs for migration
+	addDocsForMigrationProcess(t, ctx, collection)
+
+	// kick off migration
+	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// attempt to kick off again, should error
+	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
+
+	// Wait for run to complete
+	_ = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+
+	// Perform GET after migration has been ran, ensure it starts in valid 'stopped' state
+	resp = rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	migrationStatus = db.AttachmentMigrationManagerResponse{}
+	err = base.JSONUnmarshal(resp.BodyBytes(), &migrationStatus)
+	require.NoError(t, err)
+	require.Equal(t, db.BackgroundProcessStateCompleted, migrationStatus.State)
+	assert.Equal(t, int64(5), migrationStatus.DocsChanged)
+	assert.Equal(t, int64(10), migrationStatus.DocsProcessed)
+	assert.Empty(t, migrationStatus.LastErrorMessage)
+}
+
+func TestAttachmentMigrationAbort(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // turn off import feed to stop the feed migrating attachments
+		}},
+	})
+	defer rt.Close()
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+	// Wait for run on startup to complete
+	_ = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+
+	// add some docs to arrive over dcp
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		docBody := db.Body{
+			"value": 1234,
+		}
+		_, _, err := collection.Put(ctx, key, docBody)
+		require.NoError(t, err)
+	}
+
+	// start migration
+	resp := rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// stop the migration job
+	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	status := rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateStopped)
+	assert.Equal(t, int64(0), status.DocsChanged)
+}
+
+func TestAttachmentMigrationReset(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			AutoImport: false, // turn off import feed to stop the feed migrating attachments
+		}},
+	})
+	defer rt.Close()
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
+	// Wait for run on startup to complete
+	_ = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+
+	// add some docs for migration
+	addDocsForMigrationProcess(t, ctx, collection)
+
+	// start migration
+	resp := rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status := rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateRunning)
+	migrationID := status.MigrationID
+
+	// Stop migration
+	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateStopped)
+
+	// make sure status is stopped
+	resp = rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	var migrationStatus db.AttachmentManagerResponse
+	err := base.JSONUnmarshal(resp.BodyBytes(), &migrationStatus)
+	assert.NoError(t, err)
+	assert.Equal(t, db.BackgroundProcessStateStopped, migrationStatus.State)
+
+	// reset migration run
+	resp = rt.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?reset=true", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateRunning)
+	assert.NotEqual(t, migrationID, status.MigrationID)
+
+	// wait to complete
+	status = rt.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	// assert all 10 docs are processed again
+	assert.Equal(t, int64(10), status.DocsProcessed)
+}
+
+func TestAttachmentMigrationMultiNode(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar does not support DCP client, pending CBG-4249")
+	}
+	tb := base.GetTestBucket(t)
+	noCloseTB := tb.NoCloseClone()
+
+	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: noCloseTB,
+	})
+	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		CustomTestBucket: tb,
+	})
+	defer rt2.Close()
+	defer rt1.Close()
+	collection, ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+
+	// Wait for startup run to complete, assert completed status is on both nodes
+	_ = rt1.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	_ = rt2.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+
+	// add some docs for migration
+	addDocsForMigrationProcess(t, ctx, collection)
+
+	// kick off migration on node 1
+	resp := rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status := rt1.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateRunning)
+	migrationID := status.MigrationID
+
+	// stop migration
+	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=stop", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	_ = rt1.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateStopped)
+
+	// assert that node 2 also has stopped status
+	var rt2MigrationStatus db.AttachmentMigrationManagerResponse
+	resp = rt2.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	err := base.JSONUnmarshal(resp.BodyBytes(), &rt2MigrationStatus)
+	assert.NoError(t, err)
+	assert.Equal(t, db.BackgroundProcessStateStopped, rt2MigrationStatus.State)
+
+	// kick off migration run again on node 2. Should resume and have same migration id
+	resp = rt2.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	_ = rt2.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateRunning)
+
+	// assert starting on another node when already running should error
+	resp = rt1.SendAdminRequest("POST", "/{{.db}}/_attachment_migration?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
+
+	// Wait for run to be marked as complete on both nodes
+	status = rt1.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+	assert.Equal(t, migrationID, status.MigrationID)
+	_ = rt2.WaitForAttachmentMigrationStatus(t, db.BackgroundProcessStateCompleted)
+}
+
+func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *db.DatabaseCollectionWithUser) {
+	for i := 0; i < 10; i++ {
+		docBody := db.Body{
+			"value":            1234,
+			db.BodyAttachments: map[string]interface{}{"myatt": map[string]interface{}{"content_type": "text/plain", "data": "SGVsbG8gV29ybGQh"}},
+		}
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		_, doc, err := collection.Put(ctx, key, docBody)
+		require.NoError(t, err)
+		assert.NotNil(t, doc.SyncData.Attachments)
+	}
+
+	// Move some subset of the documents attachment metadata from global sync to sync data
+	for j := 0; j < 5; j++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), j)
+		value, xattrs, cas, err := collection.GetCollectionDatastore().GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
+		require.NoError(t, err)
+		syncXattr, ok := xattrs[base.SyncXattrName]
+		assert.True(t, ok)
+		globalXattr, ok := xattrs[base.GlobalXattrName]
+		assert.True(t, ok)
+
+		var attachs db.GlobalSyncData
+		err = base.JSONUnmarshal(globalXattr, &attachs)
+		require.NoError(t, err)
+
+		db.MoveAttachmentXattrFromGlobalToSync(t, ctx, key, cas, value, syncXattr, attachs.GlobalAttachments, true, collection.GetCollectionDatastore())
+	}
+}

--- a/rest/attachmentmigrationtest/main_test.go
+++ b/rest/attachmentmigrationtest/main_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2024-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package attachmentmigrationtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+func TestMain(m *testing.M) {
+	ctx := context.Background() // start of test process
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+}

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -164,6 +164,10 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleCompact)).Methods("POST")
 	dbr.Handle("/_compact",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetCompact)).Methods("GET")
+	dbr.Handle("/_attachment_migration",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleAttachmentMigration)).Methods("POST")
+	dbr.Handle("/_attachment_migration",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetAttachmentMigration)).Methods("GET")
 	dbr.Handle("/_session",
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).createUserSession)).Methods("POST")
 	dbr.Handle("/_session/{sessionid}",

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -85,3 +85,20 @@ func CreateLegacyAttachmentDoc(t *testing.T, ctx context.Context, collection *db
 
 	return attDocID
 }
+
+// maybe replace woth require eventually with t?
+func (rt *RestTester) WaitForAttachmentMigrationStatus(t *testing.T, state db.BackgroundProcessState) db.AttachmentMigrationManagerResponse {
+	var response db.AttachmentMigrationManagerResponse
+	err := rt.WaitForConditionWithOptions(func() bool {
+		resp := rt.SendAdminRequest("GET", "/{{.db}}/_attachment_migration", "")
+		RequireStatus(t, resp, http.StatusOK)
+
+		err := base.JSONUnmarshal(resp.BodyBytes(), &response)
+		require.NoError(t, err)
+
+		return response.State == state
+	}, 90, 1000)
+	require.NoError(t, err)
+
+	return response
+}


### PR DESCRIPTION
CBG-4213

- Addition of the api end point to trigger attachment migration and to get status of it
- Move tests into separate package in rest 
- Api docs for this new endpoint

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2778/
