### PR TITLE
CBG-4203 pass RevSeqNo for on demand imports

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -54,10 +54,6 @@ func (c *DatabaseCollection) getRevSeqNo(ctx context.Context, docID string) (rev
 	if err != nil {
 		return 0, 0, err
 	}
-	// CBG-4233: revSeqNo not implemented yet in rosmar
-	if c.dbCtx.BucketSpec.IsWalrusBucket() {
-		return 0, cas, err
-	}
 	revSeqNo, err = unmarshalRevSeqNo(xattrs[base.VirtualXattrRevSeqNo])
 	return revSeqNo, cas, err
 }

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -239,7 +239,7 @@ func (c *DatabaseCollection) unsupportedOptions() *UnsupportedOptions {
 
 // syncGlobalSyncAndUserXattrKeys returns the xattr keys for the user and sync xattrs.
 func (c *DatabaseCollection) syncGlobalSyncAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.GlobalXattrName, base.VirtualXattrRevSeqNo}
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.GlobalXattrName}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)
@@ -251,7 +251,7 @@ func (c *DatabaseCollection) syncGlobalSyncAndUserXattrKeys() []string {
 func (c *DatabaseCollection) syncGlobalSyncMouRevSeqNoAndUserXattrKeys() []string {
 	xattrKeys := []string{base.SyncXattrName, base.VvXattrName}
 	if c.useMou() {
-		xattrKeys = append(xattrKeys, base.MouXattrName, base.VirtualXattrRevSeqNo, base.GlobalXattrName)
+		xattrKeys = append(xattrKeys, base.MouXattrName, base.GlobalXattrName)
 	}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -239,7 +239,7 @@ func (c *DatabaseCollection) unsupportedOptions() *UnsupportedOptions {
 
 // syncGlobalSyncAndUserXattrKeys returns the xattr keys for the user and sync xattrs.
 func (c *DatabaseCollection) syncGlobalSyncAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.GlobalXattrName}
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.GlobalXattrName, base.VirtualXattrRevSeqNo}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)

--- a/db/document.go
+++ b/db/document.go
@@ -430,14 +430,19 @@ func unmarshalDocument(docid string, data []byte) (*Document, error) {
 	return doc, nil
 }
 
