### PR TITLE
CBG-4462: Avoid leaking ISGR StatsReporter goroutine underneath reconnecting replicator

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -268,7 +268,7 @@ func (a *activeReplicatorCommon) _disconnect() error {
 	return nil
 }
 
-// _stop aborts any replicator processes that run outside of a running replication (e.g: async reconnect handling)
+// _stop aborts any replicator processes that run outside of a running replication connection (e.g: async reconnect handling, statsreporter)
 func (a *activeReplicatorCommon) _stop() {
 	if a.ctxCancel != nil {
 		base.TracefCtx(a.ctx, base.KeyReplicate, "cancelling context on activeReplicatorCommon in _stop()")
@@ -369,8 +369,8 @@ func (a *activeReplicatorCommon) _publishStatus() {
 	}
 }
 
-func (arc *activeReplicatorCommon) startStatusReporter() error {
-	go func(ctx context.Context) {
+func (arc *activeReplicatorCommon) startStatusReporter(ctx context.Context) error {
+	go func() {
 		ticker := time.NewTicker(arc.config.CheckpointInterval)
 		defer ticker.Stop()
 		for {
@@ -386,7 +386,7 @@ func (arc *activeReplicatorCommon) startStatusReporter() error {
 				return
 			}
 		}
-	}(arc.ctx)
+	}()
 	return nil
 }
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -48,6 +48,10 @@ func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 	logCtx := base.CorrelationIDLogCtx(ctx, apr.config.ID+"-"+string(ActiveReplicatorTypePull))
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
+	if err := apr.startStatusReporter(); err != nil {
+		return err
+	}
+
 	err := apr._connect()
 	if err != nil {
 		_ = apr.setError(err)
@@ -89,10 +93,6 @@ func (apr *ActivePullReplicator) _connect() error {
 
 	if apr.blipSyncContext.activeCBMobileSubprotocol <= CBMobileReplicationV2 && apr.config.PurgeOnRemoval {
 		base.ErrorfCtx(apr.ctx, "Pull replicator ID:%s running with revocations enabled but target does not support revocations. Sync Gateway 3.0 required.", apr.config.ID)
-	}
-
-	if err := apr.startStatusReporter(); err != nil {
-		return err
 	}
 
 	apr.setState(ReplicationStateRunning)

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -48,7 +48,7 @@ func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 	logCtx := base.CorrelationIDLogCtx(ctx, apr.config.ID+"-"+string(ActiveReplicatorTypePull))
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
-	if err := apr.startStatusReporter(); err != nil {
+	if err := apr.startStatusReporter(apr.ctx); err != nil {
 		return err
 	}
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -53,7 +53,7 @@ func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 		apr.config.ID+"-"+string(ActiveReplicatorTypePush))
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
-	if err := apr.startStatusReporter(); err != nil {
+	if err := apr.startStatusReporter(apr.ctx); err != nil {
 		return err
 	}
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -53,6 +53,10 @@ func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 		apr.config.ID+"-"+string(ActiveReplicatorTypePush))
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
+	if err := apr.startStatusReporter(); err != nil {
+		return err
+	}
+
 	err := apr._connect()
 	if err != nil {
 		_ = apr.setError(err)
@@ -92,10 +96,6 @@ func (apr *ActivePushReplicator) _connect() error {
 		if err := apr._startPushNonCollection(); err != nil {
 			return err
 		}
-	}
-
-	if err := apr.startStatusReporter(); err != nil {
-		return err
 	}
 
 	apr.setState(ReplicationStateRunning)


### PR DESCRIPTION
CBG-4462

Avoid leaking ISGR StatsReporter goroutine underneath reconnecting replicator

- Move StatsReporter goroutine lifecycle up into Replicator Start instead of replicator connect
  - Closes up goroutine loop and status conflicts when multiple StatsReporters get spawned underneath a regularly disconnecting and reconnecting replicator.
- Manually tested with extra debug logging using two SG clusters and turning off the remote cluster underneath the replicator.
  - Cannot be easily unit tested, since it requires breaking the replication connection without tearing down the blip context - not something that we can easily do with the existing code.

## Testing
ISGR setup
```sh
$ curl -X PUT http://Administrator:password@localhost:4985/db1/_replication/db1-repl -H 'Content-Type: application/json' -d '{"direction": "pushAndPull", "remote": "http://localhost:5984/db2", "remote_username": "demo", "remote_password": "test", "continuous": true}'

$ curl -X PUT http://Administrator:password@localhost:4985/db1/_replicationStatus/db1-repl\?action\=stop
{"replication_id":"db1-repl","status":"stopping"}
```

Node 1 debug logging (from old and new `startStatusReporter` locations)
```sh
2025/02/04 21:33:08 bbrks - new - startStatusReporter() from ActivePushReplicator.Start()
2025-02-04T21:33:08 bbrks - starting StatusReporter goroutine -- db.(*activeReplicatorCommon).startStatusReporter() at active_replicator_common.go:373
2025/02/04 21:33:08 bbrks - old - startStatusReporter() from ActivePushReplicator._connect()
2025/02/04 21:33:08 bbrks - new - startStatusReporter() from ActivePullReplicator.Start()
2025-02-04T21:33:08 bbrks - starting StatusReporter goroutine -- db.(*activeReplicatorCommon).startStatusReporter() at active_replicator_common.go:373
2025/02/04 21:33:08 bbrks - old - startStatusReporter() from ActivePullReplicator._connect()
... start cycling cluster 2
2025/02/04 21:33:49 bbrks - old - startStatusReporter() from ActivePullReplicator._connect()
2025/02/04 21:33:49 bbrks - old - startStatusReporter() from ActivePushReplicator._connect()
2025/02/04 21:33:57 bbrks - old - startStatusReporter() from ActivePullReplicator._connect()
2025/02/04 21:33:57 bbrks - old - startStatusReporter() from ActivePushReplicator._connect()
2025/02/04 21:34:04 bbrks - old - startStatusReporter() from ActivePushReplicator._connect()
2025/02/04 21:34:04 bbrks - old - startStatusReporter() from ActivePullReplicator._connect()
... stop replicator
2025-02-04T21:34:09 bbrks - stopped StatusReporter goroutine -- db.(*activeReplicatorCommon).startStatusReporter.func1.1() at active_replicator_common.go:376
2025-02-04T21:34:09 bbrks - stopped StatusReporter goroutine -- db.(*activeReplicatorCommon).startStatusReporter.func1.1() at active_replicator_common.go:376
```

Cycling 2nd cluster
```sh
$ go build -tags cb_sg_enterprise,cb_sg_devmode && ./sync_gateway sg2-config.json
2025-02-04T21:32:53.190Z ==== Couchbase Sync Gateway/() EE ====
2025-02-04T21:32:53.190Z [INF] Loading content from [sg2-config.json] ...
2025-02-04T21:32:53.192Z [INF] Config: Starting in persistent mode using config group "sg2"
2025-02-04T21:32:53.192Z [INF] Logging: Console to stderr
2025-02-04T21:32:53.192Z [INF] Logging: Files disabled
2025-02-04T21:32:53.192Z [ERR] No log_file_path property specified in config, and --defaultLogFilePath command line flag was not set. Log files required for product support are not being generated. -- base.InitLogging() at logging_config.go:78

2025-02-04T21:32:53.193Z [INF] Initializing server admin connection...
2025-02-04T21:32:57.494Z [INF] Diagnostic API not enabled - skipping.
2025-02-04T21:32:57.494Z [INF] Starting metrics server on :5986
2025-02-04T21:32:57.494Z [INF] Starting admin server on :5985
2025-02-04T21:32:57.494Z [INF] Starting server on :5984 ...
^C

$ go build -tags cb_sg_enterprise,cb_sg_devmode && ./sync_gateway sg2-config.json
2025-02-04T21:33:42.677Z ==== Couchbase Sync Gateway/() EE ====
2025-02-04T21:33:42.677Z [INF] Loading content from [sg2-config.json] ...
2025-02-04T21:33:42.679Z [INF] Config: Starting in persistent mode using config group "sg2"
2025-02-04T21:33:42.679Z [INF] Logging: Console to stderr
2025-02-04T21:33:42.679Z [INF] Logging: Files disabled
2025-02-04T21:33:42.679Z [ERR] No log_file_path property specified in config, and --defaultLogFilePath command line flag was not set. Log files required for product support are not being generated. -- base.InitLogging() at logging_config.go:78

2025-02-04T21:33:42.679Z [INF] Initializing server admin connection...
2025-02-04T21:33:47.172Z [INF] Diagnostic API not enabled - skipping.
2025-02-04T21:33:47.172Z [INF] Starting metrics server on :5986
2025-02-04T21:33:47.172Z [INF] Starting admin server on :5985
2025-02-04T21:33:47.172Z [INF] Starting server on :5984 ...
^C

$ go build -tags cb_sg_enterprise,cb_sg_devmode && ./sync_gateway sg2-config.json
2025-02-04T21:33:52.845Z ==== Couchbase Sync Gateway/() EE ====
2025-02-04T21:33:52.845Z [INF] Loading content from [sg2-config.json] ...
2025-02-04T21:33:52.847Z [INF] Config: Starting in persistent mode using config group "sg2"
2025-02-04T21:33:52.847Z [INF] Logging: Console to stderr
2025-02-04T21:33:52.847Z [INF] Logging: Files disabled
2025-02-04T21:33:52.847Z [ERR] No log_file_path property specified in config, and --defaultLogFilePath command line flag was not set. Log files required for product support are not being generated. -- base.InitLogging() at logging_config.go:78

2025-02-04T21:33:52.847Z [INF] Initializing server admin connection...
2025-02-04T21:33:57.185Z [INF] Diagnostic API not enabled - skipping.
2025-02-04T21:33:57.185Z [INF] Starting metrics server on :5986
2025-02-04T21:33:57.185Z [INF] Starting admin server on :5985
2025-02-04T21:33:57.185Z [INF] Starting server on :5984 ...
^C

$ go build -tags cb_sg_enterprise,cb_sg_devmode && ./sync_gateway sg2-config.json
2025-02-04T21:34:00.097Z ==== Couchbase Sync Gateway/() EE ====
2025-02-04T21:34:00.097Z [INF] Loading content from [sg2-config.json] ...
2025-02-04T21:34:00.099Z [INF] Config: Starting in persistent mode using config group "sg2"
2025-02-04T21:34:00.099Z [INF] Logging: Console to stderr
2025-02-04T21:34:00.099Z [INF] Logging: Files disabled
2025-02-04T21:34:00.099Z [ERR] No log_file_path property specified in config, and --defaultLogFilePath command line flag was not set. Log files required for product support are not being generated. -- base.InitLogging() at logging_config.go:78

2025-02-04T21:34:00.099Z [INF] Initializing server admin connection...
2025-02-04T21:34:03.627Z [INF] Diagnostic API not enabled - skipping.
2025-02-04T21:34:03.627Z [INF] Starting metrics server on :5986
2025-02-04T21:34:03.627Z [INF] Starting admin server on :5985
2025-02-04T21:34:03.627Z [INF] Starting server on :5984 ...
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
