### PR TITLE
[3.2.2 Backport] CBG-4436: Count scheduled compaction runs as idle KV/Query ops

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -87,6 +87,7 @@ const (
 	StatAddedVersion3dot1dot4     = "3.1.4"
 	StatAddedVersion3dot2dot0     = "3.2.0"
 	StatAddedVersion3dot2dot1     = "3.2.1"
+	StatAddedVersion3dot2dot2     = "3.2.2"
 	StatAddedVersion3dot3dot0     = "3.3.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
@@ -312,6 +313,10 @@ func (g *GlobalStat) initResourceUtilizationStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.NumIdleQueryOps, err = NewIntStat(SubsystemDatabaseKey, "num_idle_query_ops", StatUnitNoUnits, NumIdleQueryOpsDesc, StatAddedVersion3dot2dot2, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 
 	resUtil.Uptime, err = NewDurStat(ResourceUtilizationSubsystem, "uptime", StatUnitNanoseconds, UptimeDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, time.Now())
 	if err != nil {
@@ -366,8 +371,9 @@ type ResourceUtilization struct {
 	// The node CPU usage calculation based values from /proc of user + system since the last time this function was called.
 	NodeCpuPercentUtil *SgwFloatStat `json:"node_cpu_percent_utilization"`
 
-	// The number of background kv operations.
-	NumIdleKvOps *SgwIntStat `json:"idle_kv_ops"`
+	// The number of background kv/query operations.
+	NumIdleKvOps    *SgwIntStat `json:"idle_kv_ops"`
+	NumIdleQueryOps *SgwIntStat `json:"idle_query_ops"`
 
 	// The memory utilization (Resident Set Size) for the process, in bytes.
 	ProcessMemoryResident *SgwIntStat `json:"process_memory_resident"`

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -314,7 +314,8 @@ const (
 
 	SyncProcessComputeDesc = "The compute unit for syncing with clients measured through cpu time and memory used for sync"
 
-	NumIdleKvOpsDesc = "The total number of idle kv operations."
+	NumIdleKvOpsDesc    = "The total number of idle kv operations."
+	NumIdleQueryOpsDesc = "The total number of idle query operations."
 )
 
 // Delta Sync stats descriptions

--- a/base/util.go
+++ b/base/util.go
@@ -851,6 +851,12 @@ func LogLevelPtr(value LogLevel) *LogLevel {
 	return &value
 }
 
+// Ptr returns a pointer to the given literal.
+// This is useful for wrapping around function calls that return a value, where you can't just use `&`.
+func Ptr[T any](v T) *T {
+	return &v
+}
+
 // StringPtr returns a pointer to the given string literal.
 func StringPtr(value string) *string {
 	return &value

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -45,11 +45,11 @@ func (t *TombstoneCompactionManager) Run(ctx context.Context, options map[string
 	database := options["database"].(*Database)
 
 	defer atomic.CompareAndSwapUint32(&database.CompactState, DBCompactRunning, DBCompactNotRunning)
-	callback := func(docsPurged *int) {
+	updateStatusCallback := func(docsPurged *int) {
 		atomic.StoreInt64(&t.PurgedDocCount, int64(*docsPurged))
 	}
 
-	_, err := database.Compact(ctx, true, callback, terminator)
+	_, err := database.Compact(ctx, true, updateStatusCallback, terminator, false)
 	if err != nil {
 		return err
 	}

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -138,6 +138,9 @@ ExpVars:
                 num_idle_kv_ops:
                   type: integer
                   description: "The total number of idle kv operations."
+                num_idle_query_ops:
+                  type: integer
+                  description: "The total number of idle query operations."
                 process_cpu_percent_utilization:
                   type: number
                   format: float

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4166,7 +4166,7 @@ func TestTombstoneCompactionPurgeInterval(t *testing.T) {
 
 			// Start compact to modify purge interval
 			database, _ := db.GetDatabase(dbc, nil)
-			_, err = database.Compact(ctx, false, func(purgedDocCount *int) {}, base.NewSafeTerminator())
+			_, err = database.Compact(ctx, false, nil, base.NewSafeTerminator(), false)
 			require.NoError(t, err)
 
 			assert.EqualValues(t, test.expectedPurgeIntervalAfterCompact, dbc.GetMetadataPurgeInterval(ctx))

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3958,6 +3958,20 @@ func TestTombstoneCompaction(t *testing.T) {
 		t.Skip("If running with no xattrs compact acts as a no-op")
 	}
 
+	tests := []struct {
+		numDocs                      int
+		runAsScheduledBackgroundTask bool
+	}{
+		// Multiples of Batch Size
+		{numDocs: db.QueryTombstoneBatch},
+		{numDocs: db.QueryTombstoneBatch * 4},
+		// Smaller Than Batch Size
+		{numDocs: 2},
+		{numDocs: db.QueryTombstoneBatch / 4},
+		// Larger than Batch Size
+		{numDocs: db.QueryTombstoneBatch + 20},
+	}
+
 	var rt *rest.RestTester
 	numCollections := 1
 
@@ -3968,64 +3982,84 @@ func TestTombstoneCompaction(t *testing.T) {
 		rt = rest.NewRestTester(t, nil)
 	}
 	defer rt.Close()
-	zero := time.Duration(0)
-	rt.GetDatabase().Options.PurgeInterval = &zero
+	rt.GetDatabase().Options.PurgeInterval = base.Ptr(time.Duration(0))
 
-	compactionTotal := 0
-	expectedBatches := 0
+	for _, test := range tests {
+		for _, runAsScheduledBackgroundTask := range []bool{false, true} {
+			t.Run(fmt.Sprintf("numDocs:%d asBackgroundTask:%v", test.numDocs, runAsScheduledBackgroundTask), func(t *testing.T) {
 
-	TestCompact := func(numDocs int) {
+				// seed with tombstones
+				for count := 0; count < test.numDocs; count++ {
+					for _, keyspace := range rt.GetKeyspaces() {
+						response := rt.SendAdminRequest("POST", fmt.Sprintf("/%s/", keyspace), `{"foo":"bar"}`)
+						assert.Equal(t, http.StatusOK, response.Code)
+						var body db.Body
+						err := base.JSONUnmarshal(response.Body.Bytes(), &body)
+						assert.NoError(t, err)
+						revID := body["rev"].(string)
+						docID := body["id"].(string)
 
-		count := 0
+						response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/%s/%s?rev=%s", keyspace, docID, revID), "")
+						assert.Equal(t, http.StatusOK, response.Code)
+					}
+				}
 
-		for count < numDocs {
-			count++
-			for _, keyspace := range rt.GetKeyspaces() {
-				response := rt.SendAdminRequest("POST", fmt.Sprintf("/%s/", keyspace), `{"foo":"bar"}`)
-				assert.Equal(t, 200, response.Code)
-				var body db.Body
-				err := base.JSONUnmarshal(response.Body.Bytes(), &body)
-				assert.NoError(t, err)
-				revId := body["rev"].(string)
-				docId := body["id"].(string)
+				expectedCompactions := test.numDocs * numCollections
+				expectedBatches := (test.numDocs/db.QueryTombstoneBatch + 1) * numCollections
 
-				response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/%s/%s?rev=%s", keyspace, docId, revId), "")
-				assert.Equal(t, 200, response.Code)
-			}
+				numCompactionsBefore := int(rt.GetDatabase().DbStats.Database().NumTombstonesCompacted.Value())
+				var numBatchesBefore int
+				if base.TestsDisableGSI() {
+					numBatchesBefore = int(rt.GetDatabase().DbStats.Query(fmt.Sprintf(base.StatViewFormat, db.DesignDocSyncHousekeeping(), db.ViewTombstones)).QueryCount.Value())
+				} else {
+					numBatchesBefore = int(rt.GetDatabase().DbStats.Query(db.QueryTypeTombstones).QueryCount.Value())
+				}
+
+				numIdleKvOpsBefore := int(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Value())
+				numIdleQueryOpsBefore := int(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleQueryOps.Value())
+
+				if runAsScheduledBackgroundTask {
+					database, err := db.CreateDatabase(rt.GetDatabase())
+					require.NoError(t, err)
+					purgedCount, err := database.Compact(base.TestCtx(t), false, nil, base.NewSafeTerminator(), true)
+					require.NoError(t, err)
+					require.Equal(t, expectedCompactions, purgedCount)
+
+					numIdleKvOpsAfter := int(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Value())
+					numIdleQueryOpsAfter := int(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleQueryOps.Value())
+
+					// cannot do equal here because there are other idle kv ops unrelated to compaction
+					assert.GreaterOrEqual(t, numIdleKvOpsAfter-numIdleKvOpsBefore, expectedCompactions)
+					assert.Equal(t, numIdleQueryOpsAfter-numIdleQueryOpsBefore, expectedBatches)
+				} else {
+					resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact", "")
+					rest.RequireStatus(t, resp, http.StatusOK)
+					err := rt.WaitForCondition(func() bool {
+						return rt.GetDatabase().TombstoneCompactionManager.GetRunState() == db.BackgroundProcessStateCompleted
+					})
+					assert.NoError(t, err)
+
+					numIdleKvOpsAfter := int(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleKvOps.Value())
+					numIdleQueryOpsAfter := int(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().NumIdleQueryOps.Value())
+
+					// ad-hoc compactions don't invoke idle ops - but we do have other idle kv ops so can't ensure it stays zero
+					assert.GreaterOrEqual(t, numIdleKvOpsAfter-numIdleKvOpsBefore, 0)
+					assert.Equal(t, numIdleQueryOpsAfter-numIdleQueryOpsBefore, 0)
+				}
+
+				actualCompactions := int(rt.GetDatabase().DbStats.Database().NumTombstonesCompacted.Value()) - numCompactionsBefore
+				require.Equal(t, expectedCompactions, actualCompactions)
+
+				var actualBatches int
+				if base.TestsDisableGSI() {
+					actualBatches = int(rt.GetDatabase().DbStats.Query(fmt.Sprintf(base.StatViewFormat, db.DesignDocSyncHousekeeping(), db.ViewTombstones)).QueryCount.Value()) - numBatchesBefore
+				} else {
+					actualBatches = int(rt.GetDatabase().DbStats.Query(db.QueryTypeTombstones).QueryCount.Value()) - numBatchesBefore
+				}
+				require.Equal(t, expectedBatches, actualBatches)
+			})
 		}
-		resp := rt.SendAdminRequest("POST", "/{{.db}}/_compact", "")
-		rest.RequireStatus(t, resp, http.StatusOK)
-
-		err := rt.WaitForCondition(func() bool {
-			time.Sleep(1 * time.Second)
-			return rt.GetDatabase().TombstoneCompactionManager.GetRunState() == db.BackgroundProcessStateCompleted
-		})
-		assert.NoError(t, err)
-
-		compactionTotal += (numDocs * numCollections)
-		require.Equal(t, compactionTotal, int(rt.GetDatabase().DbStats.Database().NumTombstonesCompacted.Value()))
-
-		var actualBatches int64
-		if base.TestsDisableGSI() {
-			actualBatches = rt.GetDatabase().DbStats.Query(fmt.Sprintf(base.StatViewFormat, db.DesignDocSyncHousekeeping(), db.ViewTombstones)).QueryCount.Value()
-		} else {
-			actualBatches = rt.GetDatabase().DbStats.Query(db.QueryTypeTombstones).QueryCount.Value()
-		}
-
-		expectedBatches += (numDocs/db.QueryTombstoneBatch + 1) * numCollections
-		require.Equal(t, expectedBatches, int(actualBatches))
 	}
-
-	// Multiples of Batch Size
-	TestCompact(db.QueryTombstoneBatch)
-	TestCompact(db.QueryTombstoneBatch * 4)
-
-	// Smaller Than Batch Size
-	TestCompact(2)
-	TestCompact(db.QueryTombstoneBatch / 4)
-
-	// Larger than Batch Size
-	TestCompact(db.QueryTombstoneBatch + 20)
 }
 
 // TestOneShotGrantTiming simulates a one-shot changes feed returning before a previously issued grant has been


### PR DESCRIPTION
CBG-4436

Backports CBG-4436 (#7310) to 3.2.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2906/
