### PR TITLE
Shorten the time it takes to process bucket pool

### DIFF
--- a/base/main_test.go
+++ b/base/main_test.go
@@ -17,6 +17,6 @@ import (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
-	tbpOptions := TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := TestBucketPoolOptions{MemWatermarkThresholdMB: 2048, ParallelBucketInit: true}
 	TestBucketPoolNoIndexes(ctx, m, tbpOptions)
 }

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -61,8 +61,10 @@ type TestBucketPool struct {
 	unclosedBucketsLock sync.Mutex
 
 	// skipCollections may be true for older Couchbase Server versions that do not support collections.
-	skipCollections   bool
-	useExistingBucket bool
+	skipCollections bool
+	// numCollectionsPerBucket is the number of collections to create in each bucket
+	numCollectionsPerBucket int
+	useExistingBucket       bool
 
 	// skipMobileXDCR may be true for older versions of Couchbase Server that don't support mobile XDCR enhancements
 	skipMobileXDCR bool
@@ -75,6 +77,8 @@ type TestBucketPoolOptions struct {
 	MemWatermarkThresholdMB uint64
 	UseDefaultScope         bool
 	RequireXDCR             bool // Test buckets will be performing XDCR, requires Server > 7 for integration test robustness
+	ParallelBucketInit      bool
+	NumCollectionsPerBucket int // setting this value in main_test.go will override the default
 }
 
 func NewTestBucketPool(ctx context.Context, bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TBPBucketInitFunc) *TestBucketPool {
@@ -83,16 +87,21 @@ func NewTestBucketPool(ctx context.Context, bucketReadierFunc TBPBucketReadierFu
 
 // NewTestBucketPool initializes a new TestBucketPool. To be called from TestMain for packages requiring test buckets.
 func NewTestBucketPoolWithOptions(ctx context.Context, bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TBPBucketInitFunc, options TestBucketPoolOptions) *TestBucketPool {
+	numCollectionsPerBucket := options.NumCollectionsPerBucket
+	if numCollectionsPerBucket == 0 {
+		numCollectionsPerBucket = tbpNumCollectionsPerBucket(ctx)
+	}
 	// We can safely skip setup when we want Walrus buckets to be used.
 	// They'll be created on-demand via GetTestBucketAndSpec,
 	// which is fast enough for Walrus that we don't need to prepare buckets ahead of time.
 	if !TestUseCouchbaseServer() || TestUseExistingBucket() {
 		tbp := TestBucketPool{
-			bucketInitFunc:    bucketInitFunc,
-			unclosedBuckets:   make(map[string]map[string]struct{}),
-			integrationMode:   TestUseCouchbaseServer(),
-			useExistingBucket: TestUseExistingBucket(),
-			useDefaultScope:   options.UseDefaultScope,
+			bucketInitFunc:          bucketInitFunc,
+			unclosedBuckets:         make(map[string]map[string]struct{}),
+			integrationMode:         TestUseCouchbaseServer(),
+			useExistingBucket:       TestUseExistingBucket(),
+			useDefaultScope:         options.UseDefaultScope,
+			numCollectionsPerBucket: numCollectionsPerBucket,
 		}
 		tbp.verbose.Set(tbpVerbose())
 		return &tbp
@@ -111,17 +120,18 @@ func NewTestBucketPoolWithOptions(ctx context.Context, bucketReadierFunc TBPBuck
 	preserveBuckets, _ := strconv.ParseBool(os.Getenv(tbpEnvPreserve))
 
 	tbp := TestBucketPool{
-		integrationMode:        true,
-		readyBucketPool:        make(chan Bucket, numBuckets),
-		bucketReadierQueue:     make(chan tbpBucketName, numBuckets),
-		bucketReadierWaitGroup: &sync.WaitGroup{},
-		ctxCancelFunc:          ctxCancelFunc,
-		preserveBuckets:        preserveBuckets,
-		bucketInitFunc:         bucketInitFunc,
-		unclosedBuckets:        make(map[string]map[string]struct{}),
-		useExistingBucket:      TestUseExistingBucket(),
-		useDefaultScope:        options.UseDefaultScope,
-		skipMobileXDCR:         true, // do not set up enableCrossClusterVersioning until Sync Gateway 4.x
+		integrationMode:         true,
+		readyBucketPool:         make(chan Bucket, numBuckets),
+		bucketReadierQueue:      make(chan tbpBucketName, numBuckets),
+		bucketReadierWaitGroup:  &sync.WaitGroup{},
+		ctxCancelFunc:           ctxCancelFunc,
+		preserveBuckets:         preserveBuckets,
+		bucketInitFunc:          bucketInitFunc,
+		unclosedBuckets:         make(map[string]map[string]struct{}),
+		useExistingBucket:       TestUseExistingBucket(),
+		useDefaultScope:         options.UseDefaultScope,
+		skipMobileXDCR:          true, // do not set up enableCrossClusterVersioning until Sync Gateway 4.x
+		numCollectionsPerBucket: numCollectionsPerBucket,
 	}
 
 	tbp.cluster = newTestCluster(ctx, UnitTestUrl(), &tbp)
@@ -142,13 +152,7 @@ func NewTestBucketPoolWithOptions(ctx context.Context, bucketReadierFunc TBPBuck
 		tbp.Fatalf(ctx, "Couldn't remove old test buckets: %v", err)
 	}
 
-	// Make sure the test buckets are created and put into the readier worker queue
-	start := time.Now()
-	if err := tbp.createTestBuckets(numBuckets, tbpBucketQuotaMB(ctx), bucketInitFunc); err != nil {
-		tbp.Fatalf(ctx, "Couldn't create test buckets: %v", err)
-	}
-	atomic.AddInt64(&tbp.stats.TotalBucketInitDurationNano, time.Since(start).Nanoseconds())
-	atomic.AddInt32(&tbp.stats.TotalBucketInitCount, int32(numBuckets))
+	go tbp.createTestBuckets(ctx, numBuckets, tbpBucketQuotaMB(ctx), bucketInitFunc, options.ParallelBucketInit)
 
 	return &tbp
 }
@@ -373,8 +377,8 @@ func (tbp *TestBucketPool) Close(ctx context.Context) {
 
 	// Cancel async workers
 	if tbp.ctxCancelFunc != nil {
-		tbp.bucketReadierWaitGroup.Wait()
 		tbp.ctxCancelFunc()
+		tbp.bucketReadierWaitGroup.Wait()
 	}
 
 	if tbp.cluster != nil {
@@ -484,7 +488,7 @@ func (tbp *TestBucketPool) createCollections(ctx context.Context, bucket Bucket)
 		tbp.Fatalf(ctx, "Bucket doesn't support dynamic collection creation %T", bucket)
 	}
 
-	for i := 0; i < tbpNumCollectionsPerBucket(ctx); i++ {
+	for i := 0; i < tbp.NumCollectionsPerBucket(); i++ {
 		scopeName := tbp.testScopeName()
 		collectionName := fmt.Sprintf("%s%d", tbpCollectionPrefix, i)
 		ctx := KeyspaceLogCtx(ctx, bucket.GetName(), scopeName, collectionName)
@@ -499,14 +503,9 @@ func (tbp *TestBucketPool) createCollections(ctx context.Context, bucket Bucket)
 }
 
 // createTestBuckets creates a new set of integration test buckets and pushes them into the readier queue.
-func (tbp *TestBucketPool) createTestBuckets(numBuckets, bucketQuotaMB int, bucketInitFunc TBPBucketInitFunc) error {
+func (tbp *TestBucketPool) createTestBuckets(ctx context.Context, numBuckets, bucketQuotaMB int, bucketInitFunc TBPBucketInitFunc, parallelBucketInit bool) {
 
-	// keep references to opened buckets for use later in this function
-	var (
-		openBuckets     = make(map[string]Bucket, numBuckets)
-		openBucketsLock sync.Mutex // protects openBuckets
-	)
-
+	start := time.Now()
 	wg := sync.WaitGroup{}
 	wg.Add(numBuckets)
 
@@ -516,17 +515,18 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets, bucketQuotaMB int, buck
 
 	// create required number of buckets (skipping any already existing ones)
 	for i := 0; i < numBuckets; i++ {
-		testBucketName := fmt.Sprintf(tbpBucketNameFormat, tbpBucketNamePrefix, i, bucketNameTimestamp)
-		ctx := BucketNameCtx(context.Background(), testBucketName)
+		bucketName := fmt.Sprintf(tbpBucketNameFormat, tbpBucketNamePrefix, i, bucketNameTimestamp)
+		ctx := BucketNameCtx(ctx, bucketName)
 
-		// Bucket creation takes a few seconds for each bucket,
-		// so create and wait for readiness concurrently.
-		go func(bucketName string) {
+		bucketInit := func() {
+			defer wg.Done()
 			ctx := BucketNameCtx(ctx, bucketName)
 
 			tbp.Logf(ctx, "Creating new test bucket")
 			err := tbp.cluster.insertBucket(ctx, bucketName, bucketQuotaMB)
-			if err != nil {
+			if ctx.Err() != nil {
+				return
+			} else if err != nil {
 				tbp.Fatalf(ctx, "Couldn't create test bucket: %v", err)
 			}
 
@@ -534,10 +534,6 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets, bucketQuotaMB int, buck
 			if err != nil {
 				tbp.Fatalf(ctx, "Timed out trying to open new bucket: %v", err)
 			}
-
-			openBucketsLock.Lock()
-			openBuckets[bucketName] = bucket
-			openBucketsLock.Unlock()
 
 			tbp.createCollections(ctx, bucket)
 
@@ -549,53 +545,54 @@ func (tbp *TestBucketPool) createTestBuckets(numBuckets, bucketQuotaMB int, buck
 				tbp.setXDCRBucketSetting(ctx, bucket)
 			}
 
-			wg.Done()
-		}(testBucketName)
-	}
+			// All the buckets are created and opened, so now we can perform some synchronous setup (e.g. Creating GSI indexes)
 
+			itemName := "bucket"
+			err, _ = RetryLoop(ctx, bucket.GetName()+"bucketInitRetry", func() (bool, error, interface{}) {
+				tbp.Logf(ctx, "Running %s through init function", itemName)
+				err := bucketInitFunc(ctx, bucket, tbp)
+				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						return false, err, nil
+					}
+					tbp.Logf(ctx, "Couldn't init %s, got error: %v - Retrying", itemName, err)
+					return true, err, nil
+				}
+				return false, nil, nil
+			}, CreateSleeperFunc(5, 1000))
+			if ctx.Err() != nil {
+				return
+			} else if err != nil {
+				tbp.Fatalf(ctx, "Couldn't init %s, got error: %v - Aborting", itemName, err)
+			}
+			tbp.readyBucketPool <- bucket
+		}
+		// Creation of buckets might be faster in parallel in the case of flush bucket, but slower if GSI is involved.
+		if parallelBucketInit {
+			go bucketInit()
+		} else {
+			bucketInit()
+		}
+	}
 	// wait for the async bucket creation and opening of buckets to finish
 	wg.Wait()
 
-	// All the buckets are created and opened, so now we can perform some synchronous setup (e.g. Creating GSI indexes)
-	for i := 0; i < numBuckets; i++ {
-		testBucketName := fmt.Sprintf(tbpBucketNameFormat, tbpBucketNamePrefix, i, bucketNameTimestamp)
-		ctx := BucketNameCtx(context.Background(), testBucketName)
+	atomic.AddInt64(&tbp.stats.TotalBucketInitDurationNano, time.Since(start).Nanoseconds())
+	atomic.AddInt32(&tbp.stats.TotalBucketInitCount, int32(numBuckets))
 
-		tbp.Logf(ctx, "running bucketInitFunc")
-		b := openBuckets[testBucketName]
-
-		itemName := "bucket"
-		if err, _ := RetryLoop(ctx, b.GetName()+"bucketInitRetry", func() (bool, error, interface{}) {
-			tbp.Logf(ctx, "Running %s through init function", itemName)
-			ctx = KeyspaceLogCtx(ctx, b.GetName(), "", "")
-			err := bucketInitFunc(ctx, b, tbp)
-			if err != nil {
-				tbp.Logf(ctx, "Couldn't init %s, got error: %v - Retrying", itemName, err)
-				return true, err, nil
-			}
-			return false, nil, nil
-		}, CreateSleeperFunc(5, 1000)); err != nil {
-			tbp.Fatalf(ctx, "Couldn't init %s, got error: %v - Aborting", itemName, err)
-		}
-
-		b.Close(ctx)
-		tbp.addBucketToReadierQueue(ctx, tbpBucketName(testBucketName))
-	}
-
-	return nil
 }
 
 // bucketReadierWorker reads a channel of "dirty" buckets (bucketReadierQueue), does something to get them ready, and then puts them back into the pool.
 // The mechanism for getting the bucket ready can vary by package being tested (for instance, a package not requiring views or GSI can use FlushBucketEmptierFunc)
 // A package requiring views or GSI, will need to pass in the db.ViewsAndGSIBucketReadier function.
 func (tbp *TestBucketPool) bucketReadierWorker(ctx context.Context, bucketReadierFunc TBPBucketReadierFunc) {
-	tbp.Logf(context.Background(), "Starting bucketReadier")
+	tbp.Logf(ctx, "Starting bucketReadier")
 
 loop:
 	for {
 		select {
 		case <-ctx.Done():
-			tbp.Logf(context.Background(), "bucketReadier got ctx cancelled")
+			tbp.Logf(ctx, "bucketReadier got ctx cancelled")
 			break loop
 
 		case dirtyBucket := <-tbp.bucketReadierQueue:
@@ -638,7 +635,7 @@ loop:
 		}
 	}
 
-	tbp.Logf(context.Background(), "Stopped bucketReadier")
+	tbp.Logf(ctx, "Stopped bucketReadier")
 }
 
 func (tbp *TestBucketPool) testScopeName() string {

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -236,7 +236,7 @@ func (tbp *TestBucketPool) GetWalrusTestBucket(t testing.TB, url string) (b Buck
 	if err != nil {
 		tbp.Fatalf(ctx, "couldn't run bucket init func: %v", err)
 	}
-	atomic.AddInt32(&tbp.stats.TotalBucketInitCount, 1)
+	tbp.stats.TotalBucketInitCount.Add(1)
 	atomic.AddInt64(&tbp.stats.TotalBucketInitDurationNano, time.Since(initFuncStart).Nanoseconds())
 	tbp.markBucketOpened(t, b)
 
@@ -578,8 +578,7 @@ func (tbp *TestBucketPool) createTestBuckets(ctx context.Context, numBuckets, bu
 	wg.Wait()
 
 	atomic.AddInt64(&tbp.stats.TotalBucketInitDurationNano, time.Since(start).Nanoseconds())
-	atomic.AddInt32(&tbp.stats.TotalBucketInitCount, int32(numBuckets))
-
+	tbp.stats.TotalBucketInitCount.Add(int32(numBuckets))
 }
 
 // bucketReadierWorker reads a channel of "dirty" buckets (bucketReadierQueue), does something to get them ready, and then puts them back into the pool.

--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -37,7 +37,7 @@ const (
 	tbpEnvBucketPoolSize     = "SG_TEST_BUCKET_POOL_SIZE"
 
 	// Creates and prepares this many collections in each bucket in the backing store.
-	tbpDefaultCollectionPoolSize = 3 // (per bucket)
+	tbpDefaultCollectionPoolSize = 2 // (per bucket)
 	tbpEnvCollectionPoolSize     = "SG_TEST_COLLECTION_POOL_SIZE"
 
 	// Allocate this much memory to each bucket.

--- a/base/main_test_bucket_pool_config.go
+++ b/base/main_test_bucket_pool_config.go
@@ -136,6 +136,10 @@ func (tbp *TestBucketPool) canUseNamedCollections(ctx context.Context) (bool, er
 
 // tbpNumBuckets returns the configured number of buckets to use in the pool.
 func tbpNumBuckets(ctx context.Context) int {
+	if TestUseExistingBucket() {
+		// SG_TEST_USE_EXISTING_BUCKET only allows for one bucket name
+		return 1
+	}
 	numBuckets := tbpDefaultBucketPoolSize
 	if envPoolSize := os.Getenv(tbpEnvBucketPoolSize); envPoolSize != "" {
 		var err error

--- a/base/main_test_bucket_pool_stats.go
+++ b/base/main_test_bucket_pool_stats.go
@@ -28,7 +28,7 @@ func (tbp *TestBucketPool) printStats() {
 	}
 
 	totalBucketInitTime := time.Duration(atomic.LoadInt64(&tbp.stats.TotalBucketInitDurationNano))
-	totalBucketInitCount := time.Duration(atomic.LoadInt32(&tbp.stats.TotalBucketInitCount))
+	totalBucketInitCount := time.Duration(tbp.stats.TotalBucketInitCount.Load())
 
 	totalBucketReadierTime := time.Duration(atomic.LoadInt64(&tbp.stats.TotalBucketReadierDurationNano))
 	totalBucketReadierCount := time.Duration(atomic.LoadInt32(&tbp.stats.TotalBucketReadierCount))
@@ -84,7 +84,7 @@ func (tbp *TestBucketPool) printStats() {
 // printStats() is called once a package's tests have finished to output these stats.
 type bucketPoolStats struct {
 	TotalBucketInitDurationNano    int64
-	TotalBucketInitCount           int32
+	TotalBucketInitCount           atomic.Int32
 	TotalBucketReadierDurationNano int64
 	TotalBucketReadierCount        int32
 	NumBucketsOpened               int32

--- a/base/main_test_bucket_pool_util.go
+++ b/base/main_test_bucket_pool_util.go
@@ -61,7 +61,7 @@ func RequireNumTestBuckets(t testing.TB, numRequired int) {
 // RequireNumTestDataStores skips the given test if there are not enough test buckets available to use.
 func RequireNumTestDataStores(t testing.TB, numRequired int) {
 	TestRequiresCollections(t)
-	available := tbpNumCollectionsPerBucket(TestCtx(t))
+	available := GTestBucketPool.NumCollectionsPerBucket()
 	if available < numRequired {
 		t.Skipf("Only had %d usable test data stores available (test requires %d)", available, numRequired)
 	}
@@ -75,4 +75,8 @@ func (tbp *TestBucketPool) NumUsableBuckets() int {
 		return 10
 	}
 	return tbpNumBuckets(context.Background()) - int(atomic.LoadUint32(&tbp.preservedBucketCount))
+}
+
+func (tbp *TestBucketPool) NumCollectionsPerBucket() int {
+	return tbp.numCollectionsPerBucket
 }

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -19,6 +19,6 @@ import (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048, ParallelBucketInit: true}
 	TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/importtest/main_test.go
+++ b/rest/importtest/main_test.go
@@ -24,6 +24,6 @@ func TestMain(m *testing.M) {
 	}
 
 	ctx := context.Background() // start of test process
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048, NumCollectionsPerBucket: 3}
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 3}
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }
 

--- a/rest/replicatortest/main_test.go
+++ b/rest/replicatortest/main_test.go
@@ -20,6 +20,6 @@ import (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 3}
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }


### PR DESCRIPTION
- Create test buckets in the background instead of before the tests. This shortens time in the case of no running tests, all tests are skipped, or a test only requires a single bucket.
- Do not wait for buckets to be torn down for test exit, since they will be deleted in the next test run.
- Only create 3 collections when we need to, otherwise create two.
- Put bucket into readyBucketPool directly instead of addToBucketReadierQueue after creation. Dropping the immediate flush saves about 6 secs per bucket for the buckets to become ready.
- Running the bucket creation in parallel is faster when Flush buckets are used, but slower when GSI is used, so running parallel init is off by default.

I would say my favorite features are creating test buckets asynchronously and not waiting for bucket teardown in test exit. This speeds up running tests interactively a good deal, especially when running small numbers of tests. One thing that it protects against is using `-run TestFoo` where `TestFoo` accidentally doesn't match anything, but the bucket pool has to start up for you to know that. Additionally, this means not having to reset `SG_TEST_BUCKET_POOL_SIZE` when running tests locally, since you only have to wait for as many buckets as you need for the test to run.

I can take or leave some of the other changes. If there's consensus about any of the changes, I'll dump them back into a jira ticket.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2894/
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2947/
