### PR TITLE
CBG-4418 Assert on full HLV in topology tests

### DIFF
--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -187,22 +188,15 @@ func (hlv *HybridLogicalVector) Equals(other *HybridLogicalVector) bool {
 	if hlv.Version != other.Version {
 		return false
 	}
-	if len(hlv.PreviousVersions) != len(other.PreviousVersions) {
+
+	if !maps.Equal(hlv.PreviousVersions, other.PreviousVersions) {
 		return false
 	}
-	for k, v := range hlv.PreviousVersions {
-		if other.PreviousVersions[k] != v {
-			return false
-		}
-	}
-	if len(hlv.MergeVersions) != len(other.MergeVersions) {
+
+	if !maps.Equal(hlv.MergeVersions, other.MergeVersions) {
 		return false
 	}
-	for k, v := range hlv.MergeVersions {
-		if other.MergeVersions[k] != v {
-			return false
-		}
-	}
+
 	return true
 }
 
@@ -234,7 +228,7 @@ func (hlv *HybridLogicalVector) DominatesSource(version Version) bool {
 
 }
 
-// AddVersion adds newVersion to the in memory representation of the HLV.
+// AddVersion adds newVersion as the current version to the in memory representation of the HLV.
 func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	var newVersionCAS uint64
 	hlvVersionCAS := hlv.Version
@@ -275,9 +269,7 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 	}
 
 	// If new version already exists PV, need to remove it
-	if _, ok := hlv.PreviousVersions[newVersion.SourceID]; ok {
-		delete(hlv.PreviousVersions, newVersion.SourceID)
-	}
+	delete(hlv.PreviousVersions, newVersion.SourceID)
 
 	hlv.Version = newVersion.Value
 	hlv.SourceID = newVersion.SourceID

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -180,6 +180,32 @@ func NewHybridLogicalVector() *HybridLogicalVector {
 	}
 }
 
