### PR TITLE
CBG-4360: Add uinx timestamp to skipped list entry

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -127,7 +127,7 @@ type LogPriorityQueue []*LogEntry
 
 type SkippedSequence struct {
 	seq       uint64
-	timeAdded time.Time
+	timeAdded int64
 }
 
 type CacheOptions struct {
@@ -896,7 +896,7 @@ func (c *changeCache) WasSkipped(x uint64) bool {
 }
 
 func (c *changeCache) PushSkipped(ctx context.Context, sequence uint64) {
-	err := c.skippedSeqs.Push(&SkippedSequence{seq: sequence, timeAdded: time.Now()})
+	err := c.skippedSeqs.Push(&SkippedSequence{seq: sequence, timeAdded: time.Now().Unix()})
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyCache, "Error pushing skipped sequence: %d, %v", sequence, err)
 		return
@@ -1066,7 +1066,8 @@ func (l *SkippedSequenceList) getOlderThan(skippedExpiry time.Duration) []uint64
 	oldSequences := make([]uint64, 0)
 	for e := l.skippedList.Front(); e != nil; e = e.Next() {
 		skippedSeq := e.Value.(*SkippedSequence)
-		if time.Since(skippedSeq.timeAdded) > skippedExpiry {
+		timeStamp := time.Unix(skippedSeq.timeAdded, 0)
+		if time.Since(timeStamp) > skippedExpiry {
 			oldSequences = append(oldSequences, skippedSeq.seq)
 		} else {
 			// skippedSeqs are ordered by arrival time, so can stop iterating once we find one


### PR DESCRIPTION
CBG-4360

- Adds a unix timestamp in place of a time.Time struct 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2790/
