### PR TITLE
CBG-4347: REST API Spec: Fix example format for `collections_processing`

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2972,7 +2972,7 @@ ResyncScopesMap:
   type: object
   additionalProperties:
     $ref: '#/CollectionNames'
-  example: {"scopeName": {"collection1", "collection2"}}
+  example: {"scopeName": ["collection1", "collection2"]}
 CollectionNames:
   description: 'List of collection names'
   type: array


### PR DESCRIPTION
CBG-4347

REST API Spec: Fix example format for `collections_processing`
The schema correctly describes format, but the example does not.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a