### PR TITLE
CBG-4432: Implement Delete on the BlipTesterClient and enable delete-related topology tests

### DIFF
--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -379,7 +379,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
 		rev := NewDocVersionFromFakeRev("2-abc")
 		// FIXME CBG-4400:  docID: doc1 was not found on the client - expecting to update doc based on parentVersion RevID: 2-abc
-		err := btcRunner.StoreRevOnClient(btc.id, docID, &rev, []byte(bodyText))
+		_, err := btcRunner.AddRev(btc.id, docID, &rev, []byte(bodyText))
 		require.NoError(t, err)
 
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
@@ -608,7 +608,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 		docVersion := client1.GetDocVersion(docID)
 
 		// Store the document and attachment on the test client
-		err := btcRunner.StoreRevOnClient(client1.id, docID, &docVersion, rawDoc)
+		_, err := btcRunner.AddRev(client1.id, docID, &docVersion, rawDoc)
 		// FIXME CBG-4400: docID: doc was not found on the client - expecting to update doc based on parentVersion RevID: 1-5fc93bd36377008f96fdae2719c174ed
 		require.NoError(t, err)
 
@@ -672,7 +672,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 
 		// Store the document and attachment on the test client
 		// FIXME CBG-4400: docID: doc was not found on the client - expecting to update doc based on parentVersion RevID: 1-5fc93bd36377008f96fdae2719c174ed
-		err := btcRunner.StoreRevOnClient(client1.id, docID, &version, rawDoc)
+		_, err := btcRunner.AddRev(client1.id, docID, &version, rawDoc)
 		require.NoError(t, err)
 		btcRunner.AttachmentsLock(client1.id).Lock()
 		btcRunner.Attachments(client1.id)[digest] = attBody

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1593,12 +1593,10 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 		return nil, err
 	}
 
-	btc._seqLast++
-	newSeq := btc._seqLast
-
 	var docVersion DocVersion
 	if btc.UseHLV() {
-		newVersion := db.Version{SourceID: fmt.Sprintf("btc-%d", btc.parent.id), Value: uint64(newSeq)}
+		// TODO: CBG-4440 Construct a HLC for Value - UnixNano is not accurate enough on Windows to generate unique values, and seq is not comparable across clients.
+		newVersion := db.Version{SourceID: fmt.Sprintf("btc-%d", btc.parent.id), Value: uint64(time.Now().UnixNano())}
 		if err := hlv.AddVersion(newVersion); err != nil {
 			return nil, err
 		}
@@ -1609,6 +1607,8 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 		docVersion = DocVersion{RevTreeID: newRevID}
 	}
 
+	btc._seqLast++
+	newSeq := btc._seqLast
 	rev := clientDocRev{clientSeq: newSeq, version: docVersion, body: body, HLV: hlv, isDelete: body == nil}
 	doc.addNewRev(rev)
 

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1593,9 +1593,12 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 		return nil, err
 	}
 
+	btc._seqLast++
+	newSeq := btc._seqLast
+
 	var docVersion DocVersion
 	if btc.UseHLV() {
-		newVersion := db.Version{SourceID: fmt.Sprintf("btc-%d", btc.parent.id), Value: uint64(time.Now().UnixNano())}
+		newVersion := db.Version{SourceID: fmt.Sprintf("btc-%d", btc.parent.id), Value: uint64(newSeq)}
 		if err := hlv.AddVersion(newVersion); err != nil {
 			return nil, err
 		}
@@ -1606,8 +1609,6 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 		docVersion = DocVersion{RevTreeID: newRevID}
 	}
 
