### PR TITLE
CBG-4399 don't try to unmarshal body if no body exists

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -485,7 +485,9 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 	}
 
 	// Non-xattr data, or sync xattr not present.  Attempt to retrieve sync metadata from document body
-	result, err = UnmarshalDocumentSyncData(body, needHistory)
+	if len(body) != 0 {
+		result, err = UnmarshalDocumentSyncData(body, needHistory)
+	}
 	return result, body, xattrValues, err
 }
 

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -327,10 +327,10 @@ func TestInvalidXattrStreamEmptyBody(t *testing.T) {
 
 	// UnmarshalDocumentSyncData wraps DecodeValueWithXattrs
 	result, rawBody, rawXattrs, err := UnmarshalDocumentSyncDataFromFeed(inputStream, base.MemcachedDataTypeXattr, "", false)
-	require.Error(t, err) // unexpected end of JSON input
+	require.NoError(t, err) // body will be nil, no xattrs are found
 	require.Nil(t, result)
 	require.Equal(t, emptyBody, rawBody)
-	require.Nil(t, rawXattrs[base.SyncXattrName])
+	require.Empty(t, rawXattrs)
 
 }
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -181,7 +181,10 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 
 	var isSGWrite bool
 	var crc32Match bool
-	if syncData != nil {
+	if syncData == nil && event.Opcode == sgbucket.FeedOpDeletion {
+		base.DebugfCtx(ctx, base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(event.Key))
+		return
+	} else if syncData != nil {
 		isSGWrite, crc32Match, _ = syncData.IsSGWrite(event.Cas, rawBody, rawXattrs[collection.userXattrKey()])
 		if crc32Match {
 			il.dbStats.Crc32MatchCount.Add(1)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -182,7 +182,6 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 	var isSGWrite bool
 	var crc32Match bool
 	if syncData == nil && event.Opcode == sgbucket.FeedOpDeletion {
-		base.DebugfCtx(ctx, base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(event.Key))
 		return
 	} else if syncData != nil {
 		isSGWrite, crc32Match, _ = syncData.IsSGWrite(event.Cas, rawBody, rawXattrs[collection.userXattrKey()])

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -14,9 +14,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -1019,4 +1021,56 @@ func getSyncAndMou(t *testing.T, collection *DatabaseCollectionWithUser, key str
 	}
 	return syncData, mou, cas
 
+}
+
+func TestImportFeedEventDeletion(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
+	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	// grab DCP event from real write
+	uuid, err := uuid.NewRandom() // use UUID to allow test to work with -count > 1
+	require.NoError(t, err)
+	docID := t.Name() + "-" + uuid.String()
+
+	feedArgs := sgbucket.FeedArguments{
+		ID:         docID,
+		Backfill:   sgbucket.FeedNoBackfill,
+		Terminator: make(chan bool),
+		Scopes:     map[string][]string{collection.ScopeName: []string{collection.Name}},
+	}
+
+	var event atomic.Value
+	callback := func(e sgbucket.FeedEvent) bool {
+		if event.Load() != nil {
+			return false
+		}
+		if e.Opcode == sgbucket.FeedOpDeletion && string(e.Key) == docID {
+			event.Store(&e)
+			close(feedArgs.Terminator)
+		}
+		return false
+	}
+
+	require.NoError(t, db.Bucket.StartDCPFeed(ctx, feedArgs, callback, nil))
+
+	cas, err := collection.dataStore.WriteTombstoneWithXattrs(ctx, docID, 0, 0, map[string][]byte{"_systemxattr": []byte(`{"key": "val"}`)}, nil, false, nil)
+	require.NoError(t, err)
+	require.NotEqual(t, uint64(0), cas)
+
+	select {
+	case <-feedArgs.Terminator:
+	case <-time.After(15 * time.Second):
+		close(feedArgs.Terminator)
+
+		if event.Load() == nil {
+			close(feedArgs.Terminator)
+			t.Fatalf("Timed out waiting for DCP event")
+		}
+	}
+	base.AssertLogContains(t, "Ignoring delete mutation", func() {
+		db.ImportListener.ImportFeedEvent(ctx, collection, *(event.Load().(*sgbucket.FeedEvent)))
+	})
 }


### PR DESCRIPTION
Used a DCP event not from RestTester so I could run `ImportFeedEvent` directly and test the log messages. There's no stats if we hit this error, so I couldn't think of a better way to test this.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2837/
