### PR TITLE
CBG-4510 fix exception when using -vv

### DIFF
--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -8,6 +8,7 @@
 
 import json
 import pathlib
+import sys
 import unittest
 
 import password_remover
@@ -128,3 +129,13 @@ def test_task_popen_exception(tmp_path):
 
     with open(pathlib.Path(runner.tmpdir) / runner.default_name) as fh:
         assert "Failed to execute ['notacommand']: Boom!" in fh.read()
+
+
+@pytest.mark.parametrize("verbosity", [0, 1, 2])
+@pytest.mark.parametrize("task_platform", [sys.platform, "fakeplatform"])
+def test_task_logging(verbosity, task_platform, tmp_path):
+    taskrunner = tasks.TaskRunner(verbosity=verbosity, tmp_dir=tmp_path)
+    task = tasks.AllOsTask("echo", "echo")
+    # fake the platform for a test
+    task.platforms = [task_platform]
+    taskrunner.run(task)

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -372,12 +372,8 @@ class TaskRunner(object):
 
     def run(self, task):
         """Run a task with a file descriptor corresponding to its log file"""
+        command_to_print = getattr(task, "command_to_print", task.command)
         if task.will_run():
-            if hasattr(task, "command_to_print"):
-                command_to_print = task.command_to_print
-            else:
-                command_to_print = task.command
-
             log("%s (%s) - " % (task.description, command_to_print), end="")
             if task.privileged and os.getuid() != 0:
                 log("skipped (needs root privs)")
@@ -406,7 +402,7 @@ class TaskRunner(object):
         elif self.verbosity >= 2:
             log(
                 'Skipping "%s" (%s): not for platform %s'
-                % (task.description, task.command_to_print, sys.platform)
+                % (task.description, command_to_print, sys.platform)
             )
 
     def redact_and_zip(self, filename, log_type, salt, node):


### PR DESCRIPTION
CBG-4510 fix exception when using -vv

Fix traceback:

```Traceback (most recent call last):
  File "/Users/torcolvin/repos/sync_gateway/./tools/sgcollect_info", line 1023, in <module>
    main()
  File "/Users/torcolvin/repos/sync_gateway/./tools/sgcollect_info", line 941, in main
    runner.run(task)
  File "/Users/torcolvin/repos/sync_gateway/tools/tasks.py", line 409, in run
    % (task.description, task.command_to_print, sys.platform)
AttributeError: 'WindowsTask' object has no attribute 'command_to_print'
```