### PR TITLE
[3.2.2 Backport] CBG-4488: Avoid deadlock in revision cache between Get and on-demand import

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -499,7 +499,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.Remove(docID, syncData.CurrentRev)
+		collection.revisionCache.Remove(ctx, docID, syncData.CurrentRev)
 	}
 	change := &LogEntry{
 		Sequence:     syncData.Sequence,

--- a/db/crud.go
+++ b/db/crud.go
@@ -2071,7 +2071,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.Remove(doc.ID, doc.CurrentRev)
+				db.revisionCache.Remove(ctx, doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -88,7 +88,7 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) Remove(docID, revID string, collectionID uint32) {
+func (rc *BypassRevisionCache) Remove(ctx context.Context, docID, revID string, collectionID uint32) {
 	// nop
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -44,7 +44,7 @@ type RevisionCache interface {
 	Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32)
 
 	// Remove eliminates a revision in the cache.
-	Remove(docID, revID string, collectionID uint32)
+	Remove(ctx context.Context, docID, revID string, collectionID uint32)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta)
@@ -150,8 +150,8 @@ func (c *collectionRevisionCache) Upsert(ctx context.Context, docRev DocumentRev
 }
 
 // Remove is for per collection access to Remove method
-func (c *collectionRevisionCache) Remove(docID, revID string) {
-	(*c.revCache).Remove(docID, revID, c.collectionID)
+func (c *collectionRevisionCache) Remove(ctx context.Context, docID, revID string) {
+	(*c.revCache).Remove(ctx, docID, revID, c.collectionID)
 }
 
 // UpdateDelta is for per collection access to UpdateDelta method


### PR DESCRIPTION
CBG-4488

Clean cherry-pick of #7326 for 3.2.2

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2921/