-	btc._seqLast++
-	newSeq := btc._seqLast
 	rev := clientDocRev{clientSeq: newSeq, version: docVersion, body: body, HLV: hlv, isDelete: body == nil}
 	doc.addNewRev(rev)
 

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1623,6 +1623,9 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 
 // Delete creates a tombstone for the document.
 func (btc *BlipTesterCollectionClient) Delete(docID string, parentVersion *DocVersion) (DocVersion, error) {
+	if parentVersion == nil {
+		return DocVersion{}, fmt.Errorf("parentVersion must be provided for delete operation")
+	}
 	newRev, err := btc.upsertDoc(docID, parentVersion, nil)
 	if err != nil {
 		return DocVersion{}, err

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -10,6 +10,7 @@ package topologytest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -113,8 +114,17 @@ func (p *CouchbaseLiteMockPeer) WriteDocument(dsName sgbucket.DataStoreName, doc
 }
 
 // DeleteDocument deletes a document on the peer. The test will fail if the document does not exist.
-func (p *CouchbaseLiteMockPeer) DeleteDocument(sgbucket.DataStoreName, string) DocMetadata {
-	return DocMetadata{}
+func (p *CouchbaseLiteMockPeer) DeleteDocument(dsName sgbucket.DataStoreName, docID string) DocMetadata {
+	p.TB().Logf("%s: Deleting document %s", p, docID)
+	client := p.getSingleSGBlipClient().CollectionClient(dsName)
+	_, parentMeta := p.getLatestDocVersion(dsName, docID)
+	parentVersion := rest.EmptyDocVersion()
+	if parentMeta != nil {
+		parentVersion = &db.DocVersion{CV: parentMeta.CV(p.TB())}
+	}
+	docVersion, err := client.Delete(docID, parentVersion)
+	require.NoError(p.TB(), err)
+	return DocMetadataFromDocVersion(p.TB(), docID, docVersion)
 }
 
 // WaitForDocVersion waits for a document to reach a specific version. The test will fail if the document does not reach the expected version in 20s.
@@ -135,20 +145,36 @@ func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName,
 }
 
 // WaitForDeletion waits for a document to be deleted. This document must be a tombstone. The test will fail if the document still exists after 20s.
-func (p *CouchbaseLiteMockPeer) WaitForDeletion(_ sgbucket.DataStoreName, _ string) {
-	require.Fail(p.TB(), "WaitForDeletion not yet implemented CBG-4257")
+func (p *CouchbaseLiteMockPeer) WaitForDeletion(dsName sgbucket.DataStoreName, docID string) {
+	client := p.getSingleSGBlipClient().CollectionClient(dsName)
+	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
+		isTombstone, err := client.IsTombstoned(docID)
+		require.NoError(c, err)
+		require.True(c, isTombstone, "expected docID %s on peer %s to be deleted", docID, p)
+	}, totalWaitTime, pollInterval)
 }
 
 // WaitForTombstoneVersion waits for a document to reach a specific version, this must be a tombstone. The test will fail if the document does not reach the expected version in 20s.
-func (p *CouchbaseLiteMockPeer) WaitForTombstoneVersion(_ sgbucket.DataStoreName, _ string, _ DocMetadata) {
-	require.Fail(p.TB(), "WaitForTombstoneVersion not yet implemented CBG-4257")
+func (p *CouchbaseLiteMockPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata) {
+	client := p.getSingleSGBlipClient().CollectionClient(dsName)
+	expectedVersion := db.DocVersion{CV: expected.CV(p.TB())}
+	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
+		isTombstone, err := client.IsVersionTombstone(docID, expectedVersion)
+		require.NoError(c, err)
+		require.True(c, isTombstone, "expected docID %s on peer %s to be deleted", docID, p)
+	}, totalWaitTime, pollInterval)
 }
 
 // RequireDocNotFound asserts that a document does not exist on the peer.
-func (p *CouchbaseLiteMockPeer) RequireDocNotFound(sgbucket.DataStoreName, string) {
-	// not implemented yet in blip client tester
-	// _, err := p.btcRunner.GetDoc(p.btc.id, docID)
-	// base.RequireDocNotFoundError(p.btcRunner.TB(), err)
+func (p *CouchbaseLiteMockPeer) RequireDocNotFound(dsName sgbucket.DataStoreName, docID string) {
+	client := p.getSingleSGBlipClient().CollectionClient(dsName)
+	isTombstone, err := client.IsTombstoned(docID)
+	if err == nil {
+		require.True(p.TB(), isTombstone, "expected docID %s on peer %s to be deleted or not exist", docID, p)
+	}
+	if !errors.Is(err, base.ErrNotFound) {
+		require.NoError(p.TB(), err)
+	}
 }
 
 // Close will shut down the peer and close any active replications on the peer.

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -10,7 +10,6 @@ package topologytest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -144,16 +143,6 @@ func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName,
 	return body
 }
 