+func (hlv *HybridLogicalVector) Equals(other *HybridLogicalVector) bool {
+	if hlv.SourceID != other.SourceID {
+		return false
+	}
+	if hlv.Version != other.Version {
+		return false
+	}
+	if len(hlv.PreviousVersions) != len(other.PreviousVersions) {
+		return false
+	}
+	for k, v := range hlv.PreviousVersions {
+		if other.PreviousVersions[k] != v {
+			return false
+		}
+	}
+	if len(hlv.MergeVersions) != len(other.MergeVersions) {
+		return false
+	}
+	for k, v := range hlv.MergeVersions {
+		if other.MergeVersions[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
 // GetCurrentVersion returns the current version from the HLV in memory.
 func (hlv *HybridLogicalVector) GetCurrentVersion() (string, uint64) {
 	return hlv.SourceID, hlv.Version
@@ -247,6 +273,12 @@ func (hlv *HybridLogicalVector) AddVersion(newVersion Version) error {
 		// source doesn't exist in PV so add
 		hlv.PreviousVersions[hlv.SourceID] = hlv.Version
 	}
+
+	// If new version already exists PV, need to remove it
+	if _, ok := hlv.PreviousVersions[newVersion.SourceID]; ok {
+		delete(hlv.PreviousVersions, newVersion.SourceID)
+	}
+
 	hlv.Version = newVersion.Value
 	hlv.SourceID = newVersion.SourceID
 	return nil

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -133,8 +133,7 @@ func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName,
 		if !assert.NotNil(c, actual, "Could not find docID:%+v on %p\nVersion %#v", docID, p, expected) {
 			return
 		}
-		assert.True(c, actual.IsHLVEqual(expected), "Actual HLV does not match expected on %s for peer %s.  Expected: %s, Actual: %s", docID, p, expected.HLV, actual.HLV)
-		assert.Equal(c, expected.CV(c), actual.CV(c), "Could not find matching CV on %s for peer %s (sourceID:%s)\nexpected: %#v\nactual:   %#v\n          body: %+v\n", docID, p, p.SourceID(), expected, actual, string(data))
+		assert.True(c, actual.IsHLVEqual(expected), "Actual HLV does not match expected on %s for peer %s.  Expected: %#v, Actual: %#v", docID, p, expected.HLV, actual.HLV)
 	}, totalWaitTime, pollInterval)
 	var body db.Body
 	require.NoError(p.TB(), base.JSONUnmarshal(data, &body))

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -133,6 +133,7 @@ func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName,
 		if !assert.NotNil(c, actual, "Could not find docID:%+v on %p\nVersion %#v", docID, p, expected) {
 			return
 		}
+		assert.True(c, actual.IsHLVEqual(expected), "Actual HLV does not match expected on %s for peer %s.  Expected: %s, Actual: %s", docID, p, expected.HLV, actual.HLV)
 		assert.Equal(c, expected.CV(c), actual.CV(c), "Could not find matching CV on %s for peer %s (sourceID:%s)\nexpected: %#v\nactual:   %#v\n          body: %+v\n", docID, p, p.SourceID(), expected, actual, string(data))
 	}, totalWaitTime, pollInterval)
 	var body db.Body

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -188,8 +188,6 @@ func (p *CouchbaseServerPeer) waitForDocVersion(dsName sgbucket.DataStoreName, d
 		// have to use p.tb instead of c because of the assert.CollectT doesn't implement TB
 		version = getDocVersion(docID, p, cas, xattrs)
 		assert.True(c, version.IsHLVEqual(expected), "Actual HLV does not match expected on %s for peer %s.  Expected: %#v, Actual: %#v", docID, p, expected, version)
-		assert.Equal(c, expected.CV(c), version.CV(c), "Could not find matching CV on %s for peer %s\nexpected: %#v\nactual:   %#v\n          body: %#v\n", docID, p, expected, version, string(docBytes))
-
 	}, totalWaitTime, pollInterval)
 	return docBytes
 }

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -128,8 +128,11 @@ func (p *CouchbaseServerPeer) WriteDocument(dsName sgbucket.DataStoreName, docID
 	p.tb.Logf("%s: Writing document %s", p, docID)
 	var lastXattrs map[string][]byte
 	// write the document LWW, ignoring any in progress writes
-	callback := func(_ []byte, xattrs map[string][]byte, _ uint64) (sgbucket.UpdatedDoc, error) {
-		lastXattrs = xattrs
+	callback := func(existingBody []byte, xattrs map[string][]byte, _ uint64) (sgbucket.UpdatedDoc, error) {
+		// only set lastXattrs if existing document is not a tombstone, they will not be preserved if this is a resurrection
+		if len(existingBody) > 0 {
+			lastXattrs = xattrs
+		}
 		return sgbucket.UpdatedDoc{Doc: body}, nil
 	}
 	cas, err := p.getCollection(dsName).WriteUpdateWithXattrs(p.Context(), docID, metadataXattrNames, 0, nil, nil, callback)
@@ -143,6 +146,7 @@ func (p *CouchbaseServerPeer) WriteDocument(dsName sgbucket.DataStoreName, docID
 
 // DeleteDocument deletes a document on the peer. The test will fail if the document does not exist.
 func (p *CouchbaseServerPeer) DeleteDocument(dsName sgbucket.DataStoreName, docID string) DocMetadata {
+	p.tb.Logf("%s: Deleting document %s", p, docID)
 	// delete the document, ignoring any in progress writes. We are allowed to delete a document that does not exist.
 	var lastXattrs map[string][]byte
 	// write the document LWW, ignoring any in progress writes
@@ -183,6 +187,7 @@ func (p *CouchbaseServerPeer) waitForDocVersion(dsName sgbucket.DataStoreName, d
 		}
 		// have to use p.tb instead of c because of the assert.CollectT doesn't implement TB
 		version = getDocVersion(docID, p, cas, xattrs)
+		assert.True(c, version.IsHLVEqual(expected), "Actual HLV does not match expected on %s for peer %s.  Expected: %#v, Actual: %#v", docID, p, expected, version)
 		assert.Equal(c, expected.CV(c), version.CV(c), "Could not find matching CV on %s for peer %s\nexpected: %#v\nactual:   %#v\n          body: %#v\n", docID, p, expected, version, string(docBytes))
 
 	}, totalWaitTime, pollInterval)
@@ -306,7 +311,6 @@ func getDocVersion(docID string, peer Peer, cas uint64, xattrs map[string][]byte
 			docVersion.ImplicitHLV = db.NewHybridLogicalVector()
 		} else {
 			require.NoError(peer.TB(), json.Unmarshal(hlvBytes, &docVersion.ImplicitHLV))
-			docVersion.ImplicitHLV = docVersion.HLV
 		}
 		require.NoError(peer.TB(), docVersion.ImplicitHLV.AddVersion(db.Version{SourceID: peer.SourceID(), Value: cas}))
 	}

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -95,7 +95,7 @@ func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		}
 		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, peerName, topologyDescription))
 		docVersion := peer.CreateDocument(dsName, docID, docBody)
