### PR TITLE
CBG-4366 enable resurrection tests

### DIFF
--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -36,6 +36,11 @@ func (rt *RestTester) Run(name string, test func(*testing.T)) {
 	})
 }
 
+func (rt *RestTester) UpdateTB(t *testing.T) {
+	var tb testing.TB = t
+	rt.testingTB.Store(&tb)
+}
+
 // GetDocBody returns the doc body for the given docID. If the document is not found, t.Fail will be called.
 func (rt *RestTester) GetDocBody(docID string) db.Body {
 	rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -170,6 +170,11 @@ func (p *CouchbaseLiteMockPeer) TB() testing.TB {
 	return p.t
 }
 
+// UpdateTB updates the testing.TB for the peer.
+func (p *CouchbaseLiteMockPeer) UpdateTB(t *testing.T) {
+	p.t = t
+}
+
 // GetBackingBucket returns the backing bucket for the peer. This is always nil.
 func (p *CouchbaseLiteMockPeer) GetBackingBucket() base.Bucket {
 	return nil

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -276,6 +276,10 @@ func (p *CouchbaseServerPeer) TB() testing.TB {
 	return p.tb
 }
 
+func (p *CouchbaseServerPeer) UpdateTB(tb *testing.T) {
+	p.tb = tb
+}
+
 // getDocVersion returns a DocVersion from a cas and xattrs with _vv (hlv) and _sync (RevTreeID).
 func getDocVersion(docID string, peer Peer, cas uint64, xattrs map[string][]byte) DocMetadata {
 	docVersion := DocMetadata{

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -501,7 +501,6 @@ func TestHLVResurrectDocumentSingleActor(t *testing.T) {
 					if strings.HasPrefix(tc.activePeerID, "cbl") {
 						t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4257")
 					}
-					t.Skip("Skipping resurection tests CBG-4366")
 
 					docID := getDocID(t)
 					body1 := []byte(fmt.Sprintf(`{"peer": "%s", "topology": "%s", "write": 1}`, tc.activePeerID, tc.description()))
@@ -539,7 +538,6 @@ func TestHLVResurrectDocumentMultiActor(t *testing.T) {
 			if strings.Contains(tc.description(), "CBL") {
 				t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4257")
 			}
-			t.Skip("skipped resurrection test, intermittent failures CBG-4372")
 
 			peers, _ := setupTests(t, tc.topology)
 

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -486,7 +486,6 @@ func TestHLVResurrectDocumentSingleActor(t *testing.T) {
 			if strings.HasPrefix(tc.activePeerID, "cbl") {
 				t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4257")
 			}
-			t.Skip("Skipping resurection tests CBG-4366")
 
 			peers, _ := setupTests(t, tc.topology, tc.activePeerID)
 

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -22,10 +22,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	totalWaitTime = 10 * time.Second
-	pollInterval  = 50 * time.Millisecond
-)
+// totalWaitTime is the time to wait for a document on a peer. This time is low for rosmar and high for Couchbase Server.
+var totalWaitTime = 3 * time.Second
+
+// pollInterval is the time to poll to see if a document is updated on a peer
+var pollInterval = 50 * time.Millisecond
+
+func init() {
+	if !base.UnitTestUrlIsWalrus() {
+		totalWaitTime = 40 * time.Second
+	}
+}
 
 // Peer represents a peer in an Mobile workflow. The types of Peers are Couchbase Server, Sync Gateway, or Couchbase Lite.
 type Peer interface {

--- a/topologytest/sync_gateway_peer_test.go
+++ b/topologytest/sync_gateway_peer_test.go
@@ -150,7 +150,7 @@ func (p *SyncGatewayPeer) WaitForDeletion(dsName sgbucket.DataStoreName, docID s
 	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
 		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
 		if err == nil {
-			assert.True(c, doc.IsDeleted(), "expected %s on %s to be deleted", doc, p)
+			assert.True(c, doc.IsDeleted(), "expected %+v on %s to be deleted", doc, p)
 			return
 		}
 		assert.True(c, base.IsDocNotFoundError(err), "expected docID %s on %s to be deleted, found err=%v", docID, p, err)
@@ -198,6 +198,11 @@ func (p *SyncGatewayPeer) Context() context.Context {
 // TB returns the testing.TB for the peer.
 func (p *SyncGatewayPeer) TB() testing.TB {
 	return p.rt.TB()
+}
+
+// UpdateTB updates the testing.TB for the peer.
+func (p *SyncGatewayPeer) UpdateTB(t *testing.T) {
+	p.rt.UpdateTB(t)
 }
 
 // GetBackingBucket returns the backing bucket for the peer.

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -10,7 +10,6 @@ package topologytest
 
 import (
 	"slices"
-	"testing"
 
 	"golang.org/x/exp/maps"
 )
@@ -20,7 +19,6 @@ type Topology struct {
 	description  string
 	peers        map[string]PeerOptions
 	replications []PeerReplicationDefinition
-	skipIf       func(t *testing.T, activePeerID string, peers map[string]Peer) // allow temporary skips while the code is being ironed out
 }
 
 // PeerNames returns a sorted list of peers.


### PR DESCRIPTION
Switch tests to use fewer buckets: for each topology use use one bucket and then each actor will run tests in sequence. Using subtests allows to run each test individually if necessary.

Need to update tb on each peer for each subtest to avoid `subtest may have called FailNow on a parent test` error.

The integration tests can still fail but they don't seem to fail more frequently than the old code. I haven't seen failures in jenkins, but I might not have run them frequently enough.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2839/
