### PR TITLE
Multi-actor/Conflict tests and BTC pull replication conflict resolution

### DIFF
--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -491,9 +491,9 @@ func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, 
 
 // ExtractHLVFromBlipMessage extracts the full HLV a string in the format seen over Blip
 // blip string may be the following formats
-//  1. cv only:    		cv
-//  2. cv and pv:  		cv;pv1,pv2
-//  3. cv, pv, and mv: 	cv;mv1,mv2;pv1,pv2
+//  1. cv only:			cv
+//  2. cv and pv:		cv;pv1,pv2
+//  3. cv+mv and pv:	cv,mv1,mv2;pv1,pv2
 //
 // Function will return list of revIDs if legacy rev ID was found in the HLV history section (PV)
 // TODO: CBG-3662 - Optimise once we've settled on and tested the format with CBL

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -346,13 +346,13 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector *HybridLogicalVecto
 		// for source if the local version for that source is lower
 		for i, v := range otherVector.PreviousVersions {
 			if hlv.PreviousVersions[i] == 0 {
-				hlv.setPreviousVersion(i, v)
+				hlv.SetPreviousVersion(i, v)
 			} else {
 				// if we get here then there is entry for this source in PV so we must check if its newer or not
 				otherHLVPVValue := v
 				localHLVPVValue := hlv.PreviousVersions[i]
 				if localHLVPVValue < otherHLVPVValue {
-					hlv.setPreviousVersion(i, v)
+					hlv.SetPreviousVersion(i, v)
 				}
 			}
 		}
@@ -384,8 +384,8 @@ func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansi
 	return outputSpec
 }
 
