### PR TITLE
CBG-4257 add HLV into BlipTesterCollectionClient

### DIFF
--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -624,3 +624,7 @@ func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
 	}
 	return nil
 }
+
+func (hlv *HybridLogicalVector) GoString() string {
+	return fmt.Sprintf("HybridLogicalVector{CurrentVersionCAS:%d, SourceID:%s, Version:%d, PreviousVersions:%+v, MergeVersions:%+v}", hlv.CurrentVersionCAS, hlv.SourceID, hlv.Version, hlv.PreviousVersions, hlv.MergeVersions)
+}

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -183,7 +183,6 @@ func (p *CouchbaseServerPeer) waitForDocVersion(dsName sgbucket.DataStoreName, d
 		}
 		// have to use p.tb instead of c because of the assert.CollectT doesn't implement TB
 		version = getDocVersion(docID, p, cas, xattrs)
-
 		assert.Equal(c, expected.CV(c), version.CV(c), "Could not find matching CV on %s for peer %s\nexpected: %#v\nactual:   %#v\n          body: %#v\n", docID, p, expected, version, string(docBytes))
 
 	}, totalWaitTime, pollInterval)

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -51,9 +51,7 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		if strings.Contains(topology.description, "CBL") {
-			// Test case flakes given the WaitForDocVersion function only waits for a docID on the cbl peer. We need to be
-			// able to wait for a specific version to arrive over pull replication
-			t.Skip("We need to be able to wait for a specific version to arrive over pull replication + unexpected body in proposeChanges: [304] issue, CBG-4257")
+			t.Skip("CBL actor can generate conflicts and push replication fails with conflict for doc in blip tester CBL-4267")
 		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
@@ -83,8 +81,10 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 // 6. start replications
 // 7. assert that the documents are deleted on all peers and have hlv sources equal to the number of active peers
 func TestMultiActorConflictDelete(t *testing.T) {
-	t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
 	for _, topology := range append(simpleTopologies, Topologies...) {
+		if strings.Contains(topology.description, "CBL") {
+			t.Skip("CBL actor can generate conflicts and push replication fails with conflict for doc in blip tester CBL-4267")
+		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()
@@ -121,8 +121,8 @@ func TestMultiActorConflictResurrect(t *testing.T) {
 		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
 	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
-		if strings.Contains(topology.description, "1.") {
-			t.Skip("CBG-4434 fail due to CBL issues, specifically for multi-actor tests")
+		if strings.Contains(topology.description, "CBL") {
+			t.Skip("CBL actor can generate conflicts and push replication fails with conflict for doc in blip tester CBL-4267")
 		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -54,13 +54,17 @@ func (v DocMetadata) GoString() string {
 }
 
 // DocMetadataFromDocVersion returns metadata DocVersion from the given document and version.
-func DocMetadataFromDocVersion(t testing.TB, docID string, version rest.DocVersion) DocMetadata {
-	// FIXME: CBG-4257, this should read the existing HLV on doc, until this happens, pv is always missing
-	hlv := db.NewHybridLogicalVector()
-	require.NoError(t, hlv.AddVersion(version.CV))
-	return DocMetadata{
+func DocMetadataFromDocVersion(t testing.TB, docID string, hlv *db.HybridLogicalVector, version rest.DocVersion) DocMetadata {
+	m := DocMetadata{
 		DocID:       docID,
 		RevTreeID:   version.RevTreeID,
 		ImplicitHLV: hlv,
 	}
+	if hlv != nil {
+		m.HLV = hlv
+	} else {
+		m.HLV = db.NewHybridLogicalVector()
+		require.NoError(t, m.HLV.AddVersion(version.CV))
+	}
+	return m
 }


### PR DESCRIPTION
I created `AddHLVRev` in addition to `AddRev` since there would be a lot of places where code would need to change. I have a proposed refactor to drop the error arg out of `AddRev` and I could evaluate whether we would want to change the signature everywhere in `rest` package and not just topology tests.

My initial revision of this PR put HLV into `DocVersion` but Ben convinced me not to do this because `DocVersion` is used as a map key in blip tester, which breaks some semantics. Additionally, we use `DocVersion` to abstract CV/revtree id only, so adding HLV means that you could end up with two versions where the cv was the same, but one would have a PV. This version is also a lot simpler.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` [https://jenkins.sgwdev.com/job/SyncGateway-Integration/2876/](https://jenkins.sgwdev.com/job/SyncGateway-Integration/2876/)
