### PR TITLE
CBG-4402 do not terminate attachment migration error on document deletion

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -2127,6 +2127,9 @@ Attachment-Migration-status:
     docs_processed:
       description: The amount of docs that have been processed through the attachment migration operation.
       type: integer
+    docs_failed:
+      description: The amount of docs that have failed to be processed through the attachment migration operation.
+      type: integer
   required:
     - status
     - start_time


### PR DESCRIPTION
A deleted document should not even be processed, before it would error in `UnmarshalDocumentSyncDataFromFeed`.

I also changed the code so that it doesn't error the job, but just skips processing this document. In the case that a document has invalid `_sync` data, I think other documents shouldn't also fail.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2883/
