### PR TITLE
CBG-4393: [3.2.3 backport] bubble up errors from startup db process to db summaries

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -117,7 +117,7 @@ func (h *handler) handleCreateDB() error {
 				"Duplicate database name %q", dbName)
 		}
 
-		_, err = h.server._applyConfig(contextNoCancel, loadedConfig, true, false)
+		_, err = h.server._applyConfig(contextNoCancel, loadedConfig, true, false, false)
 		if err != nil {
 			return databaseLoadErrorAsHTTPError(err)
 		}
@@ -1040,7 +1040,7 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -1109,7 +1109,7 @@ func (h *handler) handlePutCollectionConfigSync() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -1209,7 +1209,7 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 
@@ -1279,7 +1279,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -449,11 +449,12 @@ type DatabaseRoot struct {
 }
 
 type DbSummary struct {
-	DBName               string `json:"db_name"`
-	Bucket               string `json:"bucket"`
-	State                string `json:"state"`
-	InitializationActive bool   `json:"init_in_progress,omitempty"`
-	RequireResync        bool   `json:"require_resync,omitempty"`
+	DBName               string         `json:"db_name"`
+	Bucket               string         `json:"bucket"`
+	State                string         `json:"state"`
+	InitializationActive bool           `json:"init_in_progress,omitempty"`
+	RequireResync        bool           `json:"require_resync,omitempty"`
+	DatabaseError        *DatabaseError `json:"database_error,omitempty"`
 }
 
 func (h *handler) handleGetDB() error {

--- a/rest/database_error.go
+++ b/rest/database_error.go
@@ -1,0 +1,45 @@
+//  Copyright 2025-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package rest
+
+// DatabaseError denotes an error that occurred during database startup
+type DatabaseError struct {
+	ErrMsg string            `json:"error_message"`
+	Code   databaseErrorCode `json:"error_code"`
+}
+
+var DatabaseErrorMap = map[databaseErrorCode]string{
+	DatabaseBucketConnectionError:      "Error connecting to bucket",
+	DatabaseInvalidDatastore:           "Collection(s) not available",
+	DatabaseInitSyncInfoError:          "Error initialising sync info",
+	DatabaseInitialisationIndexError:   "Error initialising database indexes",
+	DatabaseCreateDatabaseContextError: "Error creating database context",
+	DatabaseSGRClusterError:            "Error with fetching SGR cluster definition",
+	DatabaseCreateReplicationError:     "Error creating replication during database init",
+}
+
+type databaseErrorCode uint8
+
+// Error codes exposed for each error a database can encounter on load. These codes are consumed by Capella so must remain stable.
+const (
+	DatabaseBucketConnectionError      databaseErrorCode = 1
+	DatabaseInvalidDatastore           databaseErrorCode = 2
+	DatabaseInitSyncInfoError          databaseErrorCode = 3
+	DatabaseInitialisationIndexError   databaseErrorCode = 4
+	DatabaseCreateDatabaseContextError databaseErrorCode = 5
+	DatabaseSGRClusterError            databaseErrorCode = 6
+	DatabaseCreateReplicationError     databaseErrorCode = 7
+)
+
+func NewDatabaseError(code databaseErrorCode) *DatabaseError {
+	return &DatabaseError{
+		ErrMsg: DatabaseErrorMap[code],
+		Code:   code,
+	}
+}

--- a/rest/handler_config_database.go
+++ b/rest/handler_config_database.go
@@ -87,7 +87,7 @@ func (h *handler) mutateDbConfig(mutator func(*DbConfig) error) error {
 	defer h.server.lock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false); err != nil {
+	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
 		return err
 	}
 	h.setEtag(updatedDbConfig.Version)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -936,3 +936,101 @@ func TestHeapProfileValuesPopulated(t *testing.T) {
 		})
 	}
 }
