### PR TITLE
CBG-4391: bubble up errors from startup db process to db summaries

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -117,7 +117,7 @@ func (h *handler) handleCreateDB() error {
 				"Duplicate database name %q", dbName)
 		}
 
-		_, err = h.server._applyConfig(contextNoCancel, loadedConfig, true, false)
+		_, err = h.server._applyConfig(contextNoCancel, loadedConfig, true, false, false)
 		if err != nil {
 			return databaseLoadErrorAsHTTPError(err)
 		}
@@ -1027,7 +1027,7 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -1096,7 +1096,7 @@ func (h *handler) handlePutCollectionConfigSync() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -1196,7 +1196,7 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -1266,7 +1266,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -448,11 +448,12 @@ type DatabaseRoot struct {
 }
 
 type DbSummary struct {
-	DBName               string `json:"db_name"`
-	Bucket               string `json:"bucket"`
-	State                string `json:"state"`
-	InitializationActive bool   `json:"init_in_progress,omitempty"`
-	RequireResync        bool   `json:"require_resync,omitempty"`
+	DBName               string         `json:"db_name"`
+	Bucket               string         `json:"bucket"`
+	State                string         `json:"state"`
+	InitializationActive bool           `json:"init_in_progress,omitempty"`
+	RequireResync        bool           `json:"require_resync,omitempty"`
+	DatabaseError        *DatabaseError `json:"database_error,omitempty"`
 }
 
 func (h *handler) handleGetDB() error {

--- a/rest/database_error.go
+++ b/rest/database_error.go
@@ -27,13 +27,13 @@ var DatabaseErrorMap = map[databaseErrorCode]string{
 type databaseErrorCode uint8
 
 const (
-	DatabaseBucketConnectionError databaseErrorCode = iota
-	DatabaseInvalidDatastore
-	DatabaseInitSyncInfoError
-	DatabaseInitialisationIndexError
-	DatabaseCreateDatabaseContextError
-	DatabaseSGRClusterError
-	DatabaseCreateReplicationError
+	DatabaseBucketConnectionError      databaseErrorCode = 1
+	DatabaseInvalidDatastore           databaseErrorCode = 2
+	DatabaseInitSyncInfoError          databaseErrorCode = 3
+	DatabaseInitialisationIndexError   databaseErrorCode = 4
+	DatabaseCreateDatabaseContextError databaseErrorCode = 5
+	DatabaseSGRClusterError            databaseErrorCode = 6
+	DatabaseCreateReplicationError     databaseErrorCode = 7
 )
 
 func NewDatabaseError(code databaseErrorCode) *DatabaseError {

--- a/rest/database_error.go
+++ b/rest/database_error.go
@@ -14,19 +14,7 @@ type DatabaseError struct {
 	Code   databaseErrorCode `json:"error_code"`
 }
 
-type databaseErrorCode uint8
-
-const (
-	DatabaseBucketConnectionError      databaseErrorCode = 0
-	DatabaseInvalidDatastore           databaseErrorCode = 1
-	DatabaseInitSyncInfoError          databaseErrorCode = 2
-	DatabaseInitialisationIndexError   databaseErrorCode = 3
-	DatabaseCreateDatabaseContextError databaseErrorCode = 4
-	DatabaseSGRClusterError            databaseErrorCode = 5
-	DatabaseCreateReplicationError     databaseErrorCode = 6
-)
-
-var DatabaseErrorString = []string{
+var DatabaseErrorMap = map[databaseErrorCode]string{
 	DatabaseBucketConnectionError:      "Error connecting to bucket",
 	DatabaseInvalidDatastore:           "Collection(s) not available",
 	DatabaseInitSyncInfoError:          "Error initialising sync info",
@@ -36,9 +24,21 @@ var DatabaseErrorString = []string{
 	DatabaseCreateReplicationError:     "Error creating replication during database init",
 }
 
+type databaseErrorCode uint8
+
+const (
+	DatabaseBucketConnectionError databaseErrorCode = iota
+	DatabaseInvalidDatastore
+	DatabaseInitSyncInfoError
+	DatabaseInitialisationIndexError
+	DatabaseCreateDatabaseContextError
+	DatabaseSGRClusterError
+	DatabaseCreateReplicationError
+)
+
 func NewDatabaseError(code databaseErrorCode) *DatabaseError {
 	return &DatabaseError{
-		ErrMsg: DatabaseErrorString[code],
+		ErrMsg: DatabaseErrorMap[code],
 		Code:   code,
 	}
 }

--- a/rest/database_error.go
+++ b/rest/database_error.go
@@ -1,0 +1,46 @@
+//  Copyright 2025-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package rest
+
+// DatabaseError denotes an error that occurred during database startup
+type DatabaseError struct {
+	ErrMsg string            `json:"error_message"`
+	Code   DatabaseErrorType `json:"error_code"`
+}
+
+type DatabaseErrorType uint8
+
+const (
+	DatabaseBucketConnectionError DatabaseErrorType = iota
+	DatabaseInvalidDatastore
+	DatabaseIndexError
+	DatabaseInitSyncInfoError
+	DatabaseInitialisationIndexError
+	DatabaseCreateDatabaseContextError
+	DatabaseSGRClusterError
+	DatabaseCreateReplicationError
+)
+
+var DatabaseErrorString = []string{
+	DatabaseBucketConnectionError:      "Error connecting to bucket",
+	DatabaseInvalidDatastore:           "Collection(s) not available",
+	DatabaseIndexError:                 "Error creating/building/waiting index",
+	DatabaseInitSyncInfoError:          "Error initialising sync info",
+	DatabaseInitialisationIndexError:   "Error initialising database indexes",
+	DatabaseCreateDatabaseContextError: "Error creating database context",
+	DatabaseSGRClusterError:            "Error with fetching SGR cluster definition",
+	DatabaseCreateReplicationError:     "Error creating replication during database init",
+}
+
+func NewDatabaseError(code DatabaseErrorType) *DatabaseError {
+	return &DatabaseError{
+		ErrMsg: DatabaseErrorString[code],
+		Code:   code,
+	}
+}

--- a/rest/database_error.go
+++ b/rest/database_error.go
@@ -26,6 +26,7 @@ var DatabaseErrorMap = map[databaseErrorCode]string{
 
 type databaseErrorCode uint8
 
+// Error codes exposed for each error a database can encounter on load. These codes are consumed by Capella so must remain stable.
 const (
 	DatabaseBucketConnectionError      databaseErrorCode = 1
 	DatabaseInvalidDatastore           databaseErrorCode = 2

--- a/rest/database_error.go
+++ b/rest/database_error.go
@@ -11,26 +11,24 @@ package rest
 // DatabaseError denotes an error that occurred during database startup
 type DatabaseError struct {
 	ErrMsg string            `json:"error_message"`
-	Code   DatabaseErrorType `json:"error_code"`
+	Code   databaseErrorCode `json:"error_code"`
 }
 
-type DatabaseErrorType uint8
+type databaseErrorCode uint8
 
 const (
-	DatabaseBucketConnectionError DatabaseErrorType = iota
-	DatabaseInvalidDatastore
-	DatabaseIndexError
-	DatabaseInitSyncInfoError
-	DatabaseInitialisationIndexError
-	DatabaseCreateDatabaseContextError
-	DatabaseSGRClusterError
-	DatabaseCreateReplicationError
+	DatabaseBucketConnectionError      databaseErrorCode = 0
+	DatabaseInvalidDatastore           databaseErrorCode = 1
+	DatabaseInitSyncInfoError          databaseErrorCode = 2
+	DatabaseInitialisationIndexError   databaseErrorCode = 3
+	DatabaseCreateDatabaseContextError databaseErrorCode = 4
+	DatabaseSGRClusterError            databaseErrorCode = 5
+	DatabaseCreateReplicationError     databaseErrorCode = 6
 )
 
 var DatabaseErrorString = []string{
 	DatabaseBucketConnectionError:      "Error connecting to bucket",
 	DatabaseInvalidDatastore:           "Collection(s) not available",
-	DatabaseIndexError:                 "Error creating/building/waiting index",
 	DatabaseInitSyncInfoError:          "Error initialising sync info",
 	DatabaseInitialisationIndexError:   "Error initialising database indexes",
 	DatabaseCreateDatabaseContextError: "Error creating database context",
@@ -38,7 +36,7 @@ var DatabaseErrorString = []string{
 	DatabaseCreateReplicationError:     "Error creating replication during database init",
 }
 
-func NewDatabaseError(code DatabaseErrorType) *DatabaseError {
+func NewDatabaseError(code databaseErrorCode) *DatabaseError {
 	return &DatabaseError{
 		ErrMsg: DatabaseErrorString[code],
 		Code:   code,

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -87,7 +87,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 	h.setEtag(updatedDbConfig.Version)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -113,6 +113,7 @@ type getOrAddDatabaseConfigOptions struct {
 	connectToBucketFn db.OpenBucketFn // supply a custom function for buckets, used for testing only
 	forceOnline       bool            // force the database to come online, even if startOffline is set
 	asyncOnline       bool            // Whether getOrAddDatabaseConfig should block until database is ready, when startOffline=false
+	loadFromBucket    bool            // If this is load config from bucket operation
 }
 
 func (sc *ServerContext) CreateLocalDatabase(ctx context.Context, dbs DbConfigMap) error {
@@ -354,12 +355,25 @@ func (sc *ServerContext) GetInactiveDatabase(ctx context.Context, name string) (
 	var httpErr *base.HTTPError
 	invalidConfig, ok := sc.invalidDatabaseConfigTracking.exists(name)
 	if !dbConfigFound && ok {
-		httpErr = base.HTTPErrorf(http.StatusNotFound, "Mismatch in database config for database %s bucket name: %s and backend bucket: %s groupID: %s You must update database config immediately", base.MD(name), base.MD(invalidConfig.configBucketName), base.MD(invalidConfig.persistedBucketName), base.MD(sc.Config.Bootstrap.ConfigGroupID))
+		httpErr = sc.buildErrorMessage(name, invalidConfig)
 	} else {
 		httpErr = base.HTTPErrorf(http.StatusNotFound, "no such database %q", name)
 	}
 
 	return nil, dbConfigFound, httpErr
+}
+
+// buildErrorMessage will build appropriate http error message based on the invalidConfig
+func (sc *ServerContext) buildErrorMessage(dbName string, invalidConfig *invalidConfigInfo) *base.HTTPError {
+	var err *base.HTTPError
+	if invalidConfig.databaseError != nil {
+		err = base.HTTPErrorf(http.StatusNotFound, "Database %s has an invalid configuration: %v. You must update database config immediately through create db process", dbName, invalidConfig.databaseError.ErrMsg)
+	}
+	if invalidConfig.collectionConflicts {
+		err = base.HTTPErrorf(http.StatusNotFound, "Database %s has conflicting collections. You must update database config immediately through create db process", dbName)
+	}
+	err = base.HTTPErrorf(http.StatusNotFound, "Mismatch in database config for database %s bucket name: %s and backend bucket: %s groupID: %s You must update database config immediately", base.MD(dbName), base.MD(invalidConfig.configBucketName), base.MD(invalidConfig.persistedBucketName), base.MD(sc.Config.Bootstrap.ConfigGroupID))
+	return err
 }
 
 func (sc *ServerContext) GetDbConfig(name string) *DbConfig {
@@ -410,6 +424,21 @@ func (sc *ServerContext) allDatabaseSummaries() []DbSummary {
 		}
 		if sc.DatabaseInitManager.HasActiveInitialization(name) {
 			summary.InitializationActive = true
+		}
+		dbs = append(dbs, summary)
+	}
+	sc.invalidDatabaseConfigTracking.m.RLock()
+	defer sc.invalidDatabaseConfigTracking.m.RUnlock()
+	for name, invalidConfig := range sc.invalidDatabaseConfigTracking.dbNames {
+		// skip adding any invalid dbs with no error associated with them or that exist in above list
+		if invalidConfig.databaseError == nil || sc.databases_[name] != nil {
+			continue
+		}
+		summary := DbSummary{
+			DBName:        name,
+			Bucket:        invalidConfig.configBucketName,
+			State:         db.RunStateString[db.DBOffline], // db can always be reported as offline if we have an invalid config
+			DatabaseError: invalidConfig.databaseError,
 		}
 		dbs = append(dbs, summary)
 	}
@@ -488,17 +517,18 @@ func (sc *ServerContext) ReloadDatabase(ctx context.Context, reloadDbName string
 func (sc *ServerContext) ReloadDatabaseWithConfig(nonContextStruct base.NonCancellableContext, config DatabaseConfig) error {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
-	return sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, config, true)
+	return sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, config, true, false)
 }
 
-func (sc *ServerContext) _reloadDatabaseWithConfig(ctx context.Context, config DatabaseConfig, failFast bool) error {
+func (sc *ServerContext) _reloadDatabaseWithConfig(ctx context.Context, config DatabaseConfig, failFast bool, loadFromBucket bool) error {
 	sc._removeDatabase(ctx, config.Name)
 	// use async initialization whenever using persistent config
 	asyncOnline := sc.persistentConfig
 	_, err := sc._getOrAddDatabaseFromConfig(ctx, config, getOrAddDatabaseConfigOptions{
-		useExisting: false,
-		failFast:    failFast,
-		asyncOnline: asyncOnline,
+		useExisting:    false,
+		failFast:       failFast,
+		asyncOnline:    asyncOnline,
+		loadFromBucket: loadFromBucket,
 	})
 	return err
 }
@@ -640,7 +670,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	} else {
 		bucket, err = db.ConnectToBucket(ctx, spec, options.failFast)
 	}
+	// auth error or fatal error here - is fatal whjen bucket ddoesn't exist?
 	if err != nil {
+		if options.loadFromBucket {
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseBucketConnectionError))
+		}
 		return nil, err
 	}
 
@@ -667,6 +701,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 				dataStore, err := base.GetAndWaitUntilDataStoreReady(ctx, bucket, scName, options.failFast)
 				if err != nil {
+					if options.loadFromBucket {
+						sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInvalidDatastore))
+					}
 					return nil, fmt.Errorf("error attempting to create/update database: %w", err)
 				}
 
@@ -679,7 +716,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 				// Verify whether the collection is associated with a different database's metadataID - if so, add to set requiring resync
 				resyncRequired, err := base.InitSyncInfo(dataStore, config.MetadataID)
+				// ghere if this fails, have failed iint sync info
 				if err != nil {
+					if options.loadFromBucket {
+						sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInitSyncInfoError))
+					}
 					return nil, err
 				}
 				if resyncRequired {
@@ -696,6 +737,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			scName := base.DefaultScopeAndCollectionName()
 			resyncRequired, err := base.InitSyncInfo(ds, config.MetadataID)
 			if err != nil {
+				if options.loadFromBucket {
+					sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInitSyncInfoError))
+				}
 				return nil, err
 			}
 			if resyncRequired {
@@ -731,6 +775,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// Initialize indexes using DatabaseInitManager.
 		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config)
 		if err != nil {
+			if options.loadFromBucket {
+				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInitialisationIndexError))
+			}
 			return nil, err
 		}
 	}
@@ -797,6 +844,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	contextOptions.MetadataStore = bucket.DefaultDataStore()
 	err = validateMetadataStore(ctx, contextOptions.MetadataStore)
 	if err != nil {
+		if options.loadFromBucket {
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInvalidDatastore))
+		}
 		return nil, err
 	}
 
