### PR TITLE
[3.1.12] Restore reverted stats

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -317,7 +317,6 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 	c.db.DbStats.Cache().AbandonedSeqs.Add(numRemoved)
 
 	base.InfofCtx(ctx, base.KeyCache, "CleanSkippedSequenceQueue complete.  Not Found:%d for database %s.", len(oldSkippedSequences), base.MD(c.db.Name))
-	oldSkippedSequences = nil
 	return nil
 }
 
@@ -880,14 +879,16 @@ func (h *LogPriorityQueue) Pop() interface{} {
 
 func (c *changeCache) RemoveSkipped(x uint64) error {
 	err := c.skippedSeqs.Remove(x)
-	c.db.DbStats.Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.db.DbStats.Cache().NumCurrentSeqsSkipped.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.db.DbStats.Cache().DeprecatedSkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len())) //nolint
 	return err
 }
 
 // Removes a set of sequences.  Logs warning on removal error, returns count of successfully removed.
 func (c *changeCache) RemoveSkippedSequences(ctx context.Context, sequences []uint64) (removedCount int64) {
 	numRemoved := c.skippedSeqs.RemoveSequences(ctx, sequences)
-	c.db.DbStats.Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.db.DbStats.Cache().NumCurrentSeqsSkipped.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.db.DbStats.Cache().DeprecatedSkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len())) //nolint //nolint
 	return numRemoved
 }
 
@@ -901,7 +902,8 @@ func (c *changeCache) PushSkipped(ctx context.Context, sequence uint64) {
 		base.InfofCtx(ctx, base.KeyCache, "Error pushing skipped sequence: %d, %v", sequence, err)
 		return
 	}
-	c.db.DbStats.Cache().SkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.db.DbStats.Cache().NumCurrentSeqsSkipped.Set(int64(c.skippedSeqs.skippedList.Len()))
+	c.db.DbStats.Cache().DeprecatedSkippedSeqLen.Set(int64(c.skippedSeqs.skippedList.Len())) //nolint
 }
 
 func (c *changeCache) GetSkippedSequencesOlderThanMaxWait() (oldSequences []uint64) {

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -317,16 +317,16 @@ func TestJumpInSequencesAtAllocatorSkippedSequenceFill(t *testing.T) {
 	// wait for value to move from pending to cache and skipped list to fill
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rt.GetDatabase().UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(18), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+		assert.Equal(c, int64(18), rt.GetDatabase().DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
+		assert.Equal(c, int64(18), rt.GetDatabase().DbStats.CacheStats.DeprecatedSkippedSeqLen.Value()) //nolint
 	}, time.Second*10, time.Millisecond*100)
 	docVrs := rt.UpdateDoc("doc", vrs.Rev, `{"prob": "lol"}`)
 	// wait skipped list to be emptied by release of sequence range
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rt.GetDatabase().UpdateCalculatedStats(ctx)
 		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.PendingSeqLen.Value())
-		//assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.SkippedSeqCap.Value())
-		//assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
-		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.DeprecatedSkippedSeqLen.Value()) //nolint
 	}, time.Second*10, time.Millisecond*100)
 	doc1Vrs := rt.PutDoc("doc1", `{"prop":true}`)
 	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
@@ -381,9 +381,9 @@ func TestJumpInSequencesAtAllocatorRangeInPending(t *testing.T) {
 	// assert that nothing has been pushed to skipped
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rt.GetDatabase().UpdateCalculatedStats(ctx)
-		//assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqCap.Value())
-		//assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
-		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.DeprecatedSkippedSeqCap.Value()) // nolint
+		assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.DeprecatedSkippedSeqLen.Value()) // nolint
 	}, time.Second*10, time.Millisecond*100)
 	doc1Vrs := rt.PutDoc("doc1", `{"prop":true}`)
 	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)


### PR DESCRIPTION
Cherry-picks of later commits in #7330 to restore reverted stats

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2934/
