### PR TITLE
CBG-4303: conflicting writes muti actor tests, skipping failures

### DIFF
--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -85,6 +85,7 @@ func (p *CouchbaseServerPeer) GetDocument(dsName sgbucket.DataStoreName, docID s
 // CreateDocument creates a document on the peer. The test will fail if the document already exists.
 func (p *CouchbaseServerPeer) CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) DocMetadata {
 	p.tb.Logf("%s: Creating document %s", p, docID)
+	p.tb.Logf("bucket %s", p.bucket.GetName())
 	// create document with xattrs to prevent XDCR from doing a round trip replication in this scenario:
 	// CBS1: write document (cas1, no _vv)
 	// CBS1->CBS2: XDCR replication

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -15,10 +15,19 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"golang.org/x/exp/maps"
-
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 )
+
+type ActorTest interface {
+	PeerNames() []string
+	description() string
+	docID(peerName string) string
+	collectionName() base.ScopeAndCollectionName
+}
+
+var _ ActorTest = &singleActorTest{}
+var _ ActorTest = &multiActorTest{}
 
 func getSingleDsName() base.ScopeAndCollectionName {
 	if base.TestsUseNamedCollections() {
@@ -39,7 +48,7 @@ func (t singleActorTest) description() string {
 }
 
 // docID returns a unique document ID for the test case.
-func (t singleActorTest) docID() string {
+func (t singleActorTest) docID(_ string) string {
 	return fmt.Sprintf("doc_%s", strings.ReplaceAll(t.description(), " ", "_"))
 }
 
@@ -64,6 +73,60 @@ func getSingleActorTestCase() []singleActorTest {
 	return tests
 }
 
+// multiActorTest represents a test case for a single actor in a given topology.
+type multiActorTest struct {
+	topology Topology
+}
+
+// PeerNames returns the names of all peers in the test case's topology, sorted deterministically.
+func (t multiActorTest) PeerNames() []string {
+	return t.topology.PeerNames()
+}
+
+// description returns a human-readable description of the test case.
+func (t multiActorTest) description() string {
+	return fmt.Sprintf("%s_multi_actor", t.topology.description)
+}
+
+// docID returns a unique document ID for the test case+actor combination.
+func (t multiActorTest) docID(peerName string) string {
+	return fmt.Sprintf("doc_%s_%s", strings.ReplaceAll(t.description(), " ", "_"), peerName)
+}
+
+// collectionName returns the collection name for the test case.
+func (t multiActorTest) collectionName() base.ScopeAndCollectionName {
+	return getSingleDsName()
+}
+
+func getMultiActorTestCases() []multiActorTest {
+	var tests []multiActorTest
+	for _, tc := range append(simpleTopologies, Topologies...) {
+		tests = append(tests, multiActorTest{topology: tc})
+	}
+	return tests
+}
+
+// BodyAndVersion struct to hold doc update information to assert on
+type BodyAndVersion struct {
+	docMeta    DocMetadata
+	body       []byte
+	updatePeer string
+}
+
+func stopPeerReplications(t *testing.T, peerReplications []PeerReplication) {
+	t.Logf("stopping replications for peers")
+	for _, replication := range peerReplications {
+		replication.Stop()
+	}
+}
+
+func startPeerReplications(t *testing.T, peerReplications []PeerReplication) {
+	t.Logf("starting replications for peers")
+	for _, replication := range peerReplications {
+		replication.Start()
+	}
+}
+
 // TestHLVCreateDocumentSingleActor tests creating a document with a single actor in different topologies.
 func TestHLVCreateDocumentSingleActor(t *testing.T) {
 
@@ -72,9 +135,47 @@ func TestHLVCreateDocumentSingleActor(t *testing.T) {
 		t.Run(tc.description(), func(t *testing.T) {
 			peers, _ := setupTests(t, tc.topology, tc.activePeerID)
 
+			docID := tc.docID("")
 			docBody := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s"}`, tc.activePeerID, tc.description()))
-			docVersion := peers[tc.activePeerID].CreateDocument(tc.collectionName(), tc.docID(), docBody)
-			waitForVersionAndBody(t, tc, peers, docVersion, docBody)
+			docVersion := peers[tc.activePeerID].CreateDocument(tc.collectionName(), tc.docID(""), docBody)
+			bodyVersion := BodyAndVersion{
+				docMeta:    docVersion,
+				body:       docBody,
+				updatePeer: tc.activePeerID,
+			}
+			waitForVersionAndBody(t, tc, peers, docID, bodyVersion)
+		})
+	}
+}
+
+// TestHLVCreateDocumentMultiActorConflict:
+//   - Create conflicting docs on each peer
+//   - Wait for docs last write to be replicated to all other peers
+func TestHLVCreateDocumentMultiActorConflict(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyVV)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Panics against rosmar, CBG-4378")
+	} else {
+		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
+	}
+	for _, tc := range getMultiActorTestCases() {
+		if strings.Contains(tc.description(), "CBL") {
+			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
+			// able to wait for a specific version to arrive over pull replication
+			t.Skip("We need to be able to wait for a specific version to arrive over pull replication, CBG-4257")
+		}
+		t.Run(tc.description(), func(t *testing.T) {
+			peers, replications := setupTests(t, tc.topology, "")
+
+			stopPeerReplications(t, replications)
+
+			docID := tc.docID("")
+			docVersion := createConflictingDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
+
 		})
 	}
 }
@@ -95,16 +196,67 @@ func TestHLVUpdateDocumentSingleActor(t *testing.T) {
 			}
 			peers, _ := setupTests(t, tc.topology, tc.activePeerID)
 
+			docID := tc.docID("")
 			body1 := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s", "write": 1}`, tc.activePeerID, tc.description()))
-			createVersion := peers[tc.activePeerID].CreateDocument(tc.collectionName(), tc.docID(), body1)
+			createVersion := peers[tc.activePeerID].CreateDocument(tc.collectionName(), docID, body1)
 
-			waitForVersionAndBody(t, tc, peers, createVersion, body1)
+			docVersion := BodyAndVersion{
+				docMeta:    createVersion,
+				body:       body1,
+				updatePeer: tc.activePeerID,
+			}
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
 			body2 := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s", "write": 2}`, tc.activePeerID, tc.description()))
-			updateVersion := peers[tc.activePeerID].WriteDocument(tc.collectionName(), tc.docID(), body2)
+			updateVersion := peers[tc.activePeerID].WriteDocument(tc.collectionName(), docID, body2)
 			t.Logf("createVersion: %+v, updateVersion: %+v", createVersion, updateVersion)
 			t.Logf("waiting for document version 2 on all peers")
-			waitForVersionAndBody(t, tc, peers, updateVersion, body2)
+
+			docVersion = BodyAndVersion{
+				docMeta:    updateVersion,
+				body:       body2,
+				updatePeer: tc.activePeerID,
+			}
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
+		})
+	}
+}
+
+// TestHLVUpdateDocumentMultiActorConflict:
+//   - Create conflicting docs on each peer
+//   - Start replications
+//   - Wait for last write to be replicated to all peers
+//   - Stop replications
+//   - Update all doc on all peers
+//   - Start replications and wait for last update to be replicated to all peers
+func TestHLVUpdateDocumentMultiActorConflict(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyVV)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Panics against rosmar, CBG-4378")
+	} else {
+		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
+	}
+	for _, tc := range getMultiActorTestCases() {
+		if strings.Contains(tc.description(), "CBL") {
+			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
+			// able to wait for a specific version to arrive over pull replication
+			t.Skip("We need to be able to wait for a specific version to arrive over pull replication + unexpected body in proposeChanges: [304] issue, CBG-4257")
+		}
+		t.Run(tc.description(), func(t *testing.T) {
+			peers, replications := setupTests(t, tc.topology, "")
+			stopPeerReplications(t, replications)
+
+			docID := tc.docID("")
+			docVersion := createConflictingDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
+
+			stopPeerReplications(t, replications)
+			docVersion = updateConflictingDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 		})
 	}
 }
