### PR TITLE
CBG-4373: implement flusher interface

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2873,17 +2873,12 @@ func TestBufferFlush(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, a.Save(user))
 
-	// create some changes
-	for i := 0; i < 10; i++ {
-		rt.PutDoc(fmt.Sprint(i), `{"some":"doc", "channels":["foo"]}`)
-	}
-
 	var wg sync.WaitGroup
 	var resp *TestResponse
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		resp = rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=continuous&since=0&timeout=5000&include_docs=true", "", "foo")
+		resp = rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=continuous&since=0&timeout=500&include_docs=true", "", "foo")
 		RequireStatus(t, resp, http.StatusOK)
 	}()
 	wg.Wait()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2857,3 +2857,37 @@ func TestAllDbs(t *testing.T) {
 	RequireStatus(t, resp, http.StatusOK)
 	require.Equal(t, fmt.Sprintf(`[{"db_name":"%s","bucket":"%s","state":"Online"}]`, rt.GetDatabase().Name, rt.GetDatabase().Bucket.GetName()), resp.Body.String())
 }
+
+// TestBufferFlush will test for http.ResponseWriter implements Flusher interface
+func TestBufferFlush(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
+	})
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+
+	// Create a test user
+	user, err := a.NewUser("foo", "letmein", channels.BaseSetOf(t, "foo"))
+	require.NoError(t, err)
+	require.NoError(t, a.Save(user))
+
+	// create some changes
+	for i := 0; i < 10; i++ {
+		rt.PutDoc(fmt.Sprint(i), `{"some":"doc", "channels":["foo"]}`)
+	}
+
+	var wg sync.WaitGroup
+	var resp *TestResponse
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp = rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=continuous&since=0&timeout=5000&include_docs=true", "", "foo")
+		RequireStatus(t, resp, http.StatusOK)
+	}()
+	wg.Wait()
+
+	// assert that the response is a flushed response
+	assert.True(t, resp.Flushed)
+}

--- a/rest/counted_response_writer.go
+++ b/rest/counted_response_writer.go
@@ -94,8 +94,6 @@ func (w *CountedResponseWriter) isHijackable() bool {
 }
 
 func (w *CountedResponseWriter) Flush() {
-	f, ok := w.writer.(http.Flusher)
-	if ok {
-		f.Flush()
-	}
+	f, _ := w.writer.(http.Flusher)
+	f.Flush()
 }

--- a/rest/counted_response_writer.go
+++ b/rest/counted_response_writer.go
@@ -92,3 +92,10 @@ func (w *CountedResponseWriter) isHijackable() bool {
 	_, ok := w.writer.(http.Hijacker)
 	return ok
 }
+
+func (w *CountedResponseWriter) Flush() {
+	f, ok := w.writer.(http.Flusher)
+	if ok {
+		f.Flush()
+	}
+}

--- a/rest/counted_response_writer.go
+++ b/rest/counted_response_writer.go
@@ -94,6 +94,5 @@ func (w *CountedResponseWriter) isHijackable() bool {
 }
 
 func (w *CountedResponseWriter) Flush() {
-	f, _ := w.writer.(http.Flusher)
-	f.Flush()
+	w.writer.(http.Flusher).Flush()
 }

--- a/rest/counted_response_writer_test.go
+++ b/rest/counted_response_writer_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -168,4 +169,18 @@ func TestCountableResponseWriterWithDelay(t *testing.T) {
 		})
 	}
 
+}
+
+func TestResponseWriterSupportsFLush(t *testing.T) {
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+
+			stat, err := base.NewIntStat(base.SubsystemDatabaseKey, "http_bytes_written", base.StatUnitBytes, base.PublicRestBytesWrittenDesc, base.StatAddedVersion3dot1dot0, base.StatDeprecatedVersionNotDeprecated, base.StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+			require.NoError(t, err)
+			responseWriter := getResponseWriter(t, stat, test.name, 0)
+
+			_, ok := responseWriter.(http.Flusher)
+			assert.True(t, ok)
+		})
+	}
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -39,6 +39,13 @@ const (
 	minCompressibleJSONSize = 1000
 )
 
+var _ http.Flusher = &CountedResponseWriter{}
+var _ http.Flusher = &NonCountedResponseWriter{}
+var _ http.Flusher = &EncodedResponseWriter{}
+
+var _ http.Hijacker = &CountedResponseWriter{}
+var _ http.Hijacker = &NonCountedResponseWriter{}
+
 var ErrInvalidLogin = base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 var ErrLoginRequired = base.HTTPErrorf(http.StatusUnauthorized, "Login required")
 
@@ -674,7 +681,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 	// ensure wrapped ResponseWriter implements http.Flusher
 	_, ok := h.response.(http.Flusher)
 	if !ok {
-		return fmt.Errorf("ResponseWriter does not implement Flusher interface")
+		return fmt.Errorf("http.ResponseWriter %T does not implement Flusher interface", h.response)
 	}
 	return nil
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1607,8 +1607,7 @@ func (h *handler) writeMultipart(subtype string, callback func(*multipart.Writer
 }
 
 func (h *handler) flush() {
-	r, _ := h.response.(http.Flusher)
-	r.Flush()
+	h.response.(http.Flusher).Flush()
 }
 
 // If the error parameter is non-nil, sets the response status code appropriately and

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -671,6 +671,11 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 		}
 	}
 	h.updateResponseWriter()
+	// ensure wrapped ResponseWriter implements http.Flusher
+	_, ok := h.response.(http.Flusher)
+	if !ok {
+		return fmt.Errorf("ResponseWriter does not implement Flusher interface")
+	}
 	return nil
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1607,10 +1607,8 @@ func (h *handler) writeMultipart(subtype string, callback func(*multipart.Writer
 }
 
 func (h *handler) flush() {
-	switch r := h.response.(type) {
-	case http.Flusher:
-		r.Flush()
-	}
+	r, _ := h.response.(http.Flusher)
+	r.Flush()
 }
 
 // If the error parameter is non-nil, sets the response status code appropriately and

--- a/rest/non_counted_response_writer.go
+++ b/rest/non_counted_response_writer.go
@@ -47,8 +47,6 @@ func (w *NonCountedResponseWriter) isHijackable() bool {
 }
 
 func (w *NonCountedResponseWriter) Flush() {
-	f, ok := w.ResponseWriter.(http.Flusher)
-	if ok {
-		f.Flush()
-	}
+	f, _ := w.ResponseWriter.(http.Flusher)
+	f.Flush()
 }

--- a/rest/non_counted_response_writer.go
+++ b/rest/non_counted_response_writer.go
@@ -45,3 +45,10 @@ func (w *NonCountedResponseWriter) isHijackable() bool {
 	_, ok := w.ResponseWriter.(http.Hijacker)
 	return ok
 }
+
+func (w *NonCountedResponseWriter) Flush() {
+	f, ok := w.ResponseWriter.(http.Flusher)
+	if ok {
+		f.Flush()
+	}
+}

--- a/rest/non_counted_response_writer.go
+++ b/rest/non_counted_response_writer.go
@@ -47,6 +47,5 @@ func (w *NonCountedResponseWriter) isHijackable() bool {
 }
 
 func (w *NonCountedResponseWriter) Flush() {
-	f, _ := w.ResponseWriter.(http.Flusher)
-	f.Flush()
+	w.ResponseWriter.(http.Flusher).Flush()
 }


### PR DESCRIPTION

CBG-4373

Implement flusher interface on counted and non counted response writers.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2875/
