### PR TITLE
CBG-4389: extract cv from known revs and store backup rev by cv

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1084,9 +1084,6 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	if deltaSrcRevID, isDelta := revMessage.DeltaSrc(); isDelta && !revMessage.Deleted() {
 		if !bh.sgCanUseDeltas {
 			return base.HTTPErrorf(http.StatusBadRequest, "Deltas are disabled for this peer")
-		} else if !bh.useHLV() {
-			// Disable delta sync for protocol versions < 4, CBG-3748 (backwards compatibility for revID delta sync)
-			return base.HTTPErrorf(http.StatusBadRequest, "backwards compatibility for revTree deltas not yet implemented")
 		}
 
 		//  TODO: Doing a GetRevCopy here duplicates some rev cache retrieval effort, since deltaRevSrc is always

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -772,6 +772,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	}
 	output.Write([]byte("]"))
 	response := rq.Response()
+	// Disable delta sync for protocol versions < 4, CBG-3748 (backwards compatibility for revID delta sync)
 	if bh.sgCanUseDeltas && bh.useHLV() {
 		base.DebugfCtx(bh.loggingCtx, base.KeyAll, "Setting deltas=true property on handleChanges response")
 		response.Properties[ChangesResponseDeltas] = trueProperty
@@ -865,6 +866,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 	}
 	output.Write([]byte("]"))
 	response := rq.Response()
