### PR TITLE
Write dummy system xattr on resurrection

### DIFF
--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -449,6 +449,18 @@ func TestPeerImplementation(t *testing.T) {
 			}
 			peer.WaitForDocVersion(collectionName, docID, resurrectionVersion.docMeta)
 
+			ctx := peer.Context()
+			if peer.Type() != PeerTypeCouchbaseLite {
+				collection, err := peer.GetBackingBucket().NamedDataStore(collectionName)
+				require.NoError(t, err)
+				xattrs, _, err := collection.GetXattrs(ctx, docID, metadataXattrNames)
+				require.NoError(t, err)
+				require.NotEmpty(t, xattrs)
+				if tc.peerOption.Type == PeerTypeCouchbaseServer {
+					require.Contains(t, xattrs, dummySystemXattr)
+				}
+			}
+
 		})
 	}
 


### PR DESCRIPTION
Matches behavior of `CreateDocument`.

This prevents an echo of a document in the case of:

- no document on cbs1/cbs2
- write resurrection on cbs1, no xattrs
- xdcr copy to cbs2
- document gets copied back to cbs1, since document with xattrs wins conflict resolution over document without xattrs in the case they have same cas
