### PR TITLE
CBG-4468 do not check legacy revtree if hlv is dominating

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1251,6 +1251,9 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				if addNewerVersionsErr != nil {
 					return nil, nil, false, nil, addNewerVersionsErr
 				}
+				// the new document has a dominating hlv, so we can ignore any legacy rev revtree information on the incoming document
+				revTreeConflictChecked = true
+				previousRevTreeID = doc.CurrentRev
 			} else {
 				if len(revTreeHistory) > 0 {
 					// conflict check on rev tree history, if there is a rev in rev tree history we have the parent of locally we are not in conflict

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -984,3 +984,34 @@ func TestConflictBetweenPostUpgradeCBLMutationAndPostUpgradeSGWMutation(t *testi
 	assert.Equal(t, rev1ID, bucketDoc.CurrentRev)
 	assert.Equal(t, docVersion.CV.String(), bucketDoc.HLV.GetCurrentVersionString())
 }
+
+func TestLegacyRevNotInConflict(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyCRUD)
+	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		noConflictsMode: true,
+		GuestEnabled:    true,
+		blipProtocols:   []string{db.CBMobileReplicationV4.SubprotocolString()},
+	})
+	require.NoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
+	defer bt.Close()
+	rt := bt.restTester
+	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	const docID = "doc1"
+
+	docVersion := rt.PutDocDirectly(docID, db.Body{"test": "doc"})
+	rev1ID := docVersion.RevTreeID
+
+	history := []string{docVersion.CV.String(), "1-abc"}
+	sent, _, _, err := bt.SendRevWithHistory(docID, "100@CBL1", history, []byte(`{"key": "val"}`), blip.Properties{})
+	assert.True(t, sent)
+	require.NoError(t, err)
+
+	// assert that the bucket doc is as expected
+	bucketDoc, _, err := collection.GetDocWithXattrs(ctx, docID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, "100@CBL1", bucketDoc.HLV.GetCurrentVersionString())
+	assert.NotNil(t, bucketDoc.History[rev1ID])
+	assert.Equal(t, docVersion.CV.Value, bucketDoc.HLV.PreviousVersions[docVersion.CV.SourceID])
+
+}


### PR DESCRIPTION
CBG-4468 do not check legacy revtree if hlv is dominating

It feels like there has to be a better way to express this in the code but I can not think of what it might be. Open to suggestions.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
