### PR TITLE
CBG-4313: Release unused sequences allocated when encountering CAS retries updating principals

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1057,7 +1057,7 @@ func TestUpdatePrincipal(t *testing.T) {
 }
 
 func TestUpdatePrincipalCASRetry(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth, base.KeyCRUD)
 
 	// ensure we don't batch sequences so that the number of released sequences is deterministic
 	defer SuspendSequenceBatching()()

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1075,7 +1075,7 @@ func TestUpdatePrincipalCASRetry(t *testing.T) {
 		{numCASRetries: 5},
 		{numCASRetries: 10},
 		{numCASRetries: auth.PrincipalUpdateMaxCasRetries - 1},
-		{numCASRetries: auth.PrincipalUpdateMaxCasRetries},
+		{numCASRetries: auth.PrincipalUpdateMaxCasRetries, expectError: true},
 		{numCASRetries: auth.PrincipalUpdateMaxCasRetries + 1, expectError: true},
 	}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1128,7 +1128,7 @@ func TestUpdatePrincipalCASRetry(t *testing.T) {
 
 			_, _, err = db.UpdatePrincipal(ctx, userInfo, true, true)
 			if test.expectError {
-				require.Error(t, err)
+				require.ErrorContains(t, err, "cas mismatch")
 			} else {
 				require.NoError(t, err, "Unable to update principal")
 			}

--- a/db/users.go
+++ b/db/users.go
@@ -220,6 +220,10 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		// On cas error, retry.  Otherwise break out of loop
 		if base.IsCasMismatch(err) {
 			base.InfofCtx(ctx, base.KeyAuth, "CAS mismatch updating principal %s - will retry", base.UD(princ.Name()))
+			// release the sequence number we allocated in the failed update to avoid an abandoned sequence
+			if err := dbc.sequences.releaseSequence(ctx, nextSeq); err != nil {
+				base.InfofCtx(ctx, base.KeyAuth, "Error releasing sequence number %d: %v", nextSeq, err)
+			}
 		} else {
 			return replaced, princ, err
 		}

--- a/db/users.go
+++ b/db/users.go
@@ -116,9 +116,9 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		if updates.ExplicitChannels != nil && !updatedExplicitChannels.Equals(updates.ExplicitChannels) {
 			changed = true
 		}
-		collectionAccessChanged, err := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
-		if err != nil {
-			return false, princ, err
+		collectionAccessChanged, collectionAccessErr := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
+		if collectionAccessErr != nil {
+			return false, princ, collectionAccessErr
 		} else if collectionAccessChanged {
 			changed = true
 		}

--- a/db/users.go
+++ b/db/users.go
@@ -222,7 +222,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			base.InfofCtx(ctx, base.KeyAuth, "CAS mismatch updating principal %s - will retry", base.UD(princ.Name()))
 			// release the sequence number we allocated in the failed update to avoid an abandoned sequence
 			if err := dbc.sequences.releaseSequence(ctx, nextSeq); err != nil {
-				base.InfofCtx(ctx, base.KeyAuth, "Error releasing sequence number %d: %v", nextSeq, err)
+				base.InfofCtx(ctx, base.KeyAuth, "Error releasing unused sequence %d after CAS retry: %v", nextSeq, err)
 			}
 		} else {
 			return replaced, princ, err

--- a/db/users.go
+++ b/db/users.go
@@ -222,7 +222,7 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 			base.InfofCtx(ctx, base.KeyAuth, "CAS mismatch updating principal %s - will retry", base.UD(princ.Name()))
 			// release the sequence number we allocated in the failed update to avoid an abandoned sequence
 			if err := dbc.sequences.releaseSequence(ctx, nextSeq); err != nil {
-				base.InfofCtx(ctx, base.KeyAuth, "Error releasing unused sequence %d after CAS retry: %v", nextSeq, err)
+				base.InfofCtx(ctx, base.KeyAuth, "Error releasing unused sequence %d after CAS retry for principal %s: %v", nextSeq, base.UD(princ.Name()), err)
 			}
 		} else {
 			return replaced, princ, err


### PR DESCRIPTION
CBG-4313

- Release unused sequences allocated when encountering CAS retries updating principals.
- New test to cover

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a - Not Couchbase Server specific behaviour