@@ -123,15 +275,156 @@ func TestHLVDeleteDocumentSingleActor(t *testing.T) {
 			}
 			peers, _ := setupTests(t, tc.topology, tc.activePeerID)
 
+			docID := tc.docID("")
 			body1 := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s", "write": 1}`, tc.activePeerID, tc.description()))
-			createVersion := peers[tc.activePeerID].CreateDocument(tc.collectionName(), tc.docID(), body1)
+			createVersion := peers[tc.activePeerID].CreateDocument(tc.collectionName(), docID, body1)
 
-			waitForVersionAndBody(t, tc, peers, createVersion, body1)
+			docVersion := BodyAndVersion{
+				docMeta:    createVersion,
+				body:       body1,
+				updatePeer: tc.activePeerID,
+			}
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
-			deleteVersion := peers[tc.activePeerID].DeleteDocument(tc.collectionName(), tc.docID())
+			deleteVersion := peers[tc.activePeerID].DeleteDocument(tc.collectionName(), docID)
 			t.Logf("createVersion: %+v, deleteVersion: %+v", createVersion, deleteVersion)
 			t.Logf("waiting for document deletion on all peers")
-			waitForDeletion(t, tc, peers)
+			waitForDeletion(t, tc, peers, docID, tc.activePeerID)
+		})
+	}
+}
+
+// TestHLVDeleteDocumentMultiActorConflict:
+//   - Create conflicting docs on each peer
+//   - Start replications
+//   - Wait for last write to be replicated to all peers
+//   - Stop replications
+//   - Delete docs on all peers
+//   - Start replications and assert doc is deleted on all peers
+func TestHLVDeleteDocumentMultiActorConflict(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyVV)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Panics against rosmar, CBG-4378")
+	} else {
+		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
+	}
+	for _, tc := range getMultiActorTestCases() {
+		if strings.Contains(tc.description(), "CBL") {
+			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
+			// able to wait for a specific version to arrive over pull replication
+			t.Skip("We need to be able to wait for a specific version to arrive over pull replication + unexpected body in proposeChanges: [304] issue, CBG-4257")
+		}
+		t.Run(tc.description(), func(t *testing.T) {
+			peers, replications := setupTests(t, tc.topology, "")
+			stopPeerReplications(t, replications)
+
+			docID := tc.docID("")
+			docVersion := createConflictingDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
+
+			stopPeerReplications(t, replications)
+			lastWrite := deleteConflictDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+			waitForDeletion(t, tc, peers, docID, lastWrite.updatePeer)
+		})
+	}
+}
+
+// TestHLVUpdateDeleteDocumentMultiActorConflict:
+//   - Create conflicting docs on each peer
+//   - Start replications
+//   - Wait for last write to be replicated to all peers
+//   - Stop replications
+//   - Update docs on all peers, then delete the doc on one peer
+//   - Start replications and assert doc is deleted on all peers (given the delete was the last write)
+func TestHLVUpdateDeleteDocumentMultiActorConflict(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyVV)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Panics against rosmar, CBG-4378")
+	} else {
+		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
+	}
+	for _, tc := range getMultiActorTestCases() {
+		if strings.Contains(tc.description(), "CBL") {
+			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
+			// able to wait for a specific version to arrive over pull replication
+			t.Skip("We need to be able to wait for a specific version to arrive over pull replication + unexpected body in proposeChanges: [304] issue, CBG-4257")
+		}
+		t.Run(tc.description(), func(t *testing.T) {
+			peerList := tc.PeerNames()
+			peers, replications := setupTests(t, tc.topology, "")
+			stopPeerReplications(t, replications)
+
+			docID := tc.docID("")
+			docVersion := createConflictingDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
+
+			stopPeerReplications(t, replications)
+
+			_ = updateConflictingDocs(t, tc, peers)
+
+			lastPeer := peerList[len(peerList)-1]
+			deleteVersion := peers[lastPeer].DeleteDocument(tc.collectionName(), docID)
+			t.Logf("deleteVersion: %+v", deleteVersion)
+
+			startPeerReplications(t, replications)
+			waitForDeletion(t, tc, peers, docID, lastPeer)
+		})
+	}
+}
+
+// TestHLVDeleteUpdateDocumentMultiActorConflict:
+//   - Create conflicting docs on each peer
+//   - Start replications
+//   - Wait for last write to be replicated to all peers
+//   - Stop replications
+//   - Delete docs on all peers, then update the doc on one peer
+//   - Start replications and assert doc update is replicated to all peers (given the update was the last write)
+func TestHLVDeleteUpdateDocumentMultiActorConflict(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyVV)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Panics against rosmar, CBG-4378")
+	} else {
+		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
+	}
+	for _, tc := range getMultiActorTestCases() {
+		if strings.Contains(tc.description(), "CBL") {
+			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
+			// able to wait for a specific version to arrive over pull replication
+			t.Skip("We need to be able to wait for a specific version to arrive over pull replication + unexpected body in proposeChanges: [304] issue, CBG-4257")
+		}
+		t.Run(tc.description(), func(t *testing.T) {
+			peerList := tc.PeerNames()
+			peers, replications := setupTests(t, tc.topology, "")
+			stopPeerReplications(t, replications)
+
+			docID := tc.docID("")
+			docVersion := createConflictingDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
+
+			stopPeerReplications(t, replications)
+
+			deleteConflictDocs(t, tc, peers)
+
+			// grab last peer in topology to write an update on
+			lastPeer := peerList[len(peerList)-1]
+			docBody := []byte(fmt.Sprintf(`{"topology": "%s", "write": 2}`, tc.description()))
+			docUpdateVersion := peers[lastPeer].WriteDocument(tc.collectionName(), docID, docBody)
+			t.Logf("updateVersion: %+v", docVersion)
+			docMeta := BodyAndVersion{
+				docMeta:    docUpdateVersion,
+				body:       docBody,
+				updatePeer: lastPeer,
+			}
+			startPeerReplications(t, replications)
+			waitForVersionAndBody(t, tc, peers, docID, docMeta)
 		})
 	}
 }
