### PR TITLE
CBG-4348 clarify logs around changes feed

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -371,7 +371,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		auditFields[base.AuditFieldFilter] = subChangesParams.filter()
 	}
 	if len(subChangesParams.docIDs()) > 0 {
-		auditFields[base.AuditFieldDocIDs] = base.UD(subChangesParams.docIDs()).Redact()
+		auditFields[base.AuditFieldDocIDs] = subChangesParams.docIDs()
 		auditFields[base.AuditFieldFilter] = base.DocIDsFilter
 	}
 	if continuous {
@@ -380,7 +380,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		auditFields[base.AuditFieldFeedType] = "normal"
 	}
 	if len(channels) > 0 {
-		auditFields[base.AuditFieldChannels] = base.UD(channels).Redact()
+		auditFields[base.AuditFieldChannels] = channels
 	}
 	base.Audit(bh.loggingCtx, base.AuditIDChangesFeedStarted, auditFields)
 	return nil

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -371,7 +371,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		auditFields[base.AuditFieldFilter] = subChangesParams.filter()
 	}
 	if len(subChangesParams.docIDs()) > 0 {
-		auditFields[base.AuditFieldDocIDs] = subChangesParams.docIDs()
+		auditFields[base.AuditFieldDocIDs] = base.UD(subChangesParams.docIDs()).Redact()
 		auditFields[base.AuditFieldFilter] = base.DocIDsFilter
 	}
 	if continuous {
@@ -380,7 +380,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		auditFields[base.AuditFieldFeedType] = "normal"
 	}
 	if len(channels) > 0 {
-		auditFields[base.AuditFieldChannels] = channels
+		auditFields[base.AuditFieldChannels] = base.UD(channels).Redact()
 	}
 	base.Audit(bh.loggingCtx, base.AuditIDChangesFeedStarted, auditFields)
 	return nil

--- a/db/changes.go
+++ b/db/changes.go
@@ -645,6 +645,8 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 	to := ""
 	if col.user != nil && col.user.Name() != "" {
 		to = fmt.Sprintf("  (to %s)", col.user.Name())
+	} else {
+		to = "  (to ADMIN)"
 	}
 
 	base.InfofCtx(ctx, base.KeyChanges, "MultiChangesFeed(channels: %s, options: %s) ... %s", base.UD(chans), options, base.UD(to))


### PR DESCRIPTION
CBG-4348 clarify logs around changes feed

- If admin user, log that is the admin user.
- If admin user, the channels will start at sequence 0, which is omited from TimedSet.String(). Create a RedactorBuilder on TimedSet to log the zero values.
- Change redaction from <ud>A.1,B.2</ud> to <ud>A</ud>.1,<ud>B</ud> to be able to identify redacted channels. Sequence numbers are not sensitive data.

Old logs:

```
Changes: c:#003 db:db MultiChangesFeed(channels: {<ud>*</ud>}, options: {Since: 0, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 300000, ActiveOnly: false, Revocations: false, RequestPlusSeq: 0}) ...
Changes+: c:#003 db:db MultiChangesFeed: channels expand to "" ... <ud>  (to ADMIN)</ud>
```

New logs:

```
Changes: c:#003 db:db MultiChangesFeed(channels: {<ud>*</ud>}, options: {Since: 0, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 300000, ActiveOnly: false, Revocations: false, RequestPlusSeq: 0}) ... <ud>  (to ADMIN)</ud>
Changes+: c:#003 db:db MultiChangesFeed: channels expand to "<ud>*</ud>:0" ... <ud>  (to ADMIN)</ud>
```