### PR TITLE
CBG-4250 Add pv support to rosmar xdcr

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1055,7 +1055,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 
 	var history []string
 	historyStr := rq.Properties[RevMessageHistory]
-	var incomingHLV HybridLogicalVector
+	var incomingHLV *HybridLogicalVector
 	// Build history/HLV
 	if !bh.useHLV() {
 		newDoc.RevID = rev
@@ -1073,7 +1073,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 			base.InfofCtx(bh.loggingCtx, base.KeySync, "Error parsing hlv while processing rev for doc %v.  HLV:%v Error: %v", base.UD(docID), versionVectorStr, err)
 			return base.HTTPErrorf(http.StatusUnprocessableEntity, "error extracting hlv from blip message")
 		}
-		newDoc.HLV = &incomingHLV
+		newDoc.HLV = incomingHLV
 	}
 
 	newDoc.UpdateBodyBytes(bodyBytes)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1817,7 +1817,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 
 	// create a version larger than the allocated version above
 	incomingVersion := docUpdateVersionInt + 10
-	incomingHLV := HybridLogicalVector{
+	incomingHLV := &HybridLogicalVector{
 		SourceID:         "test",
 		Version:          incomingVersion,
 		PreviousVersions: pv,
@@ -1895,7 +1895,7 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	// create a new doc update to simulate a doc update arriving over replicator from, client
 	body = Body{"key1": "value2"}
 	newDoc := createTestDocument(key, "", body, false, 0)
-	incomingHLV := HybridLogicalVector{
+	incomingHLV := &HybridLogicalVector{
 		SourceID: "test",
 		Version:  1234,
 	}
@@ -1935,7 +1935,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	pv[bucketUUID] = uint64(2)
 	// create a version larger than the allocated version above
 	incomingVersion := uint64(2 + 10)
-	incomingHLV := HybridLogicalVector{
+	incomingHLV := &HybridLogicalVector{
 		SourceID:         "test",
 		Version:          incomingVersion,
 		PreviousVersions: pv,

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -159,7 +159,7 @@ func TestConflictDetectionDominating(t *testing.T) {
 
 // createHLVForTest is a helper function to create a HLV for use in a test. Takes a list of strings in the format of <sourceID@version> and assumes
 // first entry is current version. For merge version entries you must specify 'm_' as a prefix to sourceID NOTE: it also sets cvCAS to the current version
-func createHLVForTest(tb *testing.T, inputList []string) HybridLogicalVector {
+func createHLVForTest(tb *testing.T, inputList []string) *HybridLogicalVector {
 	hlvOutput := NewHybridLogicalVector()
 
 	// first element will be current version and source pair
@@ -537,13 +537,13 @@ func TestInvalidHLVInBlipMessageForm(t *testing.T) {
 	hlv, err := extractHLVFromBlipMessage(hlvStr)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "invalid hlv in changes message received")
-	assert.Equal(t, HybridLogicalVector{}, hlv)
+	assert.Equal(t, &HybridLogicalVector{}, hlv)
 
 	hlvStr = ""
 	hlv, err = extractHLVFromBlipMessage(hlvStr)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "invalid hlv in changes message received")
-	assert.Equal(t, HybridLogicalVector{}, hlv)
+	assert.Equal(t, &HybridLogicalVector{}, hlv)
 }
 
 var extractHLVFromBlipMsgBMarkCases = []struct {
@@ -758,7 +758,7 @@ func TestVersionDeltaCalculation(t *testing.T) {
 	vvXattr, err = base.JSONMarshal(&hlv2)
 	require.NoError(t, err)
 	// convert the bytes back to an in memory format of hlv
-	memHLV = HybridLogicalVector{}
+	memHLV = &HybridLogicalVector{}
 	err = base.JSONUnmarshal(vvXattr, &memHLV)
 	require.NoError(t, err)
 

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -165,7 +165,7 @@ func (btcr *BlipTesterCollectionClient) NewBlipTesterDoc(revID string, body []by
 	}
 	if btcr.UseHLV() {
 		doc.revMode = revModeHLV
-		doc.HLV = db.NewHybridLogicalVector()
+		doc.HLV = *db.NewHybridLogicalVector()
 		_ = doc.HLV.AddVersion(VersionFromRevID(revID))
 	} else {
 		doc.revMode = revModeRevTree


### PR DESCRIPTION
Use HLV.AddVersion to update the HLV during XDCR replication, to ensure standard cv/pv handling is followed.

CBG-4250
