### PR TITLE
CBG-4501 define DatabaseLogCtx earlier

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -584,6 +584,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		dbName = spec.BucketName
 	}
 
+	// we do not have per database logging parameters, but it is still useful to have the database name in the log context. This must be set again after dbcOptionsFromConfig is called.
+	ctx = base.DatabaseLogCtx(ctx, dbName, nil)
+
 	defer func() {
 		if returnedError == nil {
 			return


### PR DESCRIPTION
CBG-4501 define DatabaseLogCtx earlier

Allows https://github.com/couchbase/sync_gateway/blob/2df936b0b2d97af3baca5375068282d4f1a892e5/rest/server_context.go#L1019
https://github.com/couchbase/sync_gateway/blob/2df936b0b2d97af3baca5375068282d4f1a892e5/rest/server_context.go#L1101C35-L1101C100

to show up tagged with database log context.