### PR TITLE
CBG-4487: Avoid deadlock in revision cache between Get and On demand import

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -499,7 +499,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.Remove(docID, syncData.CurrentRev)
+		collection.revisionCache.Remove(ctx, docID, syncData.CurrentRev)
 	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,

--- a/db/crud.go
+++ b/db/crud.go
@@ -2078,7 +2078,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Remove(doc.ID, doc.CurrentRev)
+				db.revisionCache.Remove(ctx, doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -88,7 +88,7 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Remove(docID, revID string, collectionID uint32) {
+func (rc *BypassRevisionCache) Remove(ctx context.Context, docID, revID string, collectionID uint32) {
 	// nop
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -44,7 +44,7 @@ type RevisionCache interface {
 	Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32)
 
 	// Remove eliminates a revision in the cache.
-	Remove(docID, revID string, collectionID uint32)
+	Remove(ctx context.Context, docID, revID string, collectionID uint32)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta)
@@ -150,8 +150,8 @@ func (c *collectionRevisionCache) Upsert(ctx context.Context, docRev DocumentRev
 }
 
 // Remove is for per collection access to Remove method
-func (c *collectionRevisionCache) Remove(docID, revID string) {
-	(*c.revCache).Remove(docID, revID, c.collectionID)
+func (c *collectionRevisionCache) Remove(ctx context.Context, docID, revID string) {
+	(*c.revCache).Remove(ctx, docID, revID, c.collectionID)
 }
 
 // UpdateDelta is for per collection access to UpdateDelta method

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -394,7 +394,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	// if not cache hit, we loaded from bucket. Calculate doc rev size and assign to rev cache value
 	if !cacheHit {
 		docRev.CalculateBytes()
-		value.itemBytes.Store(docRev.MemoryBytes) //= docRev.MemoryBytes
+		value.itemBytes.Store(docRev.MemoryBytes)
 	}
 	value.lock.Unlock()
 
@@ -446,7 +446,7 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 	// if not cache hit, we loaded from bucket. Calculate doc rev size and assign to rev cache value
 	if !cacheHit {
 		docRev.CalculateBytes()
-		value.itemBytes.Store(docRev.MemoryBytes) //= docRev.MemoryBytes
+		value.itemBytes.Store(docRev.MemoryBytes)
 	}
 	value.lock.Unlock()
 	return docRev, cacheHit, err
@@ -479,7 +479,7 @@ func (value *revCacheValue) updateDelta(toDelta RevisionDelta) (diffInBytes int6
 	diffInBytes = toDelta.totalDeltaBytes - previousDeltaBytes
 	value.delta = &toDelta
 	if diffInBytes != 0 {
-		value.itemBytes.Add(diffInBytes) //+= diffInBytes
+		value.itemBytes.Add(diffInBytes)
 	}
 	value.lock.Unlock()
 	return diffInBytes

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1327,16 +1327,18 @@ func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			err = collection.dataStore.Set(docID, 0, nil, []byte(fmt.Sprintf(`{"ver": "%d"}`, i)))
 			require.NoError(t, err)
-			docRev, err := db.revisionCache.GetActive(ctx, docID, collection.GetCollectionID())
-			require.NoError(t, err)
+			_, err := db.revisionCache.GetActive(ctx, docID, collection.GetCollectionID())
+			if err != nil {
+				break
+			}
 		}
 		wg.Done()
 	}()
 	wg.Wait()
+	require.NoError(t, err)
 }
 
 func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
-	base.SkipImportTestsIfNotEnabled(t)
 
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
@@ -1378,7 +1380,6 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 }
 
 func TestPutRevHighRevCacheChurn(t *testing.T) {
-	base.SkipImportTestsIfNotEnabled(t)
 
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1237,7 +1237,7 @@ func TestRevCacheOnDemand(t *testing.T) {
 		require.NoError(t, err)
 		go func() {
 			for {
-				db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta)
+				db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 			}
 		}()
 	}
@@ -1272,7 +1272,7 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 		require.NoError(t, err)
 		go func() {
 			for {
-				db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta)
+				db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 			}
 		}()
 	}

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1239,7 +1239,7 @@ func TestRevCacheOnDemand(t *testing.T) {
 		require.NoError(t, err)
 		go func() {
 			for {
-				db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+				_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 			}
 		}()
 	}
@@ -1279,7 +1279,7 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 		require.NoError(t, err)
 		go func() {
 			for {
-				db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+				_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 			}
 		}()
 	}

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"log"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -1215,6 +1216,76 @@ func TestRevCacheCapacityStat(t *testing.T) {
 	// Assert num items goes back to 0
 	assert.Equal(t, int64(0), cacheNumItems.Value())
 	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+}
