### PR TITLE
CBG-4444 create an env var override for bucket op timeout

### DIFF
--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -58,6 +58,9 @@ const (
 
 	// Creates buckets with a specific number of number of replicas
 	tbpEnvBucketNumReplicas = "SG_TEST_BUCKET_NUM_REPLICAS"
+
+	// bucket op timeout is the number of seconds that kv operations will retry. Increasing this can be necessary when flushing buckets rapidly.
+	tbpEnvBucketOpTimeout = "SG_TEST_BUCKET_OP_TIMEOUT"
 )
 
 // TestsUseNamedCollections returns true if the tests use named collections.

--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -58,9 +58,6 @@ const (
 
 	// Creates buckets with a specific number of number of replicas
 	tbpEnvBucketNumReplicas = "SG_TEST_BUCKET_NUM_REPLICAS"
-
-	// bucket op timeout is the number of seconds that kv operations will retry. Increasing this can be necessary when flushing buckets rapidly.
-	tbpEnvBucketOpTimeout = "SG_TEST_BUCKET_OP_TIMEOUT"
 )
 
 // TestsUseNamedCollections returns true if the tests use named collections.

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -11,8 +11,6 @@ package base
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -59,14 +57,8 @@ func getGocbClusterForTest(ctx context.Context, server string) (*gocb.Cluster, s
 	spec := BucketSpec{
 		Server:        server,
 		TLSSkipVerify: true,
-	}
-	bucketOpTimeout := os.Getenv(tbpEnvBucketOpTimeout)
-	if bucketOpTimeout != "" {
-		secs, err := strconv.Atoi(bucketOpTimeout)
-		if err != nil {
-			FatalfCtx(ctx, "Couldn't parse %s: %v", tbpEnvBucketOpTimeout, err)
-		}
-		spec.BucketOpTimeout = Ptr(time.Duration(secs) * time.Second)
+		// use longer timeout than DefaultBucketOpTimeout to avoid timeouts in test harness from using buckets after flush, which takes some time to reinitialize
+		BucketOpTimeout: Ptr(time.Duration(30) * time.Second),
 	}
 	connStr, err := spec.GetGoCBConnString()
 	if err != nil {


### PR DESCRIPTION
This address a problem where running a test like `TestWriteTombstone` immediately after starting the test harness will fail with: `ambiguous timeout | {"operation_id":"MutateIn","opaque":"9","time_observed":10000808,"last_dispatched_to":"172.17.0.3:11210","last_dispatched_from":"172.17.0.1:55254","last_connection_id":"7e7da8507602d388/c099ed3d3ef4cbbf"}
`

The problem arises from flush bucket not being a synchronous operation and each vbucket needs to be able ready to accept writes. This can also occur after flushing a bucket between tests, even after the initial creation.

The reason it happens more frequently on my computer is that the tests are generally faster to run, and so Couchbase Server has less time to process its bucket operations before it calls `MutateIn`. This occurs on a Linux machine running server versions 7.2->7.6.

Remove the hard coded timeout of 10 seconds since that is the default anyway. https://github.com/couchbase/sync_gateway/blob/d61c39261271d3f04c8d714c3455c1b6ad667230/base/constants.go#L154 