+
+func TestDatabaseStartupFailure(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("EE only test, requires heartbeater error")
+	}
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("LeakyBucketConfig not supported on CBS")
+	}
+
+	touchErr := errors.New("touch error")
+	rt := NewRestTester(t, &RestTesterConfig{
+		LeakyBucketConfig: &base.LeakyBucketConfig{
+			TouchCallback: func(key string) error {
+				if strings.Contains(key, "heartbeat_timeout") {
+					return touchErr
+				}
+				return nil
+			},
+		},
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	dbConfig := DatabaseConfig{
+		DbConfig: rt.NewDbConfig(),
+	}
+
+	// this call does use the leaky bucket
+	dbContext, err := rt.ServerContext().AddDatabaseFromConfigWithBucket(rt.Context(), t, dbConfig, rt.Bucket())
+	require.ErrorIs(t, err, touchErr)
+	require.Nil(t, dbContext)
+	require.Equal(t, "Offline", rt.GetDBState())
+}
+
+func TestDatabaseCollectionDeletedErrorState(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
+	rt := NewRestTesterMultipleCollections(t, nil, 3)
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+
+	dbConfig := rt.ServerContext().GetDatabaseConfig("db")
+	scopesConfig := GetCollectionsConfig(t, rt.TestBucket, 3)
+	dataStoreNames := GetDataStoreNamesFromScopesConfig(scopesConfig)
+	scope := dataStoreNames[0].ScopeName()
+
+	// remove datastore
+	b, err := base.AsGocbV2Bucket(rt.GetDatabase().Bucket)
+	require.NoError(t, err)
+	dsList, err := b.ListDataStores()
+	require.NoError(t, err)
+	require.NoError(t, b.DropDataStore(dsList[0]))
+
+	// reload db
+	err = rt.ServerContext().reloadDatabaseWithConfigLoadFromBucket(base.NewNonCancelCtx(), dbConfig.DatabaseConfig)
+	require.Error(t, err)
+
+	allDbs := rt.ServerContext().allDatabaseSummaries()
+	require.Len(t, allDbs, 1)
+	invalDb := allDbs[0]
+	require.NotNil(t, invalDb.DatabaseError)
+	assert.Equal(t, db.RunStateString[db.DBOffline], invalDb.State)
+	assert.Equal(t, invalDb.DatabaseError.ErrMsg, DatabaseErrorMap[DatabaseInvalidDatastore])
+
+	// fix db config
+	deletedCollection := dsList[0].CollectionName()
+	delete(scopesConfig[scope].Collections, deletedCollection)
+	dbConfig.Scopes = scopesConfig
+	resp := rt.CreateDatabase("db", dbConfig.DbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	allDbs = rt.ServerContext().allDatabaseSummaries()
+	require.Len(t, allDbs, 1)
+	invalDb = allDbs[0]
+	require.Nil(t, invalDb.DatabaseError)
+	assert.Equal(t, db.RunStateString[db.DBOnline], invalDb.State)
+
+	// add back the datastore
+	b, err = base.AsGocbV2Bucket(rt.GetDatabase().Bucket)
+	require.NoError(t, err)
+	err = b.CreateDataStore(ctx, dsList[0])
+	require.NoError(t, err)
+
+	// try creating db with bad collections config ensure it fails and isn't shown on all dbs
+	scopesConfig[scope] = ScopeConfig{
+		Collections: map[string]*CollectionConfig{
+			"badCollection": {},
+		},
+	}
+	dbConfig.Scopes = scopesConfig
+	dbConfig.Name = "db2"
+	resp = rt.CreateDatabase("db2", dbConfig.DbConfig)
+	RequireStatus(t, resp, http.StatusForbidden)
+
+	allDbs = rt.ServerContext().allDatabaseSummaries()
+	require.Len(t, allDbs, 1)
+}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2820,3 +2820,10 @@ func RequireGocbDCPResync(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server since rosmar has no support for DCP resync")
 	}
 }
+
+// reloadDatabaseWithConfigLoadFromBucket forces reload of db as if it was being picked up from the bucket
+func (sc *ServerContext) reloadDatabaseWithConfigLoadFromBucket(nonContextStruct base.NonCancellableContext, config DatabaseConfig) error {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+	return sc._reloadDatabaseWithConfig(nonContextStruct.Ctx, config, true, true)
+}


### PR DESCRIPTION
CBG-4393

backports #7358

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2949/
