### PR TITLE
Make CouchbaseLiteMockReplication run unidirectional only

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2282,7 +2282,6 @@ func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
 
 		initialVersion := btc.rt.PutDocWithAttachment(doc1ID, "{}", "hello.txt", "aGVsbG8gd29ybGQ=")
 		btc.rt.WaitForPendingChanges()
-		btcRunner.StartOneshotPull(btc.id)
 		btcRunner.WaitForVersion(btc.id, doc1ID, initialVersion)
 
 		value, xattrs, cas, err := ds.GetWithXattrs(ctx, doc1ID, []string{base.SyncXattrName, base.GlobalXattrName})

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -278,6 +278,10 @@ type BlipTesterCollectionClient struct {
 	ctxCancel   context.CancelFunc
 	goroutineWg sync.WaitGroup
 
+	pushRunning   base.AtomicBool
+	pushCtx       context.Context
+	pushCtxCancel context.CancelFunc
+
 	collection    string
 	collectionIdx int
 
@@ -1187,17 +1191,21 @@ func proposeChangesEntryForDoc(doc *clientDoc) proposeChangeBatchEntry {
 
 // StartPull will begin a push replication with the given options between the client and server
 func (btcc *BlipTesterCollectionClient) StartPushWithOpts(opts BlipTesterPushOptions) {
-	ctx := btcc.ctx
+	require.True(btcc.TB(), btcc.pushRunning.CASRetry(false, true), "push replication already running")
+
+	btcc.pushCtx, btcc.pushCtxCancel = context.WithCancel(btcc.ctx)
+	ctx := btcc.pushCtx
 	sinceFromStr, err := db.ParsePlainSequenceID(opts.Since)
 	require.NoError(btcc.TB(), err)
 	seq := clientSeq(sinceFromStr.SafeSequence())
 	btcc.goroutineWg.Add(1)
 	go func() {
+		defer btcc.pushRunning.Set(false)
 		defer btcc.goroutineWg.Done()
 		// TODO: CBG-4401 wire up opts.changesBatchSize and implement a flush timeout for when the client doesn't fill the batch
 		changesBatch := make([]proposeChangeBatchEntry, 0, changesBatchSize)
 		base.DebugfCtx(ctx, base.KeySGTest, "Starting push replication iteration with since=%v", seq)
-		for doc := range btcc.docsSince(btcc.ctx, seq, opts.Continuous) {
+		for doc := range btcc.docsSince(ctx, seq, opts.Continuous) {
 			changesBatch = append(changesBatch, proposeChangesEntryForDoc(doc))
 			if len(changesBatch) >= changesBatchSize {
 				base.DebugfCtx(ctx, base.KeySGTest, "Sending batch of %d changes", len(changesBatch))
@@ -1425,6 +1433,11 @@ func (btc *BlipTesterCollectionClient) StartPullSince(options BlipTesterPullOpti
 		))
 	}
 	btc.sendPullMsg(subChangesRequest)
+}
+
+func (btc *BlipTesterCollectionClient) StopPush() {
+	require.True(btc.TB(), btc.pushRunning.CASRetry(true, false), "can't stop push replication - not running")
+	btc.pushCtxCancel()
 }
 
 func (btc *BlipTesterCollectionClient) UnsubPullChanges() {
@@ -1952,6 +1965,10 @@ func (btc *BlipTesterCollectionClient) Attachments() map[string][]byte {
 
 func (btcRunner *BlipTestClientRunner) UnsubPullChanges(clientID uint32) {
 	btcRunner.SingleCollection(clientID).UnsubPullChanges()
+}
+
+func (btcRunner *BlipTestClientRunner) StopPush(clientID uint32) {
+	btcRunner.SingleCollection(clientID).StopPush()
 }
 
 func (btc *BlipTesterCollectionClient) addCollectionProperty(msg *blip.Message) {

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -174,6 +174,18 @@ func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, config PeerReplicat
 	if !ok {
 		require.Fail(p.t, fmt.Sprintf("unsupported peer type %T for pull replication", peer))
 	}
+
+	// check for existing blip runner/client and use if present - avoids creating multiple clients for the same peer
+	if pbtc, ok := p.blipClients[sg.String()]; ok {
+		return &CouchbaseLiteMockReplication{
+			activePeer:  p,
+			passivePeer: peer,
+			btc:         pbtc.btc,
+			btcRunner:   pbtc.btcRunner,
+			direction:   config.direction,
+		}
+	}
+
 	replication := &CouchbaseLiteMockReplication{
 		activePeer:  p,
 		passivePeer: peer,

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -222,13 +222,11 @@ func (p *CouchbaseLiteMockPeer) GetBackingBucket() base.Bucket {
 
 // CouchbaseLiteMockReplication represents a replication between Couchbase Lite and Sync Gateway. This can be a push or pull replication.
 type CouchbaseLiteMockReplication struct {
-	activePeer    Peer
-	passivePeer   Peer
-	btc           *rest.BlipTesterClient
-	btcRunner     *rest.BlipTestClientRunner
-	direction     PeerReplicationDirection
-	pushCtx       context.Context
-	pushCtxCancel context.CancelFunc
+	activePeer  Peer
+	passivePeer Peer
+	btc         *rest.BlipTesterClient
+	btcRunner   *rest.BlipTestClientRunner
+	direction   PeerReplicationDirection
 }
 
 // ActivePeer returns the peer sending documents

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -95,7 +95,7 @@ func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		}
 		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, peerName, topologyDescription))
 		docVersion := peer.CreateDocument(dsName, docID, docBody)
-		t.Logf("createVersion: %#v", docVersion.docMeta)
+		t.Logf("%s - createVersion: %#v", peerName, docVersion.docMeta)
 		documentVersion = append(documentVersion, docVersion)
 	}
 	index := len(documentVersion) - 1

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -364,8 +364,17 @@ func TestPeerImplementation(t *testing.T) {
 			peer := peers[tc.name]
 			// couchbase lite peer can't exist separately from sync gateway peer, CBG-4433
 			if peer.Type() == PeerTypeCouchbaseLite {
-				replication := peer.CreateReplication(peers["sg"], PeerReplicationConfig{})
-				defer replication.Stop()
+				pullReplication := peer.CreateReplication(peers["sg"], PeerReplicationConfig{
+					direction: PeerReplicationDirectionPull,
+				})
+				pullReplication.Start()
+				defer pullReplication.Stop()
+
+				pushReplication := peer.CreateReplication(peers["sg"], PeerReplicationConfig{
+					direction: PeerReplicationDirectionPush,
+				})
+				pushReplication.Start()
+				defer pushReplication.Stop()
 			}
 
 			docID := t.Name()


### PR DESCRIPTION
The topology test framework is set up so a replication only runs in one direction, however currently the underlying `BlipTesterClient` is being used to run both push and pull no matter what `config.Direction` is set to.

Fixing this makes tests relying on this unintended behaviour fail due to another bug, `CouchbaseLiteMockPeer.CreateReplication()` is creating a whole new client, with unique document storage per direction. This change means tests who used to have a full set of documents/versions because of them unintentionally pushing and pulling from other clients using the same SourceID, now do not.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