@@ -149,20 +442,32 @@ func TestHLVResurrectDocumentSingleActor(t *testing.T) {
 
 			peers, _ := setupTests(t, tc.topology, tc.activePeerID)
 
+			docID := tc.docID("")
 			body1 := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s", "write": 1}`, tc.activePeerID, tc.description()))
-			createVersion := peers[tc.activePeerID].CreateDocument(tc.collectionName(), tc.docID(), body1)
+			createVersion := peers[tc.activePeerID].CreateDocument(tc.collectionName(), tc.docID(tc.activePeerID), body1)
 
-			waitForVersionAndBody(t, tc, peers, createVersion, body1)
+			docVersion := BodyAndVersion{
+				docMeta:    createVersion,
+				body:       body1,
+				updatePeer: tc.activePeerID,
+			}
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
-			deleteVersion := peers[tc.activePeerID].DeleteDocument(tc.collectionName(), tc.docID())
+			deleteVersion := peers[tc.activePeerID].DeleteDocument(tc.collectionName(), docID)
 			t.Logf("createVersion: %+v, deleteVersion: %+v", createVersion, deleteVersion)
 			t.Logf("waiting for document deletion on all peers")
-			waitForDeletion(t, tc, peers)
+			waitForDeletion(t, tc, peers, docID, tc.activePeerID)
 
 			body2 := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s", "write": "resurrection"}`, tc.activePeerID, tc.description()))
-			resurrectVersion := peers[tc.activePeerID].WriteDocument(tc.collectionName(), tc.docID(), body2)
+			resurrectVersion := peers[tc.activePeerID].WriteDocument(tc.collectionName(), docID, body2)
 			t.Logf("createVersion: %+v, deleteVersion: %+v, resurrectVersion: %+v", createVersion, deleteVersion, resurrectVersion)
 			t.Logf("waiting for document resurrection on all peers")
+
+			docVersion = BodyAndVersion{
+				docMeta:    resurrectVersion,
+				body:       body2,
+				updatePeer: tc.activePeerID,
+			}
 
 			// Couchbase Lite peers do not know how to push a deletion yet, so we need to filter them out CBG-4257
 			nonCBLPeers := make(map[string]Peer)
@@ -171,7 +476,58 @@ func TestHLVResurrectDocumentSingleActor(t *testing.T) {
 					nonCBLPeers[peerName] = peer
 				}
 			}
