### PR TITLE
CBG-4430: fix conflict on hlv comparison when parent rev is in history

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1256,6 +1256,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 					// conflict check on rev tree history, if there is a rev in rev tree history we have the parent of locally we are not in conflict
 					parent, currentRevIndex, err = db.revTreeConflictCheck(ctx, revTreeHistory, doc, newDoc.Deleted)
 					if err != nil {
+						base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %s, local version %s, current rev %s, incoming rev tree history %v", base.UD(doc.ID), newDocHLV.GetCurrentVersionString(), doc.HLV.GetCurrentVersionString(), doc.CurrentRev, revTreeHistory)
 						return nil, nil, false, nil, err
 					}
 					revTreeConflictChecked = true

--- a/db/crud.go
+++ b/db/crud.go
@@ -1278,7 +1278,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 		// rev tree conflict check if we have rev tree history to check against + finds current rev index to allow us
 		// to add any new revision to rev tree below.
 		// Only check for rev tree conflicts if we haven't already checked above
-		if !revTreeConflictChecked {
+		if !revTreeConflictChecked && len(revTreeHistory) > 0 {
 			parent, currentRevIndex, err = db.revTreeConflictCheck(ctx, revTreeHistory, doc, newDoc.Deleted)
 			if err != nil {
 				return nil, nil, false, nil, err

--- a/db/crud.go
+++ b/db/crud.go
@@ -1256,7 +1256,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 					// conflict check on rev tree history, if there is a rev in rev tree history we have the parent of locally we are not in conflict
 					parent, currentRevIndex, err = db.revTreeConflictCheck(ctx, revTreeHistory, doc, newDoc.Deleted)
 					if err != nil {
-						base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %s, local version %s, current rev %s, incoming rev tree history %v", base.UD(doc.ID), newDocHLV.GetCurrentVersionString(), doc.HLV.GetCurrentVersionString(), doc.CurrentRev, revTreeHistory)
+						base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %s, local version %s, and conflict found in rev tree history", base.UD(doc.ID), newDocHLV.GetCurrentVersionString(), doc.HLV.GetCurrentVersionString())
 						return nil, nil, false, nil, err
 					}
 					revTreeConflictChecked = true


### PR DESCRIPTION
CBG-4430

- Create a shared function to test for rev tree conflicts 
- On failed conflict check in between hlv's we should check for rev tree conflict when we have rev tree history to work with
- If we don't check rev tree history conflict on hlv comparison then we still need to after hlv comparisons

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
