### PR TITLE
CBG-4516: [3.2.3 backport] Windows TestReplicationConfigUpdatedAt flake 

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8668,6 +8668,9 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 	currTime := configResponse.UpdatedAt
 	createdAtTime := configResponse.CreatedAt
 
+	// avoid flake where update at seems to be the same (possibly running to fast)
+	time.Sleep(10 * time.Millisecond)
+
 	resp = activeRT.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/replication1?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
@@ -8682,6 +8685,6 @@ func TestReplicationConfigUpdatedAt(t *testing.T) {
 	configResponse = db.ReplicationConfig{}
 	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &configResponse))
 
-	assert.Greater(t, configResponse.UpdatedAt.UnixNano(), currTime.UnixNano())
+	base.AssertTimeGreaterThan(t, *configResponse.UpdatedAt, *currTime)
 	assert.Equal(t, configResponse.CreatedAt.UnixNano(), createdAtTime.UnixNano())
 }


### PR DESCRIPTION

CBG-4516

Backports #7338 to avoid actions flakiness on this branch


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