@@ -811,6 +861,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	// Create the DB Context
 	dbcontext, err = db.NewDatabaseContext(ctx, dbName, bucket, autoImport, contextOptions)
 	if err != nil {
+		if options.loadFromBucket {
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseCreateDatabaseContextError))
+		}
 		return nil, err
 	}
 	dbcontext.BucketSpec = spec
@@ -855,6 +908,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 
 	cfgReplications, err := dbcontext.SGReplicateMgr.GetReplications()
 	if err != nil {
+		if options.loadFromBucket {
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseSGRClusterError))
+		}
 		return nil, err
 	}
 	// PUT replications that do not exist
@@ -868,6 +924,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 	replicationErr := dbcontext.SGReplicateMgr.PutReplications(ctx, newReplications)
 	if replicationErr != nil {
+		if options.loadFromBucket {
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseCreateReplicationError))
+		}
 		return nil, replicationErr
 	}
 
@@ -890,6 +949,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	} else {
 		atomic.StoreUint32(&dbcontext.State, db.DBStarting)
 	}
+
+	// TODO: Errors for online processes should be handled on dbcontext as its been loaded into server context below (CBG-4511)
 
 	// Register it so HTTP handlers can find it:
 	sc.databases_[dbcontext.Name] = dbcontext

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -978,6 +978,7 @@ func TestDatabaseCollectionDeletedErrorState(t *testing.T) {
 	}
 	rt := NewRestTesterMultipleCollections(t, nil, 3)
 	defer rt.Close()
