### PR TITLE
CBG-4459 validate cv when passed in

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -363,7 +363,7 @@ func TestCheckProposedVersion(t *testing.T) {
 			// proposed version is from a source not present in server HLV, and previousVersion matches server cv
 			//  Not a conflict, due to previousVersion match
 			name:            "new version,new source,prev matches",
-			newVersion:      Version{"other", incrementCas(cvValue, 100)},
+			newVersion:      Version{"otherq", incrementCas(cvValue, 100)},
 			previousVersion: &currentVersion,
 			expectedStatus:  ProposedRev_OK,
 			expectedRev:     "",
@@ -374,7 +374,7 @@ func TestCheckProposedVersion(t *testing.T) {
 			//  version and cv
 			name:            "new version,prev mismatch,new matches cv",
 			newVersion:      Version{cvSource, incrementCas(cvValue, 100)},
-			previousVersion: &Version{"other", incrementCas(cvValue, 50)},
+			previousVersion: &Version{"otherq", incrementCas(cvValue, 50)},
 			expectedStatus:  ProposedRev_OK,
 			expectedRev:     "",
 		},
@@ -388,7 +388,7 @@ func TestCheckProposedVersion(t *testing.T) {
 		{
 			// conflict - previous version is older than CV
 			name:            "conflict,same source,server updated",
-			newVersion:      Version{"other", incrementCas(cvValue, -100)},
+			newVersion:      Version{"otherq", incrementCas(cvValue, -100)},
 			previousVersion: &Version{cvSource, incrementCas(cvValue, -50)},
 			expectedStatus:  ProposedRev_Conflict,
 			expectedRev:     Version{cvSource, cvValue}.String(),
@@ -396,8 +396,8 @@ func TestCheckProposedVersion(t *testing.T) {
 		{
 			// conflict - previous version is older than CV
 			name:            "conflict,new source,server updated",
-			newVersion:      Version{"other", incrementCas(cvValue, 100)},
-			previousVersion: &Version{"other", incrementCas(cvValue, -50)},
+			newVersion:      Version{"otherq", incrementCas(cvValue, 100)},
+			previousVersion: &Version{"otherq", incrementCas(cvValue, -50)},
 			expectedStatus:  ProposedRev_Conflict,
 			expectedRev:     Version{cvSource, cvValue}.String(),
 		},
@@ -423,15 +423,15 @@ func TestCheckProposedVersion(t *testing.T) {
 
 	// New doc cases - standard insert
 	t.Run("new doc", func(t *testing.T) {
-		newVersion := Version{"other", 100}.String()
+		newVersion := Version{"otherq", 100}.String()
 		status, _ := collection.CheckProposedVersion(ctx, "doc2", newVersion, "")
 		assert.Equal(t, ProposedRev_OK_IsNew, status)
 	})
 
 	// New doc cases - insert with prev version (previous version purged from SGW)
 	t.Run("new doc with prev version", func(t *testing.T) {
-		newVersion := Version{"other", 100}.String()
-		prevVersion := Version{"another other", 50}.String()
+		newVersion := Version{"otherq", 100}.String()
+		prevVersion := Version{"2otherq", 50}.String()
 		status, _ := collection.CheckProposedVersion(ctx, "doc2", newVersion, prevVersion)
 		assert.Equal(t, ProposedRev_OK_IsNew, status)
 	})

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -10,6 +10,7 @@ package topologytest
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -209,7 +210,7 @@ func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, config PeerReplicat
 
 // SourceID returns the source ID for the peer used in <val>@<sourceID>.
 func (p *CouchbaseLiteMockPeer) SourceID() string {
-	return p.name
+	return base64.RawStdEncoding.EncodeToString([]byte(p.name))
 }
 
 // Context returns the context for the peer.


### PR DESCRIPTION
CBG-4459 validate cv when passed in

- validate that sourceID is base64, requires some test changes
- pass back better error messages if hlv was not found

The sourceID from CBL/CBS never include padding, so I used `base64.RawStdEncoding` to generate sourceIDs. Not all ASCII strings are valid base64, so I changed some strings.

I considered doing regexp parsing for invalid characters, since what was happening before this PR was that "1@abc; 2@def" was getting parsed as SourceID=`abc; 2@def` Value=`1`. I decided to just parse as base64 since this will provide more robust validation. There are two possible downsides to this: it is slightly more expensive to call `ParseVersion` and we can't use any artibrary string for source id for debugging.



## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2899/
