### PR TITLE
[3.2.3 Backport] CBG-4314: Release unused sequences allocated when encountering CAS retries updating principals

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1092,11 +1092,12 @@ func TestUpdatePrincipalCASRetry(t *testing.T) {
 				casRetryCount.Add(1)
 				casRetryCountInt = casRetryCount.Load()
 				t.Logf("foreceCASRetry %d/%d: Forcing CAS retry for key: %q", casRetryCountInt, totalCASRetriesInt, key)
-				body, originalCAS, err := tb.GetMetadataStore().GetRaw(key)
+				var body []byte
+				originalCAS, err := tb.GetMetadataStore().Get(key, &body)
 				require.NoError(t, err)
-				err = tb.GetMetadataStore().SetRaw(key, 0, nil, body)
+				err = tb.GetMetadataStore().Set(key, 0, nil, body)
 				require.NoError(t, err)
-				_, newCAS, err := tb.GetMetadataStore().GetRaw(key)
+				newCAS, err := tb.GetMetadataStore().Get(key, &body)
 				require.NoError(t, err)
 				t.Logf("foreceCASRetry %d/%d: Doc %q CAS changed from %d to %d", casRetryCountInt, totalCASRetriesInt, key, originalCAS, newCAS)
 			}

--- a/db/users.go
+++ b/db/users.go
@@ -116,9 +116,9 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		if updates.ExplicitChannels != nil && !updatedExplicitChannels.Equals(updates.ExplicitChannels) {
 			changed = true
 		}
-		collectionAccessChanged, err := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
-		if err != nil {
-			return false, princ, err
+		collectionAccessChanged, collectionAccessErr := dbc.RequiresCollectionAccessUpdate(ctx, princ, updates.CollectionAccess)
+		if collectionAccessErr != nil {
+			return false, princ, collectionAccessErr
 		} else if collectionAccessChanged {
 			changed = true
 		}
@@ -220,6 +220,10 @@ func (dbc *DatabaseContext) UpdatePrincipal(ctx context.Context, updates *auth.P
 		// On cas error, retry.  Otherwise break out of loop
 		if base.IsCasMismatch(err) {
 			base.InfofCtx(ctx, base.KeyAuth, "CAS mismatch updating principal %s - will retry", base.UD(princ.Name()))
+			// release the sequence number we allocated in the failed update to avoid an abandoned sequence
+			if err := dbc.sequences.releaseSequence(ctx, nextSeq); err != nil {
+				base.InfofCtx(ctx, base.KeyAuth, "Error releasing unused sequence %d after CAS retry for principal %s: %v", nextSeq, base.UD(princ.Name()), err)
+			}
 		} else {
 			return replaced, princ, err
 		}


### PR DESCRIPTION
CBG-4314

Clean cherry-pick of #7316 (CBG-4313) for 3.2.3 + follow-up integration test fix

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2912