+	ctx := base.TestCtx(t)
 
 	dbConfig := rt.ServerContext().GetDatabaseConfig("db")
 	scopesConfig := GetCollectionsConfig(t, rt.TestBucket, 3)
@@ -1014,6 +1015,12 @@ func TestDatabaseCollectionDeletedErrorState(t *testing.T) {
 	invalDb = allDbs[0]
 	require.Nil(t, invalDb.DatabaseError)
 	assert.Equal(t, db.RunStateString[db.DBOnline], invalDb.State)
+
+	// add back the datastore
+	b, err = base.AsGocbV2Bucket(rt.GetDatabase().Bucket)
+	require.NoError(t, err)
+	err = b.CreateDataStore(ctx, dsList[0])
+	require.NoError(t, err)
 
 	// try creating db with bad collections config ensure it fails and isn't shown on all dbs
 	scopesConfig[scope] = ScopeConfig{

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -973,7 +973,7 @@ func TestDatabaseStartupFailure(t *testing.T) {
 }
 
 func TestDatabaseCollectionDeletedErrorState(t *testing.T) {
-	if base.TestUseWalrus() {
+	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
 	rt := NewRestTesterMultipleCollections(t, nil, 3)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -971,3 +971,61 @@ func TestDatabaseStartupFailure(t *testing.T) {
 	require.Nil(t, dbContext)
 	require.Equal(t, "Offline", rt.GetDBState())
 }
+
+func TestDatabaseCollectionDeletedErrorState(t *testing.T) {
+	if base.TestUseWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
+	rt := NewRestTesterMultipleCollections(t, nil, 3)
+	defer rt.Close()
+
+	dbConfig := rt.ServerContext().GetDatabaseConfig("db")
+	scopesConfig := GetCollectionsConfig(t, rt.TestBucket, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scope := dataStoreNames[0].ScopeName()
+
+	// remove datastore
+	b, err := base.AsGocbV2Bucket(rt.GetDatabase().Bucket)
+	require.NoError(t, err)
+	dsList, err := b.ListDataStores()
+	require.NoError(t, err)
+	require.NoError(t, b.DropDataStore(dsList[0]))
+
+	// reload db
+	err = rt.ServerContext().reloadDatabaseWithConfigLoadFromBucket(base.NewNonCancelCtx(), dbConfig.DatabaseConfig)
+	require.Error(t, err)
+
+	allDbs := rt.ServerContext().allDatabaseSummaries()
+	require.Len(t, allDbs, 1)
+	invalDb := allDbs[0]
+	require.NotNil(t, invalDb.DatabaseError)
+	assert.Equal(t, db.RunStateString[db.DBOffline], invalDb.State)
+	assert.Equal(t, invalDb.DatabaseError.ErrMsg, DatabaseErrorString[DatabaseInvalidDatastore])
+
+	// fix db config
+	deletedCollection := dsList[0].CollectionName()
+	delete(scopesConfig[scope].Collections, deletedCollection)
+	dbConfig.Scopes = scopesConfig
+	resp := rt.CreateDatabase("db", dbConfig.DbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	allDbs = rt.ServerContext().allDatabaseSummaries()
+	require.Len(t, allDbs, 1)
+	invalDb = allDbs[0]
+	require.Nil(t, invalDb.DatabaseError)
+	assert.Equal(t, db.RunStateString[db.DBOnline], invalDb.State)
+
+	// try creating db with bad collections config ensure it fails and isn't shown on all dbs
+	scopesConfig[scope] = ScopeConfig{
+		Collections: map[string]*CollectionConfig{
+			"badCollection": {},
+		},
+	}
+	dbConfig.Scopes = scopesConfig
+	dbConfig.Name = "db2"
+	resp = rt.CreateDatabase("db2", dbConfig.DbConfig)
+	RequireStatus(t, resp, http.StatusForbidden)
+
+	allDbs = rt.ServerContext().allDatabaseSummaries()
+	require.Len(t, allDbs, 1)
+}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -1001,7 +1001,7 @@ func TestDatabaseCollectionDeletedErrorState(t *testing.T) {
 	invalDb := allDbs[0]
 	require.NotNil(t, invalDb.DatabaseError)
 	assert.Equal(t, db.RunStateString[db.DBOffline], invalDb.State)
-	assert.Equal(t, invalDb.DatabaseError.ErrMsg, DatabaseErrorString[DatabaseInvalidDatastore])
+	assert.Equal(t, invalDb.DatabaseError.ErrMsg, DatabaseErrorMap[DatabaseInvalidDatastore])
 
 	// fix db config
 	deletedCollection := dsList[0].CollectionName()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2840,3 +2840,10 @@ func RequireGocbDCPResync(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server since rosmar has no support for DCP resync")
 	}
 }
+
+// reloadDatabaseWithConfigLoadFromBucket forces reload of db as if it was being picked up from the bucket
+func (sc *ServerContext) reloadDatabaseWithConfigLoadFromBucket(nonContextStruct base.NonCancellableContext, config DatabaseConfig) error {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+	return sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, config, true, true)
+}


### PR DESCRIPTION
CBG-4391

- Part 1 of better error reporting for database startup for capella, part 2 will be handled in different ticket (failures in start online processes)
- Utilise the invalid db config tracking to bubble up error code + message to the all db's endpoint for use in capella
- This also allows any misconfiguration to be correct by the customer by using the create db endpoint again with a correct config
- Tried to only report errors that may be relevant to capella users (for example, you cannot toggle auto import so not reporting auto import option being invalid) 
- Test to repro the collection being deleted underneath sync gateway error


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2936/
