### PR TITLE
golangci-lint: skip prealloc/fieldalignment in all test files

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -34,37 +34,36 @@ linters:
     #- unparam # Reports unused function parameters
     - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
   disable:
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
-    - err113 # Golang linter to check the errors handling expressions
-    - funlen # Tool for detection of long functions
-    - gochecknoglobals # Checks that no globals are present in Go code
-    - gochecknoinits # Checks that no init functions are present in Go code
-    - gocognit # Computes and checks the cognitive complexity of functions
-    - gocyclo # Computes and checks the cyclomatic complexity of functions
-    - godot # Check if comments end in a period
-    - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - lll # Reports long lines
-    - nestif # Reports deeply nested if statements
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - stylecheck # Stylecheck is a replacement for golint
-    - testpackage # linter that makes you use a separate _test package
-    - whitespace # Tool for detection of leading and trailing whitespace
-    - wsl # Whitespace Linter - Forces you to use empty lines!
+    # - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
+    # - depguard # Go linter that checks if package imports are in a list of acceptable packages
+    # - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
+    # - err113 # Golang linter to check the errors handling expressions
+    # - funlen # Tool for detection of long functions
+    # - gochecknoglobals # Checks that no globals are present in Go code
+    # - gochecknoinits # Checks that no init functions are present in Go code
+    # - gocognit # Computes and checks the cognitive complexity of functions
+    # - gocyclo # Computes and checks the cyclomatic complexity of functions
+    # - godot # Check if comments end in a period
+    # - godox # Tool for detection of FIXME, TODO and other comment keywords
+    # - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    # - gomodguard # Allow and block list linter for direct Go module dependencies.
+    # - lll # Reports long lines
+    # - nestif # Reports deeply nested if statements
+    # - rowserrcheck # checks whether Err of rows is checked successfully
+    # - stylecheck # Stylecheck is a replacement for golint
+    # - testpackage # linter that makes you use a separate _test package
+    # - whitespace # Tool for detection of leading and trailing whitespace
+    # - wsl # Whitespace Linter - Forces you to use empty lines!
     # Once fixed, should enable
-    - dupl # Tool for code clone detection
-    - goconst # Finds repeated strings that could be replaced by a constant
-    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    - gosec # (gas) Inspects source code for security problems
+    # - dupl # Tool for code clone detection
+    # - goconst # Finds repeated strings that could be replaced by a constant
+    # - goprintffuncname # Checks that printf-like functions are named with `f` at the end
+    # - gosec # (gas) Inspects source code for security problems
     - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
-    - nakedret # Finds naked returns in functions greater than a specified function length
-    - prealloc # Finds slice declarations that could potentially be preallocated
-    - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - unparam # Reports unused function parameters
+    # - nakedret # Finds naked returns in functions greater than a specified function length
+    # - prealloc # Finds slice declarations that could potentially be preallocated
+    # - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
+    # - unparam # Reports unused function parameters
 
 # Don't enable fieldalignment, changing the field alignment requires checking to see if anyone uses constructors
 # without names. If there is a memory issue on a specific field, that is best found with a heap profile.
@@ -78,7 +77,7 @@ issues:
   exclude-rules:
     # cover _testing.go (utility testing files) and _test.go files
     # base/util_testing.go / rest/utilities_testing\.*.go
-    - path: (testing\.go|_test.*\.go)
+    - path: (_test.*\.go)
       linters:
         - goconst
     - path: rest/debug.go

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -76,7 +76,9 @@ linters:
 # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
 issues:
   exclude-rules:
-    - path: (_test\.go|utilities_testing\.go)
+    # cover _testing.go (utility testing files) and _test.go files
+    # base/util_testing.go / rest/utilities_testing\.*.go
+    - path: (testing\.go|_test.*\.go)
       linters:
         - goconst
     - path: rest/debug.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,28 +33,27 @@ linters:
     - unconvert # Remove unnecessary type conversions
     - unparam # Reports unused function parameters
     - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
-  disable:
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
-    - err113 # Golang linter to check the errors handling expressions
-    - funlen # Tool for detection of long functions
-    - gochecknoglobals # Checks that no globals are present in Go code
-    - gochecknoinits # Checks that no init functions are present in Go code
-    - gocognit # Computes and checks the cognitive complexity of functions
-    - gocyclo # Computes and checks the cyclomatic complexity of functions
-    - godot # Check if comments end in a period
-    - godox # Tool for detection of FIXME, TODO and other comment keywords
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - gomodguard # Allow and block list linter for direct Go module dependencies.
-    - lll # Reports long lines
-    - nestif # Reports deeply nested if statements
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - rowserrcheck # checks whether Err of rows is checked successfully
-    - stylecheck # Stylecheck is a replacement for golint
-    - testpackage # linter that makes you use a separate _test package
-    - whitespace # Tool for detection of leading and trailing whitespace
-    - wsl # Whitespace Linter - Forces you to use empty lines!
+    # disable:
+    # - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
+    # - depguard # Go linter that checks if package imports are in a list of acceptable packages
+    # - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
+    # - err113 # Golang linter to check the errors handling expressions
+    # - funlen # Tool for detection of long functions
+    # - gochecknoglobals # Checks that no globals are present in Go code
+    # - gochecknoinits # Checks that no init functions are present in Go code
+    # - gocognit # Computes and checks the cognitive complexity of functions
+    # - gocyclo # Computes and checks the cyclomatic complexity of functions
+    # - godot # Check if comments end in a period
+    # - godox # Tool for detection of FIXME, TODO and other comment keywords
+    # - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    # - gomodguard # Allow and block list linter for direct Go module dependencies.
+    # - lll # Reports long lines
+    # - nestif # Reports deeply nested if statements
+    # - rowserrcheck # checks whether Err of rows is checked successfully
+    # - stylecheck # Stylecheck is a replacement for golint
+    # - testpackage # linter that makes you use a separate _test package
+    # - whitespace # Tool for detection of leading and trailing whitespace
+    # - wsl # Whitespace Linter - Forces you to use empty lines!
 
 linters-settings:
   govet:
@@ -72,11 +71,11 @@ issues:
   exclude-rules:
     # cover _testing.go (utility testing files) and _test.go files
     # base/util_testing.go / rest/utilities_testing\.*.go
-    - path: (testing\.go|_test.*\.go)
+    - path: (_test.*\.go)
       linters:
         - goconst
         - prealloc
-    - path: (testing\.go|_test.*\.go)
+    - path: (_test.*\.go)
       linters:
         - govet
       text: fieldalignment

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,10 +70,13 @@ linters-settings:
 # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
 issues:
   exclude-rules:
-    - path: (_test\.go|utilities_testing\.go)
+    # cover _testing.go (utility testing files) and _test.go files
+    # base/util_testing.go / rest/utilities_testing\.*.go
+    - path: (testing\.go|_test.*\.go)
       linters:
         - goconst
-    - path: (_test\.go|utilities_testing\.go)
+        - prealloc
+    - path: (testing\.go|_test.*\.go)
       linters:
         - govet
       text: fieldalignment


### PR DESCRIPTION
There are test files named `*test*.go` like `utilities_testing.go` or `hlv_utilities_testing.go` and we do not care about aligning struct fields or preallocating maps/arrays for these.
