### PR TITLE
CBG-4478 switch database to offline if there is an error on synchronous reload

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -153,6 +153,9 @@ type LeakyBucketConfig struct {
 	// IncrCallback issues a callback during incr.  Used for sequence allocation race tests
 	IncrCallback func()
 
+	// TouchCallback issues a callback during touch.
+	TouchCallback func(key string) error
+
 	// When IgnoreClose is set to true, bucket.Close() is a no-op.  Used when multiple references to a bucket are active.
 	IgnoreClose bool
 }

--- a/base/leaky_datastore.go
+++ b/base/leaky_datastore.go
@@ -119,6 +119,12 @@ func (lds *LeakyDataStore) GetAndTouchRaw(k string, exp uint32) (v []byte, cas u
 	return lds.dataStore.GetAndTouchRaw(k, exp)
 }
 func (lds *LeakyDataStore) Touch(k string, exp uint32) (cas uint64, err error) {
+	if lds.config.TouchCallback != nil {
+		err := lds.config.TouchCallback(k)
+		if err != nil {
+			return 0, err
+		}
+	}
 	return lds.dataStore.Touch(k, exp)
 }
 func (lds *LeakyDataStore) Add(k string, exp uint32, v interface{}) (added bool, err error) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -940,6 +940,9 @@ func TestHeapProfileValuesPopulated(t *testing.T) {
 }
 
 func TestDatabaseStartupFailure(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("EE only test, requires heartbeater error")
+	}
 	touchErr := errors.New("touch error")
 	rt := NewRestTester(t, &RestTesterConfig{
 		LeakyBucketConfig: &base.LeakyBucketConfig{

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -946,7 +946,7 @@ func TestDatabaseStartupFailure(t *testing.T) {
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("LeakyBucketConfig not supported on CBS")
 	}
-	
+
 	touchErr := errors.New("touch error")
 	rt := NewRestTester(t, &RestTesterConfig{
 		LeakyBucketConfig: &base.LeakyBucketConfig{

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -10,12 +10,14 @@ package rest
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -935,4 +937,30 @@ func TestHeapProfileValuesPopulated(t *testing.T) {
 			require.Equal(t, test.heapProfileCollectionEnabled, sc.statsContext.heapProfileEnabled)
 		})
 	}
+}
+
+func TestDatabaseStartupFailure(t *testing.T) {
+	touchErr := errors.New("touch error")
+	rt := NewRestTester(t, &RestTesterConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{
+			TouchCallback: func(key string) error {
+				if strings.Contains(key, "heartbeat_timeout") {
+					return touchErr
+				}
+				return nil
+			},
+		},
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	dbConfig := DatabaseConfig{
+		DbConfig: rt.NewDbConfig(),
+	}
+
+	// this call does use the leaky bucket
+	dbContext, err := rt.ServerContext().AddDatabaseFromConfigWithBucket(rt.Context(), t, dbConfig, rt.Bucket())
+	require.ErrorIs(t, err, touchErr)
+	require.Nil(t, dbContext)
+	require.Equal(t, "Offline", rt.GetDBState())
 }

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -943,6 +943,10 @@ func TestDatabaseStartupFailure(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("EE only test, requires heartbeater error")
 	}
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("LeakyBucketConfig not supported on CBS")
+	}
+	
 	touchErr := errors.New("touch error")
 	rt := NewRestTester(t, &RestTesterConfig{
 		LeakyBucketConfig: &base.LeakyBucketConfig{


### PR DESCRIPTION
CBG-4478 switch database to offline if there is an error on synchronous reload

Implemented with defer since there are at least two exit pathways that return error after the state is switched to online.

- Simulate an error in `StartOnlineProcesses` by causing the heartbeater to fail. This only exists in EE code.
- Subtly fixes an existing error in the first defer of `_getOrAddDatabaseFromConfig` since `dbcontext` would always be nil, due to the way named returns work.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2922/