+
+func TestRevCacheOnDemand(t *testing.T) {
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxItemCount: 2,
+			ShardCount:   1,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	docID := "doc1"
+	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
+	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		docID := fmt.Sprintf("extraDoc%d", i)
+		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
+		require.NoError(t, err)
+		go func() {
+			for {
+				db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta)
+			}
+		}()
+	}
+	log.Printf("Updating doc to trigger on-demand import")
+	err = collection.dataStore.Set(docID, 0, nil, []byte(`{"ver": "2"}`))
+	require.NoError(t, err)
+	log.Printf("Calling getRev for %s, %s", docID, revID)
+	rev, err := collection.getRev(ctx, docID, revID, 0, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing")
+	// returns empty doc rev
+	assert.Equal(t, "", rev.DocID)
+}
+
+func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxItemCount: 20,
+			ShardCount:   1,
+			MaxBytes:     112, // equivalent to max size 2 items
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	docID := "doc1"
+	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
+	require.NoError(t, err)
+	for i := 0; i < 2; i++ {
+		docID := fmt.Sprintf("extraDoc%d", i)
+		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
+		require.NoError(t, err)
+		go func() {
+			for {
+				db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta)
+			}
+		}()
+	}
+	log.Printf("Updating doc to trigger on-demand import")
+	err = collection.dataStore.Set(docID, 0, nil, []byte(`{"ver": "2"}`))
+	require.NoError(t, err)
+	log.Printf("Calling getRev for %s, %s", docID, revID)
+	rev, err := collection.getRev(ctx, docID, revID, 0, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing")
+	// returns empty doc rev
+	assert.Equal(t, "", rev.DocID)
+
 }
 
 func BenchmarkRevisionCacheRead(b *testing.B) {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -197,7 +197,7 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 	assert.Equal(t, expValue, currMem)
 
 	// remove doc "1" to give headroom for memory based eviction
-	db.revisionCache.Remove("1", rev, collection.GetCollectionID())
+	db.revisionCache.Remove(ctx, "1", rev, collection.GetCollectionID())
 	docRev, ok = db.revisionCache.Peek(ctx, "1", rev, collection.GetCollectionID())
 	assert.False(t, ok)
 	assert.Nil(t, docRev.BodyBytes)
@@ -911,13 +911,13 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 	assert.Equal(t, expMem, cacheStats.RevisionCacheTotalMemory.Value())
 
 	// Test Remove with something in cache, assert stat decrements by expected value
-	db.revisionCache.Remove("doc5", "1-abc", collctionID)
+	db.revisionCache.Remove(ctx, "doc5", "1-abc", collctionID)
 	expMem -= 14
 	assert.Equal(t, expMem, cacheStats.RevisionCacheTotalMemory.Value())
 
 	// Test Remove with item not in cache, assert stat is unchanged
 	prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
-	db.revisionCache.Remove("doc6", "1-abc", collctionID)
+	db.revisionCache.Remove(ctx, "doc6", "1-abc", collctionID)
 	assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
 
 	// Test Update Delta, assert stat increases as expected
@@ -927,9 +927,9 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 	assert.Equal(t, expMem, cacheStats.RevisionCacheTotalMemory.Value())
 
 	// Empty cache and see memory stat is 0
-	db.revisionCache.Remove("doc3", revIDDoc3, collctionID)
-	db.revisionCache.Remove("doc2", revIDDoc2, collctionID)
-	db.revisionCache.Remove("doc1", revIDDoc1, collctionID)
+	db.revisionCache.Remove(ctx, "doc3", revIDDoc3, collctionID)
+	db.revisionCache.Remove(ctx, "doc2", revIDDoc2, collctionID)
+	db.revisionCache.Remove(ctx, "doc1", revIDDoc1, collctionID)
 
 	// TODO: pending CBG-4135 assert rev cache had 0 items in it
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
@@ -990,7 +990,7 @@ func TestRevisionCacheRemove(t *testing.T) {
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheMisses.Value())
 
-	collection.revisionCache.Remove("doc", rev1id)
+	collection.revisionCache.Remove(ctx, "doc", rev1id)
 
 	docRev, err = collection.revisionCache.Get(ctx, "doc", rev1id, true)
 	assert.NoError(t, err)
@@ -1208,10 +1208,10 @@ func TestRevCacheCapacityStat(t *testing.T) {
 	assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
 
 	// Empty cache
-	cache.Remove("doc1", "1-abc", testCollectionID)
-	cache.Remove("doc4", "1-abc", testCollectionID)
-	cache.Remove("doc5", "1-abc", testCollectionID)
-	cache.Remove("doc6", "1-abc", testCollectionID)
+	cache.Remove(ctx, "doc1", "1-abc", testCollectionID)
+	cache.Remove(ctx, "doc4", "1-abc", testCollectionID)
+	cache.Remove(ctx, "doc5", "1-abc", testCollectionID)
+	cache.Remove(ctx, "doc6", "1-abc", testCollectionID)
 
 	// Assert num items goes back to 0
 	assert.Equal(t, int64(0), cacheNumItems.Value())
@@ -1447,7 +1447,7 @@ func createThenRemoveFromRevCache(t *testing.T, ctx context.Context, docID strin
 	revIDDoc, _, err := collection.Put(ctx, docID, Body{"test": "doc"})
 	require.NoError(t, err)
 
-	db.revisionCache.Remove(docID, revIDDoc, collection.GetCollectionID())
+	db.revisionCache.Remove(ctx, docID, revIDDoc, collection.GetCollectionID())
 
 	return revIDDoc
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1219,6 +1219,8 @@ func TestRevCacheCapacityStat(t *testing.T) {
 }
 
 func TestRevCacheOnDemand(t *testing.T) {
+	base.SkipImportTestsIfNotEnabled(t)
+
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
 			MaxItemCount: 2,
@@ -1247,12 +1249,17 @@ func TestRevCacheOnDemand(t *testing.T) {
 	log.Printf("Calling getRev for %s, %s", docID, revID)
 	rev, err := collection.getRev(ctx, docID, revID, 0, nil)
 	require.Error(t, err)
+	if base.IsEnterpriseEdition() {
+		fmt.Println("here")
+	}
 	require.ErrorContains(t, err, "missing")
 	// returns empty doc rev
 	assert.Equal(t, "", rev.DocID)
 }
 
 func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
+	base.SkipImportTestsIfNotEnabled(t)
+
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
 			MaxItemCount: 20,


### PR DESCRIPTION
CBG-4487

- Refactor eviction to not acquire value lock whilst hold rev cache lock 
- made item bytes atomic 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2920/
