### PR TITLE
[3.2.2 backport] CBG-4446 create a cancel context inside BlipSyncContext

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -125,7 +125,12 @@ type LeakyBucketConfig struct {
 
 	// Returns a partial error the first time ViewCustom is called
 	FirstTimeViewCustomPartialError bool
-	PostQueryCallback               func(ddoc, viewName string, params map[string]interface{}) // Issues callback after issuing query when bucket.ViewQuery is called
+
+	// QueryCallback allows tests to set a callback that will be issued prior to issuing a view query
+	QueryCallback     func(ddoc, viewName string, params map[string]any) error
+	PostQueryCallback func(ddoc, viewName string, params map[string]interface{}) // Issues callback after issuing query when bucket.ViewQuery is called
+
+	N1QLQueryCallback func(ctx context.Context, statement string, params map[string]any, consistency ConsistencyMode, adhoc bool) error
 
 	PostN1QLQueryCallback func()
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"expvar"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ type activeReplicatorCommon struct {
 	ctxCancel             context.CancelFunc
 	reconnectActive       base.AtomicBool                                             // Tracks whether reconnect goroutine is active
 	replicatorConnectFn   func() error                                                // the function called inside reconnectLoop.
-	activeSendChanges     base.AtomicBool                                             // Tracks whether sendChanges goroutine is active.
+	activeSendChanges     atomic.Int32                                                // Tracks whether sendChanges goroutines are active, there is one per collection.
 	namedCollections      map[base.ScopeAndCollectionName]*activeReplicatorCollection // set only if the replicator is running with collections - access with forEachCollection
 	defaultCollection     *activeReplicatorCollection                                 // set only if the replicator is not running with collections - access with forEachCollection
 }

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -332,7 +332,7 @@ func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since Seq
 	apr.activeSendChanges.Add(1)
 	go func(s *blip.Sender) {
 		defer apr.activeSendChanges.Add(-1)
-		isComplete := bh.sendChanges(s, &sendChangesOptions{
+		isComplete, err := bh.sendChanges(s, &sendChangesOptions{
 			docIDs:            apr.config.DocIDs,
 			since:             since,
 			continuous:        apr.config.Continuous,
@@ -344,8 +344,15 @@ func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since Seq
 			ignoreNoConflicts: true, // force the passive side to accept a "changes" message, even in no conflicts mode.
 			changesCtx:        collectionCtx.changesCtx,
 		})
-		// On a normal completion, call complete for the replication
+		if err != nil {
+			base.InfofCtx(apr.ctx, base.KeyReplicate, "Terminating blip connection due to changes feed error: %v", err)
+			bh.ctxCancelFunc()
+			_ = apr.setError(err)
+			apr.publishStatus()
+			return
+		}
 		if isComplete {
+			// On a normal completion, call complete for the replication
 			apr.Complete()
 		}
 	}(apr.blipSender)

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -268,7 +268,7 @@ func (apr *ActivePushReplicator) Stop() error {
 		return err
 	}
 	teardownStart := time.Now()
-	for apr.activeSendChanges.IsTrue() && (time.Since(teardownStart) < time.Second*10) {
+	for apr.activeSendChanges.Load() != 0 && (time.Since(teardownStart) < time.Second*10) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	return nil
@@ -298,8 +298,17 @@ func (apr *ActivePushReplicator) _startPushNonCollection() error {
 	bh.collection = dbCollectionWithUser
 	bh.loggingCtx = bh.collection.AddCollectionContext(bh.BlipSyncContext.loggingCtx)
 
+	return apr._startSendingChanges(bh, apr.defaultCollection.Checkpointer.lastCheckpointSeq)
+}
+
+// _startSendingChanges starts a changes feed for a given collection in a goroutine and starts sending changes to the passive peer from a starting sequence value.
+func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since SequenceID) error {
+	collectionCtx, err := bh.collections.get(bh.collectionIdx)
+	if err != nil {
+		return err
+	}
 	var channels base.Set
-	if filteredChannels := apr.config.getFilteredChannels(nil); len(filteredChannels) > 0 {
+	if filteredChannels := apr.config.getFilteredChannels(bh.collectionIdx); len(filteredChannels) > 0 {
 		channels = base.SetFromArray(filteredChannels)
 	}
 
@@ -320,17 +329,12 @@ func (apr *ActivePushReplicator) _startPushNonCollection() error {
 		// No special handling for error
 	}
 
-	collectionCtx, err := bh.collections.get(nil)
-	if err != nil {
-		return err
-	}
-
-	apr.activeSendChanges.Set(true)
+	apr.activeSendChanges.Add(1)
 	go func(s *blip.Sender) {
-		defer apr.activeSendChanges.Set(false)
+		defer apr.activeSendChanges.Add(-1)
 		isComplete := bh.sendChanges(s, &sendChangesOptions{
 			docIDs:            apr.config.DocIDs,
-			since:             apr.defaultCollection.Checkpointer.lastCheckpointSeq,
+			since:             since,
 			continuous:        apr.config.Continuous,
 			activeOnly:        apr.config.ActiveOnly,
 			batchSize:         int(apr.config.ChangesBatchSize),
@@ -345,6 +349,5 @@ func (apr *ActivePushReplicator) _startPushNonCollection() error {
 			apr.Complete()
 		}
 	}(apr.blipSender)
-
 	return nil
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -348,7 +348,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		}()
 		// sendChanges runs until blip context closes, or fails due to error
 		startTime := time.Now()
-		_ = bh.sendChanges(rq.Sender, &sendChangesOptions{
+		_, err = bh.sendChanges(rq.Sender, &sendChangesOptions{
 			docIDs:            subChangesParams.docIDs(),
 			since:             subChangesParams.Since(),
 			continuous:        continuous,
@@ -361,6 +361,10 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 			changesCtx:        collectionCtx.changesCtx,
 			requestPlusSeq:    requestPlusSeq,
 		})
+		if err != nil {
+			base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "Closing blip connection due to changes feed error %+v\n", err)
+			bh.ctxCancelFunc()
+		}
 		base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Type:%s   --> Time:%v", bh.serialNumber, rq.Profile(), time.Since(startTime))
 	}()
 
@@ -428,8 +432,8 @@ func (flag changesDeletedFlag) HasFlag(deletedFlag changesDeletedFlag) bool {
 	return flag&deletedFlag != 0
 }
 
-// Sends all changes since the given sequence
-func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions) (isComplete bool) {
+// sendChanges will start a changes feed and send changes. Returns bool to indicate whether the changes feed finished and all changes were sent. The error value is only used to indicate a fatal error, where the blip connection should be terminated. If the blip connection is disconnected by the client, the error will be nil, but the boolean parameter will be false.
+func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions) (bool, error) {
 	defer func() {
 		if panicked := recover(); panicked != nil {
 			bh.replicationStats.NumHandlersPanicked.Add(1)
@@ -472,11 +476,10 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 	changesDb, err := bh.copyDatabaseCollectionWithUser(bh.collectionIdx)
 	if err != nil {
 		base.WarnfCtx(bh.loggingCtx, "[%s] error sending changes: %v", bh.blipContext.ID, err)
-		return false
-
+		return false, err
 	}
 
-	forceClose := generateBlipSyncChanges(bh.loggingCtx, changesDb, channelSet, options, opts.docIDs, func(changes []*ChangeEntry) error {
+	forceClose, err := generateBlipSyncChanges(bh.loggingCtx, changesDb, channelSet, options, opts.docIDs, func(changes []*ChangeEntry) error {
 		base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Sending %d changes", len(changes))
 		for _, change := range changes {
 			if !strings.HasPrefix(change.ID, "_") {
@@ -538,8 +541,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 		}
 		bh.db.DatabaseContext.NotifyTerminatedChanges(bh.loggingCtx, user)
 	}
-
-	return !forceClose
+	return (err == nil && !forceClose), err
 }
 
 func (bh *blipHandler) buildChangesRow(change *ChangeEntry, revID string) []interface{} {

--- a/db/changes.go
+++ b/db/changes.go
@@ -1360,16 +1360,16 @@ func (options ChangesOptions) String() string {
 	)
 }
 
-// Used by BLIP connections for changes.  Supports both one-shot and continuous changes.
-func generateBlipSyncChanges(ctx context.Context, database *DatabaseCollectionWithUser, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (forceClose bool) {
+// Used by BLIP connections for changes.  Supports both one-shot and continuous changes. Returns an error in the case that the feed does not start up, or there is a fatal error in the feed. The caller is responsible for closing the connection, no more changes will be generated. forceClose will be true if connection was terminated underneath the changes feed.
+func generateBlipSyncChanges(ctx context.Context, database *DatabaseCollectionWithUser, inChannels base.Set, options ChangesOptions, docIDFilter []string, send func([]*ChangeEntry) error) (forceClose bool, err error) {
 
 	// Store one-shot here to protect
 	isOneShot := !options.Continuous
-	err, forceClose := GenerateChanges(ctx, database, inChannels, options, docIDFilter, send)
+	err, forceClose = GenerateChanges(ctx, database, inChannels, options, docIDFilter, send)
 
 	if _, ok := err.(*ChangesSendErr); ok {
 		// If there was already an error in a send function, do not send last one shot changes message, since it probably will not work anyway.
-		return forceClose // error is probably because the client closed the connection
+		return forceClose, err // error is probably because the client closed the connection
 	}
 
 	// For one-shot changes, invoke the callback w/ nil to trigger the 'caught up' changes message.  (For continuous changes, this
@@ -1377,7 +1377,7 @@ func generateBlipSyncChanges(ctx context.Context, database *DatabaseCollectionWi
 	if isOneShot {
 		_ = send(nil)
 	}
-	return forceClose
+	return forceClose, err
 }
 
 type ChangesSendErr struct{ error }
@@ -1414,6 +1414,7 @@ func GenerateChanges(ctx context.Context, database *DatabaseCollectionWithUser, 
 	var lastSeq SequenceID
 	var feed <-chan *ChangeEntry
 	var timeout <-chan time.Time
+	var feedErr error
 
 	// feedStarted identifies whether at least one MultiChangesFeed has been started.  Used to identify when a one-shot changes is done.
 	feedStarted := false
@@ -1435,7 +1436,6 @@ loop:
 				forceClose = true
 				break loop
 			}
-			var feedErr error
 			if len(docIDFilter) > 0 {
 				feed, feedErr = database.DocIDChangesFeed(ctx, inChannels, docIDFilter, options)
 			} else {
@@ -1454,7 +1454,6 @@ loop:
 		}
 
 		var sendErr error
-
 		// Wait for either a new change, a heartbeat, or a timeout:
 		select {
 		case entry, ok := <-feed:
@@ -1463,6 +1462,7 @@ loop:
 			} else if entry == nil {
 				sendErr = send(nil)
 			} else if entry.Err != nil {
+				feedErr = entry.Err
 				break loop // error returned by feed - end changes
 			} else {
 				entries := []*ChangeEntry{entry}
@@ -1479,6 +1479,7 @@ loop:
 							waiting = true
 							break collect
 						} else if entry.Err != nil {
+							feedErr = entry.Err
 							break loop // error returned by feed - end changes
 						}
 						entries = append(entries, entry)
@@ -1531,5 +1532,5 @@ loop:
 		forceClose = true
 	}
 
-	return nil, forceClose
+	return feedErr, forceClose
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package rest
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -1205,7 +1206,7 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 		concurrentSendRevNum = 50
 	)
 	rt := NewRestTester(t, &RestTesterConfig{
-		leakyBucketConfig: &base.LeakyBucketConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{
 			UpdateCallback: func(_ string) {
 				time.Sleep(time.Millisecond * 5) // slow down rosmar - it's too quick to be throttled
 			},
@@ -3195,6 +3196,47 @@ func TestBlipDatabaseClose(t *testing.T) {
 		btcRunner.WaitForVersion(btc.id, markerDoc, markerDocVersion)
 
 		RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, "/{{.db}}/", ""), http.StatusOK)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.True(c, blipContextClosed.Load())
+		}, time.Second*10, time.Millisecond*100)
+	})
+}
+
+// Starts a continuous pull replication then updates the db to trigger a close.
+func TestChangesFeedExitDisconnect(t *testing.T) {
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
+	btcRunner := NewBlipTesterClientRunner(t)
+	var shouldChannelQueryError atomic.Bool
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &RestTesterConfig{
+			LeakyBucketConfig: &base.LeakyBucketConfig{
+				QueryCallback: func(ddoc, viewname string, params map[string]any) error {
+					if viewname == "channels" && shouldChannelQueryError.Load() {
+						return gocb.ErrTimeout
+					}
+					return nil
+				},
+				N1QLQueryCallback: func(_ context.Context, statement string, params map[string]any, consistency base.ConsistencyMode, adhoc bool) error {
+					if strings.Contains(statement, "sg_channels") && shouldChannelQueryError.Load() {
+						return gocb.ErrTimeout
+					}
+					return nil
+				},
+			},
+		})
+		defer rt.Close()
+		const username = "alice"
+		rt.CreateUser(username, []string{"*"})
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: username})
+		var blipContextClosed atomic.Bool
+		btcRunner.clients[btc.id].pullReplication.bt.blipContext.OnExitCallback = func() {
+			blipContextClosed.Store(true)
+		}
+
+		shouldChannelQueryError.Store(true)
+		btcRunner.StartPull(btc.id)
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, blipContextClosed.Load())

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3236,7 +3236,7 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 		}
 
 		shouldChannelQueryError.Store(true)
-		btcRunner.StartPull(btc.id)
+		require.NoError(t, btcRunner.StartPull(btc.id))
 
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, blipContextClosed.Load())

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -9,6 +9,7 @@
 package replicatortest
 
 import (
+	"context"
 	"encoding/json"
 	"expvar"
 	"fmt"
@@ -25,14 +26,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocb/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestReplicationAPI(t *testing.T) {
@@ -8555,10 +8558,93 @@ func TestDbConfigNoOverwriteReplications(t *testing.T) {
 	require.Equal(t, startReplicationConfig.Direction, config.Direction)
 }
 
+func TestActiveReplicatorChangesFeedExit(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
+
+	var shouldChannelQueryError atomic.Bool
+	activeRT := rest.NewRestTester(t, &rest.RestTesterConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{
+			QueryCallback: func(ddoc, viewname string, params map[string]any) error {
+				if viewname == "channels" && shouldChannelQueryError.Load() {
+					shouldChannelQueryError.Store(false)
+					return gocb.ErrTimeout
+				}
+				return nil
+			},
+			N1QLQueryCallback: func(_ context.Context, statement string, params map[string]any, consistency base.ConsistencyMode, adhoc bool) error {
+				// * channel query uses all docs index
+				if strings.Contains(statement, "sg_allDocs") && shouldChannelQueryError.Load() {
+					shouldChannelQueryError.Store(false)
+					return gocb.ErrTimeout
+				}
+				return nil
+			},
+		},
+	})
+	t.Cleanup(activeRT.Close)
+	_ = activeRT.Bucket()
+
+	passiveRT := rest.NewRestTesterPersistentConfig(t)
+	t.Cleanup(passiveRT.Close)
+
+	username := "alice"
+	passiveRT.CreateUser(username, []string{"*"})
+	passiveDBURL := passiveDBURLForAlice(passiveRT, username)
+	stats := dbReplicatorStats(t)
+	ar, err := db.NewActiveReplicator(activeRT.Context(), &db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: activeRT.GetDatabase(),
+		},
+		ChangesBatchSize:    200,
+		Continuous:          false,
+		ReplicationStatsMap: stats,
+		CollectionsEnabled:  !activeRT.GetDatabase().OnlyDefaultCollection(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, ar.Stop()) })
+
+	docID := "doc1"
+	_ = activeRT.CreateTestDoc(docID)
+
+	shouldChannelQueryError.Store(true)
+	require.NoError(t, ar.Start(activeRT.Context()))
+
+	changesResults, err := passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 1)
+	require.Equal(t, docID, changesResults.Results[0].ID)
+	require.Equal(t, int64(2), stats.NumConnectAttemptsPush.Value())
+}
 func requireBodyEqual(t *testing.T, expected string, doc *db.Document) {
 	var expectedBody db.Body
 	require.NoError(t, base.JSONUnmarshal([]byte(expected), &expectedBody))
 	require.Equal(t, expectedBody, doc.Body(base.TestCtx(t)))
+}
+
+func dbReplicatorStats(t *testing.T) *base.DbReplicatorStats {
+	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+	require.NoError(t, err)
+	dbstats, err := stats.DBReplicatorStats(t.Name())
+	require.NoError(t, err)
+	return dbstats
+}
+
+// passiveDBURLForAlice creates a public server for the passive RT and returns the URL for the alice user, e.g. http://alice:password@localhost:1234/dbname
+func passiveDBURLForAlice(rt *rest.RestTester, username string) *url.URL {
+	srv := httptest.NewServer(rt.TestPublicHandler())
+	rt.TB().Cleanup(srv.Close)
+
+	passiveDBURL, err := url.Parse(srv.URL + "/" + rt.GetDatabase().Name)
+	require.NoError(rt.TB(), err)
+
+	// Add basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
+	return passiveDBURL
 }
 
 func TestReplicationConfigUpdatedAt(t *testing.T) {

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2422,7 +2422,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		// Two callbacks to cover usage with CBS/Xattrs and without
 		revocationTester, rt := InitScenario(
 			t, &RestTesterConfig{
-				leakyBucketConfig: &base.LeakyBucketConfig{
+				LeakyBucketConfig: &base.LeakyBucketConfig{
 					GetWithXattrCallback: func(key string) error {
 						return fmt.Errorf("Leaky Bucket GetWithXattrCallback Error")
 					}, GetRawCallback: func(key string) error {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -59,7 +59,7 @@ type RestTesterConfig struct {
 	EnableNoConflictsMode           bool                        // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
 	EnableUserQueries               bool                        // Enable the feature-flag for user N1QL/etc queries
 	CustomTestBucket                *base.TestBucket            // If set, use this bucket instead of requesting a new one.
-	leakyBucketConfig               *base.LeakyBucketConfig     // Set to create and use a leaky bucket on the RT and DB. A test bucket cannot be passed in if using this option.
+	LeakyBucketConfig               *base.LeakyBucketConfig     // Set to create and use a leaky bucket on the RT and DB. A test bucket cannot be passed in if using this option.
 	adminInterface                  string                      // adminInterface overrides the default admin interface.
 	SgReplicateEnabled              bool                        // SgReplicateManager disabled by default for RestTester
 	AutoImport                      *bool
@@ -177,14 +177,14 @@ func (rt *RestTester) Bucket() base.Bucket {
 	testBucket := rt.RestTesterConfig.CustomTestBucket
 	if testBucket == nil {
 		testBucket = base.GetTestBucket(rt.TB())
-		if rt.leakyBucketConfig != nil {
-			leakyConfig := *rt.leakyBucketConfig
+		if rt.LeakyBucketConfig != nil {
+			leakyConfig := *rt.LeakyBucketConfig
 			// Ignore closures to avoid double closing panics
 			leakyConfig.IgnoreClose = true
 			testBucket = testBucket.LeakyBucketClone(leakyConfig)
 		}
-	} else if rt.leakyBucketConfig != nil {
-		rt.TB().Fatalf("A passed in TestBucket cannot be used on the RestTester when defining a leakyBucketConfig")
+	} else if rt.LeakyBucketConfig != nil {
+		rt.TB().Fatalf("A passed in TestBucket cannot be used on the RestTester when defining a LeakyBucketConfig")
 	}
 	rt.TestBucket = testBucket
 
@@ -360,7 +360,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		}
 		_, isLeaky := base.AsLeakyBucket(rt.TestBucket)
 		var err error
-		if rt.leakyBucketConfig != nil || isLeaky {
+		if rt.LeakyBucketConfig != nil || isLeaky {
 			_, err = rt.RestTesterServerContext.AddDatabaseFromConfigWithBucket(ctx, rt.TB(), *rt.DatabaseConfig, testBucket.Bucket)
 		} else {
 			_, err = rt.RestTesterServerContext.AddDatabaseFromConfig(ctx, *rt.DatabaseConfig)
@@ -448,11 +448,11 @@ func GetDataStoreNamesFromScopesConfig(config ScopesConfig) []sgbucket.DataStore
 }
 
 // LeakyBucket gets the bucket from the RestTester as a leaky bucket allowing for callbacks to be set on the fly.
-// The RestTester must have been set up to create and use a leaky bucket by setting leakyBucketConfig in the RT
+// The RestTester must have been set up to create and use a leaky bucket by setting LeakyBucketConfig in the RT
 // config when calling NewRestTester.
 func (rt *RestTester) LeakyBucket() *base.LeakyDataStore {
-	if rt.leakyBucketConfig == nil {
-		rt.TB().Fatalf("Cannot get leaky bucket when leakyBucketConfig was not set on RestTester initialisation")
+	if rt.LeakyBucketConfig == nil {
+		rt.TB().Fatalf("Cannot get leaky bucket when LeakyBucketConfig was not set on RestTester initialisation")
 	}
 	leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())
 	if !ok {


### PR DESCRIPTION
[3.2.2 backport] CBG-4446 create a cancel context inside BlipSyncContext

Straightforward cherry-pick.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2909/
