### PR TITLE
use assertions for blip client test

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2285,25 +2285,22 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
 		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
 
-		var err error
-		doc1Version, err = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
-		require.NoError(t, err)
-		doc2Version, err = btcRunner.AddRev(btc.id, doc2ID, &doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
-		require.NoError(t, err)
+		doc1Version = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+		doc2Version = btcRunner.AddRev(btc.id, doc2ID, &doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
 
-		require.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
-		require.NoError(t, rt.WaitForVersion(doc2ID, doc2Version))
+		rt.WaitForVersion(doc1ID, doc1Version)
+		rt.WaitForVersion(doc2ID, doc2Version)
 
 		collection, ctx := rt.GetSingleTestDatabaseCollection()
-		_, err = collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
+		_, err := collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
 		require.NoError(t, err)
 		_, err = collection.GetDocument(ctx, "doc2", db.DocUnmarshalAll)
 		require.NoError(t, err)
 
-		doc1Version, err = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
+		doc1Version = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
 		require.NoError(t, err)
 
-		assert.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		rt.WaitForVersion(doc1ID, doc1Version)
 
 		doc1, err := collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
 		require.NoError(t, err)
@@ -2343,15 +2340,12 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 
 		// force attachment into test client's store to validate it's fetched
 		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
-		contentType := "text/plain"
 
-		length, digest, err := btcRunner.saveAttachment(btc.id, contentType, attachmentAData)
-		require.NoError(t, err)
+		length, digest := btcRunner.saveAttachment(btc.id, attachmentAData)
 		// Update doc1, include reference to non-existing attachment with recent revpos
-		doc1Version, err = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"content_type":"%s","stub":true,"revpos":1}}}`, digest, length, contentType)))
-		require.NoError(t, err)
+		doc1Version = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(fmt.Sprintf(`{"key": "val", "_attachments":{"attachment":{"digest":"%s","length":%d,"stub":true,"revpos":1}}}`, digest, length)))
 
-		require.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
+		btc.rt.WaitForVersion(doc1ID, doc1Version)
 
 		// verify that attachment exists on document and was persisted
 		attResponse := btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
@@ -2393,15 +2387,13 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 		// Create a set of revisions before we start the replicator to ensure there's a significant amount of history to push
 		version := initialVersion
 		for i := 0; i < 25; i++ {
-			var err error
-			version, err = btcRunner.AddRev(btc.id, docID, &version, []byte(`{"update_count":`+strconv.Itoa(i)+`,"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
-			require.NoError(t, err)
+			version = btcRunner.AddRev(btc.id, docID, &version, []byte(`{"update_count":`+strconv.Itoa(i)+`,"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
 		}
 
 		// Note this references revpos 1 and therefore SGW has it - Shouldn't need proveAttachment, even when we replicate it
 		proveAttachmentBefore := btc.pushReplication.replicationStats.ProveAttachment.Value()
 		btcRunner.StartPushWithOpts(btc.id, BlipTesterPushOptions{Continuous: false})
-		require.NoError(t, rt.WaitForVersion(docID, version))
+		rt.WaitForVersion(docID, version)
 
 		proveAttachmentAfter := btc.pushReplication.replicationStats.ProveAttachment.Value()
 		assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
@@ -2412,12 +2404,10 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 
 		// Push another bunch of history, this time whilst a replicator is actively pushing them
 		for i := 25; i < 50; i++ {
-			var err error
-			version, err = btcRunner.AddRev(btc.id, docID, &version, []byte(`{"update_count":`+strconv.Itoa(i)+`,"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
-			require.NoError(t, err)
+			version = btcRunner.AddRev(btc.id, docID, &version, []byte(`{"update_count":`+strconv.Itoa(i)+`,"_attachments": {"hello.txt": {"revpos":1,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
 		}
 
-		require.NoError(t, rt.WaitForVersion(docID, version))
+		rt.WaitForVersion(docID, version)
 		proveAttachmentAfter = btc.pushReplication.replicationStats.ProveAttachment.Value()
 		assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
 	})
@@ -2633,31 +2623,25 @@ func TestCBLRevposHandling(t *testing.T) {
 		attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
 		attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
 
-		doc1Version, err := btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
-		require.NoError(t, err)
-		doc2Version, err = btcRunner.AddRev(btc.id, doc2ID, &doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
-		require.NoError(t, err)
+		doc1Version = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+		doc2Version = btcRunner.AddRev(btc.id, doc2ID, &doc2Version, []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
 
-		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
-		assert.NoError(t, btc.rt.WaitForVersion(doc2ID, doc2Version))
+		btc.rt.WaitForVersion(doc1ID, doc1Version)
+		btc.rt.WaitForVersion(doc2ID, doc2Version)
 
 		collection, ctx := btc.rt.GetSingleTestDatabaseCollection()
-		_, err = collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
+		_, err := collection.GetDocument(ctx, "doc1", db.DocUnmarshalAll)
 		require.NoError(t, err)
 		_, err = collection.GetDocument(ctx, "doc2", db.DocUnmarshalAll)
 		require.NoError(t, err)
 
 		// Update doc1, don't change attachment, use correct revpos
-		doc1Version, err = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":2}}}`))
-		require.NoError(t, err)
-
-		assert.NoError(t, btc.rt.WaitForVersion(doc1ID, doc1Version))
+		doc1Version = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":2}}}`))
+		btc.rt.WaitForVersion(doc1ID, doc1Version)
 
 		// Update doc1, don't change attachment, use revpos=generation of revid, as CBL 2.x does.  Should not proveAttachment on digest match.
-		doc1Version, err = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":4}}}`))
-		require.NoError(t, err)
-
-		require.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		doc1Version = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=","length":11,"content_type":"","stub":true,"revpos":4}}}`))
+		rt.WaitForVersion(doc1ID, doc1Version)
 
 		// Validate attachment exists
 		attResponse := btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")
@@ -2666,10 +2650,8 @@ func TestCBLRevposHandling(t *testing.T) {
 
 		attachmentPushCount := btc.rt.GetDatabase().DbStats.CBLReplicationPushStats.AttachmentPushCount.Value()
 		// Update doc1, change attachment digest with CBL revpos=generation.  Should getAttachment
-		doc1Version, err = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":5}}}`))
-		require.NoError(t, err)
-
-		require.NoError(t, rt.WaitForVersion(doc1ID, doc1Version))
+		doc1Version = btcRunner.AddRev(btc.id, doc1ID, &doc1Version, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":5}}}`))
+		rt.WaitForVersion(doc1ID, doc1Version)
 
 		// Validate attachment exists and is updated
 		attResponse = btc.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1/attachment", "")

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1244,8 +1244,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPull(btc.id)
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldFeedType: "continuous",
@@ -1257,8 +1256,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartOneshotPull(btc.id)
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldFeedType: "normal",
@@ -1270,8 +1268,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", Channels: "A,B"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldChannels: []any{"A", "B"},
@@ -1285,8 +1282,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", DocIDs: []string{docID, "non_existent"}})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldDocIDs:   []any{"blip_changes_with_docids", "non_existent"},
@@ -1301,8 +1297,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "0", DocIDs: []string{docID, "non_existent"}, Channels: "A,B"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldDocIDs:   []any{"blip_changes_with_docids_and_channels", "non_existent"},
@@ -1317,8 +1312,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 				auditableCode: func(t testing.TB, docID string, docVersion DocVersion) {
 					btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Since: "1:10"})
 					btcRunner.WaitForVersion(btc.id, docID, docVersion)
-					_, err := btcRunner.UnsubPullChanges(btc.id)
-					require.NoError(t, err)
+					btcRunner.UnsubPullChanges(btc.id)
 				},
 				expectedFields: map[string]any{
 					base.AuditFieldFeedType: "normal",
@@ -1509,14 +1503,12 @@ func TestAuditBlipCRUD(t *testing.T) {
 				attachmentName: "attachment1",
 				setupCode: func(t testing.TB, docID string) DocVersion {
 					attData := base64.StdEncoding.EncodeToString([]byte("attach"))
-					version, err := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment1":{"data":"`+attData+`"}}}`))
-					require.NoError(t, err)
-					return version
+					return btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment1":{"data":"`+attData+`"}}}`))
 				},
 				auditableCode: func(t testing.TB, docID string, version DocVersion) {
 					btcRunner.StartPushWithOpts(btc.id, BlipTesterPushOptions{Continuous: false})
 					// wait for the doc to be replicated, since that's what we're actually auditing
-					require.NoError(t, rt.WaitForVersion(docID, version))
+					rt.WaitForVersion(docID, version)
 				},
 				attachmentCreateCount: 1,
 			},

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -72,8 +72,7 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 
 		// Update the replicated doc at client along with keeping the same attachment stub.
 		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-		version, err := btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
 
 		// TODO: Replace with rt.WaitForVersion
 		// Wait for the document to be replicated at SG
@@ -144,8 +143,7 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 
 		// Update the replicated doc at client along with keeping the same attachment stub.
 		bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
-		version, err := btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
 
 		// Wait for the document to be replicated at SG
 		btc.pushReplication.WaitForMessage(2)
@@ -265,19 +263,13 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 
 		// Create two docs with the same attachment data on the client - v2 attachments intentionally result in two copies stored on the server, despite the client being able to share the data for both.
 		doc1Body := fmt.Sprintf(`{"greetings":[{"hi": "alice"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-		doc1Version, err := btcRunner.AddRev(btc.id, doc1ID, nil, []byte(doc1Body))
-		require.NoError(t, err)
-
-		err = btc.rt.WaitForVersion(doc1ID, doc1Version)
-		require.NoError(t, err)
+		doc1Version := btcRunner.AddRev(btc.id, doc1ID, nil, []byte(doc1Body))
+		btc.rt.WaitForVersion(doc1ID, doc1Version)
 
 		// create doc2 now that we know the server has the attachment - SG should still request the attachment data from the client.
 		doc2Body := fmt.Sprintf(`{"greetings":[{"howdy": "bob"}],"_attachments":{"%s":{"data":"%s"}}}`, attachmentName, attachmentDataB64)
-		doc2Version, err := btcRunner.AddRev(btc.id, doc2ID, nil, []byte(doc2Body))
-		require.NoError(t, err)
-
-		err = btc.rt.WaitForVersion(doc2ID, doc2Version)
-		require.NoError(t, err)
+		doc2Version := btcRunner.AddRev(btc.id, doc2ID, nil, []byte(doc2Body))
+		btc.rt.WaitForVersion(doc2ID, doc2Version)
 
 		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
 		assert.Equal(t, int64(0), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
@@ -305,27 +297,22 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 
 		btcRunner.StartPush(btc.id)
 
-		docVersion, err := btcRunner.AddRev(btc.id, docID, nil, []byte(`{"greetings":[{"hi": "alice"}]}`))
-		require.NoError(t, err)
-
-		docVersion, err = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "bob"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`))
-		require.NoError(t, err)
+		docVersion := btcRunner.AddRev(btc.id, docID, nil, []byte(`{"greetings":[{"hi": "alice"}]}`))
+		docVersion = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "bob"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`))
 
 		// Wait for the documents to be replicated at SG
-		require.NoError(t, rt.WaitForVersion(docID, docVersion))
+		rt.WaitForVersion(docID, docVersion)
 
 		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+docVersion.RevID, "")
 		assert.Equal(t, http.StatusOK, resp.Code)
 
 		// CBL updates the doc w/ two more revisions, 3-abc, 4-abc,
 		// sent to SG as 4-abc, history:[4-abc,3-abc,2-abc], the attachment has revpos=2
-		docVersion, err = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "charlie"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
-		require.NoError(t, err)
-		docVersion, err = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "dave"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
-		require.NoError(t, err)
+		docVersion = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "charlie"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
+		docVersion = btcRunner.AddRev(btc.id, docID, &docVersion, []byte(`{"greetings":[{"hi": "dave"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`))
 
 		// Wait for the document to be replicated at SG
-		require.NoError(t, rt.WaitForVersion(docID, docVersion))
+		rt.WaitForVersion(docID, docVersion)
 
 		resp = btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+docVersion.RevID, "")
 		assert.Equal(t, http.StatusOK, resp.Code)
@@ -380,8 +367,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		bodyText := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
 		rev := NewDocVersionFromFakeRev("2-abc")
 		// FIXME CBG-4400:  docID: doc1 was not found on the client - expecting to update doc based on parentVersion RevID: 2-abc
-		err := btcRunner.StoreRevOnClient(btc.id, docID, &rev, []byte(bodyText))
-		require.NoError(t, err)
+		btcRunner.StoreRevOnClient(btc.id, docID, &rev, []byte(bodyText))
 
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":2,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 		docVersion, err := btcRunner.PushRevWithHistory(btc.id, docID, &rev, []byte(bodyText), 2, 0)
@@ -390,7 +376,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 		assert.Equal(t, "4-abc", docVersion.RevID)
 
 		// Wait for the document to be replicated at SG
-		require.NoError(t, rt.WaitForVersion(docID, *docVersion))
+		rt.WaitForVersion(docID, *docVersion)
 
 		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"?rev="+docVersion.RevID, "")
 		assert.Equal(t, http.StatusOK, resp.Code)
@@ -547,10 +533,8 @@ func TestBlipAttachNameChange(t *testing.T) {
 		digest := db.Sha1DigestKey(attachmentA)
 
 		// Push initial attachment data
-		version, err := btcRunner.AddRev(client1.id, "doc", EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
-		require.NoError(t, err)
-
-		require.NoError(t, rt.WaitForVersion("doc", version))
+		version := btcRunner.AddRev(client1.id, "doc", EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment": {"data":"`+attachmentAData+`"}}}`))
+		rt.WaitForVersion("doc", version)
 
 		// Confirm attachment is in the bucket
 		attachmentAKey := db.MakeAttachmentKey(2, "doc", digest)
@@ -560,10 +544,8 @@ func TestBlipAttachNameChange(t *testing.T) {
 
 		// Simulate changing only the attachment name over CBL
 		// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
-		version, err = btcRunner.AddRev(client1.id, "doc", &version, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
-		require.NoError(t, err)
-		err = client1.rt.WaitForVersion("doc", version)
-		require.NoError(t, err)
+		version = btcRunner.AddRev(client1.id, "doc", &version, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"","length":11,"stub":true,"digest":"`+digest+`"}}}`))
+		client1.rt.WaitForVersion("doc", version)
 
 		// Check if attachment is still in bucket
 		bucketAttachmentA, _, err = client1.rt.GetSingleDataStore().GetRaw(attachmentAKey)
@@ -606,9 +588,8 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 		docVersion, _ := client1.rt.GetDoc(docID)
 
 		// Store the document and attachment on the test client
-		err := btcRunner.StoreRevOnClient(client1.id, docID, &docVersion, rawDoc)
+		btcRunner.StoreRevOnClient(client1.id, docID, &docVersion, rawDoc)
 		// FIXME CBG-4400: docID: doc was not found on the client - expecting to update doc based on parentVersion RevID: 1-5fc93bd36377008f96fdae2719c174ed
-		require.NoError(t, err)
 
 		btcRunner.AttachmentsLock(client1.id).Lock()
 		btcRunner.Attachments(client1.id)[digest] = attBody
@@ -622,11 +603,9 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 
 		// Simulate changing only the attachment name over CBL
 		// Use revpos 2 to simulate revpos bug in CBL 2.8 - 3.0.0
-		docVersion, err = btcRunner.AddRev(client1.id, "doc", &docVersion, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
-		require.NoError(t, err)
+		docVersion = btcRunner.AddRev(client1.id, "doc", &docVersion, []byte(`{"key":"val","_attachments":{"attach":{"revpos":2,"content_type":"test/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
 
-		err = client1.rt.WaitForVersion("doc", docVersion)
-		require.NoError(t, err)
+		client1.rt.WaitForVersion("doc", docVersion)
 
 		resp := client1.rt.SendAdminRequest("GET", "/{{.keyspace}}/doc/attach", "")
 		RequireStatus(t, resp, http.StatusOK)
@@ -669,8 +648,7 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 
 		// Store the document and attachment on the test client
 		// FIXME CBG-4400: docID: doc was not found on the client - expecting to update doc based on parentVersion RevID: 1-5fc93bd36377008f96fdae2719c174ed
-		err := btcRunner.StoreRevOnClient(client1.id, docID, &version, rawDoc)
-		require.NoError(t, err)
+		btcRunner.StoreRevOnClient(client1.id, docID, &version, rawDoc)
 		btcRunner.AttachmentsLock(client1.id).Lock()
 		btcRunner.Attachments(client1.id)[digest] = attBody
 		btcRunner.AttachmentsLock(client1.id).Unlock()
@@ -683,11 +661,8 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 		require.EqualValues(t, bucketAttachmentA, attBody)
 
 		// Update the document, leaving body intact
-		version, err = btcRunner.AddRev(client1.id, "doc", &version, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
-		require.NoError(t, err)
-
-		err = client1.rt.WaitForVersion("doc", version)
-		require.NoError(t, err)
+		version = btcRunner.AddRev(client1.id, "doc", &version, []byte(`{"key":"val1","_attachments":{"`+attName+`":{"revpos":2,"content_type":"text/plain","length":2,"stub":true,"digest":"`+digest+`"}}}`))
+		client1.rt.WaitForVersion("doc", version)
 
 		resp := client1.rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/doc/%s", attName), "")
 		RequireStatus(t, resp, http.StatusOK)

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -125,7 +124,7 @@ func TestBlipGetCollections(t *testing.T) {
 				getCollectionsRequest, err := db.NewGetCollectionsMessage(testCase.requestBody)
 				require.NoError(t, err)
 
-				require.NoError(t, btc.pushReplication.sendMsg(getCollectionsRequest))
+				btc.pushReplication.sendMsg(getCollectionsRequest)
 
 				// Check that the response we got back was processed by the norev handler
 				resp := getCollectionsRequest.Response()
@@ -172,7 +171,7 @@ func TestBlipReplicationNoDefaultCollection(t *testing.T) {
 		subChangesRequest := blip.NewRequest()
 		subChangesRequest.SetProfile(db.MessageSubChanges)
 
-		require.NoError(t, btc.pullReplication.sendMsg(subChangesRequest))
+		btc.pullReplication.sendMsg(subChangesRequest)
 		resp := subChangesRequest.Response()
 		require.Equal(t, strconv.Itoa(http.StatusBadRequest), resp.Properties[db.BlipErrorCode])
 	})
@@ -208,7 +207,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 
 		require.NoError(t, err)
 
-		require.NoError(t, btc.pushReplication.sendMsg(getCollectionsRequest))
+		btc.pushReplication.sendMsg(getCollectionsRequest)
 
 		// Check that the response we got back was processed by the GetCollections
 		resp := getCollectionsRequest.Response()
@@ -227,7 +226,7 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 		requestGetCheckpoint.SetProfile(db.MessageGetCheckpoint)
 		requestGetCheckpoint.Properties[db.BlipClient] = checkpointID1
 		requestGetCheckpoint.Properties[db.BlipCollection] = "0"
-		require.NoError(t, btc.pushReplication.sendMsg(requestGetCheckpoint))
+		btc.pushReplication.sendMsg(requestGetCheckpoint)
 		resp = requestGetCheckpoint.Response()
 		require.NotNil(t, resp)
 		errorCode, hasErrorCode = resp.Properties[db.BlipErrorCode]
@@ -302,8 +301,7 @@ func TestBlipReplicationMultipleCollections(t *testing.T) {
 		}
 
 		for _, collectionClient := range btc.collectionClients {
-			resp, err := collectionClient.UnsubPullChanges()
-			assert.NoError(t, err, "Error unsubing: %+v", resp)
+			collectionClient.UnsubPullChanges()
 		}
 	})
 }
@@ -358,8 +356,7 @@ func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
 		}
 
 		for _, collectionClient := range btc.collectionClients {
-			resp, err := collectionClient.UnsubPullChanges()
-			assert.NoError(t, err, "Error unsubing: %+v", resp)
+			collectionClient.UnsubPullChanges()
 		}
 	})
 }

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -53,16 +53,14 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 		btcRunner.StartPush(btc.id)
 
 		// Push first rev
-		version, err := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
-		require.NoError(t, err)
+		version := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val"}`))
 
 		// Push second rev with an attachment (no delta yet)
 		attData := base64.StdEncoding.EncodeToString([]byte("attach"))
 
-		version, err = btcRunner.AddRev(btc.id, docID, &version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"`+attData+`"}}}`))
 
-		require.NoError(t, rt.WaitForVersion(docID, version))
+		rt.WaitForVersion(docID, version)
 
 		collection, ctx := rt.GetSingleTestDatabaseCollection()
 		syncData, err := collection.GetDocSyncData(ctx, docID)
@@ -82,10 +80,9 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 		newBody, err := base.InjectJSONPropertiesFromBytes(body, base.KVPairBytes{Key: "update", Val: []byte(`true`)})
 		require.NoError(t, err)
 
-		version, err = btcRunner.AddRev(btc.id, docID, &version, newBody)
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, newBody)
 
-		require.NoError(t, rt.WaitForVersion(docID, version))
+		rt.WaitForVersion(docID, version)
 
 		syncData, err = collection.GetDocSyncData(ctx, docID)
 		require.NoError(t, err)
@@ -141,8 +138,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 
 		// Update the replicated doc at client by adding another attachment.
 		bodyText = `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="},"world.txt":{"data":"bGVsbG8gd29ybGQ="}}}`
