### PR TITLE
run cleanup code always even if coverage fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,9 +381,6 @@ pipeline {
 
             // Publish the junit test reports
             junit allowEmptyResults: true, testResults: 'reports/test-*.xml'
-
-            step([$class: 'WsCleanup'])
-            sh "go clean -cache"
         }
         unstable {
             // archive non-verbose outputs upon failure for inspection (each verbose output is conditionally archived on stage failure)
@@ -411,5 +408,9 @@ pipeline {
                 }
             }
         }
+        cleanup {
+            cleanWs(disableDeferredWipeout: true)
+            sh "go clean -cache"
+	}
     }
 }


### PR DESCRIPTION
I think sometimes the cleanup code isn't running for the pipeline tests. I think there might be two reasons for this:

- it can't run cleanup, so I set `disableDeferredWipeout` true
- in the `always` block, if there is an exception in uploading coverage, it won't run cleanup. I _suspect_ this is why data is not always deleted.
