### PR TITLE
Various small BlipTesterClient stability improvements

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1266,6 +1266,11 @@ func (btcc *BlipTesterCollectionClient) StartPushWithOpts(opts BlipTesterPushOpt
 
 				base.DebugfCtx(ctx, base.KeySGTest, "proposeChanges response: %s", string(rspBody))
 
+				if len(rspBody) == 0 {
+					// replication was closed underneath proposeChanges request/response - abort
+					return
+				}
+
 				var serverDeltas bool
 				if proposeChangesResponse.Properties[db.ChangesResponseDeltas] == "true" {
 					base.DebugfCtx(ctx, base.KeySGTest, "server supports deltas")


### PR DESCRIPTION
Various small BlipTesterClient stability improvements

- Improve BlipTesterClient locking (move to one lock/unlock instead of multiple via accessor methods)
- Allow `BlipTesterClient` push replication to close mid-proposeChanges without erroring because of an empty message body
- Check `BlipTesterClient` pull replication start with `subChanges` was actually successful

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a