### PR TITLE
[3.2.3 Backport] CBG-4463: Avoid leaking ISGR StatsReporter goroutine underneath reconnecting replicator (#7355)

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -268,7 +268,7 @@ func (a *activeReplicatorCommon) _disconnect() error {
 	return nil
 }
 
-// _stop aborts any replicator processes that run outside of a running replication (e.g: async reconnect handling)
+// _stop aborts any replicator processes that run outside of a running replication connection (e.g: async reconnect handling, statsreporter)
 func (a *activeReplicatorCommon) _stop() {
 	if a.ctxCancel != nil {
 		base.TracefCtx(a.ctx, base.KeyReplicate, "cancelling context on activeReplicatorCommon in _stop()")
@@ -369,8 +369,8 @@ func (a *activeReplicatorCommon) _publishStatus() {
 	}
 }
 
-func (arc *activeReplicatorCommon) startStatusReporter() error {
-	go func(ctx context.Context) {
+func (arc *activeReplicatorCommon) startStatusReporter(ctx context.Context) error {
+	go func() {
 		ticker := time.NewTicker(arc.config.CheckpointInterval)
 		defer ticker.Stop()
 		for {
@@ -386,7 +386,7 @@ func (arc *activeReplicatorCommon) startStatusReporter() error {
 				return
 			}
 		}
-	}(arc.ctx)
+	}()
 	return nil
 }
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -48,6 +48,10 @@ func (apr *ActivePullReplicator) Start(ctx context.Context) error {
 	logCtx := base.CorrelationIDLogCtx(ctx, apr.config.ID+"-"+string(ActiveReplicatorTypePull))
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
+	if err := apr.startStatusReporter(apr.ctx); err != nil {
+		return err
+	}
+
 	err := apr._connect()
 	if err != nil {
 		_ = apr.setError(err)
@@ -89,10 +93,6 @@ func (apr *ActivePullReplicator) _connect() error {
 
 	if apr.blipSyncContext.activeCBMobileSubprotocol <= CBMobileReplicationV2 && apr.config.PurgeOnRemoval {
 		base.ErrorfCtx(apr.ctx, "Pull replicator ID:%s running with revocations enabled but target does not support revocations. Sync Gateway 3.0 required.", apr.config.ID)
-	}
-
-	if err := apr.startStatusReporter(); err != nil {
-		return err
 	}
 
 	apr.setState(ReplicationStateRunning)

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -53,6 +53,10 @@ func (apr *ActivePushReplicator) Start(ctx context.Context) error {
 		apr.config.ID+"-"+string(ActiveReplicatorTypePush))
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
+	if err := apr.startStatusReporter(apr.ctx); err != nil {
+		return err
+	}
+
 	err := apr._connect()
 	if err != nil {
 		_ = apr.setError(err)
@@ -92,10 +96,6 @@ func (apr *ActivePushReplicator) _connect() error {
 		if err := apr._startPushNonCollection(); err != nil {
 			return err
 		}
-	}
-
-	if err := apr.startStatusReporter(); err != nil {
-		return err
 	}
 
 	apr.setState(ReplicationStateRunning)


### PR DESCRIPTION
CBG-4463

Clean cherry-pick of #7355 for 3.2.3

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2939/
  - unrelated failure
