### PR TITLE
CBG-4371 Make sure not to redact profiles

### DIFF
--- a/tools-tests/parser_test.py
+++ b/tools-tests/parser_test.py
@@ -16,9 +16,9 @@ def test_parser():
 def test_parser_log_redaction_salt():
     parser = sgcollect_info.create_option_parser()
     options, _ = parser.parse_args(["--log-redaction-salt=a", "foo.zip"])
-    assert options.salt_value == b"a"
+    assert options.salt_value == "a"
 
     options, _ = parser.parse_args(["foo.zip"])
-    # assert this is bytes uuid4
-    assert isinstance(options.salt_value, bytes)
-    assert len(options.salt_value) == 16
+    # assert this is a str repr of uuid4
+    assert isinstance(options.salt_value, str)
+    assert len(options.salt_value) == 36

--- a/tools-tests/parser_test.py
+++ b/tools-tests/parser_test.py
@@ -11,3 +11,20 @@ import sgcollect_info
 
 def test_parser():
     sgcollect_info.create_option_parser()
+
+
+def test_parser_log_redaction_salt():
+    parser = sgcollect_info.create_option_parser()
+    options, _ = parser.parse_args(["--log-redaction-salt=a", "foo.zip"])
+    assert options.salt_value == b"a"
+
+    options, _ = parser.parse_args(["foo.zip"])
+    # assert this is bytes uuid4
+    assert isinstance(options.salt_value, bytes)
+    assert len(options.salt_value) == 16
+
+
+def test_parser_sg_url():
+    parser = sgcollect_info.create_option_parser()
+    options, _ = parser.parse_args(["foo.zip"])
+    assert options.sync_gateway_url is None

--- a/tools-tests/parser_test.py
+++ b/tools-tests/parser_test.py
@@ -22,9 +22,3 @@ def test_parser_log_redaction_salt():
     # assert this is bytes uuid4
     assert isinstance(options.salt_value, bytes)
     assert len(options.salt_value) == 16
-
-
-def test_parser_sg_url():
-    parser = sgcollect_info.create_option_parser()
-    options, _ = parser.parse_args(["foo.zip"])
-    assert options.sync_gateway_url is None

--- a/tools-tests/sgcollect_info_test.py
+++ b/tools-tests/sgcollect_info_test.py
@@ -8,7 +8,6 @@
 
 import io
 import unittest
-import uuid
 
 import pytest
 import sgcollect_info
@@ -22,8 +21,7 @@ import sgcollect_info
         '{{"logging": {{ "log_file_path": "{tmpdir}" }} }}',
     ],
 )
-@pytest.mark.parametrize("should_redact", [True, False])
-def test_make_collect_logs_tasks(should_redact, config, tmpdir):
+def test_make_collect_logs_tasks(config, tmpdir):
     log_file = tmpdir.join("sg_info.log")
     log_file.write("foo")
     with unittest.mock.patch(
@@ -38,13 +36,10 @@ def test_make_collect_logs_tasks(should_redact, config, tmpdir):
         rotated_log_file = tmpdir.join("sg_info-01.log.gz")
         rotated_log_file.write("foo")
         tasks = sgcollect_info.make_collect_logs_tasks(
-            tmpdir,
             sg_url="fakeurl",
             sg_config_file_path="",
             sg_username="",
             sg_password="",
-            salt=str(uuid.uuid4()),
-            should_redact=should_redact,
         )
         assert [t.log_file for t in tasks] == [
             log_file.basename,
@@ -52,8 +47,7 @@ def test_make_collect_logs_tasks(should_redact, config, tmpdir):
         ]
 
 
-@pytest.mark.parametrize("should_redact", [True, False])
-def test_make_collect_logs_heap_profile(should_redact: bool, tmpdir):
+def test_make_collect_logs_heap_profile(tmpdir):
     with unittest.mock.patch(
         "sgcollect_info.urlopen_with_basic_auth",
         return_value=io.BytesIO(
@@ -65,13 +59,10 @@ def test_make_collect_logs_heap_profile(should_redact: bool, tmpdir):
         pprof_file = tmpdir.join("pprof_heap_high_01.pb.gz")
         pprof_file.write("foo")
         tasks = sgcollect_info.make_collect_logs_tasks(
-            tmpdir,
             sg_url="fakeurl",
             sg_config_file_path="",
             sg_username="",
             sg_password="",
-            salt=str(uuid.uuid4()),
-            should_redact=should_redact,
         )
         assert [tasks[0].log_file] == [pprof_file.basename]
         # ensure that this is not redacted task

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -212,6 +212,7 @@ def test_log_redact_file(tmp_path):
         "logline1: foo",
         "logline2: <ud>password</ud>",
         "logline3: log-redaction-salt=AAA",
+        "logline4: bar",
     ]
     with gzip.open(log_file, "wt") as fh:
         for line in input_log_lines:
@@ -226,6 +227,7 @@ def test_log_redact_file(tmp_path):
         "logline1: foo",
         "logline2: <ud>1700bc8ae71605063ae83d80837fa53988c635ef</ud>",
         "logline3: log-redaction-salt <redacted>",
+        "logline4: bar",
         "",  # file has trailing newline
     ]
     updated_text = os.linesep.join(output_log_lines).encode("utf-8")

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -8,6 +8,7 @@
 
 import gzip
 import json
+import os
 import pathlib
 import sys
 import unittest
@@ -227,7 +228,7 @@ def test_log_redact_file(tmp_path):
         "logline3: log-redaction-salt <redacted>",
         "",  # file has trailing newline
     ]
