### PR TITLE
CBG-4499: fix leaking goroutines

### DIFF
--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1486,7 +1486,7 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
 	require.NoError(t, err)
 
-	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
+	ctx, testCtxCancel := context.WithCancel(ctx)
 	defer testCtxCancel()
 
 	for i := 0; i < 2; i++ {
@@ -1496,7 +1496,7 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 		go func() {
 			for {
 				select {
-				case <-testCtx.Done():
+				case <-ctx.Done():
 					return
 				default:
 					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
@@ -1530,7 +1530,7 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
 	require.NoError(t, err)
 
-	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
+	ctx, testCtxCancel := context.WithCancel(ctx)
 	defer testCtxCancel()
 
 	for i := 0; i < 2; i++ {
@@ -1540,7 +1540,7 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 		go func() {
 			for {
 				select {
-				case <-testCtx.Done():
+				case <-ctx.Done():
 					return
 				default:
 					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1258,9 +1258,6 @@ func TestRevCacheOnDemand(t *testing.T) {
 	log.Printf("Calling getRev for %s, %s", docID, revID)
 	rev, err := collection.getRev(ctx, docID, revID, 0, nil)
 	require.Error(t, err)
-	if base.IsEnterpriseEdition() {
-		fmt.Println("here")
-	}
 	require.ErrorContains(t, err, "missing")
 	// returns empty doc rev
 	assert.Equal(t, "", rev.DocID)
@@ -1488,13 +1485,22 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 	docID := "doc1"
 	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
 	require.NoError(t, err)
+
+	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
+	defer testCtxCancel()
+
 	for i := 0; i < 2; i++ {
 		docID := fmt.Sprintf("extraDoc%d", i)
 		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
 		require.NoError(t, err)
 		go func() {
 			for {
-				_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+				select {
+				case <-testCtx.Done():
+					return
+				default:
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+				}
 			}
 		}()
 	}
@@ -1523,13 +1529,22 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 	docID := "doc1"
 	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
 	require.NoError(t, err)
+
+	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
+	defer testCtxCancel()
+
 	for i := 0; i < 2; i++ {
 		docID := fmt.Sprintf("extraDoc%d", i)
 		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
 		require.NoError(t, err)
 		go func() {
 			for {
-				_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+				select {
+				case <-testCtx.Done():
+					return
+				default:
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
CBG-4499

Fix leaking goroutines likely to cause test timeouts we saw previously.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
