### PR TITLE
CBG-4336: add updated at field for persisted configs

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -632,7 +632,6 @@ func (auth *Authenticator) UpdateUserEmail(u User, email string) error {
 			return nil, err
 		}
 		currentUser.SetUpdatedAt()
-		currentUser.SetCreatedAt(currentUser.GetCreatedAt())
 
 		return currentUser, nil
 	}
@@ -666,7 +665,6 @@ func (auth *Authenticator) rehashPassword(user User, password string) error {
 				return nil, err
 			}
 			currentUserImpl.SetUpdatedAt()
-			currentUserImpl.SetCreatedAt(currentUserImpl.GetCreatedAt())
 			return currentUserImpl, nil
 		} else {
 			return nil, base.ErrUpdateCancel
@@ -746,7 +744,6 @@ func (auth *Authenticator) DeleteRole(role Role, purge bool, deleteSeq uint64) e
 		p.setDeleted(true)
 		p.SetSequence(deleteSeq)
 		p.SetUpdatedAt()
-		p.SetCreatedAt(p.GetCreatedAt())
 
 		// Update channel history for default collection
 		channelHistory := auth.calculateHistory(p.Name(), deleteSeq, p.Channels(), nil, p.ChannelHistory())

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -407,6 +407,8 @@ func (auth *Authenticator) Save(p Principal) error {
 	if err := p.validate(); err != nil {
 		return err
 	}
+	// Add updated at time
+	p.setUpdatedAt()
 
 	casOut, writeErr := auth.datastore.WriteCas(p.DocID(), 0, p.Cas(), p, 0)
 	if writeErr != nil {

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -52,12 +52,11 @@ type Principal interface {
 	setDeleted(bool)
 	IsDeleted() bool
 
-	// sets the updated time for the principal document
+	// Sets the updated time for the principal document
 	SetUpdatedAt()
 
-	// gets and sets the created time for the principal document
+	// Sets the created time for the principal document
 	SetCreatedAt(t time.Time)
-	GetCreatedAt() time.Time
 
 	// Principal includes the PrincipalCollectionAccess interface for operations against
 	// the _default._default collection (stored directly on the principal for backward

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -53,7 +53,11 @@ type Principal interface {
 	IsDeleted() bool
 
 	// sets the updated time for the principal document
-	setUpdatedAt()
+	SetUpdatedAt()
+
+	// gets and sets the created time for the principal document
+	SetCreatedAt(t time.Time)
+	GetCreatedAt() time.Time
 
 	// Principal includes the PrincipalCollectionAccess interface for operations against
 	// the _default._default collection (stored directly on the principal for backward

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -52,6 +52,9 @@ type Principal interface {
 	setDeleted(bool)
 	IsDeleted() bool
 
+	// sets the updated time for the principal document
+	setUpdatedAt()
+
 	// Principal includes the PrincipalCollectionAccess interface for operations against
 	// the _default._default collection (stored directly on the principal for backward
 	// compatibility)

--- a/auth/role.go
+++ b/auth/role.go
@@ -33,6 +33,7 @@ type roleImpl struct {
 	ChannelInvalSeq   uint64                                  `json:"channel_inval_seq,omitempty"` // Sequence at which the channels were invalidated. Data remains in Channels_ for history calculation.
 	Deleted           bool                                    `json:"deleted,omitempty"`
 	CollectionsAccess map[string]map[string]*CollectionAccess `json:"collection_access,omitempty"` // Nested maps of CollectionAccess, indexed by scope and collection name
+	UpdatedAt         time.Time                               `json:"updated_at"`
 	cas               uint64
 	docID             string // key used to store the roleImpl
 }
@@ -275,6 +276,10 @@ func (role *roleImpl) accessViewKey() string {
 
 func (role *roleImpl) Name() string {
 	return role.Name_
+}
+
+func (role *roleImpl) setUpdatedAt() {
+	role.UpdatedAt = time.Now()
 }
 
 func (role *roleImpl) Sequence() uint64 {

--- a/auth/role.go
+++ b/auth/role.go
@@ -34,6 +34,7 @@ type roleImpl struct {
 	Deleted           bool                                    `json:"deleted,omitempty"`
 	CollectionsAccess map[string]map[string]*CollectionAccess `json:"collection_access,omitempty"` // Nested maps of CollectionAccess, indexed by scope and collection name
 	UpdatedAt         time.Time                               `json:"updated_at"`
+	CreatedAt         time.Time                               `json:"created_at"`
 	cas               uint64
 	docID             string // key used to store the roleImpl
 }
@@ -278,8 +279,16 @@ func (role *roleImpl) Name() string {
 	return role.Name_
 }
 
-func (role *roleImpl) setUpdatedAt() {
+func (role *roleImpl) SetUpdatedAt() {
 	role.UpdatedAt = time.Now().UTC()
+}
+
+func (role *roleImpl) SetCreatedAt(t time.Time) {
+	role.CreatedAt = t
+}
+
+func (role *roleImpl) GetCreatedAt() time.Time {
+	return role.CreatedAt
 }
 
 func (role *roleImpl) Sequence() uint64 {

--- a/auth/role.go
+++ b/auth/role.go
@@ -287,10 +287,6 @@ func (role *roleImpl) SetCreatedAt(t time.Time) {
 	role.CreatedAt = t
 }
 
-func (role *roleImpl) GetCreatedAt() time.Time {
-	return role.CreatedAt
-}
-
 func (role *roleImpl) Sequence() uint64 {
 	return role.Sequence_
 }

--- a/auth/role.go
+++ b/auth/role.go
@@ -279,7 +279,7 @@ func (role *roleImpl) Name() string {
 }
 
 func (role *roleImpl) setUpdatedAt() {
-	role.UpdatedAt = time.Now()
+	role.UpdatedAt = time.Now().UTC()
 }
 
 func (role *roleImpl) Sequence() uint64 {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -116,6 +116,7 @@ type ReplicationConfig struct {
 	BatchSize              int                       `json:"batch_size,omitempty"`
 	RunAs                  string                    `json:"run_as,omitempty"`
 	UpdatedAt              *time.Time                `json:"updated_at,omitempty"`
+	CreatedAt              *time.Time                `json:"created_at,omitempty"`
 }
 
 func DefaultReplicationConfig() ReplicationConfig {
@@ -1110,6 +1111,8 @@ func (m *sgReplicateManager) UpsertReplication(ctx context.Context, replication 
 		} else {
 			// Add a new replication to the cfg.  Set targetState based on initialState when specified.
 			replicationConfig := DefaultReplicationConfig()
+			createdAt := time.Now().UTC()
+			replicationConfig.CreatedAt = &createdAt
 			replicationConfig.ID = replication.ID
 			targetState := ReplicationStateRunning
 			if replication.InitialState != nil && *replication.InitialState == ReplicationStateStopped {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -336,7 +336,7 @@ func (rc *ReplicationConfig) Upsert(ctx context.Context, c *ReplicationUpsertCon
 		rc.RunAs = *c.RunAs
 	}
 
-	timeNow := time.Now()
+	timeNow := time.Now().UTC()
 	rc.UpdatedAt = &timeNow
 
 	if c.QueryParams != nil {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -115,6 +115,7 @@ type ReplicationConfig struct {
 	Adhoc                  bool                      `json:"adhoc,omitempty"`
 	BatchSize              int                       `json:"batch_size,omitempty"`
 	RunAs                  string                    `json:"run_as,omitempty"`
+	UpdatedAt              *time.Time                `json:"updated_at,omitempty"`
 }
 
 func DefaultReplicationConfig() ReplicationConfig {
@@ -334,6 +335,9 @@ func (rc *ReplicationConfig) Upsert(ctx context.Context, c *ReplicationUpsertCon
 	if c.RunAs != nil {
 		rc.RunAs = *c.RunAs
 	}
+
+	timeNow := time.Now()
+	rc.UpdatedAt = &timeNow
 
 	if c.QueryParams != nil {
 		// QueryParams can be either []interface{} or map[string]interface{}, so requires type-specific copying

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -536,6 +536,7 @@ func TestUpsertReplicationConfig(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprintf("%s", testCase.name), func(t *testing.T) {
 			testCase.existingConfig.Upsert(base.TestCtx(t), testCase.updatedConfig)
+			testCase.existingConfig.UpdatedAt = nil // remove updated at field for comparison below
 			equal, err := testCase.existingConfig.Equals(testCase.expectedConfig)
 			assert.NoError(t, err)
 			assert.True(t, equal)

--- a/db/users.go
+++ b/db/users.go
@@ -86,6 +86,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			if err != nil {
 				return replaced, princ, fmt.Errorf("Error creating user/role: %w", err)
 			}
+			princ.SetCreatedAt(time.Now().UTC())
 			changed = true
 		} else if !allowReplace {
 			err = base.HTTPErrorf(http.StatusConflict, "Already exists")
@@ -214,6 +215,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 				user.SetJWTLastUpdated(time.Now())
 			}
 		}
+		princ.SetUpdatedAt()
 		err = authenticator.Save(princ)
 		// On cas error, retry.  Otherwise break out of loop
 		if base.IsCasMismatch(err) {

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -1001,7 +1001,8 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 	delete(scopesConfig[scope].Collections, collection1)
 	assert.Equal(t, scopesConfig, dbCfg.Scopes)
 	originalDBCfg.Server = nil
-	dbCfg.UpdatedAt = nil // originalDBCfg fetch is from memory so has no update at time
+	dbCfg.UpdatedAt = nil // originalDBCfg fetch is from memory so has no update/create at time
+	dbCfg.CreatedAt = nil
 	assert.Equal(t, originalDBCfg, dbCfg)
 
 	// now assert that _config shows the same

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -1001,6 +1001,7 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 	delete(scopesConfig[scope].Collections, collection1)
 	assert.Equal(t, scopesConfig, dbCfg.Scopes)
 	originalDBCfg.Server = nil
+	dbCfg.UpdatedAt = nil // originalDBCfg fetch is from memory so has no update at time
 	assert.Equal(t, originalDBCfg, dbCfg)
 
 	// now assert that _config shows the same

--- a/rest/config.go
+++ b/rest/config.go
@@ -193,6 +193,7 @@ type DbConfig struct {
 	ChangesRequestPlus               *bool                            `json:"changes_request_plus,omitempty"`                 // If set, is used as the default value of request_plus for non-continuous replications
 	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`                                 // Per-database CORS config
 	Logging                          *DbLoggingConfig                 `json:"logging,omitempty"`                              // Per-database Logging config
+	UpdatedAt                        *time.Time                       `json:"updated_at,omitempty"`                           // Time at which the database config was last updated
 }
 
 type ScopesConfig map[string]ScopeConfig

--- a/rest/config.go
+++ b/rest/config.go
@@ -194,6 +194,7 @@ type DbConfig struct {
 	CORS                             *auth.CORSConfig                 `json:"cors,omitempty"`                                 // Per-database CORS config
 	Logging                          *DbLoggingConfig                 `json:"logging,omitempty"`                              // Per-database Logging config
 	UpdatedAt                        *time.Time                       `json:"updated_at,omitempty"`                           // Time at which the database config was last updated
+	CreatedAt                        *time.Time                       `json:"created_at,omitempty"`                           // Time at which the database config was created
 }
 
 type ScopesConfig map[string]ScopeConfig

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -46,6 +46,9 @@ func TestDbConfigUpdatedAtField(t *testing.T) {
 	require.NotNil(t, unmarshaledConfig.UpdatedAt)
 	currTime := unmarshaledConfig.UpdatedAt
 
+	// avoid flake where update at seems to be the same (possibly running to fast)
+	time.Sleep(500 * time.Nanosecond)
+
 	// Update the config
 	dbConfig = rt.NewDbConfig()
 	RequireStatus(t, rt.UpsertDbConfig("db1", dbConfig), http.StatusCreated)

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -135,6 +135,7 @@ func (b *bootstrapContext) InsertConfig(ctx context.Context, bucketName, groupID
 	// Step 3. Write the database config
 	timeUpdated := time.Now().UTC()
 	config.UpdatedAt = &timeUpdated
+	config.CreatedAt = &timeUpdated
 	cas, configErr := b.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey(ctx, groupID, dbName), config)
 	if configErr != nil {
 		base.InfofCtx(ctx, base.KeyConfig, "Insert for database config returned error %v", configErr)
@@ -154,6 +155,7 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 	var updatedConfig *DatabaseConfig
 	var registry *GatewayRegistry
 	var previousVersion string
+	var createdAtTime *time.Time
 
 	registryUpdated := false
 	for attempt := 1; attempt <= configUpdateMaxRetryAttempts; attempt++ {
@@ -171,6 +173,7 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 		if existingConfig == nil {
 			return 0, base.ErrNotFound
 		}
+		createdAtTime = existingConfig.CreatedAt
 
 		base.DebugfCtx(ctx, base.KeyConfig, "UpdateConfig fetched registry and database successfully")
 
@@ -229,6 +232,7 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 	// Step 2. Update the config document
 	timeUpdated := time.Now().UTC()
 	updatedConfig.UpdatedAt = &timeUpdated
+	updatedConfig.CreatedAt = createdAtTime
 	docID := PersistentConfigKey(ctx, groupID, dbName)
 	casOut, err := b.Connection.WriteMetadataDocument(ctx, bucketName, docID, updatedConfig.cfgCas, updatedConfig)
 	if err != nil {

--- a/rest/config_manager.go
+++ b/rest/config_manager.go
@@ -106,7 +106,7 @@ func (b *bootstrapContext) InsertConfig(ctx context.Context, bucketName, groupID
 		}
 
 		// Persist registry
-		registry.UpdatedAt = time.Now()
+		registry.UpdatedAt = time.Now().UTC()
 		writeErr := b.setGatewayRegistry(ctx, bucketName, registry)
 		if writeErr == nil {
 			base.DebugfCtx(ctx, base.KeyConfig, "Registry updated successfully")
@@ -133,7 +133,7 @@ func (b *bootstrapContext) InsertConfig(ctx context.Context, bucketName, groupID
 		return 0, fmt.Errorf("InsertConfig failed to persist registry after %d attempts", configUpdateMaxRetryAttempts)
 	}
 	// Step 3. Write the database config
-	timeUpdated := time.Now()
+	timeUpdated := time.Now().UTC()
 	config.UpdatedAt = &timeUpdated
 	cas, configErr := b.Connection.InsertMetadataDocument(ctx, bucketName, PersistentConfigKey(ctx, groupID, dbName), config)
 	if configErr != nil {
@@ -199,7 +199,7 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 		}
 
 		// Persist registry
-		registry.UpdatedAt = time.Now()
+		registry.UpdatedAt = time.Now().UTC()
 		writeErr := b.setGatewayRegistry(ctx, bucketName, registry)
 		if writeErr == nil {
 			base.DebugfCtx(ctx, base.KeyConfig, "UpdateConfig persisted updated registry successfully")
@@ -227,7 +227,7 @@ func (b *bootstrapContext) UpdateConfig(ctx context.Context, bucketName, groupID
 	}
 
 	// Step 2. Update the config document
-	timeUpdated := time.Now()
+	timeUpdated := time.Now().UTC()
 	updatedConfig.UpdatedAt = &timeUpdated
 	docID := PersistentConfigKey(ctx, groupID, dbName)
 	casOut, err := b.Connection.WriteMetadataDocument(ctx, bucketName, docID, updatedConfig.cfgCas, updatedConfig)

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -49,6 +49,7 @@ type GatewayRegistry struct {
 	ConfigGroups map[string]*RegistryConfigGroup `json:"config_groups"` // Map of config groups, keyed by config group ID
 	SGVersion    base.ComparableBuildVersion     `json:"sg_version"`    // Latest patch version of Sync Gateway that touched the registry
 	UpdatedAt    time.Time                       `json:"updated_at"`    // Time the registry was last updated
+	CreatedAt    time.Time                       `json:"created_at"`    // Time the registry was created
 }
 
 const GatewayRegistryVersion = "1.0"
@@ -113,6 +114,7 @@ func NewGatewayRegistry(syncGatewayVersion base.ComparableBuildVersion) *Gateway
 		ConfigGroups: make(map[string]*RegistryConfigGroup),
 		Version:      GatewayRegistryVersion,
 		SGVersion:    syncGatewayVersion,
+		CreatedAt:    time.Now().UTC(),
 	}
 }
 

--- a/rest/config_registry.go
+++ b/rest/config_registry.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -47,6 +48,7 @@ type GatewayRegistry struct {
 	Version      string                          `json:"version"`       // Registry version
 	ConfigGroups map[string]*RegistryConfigGroup `json:"config_groups"` // Map of config groups, keyed by config group ID
 	SGVersion    base.ComparableBuildVersion     `json:"sg_version"`    // Latest patch version of Sync Gateway that touched the registry
+	UpdatedAt    time.Time                       `json:"updated_at"`    // Time the registry was last updated
 }
 
 const GatewayRegistryVersion = "1.0"

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3150,12 +3150,15 @@ func TestUserUpdatedAtField(t *testing.T) {
 	dbConfig := rt.NewDbConfig()
 	RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
 
+	metaKeys := rt.GetDatabase().MetadataKeys
+
 	resp := rt.SendAdminRequest(http.MethodPost, "/db1/_user/", `{"name":"user1","password":"password"}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	ds := rt.MetadataStore()
 	var user map[string]interface{}
-	_, err := ds.Get("_sync:user:db1:user1", &user)
+	userKey := metaKeys.UserKey("user1")
+	_, err := ds.Get(userKey, &user)
 	require.NoError(t, err)
 
 	// Check that the user has an updatedAt field
@@ -3168,7 +3171,7 @@ func TestUserUpdatedAtField(t *testing.T) {
 	RequireStatus(t, resp, http.StatusOK)
 
 	user = map[string]interface{}{}
-	_, err = ds.Get("_sync:user:db1:user1", &user)
+	_, err = ds.Get(userKey, &user)
 	require.NoError(t, err)
 	newTimeStr := user["updated_at"].(string)
 	newTime, err := time.Parse(time.RFC3339, newTimeStr)
@@ -3191,8 +3194,10 @@ func TestRoleUpdatedAtField(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	ds := rt.MetadataStore()
+	metaKeys := rt.GetDatabase().MetadataKeys
+	roleKey := metaKeys.RoleKey("role1")
 	var user map[string]interface{}
-	_, err := ds.Get("_sync:role:db1:role1", &user)
+	_, err := ds.Get(roleKey, &user)
 	require.NoError(t, err)
 
 	// Check that the user has an updatedAt field
@@ -3205,7 +3210,7 @@ func TestRoleUpdatedAtField(t *testing.T) {
 	RequireStatus(t, resp, http.StatusOK)
 
 	user = map[string]interface{}{}
-	_, err = ds.Get("_sync:role:db1:role1", &user)
+	_, err = ds.Get(roleKey, &user)
 	require.NoError(t, err)
 	newTimeStr := user["updated_at"].(string)
 	newTime, err := time.Parse(time.RFC3339, newTimeStr)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3167,6 +3167,9 @@ func TestUserUpdatedAtField(t *testing.T) {
 	currTime, err := time.Parse(time.RFC3339, currTimeStr)
 	require.NoError(t, err)
 
+	// avoid flake where update at seems to be the same (possibly running to fast)
+	time.Sleep(500 * time.Nanosecond)
+
 	resp = rt.SendAdminRequest(http.MethodPut, "/db1/_user/user1", `{"name":"user1","password":"password1"}`)
 	RequireStatus(t, resp, http.StatusOK)
 
@@ -3205,6 +3208,9 @@ func TestRoleUpdatedAtField(t *testing.T) {
 	currTimeStr := user["updated_at"].(string)
 	currTime, err := time.Parse(time.RFC3339, currTimeStr)
 	require.NoError(t, err)
+
+	// avoid flake where update at seems to be the same (possibly running to fast)
+	time.Sleep(500 * time.Nanosecond)
 
 	resp = rt.SendAdminRequest(http.MethodPut, "/db1/_role/role1", `{"name":"role1","admin_channels":["ABC"]}`)
 	RequireStatus(t, resp, http.StatusOK)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3166,6 +3166,10 @@ func TestUserUpdatedAtField(t *testing.T) {
 	currTimeStr := user["updated_at"].(string)
 	currTime, err := time.Parse(time.RFC3339, currTimeStr)
 	require.NoError(t, err)
+	require.NotNil(t, user["created_at"])
+	currTimeCreatedStr := user["created_at"].(string)
+	timeCreated, err := time.Parse(time.RFC3339, currTimeCreatedStr)
+	require.NoError(t, err)
 
 	// avoid flake where update at seems to be the same (possibly running to fast)
 	time.Sleep(500 * time.Nanosecond)
@@ -3179,8 +3183,12 @@ func TestUserUpdatedAtField(t *testing.T) {
 	newTimeStr := user["updated_at"].(string)
 	newTime, err := time.Parse(time.RFC3339, newTimeStr)
 	require.NoError(t, err)
+	newCreatedStr := user["created_at"].(string)
+	newCreated, err := time.Parse(time.RFC3339, newCreatedStr)
+	require.NoError(t, err)
 
 	assert.Greater(t, newTime.UnixNano(), currTime.UnixNano())
+	assert.Equal(t, timeCreated.UnixNano(), newCreated.UnixNano())
 }
 
 func TestRoleUpdatedAtField(t *testing.T) {
@@ -3208,6 +3216,10 @@ func TestRoleUpdatedAtField(t *testing.T) {
 	currTimeStr := user["updated_at"].(string)
 	currTime, err := time.Parse(time.RFC3339, currTimeStr)
 	require.NoError(t, err)
+	require.NotNil(t, user["created_at"])
+	currTimeCreatedStr := user["created_at"].(string)
+	timeCreated, err := time.Parse(time.RFC3339, currTimeCreatedStr)
+	require.NoError(t, err)
 
 	// avoid flake where update at seems to be the same (possibly running to fast)
 	time.Sleep(500 * time.Nanosecond)
@@ -3221,6 +3233,10 @@ func TestRoleUpdatedAtField(t *testing.T) {
 	newTimeStr := user["updated_at"].(string)
 	newTime, err := time.Parse(time.RFC3339, newTimeStr)
 	require.NoError(t, err)
+	newCreatedStr := user["created_at"].(string)
+	newCreated, err := time.Parse(time.RFC3339, newCreatedStr)
+	require.NoError(t, err)
 
 	assert.Greater(t, newTime.UnixNano(), currTime.UnixNano())
+	assert.Equal(t, timeCreated.UnixNano(), newCreated.UnixNano())
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8596,7 +8596,9 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 
 	// Check that the config has an updated_at field
 	require.NotNil(t, configResponse.UpdatedAt)
+	require.NotNil(t, configResponse.CreatedAt)
 	currTime := configResponse.UpdatedAt
+	createdAtTime := configResponse.CreatedAt
 
 	// avoid flake where update at seems to be the same (possibly running to fast)
 	time.Sleep(500 * time.Nanosecond)
@@ -8614,4 +8616,5 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &configResponse))
 
 	assert.Greater(t, configResponse.UpdatedAt.UnixNano(), currTime.UnixNano())
+	assert.Equal(t, configResponse.CreatedAt.UnixNano(), createdAtTime.UnixNano())
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8598,6 +8598,9 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 	require.NotNil(t, configResponse.UpdatedAt)
 	currTime := configResponse.UpdatedAt
 
+	// avoid flake where update at seems to be the same (possibly running to fast)
+	time.Sleep(500 * time.Nanosecond)
+
 	resp = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/replication1?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -278,6 +278,7 @@ func (h *handler) deleteUserSessions() error {
 		return nil
 	}
 	user.UpdateSessionUUID()
+	user.SetUpdatedAt()
 	err = auth.Save(user)
 	if err == nil {
 		base.Audit(h.ctx(), base.AuditIDPublicUserSessionDeleteAll, base.AuditFields{base.AuditFieldUserName: userName})


### PR DESCRIPTION
CBG-4336

- Add updated at timestamp to persisted configs
- The following configs are included:
  - Registry 
  - Db configs 
  - Replication configs 
  - User and role docs 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2884/