-			waitForVersionAndBody(t, tc, peers, resurrectVersion, body2)
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
+		})
+	}
+}
+
+// TestHLVResurrectDocumentMultiActorConflict:
+//   - Create conflicting docs on each peer
+//   - Start replications
+//   - Wait for last write to be replicated to all peers
+//   - Stop replications
+//   - Delete docs on all peers, start replications assert that doc is deleted on all peers
+//   - Stop replications
+//   - Resurrect doc on all peers
+//   - Start replications and wait for last resurrection operation to be replicated to all peers
+func TestHLVResurrectDocumentMultiActorConflict(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyVV)
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Panics against rosmar, CBG-4378")
+	} else {
+		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
+	}
+	for _, tc := range getMultiActorTestCases() {
+		if strings.Contains(tc.description(), "CBL") {
+			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
+			// able to wait for a specific version to arrive over pull replication
+			t.Skip("We need to be able to wait for a specific version to arrive over pull replication + unexpected body in proposeChanges: [304] issue, CBG-4257")
+		}
+		t.Run(tc.description(), func(t *testing.T) {
+			peers, replications := setupTests(t, tc.topology, "")
+			stopPeerReplications(t, replications)
+
+			docID := tc.docID("")
+			docVersion := createConflictingDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+			waitForVersionAndBody(t, tc, peers, docID, docVersion)
+
+			stopPeerReplications(t, replications)
+			lastWrite := deleteConflictDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+
+			waitForDeletion(t, tc, peers, docID, lastWrite.updatePeer)
+
+			stopPeerReplications(t, replications)
+
+			// resurrect on
+			lastWriteVersion := updateConflictingDocs(t, tc, peers)
+
+			startPeerReplications(t, replications)
+
+			waitForVersionAndBody(t, tc, peers, docID, lastWriteVersion)
 		})
 	}
 }
@@ -187,18 +543,18 @@ func stripInternalProperties(body db.Body) {
 	delete(body, "_id")
 }
 
