### PR TITLE
CBG-4367: Retain minimum number of recent sequences during compaction

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	kMaxRecentSequences            = 20    // Maximum number of sequences stored in RecentSequences before pruning is triggered
-	kMinRecentSequences            = 5     // Minimum number of sequences stored in RecentSequences before pruning is triggered
+	kMinRecentSequences            = 5     // Minimum number of sequences that should be left stored in RecentSequences during compaction
 	unusedSequenceWarningThreshold = 10000 // Warn when releasing more than this many sequences due to existing sequence on the document
 )
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	kMaxRecentSequences            = 20    // Maximum number of sequences stored in RecentSequences before pruning is triggered
+	kMinRecentSequences            = 5     // Minimum number of sequences stored in RecentSequences before pruning is triggered
 	unusedSequenceWarningThreshold = 10000 // Warn when releasing more than this many sequences due to existing sequence on the document
 )
 
@@ -1712,6 +1713,9 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 		// so we're allowing more 'recent sequences' on the doc (20) before attempting pruning
 		stableSequence := db.changeCache.GetStableSequence(doc.ID).Seq
 		count := 0
+		// we want to keep at least kMinRecentSequences recent sequences in the recent sequences list to reduce likelihood
+		// races between compaction of resent sequences and a coalesced DCP mutation resulting in skipped/abandoned sequences
+		maxToCompact := len(doc.RecentSequences) - kMinRecentSequences
 		for _, seq := range doc.RecentSequences {
 			// Only remove sequences if they are higher than a sequence that's been seen on the
 			// feed. This is valid across SG nodes (which could each have a different nextSequence),
@@ -1719,6 +1723,9 @@ func (db *DatabaseContext) assignSequence(ctx context.Context, docSequence uint6
 			// to each node.
 			if seq < stableSequence {
 				count++
+				if count == maxToCompact {
+					break
+				}
 			} else {
 				break
 			}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1828,9 +1828,7 @@ func TestMaintainMinimumRecentSequences(t *testing.T) {
 	assert.Equal(t, 20, len(doc.RecentSequences))
 
 	// update the original doc to trigger recent sequence compaction on the doc
-	_, doc, err = collection.Put(ctx, docID, body)
-	require.NoError(t, err)
-	err = db.changeCache.waitForSequence(ctx, doc.Sequence, base.DefaultWaitForSequence)
+	_, _, err = collection.Put(ctx, docID, body)
 	require.NoError(t, err)
 
 	// Validate that the recent sequences are pruned to the minimum + recently assigned sequence


### PR DESCRIPTION
CBG-4367

- Retail minimum of 5 recent sequences during compaction of recent sequences in the sync data of a document

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2901/
