### PR TITLE
[3.2.2 backport] CBG-4480 fail test harness if dev time assertions hit

### DIFF
--- a/base/audit_types.go
+++ b/base/audit_types.go
@@ -9,6 +9,7 @@
 package base
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -150,9 +151,9 @@ func (ed *EventDescriptor) expandOptionalFieldGroups(groups []fieldGroup) {
 	}
 }
 
-func (i AuditID) MustValidateFields(f AuditFields) {
+func (i AuditID) MustValidateFields(ctx context.Context, f AuditFields) {
 	if err := i.ValidateFields(f); err != nil {
-		panic(fmt.Errorf("audit event %q (%s) invalid:\n%v", i, AuditEvents[i].Name, err))
+		AssertfCtx(ctx, "audit event %q (%s) invalid:\n%v", i, AuditEvents[i].Name, err)
 	}
 }
 

--- a/base/devmode.go
+++ b/base/devmode.go
@@ -8,7 +8,10 @@
 
 package base
 
-import "context"
+import (
+	"context"
+	"sync/atomic"
+)
 
 // IsDevMode returns true when compiled with the `cb_sg_devmode` build tag, and false otherwise.
 //
@@ -17,6 +20,9 @@ import "context"
 func IsDevMode() bool {
 	return cbSGDevModeBuildTagSet
 }
+
+// DevModeAssertionFailures is a counter of the number of assertion failures that have occurred in dev mode. This will always be zero in non-dev mode.
+var DevModeAssertionFailures atomic.Uint32
 
 // AssertfCtx panics when compiled with the `cb_sg_devmode` build tag, and just warns otherwise.
 // Callers must be aware that they are responsible for handling returns to cover the non-devmode warn case.

--- a/base/devmode_on.go
+++ b/base/devmode_on.go
@@ -11,6 +11,13 @@
 
 package base
 
+import (
+	"context"
+)
+
 const cbSGDevModeBuildTagSet = true
 
-var assertLogFn logFn = PanicfCtx
+var assertLogFn logFn = func(ctx context.Context, format string, args ...any) {
+	DevModeAssertionFailures.Add(1)
+	PanicfCtx(ctx, format, args...)
+}

--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -128,7 +128,7 @@ func Audit(ctx context.Context, id AuditID, additionalData AuditFields) {
 			globalFields = logger.globalFields
 		}
 		fields = expandFields(id, ctx, globalFields, additionalData)
-		id.MustValidateFields(fields)
+		id.MustValidateFields(ctx, fields)
 	}
 
 	if !logger.shouldLog(id, ctx) {

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -725,6 +725,11 @@ func TestBucketPoolMain(ctx context.Context, m *testing.M, bucketReadierFunc TBP
 	GTestBucketPool = NewTestBucketPoolWithOptions(ctx, bucketReadierFunc, bucketInitFunc, options)
 	teardownFuncs = append(teardownFuncs, func() { GTestBucketPool.Close(ctx) })
 
+	teardownFuncs = append(teardownFuncs, func() {
+		if DevModeAssertionFailures.Load() > 0 {
+			panic("Test harness failed due to failures from -tag cb_sg_devmode. Look at logs for panic statements.")
+		}
+	})
 	// must be the last teardown function added to the list to correctly detect leaked goroutines
 	teardownFuncs = append(teardownFuncs, SetUpTestGoroutineDump(m))
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -965,6 +965,7 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 				provider := dbCtx.Options.OIDCOptions.Providers.GetProviderForIssuer(h.ctx(), issuerUrlForDB(h, dbCtx.Name), testProviderAudiences)
 				if provider != nil && provider.ValidationKey != nil {
 					if base.StringDefault(provider.ClientID, "") == username && *provider.ValidationKey == password {
+						auditFields = base.AuditFields{base.AuditFieldAuthMethod: "basic"}
 						return nil
 					}
 				}


### PR DESCRIPTION
[3.2.2 backport] CBG-4480 fail test harness if dev time assertions hit

Cherry-pick of 142f2156bedfaec8e824d9724ce875f5de20818c

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2908/
