### PR TITLE
CBG-4421 create a simpler test setup for two cluster

### DIFF
--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -34,9 +34,10 @@ func (p *PeerBlipTesterClient) ID() uint32 {
 
 // CouchbaseLiteMockPeer represents an in-memory Couchbase Lite peer. This utilizes BlipTesterClient from the rest package to send and receive blip messages.
 type CouchbaseLiteMockPeer struct {
-	t           *testing.T
-	blipClients map[string]*PeerBlipTesterClient
-	name        string
+	t                  *testing.T
+	blipClients        map[string]*PeerBlipTesterClient
+	name               string
+	symmetricRedundant bool // there is another peer that is symmetric to this one
 }
 
 func (p *CouchbaseLiteMockPeer) String() string {
@@ -134,6 +135,11 @@ func (p *CouchbaseLiteMockPeer) Close() {
 // Type returns PeerTypeCouchbaseLite.
 func (p *CouchbaseLiteMockPeer) Type() PeerType {
 	return PeerTypeCouchbaseLite
+}
+
+// IsSymmetricRedundant returns true if there is another peer set up that is identical to this one, and this peer doesn't need to participate in unique actions.
+func (p *CouchbaseLiteMockPeer) IsSymmetricRedundant() bool {
+	return p.symmetricRedundant
 }
 
 // CreateReplication creates a replication instance

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -29,12 +29,13 @@ var metadataXattrNames = []string{base.VvXattrName, base.MouXattrName, base.Sync
 
 // CouchbaseServerPeer represents an instance of a backing server (bucket). This is rosmar unless SG_TEST_BACKING_STORE=couchbase is set.
 type CouchbaseServerPeer struct {
-	tb               testing.TB
-	bucket           base.Bucket
-	sourceID         string
-	pullReplications map[Peer]xdcr.Manager
-	pushReplications map[Peer]xdcr.Manager
-	name             string
+	tb                 testing.TB
+	bucket             base.Bucket
+	sourceID           string
+	pullReplications   map[Peer]xdcr.Manager
+	pushReplications   map[Peer]xdcr.Manager
+	name               string
+	symmetricRedundant bool
 }
 
 // CouchbaseServerReplication represents a unidirectional replication between two CouchbaseServerPeers. These are two buckets, using bucket to bucket XDCR. A rosmar implementation is used if SG_TEST_BACKING_STORE is unset.
@@ -213,9 +214,18 @@ func (p *CouchbaseServerPeer) Close() {
 	}
 }
 
+func (p *CouchbaseServerPeer) GetReplications() map[Peer]xdcr.Manager {
+	return nil
+}
+
 // Type returns PeerTypeCouchbaseServer.
 func (p *CouchbaseServerPeer) Type() PeerType {
 	return PeerTypeCouchbaseServer
+}
+
+// IsSymmetricRedundant returns true if there is another peer set up that is identical to this one, and this peer doesn't need to participate in unique actions.
+func (p *CouchbaseServerPeer) IsSymmetricRedundant() bool {
+	return p.symmetricRedundant
 }
 
 // CreateReplication creates an XDCR manager.

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -26,7 +26,7 @@ func TestMultiActorUpdate(t *testing.T) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, _ := setupTests(t, topology)
 
-			for createPeerName, createPeer := range peers {
+			for createPeerName, createPeer := range peers.ActivePeers() {
 				for updatePeerName, updatePeer := range peers {
 					if updatePeer.Type() == PeerTypeCouchbaseLite {
 						continue
@@ -58,7 +58,7 @@ func TestMultiActorDelete(t *testing.T) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, _ := setupTests(t, topology)
 
-			for createPeerName, createPeer := range peers {
+			for createPeerName, createPeer := range peers.ActivePeers() {
 				for deletePeerName, deletePeer := range peers {
 					if deletePeer.Type() == PeerTypeCouchbaseLite {
 						continue
@@ -94,7 +94,7 @@ func TestMultiActorResurrect(t *testing.T) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, _ := setupTests(t, topology)
 
-			for createPeerName, createPeer := range peers {
+			for createPeerName, createPeer := range peers.ActivePeers() {
 				for deletePeerName, deletePeer := range peers {
 					if deletePeer.Type() == PeerTypeCouchbaseLite {
 						continue

--- a/topologytest/no_race_test.go
+++ b/topologytest/no_race_test.go
@@ -1,0 +1,13 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+//go:build !race
+
+package topologytest
+
+const raceEnabled = false

--- a/topologytest/race_test.go
+++ b/topologytest/race_test.go
@@ -1,0 +1,13 @@
+// Copyright 2024-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+//go:build race
+
+package topologytest
+
+const raceEnabled = true

--- a/topologytest/single_actor_test.go
+++ b/topologytest/single_actor_test.go
@@ -21,7 +21,7 @@ func TestSingleActorCreate(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, _ := setupTests(t, topology)
-			for activePeerID, activePeer := range peers.SortedPeers() {
+			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
 					docID := getDocID(t)
@@ -44,7 +44,7 @@ func TestSingleActorUpdate(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, _ := setupTests(t, topology)
-			for activePeerID, activePeer := range peers {
+			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
 					if activePeer.Type() == PeerTypeCouchbaseLite {
@@ -79,7 +79,7 @@ func TestSingleActorDelete(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, _ := setupTests(t, topology)
-			for activePeerID, activePeer := range peers {
+			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
 					if activePeer.Type() == PeerTypeCouchbaseLite {
@@ -114,7 +114,7 @@ func TestSingleActorResurrect(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, _ := setupTests(t, topology)
-			for activePeerID, activePeer := range peers.SortedPeers() {
+			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
 					if activePeer.Type() == PeerTypeCouchbaseLite {

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -142,12 +142,12 @@ var Topologies = []Topology{
 		description: "2x CBL<->SG<->CBS XDCR only 1.3",
 		peers: map[string]PeerOptions{
 			"cbs1": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID1},
-			"cbs2": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID2},
+			"cbs2": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID2, Symmetric: true},
 			"sg1":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID1},
-			"sg2":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID2},
+			"sg2":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID2, Symmetric: true},
 			"cbl1": {Type: PeerTypeCouchbaseLite},
 			// TODO: CBG-4270, push replication only exists empemerally
-			"cbl2": {Type: PeerTypeCouchbaseLite},
+			"cbl2": {Type: PeerTypeCouchbaseLite, Symmetric: true},
 		},
 		replications: []PeerReplicationDefinition{
 			{
@@ -287,7 +287,7 @@ var simpleTopologies = []Topology{
 		description: "CBS<->CBS",
 		peers: map[string]PeerOptions{
 			"cbs1": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID1},
-			"cbs2": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID2}},
+			"cbs2": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID2, Symmetric: true}},
 		replications: []PeerReplicationDefinition{
 			{
 				activePeer:  "cbs1",
@@ -322,6 +322,42 @@ var simpleTopologies = []Topology{
 			"cbs1": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID1},
 			"sg1":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID1},
 			"cbs2": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID2},
+		},
+		replications: []PeerReplicationDefinition{
+			{
+				activePeer:  "cbs1",
+				passivePeer: "cbs2",
+				config: PeerReplicationConfig{
+					direction: PeerReplicationDirectionPush,
+				},
+			},
+			{
+				activePeer:  "cbs1",
+				passivePeer: "cbs2",
+				config: PeerReplicationConfig{
+					direction: PeerReplicationDirectionPull,
+				},
+			},
+		},
+	},
+	{
+		/*
+			+ - - - - - - +      +- - - - - - -+
+			'  cluster A  '      '  cluster B  '
+			' +---------+ '      ' +---------+ '
+			' |  cbs1   | ' <--> ' |  cbs2   | '
+			' +---------+ '      ' +---------+ '
+			' +---------+ '      ' +---------+ '
+			' |   sg1   | '      ' |   sg2   | '
+			' +---------+ '      ' +---------+ '
+			+ - - - - - - +      +- - - - - - -+
+		*/
+		description: "CBS+SG<->CBS+SG",
+		peers: map[string]PeerOptions{
+			"cbs1": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID1},
+			"sg1":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID1},
+			"cbs2": {Type: PeerTypeCouchbaseServer, BucketID: PeerBucketID2, Symmetric: true},
+			"sg2":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID2, Symmetric: true},
 		},
 		replications: []PeerReplicationDefinition{
 			{


### PR DESCRIPTION
This provides a simpler setup than test case 1.3.

Mark some nodes as redundant to speed up test process, since they would be testing identical behavior. This only applies to no conflict tests.
