### PR TITLE
CBG-4329 use rudimentary backoff to wait for cbl mock version

### DIFF
--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -88,7 +88,6 @@ func TestHLVUpdateDocumentSingleActor(t *testing.T) {
 			if strings.HasPrefix(tc.activePeerID, "cbl") {
 				t.Skip("Skipping Couchbase Lite test, returns unexpected body in proposeChanges: [304], CBG-4257")
 			}
-			t.Skip("intermittent failure in Couchbase Server and rosmar CBG-4329")
 			peers, _ := setupTests(t, tc.topology, tc.activePeerID)
 
 			body1 := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s", "write": 1}`, tc.activePeerID, tc.description()))
@@ -113,9 +112,6 @@ func TestHLVDeleteDocumentSingleActor(t *testing.T) {
 		t.Run(tc.description(), func(t *testing.T) {
 			if strings.HasPrefix(tc.activePeerID, "cbl") {
 				t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4257")
-			}
-			if !base.UnitTestUrlIsWalrus() {
-				t.Skip("intermittent failure in Couchbase Server CBG-4329")
 			}
 			peers, _ := setupTests(t, tc.topology, tc.activePeerID)
 

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -23,14 +23,19 @@ type DocMetadata struct {
 	ImplicitCV *db.Version             // ImplicitCV is the version of the document, if there was no HLV
 }
 
-func (v DocMetadata) CV() string {
+// CV returns the current version of the document.
+func (v DocMetadata) CV() db.Version {
 	if v.HLV == nil {
+		// If there is no HLV, then the version is implicit from the current ver@sourceID
 		if v.ImplicitCV == nil {
-			return ""
+			return db.Version{}
 		}
-		return v.ImplicitCV.String()
+		return *v.ImplicitCV
 	}
-	return v.HLV.GetCurrentVersionString()
+	return db.Version{
+		SourceID: v.HLV.SourceID,
+		Value:    v.HLV.Version,
+	}
 }
 
 // DocMetadataFromDocument returns a DocVersion from the given document.


### PR DESCRIPTION
CBG-4329 use rudimentary backoff to wait for cbl mock version

The errors in this test were because `WaitForDocVersion` weren't waiting for a specific version. This code will be reworked soon.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