+	// Disable delta sync for protocol versions < 4, CBG-3748 (backwards compatibility for revID delta sync)
 	if bh.sgCanUseDeltas && bh.useHLV() {
 		base.DebugfCtx(bh.loggingCtx, base.KeyAll, "Setting deltas=true property on proposeChanges response")
 		response.Properties[ChangesResponseDeltas] = trueProperty
@@ -1083,6 +1085,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		if !bh.sgCanUseDeltas {
 			return base.HTTPErrorf(http.StatusBadRequest, "Deltas are disabled for this peer")
 		} else if !bh.useHLV() {
+			// Disable delta sync for protocol versions < 4, CBG-3748 (backwards compatibility for revID delta sync)
 			return base.HTTPErrorf(http.StatusBadRequest, "backwards compatibility for revTree deltas not yet implemented")
 		}
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -354,10 +354,20 @@ func (bsc *BlipSyncContext) handleChangesResponse(ctx context.Context, sender *b
 				knownRevsByDoc[docID] = knownRevs
 			}
 
-			// The first element of the knownRevsArray returned from CBL is the parent revision to use as deltaSrc
+			// The first element of the knownRevsArray returned from CBL is the parent revision to use as deltaSrc for
+			// revtree clients, for HLV clients the first element is the HLV
 			if bsc.useDeltas && len(knownRevsArray) > 0 {
 				if revID, ok := knownRevsArray[0].(string); ok {
-					deltaSrcRevID = revID
+					if bsc.useHLV() {
+						msgHLV, err := extractHLVFromBlipMessage(revID)
+						if err != nil {
+							base.ErrorfCtx(ctx, "Invalid known rev format for hlv on doc: %s", docID)
+							return nil
+						}
+						deltaSrcRevID = msgHLV.GetCurrentVersionString()
+					} else {
+						deltaSrcRevID = revID
+					}
 				}
 			}
 
@@ -372,7 +382,8 @@ func (bsc *BlipSyncContext) handleChangesResponse(ctx context.Context, sender *b
 
 			var err error
 
-			if deltaSrcRevID != "" {
+			// fallback to sending full revisions for non hlv aware peers, CBG-3748
+			if deltaSrcRevID != "" && bsc.useHLV() {
 				err = bsc.sendRevAsDelta(ctx, sender, docID, rev, deltaSrcRevID, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx)
 			} else {
 				err = bsc.sendRevision(ctx, sender, docID, rev, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2606,10 +2606,7 @@ func (db *DatabaseCollectionWithUser) postWriteUpdateHLV(ctx context.Context, do
 		doc.HLV.CurrentVersionCAS = casOut
 	}
 	// backup new revision to the bucket now we have a doc assigned a CV (post macro expansion) for delta generation purposes
-	backupRev := db.deltaSyncEnabled()
-	if backupRev {
-		backupRev = db.deltaSyncRevMaxAgeSeconds() != 0
-	}
+	backupRev := db.deltaSyncEnabled() && db.deltaSyncRevMaxAgeSeconds() != 0
 	if db.UseXattrs() && backupRev {
 		var newBodyWithAtts = doc._rawBody
 		if len(doc.Attachments) > 0 {

--- a/db/crud.go
+++ b/db/crud.go
@@ -879,19 +879,13 @@ func (db *DatabaseCollectionWithUser) getAvailableRevAttachments(ctx context.Con
 
 // Moves a revision's ancestor's body out of the document object and into a separate db doc.
 func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, doc *Document, newDoc *Document) {
-	newBodyBytes, err := newDoc.BodyBytes(ctx)
-	if err != nil {
-		base.WarnfCtx(ctx, "Error getting body bytes when backing up ancestor revs")
-		return
-	}
 
 	// Find an ancestor that still has JSON in the document:
 	var json []byte
 	ancestorRevId := newDoc.RevID
 	for {
 		if ancestorRevId = doc.History.getParent(ancestorRevId); ancestorRevId == "" {
-			// No ancestors with JSON found.  Check if we need to back up current rev for delta sync, then return
-			db.backupRevisionJSON(ctx, doc.ID, newDoc.RevID, "", newBodyBytes, nil, doc.Attachments)
+			// No ancestors with JSON found. Return early
 			return
 		} else if json = doc.getRevisionBodyJSON(ctx, ancestorRevId, db.RevisionBodyLoader); json != nil {
 			break
@@ -899,7 +893,7 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 	}
 
 	// Back up the revision JSON as a separate doc in the bucket:
-	db.backupRevisionJSON(ctx, doc.ID, newDoc.RevID, ancestorRevId, newBodyBytes, json, doc.Attachments)
+	db.backupRevisionJSON(ctx, doc.ID, doc.HLV.GetCurrentVersionString(), json)
 
 	// Nil out the ancestor rev's body in the document struct:
 	if ancestorRevId == doc.CurrentRev {
@@ -2612,7 +2606,11 @@ func (db *DatabaseCollectionWithUser) postWriteUpdateHLV(ctx context.Context, do
 		doc.HLV.CurrentVersionCAS = casOut
 	}
 	// backup new revision to the bucket now we have a doc assigned a CV (post macro expansion) for delta generation purposes
-	if db.UseXattrs() {
+	backupRev := db.deltaSyncEnabled()
+	if backupRev {
+		backupRev = db.deltaSyncRevMaxAgeSeconds() != 0
+	}
+	if db.UseXattrs() && backupRev {
 		var newBodyWithAtts = doc._rawBody
 		if len(doc.Attachments) > 0 {
 			var err error

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1196,6 +1196,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 }
 
 func TestGetAvailableRevAttachments(t *testing.T) {
+	t.Skip("Revs are backed up by hash of CV now, test needs to fetch backup rev by revID, CBG-3748 (backwards compatibility for revID)")
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -453,6 +453,7 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 		base.ErrorfCtx(ctx, "pending CBG-3814 support of channel removal for CV: %v", err)
 	}
 
+	deleted = doc.Deleted
 	channels = doc.SyncData.getCurrentChannels()
 	revid = doc.CurrentRev
 	hlv = doc.HLV
@@ -462,7 +463,7 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 
 func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document, cv Version) (bodyBytes []byte, attachments AttachmentsMeta, err error) {
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {
-		bodyBytes, err = c.getOldRevisionJSON(ctx, doc.ID, doc.CurrentRev)
+		bodyBytes, err = c.getOldRevisionJSON(ctx, doc.ID, cv.String())
 		if err != nil || bodyBytes == nil {
 			return nil, nil, err
 		}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -463,7 +463,7 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 
 func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document, cv Version) (bodyBytes []byte, attachments AttachmentsMeta, err error) {
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {
-		bodyBytes, err = c.getOldRevisionJSON(ctx, doc.ID, cv.String())
+		bodyBytes, err = c.getOldRevisionJSON(ctx, doc.ID, base.Crc32cHashString([]byte(cv.String())))
 		if err != nil || bodyBytes == nil {
 			return nil, nil, err
 		}

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -548,6 +548,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 }
 
 func TestBypassRevisionCache(t *testing.T) {
+	t.Skip("Revs are backed up by hash of CV now, test needs to fetch backup rev by revID, CBG-3748 (backwards compatibility for revID)")
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db, ctx := setupTestDB(t)

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -112,7 +112,7 @@ func TestBackupOldRevision(t *testing.T) {
 
 	docID := t.Name()
 
-	rev1ID, _, err := collection.Put(ctx, docID, Body{"test": true})
+	rev1ID, docRev1, err := collection.Put(ctx, docID, Body{"test": true})
 	require.NoError(t, err)
 
 	// make sure we didn't accidentally store an empty old revision
@@ -121,7 +121,8 @@ func TestBackupOldRevision(t *testing.T) {
 	assert.Equal(t, "404 missing", err.Error())
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
+	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {
@@ -131,15 +132,17 @@ func TestBackupOldRevision(t *testing.T) {
 
 	// create rev 2 and check backups for both revs
 	rev2ID := "2-abc"
-	_, _, err = collection.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true, ExistingVersionWithUpdateToHLV)
+	docRev2, _, err := collection.PutExistingRevWithBody(ctx, docID, Body{"test": true, "updated": true}, []string{rev2ID, rev1ID}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// now in all cases we'll have rev 1 backed up (for at least 5 minutes)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
+	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	require.NoError(t, err)
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev2ID)
+	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -684,6 +684,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 }
 
 func TestConflictWithInvalidAttachment(t *testing.T) {
+	t.Skip("Revs are backed up by hash of CV now, test needs to fetch backup rev by revID, CBG-3748 (backwards compatibility for revID)")
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -223,8 +223,9 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		// Check EE is delta, and CE is full-body replication
 		// msg, ok = client.pullReplication.WaitForMessage(5)
 		msg = btcRunner.WaitForBlipRevMessage(client.id, doc1ID, version2)
-
-		if base.IsEnterpriseEdition() {
+		// Delta sync only works for Version vectors, CBG-3748 (backwards compatibility for revID)
+		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
+		if sgCanUseDeltas {
 			// Check the request was sent with the correct deltaSrc property
 			client.AssertDeltaSrcProperty(t, msg, version)
 			// Check the request body was the actual delta
@@ -238,7 +239,10 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 			msgBody, err := msg.Body()
 			assert.NoError(t, err)
 			assert.NotEqual(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
-			assert.Contains(t, string(msgBody), `"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}`)
+			assert.Contains(t, string(msgBody), `"stub":true`)
+			assert.Contains(t, string(msgBody), `"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="`)
+			assert.Contains(t, string(msgBody), `"revpos":2`)
+			assert.Contains(t, string(msgBody), `"length":11`)
 			assert.Contains(t, string(msgBody), `"greetings":[{"hello":"world!"},{"hi":"alice"}]`)
 		}
 
@@ -306,7 +310,9 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		msg := btcRunner.WaitForBlipRevMessage(client.id, docID, version2)
 
 		// Check EE is delta, and CE is full-body replication
-		if base.IsEnterpriseEdition() {
+		// Delta sync only works for Version vectors, CBG-3748 (backwards compatibility for revID)
+		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
+		if sgCanUseDeltas {
 			// Check the request was sent with the correct deltaSrc property
 			client.AssertDeltaSrcProperty(t, msg, version)
 			// Check the request body was the actual delta
@@ -351,6 +357,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for rev tree replication, CBG-3748
 	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			&rtConfig)
@@ -546,8 +553,9 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 			deltasRequestedEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
 			deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 		}
-
-		if sgUseDeltas {
+		// delta sync not implemented for rev tree replication, CBG-3748
+		sgCanUseDelta := base.IsEnterpriseEdition() && client.UseHLV()
+		if sgCanUseDelta {
 			assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
 			assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
 			assert.Equal(t, deltasRequestedStart+1, deltasRequestedEnd)
@@ -686,7 +694,9 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 			deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 		}
 
-		if sgUseDeltas {
+		// delta sync not implemented for rev tree replication, CBG-3748
+		sgCanUseDelta := base.IsEnterpriseEdition() && client1.UseHLV()
+		if sgCanUseDelta {
 			assert.Equal(t, deltaCacheHitsStart+1, deltaCacheHitsEnd)
 			assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
 			assert.Equal(t, deltasRequestedStart+2, deltasRequestedEnd)
@@ -732,6 +742,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		defer client.Close()
 
 		client.ClientDeltas = true
+		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
 		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
@@ -758,11 +769,16 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 		// Check EE is delta
 		// Check the request was sent with the correct deltaSrc property
-		client.AssertDeltaSrcProperty(t, msg, version1)
+		// delta sync not implemented for rev tree replication, CBG-3748
+		if sgCanUseDeltas {
+			client.AssertDeltaSrcProperty(t, msg, version1)
+		} else {
+			assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+		}
 		// Check the request body was the actual delta
 		msgBody, err := msg.Body()
 		assert.NoError(t, err)
-		if sgUseDeltas {
+		if sgCanUseDeltas {
 			assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
 		} else {
 			assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
@@ -777,11 +793,15 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		msg2 := btcRunner.WaitForBlipRevMessage(client2.id, docID, version2)
 
 		// Check the request was sent with the correct deltaSrc property
-		client2.AssertDeltaSrcProperty(t, msg2, version1)
+		if sgCanUseDeltas {
+			client2.AssertDeltaSrcProperty(t, msg2, version1)
+		} else {
+			assert.Equal(t, "", msg2.Properties[db.RevMessageDeltaSrc])
+		}
 		// Check the request body was the actual delta
 		msgBody2, err := msg2.Body()
 		assert.NoError(t, err)
-		if sgUseDeltas {
+		if sgCanUseDeltas {
 			assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody2))
 		} else {
 			assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody2))
@@ -790,7 +810,8 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		updatedDeltaCacheHits := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
 		updatedDeltaCacheMisses := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
 
-		if sgUseDeltas {
+		// delta sync not implemented for rev tree replication, CBG-3748
+		if sgCanUseDeltas {
 			assert.Equal(t, deltaCacheHits+1, updatedDeltaCacheHits)
 			assert.Equal(t, deltaCacheMisses, updatedDeltaCacheMisses)
 		} else {
@@ -827,6 +848,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer client.Close()
 		client.ClientDeltas = true
+		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
 
 		btcRunner.StartPull(client.id)
 
@@ -842,7 +864,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		// Check EE is delta, and CE is full-body replication
 		msg := client.waitForReplicationMessage(collection, 2)
 
-		if base.IsEnterpriseEdition() && sgUseDeltas {
+		if base.IsEnterpriseEdition() && sgCanUseDeltas {
 			// Check the request was sent with the correct deltaSrc property
 			client.AssertDeltaSrcProperty(t, msg, version)
 			// Check the request body was the actual delta
@@ -887,7 +909,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 		_, err = btcRunner.PushRev(client.id, docID, deletedVersion, []byte(`{"undelete":true}`))
 
-		if base.IsEnterpriseEdition() && sgUseDeltas {
+		if base.IsEnterpriseEdition() && sgCanUseDeltas {
 			// Now make the client push up a delta that has the parent of the tombstone.
 			// This is not a valid scenario, and is actively prevented on the CBL side.
 			assert.Error(t, err)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -179,15 +179,17 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 	// 1. Create revision with history
 	docID := t.Name()
 	version := rt.PutDocDirectly(docID, rest.JsonToMap(t, `{"val":-1}`))
-	revID := version.RevTreeID
+	cv := version.CV.String()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	for i := 0; i < 10; i++ {
 		version = rt.UpdateDocDirectly(docID, version, rest.JsonToMap(t, fmt.Sprintf(`{"val":%d}`, i)))
 		// Purge old revision JSON to simulate expiry, and to verify import doesn't attempt multiple retrievals
-		purgeErr := collection.PurgeOldRevisionJSON(ctx, docID, revID)
+		// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+		cvHash := base.Crc32cHashString([]byte(cv))
+		purgeErr := collection.PurgeOldRevisionJSON(ctx, docID, cvHash)
 		require.NoError(t, purgeErr)
-		revID = version.RevTreeID
+		cv = version.CV.String()
 	}
 
 	// 2. Modify doc via SDK


### PR DESCRIPTION
CBG-4389

- Extract cv from known revs 
- Disable delta sync for revTree clients 
- Switch to backup rev by cv, using hash of cv for concerns about key length
- Move backup for current rev to post update hlv function as due to macro expansion we don't have a version for cv at the backup rev function

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2862/
