### PR TITLE
CBG-3838 increase debug logging to diagnose test flake

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2220,6 +2220,7 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 


### PR DESCRIPTION
I can't see what is going on with this continued test failure but I think debug logging will be helpful. 

https://jenkins.sgwdev.com/job/Sync%20Gateway%20Pipeline/job/main/229/testReport/junit/EE-github/com_couchbase_sync_gateway_rest/TestAttachmentDeleteOnExpiry/
