### PR TITLE
Add replication stats logging to topologytests

### DIFF
--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -50,18 +50,20 @@ func stripInternalProperties(body db.Body) {
 }
 
 // waitForVersionAndBody waits for a document to reach a specific version on all peers.
-func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string, expectedVersion BodyAndVersion) {
+func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, replications Replications, docID string, expectedVersion BodyAndVersion) {
+	t.Logf("waiting for doc version on all peers, written from %s: %#v", expectedVersion.updatePeer, expectedVersion)
 	for _, peer := range peers.SortedPeers() {
 		t.Logf("waiting for doc version on peer %s, written from %s: %#v", peer, expectedVersion.updatePeer, expectedVersion)
-		body := peer.WaitForDocVersion(dsName, docID, expectedVersion.docMeta)
+		body := peer.WaitForDocVersion(dsName, docID, expectedVersion.docMeta, replications)
 		requireBodyEqual(t, expectedVersion.body, body)
 	}
 }
 
-func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string, expectedVersion BodyAndVersion) {
+func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, replications Replications, docID string, expectedVersion BodyAndVersion) {
+	t.Logf("waiting for tombstone version on all peers, written from %s: %#v", expectedVersion.updatePeer, expectedVersion)
 	for _, peer := range peers.SortedPeers() {
 		t.Logf("waiting for tombstone version on peer %s, written from %s: %#v", peer, expectedVersion.updatePeer, expectedVersion)
-		peer.WaitForTombstoneVersion(dsName, docID, expectedVersion.docMeta)
+		peer.WaitForTombstoneVersion(dsName, docID, expectedVersion.docMeta, replications)
 	}
 }
 

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -31,7 +31,7 @@ func TestMultiActorConflictCreate(t *testing.T) {
 			docID := getDocID(t)
 			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, docID, docVersion)
+			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
 
 		})
 	}
@@ -61,13 +61,13 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
 
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, docID, docVersion)
+			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
 
 			replications.Stop()
 
 			docVersion = updateConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, docID, docVersion)
+			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
 		})
 	}
 }
@@ -93,13 +93,13 @@ func TestMultiActorConflictDelete(t *testing.T) {
 			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
 
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, docID, docVersion)
+			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
 
 			replications.Stop()
 			lastWrite := deleteConflictDocs(t, collectionName, peers, docID)
 
 			replications.Start()
-			waitForTombstoneVersion(t, collectionName, peers, docID, lastWrite)
+			waitForTombstoneVersion(t, collectionName, peers, replications, docID, lastWrite)
 		})
 	}
 }
@@ -132,20 +132,20 @@ func TestMultiActorConflictResurrect(t *testing.T) {
 			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
 
 			replications.Start()
-			waitForVersionAndBody(t, collectionName, peers, docID, docVersion)
+			waitForVersionAndBody(t, collectionName, peers, replications, docID, docVersion)
 
 			replications.Stop()
 			lastWrite := deleteConflictDocs(t, collectionName, peers, docID)
 
 			replications.Start()
 
-			waitForTombstoneVersion(t, collectionName, peers, docID, lastWrite)
+			waitForTombstoneVersion(t, collectionName, peers, replications, docID, lastWrite)
 			replications.Stop()
 
 			lastWriteVersion := updateConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
 
-			waitForVersionAndBody(t, collectionName, peers, docID, lastWriteVersion)
+			waitForVersionAndBody(t, collectionName, peers, replications, docID, lastWriteVersion)
 		})
 	}
 }

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,9 +44,8 @@ func (v DocMetadata) IsHLVEqual(other DocMetadata) bool {
 		return other.hlvEquals(v.ImplicitHLV)
 	} else if v.HLV != nil {
 		return other.hlvEquals(v.HLV)
-	} else {
-		return other.ImplicitHLV == nil && other.HLV == nil
 	}
+	return other.ImplicitHLV == nil && other.HLV == nil
 }
 
 func (v DocMetadata) hlvEquals(hlv *db.HybridLogicalVector) bool {
@@ -53,10 +53,8 @@ func (v DocMetadata) hlvEquals(hlv *db.HybridLogicalVector) bool {
 		return v.ImplicitHLV.Equals(hlv)
 	} else if v.HLV != nil {
 		return v.HLV.Equals(hlv)
-	} else {
-		return hlv == nil
 	}
-
+	return hlv == nil
 }
 
 // DocMetadataFromDocument returns a DocVersion from the given document.
@@ -88,4 +86,9 @@ func DocMetadataFromDocVersion(t testing.TB, docID string, hlv *db.HybridLogical
 		require.NoError(t, m.HLV.AddVersion(version.CV))
 	}
 	return m
+}
+
+// assertHLVEqual asserts that the HLV of the version is equal to the expected HLV.
+func assertHLVEqual(t assert.TestingT, docID string, p string, version DocMetadata, body []byte, expected DocMetadata, replications Replications) {
+	assert.True(t, version.IsHLVEqual(expected), "Actual HLV does not match expected on %s for peer %s.  Expected: %#v, Actual: %#v\nActual Body: %s\nReplications:\n%s", docID, p, expected, version, body, replications.Stats())
 }


### PR DESCRIPTION
- move logging for CRUD ops and subsequent versions to inside operations so calling tests do not have to log
- add `replications.Stats` logging to HLV assertions