-// WaitForDeletion waits for a document to be deleted. This document must be a tombstone. The test will fail if the document still exists after 20s.
-func (p *CouchbaseLiteMockPeer) WaitForDeletion(dsName sgbucket.DataStoreName, docID string) {
-	client := p.getSingleSGBlipClient().CollectionClient(dsName)
-	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
-		isTombstone, err := client.IsTombstoned(docID)
-		require.NoError(c, err)
-		require.True(c, isTombstone, "expected docID %s on peer %s to be deleted", docID, p)
-	}, totalWaitTime, pollInterval)
-}
-
 // WaitForTombstoneVersion waits for a document to reach a specific version, this must be a tombstone. The test will fail if the document does not reach the expected version in 20s.
 func (p *CouchbaseLiteMockPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata) {
 	client := p.getSingleSGBlipClient().CollectionClient(dsName)
@@ -163,18 +152,6 @@ func (p *CouchbaseLiteMockPeer) WaitForTombstoneVersion(dsName sgbucket.DataStor
 		require.NoError(c, err)
 		require.True(c, isTombstone, "expected docID %s on peer %s to be deleted", docID, p)
 	}, totalWaitTime, pollInterval)
-}
-
-// RequireDocNotFound asserts that a document does not exist on the peer.
-func (p *CouchbaseLiteMockPeer) RequireDocNotFound(dsName sgbucket.DataStoreName, docID string) {
-	client := p.getSingleSGBlipClient().CollectionClient(dsName)
-	isTombstone, err := client.IsTombstoned(docID)
-	if err == nil {
-		require.True(p.TB(), isTombstone, "expected docID %s on peer %s to be deleted or not exist", docID, p)
-	}
-	if !errors.Is(err, base.ErrNotFound) {
-		require.NoError(p.TB(), err)
-	}
 }
 
 // Close will shut down the peer and close any active replications on the peer.

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -163,14 +163,6 @@ func (p *CouchbaseServerPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, d
 	return body
 }
 
-// WaitForDeletion waits for a document to be deleted. This document must be a tombstone. The test will fail if the document still exists after 20s.
-func (p *CouchbaseServerPeer) WaitForDeletion(dsName sgbucket.DataStoreName, docID string) {
-	require.EventuallyWithT(p.tb, func(c *assert.CollectT) {
-		_, err := p.getCollection(dsName).Get(docID, nil)
-		assert.True(c, base.IsDocNotFoundError(err), "expected docID %s to be deleted from peer %s, found err=%v", docID, p.name, err)
-	}, totalWaitTime, pollInterval)
-}
-
 // WaitForTombstoneVersion waits for a document to reach a specific version, this must be a tombstone. The test will fail if the document does not reach the expected version in 20s.
 func (p *CouchbaseServerPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata) {
 	docBytes := p.waitForDocVersion(dsName, docID, expected)
@@ -196,12 +188,6 @@ func (p *CouchbaseServerPeer) waitForDocVersion(dsName sgbucket.DataStoreName, d
 
 	}, totalWaitTime, pollInterval)
 	return docBytes
