### PR TITLE
CBG-4397 use unique document names for topology tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ issues:
     - path: (_test\.go|utilities_testing\.go)
       linters:
         - goconst
+        - prealloc
     - path: (_test\.go|utilities_testing\.go)
       linters:
         - govet

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -13,12 +13,18 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/xdcr"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	totalWaitTime = 10 * time.Second
+	pollInterval  = 50 * time.Millisecond
 )
 
 // Peer represents a peer in an Mobile workflow. The types of Peers are Couchbase Server, Sync Gateway, or Couchbase Lite.
@@ -224,7 +230,7 @@ func createPeers(t *testing.T, peersOptions map[string]PeerOptions) map[string]P
 	peers := make(map[string]Peer, len(peersOptions))
 	for id, peerOptions := range peersOptions {
 		peer := NewPeer(t, id, buckets, peerOptions)
-		t.Logf("TopologyTest: created peer %s, SourceID=%+v", id, peer.SourceID())
+		t.Logf("TopologyTest: created peer %s", peer)
 		t.Cleanup(func() {
 			peer.Close()
 		})

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -9,6 +9,8 @@
 package topologytest
 
 import (
+	"fmt"
+
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 )
@@ -47,6 +49,10 @@ func DocMetadataFromDocument(doc *db.Document) DocMetadata {
 		Cas:       doc.Cas,
 		HLV:       doc.HLV,
 	}
+}
+
+func (v DocMetadata) GoString() string {
+	return fmt.Sprintf("DocMetadata{\nDocID:%s\n\tRevTreeID:%s\n\tHLV:%+v\n\tMou:%+v\n\tCas:%d\n\tImplicitCV:%+v\n}", v.DocID, v.RevTreeID, v.HLV, v.Mou, v.Cas, v.ImplicitCV)
 }
 
 // DocMetadataFromDocVersion returns metadata DocVersion from the given document and version.

--- a/xdcr/cbs_xdcr.go
+++ b/xdcr/cbs_xdcr.go
@@ -135,7 +135,7 @@ func (x *couchbaseServerManager) Start(ctx context.Context) error {
 		return err
 	}
 	if statusCode != http.StatusOK {
-		return fmt.Errorf("Could not create xdcr cluster: %s. %s %s -> (%d) %s", xdcrClusterName, method, url, statusCode, output)
+		return fmt.Errorf("Could not create xdcr replication: %s. %s %s -> (%d) %s", xdcrClusterName, method, url, statusCode, output)
 	}
 	type replicationOutput struct {
 		ID string `json:"id"`


### PR DESCRIPTION
CBG-4397 Cleanup topologytests

- Use unique name for each test single actor test, this used to use the same name for each topology, but not each test. This ensures the documents are not lingering from previous tests. Unlike Sync Gateway, XDCR will pay attention to deleted documents. This means due to the way the bucket pool works, the documents with the same name can linger between tests. E.g. `TestHLVCreate` and `TestHLVUpdate` will have duplicate values. I would not have expected that this would make a difference, since the tests recreate the document and wait for the new versions.

Debugability:

- rename rosmar buckets to bucket1,bucket2
- Log full bucket + sourceID with the peer
- log replication directions
- add prealloc to skipped linter to avoid having to preallocate test cases
- add GoString to deep print HLV/Mou

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2830/