### PR TITLE
Move assertions into blip test code

### DIFF
--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1245,8 +1245,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPull(btc.id)
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldFeedType: "continuous",
@@ -1258,8 +1257,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartOneshotPull(btc.id)
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldFeedType: "normal",
@@ -1271,8 +1269,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", Channels: "A,B"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldChannels: []any{"A", "B"},
@@ -1286,8 +1283,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", DocIDs: []string{docID, "non_existent"}})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldDocIDs:   []any{"blip_changes_with_docids", "non_existent"},
@@ -1302,8 +1298,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", DocIDs: []string{docID, "non_existent"}, Channels: "A,B"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldDocIDs:   []any{"blip_changes_with_docids_and_channels", "non_existent"},
@@ -1318,8 +1313,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "1:10"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldFeedType: "normal",
@@ -1510,14 +1504,12 @@ func TestAuditBlipCRUD(t *testing.T) {
 				attachmentName: "attachment1",
 				setupCode: func(t testing.TB, docID string) DocVersion {
 					attData := base64.StdEncoding.EncodeToString([]byte("attach"))
-					version, err := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment1":{"data":"`+attData+`"}}}`))
-					require.NoError(t, err)
-					return version
+					return btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment1":{"data":"`+attData+`"}}}`))
 				},
 				auditableCode: func(t testing.TB, docID string, version DocVersion) {
 					btcRunner.StartPushWithOpts(btc.id, BlipTesterPushOptions{Continuous: false})
 					// wait for the doc to be replicated, since that's what we're actually auditing
-					require.NoError(t, rt.WaitForVersion(docID, version))
+					rt.WaitForVersion(docID, version)
 				},
 				attachmentCreateCount: 1,
 			},

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -71,8 +71,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 
 		// Update the replicated doc at client along with keeping the same attachment stub.
 		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-		version, err := btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
 
 		// TODO: Replace with rt.WaitForVersion
 		// Wait for the document to be replicated at SG
@@ -144,8 +143,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 
 		// Update the replicated doc at client along with keeping the same attachment stub.
 		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-		version, err := btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
 
 		// Wait for the document to be replicated at SG
 		btc.pushReplication.WaitForMessage(2)
@@ -265,19 +263,14 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 
 		// Create two docs with the same attachment data on the client - v2 attachments intentionally result in two copies stored on the server, despite the client being able to share the data for both.
 		doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-		doc1Version, err := btcRunner.AddRev(btc.id, doc1ID, nil, []byte(doc1Body))
-		require.NoError(t, err)
-
-		err = btc.rt.WaitForVersion(doc1ID, doc1Version)
-		require.NoError(t, err)
+		doc1Version := btcRunner.AddRev(btc.id, doc1ID, nil, []byte(doc1Body))
+		btc.rt.WaitForVersion(doc1ID, doc1Version)
 
 		// create doc2 now that we know the server has the attachment - SG should still request the attachment data from the client.
 		doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-		doc2Version, err := btcRunner.AddRev(btc.id, doc2ID, nil, []byte(doc2Body))
-		require.NoError(t, err)
+		doc2Version := btcRunner.AddRev(btc.id, doc2ID, nil, []byte(doc2Body))
 
-		err = btc.rt.WaitForVersion(doc2ID, doc2Version)
-		require.NoError(t, err)
+		btc.rt.WaitForVersion(doc2ID, doc2Version)
 
 		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
 		assert.Equal(t, int64(0), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
@@ -305,14 +298,12 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 
 		btcRunner.StartPush(btc.id)
 
-		docVersion, err := btcRunner.AddRev(btc.id, docID, nil, []byte(`{"greetings":[{"hi": "alice"}]}`))
-		require.NoError(t, err)
+		docVersion := btcRunner.AddRev(btc.id, docID, nil, []byte(`{"greetings":[{"hi": "alice"}]}`))
 
-		docVersion, err = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "bob"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`))
-		require.NoError(t, err)
+		docVersion = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "bob"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`))
 
 		// Wait for the documents to be replicated at SG
-		require.NoError(t, rt.WaitForVersion(docID, docVersion))
+		rt.WaitForVersion(docID, docVersion)
 
 		collection, ctx := rt.GetSingleTestDatabaseCollection()
 		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalNoHistory)
