### PR TITLE
refactor topologytests

### DIFF
--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -129,6 +129,11 @@ func (p *CouchbaseLiteMockPeer) Close() {
 	}
 }
 
+// Type returns PeerTypeCouchbaseLite.
+func (p *CouchbaseLiteMockPeer) Type() PeerType {
+	return PeerTypeCouchbaseLite
+}
+
 // CreateReplication creates a replication instance
 func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, _ PeerReplicationConfig) PeerReplication {
 	sg, ok := peer.(*SyncGatewayPeer)

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -220,6 +220,11 @@ func (p *CouchbaseServerPeer) Close() {
 	}
 }
 
+// Type returns PeerTypeCouchbaseServer.
+func (p *CouchbaseServerPeer) Type() PeerType {
+	return PeerTypeCouchbaseServer
+}
+
 // CreateReplication creates an XDCR manager.
 func (p *CouchbaseServerPeer) CreateReplication(passivePeer Peer, config PeerReplicationConfig) PeerReplication {
 	switch config.direction {

--- a/topologytest/sync_gateway_peer_test.go
+++ b/topologytest/sync_gateway_peer_test.go
@@ -179,6 +179,11 @@ func (p *SyncGatewayPeer) Close() {
 	p.rt.Close()
 }
 
+// Type returns PeerTypeSyncGateway.
+func (p *SyncGatewayPeer) Type() PeerType {
+	return PeerTypeSyncGateway
+}
+
 // CreateReplication creates a replication instance. This is currently not supported for Sync Gateway peers. A future ISGR implementation will support this.
 func (p *SyncGatewayPeer) CreateReplication(_ Peer, _ PeerReplicationConfig) PeerReplication {
 	require.Fail(p.rt.TB(), "can not create a replication with Sync Gateway as an active peer")

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -8,24 +8,11 @@
 
 package topologytest
 
-import (
-	"slices"
-
-	"golang.org/x/exp/maps"
-)
-
 // Topology defines a topology for a set of peers and replications. This can include Couchbase Server, Sync Gateway, and Couchbase Lite peers, with push or pull replications between them.
 type Topology struct {
 	description  string
 	peers        map[string]PeerOptions
 	replications []PeerReplicationDefinition
-}
-
-// PeerNames returns a sorted list of peers.
-func (t Topology) PeerNames() []string {
-	peerNames := maps.Keys(t.peers)
-	slices.Sort(peerNames)
-	return peerNames
 }
 
 // Topologies represents user configurations of replications.


### PR DESCRIPTION
This is prep for upcoming changes and made things easier to debug by making assertion functions easier to call independently for debugging.

- use consistent naming for updating documents with keys activePeer and action
- create a Peers type for running SortedPeers to get a sorted list of peers for deterministic test purposes
- be able to query Type of peer
- remove ActorTest abstraction to be able to run assertions more easily, since they are non specific to a particular type of test

The multi actor tests are not yet doing the right things, so examining the tests themselves is not very useful.
