### PR TITLE
Automatically collect heap profiles from high memory in tests

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -513,6 +513,10 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets, bucketQuotaMB int, buck
 	// create required number of buckets (skipping any already existing ones)
 	for i := 0; i < numBuckets; i++ {
 		testBucketName := fmt.Sprintf(tbpBucketNameFormat, tbpBucketNamePrefix, i, bucketNameTimestamp)
+		// shorten the name for rosmar buckets since they are in memory only
+		if UnitTestUrlIsWalrus() {
+			testBucketName = fmt.Sprintf("bucket%d", i)
+		}
 		ctx := BucketNameCtx(context.Background(), testBucketName)
 
 		// Bucket creation takes a few seconds for each bucket,


### PR DESCRIPTION
This collects high heap profiles in the directory that the tests exist, every 5 secs. I could turn this into an opt-in variable - I think I always want this running locally. Having this run in github actions is useless because we don't upload the artifacts. Using in jenkins might be useful since often times the high memory usage comes from couchbase server. In this case, we could re-run locally however.

Unrelated, except in debugging the same problem, I changed the bucket names for rosmar so that it was easier to read.