### PR TITLE
CBG-4466 Evaluate full HLV when available during proposeChanges

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -841,7 +841,7 @@ func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 		}
 		if versionVectorProtocol && changeIsVector {
 			proposedVersionStr := ExtractCVFromProposeChangesRev(rev)
-			status, currentRev = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, proposedVersionStr, parentRevID)
+			status, currentRev = bh.collection.CheckProposedVersion(bh.loggingCtx, docID, proposedVersionStr, parentRevID, rev)
 		} else {
 			changesContainLegacyRevs = true
 			status, currentRev = bh.collection.CheckProposedRev(bh.loggingCtx, docID, rev, parentRevID)

--- a/db/crud.go
+++ b/db/crud.go
@@ -3211,7 +3211,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 }
 
 // CheckProposedVersion - given DocID and a version in string form, check whether it can be added without conflict.
-func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, docid, proposedVersionStr string, previousRev string) (status ProposedRevStatus, currentVersion string) {
+func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, docid, proposedVersionStr string, previousRev string, proposedHLVString string) (status ProposedRevStatus, currentVersion string) {
 
 	proposedVersion, err := ParseVersion(proposedVersionStr)
 	if err != nil {
@@ -3259,7 +3259,20 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 		// previousVersion didn't match, but proposed version and server CV have matching source, and proposed version is newer
 		return ProposedRev_OK, ""
 	} else {
-		// Conflict, return the current cv.  This may be a false positive conflict if the client has replicated
+		// Temporary (CBG-4466): check the full HLV that's being sent by CBL with proposeChanges messages.
+		// If the current server cv is dominated by the incoming HLV (i.e. the incoming HLV has an entry for the same source
+		// with a version that's greater than or equal to the server's cv), then we can accept the proposed version.
+		proposedHLV, _, err := ExtractHLVFromBlipMessage(proposedHLVString)
+		if err != nil {
+			base.DebugfCtx(ctx, base.KeyCRUD, "CheckProposedVersion for doc %s unable to extract proposedHLV from rev message, treating as conflict: %v", base.UD(docid), err)
+		} else {
+			if proposedHLV.DominatesSource(localDocCV) {
+				base.DebugfCtx(ctx, base.KeyCRUD, "CheckProposedVersion returning OK for doc %s because incoming HLV dominates cv", base.UD(docid))
+				return ProposedRev_OK, ""
+			}
+		}
+
+		//Conflict, return the current cv.  This may be a false positive conflict if the client has replicated
 		// the server cv via a different peer.  Client is responsible for performing this check based on the
 		// returned localDocCV
 		return ProposedRev_Conflict, localDocCV.String()


### PR DESCRIPTION
Until client-side check of HLV (using returned cv with conflict) is supported, use provided full HLV to identify whether proposed change is in conflict, regardless of previousRev.

CBG-4466

