### PR TITLE
[3.2.3 backport] CBG-4492 avoid nested read lock

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -313,19 +313,14 @@ func (a *activeReplicatorCommon) getState() string {
 	return a.state
 }
 
-func (a *activeReplicatorCommon) _getStateWithErrorMessage() (state string, lastErrorMessage string) {
+// getStateWithErrorMessage returns the current state and last error message for the replicator.
+func (a *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastErrorMessage string) {
 	a.stateErrorLock.RLock()
 	defer a.stateErrorLock.RUnlock()
 	if a.lastError == nil {
 		return a.state, ""
 	}
 	return a.state, a.lastError.Error()
-}
-
-func (a *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastErrorMessage string) {
-	a.stateErrorLock.RLock()
-	defer a.stateErrorLock.RUnlock()
-	return a._getStateWithErrorMessage()
 }
 
 func (a *activeReplicatorCommon) GetStats() *BlipSyncStats {

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -227,7 +227,7 @@ func (apr *ActivePullReplicator) _getStatus() *ReplicationStatus {
 		ID: apr.CheckpointID,
 	}
 
-	status.Status, status.ErrorMessage = apr._getStateWithErrorMessage()
+	status.Status, status.ErrorMessage = apr.getStateWithErrorMessage()
 
 	pullStats := apr.replicationStats
 	status.DocsRead = pullStats.HandleRevCount.Value()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -181,7 +181,7 @@ func (apr *ActivePushReplicator) _initCheckpointer(remoteCheckpoints []replicati
 // requires apr.lock
 func (apr *ActivePushReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{}
-	status.Status, status.ErrorMessage = apr._getStateWithErrorMessage()
+	status.Status, status.ErrorMessage = apr.getStateWithErrorMessage()
 
 	pushStats := apr.replicationStats
 	status.DocsWritten = pushStats.SendRevCount.Value()


### PR DESCRIPTION
[3.2.3 backport] CBG-4492 avoid nested read lock

backport of be4c2defb6ed3bd807e28dbe0715201925db052f, required so for ff7a6dc566a42e33fc81ae9ac6386c53c5c2db62.