### PR TITLE
CBG-4403: update rev cache size api docs for size stat

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1302,9 +1302,9 @@ Database:
           properties:
             size:
               description: |-
-                The maximum number of revisions that can be stored in the revision cache. 
-                Note when running with greater than 1 shard count we add 10% capacity overall to avoid early eviction when some shards fill up before others, 
-                so you may find that the capacity stat (revision_cache_num_items) will climb to the defined rev cache size + 10%.
+                The maximum number of revisions that can be stored in the revision cache.
+                Note when running with greater than 1 shard count we add 10% capacity overall to avoid early eviction when some shards fill up before others, so
+                you may find that the capacity stat (revision_cache_num_items) will climb to the defined rev cache size + 10%.
               type: string
               default: 5000
             max_memory_count_mb:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1301,7 +1301,10 @@ Database:
           type: object
           properties:
             size:
-              description: The maximum number of revisions that can be stored in the revision cache.
+              description: |-
+                The maximum number of revisions that can be stored in the revision cache. 
+                Note when running with greater than 1 shard count we add 10% capacity overall to avoid early eviction when some shards fill up before others, 
+                so you may find that the capacity stat (revision_cache_num_items) will climb to the defined rev cache size + 10%.
               type: string
               default: 5000
             max_memory_count_mb:


### PR DESCRIPTION
CBG-4403

- We recently added a size stat for rev cache, we need to add a disclaimer to rev cache sizing on api docs to show that that the defined size in the api could be exceeded by 10%.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
