### PR TITLE
Add trace logging for changes response

### DIFF
--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -296,6 +296,10 @@ func (bsc *BlipSyncContext) handleChangesResponse(ctx context.Context, sender *b
 		return err
 	}
 
+	if base.LogTraceEnabled(ctx, base.KeySyncMsg) {
+		base.TracefCtx(ctx, base.KeySyncMsg, "Recv Rsp %s: Body: '%s' Properties: %v", response, base.UD(respBody), base.UD(response.Properties))
+	}
+
 	if response.Type() == blip.ErrorType {
 		return fmt.Errorf("Client returned error in changesResponse: %s", respBody)
 	}


### PR DESCRIPTION
This logging was just missing in this spot, we do log this in other places like:

https://github.com/couchbase/sync_gateway/blob/8986872dddf91054811fccaed7bc78e094c8cc88/db/blip_sync_context.go#L200
https://github.com/couchbase/sync_gateway/blob/8986872dddf91054811fccaed7bc78e094c8cc88/db/blip_sync_context.go#L226