@@ -322,13 +313,11 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 
 		// CBL updates the doc w/ two more revisions, 3-abc, 4-abc,
 		// sent to SG as 4-abc, history:[4-abc,3-abc,2-abc], the attachment has revpos=2
-		docVersion, err = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "charlie"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
-		require.NoError(t, err)
-		docVersion, err = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "dave"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
-		require.NoError(t, err)
+		docVersion = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "charlie"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
+		docVersion = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "dave"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
 
 		// Wait for the document to be replicated at SG
-		require.NoError(t, rt.WaitForVersion(docID, docVersion))
+		rt.WaitForVersion(docID, docVersion)
 
 		doc, err = collection.GetDocument(ctx, docID, db.DocUnmarshalNoHistory)
 		require.NoError(t, err)
@@ -379,8 +368,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
 		rev := NewDocVersionFromFakeRev("2-abc")
 		// FIXME CBG-4400:  docID: doc1 was not found on the client - expecting to update doc based on parentVersion RevID: 2-abc
-		_, err := btcRunner.AddRev(btc.id, docID, &rev, []byte(bodyText))
-		require.NoError(t, err)
+		_ = btcRunner.AddRev(btc.id, docID, &rev, []byte(bodyText))
 
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 		docVersion, err := btcRunner.PushRevWithHistory(btc.id, docID, &rev, []byte(bodyText), 2, 0)
@@ -389,7 +377,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		assert.Equal(t, "4-abc", docVersion.RevTreeID)
 
 		// Wait for the document to be replicated at SG
-		require.NoError(t, rt.WaitForVersion(docID, *docVersion))
+		rt.WaitForVersion(docID, *docVersion)
 
 		collection, ctx := rt.GetSingleTestDatabaseCollection()
 		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalNoHistory)