-// setPreviousVersion will take a source/version pair and add it to the HLV previous versions map
-func (hlv *HybridLogicalVector) setPreviousVersion(source string, version uint64) {
+// SetPreviousVersion will take a source/version pair and add it to the HLV previous versions map
+func (hlv *HybridLogicalVector) SetPreviousVersion(source string, version uint64) {
 	if hlv.PreviousVersions == nil {
 		hlv.PreviousVersions = make(HLVVersions)
 	}

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -384,7 +384,7 @@ func (hlv *HybridLogicalVector) computeMacroExpansions() []sgbucket.MacroExpansi
 	return outputSpec
 }
 
-// SetPreviousVersion will take a source/version pair and add it to the HLV previous versions map
+// SetPreviousVersion will take a source/version pair and sets the value for the given source in the previous versions map
 func (hlv *HybridLogicalVector) SetPreviousVersion(source string, version uint64) {
 	if hlv.PreviousVersions == nil {
 		hlv.PreviousVersions = make(HLVVersions)

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -443,6 +443,41 @@ func (hlv *HybridLogicalVector) ToHistoryForHLV() string {
 	return s.String()
 }
 
+func FromHistoryForHLV(history string) (*HybridLogicalVector, error) {
+	hlv := NewHybridLogicalVector()
+	// split the history string into PV and MV
+	versionSets := strings.Split(history, ";")
+	switch len(versionSets) {
+	case 0:
+		// no versions present
+		return hlv, nil
+	case 2:
+		// MV
+		mvs := strings.Split(versionSets[1], ",")
+		for _, mv := range mvs {
+			v, err := ParseVersion(mv)
+			if err != nil {
+				return nil, err
+			}
+			hlv.MergeVersions[v.SourceID] = v.Value
+		}
+		fallthrough
+	case 1:
+		// PV
+		pvs := strings.Split(versionSets[0], ",")
+		for _, pv := range pvs {
+			v, err := ParseVersion(pv)
+			if err != nil {
+				return nil, err
+			}
+			hlv.PreviousVersions[v.SourceID] = v.Value
+		}
+	default:
+		return nil, fmt.Errorf("Invalid history string format")
+	}
+	return hlv, nil
+}
+
 // appendRevocationMacroExpansions adds macro expansions for the channel map.  Not strictly an HLV operation
 // but putting the function here as it's required when the HLV's current version is being macro expanded
 func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, channelNames []string) (updatedSpec []sgbucket.MacroExpansionSpec) {

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -492,8 +492,8 @@ func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, 
 // ExtractHLVFromBlipMessage extracts the full HLV a string in the format seen over Blip
 // blip string may be the following formats
 //  1. cv only:    		cv
-//  2. cv and pv:  		cv;pv
-//  3. cv, pv, and mv: 	cv;mv;pv
+//  2. cv and pv:  		cv;pv1,pv2
+//  3. cv, pv, and mv: 	cv;mv1,mv2;pv1,pv2
 //
 // Function will return list of revIDs if legacy rev ID was found in the HLV history section (PV)
 // TODO: CBG-3662 - Optimise once we've settled on and tested the format with CBL

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -273,7 +273,7 @@ func (hlv *HybridLogicalVector) InvalidateMV() {
 		if source == hlv.SourceID {
 			continue
 		}
-		hlv.setPreviousVersion(source, value)
+		hlv.SetPreviousVersion(source, value)
 	}
 	hlv.MergeVersions = nil
 }

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -596,6 +596,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 			if btc.UseHLV() {
 				var incomingHLV *db.HybridLogicalVector
 				if revHistory != "" {
+					// TODO: Replace with new Beta version/handling
 					incomingHLV, err = db.FromHistoryForHLV(revHistory)
 					require.NoError(btr.TB(), err, "error extracting HLV history %q: %v", revHistory, err)
 					hlv = *incomingHLV
@@ -1115,11 +1116,11 @@ func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTes
 	if !opts.ConflictResolver.IsValid() {
 		require.FailNowf(btcRunner.TB(), "invalid conflict resolver", "invalid conflict resolver %q", opts.ConflictResolver)
 	}
-	if opts.SourceID == "" {
-		opts.SourceID = "blipclient"
-	}
 	id, err := uuid.NewRandom()
 	require.NoError(btcRunner.TB(), err)
+	if opts.SourceID == "" {
+		opts.SourceID = fmt.Sprintf("btc-%d", id.ID())
+	}
 
 	client = &BlipTesterClient{
 		BlipTesterClientOpts: *opts,

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -601,8 +601,8 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 			if btc.UseHLV() {
 				var incomingHLV *db.HybridLogicalVector
 				if revHistory != "" {
-					incomingHLV, _, err = db.ExtractHLVFromBlipMessage(revHistory)
-					require.NoError(btr.TB(), err, "error extracting HLV %q: %v", revHistory, err)
+					incomingHLV, err = db.FromHistoryForHLV(revHistory)
+					require.NoError(btr.TB(), err, "error extracting HLV history %q: %v", revHistory, err)
 					hlv = *incomingHLV
 				}
 				incomingCV, err := db.ParseVersion(revID)
@@ -849,8 +849,8 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		if btc.UseHLV() {
 			var incomingHLV *db.HybridLogicalVector
 			if revHistory != "" {
-				incomingHLV, _, err = db.ExtractHLVFromBlipMessage(revHistory)
-				require.NoError(btr.TB(), err, "error extracting HLV %q: %v", revHistory, err)
+				incomingHLV, err = db.FromHistoryForHLV(revHistory)
+				require.NoError(btr.TB(), err, "error extracting HLV history %q: %v", revHistory, err)
 				hlv = *incomingHLV
 			}
 			incomingCV, err := db.ParseVersion(revID)

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -863,6 +863,11 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 			if latestClientRev != nil {
 				clientCV := latestClientRev.version.CV
 
+				// safety check - ensure SG is not sending a rev that we already had - ensures changes feed messaging is working correctly to prevent
+				if clientCV.SourceID == incomingCV.SourceID && clientCV.Value == incomingCV.Value {
+					require.FailNow(btc.TB(), "incoming revision %v is equal to client revision %v - should've been filtered via changes response before ending up as a rev", incomingCV, clientCV)
+				}
+
 				// incoming rev older than stored client version and comes from a different source - need to resolve
 				if incomingCV.Value < clientCV.Value && incomingCV.SourceID != clientCV.SourceID {
 					btc.TB().Logf("Detected conflict on pull of doc %q (clientCV:%v - incomingCV:%v incomingHLV:%#v)", docID, clientCV, incomingCV, incomingHLV)

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -299,12 +299,6 @@ func (cd *clientDoc) currentVersion(t testing.TB) *db.Version {
 	return &rev.version.CV
 }
 
-func (cd *clientDoc) _currentVersion(t testing.TB) *db.Version {
-	rev, err := cd._latestRev()
-	require.NoError(t, err)
-	return &rev.version.CV
-}
-
 type BlipTesterCollectionClient struct {
 	parent *BlipTesterClient
 

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -881,6 +881,9 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					// no conflict - accept incoming rev
 					versionToWrite = DocVersion{CV: incomingCV}
 				}
+			} else {
+				// no existing rev - accept incoming rev
+				versionToWrite = DocVersion{CV: incomingCV}
 			}
 			require.NoError(btc.TB(), hlv.AddVersion(versionToWrite.CV), "couldn't add new CV into doc HLV")
 		} else {

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -65,7 +65,11 @@ func (p *CouchbaseLiteMockPeer) GetDocument(dsName sgbucket.DataStoreName, docID
 	bodyBytes, meta := p.getLatestDocVersion(dsName, docID)
 	require.NotNil(p.TB(), meta, "docID:%s not found on %s", docID, p)
 	var body db.Body
-	require.NoError(p.TB(), base.JSONUnmarshal(bodyBytes, &body))
+	// it's easier if all clients can return consistent bodies for tombstones
+	// lets just settle on nil, since we still need special handling anyway for `` vs `{}` so unmarshal doesn't barf
+	if len(bodyBytes) > 0 && string(bodyBytes) != base.EmptyDocument {
+		require.NoError(p.TB(), base.JSONUnmarshal(bodyBytes, &body))
+	}
 	return *meta, body
 }
 

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -342,6 +342,8 @@ func getBodyAndVersion(peer Peer, collection sgbucket.DataStore, docID string) (
 	require.NoError(peer.TB(), err)
 	// get hlv to construct DocVersion
 	var body db.Body
-	require.NoError(peer.TB(), base.JSONUnmarshal(docBytes, &body))
+	if len(docBytes) > 0 {
+		require.NoError(peer.TB(), base.JSONUnmarshal(docBytes, &body))
+	}
 	return getDocVersion(docID, peer, cas, xattrs), body
 }

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -91,10 +91,6 @@ func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		if backingPeers[peerName] {
 			continue
 		}
-		if peer.Type() == PeerTypeCouchbaseLite {
-			// FIXME: Skipping Couchbase Lite tests for multi actor conflicts, CBG-4434
-			continue
-		}
 		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, peerName, topologyDescription))
 		docVersion := peer.CreateDocument(dsName, docID, docBody)
 		t.Logf("%s - createVersion: %#v", peerName, docVersion.docMeta)

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -71,7 +71,7 @@ func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, p
 // waitForConvergingVersion waits for the same document version to reach all peers.
 func waitForConvergingVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string) {
 	t.Logf("waiting for converged doc versions across all peers")
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithTf(t, func(c *assert.CollectT) {
 		for peerAid, peerA := range peers.SortedPeers() {
 			docMetaA, bodyA := peerA.GetDocument(dsName, docID)
 			for peerBid, peerB := range peers.SortedPeers() {
@@ -84,7 +84,19 @@ func waitForConvergingVersion(t *testing.T, dsName base.ScopeAndCollectionName, 
 				require.Equalf(c, bodyA, bodyB, "body mismatch: %s:%s != %s:%s", peerAid, bodyA, peerBid, bodyB)
 			}
 		}
-	}, totalWaitTime, pollInterval)
+	}, totalWaitTime, pollInterval, "Peers did not converge on version for doc %q\nGlobal state for all peers:\n%s", docID, peers.PrintGlobalDocState(t, dsName, docID))
+}
+
+// PrintGlobalDocState returns the current state of a document across all peers, and also logs it on `t`.
+func (p Peers) PrintGlobalDocState(t testing.TB, dsName base.ScopeAndCollectionName, docID string) string {
+	var globalState strings.Builder
+	for peerName, peer := range p {
+		docMeta, body := peer.GetDocument(dsName, docID)
+		globalState.WriteString(fmt.Sprintf("====\npeer(%s)\n----\n%#v\nbody:%v\n", peerName, docMeta, body))
+	}
+	globalStateStr := globalState.String()
+	t.Logf("Global doc %q state for all peers:\n%s", docID, globalStateStr)
+	return globalStateStr
 }
 
 // removeSyncGatewayBackingPeers will check if there is sync gateway in topology, if so will track the backing CBS
@@ -125,7 +137,7 @@ func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		}
 		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "update"}`, peerName, topologyDescription))
 		docVersion := peer.WriteDocument(dsName, docID, docBody)
-		t.Logf("updateVersion: %#v", docVersion.docMeta)
+		t.Logf("%s - updateVersion: %#v", peerName, docVersion.docMeta)
 	}
 }
 
@@ -137,7 +149,7 @@ func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers 
 			continue
 		}
 		deleteVersion := peer.DeleteDocument(dsName, docID)
-		t.Logf("deleteVersion: %#v", deleteVersion)
+		t.Logf("%s - deleteVersion: %#v", peerName, deleteVersion)
 	}
 }
 

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -69,7 +69,7 @@ func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, p
 }
 
 // waitForConvergingVersion waits for the same document version to reach all peers.
-func waitForConvergingVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string) {
+func waitForConvergingVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, replications Replications, docID string) {
 	t.Logf("waiting for converged doc versions across all peers")
 	if !assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		for peerAid, peerA := range peers.SortedPeers() {
@@ -86,7 +86,7 @@ func waitForConvergingVersion(t *testing.T, dsName base.ScopeAndCollectionName, 
 		}
 	}, totalWaitTime, pollInterval) {
 		// do if !assert->require pattern so we can delay PrintGlobalDocState evaluation
-		require.FailNowf(t, "Peers did not converge on version", "Global state for doc %q on all peers:\n%s", docID, peers.PrintGlobalDocState(t, dsName, docID))
+		require.FailNowf(t, "Peers did not converge on version", "Global state for doc %q on all peers:\n%s\nReplications: %s", docID, peers.PrintGlobalDocState(t, dsName, docID), replications)
 	}
 }
 

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,6 +68,25 @@ func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, p
 	}
 }
 
+// waitForConvergingVersion waits for the same document version to reach all peers.
+func waitForConvergingVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string) {
+	t.Logf("waiting for converged doc versions across all peers")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for peerAid, peerA := range peers.SortedPeers() {
+			docMetaA, bodyA := peerA.GetDocument(dsName, docID)
+			for peerBid, peerB := range peers.SortedPeers() {
+				if peerAid == peerBid {
+					continue
+				}
+				docMetaB, bodyB := peerB.GetDocument(dsName, docID)
+				cvA, cvB := docMetaA.CV(t), docMetaB.CV(t)
+				require.Equalf(c, cvA, cvB, "CV mismatch: %s:%#v != %s:%#v", peerAid, docMetaA, peerBid, docMetaB)
+				require.Equalf(c, bodyA, bodyB, "body mismatch: %s:%s != %s:%s", peerAid, bodyA, peerBid, bodyB)
+			}
+		}
+	}, totalWaitTime, pollInterval)
+}
+
 // removeSyncGatewayBackingPeers will check if there is sync gateway in topology, if so will track the backing CBS
 // so we can skip creating docs on these peers (avoiding conflicts between docs created on the SGW and cbs)
 func removeSyncGatewayBackingPeers(peers map[string]Peer) map[string]bool {
@@ -82,9 +102,9 @@ func removeSyncGatewayBackingPeers(peers map[string]Peer) map[string]bool {
 	return peersToRemove
 }
 
-// createConflictingDocs will create a doc on each peer of the same doc ID to create conflicting documents, then
-// returns the last peer to have a doc created on it
-func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID, topologyDescription string) (lastWrite BodyAndVersion) {
+// createConflictingDocs will create a doc on each peer of the same doc ID to create conflicting documents.
+// It is not known at this stage which write the "winner" will be, since conflict resolution can happen at replication time which may not be LWW, or may be LWW but with a new value.
+func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID, topologyDescription string) {
 	backingPeers := removeSyncGatewayBackingPeers(peers)
 	documentVersion := make([]BodyAndVersion, 0, len(peers))
 	for peerName, peer := range peers {
@@ -96,15 +116,10 @@ func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		t.Logf("%s - createVersion: %#v", peerName, docVersion.docMeta)
 		documentVersion = append(documentVersion, docVersion)
 	}
-	index := len(documentVersion) - 1
-	lastWrite = documentVersion[index]
-
-	return lastWrite
 }
 
-// updateConflictingDocs will update a doc on each peer of the same doc ID to create conflicting document mutations, then
-// returns the last peer to have a doc updated on it.
-func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID, topologyDescription string) (lastWrite BodyAndVersion) {
+// updateConflictingDocs will update a doc on each peer of the same doc ID to create conflicting document mutations
+func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID, topologyDescription string) {
 	backingPeers := removeSyncGatewayBackingPeers(peers)
 	var documentVersion []BodyAndVersion
 	for peerName, peer := range peers {
@@ -116,15 +131,10 @@ func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		t.Logf("updateVersion: %#v", docVersion.docMeta)
 		documentVersion = append(documentVersion, docVersion)
 	}
-	index := len(documentVersion) - 1
-	lastWrite = documentVersion[index]
-
-	return lastWrite
 }
 
-// deleteConflictDocs will delete a doc on each peer of the same doc ID to create conflicting document deletions, then
-// returns the last peer to have a doc deleted on it
-func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string) (lastWrite BodyAndVersion) {
+// deleteConflictDocs will delete a doc on each peer of the same doc ID to create conflicting document deletions
+func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string) {
 	backingPeers := removeSyncGatewayBackingPeers(peers)
 	var documentVersion []BodyAndVersion
 	for peerName, peer := range peers {
@@ -135,10 +145,6 @@ func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers 
 		t.Logf("deleteVersion: %#v", deleteVersion)
 		documentVersion = append(documentVersion, BodyAndVersion{docMeta: deleteVersion, updatePeer: peerName})
 	}
-	index := len(documentVersion) - 1
-	lastWrite = documentVersion[index]
-
-	return lastWrite
 }
 
 // getDocID returns a unique doc ID for the test case. Note: when running with Couchbase Server and -count > 1, this will return duplicate IDs for count 2 and higher and they can conflict due to the way bucket pool works.

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -106,7 +106,6 @@ func removeSyncGatewayBackingPeers(peers map[string]Peer) map[string]bool {
 // It is not known at this stage which write the "winner" will be, since conflict resolution can happen at replication time which may not be LWW, or may be LWW but with a new value.
 func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID, topologyDescription string) {
 	backingPeers := removeSyncGatewayBackingPeers(peers)
-	documentVersion := make([]BodyAndVersion, 0, len(peers))
 	for peerName, peer := range peers {
 		if backingPeers[peerName] {
 			continue
@@ -114,14 +113,12 @@ func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, peerName, topologyDescription))
 		docVersion := peer.CreateDocument(dsName, docID, docBody)
 		t.Logf("%s - createVersion: %#v", peerName, docVersion.docMeta)
-		documentVersion = append(documentVersion, docVersion)
 	}
 }
 
 // updateConflictingDocs will update a doc on each peer of the same doc ID to create conflicting document mutations
 func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID, topologyDescription string) {
 	backingPeers := removeSyncGatewayBackingPeers(peers)
-	var documentVersion []BodyAndVersion
 	for peerName, peer := range peers {
 		if backingPeers[peerName] {
 			continue
@@ -129,21 +126,18 @@ func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "update"}`, peerName, topologyDescription))
 		docVersion := peer.WriteDocument(dsName, docID, docBody)
 		t.Logf("updateVersion: %#v", docVersion.docMeta)