-		t.Logf("createVersion: %+v", docVersion.docMeta)
+		t.Logf("createVersion: %#v", docVersion.docMeta)
 		documentVersion = append(documentVersion, docVersion)
 	}
 	index := len(documentVersion) - 1
@@ -115,7 +115,7 @@ func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		}
 		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "update"}`, peerName, topologyDescription))
 		docVersion := peer.WriteDocument(dsName, docID, docBody)
-		t.Logf("updateVersion: %+v", docVersion.docMeta)
+		t.Logf("updateVersion: %#v", docVersion.docMeta)
 		documentVersion = append(documentVersion, docVersion)
 	}
 	index := len(documentVersion) - 1
@@ -134,7 +134,7 @@ func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers 
 			continue
 		}
 		deleteVersion := peer.DeleteDocument(dsName, docID)
-		t.Logf("deleteVersion: %+v", deleteVersion)
+		t.Logf("deleteVersion: %#v", deleteVersion)
 		documentVersion = append(documentVersion, BodyAndVersion{docMeta: deleteVersion, updatePeer: peerName})
 	}
 	index := len(documentVersion) - 1

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -30,7 +30,7 @@ import (
 var totalWaitTime = 3 * time.Second
 
 // pollInterval is the time to poll to see if a document is updated on a peer
-var pollInterval = 50 * time.Millisecond
+var pollInterval = 1 * time.Millisecond
 
 func init() {
 	if !base.UnitTestUrlIsWalrus() || raceEnabled {

--- a/topologytest/single_actor_test.go
+++ b/topologytest/single_actor_test.go
@@ -56,7 +56,7 @@ func TestSingleActorUpdate(t *testing.T) {
 
 					body2 := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "update"}`, activePeerID, topology.description))
 					updateVersion := activePeer.WriteDocument(collectionName, docID, body2)
-					t.Logf("createVersion: %+v, updateVersion: %+v", createVersion.docMeta, updateVersion.docMeta)
+					t.Logf("createVersion: %#v, updateVersion: %#v", createVersion.docMeta, updateVersion.docMeta)
 					t.Logf("waiting for document version 2 on all peers")
 
 					waitForVersionAndBody(t, collectionName, peers, docID, updateVersion)

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -38,6 +38,27 @@ func (v DocMetadata) CV(t require.TestingT) db.Version {
 	return db.Version{}
 }
 
+func (v DocMetadata) IsHLVEqual(other DocMetadata) bool {
+	if v.ImplicitHLV != nil {
+		return other.hlvEquals(v.ImplicitHLV)
+	} else if v.HLV != nil {
+		return other.hlvEquals(v.HLV)
+	} else {
+		return other.ImplicitHLV == nil && other.HLV == nil
+	}
+}
+
+func (v DocMetadata) hlvEquals(hlv *db.HybridLogicalVector) bool {
+	if v.ImplicitHLV != nil {
+		return v.ImplicitHLV.Equals(hlv)
+	} else if v.HLV != nil {
+		return v.HLV.Equals(hlv)
+	} else {
+		return hlv == nil
+	}
+
+}
+
 // DocMetadataFromDocument returns a DocVersion from the given document.
 func DocMetadataFromDocument(doc *db.Document) DocMetadata {
 	return DocMetadata{


### PR DESCRIPTION
CBG-4418

Modify waitForVersionAndBody to wait for and assert on full HLV instead of cv only.

Includes additional fixes required to get tests passing when checking full HLV:
- When calling HLV.AddVersion, remove existing entry for source from PV (when present)
- in CouchbaseServerPeer.WriteDocument, do not populate lastXattrs for document resurrection case (Couchbase doesn't preserve xattrs on resurrection)
- in getDocVersion (peer tests), remove unnecessary copy of HLV (previous HLV is being directly unmarshalled into Implicit HLV)

Also reduces pollInterval for topology tests to reduce test execution time (avoids minimum required wait time for each check).

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