-func waitForVersionAndBody(t *testing.T, testCase singleActorTest, peers map[string]Peer, expectedVersion DocMetadata, expectedBody []byte) {
+func waitForVersionAndBody(t *testing.T, testCase ActorTest, peers map[string]Peer, docID string, expectedVersion BodyAndVersion) {
 	// sort peer names to make tests more deterministic
 	peerNames := maps.Keys(peers)
 	for _, peerName := range peerNames {
 		peer := peers[peerName]
-		t.Logf("waiting for doc version on %s, written from %s", peer, testCase.activePeerID)
-		body := peer.WaitForDocVersion(testCase.collectionName(), testCase.docID(), expectedVersion)
-		requireBodyEqual(t, expectedBody, body)
+		t.Logf("waiting for doc version on %s, written from %s", peer, expectedVersion.updatePeer)
+		body := peer.WaitForDocVersion(testCase.collectionName(), docID, expectedVersion.docMeta)
+		requireBodyEqual(t, expectedVersion.body, body)
 	}
 }
 
-func waitForDeletion(t *testing.T, testCase singleActorTest, peers map[string]Peer) {
+func waitForDeletion(t *testing.T, testCase ActorTest, peers map[string]Peer, docID string, deleteActor string) {
 	// sort peer names to make tests more deterministic
 	peerNames := maps.Keys(peers)
 	for _, peerName := range peerNames {
@@ -207,7 +563,81 @@ func waitForDeletion(t *testing.T, testCase singleActorTest, peers map[string]Pe
 			continue
 		}
 		peer := peers[peerName]
-		t.Logf("waiting for doc to be deleted on %s, written from %s", peer, testCase.activePeerID)
-		peer.WaitForDeletion(testCase.collectionName(), testCase.docID())
+		t.Logf("waiting for doc to be deleted on %s, written from %s", peer, deleteActor)
+		peer.WaitForDeletion(testCase.collectionName(), docID)
 	}
+}
+
+// removeSyncGatewayBackingPeers will check if there is sync gateway in topology, if so will track the backing CBS
+// so we can skip creating docs on these peers (avoiding conflicts between docs created on the SGW and cbs)
+func removeSyncGatewayBackingPeers(peers map[string]Peer) map[string]bool {
+	peersToRemove := make(map[string]bool)
+	if peers["sg1"] != nil {
+		// remove the backing store from doc update cycle to avoid conflicts on creating the document in bucket
+		peersToRemove["cbs1"] = true
+	}
+	if peers["sg2"] != nil {
+		// remove the backing store from doc update cycle to avoid conflicts on creating the document in bucket
+		peersToRemove["cbs2"] = true
+	}
+	return peersToRemove
+}
+
+// createConflictingDocs will create a doc on each peer of the same doc ID to create conflicting documents, then
+// returns the last peer to have a doc created on it
+func createConflictingDocs(t *testing.T, tc multiActorTest, peers map[string]Peer) (lastWrite BodyAndVersion) {
+	backingPeers := removeSyncGatewayBackingPeers(peers)
+	var documentVersion []BodyAndVersion
+	for _, peerName := range tc.PeerNames() {
+		if backingPeers[peerName] {
+			continue
+		}
+		docBody := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s"}`, peerName, tc.description()))
+		docVersion := peers[peerName].CreateDocument(tc.collectionName(), tc.docID(""), docBody)
+		t.Logf("createVersion: %+v", docVersion)
+		documentVersion = append(documentVersion, BodyAndVersion{docMeta: docVersion, body: docBody, updatePeer: peerName})
+	}
+	index := len(documentVersion) - 1
+	lastWrite = documentVersion[index]
+
+	return lastWrite
+}
+
+// updateConflictingDocs will update a doc on each peer of the same doc ID to create conflicting document mutations, then
+// returns the last peer to have a doc updated on it
+func updateConflictingDocs(t *testing.T, tc multiActorTest, peers map[string]Peer) (lastWrite BodyAndVersion) {
+	backingPeers := removeSyncGatewayBackingPeers(peers)
+	var documentVersion []BodyAndVersion
+	for _, peerName := range tc.PeerNames() {
+		if backingPeers[peerName] {
+			continue
+		}
+		docBody := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s", "write": 2}`, peerName, tc.description()))
+		docVersion := peers[peerName].WriteDocument(tc.collectionName(), tc.docID(""), docBody)
+		t.Logf("updateVersion: %+v", docVersion)
+		documentVersion = append(documentVersion, BodyAndVersion{docMeta: docVersion, body: docBody, updatePeer: peerName})
+	}
+	index := len(documentVersion) - 1
+	lastWrite = documentVersion[index]
+
+	return lastWrite
+}
+
+// deleteConflictDocs will delete a doc on each peer of the same doc ID to create conflicting document deletions, then
+// returns the last peer to have a doc deleted on it
+func deleteConflictDocs(t *testing.T, tc multiActorTest, peers map[string]Peer) (lastWrite BodyAndVersion) {
+	backingPeers := removeSyncGatewayBackingPeers(peers)
+	var documentVersion []BodyAndVersion
+	for _, peerName := range tc.PeerNames() {
+		if backingPeers[peerName] {
+			continue
+		}
+		deleteVersion := peers[peerName].DeleteDocument(tc.collectionName(), tc.docID(""))
+		t.Logf("deleteVersion: %+v", deleteVersion)
+		documentVersion = append(documentVersion, BodyAndVersion{docMeta: deleteVersion, updatePeer: peerName})
+	}
+	index := len(documentVersion) - 1
+	lastWrite = documentVersion[index]
+
+	return lastWrite
 }

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -92,10 +92,6 @@ func (t multiActorTest) singleDocID() string {
 	return fmt.Sprintf("doc_%s", strings.ReplaceAll(t.description(), " ", "_"))
 }
 
-func (t multiActorTest) peerDocID(peerName string) string {
-	return fmt.Sprintf("doc_%s_%s", strings.ReplaceAll(t.description(), " ", "_"), peerName)
-}
-
 // collectionName returns the collection name for the test case.
 func (t multiActorTest) collectionName() base.ScopeAndCollectionName {
 	return getSingleDsName()

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -112,13 +112,13 @@ type BodyAndVersion struct {
 	updatePeer string // the peer this particular document version mutation originated from
 }
 
-func stopPeerReplications(t *testing.T, peerReplications []PeerReplication) {
+func stopPeerReplications(peerReplications []PeerReplication) {
 	for _, replication := range peerReplications {
 		replication.Stop()
 	}
 }
 
-func startPeerReplications(t *testing.T, peerReplications []PeerReplication) {
+func startPeerReplications(peerReplications []PeerReplication) {
 	for _, replication := range peerReplications {
 		replication.Start()
 	}
@@ -159,12 +159,12 @@ func TestHLVCreateDocumentMultiActorConflict(t *testing.T) {
 		t.Run(tc.description(), func(t *testing.T) {
 			peers, replications := setupTests(t, tc.topology, "")
 
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			docID := tc.singleDocID()
 			docVersion := createConflictingDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 
 			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
@@ -226,18 +226,18 @@ func TestHLVUpdateDocumentMultiActorConflict(t *testing.T) {
 		}
 		t.Run(tc.description(), func(t *testing.T) {
 			peers, replications := setupTests(t, tc.topology, "")
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			docID := tc.singleDocID()
 			docVersion := createConflictingDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 			docVersion = updateConflictingDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 		})
 	}
@@ -293,18 +293,18 @@ func TestHLVDeleteDocumentMultiActorConflict(t *testing.T) {
 		}
 		t.Run(tc.description(), func(t *testing.T) {
 			peers, replications := setupTests(t, tc.topology, "")
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			docID := tc.singleDocID()
 			docVersion := createConflictingDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 			lastWrite := deleteConflictDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForDeletion(t, tc, peers, docID, lastWrite.updatePeer)
 		})
 	}
@@ -333,15 +333,15 @@ func TestHLVUpdateDeleteDocumentMultiActorConflict(t *testing.T) {
 		t.Run(tc.description(), func(t *testing.T) {
 			peerList := tc.PeerNames()
 			peers, replications := setupTests(t, tc.topology, "")
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			docID := tc.singleDocID()
 			docVersion := createConflictingDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			_ = updateConflictingDocs(t, tc, peers, docID)
 
@@ -349,7 +349,7 @@ func TestHLVUpdateDeleteDocumentMultiActorConflict(t *testing.T) {
 			deleteVersion := peers[lastPeer].DeleteDocument(tc.collectionName(), docID)
 			t.Logf("deleteVersion: %+v", deleteVersion)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForDeletion(t, tc, peers, docID, lastPeer)
 		})
 	}
@@ -378,15 +378,15 @@ func TestHLVDeleteUpdateDocumentMultiActorConflict(t *testing.T) {
 		t.Run(tc.description(), func(t *testing.T) {
 			peerList := tc.PeerNames()
 			peers, replications := setupTests(t, tc.topology, "")
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			docID := tc.singleDocID()
 			docVersion := createConflictingDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			deleteConflictDocs(t, tc, peers, docID)
 
@@ -395,7 +395,7 @@ func TestHLVDeleteUpdateDocumentMultiActorConflict(t *testing.T) {
 			docBody := []byte(fmt.Sprintf(`{"topology": "%s", "write": 2}`, tc.description()))
 			docUpdateVersion := peers[lastPeer].WriteDocument(tc.collectionName(), docID, docBody)
 			t.Logf("updateVersion: %+v", docVersion.docMeta)
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForVersionAndBody(t, tc, peers, docID, docUpdateVersion)
 		})
 	}
@@ -465,27 +465,27 @@ func TestHLVResurrectDocumentMultiActorConflict(t *testing.T) {
 		}
 		t.Run(tc.description(), func(t *testing.T) {
 			peers, replications := setupTests(t, tc.topology, "")
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			docID := tc.singleDocID()
 			docVersion := createConflictingDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 			waitForVersionAndBody(t, tc, peers, docID, docVersion)
 
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 			lastWrite := deleteConflictDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 
 			waitForDeletion(t, tc, peers, docID, lastWrite.updatePeer)
 
-			stopPeerReplications(t, replications)
+			stopPeerReplications(replications)
 
 			// resurrect on
 			lastWriteVersion := updateConflictingDocs(t, tc, peers, docID)
 
-			startPeerReplications(t, replications)
+			startPeerReplications(replications)
 
 			waitForVersionAndBody(t, tc, peers, docID, lastWriteVersion)
 		})

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -26,9 +26,9 @@ type Peer interface {
 	// GetDocument returns the latest version of a document. The test will fail the document does not exist.
 	GetDocument(dsName sgbucket.DataStoreName, docID string) (DocMetadata, db.Body)
 	// CreateDocument creates a document on the peer. The test will fail if the document already exists.
-	CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) DocMetadata
+	CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion
 	// WriteDocument upserts a document to the peer. The test will fail if the write does not succeed. Reasons for failure might be sync function rejections for Sync Gateway rejections.
-	WriteDocument(dsName sgbucket.DataStoreName, docID string, body []byte) DocMetadata
+	WriteDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion
 	// DeleteDocument deletes a document on the peer. The test will fail if the document does not exist.
 	DeleteDocument(dsName sgbucket.DataStoreName, docID string) DocMetadata
 
@@ -280,14 +280,14 @@ func TestPeerImplementation(t *testing.T) {
 			// Create
 			createBody := []byte(`{"op": "creation"}`)
 			createVersion := peer.CreateDocument(collectionName, docID, []byte(`{"op": "creation"}`))
-			require.NotEmpty(t, createVersion.CV)
+			require.NotEmpty(t, createVersion.docMeta.CV)
 			if tc.peerOption.Type == PeerTypeCouchbaseServer {
-				require.Empty(t, createVersion.RevTreeID)
+				require.Empty(t, createVersion.docMeta.RevTreeID)
 			} else {
-				require.NotEmpty(t, createVersion.RevTreeID)
+				require.NotEmpty(t, createVersion.docMeta.RevTreeID)
 			}
 
-			peer.WaitForDocVersion(collectionName, docID, createVersion)
+			peer.WaitForDocVersion(collectionName, docID, createVersion.docMeta)
 			// Check Get after creation
 			roundtripGetVersion, roundtripGetbody := peer.GetDocument(collectionName, docID)
 			require.Equal(t, createVersion, roundtripGetVersion)
@@ -296,15 +296,15 @@ func TestPeerImplementation(t *testing.T) {
 			// Update
 			updateBody := []byte(`{"op": "update"}`)
 			updateVersion := peer.WriteDocument(collectionName, docID, updateBody)
-			require.NotEmpty(t, updateVersion.CV)
-			require.NotEqual(t, updateVersion.CV(), createVersion.CV())
+			require.NotEmpty(t, updateVersion.docMeta.CV)
+			require.NotEqual(t, updateVersion.docMeta.CV(), createVersion.docMeta.CV())
 			if tc.peerOption.Type == PeerTypeCouchbaseServer {
-				require.Empty(t, updateVersion.RevTreeID)
+				require.Empty(t, updateVersion.docMeta.RevTreeID)
 			} else {
-				require.NotEmpty(t, updateVersion.RevTreeID)
-				require.NotEqual(t, updateVersion.RevTreeID, createVersion.RevTreeID)
+				require.NotEmpty(t, updateVersion.docMeta.RevTreeID)
+				require.NotEqual(t, updateVersion.docMeta.RevTreeID, createVersion.docMeta.RevTreeID)
 			}
-			peer.WaitForDocVersion(collectionName, docID, updateVersion)
+			peer.WaitForDocVersion(collectionName, docID, updateVersion.docMeta)
 
 			// Check Get after update
 			roundtripGetVersion, roundtripGetbody = peer.GetDocument(collectionName, docID)
@@ -314,14 +314,14 @@ func TestPeerImplementation(t *testing.T) {
 			// Delete
 			deleteVersion := peer.DeleteDocument(collectionName, docID)
 			require.NotEmpty(t, deleteVersion.CV())
-			require.NotEqual(t, deleteVersion.CV(), updateVersion.CV())
-			require.NotEqual(t, deleteVersion.CV(), createVersion.CV())
+			require.NotEqual(t, deleteVersion.CV(), updateVersion.docMeta.CV())
+			require.NotEqual(t, deleteVersion.CV(), createVersion.docMeta.CV())
 			if tc.peerOption.Type == PeerTypeCouchbaseServer {
 				require.Empty(t, deleteVersion.RevTreeID)
 			} else {
 				require.NotEmpty(t, deleteVersion.RevTreeID)
-				require.NotEqual(t, deleteVersion.RevTreeID, createVersion.RevTreeID)
-				require.NotEqual(t, deleteVersion.RevTreeID, updateVersion.RevTreeID)
+				require.NotEqual(t, deleteVersion.RevTreeID, createVersion.docMeta.RevTreeID)
+				require.NotEqual(t, deleteVersion.RevTreeID, updateVersion.docMeta.RevTreeID)
 			}
 			peer.RequireDocNotFound(collectionName, docID)
 
@@ -329,19 +329,19 @@ func TestPeerImplementation(t *testing.T) {
 
 			resurrectionBody := []byte(`{"op": "resurrection"}`)
 			resurrectionVersion := peer.WriteDocument(collectionName, docID, resurrectionBody)
-			require.NotEmpty(t, resurrectionVersion.CV())
-			require.NotEqual(t, resurrectionVersion.CV(), deleteVersion.CV())
-			require.NotEqual(t, resurrectionVersion.CV(), updateVersion.CV())
-			require.NotEqual(t, resurrectionVersion.CV(), createVersion.CV())
+			require.NotEmpty(t, resurrectionVersion.docMeta.CV())
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(), deleteVersion.CV())
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(), updateVersion.docMeta.CV())
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(), createVersion.docMeta.CV())
 			if tc.peerOption.Type == PeerTypeCouchbaseServer {
-				require.Empty(t, resurrectionVersion.RevTreeID)
+				require.Empty(t, resurrectionVersion.docMeta.RevTreeID)
 			} else {
-				require.NotEmpty(t, resurrectionVersion.RevTreeID)
-				require.NotEqual(t, resurrectionVersion.RevTreeID, createVersion.RevTreeID)
-				require.NotEqual(t, resurrectionVersion.RevTreeID, updateVersion.RevTreeID)
-				require.NotEqual(t, resurrectionVersion.RevTreeID, deleteVersion.RevTreeID)
+				require.NotEmpty(t, resurrectionVersion.docMeta.RevTreeID)
+				require.NotEqual(t, resurrectionVersion.docMeta.RevTreeID, createVersion.docMeta.RevTreeID)
+				require.NotEqual(t, resurrectionVersion.docMeta.RevTreeID, updateVersion.docMeta.RevTreeID)
+				require.NotEqual(t, resurrectionVersion.docMeta.RevTreeID, deleteVersion.RevTreeID)
 			}
-			peer.WaitForDocVersion(collectionName, docID, resurrectionVersion)
+			peer.WaitForDocVersion(collectionName, docID, resurrectionVersion.docMeta)
 
 		})
 	}

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -290,7 +290,7 @@ func TestPeerImplementation(t *testing.T) {
 			peer.WaitForDocVersion(collectionName, docID, createVersion.docMeta)
 			// Check Get after creation
 			roundtripGetVersion, roundtripGetbody := peer.GetDocument(collectionName, docID)
-			require.Equal(t, createVersion, roundtripGetVersion)
+			require.Equal(t, createVersion.docMeta, roundtripGetVersion)
 			require.JSONEq(t, string(createBody), string(base.MustJSONMarshal(t, roundtripGetbody)))
 
 			// Update
@@ -308,7 +308,7 @@ func TestPeerImplementation(t *testing.T) {
 
 			// Check Get after update
 			roundtripGetVersion, roundtripGetbody = peer.GetDocument(collectionName, docID)
-			require.Equal(t, updateVersion, roundtripGetVersion)
+			require.Equal(t, updateVersion.docMeta, roundtripGetVersion)
 			require.JSONEq(t, string(updateBody), string(base.MustJSONMarshal(t, roundtripGetbody)))
 
 			// Delete

--- a/topologytest/sync_gateway_peer_test.go
+++ b/topologytest/sync_gateway_peer_test.go
@@ -65,7 +65,7 @@ func (p *SyncGatewayPeer) GetDocument(dsName sgbucket.DataStoreName, docID strin
 }
 
 // CreateDocument creates a document on the peer. The test will fail if the document already exists.
-func (p *SyncGatewayPeer) CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) DocMetadata {
+func (p *SyncGatewayPeer) CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion {
 	p.TB().Logf("%s: Creating document %s", p, docID)
 	return p.WriteDocument(dsName, docID, body)
 }
@@ -101,9 +101,14 @@ func (p *SyncGatewayPeer) writeDocument(dsName sgbucket.DataStoreName, docID str
 }
 
 // WriteDocument writes a document to the peer. The test will fail if the write does not succeed.
-func (p *SyncGatewayPeer) WriteDocument(dsName sgbucket.DataStoreName, docID string, body []byte) DocMetadata {
+func (p *SyncGatewayPeer) WriteDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion {
 	p.TB().Logf("%s: Writing document %s", p, docID)
-	return p.writeDocument(dsName, docID, body)
+	docMetadata := p.writeDocument(dsName, docID, body)
+	return BodyAndVersion{
+		docMeta:    docMetadata,
+		body:       body,
+		updatePeer: p.name,
+	}
 }
 
 // DeleteDocument deletes a document on the peer. The test will fail if the document does not exist.


### PR DESCRIPTION
CBG-4303

- Adds test for multi actor conflicting writes
- Skipping all tests due to general flake issues and panics against rosmar. tickets are [CBG-4379](https://jira.issues.couchbase.com/browse/CBG-4379) and [CBG-4378](https://jira.issues.couchbase.com/browse/CBG-4378) respectively 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2812/


[CBG-4379]: https://couchbasecloud.atlassian.net/browse/CBG-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CBG-4378]: https://couchbasecloud.atlassian.net/browse/CBG-4378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