-		documentVersion = append(documentVersion, docVersion)
 	}
 }
 
 // deleteConflictDocs will delete a doc on each peer of the same doc ID to create conflicting document deletions
 func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string) {
 	backingPeers := removeSyncGatewayBackingPeers(peers)
-	var documentVersion []BodyAndVersion
 	for peerName, peer := range peers {
 		if backingPeers[peerName] {
 			continue
 		}
 		deleteVersion := peer.DeleteDocument(dsName, docID)
 		t.Logf("deleteVersion: %#v", deleteVersion)
-		documentVersion = append(documentVersion, BodyAndVersion{docMeta: deleteVersion, updatePeer: peerName})
 	}
 }
 

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -9,7 +9,6 @@
 package topologytest
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -42,9 +41,6 @@ func TestMultiActorConflictCreate(t *testing.T) {
 // 7. assert that the documents are deleted on all peers and have hlv sources equal to the number of active peers
 func TestMultiActorConflictUpdate(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
-		if strings.Contains(topology.description, "CBL") {
-			t.Skip("CBL actor can generate conflicts and push replication fails with conflict for doc in blip tester CBL-4267")
-		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()
@@ -74,9 +70,6 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 // 7. assert that the documents are deleted on all peers and have hlv sources equal to the number of active peers
 func TestMultiActorConflictDelete(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
-		if strings.Contains(topology.description, "CBL") {
-			t.Skip("CBL actor can generate conflicts and push replication fails with conflict for doc in blip tester CBL-4267")
-		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()
@@ -110,9 +103,6 @@ func TestMultiActorConflictDelete(t *testing.T) {
 // 11. assert that the documents are resurrected on all peers and have hlv sources equal to the number of active peers and the document body is equivalent to the last write
 func TestMultiActorConflictResurrect(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
-		if strings.Contains(topology.description, "CBL") {
-			t.Skip("CBL actor can generate conflicts and push replication fails with conflict for doc in blip tester CBL-4267")
-		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -70,6 +70,13 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 func TestMultiActorConflictDelete(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
+			switch topology.description {
+			case "2x CBL<->SG<->CBS XDCR only 1.3",
+				"CBL<->SG<->CBS1 CBS1<->CBS2 1.2":
+				// FIXME: CBG-4458
+				t.Skip("CBG-4458")
+			}
+
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()
 
@@ -103,6 +110,13 @@ func TestMultiActorConflictDelete(t *testing.T) {
 func TestMultiActorConflictResurrect(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
+			switch topology.description {
+			case "2x CBL<->SG<->CBS XDCR only 1.3",
+				"CBL<->SG<->CBS1 CBS1<->CBS2 1.2":
+				// FIXME: CBG-4458
+				t.Skip("CBG-4458")
+			}
+
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()
 

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -70,13 +70,6 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 func TestMultiActorConflictDelete(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
-			switch topology.description {
-			case "2x CBL<->SG<->CBS XDCR only 1.3",
-				"CBL<->SG<->CBS1 CBS1<->CBS2 1.2":
-				// FIXME: CBG-4458
-				t.Skip("CBG-4458")
-			}
-
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()
 
@@ -110,13 +103,6 @@ func TestMultiActorConflictDelete(t *testing.T) {
 func TestMultiActorConflictResurrect(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
-			switch topology.description {
-			case "2x CBL<->SG<->CBS XDCR only 1.3",
-				"CBL<->SG<->CBS1 CBS1<->CBS2 1.2":
-				// FIXME: CBG-4458
-				t.Skip("CBG-4458")
-			}
-
 			collectionName, peers, replications := setupTests(t, topology)
 			replications.Stop()
 

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -23,10 +23,9 @@ func TestMultiActorConflictCreate(t *testing.T) {
 			replications.Stop()
 
 			docID := getDocID(t)
-			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
+			createConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
-
+			waitForConvergingVersion(t, collectionName, peers, replications, docID)
 		})
 	}
 }
@@ -46,16 +45,16 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 			replications.Stop()
 
 			docID := getDocID(t)
-			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
+			createConflictingDocs(t, collectionName, peers, docID, topology.description)
 
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
+			waitForConvergingVersion(t, collectionName, peers, replications, docID)
 
 			replications.Stop()
 
-			docVersion = updateConflictingDocs(t, collectionName, peers, docID, topology.description)
+			updateConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
+			waitForConvergingVersion(t, collectionName, peers, replications, docID)
 		})
 	}
 }
@@ -75,16 +74,16 @@ func TestMultiActorConflictDelete(t *testing.T) {
 			replications.Stop()
 
 			docID := getDocID(t)
-			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
+			createConflictingDocs(t, collectionName, peers, docID, topology.description)
 
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
+			waitForConvergingVersion(t, collectionName, peers, replications, docID)
 
 			replications.Stop()
-			lastWrite := deleteConflictDocs(t, collectionName, peers, docID)
+			deleteConflictDocs(t, collectionName, peers, docID)
 
 			replications.Start()
-			waitForTombstoneVersion(t, collectionName, peers, replications, docID, lastWrite)
+			waitForConvergingVersion(t, collectionName, peers, replications, docID)
 		})
 	}
 }
@@ -108,23 +107,23 @@ func TestMultiActorConflictResurrect(t *testing.T) {
 			replications.Stop()
 
 			docID := getDocID(t)
-			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
+			createConflictingDocs(t, collectionName, peers, docID, topology.description)
 
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
+			waitForConvergingVersion(t, collectionName, peers, replications, docID)
 
 			replications.Stop()
-			lastWrite := deleteConflictDocs(t, collectionName, peers, docID)
+			deleteConflictDocs(t, collectionName, peers, docID)
 
 			replications.Start()
 
-			waitForTombstoneVersion(t, collectionName, peers, replications, docID, lastWrite)
+			waitForConvergingVersion(t, collectionName, peers, replications, docID)
 			replications.Stop()
 
-			lastWriteVersion := updateConflictingDocs(t, collectionName, peers, docID, topology.description)
+			updateConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
 
-			waitForVersionAndBody(t, collectionName, peers, replications, docID, lastWriteVersion)
+			waitForConvergingVersion(t, collectionName, peers, replications, docID)
 		})
 	}
 }

--- a/topologytest/sync_gateway_peer_test.go
+++ b/topologytest/sync_gateway_peer_test.go
@@ -63,7 +63,11 @@ func (p *SyncGatewayPeer) GetDocument(dsName sgbucket.DataStoreName, docID strin
 	collection, ctx := p.getCollection(dsName)
 	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
 	require.NoError(p.TB(), err)
-	return DocMetadataFromDocument(doc), doc.Body(ctx)
+	var body db.Body
+	if !doc.IsDeleted() {
+		body = doc.Body(ctx)
+	}
+	return DocMetadataFromDocument(doc), body
 }
 
 // CreateDocument creates a document on the peer. The test will fail if the document already exists.

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -69,7 +69,7 @@ func DocMetadataFromDocument(doc *db.Document) DocMetadata {
 }
 
 func (v DocMetadata) GoString() string {
-	return fmt.Sprintf("DocMetadata{\nDocID:%s\n\tRevTreeID:%s\n\tHLV:%+v\n\tMou:%+v\n\tCas:%d\n\tImplicitHLV:%+v\n}", v.DocID, v.RevTreeID, v.HLV, v.Mou, v.Cas, v.ImplicitHLV)
+	return fmt.Sprintf("DocMetadata{\n\tDocID: %q,\n\tRevTreeID:%q,\n\tHLV:%+v,\n\tMou:%+v,\n\tCas:%d,\n\tImplicitHLV:%+v,\n}", v.DocID, v.RevTreeID, v.HLV, v.Mou, v.Cas, v.ImplicitHLV)
 }
 
 // DocMetadataFromDocVersion returns metadata DocVersion from the given document and version.


### PR DESCRIPTION
Enable multi-actor and conflict tests and allow BlipTesterClient to resolve conflicts and push up as new version.

Spun off two failing subtests into new ticket (CBG-4458) to get other improvements into `release/anemone`