### PR TITLE
CBG-4442 proposeChanges fix for VV proposed version and legacy previousRev

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -837,7 +837,6 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 
 		changeIsVector := false
 		if versionVectorProtocol {
-			// only check if rev is vector in VV replication mode
 			changeIsVector = strings.Contains(rev, "@")
 		}
 		if versionVectorProtocol && changeIsVector {


### PR DESCRIPTION
Handle the cases where proposedRev is in VV format, but parent/previous rev is revTreeID.

CBG-4442