### PR TITLE
Revert "CBG-4321: store skipped sequences as single entries below a certain threshold"

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -989,13 +989,7 @@ func (c *changeCache) PushSkipped(ctx context.Context, startSeq uint64, endSeq u
 		base.InfofCtx(ctx, base.KeyCache, "cannot push negative skipped sequence range to skipped list: %d %d", startSeq, endSeq)
 		return
 	}
-	numSeqs := (endSeq - startSeq) + 1
-	if numSeqs > MinSequencesForRange {
-		c.skippedSeqs.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(startSeq, endSeq))
-	} else {
-		// push sequences as separate entries
-		c.skippedSeqs.PushSkippedSequenceEntries(startSeq, endSeq, int64(numSeqs))
-	}
+	c.skippedSeqs.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(startSeq, endSeq))
 }
 
 // waitForSequence blocks up to maxWaitTime until the given sequence has been received.

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -315,7 +315,7 @@ func TestJumpInSequencesAtAllocatorSkippedSequenceFill(t *testing.T) {
 	// wait for value to move from pending to cache and skipped list to fill
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rt.GetDatabase().UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(18), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+		assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	docVrs := rt.UpdateDoc("doc", vrs, `{"prob": "lol"}`)


### PR DESCRIPTION
Reverts couchbase/sync_gateway#7173