### PR TITLE
CBG-4417 construct missing CV entry from HLV if not present

### DIFF
--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -58,20 +58,6 @@ func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, pee
 	}
 }
 
-// waitForVersionAndBodyOnNonActivePeers waits for a document to reach a specific version on all non-active peers. This is stub until CBG-4417 is implemented.
-func waitForVersionAndBodyOnNonActivePeers(t *testing.T, dsName base.ScopeAndCollectionName, docID string, peers Peers, expectedVersion BodyAndVersion) {
-	for peerName := range peers.SortedPeers() {
-		if peerName == expectedVersion.updatePeer {
-			// skip peer the write came from
-			continue
-		}
-		peer := peers[peerName]
-		t.Logf("waiting for doc version %#v on %s, update written from %s", expectedVersion, peer, expectedVersion.updatePeer)
-		body := peer.WaitForDocVersion(dsName, docID, expectedVersion.docMeta)
-		requireBodyEqual(t, expectedVersion.body, body)
-	}
-}
-
 func waitForDeletion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string, deleteActor string) {
 	for peerName, peer := range peers {
 		if peer.Type() == PeerTypeCouchbaseLite {

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -69,8 +69,7 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 
 			docVersion = updateConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
-			// FIXME: CBG-4417 this can be replaced with waitForVersionAndBody when implicit HLV exists
-			waitForVersionAndBodyOnNonActivePeers(t, collectionName, docID, peers, docVersion)
+			waitForVersionAndBody(t, collectionName, peers, docID, docVersion)
 		})
 	}
 }
@@ -155,7 +154,7 @@ func TestMultiActorConflictResurrect(t *testing.T) {
 			lastWriteVersion := updateConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
 
-			waitForVersionAndBodyOnNonActivePeers(t, collectionName, docID, peers, lastWriteVersion)
+			waitForVersionAndBody(t, collectionName, peers, docID, lastWriteVersion)
 		})
 	}
 }

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -58,8 +58,7 @@ func TestMultiActorUpdate(t *testing.T) {
 			for peerName := range peers.SortedPeers() {
 				docID := getDocID(t) + "_" + peerName
 				docBodyAndVersion := docVersionList[peerName]
-				// FIXME: CBG-4417 this can be replaced with waitForVersionAndBody when implicit HLV exists
-				waitForVersionAndBodyOnNonActivePeers(t, collectionName, docID, peers, docBodyAndVersion)
+				waitForVersionAndBody(t, collectionName, peers, docID, docBodyAndVersion)
 			}
 
 		})
@@ -126,8 +125,7 @@ func TestMultiActorResurrect(t *testing.T) {
 			for updatePeerName := range peers {
 				docID := getDocID(t) + "_" + updatePeerName
 				docVersion := docVersionList[updatePeerName]
-				// FIXME: CBG-4417 this can be replaced with waitForVersionAndBody when implicit HLV exists
-				waitForVersionAndBodyOnNonActivePeers(t, collectionName, docID, peers, docVersion)
+				waitForVersionAndBody(t, collectionName, peers, docID, docVersion)
 			}
 		})
 	}

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -358,7 +358,7 @@ func TestPeerImplementation(t *testing.T) {
 			updateBody := []byte(`{"op": "update"}`)
 			updateVersion := peer.WriteDocument(collectionName, docID, updateBody)
 			require.NotEmpty(t, updateVersion.docMeta.CV)
-			require.NotEqual(t, updateVersion.docMeta.CV(), createVersion.docMeta.CV())
+			require.NotEqual(t, updateVersion.docMeta.CV(t), createVersion.docMeta.CV(t))
 			if tc.peerOption.Type == PeerTypeCouchbaseServer {
 				require.Empty(t, updateVersion.docMeta.RevTreeID)
 			} else {
@@ -374,9 +374,9 @@ func TestPeerImplementation(t *testing.T) {
 
 			// Delete
 			deleteVersion := peer.DeleteDocument(collectionName, docID)
-			require.NotEmpty(t, deleteVersion.CV())
-			require.NotEqual(t, deleteVersion.CV(), updateVersion.docMeta.CV())
-			require.NotEqual(t, deleteVersion.CV(), createVersion.docMeta.CV())
+			require.NotEmpty(t, deleteVersion.CV(t))
+			require.NotEqual(t, deleteVersion.CV(t), updateVersion.docMeta.CV(t))
+			require.NotEqual(t, deleteVersion.CV(t), createVersion.docMeta.CV(t))
 			if tc.peerOption.Type == PeerTypeCouchbaseServer {
 				require.Empty(t, deleteVersion.RevTreeID)
 			} else {
@@ -390,10 +390,10 @@ func TestPeerImplementation(t *testing.T) {
 
 			resurrectionBody := []byte(`{"op": "resurrection"}`)
 			resurrectionVersion := peer.WriteDocument(collectionName, docID, resurrectionBody)
-			require.NotEmpty(t, resurrectionVersion.docMeta.CV())
-			require.NotEqual(t, resurrectionVersion.docMeta.CV(), deleteVersion.CV())
-			require.NotEqual(t, resurrectionVersion.docMeta.CV(), updateVersion.docMeta.CV())
-			require.NotEqual(t, resurrectionVersion.docMeta.CV(), createVersion.docMeta.CV())
+			require.NotEmpty(t, resurrectionVersion.docMeta.CV(t))
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), deleteVersion.CV(t))
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), updateVersion.docMeta.CV(t))
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), createVersion.docMeta.CV(t))
 			if tc.peerOption.Type == PeerTypeCouchbaseServer {
 				require.Empty(t, resurrectionVersion.docMeta.RevTreeID)
 			} else {

--- a/topologytest/sync_gateway_peer_test.go
+++ b/topologytest/sync_gateway_peer_test.go
@@ -139,7 +139,7 @@ func (p *SyncGatewayPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID
 		// Only assert on CV since RevTreeID might not be present if this was a Couchbase Server write
 		bodyBytes, err := doc.BodyBytes(ctx)
 		assert.NoError(c, err)
-		assert.Equal(c, expected.CV(), version.CV(), "Could not find matching CV on %s for peer %s (sourceID:%s)\nexpected: %#v\nactual:   %#v\n          body: %+v\n", docID, p, p.SourceID(), expected, version, string(bodyBytes))
+		assert.Equal(c, expected.CV(c), version.CV(c), "Could not find matching CV on %s for peer %s (sourceID:%s)\nexpected: %#v\nactual:   %#v\n          body: %+v\n", docID, p, p.SourceID(), expected, version, string(bodyBytes))
 	}, totalWaitTime, pollInterval)
 	return doc.Body(ctx)
 }

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -10,34 +10,32 @@ package topologytest
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/require"
 )
 
 // DocMetadata is a struct that contains metadata about a document. It contains the relevant information for testing versions of documents, as well as debugging information.
 type DocMetadata struct {
-	DocID      string                  // DocID is the document ID
-	RevTreeID  string                  // RevTreeID is the rev treee ID of a document, may be empty not present
-	HLV        *db.HybridLogicalVector // HLV is the hybrid logical vector of the document, may not be present
-	Mou        *db.MetadataOnlyUpdate  // Mou is the metadata only update of the document, may not be present
-	Cas        uint64                  // Cas is the cas value of the document
-	ImplicitCV *db.Version             // ImplicitCV is the version of the document, if there was no HLV
+	DocID       string                  // DocID is the document ID
+	RevTreeID   string                  // RevTreeID is the rev treee ID of a document, may be empty not present
+	HLV         *db.HybridLogicalVector // HLV is the hybrid logical vector of the document, may not be present
+	Mou         *db.MetadataOnlyUpdate  // Mou is the metadata only update of the document, may not be present
+	Cas         uint64                  // Cas is the cas value of the document
+	ImplicitHLV *db.HybridLogicalVector // ImplicitHLV is the version of the document, if there was no HLV
 }
 
 // CV returns the current version of the document.
