### PR TITLE
CBG-4486 avoid nested read lock

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -313,19 +313,14 @@ func (a *activeReplicatorCommon) getState() string {
 	return a.state
 }
 
-func (a *activeReplicatorCommon) _getStateWithErrorMessage() (state string, lastErrorMessage string) {
+// getStateWithErrorMessage returns the current state and last error message for the replicator.
+func (a *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastErrorMessage string) {
 	a.stateErrorLock.RLock()
 	defer a.stateErrorLock.RUnlock()
 	if a.lastError == nil {
 		return a.state, ""
 	}
 	return a.state, a.lastError.Error()
-}
-
-func (a *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastErrorMessage string) {
-	a.stateErrorLock.RLock()
-	defer a.stateErrorLock.RUnlock()
-	return a._getStateWithErrorMessage()
 }
 
 func (a *activeReplicatorCommon) GetStats() *BlipSyncStats {

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -227,7 +227,7 @@ func (apr *ActivePullReplicator) _getStatus() *ReplicationStatus {
 		ID: apr.CheckpointID,
 	}
 
-	status.Status, status.ErrorMessage = apr._getStateWithErrorMessage()
+	status.Status, status.ErrorMessage = apr.getStateWithErrorMessage()
 
 	pullStats := apr.replicationStats
 	status.DocsRead = pullStats.HandleRevCount.Value()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -181,7 +181,7 @@ func (apr *ActivePushReplicator) _initCheckpointer(remoteCheckpoints []replicati
 // requires apr.lock
 func (apr *ActivePushReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{}
-	status.Status, status.ErrorMessage = apr._getStateWithErrorMessage()
+	status.Status, status.ErrorMessage = apr.getStateWithErrorMessage()
 
 	pushStats := apr.replicationStats
 	status.DocsWritten = pushStats.SendRevCount.Value()


### PR DESCRIPTION
Fixes a mistake and avoids a deadlock that occurs when RWMutex.Lock() is called between the two RWMutex.RLock() calls

This was a mistake in https://github.com/couchbase/sync_gateway/commit/0efa2a4ea3959878ab75c8da9c629df61a57329e.

The deadlock occurs due to the behavior of `sync.RWMutex`:

> If any goroutine calls [RWMutex.Lock](https://pkg.go.dev/sync#RWMutex.Lock) while the lock is already held by one or more readers, concurrent calls to [RWMutex.RLock](https://pkg.go.dev/sync#RWMutex.RLock) will block until the writer has acquired (and released) the lock, to ensure that the lock eventually becomes available to the writer. Note that this prohibits recursive read-locking.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
