### PR TITLE
CBG-4408 disable CBS topologytests by default

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -61,6 +61,9 @@ const (
 
 	// Creates buckets with a specific number of number of replicas
 	tbpEnvBucketNumReplicas = "SG_TEST_BUCKET_NUM_REPLICAS"
+
+	// Environment variable to specify the topology tests to run
+	TbpEnvTopologyTests = "SG_TEST_TOPOLOGY_TESTS"
 )
 
 // TestsUseNamedCollections returns true if the tests use named collections.

--- a/topologytest/main_test.go
+++ b/topologytest/main_test.go
@@ -12,6 +12,8 @@ package topologytest
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -20,6 +22,11 @@ import (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
+	runTests, _ := strconv.ParseBool(os.Getenv(base.TbpEnvTopologyTests))
+	if !base.UnitTestUrlIsWalrus() && !runTests {
+		base.SkipTestMain(m, "Tests are disabled for Couchbase Server by default, to enable set %s=true environment variable", base.TbpEnvTopologyTests)
+		return
+	}
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
 	// Do not create indexes for this test, so they are built by server_context.go
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)


### PR DESCRIPTION
These tests fail intermittently and take a long time. I do not want these running by default in jenkins.

Should I have them run locally without the opt-in variable and just disabled in jenkins? I will create an option in jenkins to be able to set this env variable once we settle on a name.