-func (v DocMetadata) CV() db.Version {
-	if v.HLV == nil {
-		// If there is no HLV, then the version is implicit from the current ver@sourceID
-		if v.ImplicitCV == nil {
-			return db.Version{}
-		}
-		return *v.ImplicitCV
+func (v DocMetadata) CV(t require.TestingT) db.Version {
+	if v.ImplicitHLV != nil {
+		return *v.ImplicitHLV.ExtractCurrentVersionFromHLV()
+	} else if v.HLV != nil {
+		return *v.HLV.ExtractCurrentVersionFromHLV()
 	}
-	return db.Version{
-		SourceID: v.HLV.SourceID,
-		Value:    v.HLV.Version,
-	}
+	require.FailNow(t, "no hlv available %#v", v)
+	return db.Version{}
 }
 
 // DocMetadataFromDocument returns a DocVersion from the given document.
@@ -52,14 +50,17 @@ func DocMetadataFromDocument(doc *db.Document) DocMetadata {
 }
 
 func (v DocMetadata) GoString() string {
-	return fmt.Sprintf("DocMetadata{\nDocID:%s\n\tRevTreeID:%s\n\tHLV:%+v\n\tMou:%+v\n\tCas:%d\n\tImplicitCV:%+v\n}", v.DocID, v.RevTreeID, v.HLV, v.Mou, v.Cas, v.ImplicitCV)
+	return fmt.Sprintf("DocMetadata{\nDocID:%s\n\tRevTreeID:%s\n\tHLV:%+v\n\tMou:%+v\n\tCas:%d\n\tImplicitHLV:%+v\n}", v.DocID, v.RevTreeID, v.HLV, v.Mou, v.Cas, v.ImplicitHLV)
 }
 
 // DocMetadataFromDocVersion returns metadata DocVersion from the given document and version.
-func DocMetadataFromDocVersion(docID string, version rest.DocVersion) DocMetadata {
+func DocMetadataFromDocVersion(t testing.TB, docID string, version rest.DocVersion) DocMetadata {
+	// FIXME: CBG-4257, this should read the existing HLV on doc, until this happens, pv is always missing
+	hlv := db.NewHybridLogicalVector()
+	require.NoError(t, hlv.AddVersion(version.CV))
 	return DocMetadata{
-		DocID:      docID,
-		RevTreeID:  version.RevTreeID,
-		ImplicitCV: &version.CV,
+		DocID:       docID,
+		RevTreeID:   version.RevTreeID,
+		ImplicitHLV: hlv,
 	}
 }


### PR DESCRIPTION
Create a concept of an implicit HLV. This address a problem of replication that have Couchbase Server without Sync Gateway. If a past write contained an `_vv` entry, and then an update was performed on that same document, the `_vv` on the Couchbase Server only node is out of date - the implicit HLV needs to add the current cas@sourceID.

Previously, the code only worked if there were no pv entries.

This isn't implemented for Couchbase Lite because there's no concept of document storage, so we do not necessarily have a concept of merged local and remote pv. In order to fix this, it will involve modifying BlipTester code which I do not want to do in this PR.