-func unmarshalDocumentWithXattrs(ctx context.Context, docid string, data, syncXattrData, hlvXattrData, mouXattrData, userXattrData, virtualXattr []byte, globalSyncData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
-
+func unmarshalDocumentWithXattrs(ctx context.Context, docid string, data, syncXattrData, hlvXattrData, mouXattrData, userXattrData, revSeqNo []byte, globalSyncData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 	if len(syncXattrData) == 0 && len(hlvXattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
+		if doc != nil {
+			doc.RevSeqNo, err = unmarshalRevSeqNo(revSeqNo)
+			if err != nil {
+				return nil, pkgerrors.WithStack(base.RedactErrorf("Failed convert rev seq number during UnmarshalWithXattrs() doc with id: %s. Error: %v", base.UD(doc.ID), err))
+			}
+		}
 	} else {
 		doc = NewDocument(docid)
-		err = doc.UnmarshalWithXattrs(ctx, data, syncXattrData, hlvXattrData, virtualXattr, globalSyncData, unmarshalLevel)
+		err = doc.UnmarshalWithXattrs(ctx, data, syncXattrData, hlvXattrData, revSeqNo, globalSyncData, unmarshalLevel)
 	}
 	if err != nil {
 		return nil, err
@@ -1117,7 +1122,7 @@ func (doc *Document) MarshalJSON() (data []byte, err error) {
 // unmarshalLevel is anything less than the full document + metadata, the raw data is retained for subsequent
 // lazy unmarshalling as needed.
 // Must handle cases where document body and hlvXattrData are present without syncXattrData for all DocumentUnmarshalLevel
-func (doc *Document) UnmarshalWithXattrs(ctx context.Context, data, syncXattrData, hlvXattrData, virtualXattr []byte, globalSyncData []byte, unmarshalLevel DocumentUnmarshalLevel) error {
+func (doc *Document) UnmarshalWithXattrs(ctx context.Context, data, syncXattrData, hlvXattrData, revSeqNo []byte, globalSyncData []byte, unmarshalLevel DocumentUnmarshalLevel) error {
 	if doc.ID == "" {
 		base.WarnfCtx(ctx, "Attempted to unmarshal document without ID set")
 		return errors.New("Document was unmarshalled without ID set")
@@ -1140,18 +1145,11 @@ func (doc *Document) UnmarshalWithXattrs(ctx context.Context, data, syncXattrDat
 				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal HLV during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), err))
 			}
 		}
-		if virtualXattr != nil {
-			var revSeqNo string
-			err := base.JSONUnmarshal(virtualXattr, &revSeqNo)
+		if revSeqNo != nil {
+			var err error
+			doc.RevSeqNo, err = unmarshalRevSeqNo(revSeqNo)
 			if err != nil {
-				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal doc virtual revSeqNo xattr during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), err))
-			}
-			if revSeqNo != "" {
-				revNo, err := strconv.ParseUint(revSeqNo, 10, 64)
-				if err != nil {
-					return pkgerrors.WithStack(base.RedactErrorf("Failed convert rev seq number %q during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", revSeqNo, base.UD(doc.ID), err))
-				}
-				doc.RevSeqNo = revNo
+				return pkgerrors.WithStack(base.RedactErrorf("Failed to unmarshal RevSeqNo during UnmarshalWithXattrs() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), err))
 			}
 		}
 		if len(globalSyncData) > 0 {
@@ -1384,4 +1382,21 @@ func (s *SyncData) GetRevAndVersion() (rav channels.RevAndVersion) {
 		rav.CurrentVersion = string(base.Uint64CASToLittleEndianHex(s.HLV.Version))
 	}
 	return rav
+}
+
+// unmarshalRevSeqNo unmarshals the rev seq number from the provided bytes, expects a string representation of the uint64.
+func unmarshalRevSeqNo(revSeqNoBytes []byte) (uint64, error) {
+	if len(revSeqNoBytes) == 0 {
+		return 0, nil
+	}
+	var revSeqNoString string
+	err := base.JSONUnmarshal(revSeqNoBytes, &revSeqNoString)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to unmarshal rev seq number %s", revSeqNoBytes)
+	}
+	revSeqNo, err := strconv.ParseUint(revSeqNoString, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("Failed convert rev seq number %s", revSeqNoBytes)
+	}
+	return revSeqNo, nil
 }

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -129,7 +129,7 @@ func TestOnDemandImportMou(t *testing.T) {
 	// On-demand write
 	// Create via the SDK
 	t.Run("on-demand write", func(t *testing.T) {
-		for _, funcName := range []string{"Put", "PutExistingRev", "PutExistingCurrentVersion", "PutExistingRevWithConflictResolution"} {
+		for _, funcName := range []string{"Put", "PutExistingRev", "PutExistingCurrentVersion"} {
 			t.Run(funcName, func(t *testing.T) {
 				writeKey := baseKey + "_" + funcName
 				bodyBytes := []byte(`{"foo":"bar"}`)
@@ -165,17 +165,6 @@ func TestOnDemandImportMou(t *testing.T) {
 					hlv := NewHybridLogicalVector()
 					var legacyRevList []string
 					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList)
-					assertHTTPError(t, err, 409)
-				case "PutExistingRevWithConflictResolution":
-					fakeRevID := "1-abc"
-					docHistory := []string{fakeRevID}
-					noConflicts := true
-					forceAllowConflictingTombstone := false
-					conflictResolverFunc, err := NewConflictResolverFunc(ctx, ConflictResolverRemoteWins, "", time.Duration(base.DefaultJavascriptTimeoutSecs)*time.Second)
-					require.NoError(t, err)
-					conflictResolver := NewConflictResolver(conflictResolverFunc, nil)
-					_, _, err = collection.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
-					require.NoError(t, err)
 					assertHTTPError(t, err, 409)
 				default:
 					require.FailNow(t, fmt.Sprintf("unexpected funcName: %s", funcName))

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -61,10 +61,7 @@ func TestFeedImport(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(syncXattr, &syncData))
 	require.NotZero(t, syncData.Sequence, "Sequence should not be zero for imported doc")
 	revSeqNo := RetrieveDocRevSeqNo(t, xattrs[base.VirtualXattrRevSeqNo])
-	// CBG-4233: revSeqNo not implemented yet in rosmar
-	if !base.UnitTestUrlIsWalrus() {
-		require.NotZero(t, revSeqNo, "RevSeqNo should not be zero for imported doc")
-	}
+	require.NotZero(t, revSeqNo, "RevSeqNo should not be zero for imported doc")
 
 	// verify mou and rev seqno
 	xattrs, _, err = collection.dataStore.GetXattrs(ctx, key, []string{base.MouXattrName, base.VirtualXattrRevSeqNo})
@@ -76,11 +73,8 @@ func TestFeedImport(t *testing.T) {
 		require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
 		require.Equal(t, base.CasToString(writeCas), mou.PreviousHexCAS)
 		require.Equal(t, base.CasToString(importCas), mou.HexCAS)
-		// CBG-4233: revSeqNo not implemented yet in rosmar
-		if !base.UnitTestUrlIsWalrus() {
-			// curr revSeqNo should be 2, so prev revSeqNo is 1
-			require.Equal(t, revSeqNo-1, mou.PreviousRevSeqNo)
-		}
+		// curr revSeqNo should be 2, so prev revSeqNo is 1
+		require.Equal(t, revSeqNo-1, mou.PreviousRevSeqNo)
 	} else {
 		// Expect not found fetching mou xattr
 		require.Error(t, err)
@@ -117,10 +111,7 @@ func TestOnDemandImportMou(t *testing.T) {
 			require.NotNil(t, doc.MetadataOnlyUpdate)
 			require.Equal(t, base.CasToString(writeCas), doc.MetadataOnlyUpdate.PreviousHexCAS)
 			require.Equal(t, base.CasToString(doc.Cas), doc.MetadataOnlyUpdate.HexCAS)
-			// CBG-4233: revSeqNo not implemented yet in rosmar
-			if !base.UnitTestUrlIsWalrus() {
-				require.Equal(t, uint64(1), doc.MetadataOnlyUpdate.PreviousRevSeqNo)
-			}
+			require.Equal(t, uint64(1), doc.MetadataOnlyUpdate.PreviousRevSeqNo)
 		} else {
 			require.Nil(t, doc.MetadataOnlyUpdate)
 		}
@@ -181,10 +172,7 @@ func TestOnDemandImportMou(t *testing.T) {
 					require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
 					require.Equal(t, base.CasToString(writeCas), mou.PreviousHexCAS)
 					require.Equal(t, base.CasToString(importCas), mou.HexCAS)
-					// CBG-4233: revSeqNo not implemented yet in rosmar
-					if !base.UnitTestUrlIsWalrus() {
-						require.Equal(t, uint64(1), mou.PreviousRevSeqNo)
-					}
+					require.Equal(t, uint64(1), mou.PreviousRevSeqNo)
 				} else {
 					// expect not found fetching mou xattr
 					require.Error(t, err)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -165,12 +165,13 @@ func TestOnDemandImportMou(t *testing.T) {
 					hlv := NewHybridLogicalVector()
 					var legacyRevList []string
 					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList)
+					assertHTTPError(t, err, 409)
 				case "PutExistingRevWithConflictResolution":
 					fakeRevID := "1-abc"
 					docHistory := []string{fakeRevID}
 					noConflicts := true
 					forceAllowConflictingTombstone := false
-					conflictResolverFunc, err := NewConflictResolverFunc(ctx, ConflictResolverLocalWins, "", time.Duration(base.DefaultJavascriptTimeoutSecs)*time.Second)
+					conflictResolverFunc, err := NewConflictResolverFunc(ctx, ConflictResolverRemoteWins, "", time.Duration(base.DefaultJavascriptTimeoutSecs)*time.Second)
 					require.NoError(t, err)
 					conflictResolver := NewConflictResolver(conflictResolverFunc, nil)
 					_, _, err = collection.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -129,38 +129,77 @@ func TestOnDemandImportMou(t *testing.T) {
 	// On-demand write
 	// Create via the SDK
 	t.Run("on-demand write", func(t *testing.T) {
-		writeKey := baseKey + "write"
-		bodyBytes := []byte(`{"foo":"bar"}`)
-		body := Body{}
-		err := body.Unmarshal(bodyBytes)
-		assert.NoError(t, err, "Error unmarshalling body")
-		collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-		writeCas, err := collection.dataStore.WriteCas(writeKey, 0, 0, bodyBytes, 0)
-		require.NoError(t, err)
+		for _, funcName := range []string{"Put", "PutExistingRev", "PutExistingCurrentVersion", "PutExistingRevWithConflictResolution"} {
+			t.Run(funcName, func(t *testing.T) {
+				writeKey := baseKey + "_" + funcName
+				bodyBytes := []byte(`{"foo":"bar"}`)
+				body := Body{}
+				err := body.Unmarshal(bodyBytes)
+				assert.NoError(t, err, "Error unmarshalling body")
+				collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+				writeCas, err := collection.dataStore.WriteCas(writeKey, 0, 0, bodyBytes, 0)
+				require.NoError(t, err)
 
-		// Update the document to trigger on-demand import.  Write will be a conflict, but import should be performed
-		_, doc, err := collection.Put(ctx, writeKey, Body{"foo": "baz"})
-		require.Nil(t, doc)
-		assertHTTPError(t, err, 409)
+				newDoc := &Document{
+					ID: writeKey,
+				}
+				newDoc.UpdateBodyBytes([]byte(`{"foo": "baz"}`))
 
-		// fetch the mou xattr directly doc to confirm import (to avoid triggering on-demand get import)
-		// verify mou
-		xattrs, importCas, err := collection.dataStore.GetXattrs(ctx, writeKey, []string{base.MouXattrName})
-		if db.UseMou() {
-			require.NoError(t, err)
-			mouXattr, mouOk := xattrs[base.MouXattrName]
-			var mou *MetadataOnlyUpdate
-			require.True(t, mouOk)
-			require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
-			require.Equal(t, base.CasToString(writeCas), mou.PreviousHexCAS)
-			require.Equal(t, base.CasToString(importCas), mou.HexCAS)
-			// CBG-4233: revSeqNo not implemented yet in rosmar
-			if !base.UnitTestUrlIsWalrus() {
-				require.Equal(t, uint64(1), mou.PreviousRevSeqNo)
-			}
-		} else {
-			// expect not found fetching mou xattr
-			require.Error(t, err)
+				_, rawBucketDoc, err := collection.GetDocumentWithRaw(ctx, writeKey, DocUnmarshalSync)
+				require.NoError(t, err)
+
+				switch funcName {
+				case "Put":
+					// Update the document to trigger on-demand import.  Write will be a conflict, but import should be performed
+					_, doc, err := collection.Put(ctx, writeKey, Body{"foo": "baz"})
+					require.Nil(t, doc)
+					assertHTTPError(t, err, 409)
+				case "PutExistingRev":
+					fakeRevID := "1-abc"
+					docHistory := []string{fakeRevID}
+					noConflicts := true
+					forceAllowConflictingTombstone := false
+					_, _, err := collection.PutExistingRev(ctx, newDoc, docHistory, noConflicts, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
+					assertHTTPError(t, err, 409)
+				case "PutExistingCurrentVersion":
+					hlv := NewHybridLogicalVector()
+					var legacyRevList []string
+					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList)
+				case "PutExistingRevWithConflictResolution":
+					fakeRevID := "1-abc"
+					docHistory := []string{fakeRevID}
+					noConflicts := true
+					forceAllowConflictingTombstone := false
+					conflictResolverFunc, err := NewConflictResolverFunc(ctx, ConflictResolverLocalWins, "", time.Duration(base.DefaultJavascriptTimeoutSecs)*time.Second)
+					require.NoError(t, err)
+					conflictResolver := NewConflictResolver(conflictResolverFunc, nil)
+					_, _, err = collection.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
+					require.NoError(t, err)
+					assertHTTPError(t, err, 409)
+				default:
+					require.FailNow(t, fmt.Sprintf("unexpected funcName: %s", funcName))
+				}
+
+				// fetch the mou xattr directly doc to confirm import (to avoid triggering on-demand get import)
+				// verify mou
+				xattrs, importCas, err := collection.dataStore.GetXattrs(ctx, writeKey, []string{base.MouXattrName})
+				if db.UseMou() {
+					require.NoError(t, err)
+					mouXattr, mouOk := xattrs[base.MouXattrName]
+					var mou *MetadataOnlyUpdate
+					require.True(t, mouOk)
+					require.NoError(t, base.JSONUnmarshal(mouXattr, &mou))
+					require.Equal(t, base.CasToString(writeCas), mou.PreviousHexCAS)
+					require.Equal(t, base.CasToString(importCas), mou.HexCAS)
+					// CBG-4233: revSeqNo not implemented yet in rosmar
+					if !base.UnitTestUrlIsWalrus() {
+						require.Equal(t, uint64(1), mou.PreviousRevSeqNo)
+					}
+				} else {
+					// expect not found fetching mou xattr
+					require.Error(t, err)
+				}
+			})
 		}
 	})
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -749,10 +749,6 @@ func (c *DatabaseCollection) GetDocumentCurrentVersion(t testing.TB, key string)
 
 // retrieveDocRevSeNo will take the $document xattr and return the revSeqNo defined in that xattr
 func RetrieveDocRevSeqNo(t *testing.T, docxattr []byte) uint64 {
-	// virtual xattr not implemented for rosmar CBG-4233
-	if base.UnitTestUrlIsWalrus() {
-		return 0
-	}
 	require.NotNil(t, docxattr)
 	var retrievedDocumentRevNo string
 	require.NoError(t, base.JSONUnmarshal(docxattr, &retrievedDocumentRevNo))

--- a/go.mod
+++ b/go.mod
@@ -103,5 +103,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	nhooyr.io/websocket v1.8.17 // indirect
 )
-
-replace github.com/couchbaselabs/rosmar => ../rosmar

--- a/go.mod
+++ b/go.mod
@@ -103,3 +103,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	nhooyr.io/websocket v1.8.17 // indirect
 )
+
+replace github.com/couchbaselabs/rosmar => ../rosmar

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20241219222419-f9921fccab90
+	github.com/couchbaselabs/rosmar v0.0.0-20250110001838-ab0121bb9242
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.0.4
@@ -29,7 +29,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
-	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f
+	github.com/robertkrimen/otto v0.5.1
 	github.com/samuel/go-metrics v0.0.0-20150819231912-7ccf3e0e1fb1
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/shirou/gopsutil/v3 v3.24.5

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
-	github.com/robertkrimen/otto v0.5.1
+	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f
 	github.com/samuel/go-metrics v0.0.0-20150819231912-7ccf3e0e1fb1
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/shirou/gopsutil/v3 v3.24.5

--- a/go.sum
+++ b/go.sum
@@ -19,10 +19,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chromedp/cdproto v0.0.0-20230802225258-3cf4e6d46a89/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
 github.com/chromedp/chromedp v0.9.2/go.mod h1:LkSXJKONWTCHAfQasKFUZI+mxqS4tZqhmtGzzhLsnLs=
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
-github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
-github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
@@ -76,8 +74,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28 h1:lhGOw8rNG6RAadmmaJAF3PJ7MNt7rFuWG7BHCYMgnGE=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20241219222419-f9921fccab90 h1:rQfOVEJvF8uGdRsWqNC4WZo5I6gOysFdE/1r0RyxEoE=
-github.com/couchbaselabs/rosmar v0.0.0-20241219222419-f9921fccab90/go.mod h1:suZBurj14d2YtLOW8pBc8mjQN8MhPFHHgPbqX1fDDlE=
+github.com/couchbaselabs/rosmar v0.0.0-20250110001838-ab0121bb9242 h1:Gb6jaSXG6KfJFT6zGmNaCK/Ljd+yVQIo7QifBhBF11Y=
+github.com/couchbaselabs/rosmar v0.0.0-20250110001838-ab0121bb9242/go.mod h1:suZBurj14d2YtLOW8pBc8mjQN8MhPFHHgPbqX1fDDlE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -190,8 +188,6 @@ github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f h1:a7clxaGmmqtdNTXyvrp/lVO/Gnkzlhc/+dLs5v965GM=
-github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f/go.mod h1:/mK7FZ3mFYEn9zvNPhpngTyatyehSwte5bJZ4ehL5Xw=
 github.com/robertkrimen/otto v0.5.1 h1:avDI4ToRk8k1hppLdYFTuuzND41n37vPGJU7547dGf0=
 github.com/robertkrimen/otto v0.5.1/go.mod h1:bS433I4Q9p+E5pZLu7r17vP6FkE6/wLxBdmKjoqJXF8=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
@@ -346,7 +342,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
-gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbRxng+XOj5ITVgY24WcbNnQopyfKoYQ=
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f h1:a7clxaGmmqtdNTXyvrp/lVO/Gnkzlhc/+dLs5v965GM=
 github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f/go.mod h1:/mK7FZ3mFYEn9zvNPhpngTyatyehSwte5bJZ4ehL5Xw=
+github.com/robertkrimen/otto v0.5.1 h1:avDI4ToRk8k1hppLdYFTuuzND41n37vPGJU7547dGf0=
+github.com/robertkrimen/otto v0.5.1/go.mod h1:bS433I4Q9p+E5pZLu7r17vP6FkE6/wLxBdmKjoqJXF8=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/samuel/go-metrics v0.0.0-20150819231912-7ccf3e0e1fb1 h1:UrKfubnICxHKc+p+6ePllH2U6FYR5zI+v9r3vWqDSdc=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,10 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chromedp/cdproto v0.0.0-20230802225258-3cf4e6d46a89/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
 github.com/chromedp/chromedp v0.9.2/go.mod h1:LkSXJKONWTCHAfQasKFUZI+mxqS4tZqhmtGzzhLsnLs=
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
@@ -188,8 +190,8 @@ github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe
 github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/robertkrimen/otto v0.5.1 h1:avDI4ToRk8k1hppLdYFTuuzND41n37vPGJU7547dGf0=
-github.com/robertkrimen/otto v0.5.1/go.mod h1:bS433I4Q9p+E5pZLu7r17vP6FkE6/wLxBdmKjoqJXF8=
+github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f h1:a7clxaGmmqtdNTXyvrp/lVO/Gnkzlhc/+dLs5v965GM=
+github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f/go.mod h1:/mK7FZ3mFYEn9zvNPhpngTyatyehSwte5bJZ4ehL5Xw=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/samuel/go-metrics v0.0.0-20150819231912-7ccf3e0e1fb1 h1:UrKfubnICxHKc+p+6ePllH2U6FYR5zI+v9r3vWqDSdc=
@@ -342,6 +344,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbRxng+XOj5ITVgY24WcbNnQopyfKoYQ=
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -66,13 +66,10 @@ func TestImportFeed(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// CBG-4233 rosmar does not yet support RevSeqNo
-	if !base.UnitTestUrlIsWalrus() {
-		xattrs, _, err := dataStore.GetXattrs(rt.Context(), mobileKey, []string{base.MouXattrName, base.VirtualXattrRevSeqNo})
-		require.NoError(t, err)
-		require.Equal(t, uint64(2), db.RetrieveDocRevSeqNo(t, xattrs[base.VirtualXattrRevSeqNo]))
-		require.Equal(t, uint64(1), getMou(t, xattrs[base.MouXattrName]).PreviousRevSeqNo)
-	}
+	xattrs, _, err := dataStore.GetXattrs(rt.Context(), mobileKey, []string{base.MouXattrName, base.VirtualXattrRevSeqNo})
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), db.RetrieveDocRevSeqNo(t, xattrs[base.VirtualXattrRevSeqNo]))
+	require.Equal(t, uint64(1), getMou(t, xattrs[base.MouXattrName]).PreviousRevSeqNo)
 	// Attempt to get the document via Sync Gateway.
 	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+mobileKey, "")
 	assert.Equal(t, 200, response.Code)
@@ -626,13 +623,10 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
-	// CBG-4233 rosmar does not yet support RevSeqNo
 	xattrs, cas, err := dataStore.GetXattrs(rt.Context(), mobileKey, []string{base.MouXattrName, base.VirtualXattrRevSeqNo})
 	require.NoError(t, err)
-	if !base.UnitTestUrlIsWalrus() {
-		require.Equal(t, uint64(2), db.RetrieveDocRevSeqNo(t, xattrs[base.VirtualXattrRevSeqNo]))
-		require.Equal(t, uint64(1), getMou(t, xattrs[base.MouXattrName]).PreviousRevSeqNo)
-	}
+	require.Equal(t, uint64(2), db.RetrieveDocRevSeqNo(t, xattrs[base.VirtualXattrRevSeqNo]))
+	require.Equal(t, uint64(1), getMou(t, xattrs[base.MouXattrName]).PreviousRevSeqNo)
 
 	// Modify the document via the SDK to add a new, non-mobile xattr
 	xattrVal := make(map[string]interface{})
@@ -2395,9 +2389,6 @@ func TestImportUpdateExpiry(t *testing.T) {
 
 func TestPrevRevNoPopulationImportFeed(t *testing.T) {
 	base.SkipImportTestsIfNotEnabled(t)
-	if base.UnitTestUrlIsWalrus() {
-		t.Skipf("test requires CBS for previous rev no assertion, CBG-4233")
-	}
 
 	rtConfig := rest.RestTesterConfig{
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{


### PR DESCRIPTION
Pass `RevSeqNo` for on demand imports, write and get.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

Blocked on https://github.com/couchbaselabs/rosmar/pull/43

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2893/