@@ -548,10 +536,9 @@ func TestBlipAttachNameChange(t *testing.T) {
 		digest := db.Sha1DigestKey(attachmentA)
 
 		// Push initial attachment data
-		version, err := btcRunner.AddRev(client1.id, docID, EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
-		require.NoError(t, err)
+		version := btcRunner.AddRev(client1.id, docID, EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
 
-		require.NoError(t, rt.WaitForVersion("doc", version))
+		rt.WaitForVersion("doc", version)
 
 		// Confirm attachment is in the bucket
 		attachmentAKey := db.MakeAttachmentKey(2, docID, digest)
@@ -561,10 +548,8 @@ func TestBlipAttachNameChange(t *testing.T) {
 
 		// Simulate changing only the attachment name over CBL
 		// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
-		version, err = btcRunner.AddRev(client1.id, docID, &version, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
-		require.NoError(t, err)
-		err = client1.rt.WaitForVersion(docID, version)
-		require.NoError(t, err)
+		version = btcRunner.AddRev(client1.id, docID, &version, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
+		client1.rt.WaitForVersion(docID, version)
 
 		// Check if attachment is still in bucket
 		bucketAttachmentA, _, err = client1.rt.GetSingleDataStore().GetRaw(attachmentAKey)
@@ -608,9 +593,8 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 		docVersion := client1.GetDocVersion(docID)
 
 		// Store the document and attachment on the test client
-		_, err := btcRunner.AddRev(client1.id, docID, &docVersion, rawDoc)
+		_ = btcRunner.AddRev(client1.id, docID, &docVersion, rawDoc)
 		// FIXME CBG-4400: docID: doc was not found on the client - expecting to update doc based on parentVersion RevID: 1-5fc93bd36377008f96fdae2719c174ed
-		require.NoError(t, err)
 
 		btcRunner.AttachmentsLock(client1.id).Lock()
 		btcRunner.Attachments(client1.id)[digest] = attBody
@@ -624,11 +608,9 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 
 		// Simulate changing only the attachment name over CBL
 		// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
-		docVersion, err = btcRunner.AddRev(client1.id, "doc", &docVersion, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
-		require.NoError(t, err)
+		docVersion = btcRunner.AddRev(client1.id, "doc", &docVersion, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
 
-		err = client1.rt.WaitForVersion("doc", docVersion)
-		require.NoError(t, err)
+		client1.rt.WaitForVersion("doc", docVersion)
 
 		resp := client1.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
 		RequireStatus(t, resp, http.StatusOK)
@@ -672,8 +654,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 
 		// Store the document and attachment on the test client
 		// FIXME CBG-4400: docID: doc was not found on the client - expecting to update doc based on parentVersion RevID: 1-5fc93bd36377008f96fdae2719c174ed
-		_, err := btcRunner.AddRev(client1.id, docID, &version, rawDoc)
-		require.NoError(t, err)
+		_ = btcRunner.AddRev(client1.id, docID, &version, rawDoc)
 		btcRunner.AttachmentsLock(client1.id).Lock()
 		btcRunner.Attachments(client1.id)[digest] = attBody
 		btcRunner.AttachmentsLock(client1.id).Unlock()
@@ -686,11 +667,9 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 		require.EqualValues(t, bucketAttachmentA, attBody)
 
 		// Update the document, leaving body intact
-		version, err = btcRunner.AddRev(client1.id, "doc", &version, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(client1.id, "doc", &version, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
 
-		err = client1.rt.WaitForVersion("doc", version)
-		require.NoError(t, err)
+		client1.rt.WaitForVersion("doc", version)
 
 		resp := client1.rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/doc/%s", attName), "")
 		RequireStatus(t, resp, http.StatusOK)

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -125,7 +124,7 @@ func TestBlipGetCollections(t *testing.T) {
 				getCollectionsRequest, err := db.NewGetCollectionsMessage(testCase.requestBody)
 				require.NoError(t, err)
 
-				require.NoError(t, btc.pushReplication.sendMsg(getCollectionsRequest))
+				btc.pushReplication.sendMsg(getCollectionsRequest)
 
 				// Check that the response we got back was processed by the norev handler
 				resp := getCollectionsRequest.Response()
@@ -172,7 +171,7 @@ func TestBlipReplicationNoDefaultCollection(t *testing.T) {
 		subChangesRequest := blip.NewRequest()
 		subChangesRequest.SetProfile(db.MessageSubChanges)
 
-		require.NoError(t, btc.pullReplication.sendMsg(subChangesRequest))
+		btc.pullReplication.sendMsg(subChangesRequest)
 		resp := subChangesRequest.Response()
 		require.Equal(t, strconv.Itoa(http.StatusBadRequest), resp.Properties[db.BlipErrorCode])
 	})
@@ -208,7 +207,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 
 		require.NoError(t, err)
 
-		require.NoError(t, btc.pushReplication.sendMsg(getCollectionsRequest))
+		btc.pushReplication.sendMsg(getCollectionsRequest)
 
 		// Check that the response we got back was processed by the GetCollections
 		resp := getCollectionsRequest.Response()
@@ -227,7 +226,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 		requestGetCheckpoint.SetProfile(db.MessageGetCheckpoint)
 		requestGetCheckpoint.Properties[db.BlipClient] = checkpointID1
 		requestGetCheckpoint.Properties[db.BlipCollection] = "0"
-		require.NoError(t, btc.pushReplication.sendMsg(requestGetCheckpoint))
+		btc.pushReplication.sendMsg(requestGetCheckpoint)
 		resp = requestGetCheckpoint.Response()
 		require.NotNil(t, resp)
 		errorCode, hasErrorCode = resp.Properties[db.BlipErrorCode]
@@ -301,8 +300,7 @@ func TestBlipReplicationMultipleCollections(t *testing.T) {
 		}
 
 		for _, collectionClient := range btc.collectionClients {
-			resp, err := collectionClient.UnsubPullChanges()
-			assert.NoError(t, err, "Error unsubing: %+v", resp)
+			collectionClient.UnsubPullChanges()
 		}
 	})
 }
@@ -355,8 +353,7 @@ func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
 		}
 
 		for _, collectionClient := range btc.collectionClients {
-			resp, err := collectionClient.UnsubPullChanges()
-			assert.NoError(t, err, "Error unsubing: %+v", resp)
+			collectionClient.UnsubPullChanges()
 		}
 	})
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2265,7 +2265,7 @@ func TestBlipNorev(t *testing.T) {
 		// Request that the handler used to process the message is sent back in the response
 		norevMsg.Properties[db.SGShowHandler] = "true"
 
-		assert.NoError(t, btc.pushReplication.sendMsg(norevMsg.Message))
+		btc.pushReplication.sendMsg(norevMsg.Message)
 
 		// Check that the response we got back was processed by the norev handler
 		resp := norevMsg.Response()
@@ -2609,81 +2609,88 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 	testCases := []struct {
 		name                        string
 		inputBody                   map[string]interface{}
-		expectReject                bool
+		rejectMsg                   string
+		errorCode                   string
 		skipDocContentsVerification *bool
 	}{
 		{
-			name:         "Valid document",
-			inputBody:    map[string]interface{}{"document": "is valid"},
-			expectReject: false,
+			name:      "Valid document",
+			inputBody: map[string]interface{}{"document": "is valid"},
 		},
 		{
-			name:         "Valid document with special prop",
-			inputBody:    map[string]interface{}{"_cookie": "is valid"},
-			expectReject: false,
+			name:      "Valid document with special prop",
+			inputBody: map[string]interface{}{"_cookie": "is valid"},
 		},
 		{
-			name:         "Invalid _sync",
-			inputBody:    map[string]interface{}{"_sync": true},
-			expectReject: true,
+			name:      "Invalid _sync",
+			inputBody: map[string]interface{}{"_sync": true},
+			errorCode: "404",
+			rejectMsg: "top-level property '_sync' is a reserved internal property",
 		},
 		{
-			name:         "Valid _id",
-			inputBody:    map[string]interface{}{"_id": "documentid"},
-			expectReject: true,
+			name:      "Valid _id",
+			inputBody: map[string]interface{}{"_id": "documentid"},
+			errorCode: "404",
+			rejectMsg: "top-level property '_id' is a reserved internal property",
 		},
 		{
-			name:         "Valid _rev",
-			inputBody:    map[string]interface{}{"_rev": "1-abc"},
-			expectReject: true,
+			name:      "Valid _rev",
+			inputBody: map[string]interface{}{"_rev": "1-abc"},
+			errorCode: "404",
+			rejectMsg: "top-level property '_rev' is a reserved internal property",
 		},
 		{
-			name:         "Valid _deleted",
-			inputBody:    map[string]interface{}{"_deleted": false},
-			expectReject: true,
+			name:      "Valid _deleted",
+			inputBody: map[string]interface{}{"_deleted": false},
+			errorCode: "404",
+			rejectMsg: "top-level property '_deleted' is a reserved internal property",
 		},
 		{
-			name:         "Invalid _attachments",
-			inputBody:    map[string]interface{}{"_attachments": false},
-			expectReject: true,
+			name:      "Invalid _attachments",
+			inputBody: map[string]interface{}{"_attachments": false},
+			errorCode: "400",
+			rejectMsg: "Invalid _attachments",
 		},
 		{
 			name:                        "Valid _attachments",
 			inputBody:                   map[string]interface{}{"_attachments": map[string]interface{}{"attch": map[string]interface{}{"data": "c2d3IGZ0dw=="}}},
-			expectReject:                false,
 			skipDocContentsVerification: base.BoolPtr(true),
 		},
 		{
 			name:                        "_revisions",
 			inputBody:                   map[string]interface{}{"_revisions": false},
-			expectReject:                true,
 			skipDocContentsVerification: base.BoolPtr(true),
+			rejectMsg:                   "top-level property '_revisions' is a reserved internal property",
+			errorCode:                   "404",
 		},
 		{
 			name:                        "Valid _exp",
 			inputBody:                   map[string]interface{}{"_exp": "123"},
-			expectReject:                false,
 			skipDocContentsVerification: base.BoolPtr(true),
 		},
 		{
-			name:         "Invalid _exp",
-			inputBody:    map[string]interface{}{"_exp": "abc"},
-			expectReject: true,
+			name:      "Invalid _exp",
+			inputBody: map[string]interface{}{"_exp": "abc"},
+			errorCode: "400",
+			rejectMsg: "Unable to parse expiry",
 		},
 		{
-			name:         "_purged",
-			inputBody:    map[string]interface{}{"_purged": false},
-			expectReject: true,
+			name:      "_purged",
+			inputBody: map[string]interface{}{"_purged": false},
+			rejectMsg: "user defined top-level property '_purged' is not allowed",
+			errorCode: "400",
 		},
 		{
-			name:         "_removed",
-			inputBody:    map[string]interface{}{"_removed": false},
-			expectReject: true,
+			name:      "_removed",
+			inputBody: map[string]interface{}{"_removed": false},
+			rejectMsg: "revision is not accessible",
+			errorCode: "404",
 		},
 		{
-			name:         "_sync_cookies",
-			inputBody:    map[string]interface{}{"_sync_cookies": true},
-			expectReject: true,
+			name:      "_sync_cookies",
+			inputBody: map[string]interface{}{"_sync_cookies": true},
+			rejectMsg: "user defined top-level properties that start with '_sync_' are not allowed",
+			errorCode: "400",
 		},
 		{
 			name: "Valid user defined uppercase properties", // Uses internal properties names but in upper case
@@ -2692,7 +2699,6 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 				"_ID": true, "_REV": true, "_DELETED": true, "_ATTACHMENTS": true, "_REVISIONS": true,
 				"_EXP": true, "_PURGED": true, "_REMOVED": true, "_SYNC_COOKIES": true,
 			},
-			expectReject: false,
 		},
 	}
 
@@ -2720,15 +2726,24 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 				require.NoError(t, err)
 
 				// push each rev manually so we can error check the replication synchronously
-				_, err = btcRunner.PushUnsolicitedRev(client.id, docID, nil, rawBody)
-				if test.expectReject {
-					assert.Error(t, err)
+				revRequest := blip.NewRequest()
+				revRequest.SetProfile(db.MessageRev)
+				revRequest.Properties[db.RevMessageID] = docID
+				revRequest.Properties[db.RevMessageRev] = "1-abc" // use a fake rev
+				revRequest.SetBody(rawBody)
+				client.addCollectionProperty(revRequest)
+				client.pushReplication.sendMsg(revRequest)
+				resp := revRequest.Response()
+				respBody, err := resp.Body()
+				require.NoError(t, err)
+				if test.rejectMsg != "" {
+					require.Contains(t, string(respBody), test.rejectMsg)
+					require.Equal(t, test.errorCode, resp.Properties["Error-Code"])
 					return
 				}
-				require.NoError(t, err)
+				require.Len(t, respBody, 0, "Expected nil response body got %s", string(respBody))
 
 				// Wait for rev to be received on RT
-				rt.WaitForPendingChanges()
 				changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "", true)
 				require.NoError(t, err)
 
@@ -2789,8 +2804,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	defer func() { require.NoError(t, ar.Stop()) }()
 
 	activeRT.WaitForPendingChanges()
-	err = activeRT.WaitForVersion(docID, version)
-	require.NoError(t, err)
+	activeRT.WaitForVersion(docID, version)
 
 	base.RequireWaitForStat(t, pullStats.HandleRevCount.Value, 1)
 	assert.NotEqualValues(t, 0, pullStats.HandleRevBytes.Value())
@@ -2958,9 +2972,7 @@ func TestUnsubChanges(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 		// Confirm no error message or panic is returned in response
-		response, err := btcRunner.UnsubPullChanges(btc.id)
-		assert.NoError(t, err)
-		assert.Empty(t, response)
+		btcRunner.UnsubPullChanges(btc.id)
 
 		// Sub changes
 		btcRunner.StartPull(btc.id)
@@ -2972,24 +2984,20 @@ func TestUnsubChanges(t *testing.T) {
 		require.EqualValues(t, 1, activeReplStat.Value())
 
 		// Unsub changes
-		response, err = btcRunner.UnsubPullChanges(btc.id)
-		assert.NoError(t, err)
-		assert.Empty(t, response)
+		btcRunner.UnsubPullChanges(btc.id)
 		// Wait for unsub changes to stop the sub changes being sent before sending document up
 		base.RequireWaitForStat(t, activeReplStat.Value, 0)
 
 		// Confirm no more changes are being sent
 		doc2Version := rt.PutDocDirectly(doc2ID, db.Body{"key": "val1"})
-		err = rt.WaitForConditionWithOptions(func() bool {
+		err := rt.WaitForConditionWithOptions(func() bool {
 			_, found := btcRunner.GetVersion(btc.id, "doc2", doc2Version)
 			return found
 		}, 10, 100)
 		assert.Error(t, err)
 
 		// Confirm no error message is still returned when no subchanges active
-		response, err = btcRunner.UnsubPullChanges(btc.id)
-		assert.NoError(t, err)
-		assert.Empty(t, response)
+		btcRunner.UnsubPullChanges(btc.id)
 
 		// Confirm the pull replication can be restarted and it syncs doc2
 		btcRunner.StartPull(btc.id)
@@ -3174,9 +3182,7 @@ func TestBlipRefreshUser(t *testing.T) {
 		unsubChangesRequest := blip.NewRequest()
 		unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
 		btc.addCollectionProperty(unsubChangesRequest)
-
-		err := btc.pullReplication.sendMsg(unsubChangesRequest)
-		require.NoError(t, err)
+		btc.pullReplication.sendMsg(unsubChangesRequest)
 
 		testResponse := unsubChangesRequest.Response()
 		require.Equal(t, strconv.Itoa(db.CBLReconnectErrorCode), testResponse.Properties[db.BlipErrorCode])

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -52,16 +52,14 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 		btcRunner.StartPush(btc.id)
 
 		// Push first rev
-		version, err := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
-		require.NoError(t, err)
+		version := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
 
 		// Push second rev with an attachment (no delta yet)
 		attData := base64.StdEncoding.EncodeToString([]byte("attach"))
 
-		version, err = btcRunner.AddRev(btc.id, docID, &version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
 
-		require.NoError(t, rt.WaitForVersion(docID, version))
+		rt.WaitForVersion(docID, version)
 
 		collection, ctx := rt.GetSingleTestDatabaseCollection()
 		syncData, err := collection.GetDocSyncData(ctx, docID)
@@ -81,10 +79,9 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 		newBody, err := base.InjectJSONPropertiesFromBytes(body, base.KVPairBytes{Key: "update", Val: []byte(`true`)})
 		require.NoError(t, err)
 
-		version, err = btcRunner.AddRev(btc.id, docID, &version, newBody)
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, newBody)
 
-		require.NoError(t, rt.WaitForVersion(docID, version))
+		rt.WaitForVersion(docID, version)
 
 		syncData, err = collection.GetDocSyncData(ctx, docID)
 		require.NoError(t, err)
@@ -141,8 +138,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 
 		// Update the replicated doc at client by adding another attachment.
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="},"world.txt":{"data":"bGVsbG8gd29ybGQ="}}}`
-		version, err := btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
 
 		// Wait for the document to be replicated at SG
 		btc.pushReplication.WaitForMessage(2)
@@ -867,8 +863,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 		// create doc1 rev 2-abc on client
-		newRev, err := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-		assert.NoError(t, err)
+		newRev := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 
 		// Check EE is delta, and CE is full-body replication
 		msg := client.waitForReplicationMessage(collection, 2)
@@ -916,7 +911,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 			deltaPushDocCountStart = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
 		}
 
-		_, err = btcRunner.PushUnsolicitedRev(client.id, docID, &deletedVersion, []byte(`{"undelete":true}`))
+		_, err := btcRunner.PushUnsolicitedRev(client.id, docID, &deletedVersion, []byte(`{"undelete":true}`))
 
 		if base.IsEnterpriseEdition() && sgCanUseDeltas {
 			// Now make the client push up a delta that has the parent of the tombstone.
@@ -974,8 +969,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 		// create doc1 rev 2-abcxyz on client
-		newRev, err := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-		assert.NoError(t, err)
+		newRev := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 		// Check EE is delta, and CE is full-body replication
 		msg := client.waitForReplicationMessage(collection, 2)
 

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -69,10 +69,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 		go func() {
 			for i := 0; shouldCreateDocs.IsTrue(); i++ {
 				// this will begin to error when the database is reloaded underneath the replication
-				_, err := btcRunner.AddRev(client.id, fmt.Sprintf("doc%d", i), EmptyDocVersion(), []byte(fmt.Sprintf(`{"i":%d}`, i)))
-				if err != nil {
-					lastPushRevErr.Store(err)
-				}
+				_ = btcRunner.AddRev(client.id, fmt.Sprintf("doc%d", i), EmptyDocVersion(), []byte(fmt.Sprintf(`{"i":%d}`, i)))
 			}
 			rt.WaitForPendingChanges()
 			wg.Done()

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -52,11 +52,10 @@ func TestBlipClientPushAndPullReplication(t *testing.T) {
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
 		// update doc1 on client
-		_, err := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-		assert.NoError(t, err)
+		_ = btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 
 		// wait for update to arrive on SG
-		_, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", seq), "", true)
+		_, err := rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", seq), "", true)
 		require.NoError(t, err)
 
 		body := rt.GetDocBody(docID)

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -222,7 +222,7 @@ func TestProcessLegacyRev(t *testing.T) {
 	sent, _, _, err := bt.SendRevWithHistory("doc1", "2-bcd", history, []byte(`{"key": "val"}`), blip.Properties{})
 	assert.True(t, sent)
 	assert.NoError(t, err)
-	require.NoError(t, rt.WaitForVersion("doc1", DocVersion{RevTreeID: "2-bcd"}))
+	rt.WaitForVersion("doc1", DocVersion{RevTreeID: "2-bcd"})
 
 	// assert we can fetch this doc rev
 	resp := rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1?rev=2-bcd", "")
@@ -242,7 +242,7 @@ func TestProcessLegacyRev(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	require.NoError(t, rt.WaitForVersion("foo", DocVersion{RevTreeID: "1-abc"}))
+	rt.WaitForVersion("foo", DocVersion{RevTreeID: "1-abc"})
 	// assert we can fetch this doc rev
 	resp = rt.SendAdminRequest("GET", "/{{.keyspace}}/foo?rev=1-abc", "")
 	RequireStatus(t, resp, 200)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -16,10 +16,12 @@ import (
 	"net/url"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -127,30 +129,24 @@ func (rt *RestTester) GetDatabaseRoot(dbname string) DatabaseRoot {
 }
 
 // WaitForVersion retries a GET for a given document version until it returns 200 or 201 for a given document and revision. If version is not found, the test will fail.
-func (rt *RestTester) WaitForVersion(docID string, version DocVersion) error {
+func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 	if version.RevTreeID == "" {
 		require.NotEqualf(rt.TB(), "", version.CV.String(), "Expeted CV if RevTreeID is empty in WaitForVersion")
 	}
-	return rt.WaitForCondition(func() bool {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID+"?show_cv=true", "")
-		if rawResponse.Code != 200 && rawResponse.Code != 201 {
-			return false
+		if !assert.Contains(c, []int{http.StatusOK, http.StatusCreated}, rawResponse.Code) {
+			return
 		}
 		var body db.Body
 		require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
-		if version.RevTreeID != "" && body.ExtractRev() != version.RevTreeID {
-			return false
+		if version.RevTreeID != "" {
+			assert.Equal(c, version.RevTreeID, body.ExtractRev())
 		}
-		if !version.CV.IsEmpty() && body["_cv"].(string) != version.CV.String() {
-			return false
+		if !version.CV.IsEmpty() {
+			assert.Equal(c, version.CV.String(), body["_cv"].(string))
 		}
-		return true
-	})
-}
-
-// WaitForRev retries a GET until it returns 200 or 201. If revision is not found, the test will fail. This function is deprecated for RestTester.WaitForVersion
-func (rt *RestTester) WaitForRev(docID, revID string) error {
-	return rt.WaitForVersion(docID, DocVersion{RevTreeID: revID})
+	}, 10*time.Second, 50*time.Millisecond)
 }
 
 func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string, error) {

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -247,8 +247,7 @@ func (r *CouchbaseLiteMockReplication) Start() {
 // Stop halts the replication. The replication can be restarted after it is stopped.
 func (r *CouchbaseLiteMockReplication) Stop() {
 	r.btc.TB().Logf("stopping CBL replication: %s", r)
-	_, err := r.btcRunner.UnsubPullChanges(r.btc.ID())
-	require.NoError(r.btcRunner.TB(), err)
+	r.btcRunner.UnsubPullChanges(r.btc.ID())
 }
 
 func (r *CouchbaseLiteMockReplication) String() string {


### PR DESCRIPTION
The overall motivations are to make the code easier to debug by putting the error with a stack trace where the error hits, rather than in the returned code and need to use a debugger to trace it.

Feel free to not take this PR, I did this while working on a separate ticket where I got foiled by some of these errors.

- Change functions that check for errors to enforce with `require` statements
- Change `TestBlipInternalPropertiesHandling` to check for specific error messages, before it was hitting errors in `_attachments` from `PushUnsolicitedRev` that weren't from server
- fiddle with attachment handling code to enforce errors more clearly for debugging if `_attachments` block is ill formatted, rather than just skipping an attachment.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2882/
