### PR TITLE
CBG-4464: [3.2.3 backport] Retry index creation for longer

### DIFF
--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -256,7 +256,8 @@ func BuildDeferredIndexes(ctx context.Context, s N1QLStore, indexSet []string) e
 		}
 		return err != nil, err, nil
 	}
-	sleeper := CreateDoublingSleeperDurationFunc(500, time.Second*30)
+	// Initial retry 1 seconds, max wait 30s, waits up to 10m
+	sleeper := CreateMaxDoublingSleeperFunc(20, 1000, 30000)
 	err, _ := RetryLoop(ctx, "BuildDeferredIndexes", worker, sleeper)
 	if err != nil {
 		return err

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -295,8 +295,8 @@ func (i *SGIndex) createIfNeeded(ctx context.Context, bucket base.N1QLStore, opt
 		IndexTombstones: i.shouldIndexTombstones(options.UseXattrs),
 	}
 
-	// Initial retry 500ms, max wait 1s, waits up to ~15s
-	sleeper := base.CreateMaxDoublingSleeperFunc(15, 500, 1000)
+	// Initial retry 1 seconds, max wait 30s, waits up to 10m
+	sleeper := base.CreateMaxDoublingSleeperFunc(20, 1000, 30000)
 
 	// start a retry loop to create index,
 	worker := func() (shouldRetry bool, err error, value interface{}) {


### PR DESCRIPTION
CBG-4464

- backport of #7347

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2943/