-		version, err := btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
-		require.NoError(t, err)
+		version = btcRunner.AddRev(btc.id, docID, &version, []byte(bodyText))
 
 		// Wait for the document to be replicated at SG
 		btc.pushReplication.WaitForMessage(2)
@@ -825,8 +821,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 		// create doc1 rev 2-abc on client
-		newRev, err := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-		assert.NoError(t, err)
+		newRev := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 
 		// Check EE is delta, and CE is full-body replication
 		msg := client.waitForReplicationMessage(collection, 2)
@@ -874,7 +869,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 			deltaPushDocCountStart = rt.GetDatabase().DbStats.DeltaSync().DeltaPushDocCount.Value()
 		}
 
-		_, err = btcRunner.PushUnsolicitedRev(client.id, docID, &deletedVersion, []byte(`{"undelete":true}`))
+		_, err := btcRunner.PushUnsolicitedRev(client.id, docID, &deletedVersion, []byte(`{"undelete":true}`))
 
 		if base.IsEnterpriseEdition() {
 			// Now make the client push up a delta that has the parent of the tombstone.
@@ -932,8 +927,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 		// create doc1 rev 2-abcxyz on client
-		newRev, err := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-		assert.NoError(t, err)
+		newRev := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 		// Check EE is delta, and CE is full-body replication
 		msg := client.waitForReplicationMessage(collection, 2)
 

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -69,10 +69,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 		go func() {
 			for i := 0; shouldCreateDocs.IsTrue(); i++ {
 				// this will begin to error when the database is reloaded underneath the replication
-				_, err := btcRunner.AddRev(client.id, fmt.Sprintf("doc%d", i), EmptyDocVersion(), []byte(fmt.Sprintf(`{"i":%d}`, i)))
-				if err != nil {
-					lastPushRevErr.Store(err)
-				}
+				btcRunner.AddRev(client.id, fmt.Sprintf("doc%d", i), EmptyDocVersion(), []byte(fmt.Sprintf(`{"i":%d}`, i)))
 			}
 			rt.WaitForPendingChanges()
 			wg.Done()

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -44,11 +44,10 @@ func TestBlipClientPushAndPullReplication(t *testing.T) {
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
 		// update doc1 on client
-		newRev, err := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
-		assert.NoError(t, err)
+		newRev := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 
 		// wait for update to arrive on SG
-		require.NoError(t, rt.WaitForVersion(docID, newRev))
+		rt.WaitForVersion(docID, newRev)
 
 		body := rt.GetDocVersion("doc1", newRev)
 		require.Equal(t, "bob", body["greetings"].([]interface{})[2].(map[string]interface{})["howdy"])

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -355,8 +355,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 		btcr := btc.getCollectionClientFromMessage(msg)
 
-		attData, err := btcr.getAttachment(digest)
-		require.NoError(btr.TB(), err, "error getting client attachment: %v", err)
+		attData := btcr.getAttachment(digest)
 
 		proof := db.ProveAttachment(ctx, attData, nonce)
 
@@ -588,8 +587,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 				btcr.attachmentsLock.RUnlock()
 
 				for _, digest := range knownDigests {
-					attData, err := btcr.getAttachment(digest)
-					require.NoError(btr.TB(), err)
+					attData := btcr.getAttachment(digest)
 					nonce, proof, err := db.GenerateProofOfAttachment(ctx, attData)
 					require.NoError(btr.TB(), err)
 
@@ -599,8 +597,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					outrq.Properties[db.ProveAttachmentDigest] = digest
 					outrq.SetBody(nonce)
 
-					err = btcr.sendPullMsg(outrq)
-					require.NoError(btr.TB(), err)
+					btcr.sendPullMsg(outrq)
 
 					resp := outrq.Response()
 					btc.pullReplication.storeMessage(resp)
@@ -635,8 +632,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 						outrq.Properties[db.GetAttachmentID] = docID
 					}
 
-					err := btcr.sendPullMsg(outrq)
-					require.NoError(btr.TB(), err)
+					btcr.sendPullMsg(outrq)
 
 					resp := outrq.Response()
 					btc.pullReplication.storeMessage(resp)
@@ -718,16 +714,11 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		btr.storeMessage(msg)
 
 		digest, ok := msg.Properties[db.GetAttachmentDigest]
-		if !ok {
-			base.PanicfCtx(ctx, "couldn't find digest in getAttachment message properties")
-		}
+		require.True(btr.TB(), ok, "couldn't find digest in getAttachment message properties")
 
 		btcr := btc.getCollectionClientFromMessage(msg)
 
-		attachment, err := btcr.getAttachment(digest)
-		if err != nil {
-			base.PanicfCtx(ctx, "couldn't find attachment for digest: %v", digest)
-		}
+		attachment := btcr.getAttachment(digest)
 
 		response := msg.Response()
 		response.SetBody(attachment)
@@ -782,17 +773,15 @@ func (btc *BlipTesterCollectionClient) TB() testing.TB {
 	return btc.parent.rt.TB()
 }
 
-// saveAttachment takes a content-type, and base64 encoded data and stores the attachment on the client
-func (btc *BlipTesterCollectionClient) saveAttachment(_, base64data string) (dataLength int, digest string, err error) {
+// saveAttachment takes base64 encoded data and stores the attachment on the client.
+func (btc *BlipTesterCollectionClient) saveAttachment(base64data string) (dataLength int, digest string) {
 	btc.attachmentsLock.Lock()
 	defer btc.attachmentsLock.Unlock()
 
 	ctx := base.DatabaseLogCtx(base.TestCtx(btc.parent.rt.TB()), btc.parent.rt.GetDatabase().Name, nil)
 
 	data, err := base64.StdEncoding.DecodeString(base64data)
-	if err != nil {
-		return 0, "", err
-	}
+	require.NoError(btc.TB(), err)
 
 	digest = db.Sha1DigestKey(data)
 	if _, found := btc._attachments[digest]; found {
@@ -801,19 +790,17 @@ func (btc *BlipTesterCollectionClient) saveAttachment(_, base64data string) (dat
 		btc._attachments[digest] = data
 	}
 
-	return len(data), digest, nil
+	return len(data), digest
 }
 
-func (btc *BlipTesterCollectionClient) getAttachment(digest string) (attachment []byte, err error) {
+func (btc *BlipTesterCollectionClient) getAttachment(digest string) (attachment []byte) {
 	btc.attachmentsLock.RLock()
 	defer btc.attachmentsLock.RUnlock()
 
 	attachment, found := btc._attachments[digest]
-	if !found {
-		return nil, fmt.Errorf("attachment not found")
-	}
+	require.True(btc.TB(), found, "attachment with digest %s not found", digest)
 
-	return attachment, nil
+	return attachment
 }
 
 func (btc *BlipTesterCollectionClient) updateLastReplicatedRev(docID string, version DocVersion) {
@@ -841,7 +828,7 @@ func (btc *BlipTesterCollectionClient) getLastReplicatedRev(docID string) (versi
 	return latestServerVersion, latestServerVersion.RevID != ""
 }
 
-func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, skipCollectionsInitialization bool) (*BlipTesterReplicator, error) {
+func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, skipCollectionsInitialization bool) *BlipTesterReplicator {
 	bt, err := NewBlipTesterFromSpecWithRT(tb, &BlipTesterSpec{
 		connectingPassword:            RestTesterDefaultUserPassword,
 		connectingUsername:            btc.Username,
@@ -850,9 +837,7 @@ func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, s
 		skipCollectionsInitialization: skipCollectionsInitialization,
 		origin:                        btc.origin,
 	}, btc.rt)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(tb, err)
 
 	r := &BlipTesterReplicator{
 		id:       id,
@@ -862,7 +847,7 @@ func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, s
 
 	r.initHandlers(btc)
 
-	return r, nil
+	return r
 }
 
 // getCollectionsForBLIP returns collections configured by a single database instance on a restTester. If only default collection exists, it will skip returning it to test "legacy" blip mode.
@@ -896,8 +881,7 @@ func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTes
 		id:                   id.ID(),
 	}
 	btcRunner.clients[client.id] = client
-	err = client.createBlipTesterReplications()
-	require.NoError(btcRunner.TB(), err)
+	client.createBlipTesterReplications()
 
 	return client
 }
@@ -945,26 +929,18 @@ func (btc *BlipTesterClient) tearDownBlipClientReplications() {
 	btc.pushReplication.Close()
 }
 
-func (btc *BlipTesterClient) createBlipTesterReplications() error {
+func (btc *BlipTesterClient) createBlipTesterReplications() {
 	id, err := uuid.NewRandom()
-	if err != nil {
-		return err
-	}
+	require.NoError(btc.TB(), err)
 
-	if btc.pushReplication, err = newBlipTesterReplication(btc.TB(), "push"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization); err != nil {
-		return err
-	}
-	if btc.pullReplication, err = newBlipTesterReplication(btc.TB(), "pull"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization); err != nil {
-		return err
-	}
+	btc.pushReplication = newBlipTesterReplication(btc.TB(), "push"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization)
+	btc.pullReplication = newBlipTesterReplication(btc.TB(), "pull"+id.String(), btc, btc.BlipTesterClientOpts.SkipCollectionsInitialization)
 
 	collections := getCollectionsForBLIP(btc.TB(), btc.rt)
 	if !btc.BlipTesterClientOpts.SkipCollectionsInitialization && len(collections) > 0 {
 		btc.collectionClients = make([]*BlipTesterCollectionClient, len(collections))
 		for i, collection := range collections {
-			if err := btc.initCollectionReplication(collection, i); err != nil {
-				return err
-			}
+			btc.initCollectionReplication(collection, i)
 		}
 	} else {
 		l := sync.RWMutex{}
@@ -983,11 +959,9 @@ func (btc *BlipTesterClient) createBlipTesterReplications() error {
 
 	btc.pullReplication.bt.avoidRestTesterClose = true
 	btc.pushReplication.bt.avoidRestTesterClose = true
-
-	return nil
 }
 
-func (btc *BlipTesterClient) initCollectionReplication(collection string, collectionIdx int) error {
+func (btc *BlipTesterClient) initCollectionReplication(collection string, collectionIdx int) {
 	l := sync.RWMutex{}
 	ctx, ctxCancel := context.WithCancel(btc.rt.Context())
 	btcReplicator := &BlipTesterCollectionClient{
@@ -1005,7 +979,6 @@ func (btc *BlipTesterClient) initCollectionReplication(collection string, collec
 	btcReplicator.collectionIdx = collectionIdx
 
 	btc.collectionClients[collectionIdx] = btcReplicator
-	return nil
 }
 
 func (btc *BlipTesterClient) waitForReplicationMessage(collection *db.DatabaseCollection, serialNumber blip.MessageNumber) *blip.Message {
@@ -1130,17 +1103,11 @@ func (btcc *BlipTesterCollectionClient) StartPushWithOpts(opts BlipTesterPushOpt
 
 				btcc.addCollectionProperty(proposeChangesRequest)
 
-				if err := btcc.sendPushMsg(proposeChangesRequest); err != nil {
-					btcc.TB().Errorf("Error sending proposeChanges: %v", err)
-					return
-				}
+				btcc.sendPushMsg(proposeChangesRequest)
 
 				proposeChangesResponse := proposeChangesRequest.Response()
 				rspBody, err := proposeChangesResponse.Body()
-				if err != nil {
-					btcc.TB().Errorf("Error reading proposeChanges response body: %v", err)
-					return
-				}
+				require.NoError(btcc.TB(), err)
 				errorDomain := proposeChangesResponse.Properties["Error-Domain"]
 				errorCode := proposeChangesResponse.Properties["Error-Code"]
 				if errorDomain != "" && errorCode != "" {
@@ -1190,30 +1157,18 @@ func (btcc *BlipTesterCollectionClient) StartPushWithOpts(opts BlipTesterPushOpt
 							base.DebugfCtx(ctx, base.KeySGTest, "specifying last known server version as deltaSrc for doc %s = %v", change.docID, change.latestServerVersion)
 							revRequest.Properties[db.RevMessageDeltaSrc] = change.latestServerVersion.RevID
 							var parentBodyUnmarshalled db.Body
-							if err := parentBodyUnmarshalled.Unmarshal(serverRev.body); err != nil {
-								require.FailNow(btcc.TB(), "Error unmarshalling parent body: %v", err)
-								return
-							}
+							require.NoError(btcc.TB(), parentBodyUnmarshalled.Unmarshal(serverRev.body))
 							var newBodyUnmarshalled db.Body
-							if err := newBodyUnmarshalled.Unmarshal(docBody); err != nil {
-								require.FailNow(btcc.TB(), "Error unmarshalling new body: %v", err)
-								return
-							}
+							require.NoError(btcc.TB(), newBodyUnmarshalled.Unmarshal(docBody))
 							delta, err := base.Diff(parentBodyUnmarshalled, newBodyUnmarshalled)
-							if err != nil {
-								require.FailNow(btcc.TB(), "Error creating delta: %v", err)
-								return
-							}
+							require.NoError(btcc.TB(), err)
 							revRequest.SetBody(delta)
 						} else {
 							revRequest.SetBody(docBody)
 						}
 
 						btcc.addCollectionProperty(revRequest)
-						if err := btcc.sendPushMsg(revRequest); err != nil {
-							btcc.TB().Errorf("Error sending rev: %v", err)
-							return
-						}
+						btcc.sendPushMsg(revRequest)
 						base.DebugfCtx(ctx, base.KeySGTest, "sent doc %s / %v", change.docID, change.version)
 						// block until remote has actually processed the rev and sent a response
 						revResp := revRequest.Response()
@@ -1311,33 +1266,19 @@ func (btc *BlipTesterCollectionClient) StartPullSince(options BlipTesterPullOpti
 			},
 		))
 	}
-	require.NoError(btc.TB(), btc.sendPullMsg(subChangesRequest))
+	btc.sendPullMsg(subChangesRequest)
 }
 
-func (btc *BlipTesterCollectionClient) UnsubPullChanges() (response []byte, err error) {
+// UnsubPullChanges will send an UnsubChanges message to the server to stop the pull replication. Fails test harness if Sync Gateway responds with an error.
+func (btc *BlipTesterCollectionClient) UnsubPullChanges() {
 	unsubChangesRequest := blip.NewRequest()
 	unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
 
-	err = btc.sendPullMsg(unsubChangesRequest)
-	if err != nil {
-		return nil, err
-	}
+	btc.sendPullMsg(unsubChangesRequest)
 
-	response, err = unsubChangesRequest.Response().Body()
-	return response, err
-}
-
-func (btc *BlipTesterCollectionClient) UnsubPushChanges() (response []byte, err error) {
-	unsubChangesRequest := blip.NewRequest()
-	unsubChangesRequest.SetProfile(db.MessageUnsubChanges)
-
-	err = btc.sendPushMsg(unsubChangesRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	response, err = unsubChangesRequest.Response().Body()
-	return response, err
+	response, err := unsubChangesRequest.Response().Body()
+	require.NoError(btc.TB(), err)
+	require.Empty(btc.TB(), response)
 }
 
 // Close will empty the stored docs and close the underlying replications.
@@ -1358,34 +1299,23 @@ func (btc *BlipTesterCollectionClient) Close() {
 	btc._attachments = make(map[string][]byte, 0)
 }
 
-func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) (err error) {
-
-	if !btr.bt.sender.Send(msg) {
-		return fmt.Errorf("error sending message")
-	}
+func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) {
+	require.True(btr.TB(), btr.bt.sender.Send(msg))
 	btr.storeMessage(msg)
-	return nil
 }
 
 // upsertDoc will create or update the doc based on whether parentVersion is passed or not. Enforces MVCC update.
-func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *DocVersion, body []byte) (*clientDocRev, error) {
+func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *DocVersion, body []byte) *clientDocRev {
 	btc.seqLock.Lock()
 	defer btc.seqLock.Unlock()
 	oldSeq, ok := btc._seqFromDocID[docID]
 	var doc *clientDoc
 	if ok {
-		if parentVersion == nil {
-			return nil, fmt.Errorf("docID: %v already exists on the client with seq: %v - expecting to create doc based on nil parentVersion", docID, oldSeq)
-		}
+		require.NotNil(btc.TB(), parentVersion, "docID: %v already exists on the client with seq: %v - expecting to create doc based on not nil parentVersion", docID, oldSeq)
 		doc, ok = btc._seqStore[oldSeq]
-		if !ok {
-			require.FailNow(btc.TB(), "seq %q for docID %q found but no doc in _seqStore", oldSeq, docID)
-			return nil, fmt.Errorf("seq %q for docID %q found but no doc in _seqStore", oldSeq, docID)
-		}
+		require.True(btc.TB(), ok, "seq %q for docID %q found but no doc in _seqStore", oldSeq, docID)
 	} else {
-		if parentVersion != nil {
-			return nil, fmt.Errorf("docID: %v was not found on the client - expecting to update doc based on parentVersion %v", docID, parentVersion)
-		}
+		require.Nil(btc.TB(), parentVersion, "docID: %v was not found on the client - expecting to create doc based on nil parentVersion, parentVersion=%v", docID, parentVersion)
 		doc = &clientDoc{
 			id:              docID,
 			_latestSeq:      0,
@@ -1399,16 +1329,11 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 		latestRev, err := doc.latestRev()
 		require.NoError(btc.TB(), err)
 		latestVersion := latestRev.version
-		if *parentVersion != latestVersion {
-			return nil, fmt.Errorf("latest version for docID: %v is %v, expected parentVersion: %v", docID, latestVersion, parentVersion)
-		}
+		require.Equal(btc.TB(), *parentVersion, latestVersion, "latest version for docID: %v is %v, expected parentVersion: %v", docID, latestVersion, parentVersion)
 		newGen = parentVersion.RevIDGeneration() + 1
 	}
 
-	body, err := btc.ProcessInlineAttachments(body, newGen)
-	if err != nil {
-		return nil, err
-	}
+	body = btc.ProcessInlineAttachments(body, newGen)
 
 	digest := "abc" // TODO: Generate rev ID digest based on body hash?
 
@@ -1425,17 +1350,14 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 	// new sequence written, wake up changes feeds
 	btc._seqCond.Broadcast()
 
-	return &rev, nil
+	return &rev
 }
 
 // AddRev creates a revision on the client.
 // The rev ID is always: "N-abc", where N is rev generation for predictability.
-func (btc *BlipTesterCollectionClient) AddRev(docID string, parentVersion *DocVersion, body []byte) (DocVersion, error) { // Inline attachment processing
-	newRev, err := btc.upsertDoc(docID, parentVersion, body)
-	if err != nil {
-		return DocVersion{}, err
-	}
-	return newRev.version, nil
+func (btc *BlipTesterCollectionClient) AddRev(docID string, parentVersion *DocVersion, body []byte) DocVersion {
+	newRev := btc.upsertDoc(docID, parentVersion, body)
+	return newRev.version
 }
 
 func (btc *BlipTesterCollectionClient) PushUnsolicitedRev(docID string, parentRev *DocVersion, body []byte) (version *DocVersion, err error) {
@@ -1455,10 +1377,7 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID string, parentVe
 	}
 
 	// Inline attachment processing
-	body, err = btc.ProcessInlineAttachments(body, revGen)
-	if err != nil {
-		return nil, err
-	}
+	body = btc.ProcessInlineAttachments(body, revGen)
 
 	var parentDocBody []byte
 	if parentVersion != nil {
@@ -1472,10 +1391,7 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID string, parentVe
 	}
 
 	newRevID := fmt.Sprintf("%d-%s", revGen, "abc")
-	newRev, err := btc.upsertDoc(docID, parentVersion, body)
-	if err != nil {
-		return nil, fmt.Errorf("error upserting doc: %v", err)
-	}
+	newRev := btc.upsertDoc(docID, parentVersion, body)
 
 	// send a proposeChanges message with the single rev we just created on the client
 	proposeChangesRequest := blip.NewRequest()
@@ -1488,15 +1404,11 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID string, parentVe
 
 	btc.addCollectionProperty(proposeChangesRequest)
 
-	if err := btc.sendPushMsg(proposeChangesRequest); err != nil {
-		return nil, err
-	}
+	btc.sendPushMsg(proposeChangesRequest)
 
 	proposeChangesResponse := proposeChangesRequest.Response()
 	rspBody, err := proposeChangesResponse.Body()
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(btc.TB(), err)
 	errorDomain := proposeChangesResponse.Properties["Error-Domain"]
 	errorCode := proposeChangesResponse.Properties["Error-Code"]
 	if errorDomain != "" && errorCode != "" {
@@ -1517,20 +1429,10 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID string, parentVe
 	if btc.parent.ClientDeltas && proposeChangesResponse.Properties[db.ProposeChangesResponseDeltas] == "true" && parentVersion != nil {
 		base.DebugfCtx(ctx, base.KeySync, "Sending deltas from test client from parent %v", parentVersion)
 		var parentDocJSON, newDocJSON db.Body
-		err := parentDocJSON.Unmarshal(parentDocBody)
-		if err != nil {
-			return nil, err
-		}
-
-		err = newDocJSON.Unmarshal(body)
-		if err != nil {
-			return nil, err
-		}
-
+		require.NoError(btc.TB(), parentDocJSON.Unmarshal(parentDocBody))
+		require.NoError(btc.TB(), newDocJSON.Unmarshal(body))
 		delta, err := base.Diff(parentDocJSON, newDocJSON)
-		if err != nil {
-			return nil, err
-		}
+		require.NoError(btc.TB(), err)
 		revRequest.Properties[db.RevMessageDeltaSrc] = parentVersion.RevID
 		body = delta
 	} else {
@@ -1539,16 +1441,11 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID string, parentVe
 
 	revRequest.SetBody(body)
 
-	if err := btc.sendPushMsg(revRequest); err != nil {
-		return nil, err
-	}
+	btc.sendPushMsg(revRequest)
 
 	revResponse := revRequest.Response()
 	rspBody, err = revResponse.Body()
-	if err != nil {
-		return nil, fmt.Errorf("error getting body of revResponse: %v", err)
-	}
-
+	require.NoError(btc.TB(), err)
 	if revResponse.Type() == blip.ErrorType {
 		return nil, fmt.Errorf("error %s %s from revResponse: %s", revResponse.Properties["Error-Domain"], revResponse.Properties["Error-Code"], rspBody)
 	}
@@ -1557,61 +1454,48 @@ func (btc *BlipTesterCollectionClient) PushRevWithHistory(docID string, parentVe
 	return &newRev.version, nil
 }
 
-func (btc *BlipTesterCollectionClient) StoreRevOnClient(docID string, parentVersion *DocVersion, body []byte) error {
-	_, err := btc.upsertDoc(docID, parentVersion, body)
-	return err
+func (btc *BlipTesterCollectionClient) StoreRevOnClient(docID string, parentVersion *DocVersion, body []byte) {
+	btc.upsertDoc(docID, parentVersion, body)
 }
 
-func (btc *BlipTesterCollectionClient) ProcessInlineAttachments(inputBody []byte, revGen int) (outputBody []byte, err error) {
-	if bytes.Contains(inputBody, []byte(db.BodyAttachments)) {
-		var newDocJSON map[string]interface{}
-		if err := base.JSONUnmarshal(inputBody, &newDocJSON); err != nil {
-			return nil, err
-		}
-		if attachments, ok := newDocJSON[db.BodyAttachments]; ok {
-			if attachmentMap, ok := attachments.(map[string]interface{}); ok {
-				for attachmentName, inlineAttachment := range attachmentMap {
-					inlineAttachmentMap := inlineAttachment.(map[string]interface{})
-					attachmentData, ok := inlineAttachmentMap["data"]
-					if !ok {
-						if isStub, _ := inlineAttachmentMap["stub"].(bool); isStub {
-							// push the stub as-is
-							continue
-						}
-						return nil, fmt.Errorf("couldn't find data property for inline attachment")
-					}
-
-					// Transform inline attachment data into metadata
-					data, ok := attachmentData.(string)
-					if !ok {
-						return nil, fmt.Errorf("inline attachment data was not a string")
-					}
-
-					contentType, _ := inlineAttachmentMap["content_type"].(string)
-
-					length, digest, err := btc.saveAttachment(contentType, data)
-					if err != nil {
-						return nil, err
-					}
-
-					attachmentMap[attachmentName] = map[string]interface{}{
-						"content_type": contentType,
-						"digest":       digest,
-						"length":       length,
-						"revpos":       revGen,
-						"stub":         true,
-					}
-					newDocJSON[db.BodyAttachments] = attachmentMap
-				}
-			}
-			var err error
-			if outputBody, err = base.JSONMarshal(newDocJSON); err != nil {
-				return nil, err
-			}
-			return outputBody, nil
-		}
+func (btc *BlipTesterCollectionClient) ProcessInlineAttachments(inputBody []byte, revGen int) (outputBody []byte) {
+	if !bytes.Contains(inputBody, []byte(db.BodyAttachments)) {
+		return inputBody
 	}
-	return inputBody, nil
+
+	var newDocJSON map[string]interface{}
+	require.NoError(btc.TB(), base.JSONUnmarshal(inputBody, &newDocJSON))
+	attachments, ok := newDocJSON[db.BodyAttachments]
+	if !ok {
+		return inputBody
+	}
+	attachmentMap, ok := attachments.(map[string]interface{})
+	require.True(btc.TB(), ok)
+	for attachmentName, inlineAttachment := range attachmentMap {
+		inlineAttachmentMap := inlineAttachment.(map[string]interface{})
+		attachmentData, ok := inlineAttachmentMap["data"]
+		if !ok {
+			isStub, _ := inlineAttachmentMap["stub"].(bool)
+			require.True(btc.TB(), isStub, "couldn't find data and stub property for inline attachment %#v : %v", attachmentName, inlineAttachmentMap)
+			// push the stub as-is
+			continue
+		}
+
+		// Transform inline attachment data into metadata
+		data, ok := attachmentData.(string)
+		require.True(btc.TB(), ok, "inline attachment data was not a string, got %T", attachmentData)
+
+		length, digest := btc.saveAttachment(data)
+
+		attachmentMap[attachmentName] = map[string]interface{}{
+			"digest": digest,
+			"length": length,
+			"revpos": revGen,
+			"stub":   true,
+		}
+		newDocJSON[db.BodyAttachments] = attachmentMap
+	}
+	return base.MustJSONMarshal(btc.TB(), newDocJSON)
 }
 
 // GetVersion returns the data stored in the Client under the given docID and version
@@ -1789,7 +1673,9 @@ func (btcRunner *BlipTestClientRunner) StartOneshotPullRequestPlus(clientID uint
 	btcRunner.SingleCollection(clientID).StartOneshotPullRequestPlus()
 }
 
-func (btcRunner *BlipTestClientRunner) AddRev(clientID uint32, docID string, version *DocVersion, body []byte) (DocVersion, error) {
+// AddRev creates a revision on the client.
+// The rev ID is always: "N-abc", where N is rev generation for predictability.
+func (btcRunner *BlipTestClientRunner) AddRev(clientID uint32, docID string, version *DocVersion, body []byte) DocVersion {
 	return btcRunner.SingleCollection(clientID).AddRev(docID, version, body)
 }
 
@@ -1805,12 +1691,13 @@ func (btcRunner *BlipTestClientRunner) GetVersion(clientID uint32, docID string,
 	return btcRunner.SingleCollection(clientID).GetVersion(docID, docVersion)
 }
 
-func (btcRunner *BlipTestClientRunner) saveAttachment(clientID uint32, contentType string, attachmentData string) (int, string, error) {
-	return btcRunner.SingleCollection(clientID).saveAttachment(contentType, attachmentData)
+// saveAttachment takes base64 encoded data and stores the attachment on the client.
+func (btcRunner *BlipTestClientRunner) saveAttachment(clientID uint32, attachmentData string) (int, string) {
+	return btcRunner.SingleCollection(clientID).saveAttachment(attachmentData)
 }
 
-func (btcRunner *BlipTestClientRunner) StoreRevOnClient(clientID uint32, docID string, parentVersion *DocVersion, body []byte) error {
-	return btcRunner.SingleCollection(clientID).StoreRevOnClient(docID, parentVersion, body)
+func (btcRunner *BlipTestClientRunner) StoreRevOnClient(clientID uint32, docID string, parentVersion *DocVersion, body []byte) {
+	btcRunner.SingleCollection(clientID).StoreRevOnClient(docID, parentVersion, body)
 }
 
 func (btcRunner *BlipTestClientRunner) PushRevWithHistory(clientID uint32, docID string, parentVersion *DocVersion, body []byte, revCount, prunedRevCount int) (*DocVersion, error) {
@@ -1833,8 +1720,9 @@ func (btc *BlipTesterCollectionClient) Attachments() map[string][]byte {
 	return btc._attachments
 }
 
-func (btcRunner *BlipTestClientRunner) UnsubPullChanges(clientID uint32) ([]byte, error) {
-	return btcRunner.SingleCollection(clientID).UnsubPullChanges()
+// UnsubPullChanges will send an UnsubChanges message to the server to stop the pull replication. Fails test harness if Sync Gateway responds with an error.
+func (btcRunner *BlipTestClientRunner) UnsubPullChanges(clientID uint32) {
+	btcRunner.SingleCollection(clientID).UnsubPullChanges()
 }
 
 func (btc *BlipTesterCollectionClient) addCollectionProperty(msg *blip.Message) {
@@ -1871,14 +1759,14 @@ func (btc *BlipTesterClient) getCollectionClientFromMessage(msg *blip.Message) *
 	return btc.collectionClients[idx]
 }
 
-func (btc *BlipTesterCollectionClient) sendPullMsg(msg *blip.Message) error {
+func (btc *BlipTesterCollectionClient) sendPullMsg(msg *blip.Message) {
 	btc.addCollectionProperty(msg)
-	return btc.parent.pullReplication.sendMsg(msg)
+	btc.parent.pullReplication.sendMsg(msg)
 }
 
-func (btc *BlipTesterCollectionClient) sendPushMsg(msg *blip.Message) error {
+func (btc *BlipTesterCollectionClient) sendPushMsg(msg *blip.Message) {
 	btc.addCollectionProperty(msg)
-	return btc.parent.pushReplication.sendMsg(msg)
+	btc.parent.pushReplication.sendMsg(msg)
 }
 
 func (c *BlipTesterCollectionClient) lastSeq() clientSeq {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -6515,13 +6515,13 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 				expectedRevID = "1-e5d43a9cdc4a2d4e258800dfc37e9d77"
 			}
 
+			version := rest.DocVersion{RevID: expectedRevID}
 			// Wait for doc to show up on side that the resurrection was done
 			if test.resurrectLocal {
-				err = localActiveRT.WaitForRev(doc2ID, expectedRevID)
+				localActiveRT.WaitForVersion(doc2ID, version)
 			} else {
-				err = remotePassiveRT.WaitForRev(doc2ID, expectedRevID)
+				remotePassiveRT.WaitForVersion(doc2ID, version)
 			}
-			require.NoError(t, err)
 
 			// Start the replication
 			_ = localActiveRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/replication?action=start", "")
@@ -6529,11 +6529,10 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 			// Wait for doc to replicate from side resurrection was done on to the other side
 			if test.resurrectLocal {
-				err = remotePassiveRT.WaitForRev(doc2ID, expectedRevID)
+				remotePassiveRT.WaitForVersion(doc2ID, version)
 			} else {
-				err = localActiveRT.WaitForRev(doc2ID, expectedRevID)
+				localActiveRT.WaitForVersion(doc2ID, version)
 			}
-			assert.NoError(t, err)
 		})
 	}
 }
@@ -6979,7 +6978,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			activeRT.CreateReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePushAndPull, nil, true, db.ConflictResolverLocalWins)
 			activeRT.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-			assert.NoError(t, remoteRT.WaitForVersion(docID, newVersion))
+			remoteRT.WaitForVersion(docID, newVersion)
 
 			// Stop the replication
 			response := activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=stop", "")
@@ -7187,7 +7186,7 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 			activeRT.CreateReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePushAndPull, nil, true, test.conflictResolution)
 			activeRT.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-			assert.NoError(t, remoteRT.WaitForVersion(docID, newVersion))
+			remoteRT.WaitForVersion(docID, newVersion)
 
 			response := activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=stop", "")
 			rest.RequireStatus(t, response, http.StatusOK)
@@ -7218,10 +7217,8 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 			response = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=start", "")
 			rest.RequireStatus(t, response, http.StatusOK)
 
-			waitErr := activeRT.WaitForVersion(docID, test.expectedFinalVersion)
-			assert.NoError(t, waitErr)
-			waitErr = remoteRT.WaitForVersion(docID, test.expectedFinalVersion)
-			require.NoError(t, waitErr)
+			activeRT.WaitForVersion(docID, test.expectedFinalVersion)
+			remoteRT.WaitForVersion(docID, test.expectedFinalVersion)
 
 			localDoc := activeRT.GetDocBody(docID)
 			localVersion := localDoc.ExtractRev()
@@ -7355,7 +7352,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 
 	// Create a document //
 	version := activeRT.PutDoc("test", `{"field1":"f1_1","field2":"f2_1"}`)
-	require.NoError(t, activeRT.WaitForVersion("test", version))
+	activeRT.WaitForVersion("test", version)
 
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
@@ -7383,7 +7380,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	assert.NoError(t, ar.Start(activeCtx))
 
 	// Wait for active to replicate to passive
-	require.NoError(t, passiveRT.WaitForVersion("test", version))
+	passiveRT.WaitForVersion("test", version)
 
 	// Delete active document
 	deletedVersion := activeRT.DeleteDocReturnVersion("test", version)
@@ -7416,8 +7413,7 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	resurrectedVersion := activeRT.UpdateDoc("test", deletedVersion, `{"field2":"f2_2"}`)
 
 	// Replicate resurrection to passive
-	err = passiveRT.WaitForVersion("test", resurrectedVersion)
-	assert.NoError(t, err) // If error, problem not fixed
+	passiveRT.WaitForVersion("test", resurrectedVersion)
 
 	// Shutdown replicator to close out
 	require.NoError(t, ar.Stop())
@@ -7474,7 +7470,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 	// Create a document //
 	version := activeRT.PutDoc("test", `{"field1":"f1_1","field2":"f2_1"}`)
-	require.NoError(t, activeRT.WaitForVersion("test", version))
+	activeRT.WaitForVersion("test", version)
 
 	// Set-up replicator //
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
@@ -7502,7 +7498,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 	assert.NoError(t, ar.Start(activeCtx))
 
-	require.NoError(t, passiveRT.WaitForVersion("test", version))
+	passiveRT.WaitForVersion("test", version)
 
 	assert.NoError(t, ar.Stop())
 
@@ -7520,8 +7516,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 	assert.NoError(t, ar.Start(activeCtx))
 	// Check if it replicated
-	err = passiveRT.WaitForVersion("test", version2)
-	assert.NoError(t, err)
+	passiveRT.WaitForVersion("test", version2)
 
 	assert.NoError(t, ar.Stop())
 }
@@ -7560,15 +7555,15 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	// Create the docs //
 	// Doc rev 1
 	version1 := activeRT.PutDoc(docID, `{"key":"12","channels": ["rev1chan"]}`)
-	require.NoError(t, activeRT.WaitForVersion(docID, version1))
+	activeRT.WaitForVersion(docID, version1)
 
 	// doc rev 2
 	version2 := activeRT.UpdateDoc(docID, version1, `{"key":"12","channels":["rev2+3chan"]}`)
-	require.NoError(t, activeRT.WaitForVersion(docID, version2))
+	activeRT.WaitForVersion(docID, version2)
 
 	// Doc rev 3
 	version3 := activeRT.UpdateDoc(docID, version2, `{"key":"3","channels":["rev2+3chan"]}`)
-	require.NoError(t, activeRT.WaitForVersion(docID, version3))
+	activeRT.WaitForVersion(docID, version3)
 
 	activeRT.GetDatabase().FlushRevisionCacheForTest()
 	err := activeRT.GetSingleDataStore().Delete(fmt.Sprintf("_sync:rev:%s:%d:%s", t.Name(), len(version2.RevID), version2.RevID))
@@ -7855,8 +7850,7 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 
 	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateRunning)
 
-	err = passiveRT.WaitForVersion(docID, version)
-	require.NoError(t, err)
+	passiveRT.WaitForVersion(docID, version)
 
 	resp = activeRT.SendAdminRequest("GET", "/{{.db}}/_replication/"+t.Name(), "")
 	rest.RequireStatus(t, resp, 200)
@@ -7896,8 +7890,7 @@ func TestReplicatorCheckpointOnStop(t *testing.T) {
 	activeRT.CreateReplication(t.Name(), remoteURL, db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
 	activeRT.WaitForReplicationStatus(t.Name(), db.ReplicationStateRunning)
 
-	err = passiveRT.WaitForRev("test", rev)
-	require.NoError(t, err)
+	passiveRT.WaitForVersion("test", rest.DocVersion{RevID: rev})
 
 	// assert on the processed seq list being updated before stopping the active replicator
 	ar, ok := activeRT.GetDatabase().SGReplicateMgr.GetLocalActiveReplicatorForTest(t, t.Name())

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -16,10 +16,12 @@ import (
 	"net/url"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,22 +124,17 @@ func (rt *RestTester) GetDatabaseRoot(dbname string) DatabaseRoot {
 }
 
 // WaitForVersion retries a GET for a given document version until it returns 200 or 201 for a given document and revision. If version is not found, the test will fail.
-func (rt *RestTester) WaitForVersion(docID string, version DocVersion) error {
+func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 	require.NotEqual(rt.TB(), "", version.RevID)
-	return rt.WaitForCondition(func() bool {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")
-		if rawResponse.Code != 200 && rawResponse.Code != 201 {
-			return false
+		if !assert.Contains(c, []int{200, 201}, rawResponse.Code, "Unexpected status code for %s", rawResponse.Body.String()) {
+			return
 		}
 		var body db.Body
 		require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
-		return body.ExtractRev() == version.RevID
-	})
-}
-
-// WaitForRev retries a GET until it returns 200 or 201. If revision is not found, the test will fail. This function is deprecated for RestTester.WaitForVersion
-func (rt *RestTester) WaitForRev(docID, revID string) error {
-	return rt.WaitForVersion(docID, DocVersion{RevID: revID})
+		assert.Equal(c, version.RevID, body.ExtractRev(), "Unexpected revision for %s", rawResponse.Body.String())
+	}, time.Second*10, time.Millisecond*10)
 }
 
 func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string, error) {


### PR DESCRIPTION
This is a main counterpart to https://github.com/couchbase/sync_gateway/commit/ab6ad03d1be8465efa6b1ca138aad1b24ea32432, which also has some intermittent test failures I have not yet found.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2891/
