### PR TITLE
Topology test fixes

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1242,7 +1242,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 			}
 		} else {
 			if doc.HLV.isDominating(newDocHLV) {
-				base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add", base.UD(newDoc.ID))
+				base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add.  existing: %#v  new:%#v", base.UD(newDoc.ID), doc.HLV, newDocHLV)
 				return nil, nil, false, nil, base.ErrUpdateCancel // No new revisions to add
 			}
 			if newDocHLV.isDominating(doc.HLV) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -968,7 +968,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 			d.HLV.CurrentVersionCAS = d.Cas
 			base.DebugfCtx(ctx, base.KeyVV, "Adding new version to HLV due to import for doc %s, updated HLV %+v", base.UD(d.ID), d.HLV)
 		} else {
-			base.DebugfCtx(ctx, base.KeyVV, "Not updating HLV to _mou.cas == doc.cas for doc %s, extant HLV %+v", base.UD(d.ID), d.HLV)
+			base.DebugfCtx(ctx, base.KeyVV, "Not updating HLV due to _mou.cas == doc.cas for doc %s, extant HLV %+v", base.UD(d.ID), d.HLV)
 		}
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1446,6 +1446,12 @@ func (btc *BlipTesterCollectionClient) StartPullSince(options BlipTesterPullOpti
 func (btc *BlipTesterCollectionClient) StopPush() {
 	require.True(btc.TB(), btc.pushRunning.CASRetry(true, false), "can't stop push replication - not running")
 	btc.pushCtxCancel()
+
+	// wait for push replication to stop running
+	require.EventuallyWithT(btc.TB(), func(c *assert.CollectT) {
+		assert.False(c, btc.pushRunning.IsTrue())
+	}, 10*time.Second, 1*time.Millisecond)
+
 }
 
 func (btc *BlipTesterCollectionClient) UnsubPullChanges() {

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -52,7 +52,7 @@ func stripInternalProperties(body db.Body) {
 // waitForVersionAndBody waits for a document to reach a specific version on all peers.
 func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string, expectedVersion BodyAndVersion) {
 	for _, peer := range peers.SortedPeers() {
-		t.Logf("waiting for doc version %#v on %s, written from %s", expectedVersion, peer, expectedVersion.updatePeer)
+		t.Logf("waiting for doc version on peer %s, written from %s: %#v", peer, expectedVersion.updatePeer, expectedVersion)
 		body := peer.WaitForDocVersion(dsName, docID, expectedVersion.docMeta)
 		requireBodyEqual(t, expectedVersion.body, body)
 	}
@@ -60,7 +60,7 @@ func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, pee
 
 func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string, expectedVersion BodyAndVersion) {
 	for _, peer := range peers.SortedPeers() {
-		t.Logf("waiting for tombstone version %#v on %s, written from %s", expectedVersion, peer, expectedVersion.updatePeer)
+		t.Logf("waiting for tombstone version on peer %s, written from %s: %#v", peer, expectedVersion.updatePeer, expectedVersion)
 		peer.WaitForTombstoneVersion(dsName, docID, expectedVersion.docMeta)
 	}
 }

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -316,7 +316,7 @@ func updatePeersT(t *testing.T, peers map[string]Peer) {
 
 // setupTests returns a map of peers and a list of replications. The peers will be closed and the buckets will be destroyed by t.Cleanup.
 func setupTests(t *testing.T, topology Topology) (base.ScopeAndCollectionName, Peers, Replications) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyVV, base.KeyCRUD)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyVV, base.KeyCRUD, base.KeySync)
 	peers := createPeers(t, topology.peers)
 	replications := createPeerReplications(t, peers, topology.replications)
 

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -316,7 +316,7 @@ func updatePeersT(t *testing.T, peers map[string]Peer) {
 
 // setupTests returns a map of peers and a list of replications. The peers will be closed and the buckets will be destroyed by t.Cleanup.
 func setupTests(t *testing.T, topology Topology) (base.ScopeAndCollectionName, Peers, Replications) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyVV)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyVV, base.KeyCRUD)
 	peers := createPeers(t, topology.peers)
 	replications := createPeerReplications(t, peers, topology.replications)
 

--- a/topologytest/single_actor_test.go
+++ b/topologytest/single_actor_test.go
@@ -118,13 +118,13 @@ func TestSingleActorResurrect(t *testing.T) {
 					waitForVersionAndBody(t, collectionName, peers, docID, createVersion)
 
 					deleteVersion := activePeer.DeleteDocument(collectionName, docID)
-					t.Logf("createVersion: %+v, deleteVersion: %+v", createVersion, deleteVersion)
+					t.Logf("createVersion: %#v, deleteVersion: %#v", createVersion, deleteVersion)
 					t.Logf("waiting for document deletion on all peers")
 					waitForTombstoneVersion(t, collectionName, peers, docID, BodyAndVersion{docMeta: deleteVersion, updatePeer: activePeerID})
 
 					body2 := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "resurrect"}`, activePeerID, topology.description))
 					resurrectVersion := activePeer.WriteDocument(collectionName, docID, body2)
-					t.Logf("createVersion: %+v, deleteVersion: %+v, resurrectVersion: %+v", createVersion.docMeta, deleteVersion, resurrectVersion.docMeta)
+					t.Logf("createVersion: %#v, deleteVersion: %#v, resurrectVersion: %#v", createVersion.docMeta, deleteVersion, resurrectVersion.docMeta)
 					t.Logf("waiting for document resurrection on all peers")
 
 					waitForVersionAndBody(t, collectionName, peers, docID, resurrectVersion)

--- a/xdcr/rosmar_xdcr.go
+++ b/xdcr/rosmar_xdcr.go
@@ -402,8 +402,10 @@ func updateHLV(xattrs map[string][]byte, sourceHLV *db.HybridLogicalVector, sour
 	if sourceMou != nil {
 		// removing _mou.cas and _mou.pRev matches cbs xdcr behavior.
 		// CBS xdcr maybe should clear _mou.pCas as well, but it is not a problem since all checks for _mou.cas should check current cas for _mou being up to date.
-		//sourceMou.HexCAS = ""
-		sourceMou.PreviousRevSeqNo = 0
+		if sourceMou.CAS() != sourceCas {
+			sourceMou.HexCAS = ""
+			sourceMou.PreviousRevSeqNo = 0
+		}
 		var err error
 		xattrs[base.MouXattrName], err = json.Marshal(sourceMou)
 		if err != nil {

--- a/xdcr/rosmar_xdcr.go
+++ b/xdcr/rosmar_xdcr.go
@@ -402,7 +402,7 @@ func updateHLV(xattrs map[string][]byte, sourceHLV *db.HybridLogicalVector, sour
 	if sourceMou != nil {
 		// removing _mou.cas and _mou.pRev matches cbs xdcr behavior.
 		// CBS xdcr maybe should clear _mou.pCas as well, but it is not a problem since all checks for _mou.cas should check current cas for _mou being up to date.
-		sourceMou.HexCAS = ""
+		//sourceMou.HexCAS = ""
 		sourceMou.PreviousRevSeqNo = 0
 		var err error
 		xattrs[base.MouXattrName], err = json.Marshal(sourceMou)


### PR DESCRIPTION
Test logging enhancements:
- verbose HLV logging in a few more places
- turn on Sync and CRUD log keys for topology tests

Flaky test fixes:
- Fix changes processing in blip test client to not request revs when version in changes message is already known to the client
- Change StopPush in blipTestClient to synchronously wait for push processing to be stopped
- rosmar XDCR: replicate _mou to target when it is not obsolete