### PR TITLE
CBG-4407 synchronously stop xdcr from CBS

### DIFF
--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -123,6 +123,7 @@ if [ "${MULTI_NODE:-}" == "true" ]; then
 else
     # single node
     ./integration-test/start_server.sh "${COUCHBASE_SERVER_VERSION}"
+    export SG_TEST_COUCHBASE_SERVER_DOCKER_NAME="couchbase"
 fi
 
 # Set up test environment variables for CBS runs


### PR DESCRIPTION
This increases the time of the XDCR package by about 20% on my computer.

Greps the `goxdcr.log` file for the magic string. Tested on local Linux, docker linux, cbdinocluster multi node setup (where this is not supported). I can not successfully run Couchbase Server on Mac for reasons that are not related to this ticket and I am reluctant to sink more time into debugging right now.

This will require setting `export SG_TEST_COUCHBASE_SERVER_DOCKER_NAME="couchbase"` if couchbase server docker is used, but the error message should say that.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2887/