-}
-
-// RequireDocNotFound asserts that a document does not exist on the peer.
-func (p *CouchbaseServerPeer) RequireDocNotFound(dsName sgbucket.DataStoreName, docID string) {
-	_, err := p.getCollection(dsName).Get(docID, nil)
-	base.RequireDocNotFoundError(p.tb, err)
 }
 
 // Close will shut down the peer and close any active replications on the peer.

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -59,11 +59,7 @@ func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, pee
 }
 
 func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string, expectedVersion BodyAndVersion) {
-	for peerName, peer := range peers.SortedPeers() {
-		if peer.Type() == PeerTypeCouchbaseLite {
-			t.Logf("skipping deletion check for Couchbase Lite peer %s, CBG-4432", peerName)
-			continue
-		}
+	for _, peer := range peers.SortedPeers() {
 		t.Logf("waiting for tombstone version %#v on %s, written from %s", expectedVersion, peer, expectedVersion.updatePeer)
 		peer.WaitForTombstoneVersion(dsName, docID, expectedVersion.docMeta)
 	}
@@ -138,11 +134,7 @@ func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers 
 			continue
 		}
 		deleteVersion := peer.DeleteDocument(dsName, docID)
-		if peer.Type() == PeerTypeCouchbaseLite {
-			t.Logf("Don't include deleteVersion from Couchbase Lite peers when determining lastWrite %s, CBG-4432", peerName)
-			continue
-		}
-		t.Logf("deleteVersion on peer %s: %+v", peerName, deleteVersion)
+		t.Logf("deleteVersion: %+v", deleteVersion)
 		documentVersion = append(documentVersion, BodyAndVersion{docMeta: deleteVersion, updatePeer: peerName})
 	}
 	index := len(documentVersion) - 1

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -83,9 +83,7 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 // 6. start replications
 // 7. assert that the documents are deleted on all peers and have hlv sources equal to the number of active peers
 func TestMultiActorConflictDelete(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
-	}
+	t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -56,11 +56,6 @@ func TestMultiActorDelete(t *testing.T) {
 
 			for createPeerName, createPeer := range peers.ActivePeers() {
 				for deletePeerName, deletePeer := range peers {
-					// CBG-4432: implement delete document in blip tester
-					if deletePeer.Type() == PeerTypeCouchbaseLite {
-						continue
-					}
-
 					docID := getDocID(t) + "_create=" + createPeerName + ",update=" + deletePeerName
 					body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, deletePeer, topology.description))
 					createVersion := createPeer.CreateDocument(collectionName, docID, body1)
@@ -93,10 +88,6 @@ func TestMultiActorResurrect(t *testing.T) {
 
 			for createPeerName, createPeer := range peers.ActivePeers() {
 				for deletePeerName, deletePeer := range peers {
-					// CBG-4432: implement delete document in blip tester
-					if deletePeer.Type() == PeerTypeCouchbaseLite {
-						continue
-					}
 					for resurrectPeerName, resurrectPeer := range peers {
 						docID := getDocID(t) + "_create=" + createPeerName + ",delete=" + deletePeerName + ",resurrect=" + resurrectPeerName
 						body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "resurrectPeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, deletePeer, resurrectPeer, topology.description))

--- a/topologytest/single_actor_test.go
+++ b/topologytest/single_actor_test.go
@@ -79,9 +79,6 @@ func TestSingleActorDelete(t *testing.T) {
 			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
-					if activePeer.Type() == PeerTypeCouchbaseLite {
-						t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4433")
-					}
 
 					docID := getDocID(t)
 					body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, activePeerID, topology.description))
@@ -114,9 +111,6 @@ func TestSingleActorResurrect(t *testing.T) {
 			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
-					if activePeer.Type() == PeerTypeCouchbaseLite {
-						t.Skip("Skipping Couchbase Lite test, does not know how to push a deletion yet CBG-4433")
-					}
 
 					docID := getDocID(t)
 					body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, activePeerID, topology.description))

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -146,7 +146,6 @@ var Topologies = []Topology{
 			"sg1":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID1},
 			"sg2":  {Type: PeerTypeSyncGateway, BucketID: PeerBucketID2, Symmetric: true},
 			"cbl1": {Type: PeerTypeCouchbaseLite},
-			// TODO: CBG-4270, push replication only exists empemerally
 			"cbl2": {Type: PeerTypeCouchbaseLite, Symmetric: true},
 		},
 		replications: []PeerReplicationDefinition{


### PR DESCRIPTION
CBG-4432

- Allows BlipTesterClient to delete docs and push them as tombstones.
- Enables topology tests utilizing deletes

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2873/
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2874/
