### PR TITLE
CBG-4422: move setting the collection set on resync status to init fu…

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -567,7 +567,7 @@ func (dc *DCPClient) deactivateVbucket(vbID uint16) {
 
 func (dc *DCPClient) onStreamEnd(e endStreamEvent) {
 	if e.err == nil {
-		//DebugfCtx(dc.ctx, KeyDCP, "Stream (vb:%d) closed, all items streamed", e.vbID)
+		DebugfCtx(dc.ctx, KeyDCP, "Stream (vb:%d) closed, all items streamed", e.vbID)
 		dc.deactivateVbucket(e.vbID)
 		return
 	}

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -567,7 +567,7 @@ func (dc *DCPClient) deactivateVbucket(vbID uint16) {
 
 func (dc *DCPClient) onStreamEnd(e endStreamEvent) {
 	if e.err == nil {
-		DebugfCtx(dc.ctx, KeyDCP, "Stream (vb:%d) closed, all items streamed", e.vbID)
+		//DebugfCtx(dc.ctx, KeyDCP, "Stream (vb:%d) closed, all items streamed", e.vbID)
 		dc.deactivateVbucket(e.vbID)
 		return
 	}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -110,6 +110,8 @@ func TestResyncDCPInit(t *testing.T) {
 			}()
 
 			options := make(map[string]interface{})
+			options["database"] = db
+			options["collections"] = ResyncCollections{}
 			if testCase.forceReset {
 				options["reset"] = true
 			}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -728,6 +728,12 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 			_, ok := (rt.GetDatabase().ResyncManager.Process).(*db.ResyncManagerDCP)
 			require.True(t, ok)
 
+			// create documents in DB to cause resync to take a few seconds
+			for i := 0; i < 1000; i++ {
+				resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/"+fmt.Sprint(i), `{"value":1}`)
+				rest.RequireStatus(t, resp, http.StatusCreated)
+			}
+
 			rt.TakeDbOffline()
 
 			if !testCase.specifyCollection {
@@ -738,9 +744,10 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 				resp := rt.SendAdminRequest("POST", "/db/_resync?action=start", payload)
 				rest.RequireStatus(t, resp, http.StatusOK)
 			}
+			statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+			assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
 
-			statusResponse := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-
+			statusResponse = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 			assert.ElementsMatch(t, statusResponse.CollectionsProcessing[scopeName], testCase.expectedResult[scopeName])
 		})
 	}


### PR DESCRIPTION
CBG-4422

- move setting the collection set on resync status to init function to avoid delay between status running and collection set appearing in status
- create a new struct to hold collection information needed in Run() function 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2902/
