### PR TITLE
CBG-4374: [3.2.2 backport] implement flusher interface 

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2892,3 +2892,32 @@ func TestAllDbs(t *testing.T) {
 	RequireStatus(t, resp, http.StatusOK)
 	require.Equal(t, fmt.Sprintf(`[{"db_name":"%s","bucket":"%s","state":"Online"}]`, rt.GetDatabase().Name, rt.GetDatabase().Bucket.GetName()), resp.Body.String())
 }
+
+// TestBufferFlush will test for http.ResponseWriter implements Flusher interface
+func TestBufferFlush(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
+	})
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+
+	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
+
+	// Create a test user
+	user, err := a.NewUser("foo", "letmein", channels.BaseSetOf(t, "foo"))
+	require.NoError(t, err)
+	require.NoError(t, a.Save(user))
+
+	var wg sync.WaitGroup
+	var resp *TestResponse
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		resp = rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=continuous&since=0&timeout=500&include_docs=true", "", "foo")
+		RequireStatus(t, resp, http.StatusOK)
+	}()
+	wg.Wait()
+
+	// assert that the response is a flushed response
+	assert.True(t, resp.Flushed)
+}

--- a/rest/counted_response_writer.go
+++ b/rest/counted_response_writer.go
@@ -92,3 +92,7 @@ func (w *CountedResponseWriter) isHijackable() bool {
 	_, ok := w.writer.(http.Hijacker)
 	return ok
 }
+
+func (w *CountedResponseWriter) Flush() {
+	w.writer.(http.Flusher).Flush()
+}

--- a/rest/counted_response_writer_test.go
+++ b/rest/counted_response_writer_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -168,4 +169,18 @@ func TestCountableResponseWriterWithDelay(t *testing.T) {
 		})
 	}
 
+}
+
+func TestResponseWriterSupportsFLush(t *testing.T) {
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+
+			stat, err := base.NewIntStat(base.SubsystemDatabaseKey, "http_bytes_written", base.StatUnitBytes, base.PublicRestBytesWrittenDesc, base.StatAddedVersion3dot1dot0, base.StatDeprecatedVersionNotDeprecated, base.StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+			require.NoError(t, err)
+			responseWriter := getResponseWriter(t, stat, test.name, 0)
+
+			_, ok := responseWriter.(http.Flusher)
+			assert.True(t, ok)
+		})
+	}
 }

--- a/rest/non_counted_response_writer.go
+++ b/rest/non_counted_response_writer.go
@@ -45,3 +45,7 @@ func (w *NonCountedResponseWriter) isHijackable() bool {
 	_, ok := w.ResponseWriter.(http.Hijacker)
 	return ok
 }
+
+func (w *NonCountedResponseWriter) Flush() {
+	w.ResponseWriter.(http.Flusher).Flush()
+}


### PR DESCRIPTION

CBG-4374

- backport of #7256

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
