### PR TITLE
CBG-4383 handle no revpos in attachment block

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -294,7 +294,9 @@ func (c *DatabaseCollection) ForEachStubAttachment(body Body, minRevpos int, doc
 			return base.HTTPErrorf(http.StatusBadRequest, "Invalid attachment")
 		}
 		if meta["data"] == nil {
-			if revpos, ok := base.ToInt64(meta["revpos"]); revpos < int64(minRevpos) || !ok {
+			// default to zero if not present
+			revpos, _ := base.ToInt64(meta["revpos"])
+			if revpos < int64(minRevpos) {
 				continue
 			}
 			digest, ok := meta["digest"].(string)

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -294,9 +294,7 @@ func (c *DatabaseCollection) ForEachStubAttachment(body Body, minRevpos int, doc
 			return base.HTTPErrorf(http.StatusBadRequest, "Invalid attachment")
 		}
 		if meta["data"] == nil {
-			// default to zero if not present
-			revpos, _ := base.ToInt64(meta["revpos"])
-			if revpos < int64(minRevpos) {
+			if revpos, ok := base.ToInt64(meta["revpos"]); revpos < int64(minRevpos) || (!ok && minRevpos > 0) {
 				continue
 			}
 			digest, ok := meta["digest"].(string)

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2946,3 +2946,55 @@ func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
 	attMeta := globalXattr.GlobalAttachments["camera.txt"].(map[string]interface{})
 	assert.Equal(t, float64(20), attMeta["length"])
 }
+
+func TestBlipPushRevWithAttachment(t *testing.T) {
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		// Setup
+		rt := NewRestTesterPersistentConfig(t)
+		defer rt.Close()
+		const username = "bernard"
+
+		opts := &BlipTesterClientOpts{Username: username, SupportedBLIPProtocols: SupportedBLIPProtocols}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		docID := "doc1"
+		attachmentName := "attachment1"
+		attachmentData := "attachmentContents"
+
+		contentType := "text/plain"
+
+		length, digest, err := btcRunner.saveAttachment(btc.id, contentType, base64.StdEncoding.EncodeToString([]byte(attachmentData)))
+		require.NoError(t, err)
+
+		blipBody := db.Body{
+			"key": "val",
+			"_attachments": db.Body{
+				"attachment1": db.Body{
+					"digest": digest,
+					"stub":   true,
+					"length": length,
+				},
+			},
+		}
+		version1, err := btcRunner.PushRev(btc.id, docID, EmptyDocVersion(), base.MustJSONMarshal(t, blipBody))
+		require.NoError(t, err)
+		body := rt.GetDocBody(docID)
+		require.Equal(t, db.Body{
+			"key": "val",
+			"_attachments": map[string]any{
+				"attachment1": map[string]any{
+					"digest": digest,
+					"stub":   true,
+					"revpos": float64(1),
+					"length": float64(length),
+				},
+			},
+			"_id":  docID,
+			"_rev": version1.RevTreeID,
+		}, body)
+		response := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s/%s", docID, attachmentName), "")
+		RequireStatus(t, response, http.StatusOK)
+		require.Equal(t, attachmentData, string(response.BodyBytes()))
+	})
+}


### PR DESCRIPTION
CBG-4383 handle no revpos in attachment block

I'm not sure whether to implicit treat no revpos as 0 is OK or if I should avoid this entirely. `TestForEachStubAttachment` has code that relies on checking `revpos`.

I'm also not sure if we should output `revpos` in the output of GET `/ks/doc` but probably for pre 3.x compatibility.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2816/
