### PR TITLE
CBG-4370 preqreq deduplicate active replicator pull changes

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"expvar"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ type activeReplicatorCommon struct {
 	ctxCancel             context.CancelFunc
 	reconnectActive       base.AtomicBool                                             // Tracks whether reconnect goroutine is active
 	replicatorConnectFn   func() error                                                // the function called inside reconnectLoop.
-	activeSendChanges     base.AtomicBool                                             // Tracks whether sendChanges goroutine is active.
+	activeSendChanges     atomic.Int32                                                // Tracks whether sendChanges goroutines are active, there is one per collection.
 	namedCollections      map[base.ScopeAndCollectionName]*activeReplicatorCollection // set only if the replicator is running with collections - access with forEachCollection
 	defaultCollection     *activeReplicatorCollection                                 // set only if the replicator is not running with collections - access with forEachCollection
 }

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -268,7 +268,7 @@ func (apr *ActivePushReplicator) Stop() error {
 		return err
 	}
 	teardownStart := time.Now()
-	for apr.activeSendChanges.IsTrue() && (time.Since(teardownStart) < time.Second*10) {
+	for apr.activeSendChanges.Load() != 0 && (time.Since(teardownStart) < time.Second*10) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	return nil
@@ -298,8 +298,17 @@ func (apr *ActivePushReplicator) _startPushNonCollection() error {
 	bh.collection = dbCollectionWithUser
 	bh.loggingCtx = bh.collection.AddCollectionContext(bh.BlipSyncContext.loggingCtx)
 
+	return apr._startSendingChanges(bh, apr.defaultCollection.Checkpointer.lastCheckpointSeq)
+}
+
+// _startSendingChanges starts a changes feed for a given collection in a goroutine and starts sending changes to the passive peer from a starting sequence value.
+func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since SequenceID) error {
+	collectionCtx, err := bh.collections.get(bh.collectionIdx)
+	if err != nil {
+		return err
+	}
 	var channels base.Set
-	if filteredChannels := apr.config.getFilteredChannels(nil); len(filteredChannels) > 0 {
+	if filteredChannels := apr.config.getFilteredChannels(bh.collectionIdx); len(filteredChannels) > 0 {
 		channels = base.SetFromArray(filteredChannels)
 	}
 
@@ -320,17 +329,12 @@ func (apr *ActivePushReplicator) _startPushNonCollection() error {
 		// No special handling for error
 	}
 
-	collectionCtx, err := bh.collections.get(nil)
-	if err != nil {
-		return err
-	}
-
-	apr.activeSendChanges.Set(true)
+	apr.activeSendChanges.Add(1)
 	go func(s *blip.Sender) {
-		defer apr.activeSendChanges.Set(false)
+		defer apr.activeSendChanges.Add(-1)
 		isComplete := bh.sendChanges(s, &sendChangesOptions{
 			docIDs:            apr.config.DocIDs,
-			since:             apr.defaultCollection.Checkpointer.lastCheckpointSeq,
+			since:             since,
 			continuous:        apr.config.Continuous,
 			activeOnly:        apr.config.ActiveOnly,
 			batchSize:         int(apr.config.ChangesBatchSize),
@@ -345,6 +349,5 @@ func (apr *ActivePushReplicator) _startPushNonCollection() error {
 			apr.Complete()
 		}
 	}(apr.blipSender)
-
 	return nil
 }


### PR DESCRIPTION
In https://github.com/couchbase/sync_gateway/pull/7201, I am going to change the code behind `sendChanges`. I didn't want to worry about doing it in two places, so I refactored the collection and non collection code into one place.
 
 Fix incidental error where `activeSendChanges` was a bool but actually needed to a be a counter for N collections.
 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2818/
