### PR TITLE
Add `release/anemone` integration test trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,6 +341,15 @@ pipeline {
                                 build job: 'MasterIntegration', quietPeriod: 3600, wait: false
                             }
                         }
+                        stage('anemone') {
+                            when { branch 'release/anemone' }
+                            steps {
+                                echo 'Queueing Integration test for branch "release/anemone" ...'
+                                // Queues up an async integration test run using default build params (anemone branch),
+                                // but waits up to an hour for batches of PR merges before actually running (via quietPeriod)
+                                build job: 'AnemoneIntegration', quietPeriod: 3600, wait: false
+                            }
+                        }
 
                         stage('PR') {
                             // TODO: Remove skip


### PR DESCRIPTION
Similar to `main` - have a standalone job that runs on only `release/anemone` for merged commits that we can use to independently track coverage, progress and test stability for v4

https://jenkins.sgwdev.com/job/AnemoneIntegration/ 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a