-    updated_text = "\n".join(output_log_lines).encode("utf-8")
+    updated_text = os.linesep.join(output_log_lines).encode("utf-8")
 
     redacted_text = gzip.open(redacted_file).read()
     assert redacted_text == updated_text

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -218,7 +218,7 @@ def test_log_redact_file(tmp_path):
         for line in input_log_lines:
             fh.write(line + "\n")
 
-    salt = b"AA"
+    salt = "AA"
     redactor = tasks.LogRedactor(salt, tmp_path)
     redacted_file = redactor.redact_file(log_file.name, log_file)
 

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -222,7 +222,6 @@ def test_log_redact_file(tmp_path):
     redactor = tasks.LogRedactor(salt, tmp_path)
     redacted_file = redactor.redact_file(log_file.name, log_file)
 
-    assert False
     output_log_lines = [
         "RedactLevel:partial,HashOfSalt:e2512172abf8cc9f67fdd49eb6cacf2df71bbad3",
         "logline1: foo",

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -138,3 +138,59 @@ def test_task_logging(verbosity, task_platform, tmp_path):
     # fake the platform for a test
     task.platforms = [task_platform]
     taskrunner.run(task)
+
+
+@pytest.mark.parametrize(
+    "filename,redactable",
+    [
+        (
+            "sync_gateway",
+            False,
+        ),
+        (
+            "sync_gateway.exe",
+            False,
+        ),
+        (
+            "sync_gateway.exe",
+            False,
+        ),
+        (
+            "/abs/path/sync_gateway",
+            False,
+        ),
+        (
+            "pprof_heap_high_01.pb.gz",
+            False,
+        ),
+        (
+            "pprof.pb",
+            False,
+        ),
+        (
+            "/abs/path/pprof.pb",
+            False,
+        ),
+        (
+            "sg_info.log",
+            True,
+        ),
+        (
+            "sg_info-01.log.gz",
+            True,
+        ),
+        (
+            "/abs/path/sg_info.log",
+            True,
+        ),
+        (
+            "/abs/path/sg_info-01.log.gz",
+            True,
+        ),
+    ],
+)
+@pytest.mark.parametrize("use_pathlib", [True, False])
+def test_redactable_filename(use_pathlib, filename, redactable):
+    if use_pathlib:
+        filename = pathlib.Path(filename)
+    assert tasks.redactable_file(filename) is redactable

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -222,6 +222,7 @@ def test_log_redact_file(tmp_path):
     redactor = tasks.LogRedactor(salt, tmp_path)
     redacted_file = redactor.redact_file(log_file.name, log_file)
 
+    assert False
     output_log_lines = [
         "RedactLevel:partial,HashOfSalt:e2512172abf8cc9f67fdd49eb6cacf2df71bbad3",
         "logline1: foo",

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -8,7 +8,6 @@
 
 import gzip
 import json
-import os
 import pathlib
 import sys
 import unittest
@@ -228,7 +227,7 @@ def test_log_redact_file(tmp_path):
         "logline3: log-redaction-salt <redacted>",
         "",  # file has trailing newline
     ]
-    updated_text = os.linesep.join(output_log_lines).encode("utf-8")
+    updated_text = "\n".join(output_log_lines).encode("utf-8")
 
     redacted_text = gzip.open(redacted_file).read()
     assert redacted_text == updated_text

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -16,6 +16,7 @@ import glob
 import json
 import optparse
 import os
+import pathlib
 import platform
 import re
 import ssl
@@ -26,11 +27,13 @@ import urllib.parse
 import urllib.request
 import uuid
 from sys import platform as _platform
+from typing import List, Optional
 
 import password_remover
 from tasks import (
     AllOsTask,
     CbcollectInfoOptions,
+    PythonTask,
     TaskRunner,
     add_file_task,
     add_gzip_file_task,
@@ -41,6 +44,7 @@ from tasks import (
     log,
     make_curl_task,
     make_os_tasks,
+    redactable_file,
     setup_stdin_watcher,
 )
 
@@ -321,8 +325,14 @@ def urlopen_with_basic_auth(url, username, password):
 
 
 def make_collect_logs_tasks(
-    zip_dir, sg_url, sg_config_file_path, sg_username, sg_password, salt, should_redact
-):
+    zip_dir: str,
+    sg_url: Optional[str],
+    sg_config_file_path: Optional[str],
+    sg_username: Optional[str],
+    sg_password: Optional[str],
+    salt: Optional[str],
+    should_redact: bool,
+) -> List[PythonTask]:
     sg_log_files = {
         "sg_error.log": "sg_error.log",
         "sg_warn.log": "sg_warn.log",
@@ -385,9 +395,22 @@ def make_collect_logs_tasks(
         os_home_dirs.append(guessed_log_path)
 
     # Keep a dictionary of log file paths we've added, to avoid adding duplicates
-    sg_log_file_paths = {}
+    sg_log_file_paths: set[pathlib.Path] = set()
 
-    sg_tasks = []
+    sg_tasks: List[PythonTask] = []
+
+    def add_file_collection_task(filename: pathlib.Path):
+        canonical_filename = pathlib.Path(filename)
+        canonical_filename.resolve()
+        if canonical_filename in sg_log_file_paths:
+            return
+        sg_log_file_paths.add(canonical_filename)
+        if not should_redact or not redactable_file(filename):
+            task = add_file_task(sourcefile_path=filename)
+            task.no_header = True
+            sg_tasks.append(task)
+        else:
+            sg_tasks.append(add_gzip_file_task(sourcefile_path=filename, salt=salt))
 
     def lookup_std_log_files(files, dirs):
         for dir in dirs:
@@ -396,23 +419,12 @@ def make_collect_logs_tasks(
                 # Collect active and rotated log files from the default log locations.
                 pattern_rotated = os.path.join(dir, "{0}*{1}".format(name, ext))
                 for std_log_file in glob.glob(pattern_rotated):
-                    if std_log_file not in sg_log_file_paths:
-                        sg_tasks.append(add_file_task(sourcefile_path=std_log_file))
-                        sg_log_file_paths[std_log_file] = std_log_file
+                    add_file_collection_task(std_log_file)
 
                 # Collect archived log files from the default log locations.
                 pattern_archived = os.path.join(dir, "{0}*{1}.gz".format(name, ext))
                 for std_log_file in glob.glob(pattern_archived):
-                    if std_log_file not in sg_log_file_paths:
-                        if should_redact:
-                            task = add_gzip_file_task(
-                                sourcefile_path=std_log_file, salt=salt
-                            )
-                            sg_tasks.append(task)
-                        else:
-                            task = add_file_task(sourcefile_path=std_log_file)
-                            task.no_header = True
-                            sg_tasks.append(task)
+                    add_file_collection_task(std_log_file)
 
     # Lookup each standard SG log files in each standard SG log directories.
     lookup_std_log_files(sg_log_files, os_home_dirs)
@@ -440,13 +452,7 @@ def make_collect_logs_tasks(
         )
         for log_file_item_name in glob.iglob(rotated_logs_pattern):
             log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
-            # As long as a task that monitors this log file path has not already been added, add a new task
-            if log_file_item_path not in sg_log_file_paths:
-                print("Capturing rotated log file {0}".format(log_file_item_path))
-                task = add_file_task(sourcefile_path=log_file_item_path)
-                sg_tasks.append(task)
-                # Track which log file paths have been added so far.
-                sg_log_file_paths[log_file_item_path] = log_file_item_path
+            add_file_collection_task(log_file_item_path)
 
         # Lookup standard SG log files inside the parent directory.
         lookup_std_log_files(sg_log_files, [log_file_parent_dir])
@@ -467,14 +473,7 @@ def make_collect_logs_tasks(
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
-                # As long as a task that monitors this log file path has not already been added, add a new task
-                if log_file_item_path not in sg_log_file_paths:
-                    print("Capturing rotated log file {0}".format(log_file_item_path))
-                    task = add_file_task(sourcefile_path=log_file_item_path)
-                    sg_tasks.append(task)
-
-                    # Track which log file paths have been added so far
-                    sg_log_file_paths[log_file_item_path] = log_file_item_path
+                add_file_collection_task(log_file_item_path)
 
             # try gzipped logs too
             # e.g: sg_info-2018-12-31T13-33-41.055.log.gz
@@ -483,27 +482,7 @@ def make_collect_logs_tasks(
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
-                # As long as a task that monitors this log file path has not already been added, add a new task
-                if log_file_item_path not in sg_log_file_paths:
-                    print(
-                        "Capturing compressed rotated log file {0}".format(
-                            log_file_item_path
-                        )
-                    )
-                    # If we're redacting a gzipped log file, we'll need to extract, redact and recompress it.
-                    # If we're not redacting, we can skip extraction entirely, and use the existing .gz log file.
-                    if should_redact:
-                        task = add_gzip_file_task(
-                            sourcefile_path=log_file_item_path, salt=salt
-                        )
-                        sg_tasks.append(task)
-                    else:
-                        task = add_file_task(sourcefile_path=log_file_item_path)
-                        task.no_header = True
-                        sg_tasks.append(task)
-
-                    # Track which log file paths have been added so far
-                    sg_log_file_paths[log_file_item_path] = log_file_item_path
+                add_file_collection_task(log_file_item_path)
 
     return sg_tasks
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -91,19 +91,6 @@ def delete_zip(filename):
         print("Zipfile ({0}) deletion failed: {1}".format(filename, e))
 
 
-def set_salt_value(
-    option: optparse.Option, opt: str, value: str, parser: optparse.OptionParser
-):
-    """
-    optparse callback to validate the salt value. Sets a string salt value as bytes.
-    """
-    if value is not None:
-        try:
-            parser.values.salt_value = value.encode("ascii")
-        except ValueError:
-            parser.error("Invalid UUID: {0}".format(value))
-
-
 def create_option_parser():
     parser = optparse.OptionParser(usage=USAGE, option_class=CbcollectInfoOptions)
     parser.add_option(
@@ -148,10 +135,7 @@ def create_option_parser():
     parser.add_option(
         "--log-redaction-salt",
         dest="salt_value",
-        default=uuid.uuid4().bytes,
-        callback=set_salt_value,
-        action="callback",
-        type="string",
+        default=str(uuid.uuid4()),
         help="Is used to salt the hashing of tagged data, \
                             defaults to random uuid. If input by user it should \
                             be provided along with --log-redaction-level option",

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -36,7 +36,6 @@ from tasks import (
     PythonTask,
     TaskRunner,
     add_file_task,
-    add_gzip_file_task,
     do_upload,
     dump_utilities,
     flatten,
@@ -44,7 +43,6 @@ from tasks import (
     log,
     make_curl_task,
     make_os_tasks,
-    redactable_file,
     setup_stdin_watcher,
 )
 
@@ -93,6 +91,19 @@ def delete_zip(filename):
         print("Zipfile ({0}) deletion failed: {1}".format(filename, e))
 
 
+def set_salt_value(
+    option: optparse.Option, opt: str, value: str, parser: optparse.OptionParser
+):
+    """
+    optparse callback to validate the salt value. Sets a string salt value as bytes.
+    """
+    if value is not None:
+        try:
+            parser.values.salt_value = value.encode("ascii")
+        except ValueError:
+            parser.error("Invalid UUID: {0}".format(value))
+
+
 def create_option_parser():
     parser = optparse.OptionParser(usage=USAGE, option_class=CbcollectInfoOptions)
     parser.add_option(
@@ -137,7 +148,10 @@ def create_option_parser():
     parser.add_option(
         "--log-redaction-salt",
         dest="salt_value",
-        default=str(uuid.uuid4()),
+        default=uuid.uuid4().bytes,
+        callback=set_salt_value,
+        action="callback",
+        type="string",
         help="Is used to salt the hashing of tagged data, \
                             defaults to random uuid. If input by user it should \
                             be provided along with --log-redaction-level option",
@@ -325,13 +339,10 @@ def urlopen_with_basic_auth(url, username, password):
 
 
 def make_collect_logs_tasks(
-    zip_dir: str,
-    sg_url: Optional[str],
+    sg_url: str,
     sg_config_file_path: Optional[str],
     sg_username: Optional[str],
     sg_password: Optional[str],
-    salt: Optional[str],
-    should_redact: bool,
 ) -> List[PythonTask]:
     sg_log_files = {
         "sg_error.log": "sg_error.log",
@@ -405,12 +416,9 @@ def make_collect_logs_tasks(
         if canonical_filename in sg_log_file_paths:
             return
         sg_log_file_paths.add(canonical_filename)
-        if not should_redact or not redactable_file(filename):
-            task = add_file_task(sourcefile_path=filename)
-            task.no_header = True
-            sg_tasks.append(task)
-        else:
-            sg_tasks.append(add_gzip_file_task(sourcefile_path=filename, salt=salt))
+        task = add_file_task(sourcefile_path=filename)
+        task.no_header = True
+        sg_tasks.append(task)
 
     def lookup_std_log_files(files, dirs):
         for dir in dirs:
@@ -510,8 +518,12 @@ def get_db_list(sg_url, sg_username, sg_password):
 #   Server config
 #   Each DB config
 def make_config_tasks(
-    zip_dir, sg_config_path, sg_url, sg_username, sg_password, should_redact
-):
+    sg_config_path: str,
+    sg_url: str,
+    sg_username: Optional[str],
+    sg_password: Optional[str],
+    should_redact: bool,
+) -> List[PythonTask]:
     collect_config_tasks = []
 
     # Here are the "usual suspects" to probe for finding the static config
@@ -678,15 +690,13 @@ def make_download_expvars_task(sg_url, sg_username, sg_password):
 
 
 def make_sg_tasks(
-    zip_dir,
-    sg_url,
-    sg_username,
-    sg_password,
-    sync_gateway_config_path_option,
-    sync_gateway_executable_path,
-    should_redact,
-    salt,
-):
+    sg_url: str,
+    sg_username: Optional[str],
+    sg_password: Optional[str],
+    sync_gateway_config_path_option: Optional[str],
+    sync_gateway_executable_path: Optional[str],
+    should_redact: bool,
+) -> List[PythonTask]:
     # Get path to sg binary (reliable) and config (not reliable)
     sg_binary_path, sg_config_path = get_paths_from_expvars(
         sg_url, sg_username, sg_password
@@ -719,7 +729,10 @@ def make_sg_tasks(
 
     # Collect logs
     collect_logs_tasks = make_collect_logs_tasks(
-        zip_dir, sg_url, sg_config_path, sg_username, sg_password, salt, should_redact
+        sg_url,
+        sg_config_path,
+        sg_username,
+        sg_password,
     )
 
     py_expvar_task = make_download_expvars_task(sg_url, sg_username, sg_password)
@@ -738,7 +751,7 @@ def make_sg_tasks(
 
     # Add a task to collect Sync Gateway config
     config_tasks = make_config_tasks(
-        zip_dir, sg_config_path, sg_url, sg_username, sg_password, should_redact
+        sg_config_path, sg_url, sg_username, sg_password, should_redact
     )
 
     # Curl the /_status
@@ -930,14 +943,12 @@ def main():
 
     # Run SG specific tasks
     for task in make_sg_tasks(
-        zip_dir,
         sg_url,
         sg_username,
         sg_password,
         options.sync_gateway_config,
         options.sync_gateway_executable,
         should_redact,
-        options.salt_value,
     ):
         runner.run(task)
 

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -33,7 +33,7 @@ from typing import Callable, List, Optional, Union
 
 
 class LogRedactor:
-    def __init__(self, salt: bytes, tmpdir: Union[str, pathlib.Path]):
+    def __init__(self, salt: str, tmpdir: Union[str, pathlib.Path]):
         self.target_dir = os.path.join(tmpdir, "redacted")
         os.makedirs(self.target_dir)
 
@@ -70,8 +70,8 @@ class LogRedactor:
 
 
 class CouchbaseLogProcessor:
-    def __init__(self, salt):
-        self.salt = salt
+    def __init__(self, salt: str):
+        self.salt = salt.encode("ascii")
 
     def do(self, line: bytes) -> bytes:
         if b"RedactLevel" in line:
@@ -85,8 +85,8 @@ class CouchbaseLogProcessor:
 
 
 class RegularLogProcessor:
-    def __init__(self, salt: bytes):
-        self.salt = salt
+    def __init__(self, salt: str):
+        self.salt = salt.encode("ascii")
         self.rexes = [
             (re.compile(b"(<ud>)(.+?)(</ud>)"), self._redact_userdata),
             (re.compile(rb"(log-redaction-salt)(.+)"), self.redact_salt),
@@ -388,7 +388,7 @@ class TaskRunner(object):
                 % (task.description, command_to_print, sys.platform)
             )
 
-    def redact_and_zip(self, filename: str, log_type: str, salt: bytes, node: str):
+    def redact_and_zip(self, filename: str, log_type: str, salt: str, node: str):
         """
         Redacts all files defined by writing a copy into a temporary directory. Zips up the directory as filename.
 

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -85,7 +85,6 @@ class CouchbaseLogProcessor:
 
 
 class RegularLogProcessor:
-
     def __init__(self, salt: bytes):
         self.salt = salt
         self.rexes = [

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -89,7 +89,7 @@ class RegularLogProcessor:
         self.salt = salt
         self.rexes = [
             (re.compile(b"(<ud>)(.+?)(</ud>)"), self._redact_userdata),
-            (re.compile(rb"(log-redaction-salt)(.+)(\r?)"), self.redact_salt),
+            (re.compile(rb"(log-redaction-salt)(.+)"), self.redact_salt),
         ]
 
     def _redact_userdata(self, match: re.Match) -> bytes:
@@ -100,7 +100,10 @@ class RegularLogProcessor:
 
     def redact_salt(self, match: re.Match) -> bytes:
         result = match.group(1)
-        result += b" <redacted>" + match.group(3)
+        result += b" <redacted>"
+        # on windows, make sure we don't lose the \r
+        if match.group(0).endswith(b"\r"):
+            result += b"\r"
         return result
 
     def do(self, line: bytes) -> bytes:

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -100,7 +100,7 @@ class RegularLogProcessor:
 
     def redact_salt(self, match: re.Match) -> bytes:
         result = match.group(1)
-        result += b" <redacted>"
+        result += b" <redacted>" + match.group(3)
         return result
 
     def do(self, line: bytes) -> bytes:

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -77,9 +77,9 @@ class CouchbaseLogProcessor:
         if b"RedactLevel" in line:
             # salt + salt to maintain consistency with other
             # occurrences of hashed salt in the logs.
-            return b"RedactLevel:partial,HashOfSalt:%b\n" % generate_hash(
+            return b"RedactLevel:partial,HashOfSalt:%b" % generate_hash(
                 self.salt + self.salt
-            ).hexdigest().encode("utf-8")
+            ).hexdigest().encode("utf-8") + os.linesep.encode("ascii")
         else:
             return line
 


### PR DESCRIPTION
CBG-4371 Make sure not to redact profiles

With -redact set, `pprof*.gz` files would be redacted with `add_gzip_file_task(sourcefile_path=filename, salt=salt)`. This meant that when the files get opened in text mode https://github.com/couchbase/sync_gateway/blob/b77c0b493aea1f619023a2f3ea03945f015dc177/tools/tasks.py#L534 then might be doing something unwanted to gzipped contents as well as then trying to do a regex replacement on it https://github.com/couchbase/sync_gateway/blob/b77c0b493aea1f619023a2f3ea03945f015dc177/tools/tasks.py#L128

Since I centralized the code to collect log files, run `pathlib.Path.resolve()` on the path of the file to normalize a path from duplicate slashes or same directories. It is possible to add a path with duplicate names with `log_file_path` and also in `/home/sync_gateway/logs`. 

This code is quite well tested by existing test `test_make_collect_logs_tasks`
