### PR TITLE
CBG-4313 follow-up: Fix test LeakyBucket incorrect use of SetRaw

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1097,7 +1097,7 @@ func TestUpdatePrincipalCASRetry(t *testing.T) {
 				require.NoError(t, err)
 				err = tb.GetMetadataStore().Set(key, 0, nil, body)
 				require.NoError(t, err)
-				_, newCAS, err := tb.GetMetadataStore().GetRaw(key)
+				newCAS, err := tb.GetMetadataStore().Get(key, &body)
 				require.NoError(t, err)
 				t.Logf("foreceCASRetry %d/%d: Doc %q CAS changed from %d to %d", casRetryCountInt, totalCASRetriesInt, key, originalCAS, newCAS)
 			}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1092,9 +1092,10 @@ func TestUpdatePrincipalCASRetry(t *testing.T) {
 				casRetryCount.Add(1)
 				casRetryCountInt = casRetryCount.Load()
 				t.Logf("foreceCASRetry %d/%d: Forcing CAS retry for key: %q", casRetryCountInt, totalCASRetriesInt, key)
-				body, originalCAS, err := tb.GetMetadataStore().GetRaw(key)
+				var body []byte
+				originalCAS, err := tb.GetMetadataStore().Get(key, &body)
 				require.NoError(t, err)
-				err = tb.GetMetadataStore().SetRaw(key, 0, nil, body)
+				err = tb.GetMetadataStore().Set(key, 0, nil, body)
 				require.NoError(t, err)
 				_, newCAS, err := tb.GetMetadataStore().GetRaw(key)
 				require.NoError(t, err)


### PR DESCRIPTION
CBG-4313 follow-up test fix (integration only failure)

Preserve JSON doc type in bucket by using Set instead of SetRaw

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2911/
