### PR TITLE
CBG-4466 support mv

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1079,7 +1079,12 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	} else {
 		versionVectorStr := rev
 		if historyStr != "" {
-			versionVectorStr += ";" + historyStr
+			// this means that there is a mv
+			if strings.Contains(historyStr, ";") {
+				versionVectorStr += "," + historyStr
+			} else {
+				versionVectorStr += ";" + historyStr
+			}
 		}
 		incomingHLV, legacyRevList, err = ExtractHLVFromBlipMessage(versionVectorStr)
 		if err != nil {

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -348,7 +348,7 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector *HybridLogicalVecto
 		return err
 	}
 
-	// Copy incoming merge versions (existing merge versions will have been moved to pv by AddVersion)
+	// Copy incoming merge versions (previously existing merge versions will have been moved to pv by AddVersion)
 	for i, v := range otherVector.MergeVersions {
 		hlv.setMergeVersion(i, v)
 	}
@@ -370,10 +370,9 @@ func (hlv *HybridLogicalVector) AddNewerVersions(otherVector *HybridLogicalVecto
 		}
 	}
 	// ensure no duplicates of cv, mv in pv
-	if _, ok := hlv.PreviousVersions[hlv.SourceID]; ok {
-		delete(hlv.PreviousVersions, hlv.SourceID)
-	}
-	for source, _ := range hlv.MergeVersions {
+	delete(hlv.PreviousVersions, hlv.SourceID)
+
+	for source := range hlv.MergeVersions {
 		delete(hlv.PreviousVersions, source)
 	}
 

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1111,7 +1111,6 @@ func TestHLVAddNewerVersionsWithMV(t *testing.T) {
 				Version:  4,
 				SourceID: "c",
 			},
-			// does not update with incoming versions?
 			finalHLV: HybridLogicalVector{
 				Version:  4,
 				SourceID: "c",

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -166,8 +166,10 @@ func (h *HLVAgent) SourceID() string {
 // encodeTestHistory converts a simplified version history of the form "1@abc,2@def;3@ghi" to use hex-encoded versions and
 // base64 encoded sources
 func EncodeTestHistory(historyString string) (encodedString string) {
-	// possible versionSets are pv;mv
-	// possible versionSets are pv;mv
+	// possible versionSets:
+	// 	mv,mv;pv,pv
+	// 	mv,mv;
+	// 	pv,pv
 	versionSets := strings.Split(historyString, ";")
 	if len(versionSets) == 0 {
 		return ""
@@ -183,6 +185,7 @@ func EncodeTestHistory(historyString string) (encodedString string) {
 			if index > 0 {
 				encodedString += ","
 			}
+			fmt.Printf("version: %s encoded: %s\n", version, EncodeTestVersion(version))
 			encodedString += EncodeTestVersion(version)
 		}
 	}

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -185,7 +185,6 @@ func EncodeTestHistory(historyString string) (encodedString string) {
 			if index > 0 {
 				encodedString += ","
 			}
-			fmt.Printf("version: %s encoded: %s\n", version, EncodeTestVersion(version))
 			encodedString += EncodeTestVersion(version)
 		}
 	}


### PR DESCRIPTION
CBG-4466 support mv

commit e9c4d1c571a07c6d3f91f80d3fa7e04a04087290 (first commit) is just rewriting the test so that I can make sense of the new format. I think the `createHLVForTest` is hazardous because it has its own shorthand syntax. Once we are happy with the blip message type, I think we could use that for constructing a string.

- Switched some tests to use small enough integers so that hex representation and decimal representation are the same for testing
- `TestPutRev4` used mv, but it had duplicate mv and pv values, so the test needed to be changed

Added:

- `TestBlipMergeVersions` which will round trip a merge version (working). This uses a rev message directly because there's not a great way with the `BlipTesterClient` to push a message with custom properties. This would be a future enhancement. It uses btcRunner to pull revisions. This test can be extended to support other features.

TODO:

- [x] Change `HybridLogicalVector.AddNewerVersions` to update mv. Cases: (1) move mv to pv (2) move existing mv to pv, and replace with incoming mv.   These are started in `TestHLVUpdateMV`.
- [ ] Run `BenchmarkExtractHLVFromBlipMessage` to see if extra validation to check for incorrect duplicate values in cv/mv/pv is a problem.
- [ ] Evaluate test cases for non rev messages and processing full hlv. Cases: (1) CBL response to changes message (with and without delta). (2) `proposeChanges`

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
