### PR TITLE
CBG-4257 implement more parts of CouchbaseLiteMockPeer

### DIFF
--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -32,6 +32,10 @@ func (p *PeerBlipTesterClient) ID() uint32 {
 	return p.btc.ID()
 }
 
+func (p *PeerBlipTesterClient) CollectionClient(dsName sgbucket.DataStoreName) *rest.BlipTesterCollectionClient {
+	return p.btcRunner.Collection(p.ID(), fmt.Sprintf("%s.%s", dsName.ScopeName(), dsName.CollectionName()))
+}
+
 // CouchbaseLiteMockPeer represents an in-memory Couchbase Lite peer. This utilizes BlipTesterClient from the rest package to send and receive blip messages.
 type CouchbaseLiteMockPeer struct {
 	t           *testing.T
@@ -43,18 +47,30 @@ func (p *CouchbaseLiteMockPeer) String() string {
 	return fmt.Sprintf("%s (sourceid:%s)", p.name, p.SourceID())
 }
 
-// GetDocument returns the latest version of a document. The test will fail the document does not exist.
-func (p *CouchbaseLiteMockPeer) GetDocument(_ sgbucket.DataStoreName, _ string) (DocMetadata, db.Body) {
-	// this isn't yet collection aware, using single default collection
-	return DocMetadata{}, nil
+// getLatestDocVersion returns the latest body and version of a document. If the document does not exist, it will return nil.
+func (p *CouchbaseLiteMockPeer) getLatestDocVersion(dsName sgbucket.DataStoreName, docID string) ([]byte, *DocMetadata) {
+	client := p.getSingleSGBlipClient().CollectionClient(dsName)
+	body, version := client.GetDoc(docID)
+	if version == nil {
+		return nil, nil
+	}
+	meta := DocMetadataFromDocVersion(p.TB(), docID, *version)
+	return body, &meta
 }
 
-// getSingleBlipClient returns the single blip client for the peer. If there are multiple clients, or not clients it will fail the test. This is temporary to stub support for multiple Sync Gateway peers.
-func (p *CouchbaseLiteMockPeer) getSingleBlipClient() *PeerBlipTesterClient {
-	// this isn't yet collection aware, using single default collection
-	if len(p.blipClients) != 1 {
-		require.Fail(p.t, "blipClients haven't been created for %s, a temporary limitation of CouchbaseLiteMockPeer", p)
-	}
+// GetDocument returns the latest version of a document. The test will fail the document does not exist.
+func (p *CouchbaseLiteMockPeer) GetDocument(dsName sgbucket.DataStoreName, docID string) (DocMetadata, db.Body) {
+	bodyBytes, meta := p.getLatestDocVersion(dsName, docID)
+	require.NotNil(p.TB(), meta, "docID:%s not found on %s", docID, p)
+	var body db.Body
+	require.NoError(p.TB(), base.JSONUnmarshal(bodyBytes, &body))
+	return *meta, body
+}
+
+// getSingleSGBlipClient returns the single blip client for the peer. If there are multiple clients, or no clients it will fail the test. This is temporary to stub support for multiple Sync Gateway peers, see CBG-4433.
+func (p *CouchbaseLiteMockPeer) getSingleSGBlipClient() *PeerBlipTesterClient {
+	// couchbase lite peer can't exist separately from sync gateway peer, CBG-4433
+	require.Len(p.TB(), p.blipClients, 1, "blipClients haven't been created for %s, a temporary limitation of CouchbaseLiteMockPeer", p)
 	for _, c := range p.blipClients {
 		return c
 	}
@@ -65,19 +81,29 @@ func (p *CouchbaseLiteMockPeer) getSingleBlipClient() *PeerBlipTesterClient {
 // CreateDocument creates a document on the peer. The test will fail if the document already exists.
 func (p *CouchbaseLiteMockPeer) CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion {
 	p.t.Logf("%s: Creating document %s", p, docID)
-	return p.WriteDocument(dsName, docID, body)
+	client := p.getSingleSGBlipClient().CollectionClient(dsName)
+	docVersion, err := client.AddRev(docID, rest.EmptyDocVersion(), body)
+	require.NoError(p.TB(), err)
+	docMetadata := DocMetadataFromDocVersion(p.TB(), docID, docVersion)
+	return BodyAndVersion{
+		docMeta:    docMetadata,
+		body:       body,
+		updatePeer: p.name,
+	}
 }
 
 // WriteDocument writes a document to the peer. The test will fail if the write does not succeed.
-func (p *CouchbaseLiteMockPeer) WriteDocument(_ sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion {
+func (p *CouchbaseLiteMockPeer) WriteDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion {
 	p.TB().Logf("%s: Writing document %s", p, docID)
-	// this isn't yet collection aware, using single default collection
-	client := p.getSingleBlipClient()
-	// set an HLV here.
-	docVersion, err := client.btcRunner.AddRev(client.ID(), docID, rest.EmptyDocVersion(), body)
-	require.NoError(client.btcRunner.TB(), err)
-	// FIXME: CBG-4257, this should read the existing HLV on doc, until this happens, pv is always missing
-	docMetadata := DocMetadataFromDocVersion(client.btc.TB(), docID, docVersion)
+	client := p.getSingleSGBlipClient().CollectionClient(dsName)
+	_, parentMeta := p.getLatestDocVersion(dsName, docID)
+	parentVersion := rest.EmptyDocVersion()
+	if parentMeta != nil {
+		parentVersion = &db.DocVersion{CV: parentMeta.CV(p.TB())}
+	}
+	docVersion, err := client.AddRev(docID, parentVersion, body)
+	require.NoError(p.TB(), err)
+	docMetadata := DocMetadataFromDocVersion(p.TB(), docID, docVersion)
 	return BodyAndVersion{
 		docMeta:    docMetadata,
 		body:       body,
@@ -91,17 +117,17 @@ func (p *CouchbaseLiteMockPeer) DeleteDocument(sgbucket.DataStoreName, string) D
 }
 
 // WaitForDocVersion waits for a document to reach a specific version. The test will fail if the document does not reach the expected version in 20s.
-func (p *CouchbaseLiteMockPeer) WaitForDocVersion(_ sgbucket.DataStoreName, docID string, docVersion DocMetadata) db.Body {
-	// this isn't yet collection aware, using single default collection
-	client := p.getSingleBlipClient()
+func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata) db.Body {
 	var data []byte
 	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
-		var found bool
-		data, found = client.btcRunner.GetVersion(client.ID(), docID, rest.DocVersion{CV: docVersion.CV(c)})
-		if !assert.True(c, found, "Could not find docID:%+v on %p\nVersion %#v", docID, p, docVersion) {
+		var actual *DocMetadata
+		data, actual = p.getLatestDocVersion(dsName, docID)
+		if !assert.NotNil(c, actual, "Could not find docID:%+v on %p\nVersion %#v", docID, p, expected) {
 			return
 		}
-	}, totalWaitTime, pollInterval, "BlipTesterClient timed out waiting for doc %+v Version %#v", docID, docVersion)
+		assert.Equal(c, expected.CV(c), actual.CV(c), "Could not find matching CV on %s for peer %s (sourceID:%s)\nexpected: %#v\nactual:   %#v\n          body: %+v\n", docID, p, p.SourceID(), expected, actual, string(data))
+
+	}, totalWaitTime, pollInterval)
 	var body db.Body
 	require.NoError(p.TB(), base.JSONUnmarshal(data, &body))
 	return body

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -61,7 +61,7 @@ func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, pee
 func waitForDeletion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string, deleteActor string) {
 	for peerName, peer := range peers {
 		if peer.Type() == PeerTypeCouchbaseLite {
-			t.Logf("skipping deletion check for Couchbase Lite peer %s, CBG-4257", peerName)
+			t.Logf("skipping deletion check for Couchbase Lite peer %s, CBG-4432", peerName)
 			continue
 		}
 		t.Logf("waiting for doc to be deleted on %s, written from %s", peer, deleteActor)
@@ -94,7 +94,7 @@ func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 			continue
 		}
 		if peer.Type() == PeerTypeCouchbaseLite {
-			// FIXME: Skipping Couchbase Lite test, returns unexpected body in proposeChanges: [304], CBG-4257
+			// FIXME: Skipping Couchbase Lite tests for multi actor conflicts, CBG-4434
 			continue
 		}
 		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, peerName, topologyDescription))

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -123,7 +123,7 @@ func TestMultiActorConflictResurrect(t *testing.T) {
 		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
 	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
-		if strings.Contains(topology.description, "1.3") {
+		if strings.Contains(topology.description, "1.") {
 			t.Skip("CBG-4434 fail due to CBL issues, specifically for multi-actor tests")
 		}
 		t.Run(topology.description, func(t *testing.T) {

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -87,11 +87,6 @@ func TestMultiActorConflictDelete(t *testing.T) {
 		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
 	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
-		if strings.Contains(topology.description, "CBL") {
-			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
-			// able to wait for a specific version to arrive over pull replication
-			t.Skip("We need to be able to wait for a specific version to arrive over pull replication + unexpected body in proposeChanges: [304] issue, CBG-4257")
-		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()
@@ -128,10 +123,8 @@ func TestMultiActorConflictResurrect(t *testing.T) {
 		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
 	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
-		if strings.Contains(topology.description, "CBL") {
-			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
-			// able to wait for a specific version to arrive over pull replication
-			t.Skip("We need to be able to wait for a specific version to arrive over pull replication + unexpected body in proposeChanges: [304] issue, CBG-4257")
+		if strings.Contains(topology.description, "1.3") {
+			t.Skip("CBG-4434 fail due to CBL issues, specifically for multi-actor tests")
 		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -28,10 +28,6 @@ func TestMultiActorUpdate(t *testing.T) {
 
 			for createPeerName, createPeer := range peers {
 				for updatePeerName, updatePeer := range peers {
-					if updatePeer.Type() == PeerTypeCouchbaseLite {
-						continue
-					}
-
 					docID := getDocID(t) + "_create=" + createPeerName + ",update=" + updatePeerName
 					body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "updatePeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, updatePeer, topology.description))
 					createVersion := createPeer.CreateDocument(collectionName, docID, body1)
@@ -60,6 +56,7 @@ func TestMultiActorDelete(t *testing.T) {
 
 			for createPeerName, createPeer := range peers {
 				for deletePeerName, deletePeer := range peers {
+					// CBG-4432: implement delete document in blip tester
 					if deletePeer.Type() == PeerTypeCouchbaseLite {
 						continue
 					}
@@ -96,6 +93,7 @@ func TestMultiActorResurrect(t *testing.T) {
 
 			for createPeerName, createPeer := range peers {
 				for deletePeerName, deletePeer := range peers {
+					// CBG-4432: implement delete document in blip tester
 					if deletePeer.Type() == PeerTypeCouchbaseLite {
 						continue
 					}

--- a/topologytest/single_actor_test.go
+++ b/topologytest/single_actor_test.go
@@ -47,9 +47,6 @@ func TestSingleActorUpdate(t *testing.T) {
 			for activePeerID, activePeer := range peers {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
-					if activePeer.Type() == PeerTypeCouchbaseLite {
-						t.Skip("Skipping Couchbase Lite test, returns unexpected body in proposeChanges: [304], CBG-4257")
-					}
 
 					docID := getDocID(t)
 					body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, activePeerID, topology.description))
@@ -83,7 +80,7 @@ func TestSingleActorDelete(t *testing.T) {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
 					if activePeer.Type() == PeerTypeCouchbaseLite {
-						t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4257")
+						t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4433")
 					}
 
 					docID := getDocID(t)
@@ -118,7 +115,7 @@ func TestSingleActorResurrect(t *testing.T) {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
 					if activePeer.Type() == PeerTypeCouchbaseLite {
-						t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4257")
+						t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4433")
 					}
 
 					docID := getDocID(t)


### PR DESCRIPTION
This doesn't implement deletion, which is blocked on another ticket. Updated some ticket numbers in the code.

`WriteDocument` doesn't really do a LWW either, if it behaved like `WriteDocument` for other peers it would perform a cas-unsafe write, but as is it only does one loop.