### PR TITLE
CBG-4450: test flake where nanoseconds are the same in the config between updates

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8681,6 +8681,9 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 	currTime := configResponse.UpdatedAt
 	createdAtTime := configResponse.CreatedAt
 
+	// avoid flake where update at seems to be the same (possibly running to fast)
+	time.Sleep(500 * time.Nanosecond)
+
 	resp = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/replication1?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8682,7 +8682,7 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 	createdAtTime := configResponse.CreatedAt
 
 	// avoid flake where update at seems to be the same (possibly running to fast)
-	time.Sleep(500 * time.Nanosecond)
+	time.Sleep(10 * time.Millisecond)
 
 	resp = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/replication1?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -8698,6 +8698,6 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 	configResponse = db.ReplicationConfig{}
 	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &configResponse))
 
-	assert.Greater(t, configResponse.UpdatedAt.UnixNano(), currTime.UnixNano())
+	base.AssertTimeGreaterThan(t, *configResponse.UpdatedAt, *currTime)
 	assert.Equal(t, configResponse.CreatedAt.UnixNano(), createdAtTime.UnixNano())
 }


### PR DESCRIPTION
CBG-4450

- Add sleep to ensure nanosecond difference between config updates
- Particularly flakes on windows, as result re ran CI 3 times for windows - no flake

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
