### PR TITLE
Update golangci-lint and remove removed linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
         with:
           go-version: 1.23.3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.62.2
           args: --config=.golangci-strict.yml
 
   test:

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -46,7 +46,6 @@ linters:
     - godot # Check if comments end in a period
     - godox # Tool for detection of FIXME, TODO and other comment keywords
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomnd # An analyzer to detect magic numbers.
     - gomodguard # Allow and block list linter for direct Go module dependencies.
     - lll # Reports long lines
     - nestif # Reports deeply nested if statements

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,6 @@ linters:
     - godot # Check if comments end in a period
     - godox # Tool for detection of FIXME, TODO and other comment keywords
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomnd # An analyzer to detect magic numbers.
     - gomodguard # Allow and block list linter for direct Go module dependencies.
     - lll # Reports long lines
     - nestif # Reports deeply nested if statements


### PR DESCRIPTION
gomnd was removed in golangci-lint 1.62 and flags as a warning when running newer golangci-lint versions