### PR TITLE
Do not error when getting stats

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1007,11 +1007,11 @@ func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTes
 	if !opts.AllowCreationWithoutBlipTesterClientRunner && !btcRunner.initialisedInsideRunnerCode {
 		require.FailNow(btcRunner.TB(), "must initialise BlipTesterClient inside Run() method")
 	}
-	if opts.SourceID == "" {
-		opts.SourceID = "blipclient"
-	}
 	id, err := uuid.NewRandom()
 	require.NoError(btcRunner.TB(), err)
+	if opts.SourceID == "" {
+		opts.SourceID = fmt.Sprintf("btc-%d", id.ID())
+	}
 
 	client = &BlipTesterClient{
 		BlipTesterClientOpts: *opts,
@@ -1561,7 +1561,7 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 	var docVersion DocVersion
 	if btc.UseHLV() {
 		// TODO: CBG-4440 Construct a HLC for Value - UnixNano is not accurate enough on Windows to generate unique values, and seq is not comparable across clients.
-		newVersion := db.Version{SourceID: fmt.Sprintf("btc-%d", btc.parent.id), Value: uint64(time.Now().UnixNano())}
+		newVersion := db.Version{SourceID: btc.parent.SourceID, Value: uint64(time.Now().UnixNano())}
 		require.NoError(btc.TB(), hlv.AddVersion(newVersion))
 		docVersion = DocVersion{CV: *hlv.ExtractCurrentVersionFromHLV()}
 	} else {

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -198,7 +198,7 @@ func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, config PeerReplicat
 		Channels:               []string{"*"},
 		SupportedBLIPProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()},
 		AllowCreationWithoutBlipTesterClientRunner: true,
-		SourceID: peer.SourceID(),
+		SourceID: p.SourceID(),
 	},
 	)
 	p.blipClients[sg.String()] = &PeerBlipTesterClient{

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -82,7 +82,9 @@ func (r *CouchbaseServerReplication) String() string {
 
 func (r *CouchbaseServerReplication) Stats() string {
 	stats, err := r.manager.Stats(r.ctx)
-	require.NoError(r.t, err)
+	if err != nil {
+		return fmt.Sprintf("error getting stats: %v", err)
+	}
 	return fmt.Sprintf("%+v", *stats)
 }
 

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -11,8 +11,6 @@ package topologytest
 import (
 	"strings"
 	"testing"
-
-	"github.com/couchbase/sync_gateway/base"
 )
 
 // TestMultiActorConflictCreate
@@ -20,9 +18,6 @@ import (
 // 2. start replications
 // 3. wait for documents to exist with hlv sources equal to the number of active peers
 func TestMultiActorConflictCreate(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
-	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
@@ -46,9 +41,6 @@ func TestMultiActorConflictCreate(t *testing.T) {
 // 6. start replications
 // 7. assert that the documents are deleted on all peers and have hlv sources equal to the number of active peers
 func TestMultiActorConflictUpdate(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
-	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		if strings.Contains(topology.description, "CBL") {
 			t.Skip("CBL actor can generate conflicts and push replication fails with conflict for doc in blip tester CBL-4267")
@@ -117,9 +109,6 @@ func TestMultiActorConflictDelete(t *testing.T) {
 // 10. start replications
 // 11. assert that the documents are resurrected on all peers and have hlv sources equal to the number of active peers and the document body is equivalent to the last write
 func TestMultiActorConflictResurrect(t *testing.T) {
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("Flakey failures on multi actor conflicting writes, CBG-4379")
-	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		if strings.Contains(topology.description, "CBL") {
 			t.Skip("CBL actor can generate conflicts and push replication fails with conflict for doc in blip tester CBL-4267")

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -11,8 +11,6 @@ package topologytest
 import (
 	"fmt"
 	"testing"
-
-	"github.com/couchbase/sync_gateway/base"
 )
 
 // TestMultiActorUpdate tests that a single actor can update a document that was created on a different peer.
@@ -78,9 +76,6 @@ func TestMultiActorDelete(t *testing.T) {
 // 6. resurrect each document on a single peer
 // 7. wait for the hlv for updated documents to be synchronized
 func TestMultiActorResurrect(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("CBG-4419: this test fails xdcr with: could not write doc: cas mismatch: expected 0, really 1 -- xdcr.(*rosmarManager).processEvent() at rosmar_xdcr.go:201")
-	}
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)


### PR DESCRIPTION
Stats might not be available if replication isn't running anymore, or prometheus stats were not up to date. We do not want this to prevent logging.

https://jenkins.sgwdev.com/job/Topology%20Integration/19/testReport/junit/github/com_couchbase_sync_gateway_topologytest/TestMultiActorConflictDelete_CBS_SG___CBS/
