### PR TITLE
CBG-4396: [3.2.3 backport] remove debug logging that looks like errors

### DIFF
--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -235,7 +235,6 @@ func (c *Collection) subdocGetBodyAndXattrs(ctx context.Context, k string, xattr
 				xattrContentErr := res.ContentAt(uint(i), &xattr)
 				if xattrContentErr != nil {
 					xattrErrors = append(xattrErrors, xattrContentErr)
-					DebugfCtx(ctx, KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
 					continue
 				}
 				xattrs[xattrKey] = xattr
@@ -252,10 +251,6 @@ func (c *Collection) subdocGetBodyAndXattrs(ctx context.Context, k string, xattr
 				return false, ErrXattrNotFound, cas
 			}
 
-			if docContentErr != nil {
-				DebugfCtx(ctx, KeyCRUD, "No document body found for key=%s, xattrKeys=%s: %v", UD(k), UD(xattrKeys), docContentErr)
-			}
-
 		case gocbcore.ErrMemdSubDocMultiPathFailureDeleted:
 			//   ErrSubDocMultiPathFailureDeleted - one of the subdoc operations failed, and the doc is deleted.  Occurs when xattr may exist but doc is deleted (tombstone)
 			cas = uint64(res.Cas())
@@ -265,7 +260,6 @@ func (c *Collection) subdocGetBodyAndXattrs(ctx context.Context, k string, xattr
 				xattrContentErr := res.ContentAt(uint(i), xattr)
 				if xattrContentErr != nil {
 					xattrErrors = append(xattrErrors, xattrContentErr)
-					DebugfCtx(ctx, KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
 					continue
 				}
 				xattrs[xattrKey] = xattr
@@ -273,12 +267,10 @@ func (c *Collection) subdocGetBodyAndXattrs(ctx context.Context, k string, xattr
 
 			if len(xattrErrors) == len(xattrs) {
 				// No doc, no xattrs means the doc isn't found
-				DebugfCtx(ctx, KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKeys), xattrErrors)
 				return false, ErrNotFound, cas
 			}
 
 			if len(xattrErrors) > 0 {
-				DebugfCtx(ctx, KeyCRUD, "Partial xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKeys), xattrErrors)
 				return false, ErrXattrPartialFound, cas
 			}
 


### PR DESCRIPTION
CBG-4396

Backports #7222

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
