### PR TITLE
CBG-4511: observability errors for online process

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -137,6 +137,7 @@ type DatabaseContext struct {
 	CORS                         *auth.CORSConfig               // CORS configuration
 	EnableMou                    bool                           // Write _mou xattr when performing metadata-only update.  Set based on bucket capability on connect
 	WasInitializedSynchronously  bool                           // true if the database was initialized synchronously
+	DatabaseStartupError         *DatabaseError                 // Error that occurred during database online processes startup
 }
 
 type Scope struct {
@@ -2277,6 +2278,8 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	defer func() {
 		if returnedError != nil {
+			// indicate something has gine wrong in the online processes
+			db.DatabaseStartupError = NewDatabaseError(DatabaseOnlineProcessError)
 			// grab bucket lock so stopOnlineProcesses is not called at the same time as db.Close()
 			db.BucketLock.RLock()
 			defer db.BucketLock.RUnlock()

--- a/db/database.go
+++ b/db/database.go
@@ -2278,7 +2278,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	defer func() {
 		if returnedError != nil {
-			// indicate something has gine wrong in the online processes
+			// indicate something has gone wrong in the online processes
 			db.DatabaseStartupError = NewDatabaseError(DatabaseOnlineProcessError)
 			// grab bucket lock so stopOnlineProcesses is not called at the same time as db.Close()
 			db.BucketLock.RLock()

--- a/db/database_error.go
+++ b/db/database_error.go
@@ -18,7 +18,7 @@ var DatabaseErrorMap = map[databaseErrorCode]string{
 	DatabaseBucketConnectionError:      "Error connecting to bucket",
 	DatabaseInvalidDatastore:           "Collection(s) not available",
 	DatabaseInitSyncInfoError:          "Error initialising sync info",
-	DatabaseInitialisationIndexError:   "Error initialising database indexes",
+	DatabaseInitializationIndexError:   "Error initialising database indexes",
 	DatabaseCreateDatabaseContextError: "Error creating database context",
 	DatabaseSGRClusterError:            "Error with fetching SGR cluster definition",
 	DatabaseCreateReplicationError:     "Error creating replication during database init",
@@ -32,7 +32,7 @@ const (
 	DatabaseBucketConnectionError      databaseErrorCode = 1
 	DatabaseInvalidDatastore           databaseErrorCode = 2
 	DatabaseInitSyncInfoError          databaseErrorCode = 3
-	DatabaseInitialisationIndexError   databaseErrorCode = 4
+	DatabaseInitializationIndexError   databaseErrorCode = 4
 	DatabaseCreateDatabaseContextError databaseErrorCode = 5
 	DatabaseSGRClusterError            databaseErrorCode = 6
 	DatabaseCreateReplicationError     databaseErrorCode = 7

--- a/db/database_error.go
+++ b/db/database_error.go
@@ -6,7 +6,7 @@
 //  software will be governed by the Apache License, Version 2.0, included in
 //  the file licenses/APL2.txt.
 
-package rest
+package db
 
 // DatabaseError denotes an error that occurred during database startup
 type DatabaseError struct {
@@ -22,6 +22,7 @@ var DatabaseErrorMap = map[databaseErrorCode]string{
 	DatabaseCreateDatabaseContextError: "Error creating database context",
 	DatabaseSGRClusterError:            "Error with fetching SGR cluster definition",
 	DatabaseCreateReplicationError:     "Error creating replication during database init",
+	DatabaseOnlineProcessError:         "Error attempting to start online process",
 }
 
 type databaseErrorCode uint8
@@ -35,6 +36,7 @@ const (
 	DatabaseCreateDatabaseContextError databaseErrorCode = 5
 	DatabaseSGRClusterError            databaseErrorCode = 6
 	DatabaseCreateReplicationError     databaseErrorCode = 7
+	DatabaseOnlineProcessError         databaseErrorCode = 8
 )
 
 func NewDatabaseError(code databaseErrorCode) *DatabaseError {

--- a/db/database_error.go
+++ b/db/database_error.go
@@ -17,8 +17,8 @@ type DatabaseError struct {
 var DatabaseErrorMap = map[databaseErrorCode]string{
 	DatabaseBucketConnectionError:      "Error connecting to bucket",
 	DatabaseInvalidDatastore:           "Collection(s) not available",
-	DatabaseInitSyncInfoError:          "Error initialising sync info",
-	DatabaseInitializationIndexError:   "Error initialising database indexes",
+	DatabaseInitSyncInfoError:          "Error initializing sync info",
+	DatabaseInitializationIndexError:   "Error initializing database indexes",
 	DatabaseCreateDatabaseContextError: "Error creating database context",
 	DatabaseSGRClusterError:            "Error with fetching SGR cluster definition",
 	DatabaseCreateReplicationError:     "Error creating replication during database init",

--- a/rest/api.go
+++ b/rest/api.go
@@ -448,12 +448,12 @@ type DatabaseRoot struct {
 }
 
 type DbSummary struct {
-	DBName               string         `json:"db_name"`
-	Bucket               string         `json:"bucket"`
-	State                string         `json:"state"`
-	InitializationActive bool           `json:"init_in_progress,omitempty"`
-	RequireResync        bool           `json:"require_resync,omitempty"`
-	DatabaseError        *DatabaseError `json:"database_error,omitempty"`
+	DBName               string            `json:"db_name"`
+	Bucket               string            `json:"bucket"`
+	State                string            `json:"state"`
+	InitializationActive bool              `json:"init_in_progress,omitempty"`
+	RequireResync        bool              `json:"require_resync,omitempty"`
+	DatabaseError        *db.DatabaseError `json:"database_error,omitempty"`
 }
 
 func (h *handler) handleGetDB() error {

--- a/rest/config.go
+++ b/rest/config.go
@@ -308,7 +308,7 @@ type invalidConfigInfo struct {
 	configBucketName    string
 	persistedBucketName string
 	collectionConflicts bool
-	databaseError       *DatabaseError
+	databaseError       *db.DatabaseError
 }
 
 type invalidDatabaseConfigs struct {
@@ -351,7 +351,7 @@ func (sc *ScopesConfig) HasNewCollection(previousCollectionMap map[string]struct
 
 // addInvalidDatabase adds a db to invalid dbconfig map if it doesn't exist in there yet and will log for it at warning level
 // if the db already exists there we will calculate if we need to log again according to the config update interval
-func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname string, cnf DatabaseConfig, bucket string, databaseErr *DatabaseError) {
+func (d *invalidDatabaseConfigs) addInvalidDatabase(ctx context.Context, dbname string, cnf DatabaseConfig, bucket string, databaseErr *db.DatabaseError) {
 	d.m.Lock()
 	defer d.m.Unlock()
 	if d.dbNames[dbname] == nil {
@@ -1839,7 +1839,7 @@ func (sc *ServerContext) handleInvalidDatabaseConfig(ctx context.Context, bucket
 	sc._handleInvalidDatabaseConfig(ctx, bucket, cnf, nil)
 }
 
-func (sc *ServerContext) _handleInvalidDatabaseConfig(ctx context.Context, bucket string, cnf DatabaseConfig, databaseErr *DatabaseError) {
+func (sc *ServerContext) _handleInvalidDatabaseConfig(ctx context.Context, bucket string, cnf DatabaseConfig, databaseErr *db.DatabaseError) {
 	// track corrupt database context
 	sc.invalidDatabaseConfigTracking.addInvalidDatabase(ctx, cnf.Name, cnf, bucket, databaseErr)
 	// don't load config + remove from server context (apart from corrupt database map)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -774,7 +774,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config)
 		if err != nil {
 			if options.loadFromBucket {
-				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitialisationIndexError))
+				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitializationIndexError))
 			}
 			return nil, err
 		}
@@ -968,7 +968,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			initError := <-dbInitDoneChan
 			if initError != nil {
 				// report error in building/creating indexes
-				dbcontext.DatabaseStartupError = db.NewDatabaseError(db.DatabaseInitialisationIndexError)
+				dbcontext.DatabaseStartupError = db.NewDatabaseError(db.DatabaseInitializationIndexError)
 				atomic.StoreUint32(&dbcontext.State, db.DBOffline)
 				_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(ctx, dbName, "offline", dbLoadedStateChangeMsg, &sc.Config.API.AdminInterface)
 				return nil, initError
@@ -1003,7 +1003,7 @@ func (sc *ServerContext) asyncDatabaseOnline(nonCancelCtx base.NonCancellableCon
 		initError := <-doneChan
 		if initError != nil {
 			base.WarnfCtx(ctx, "Async database init returned error: %v", initError)
-			dbc.DatabaseStartupError = db.NewDatabaseError(db.DatabaseInitialisationIndexError)
+			dbc.DatabaseStartupError = db.NewDatabaseError(db.DatabaseInitializationIndexError)
 			atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOffline)
 			return
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -412,9 +412,10 @@ func (sc *ServerContext) allDatabaseSummaries() []DbSummary {
 	for name, dbctx := range sc.databases_ {
 		state := db.RunStateString[atomic.LoadUint32(&dbctx.State)]
 		summary := DbSummary{
-			DBName: name,
-			Bucket: dbctx.Bucket.GetName(),
-			State:  state,
+			DBName:        name,
+			Bucket:        dbctx.Bucket.GetName(),
+			State:         state,
+			DatabaseError: dbctx.DatabaseStartupError,
 		}
 		if state == db.RunStateString[db.DBOffline] {
 			if len(dbctx.RequireResync.ScopeAndCollectionNames()) > 0 {
@@ -671,7 +672,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 	if err != nil {
 		if options.loadFromBucket {
-			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseBucketConnectionError))
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseBucketConnectionError))
 		}
 		return nil, err
 	}
@@ -700,7 +701,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				dataStore, err := base.GetAndWaitUntilDataStoreReady(ctx, bucket, scName, options.failFast)
 				if err != nil {
 					if options.loadFromBucket {
-						sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInvalidDatastore))
+						sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInvalidDatastore))
 					}
 					return nil, fmt.Errorf("error attempting to create/update database: %w", err)
 				}
@@ -716,7 +717,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 				resyncRequired, err := base.InitSyncInfo(dataStore, config.MetadataID)
 				if err != nil {
 					if options.loadFromBucket {
-						sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInitSyncInfoError))
+						sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitSyncInfoError))
 					}
 					return nil, err
 				}
@@ -735,7 +736,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 			resyncRequired, err := base.InitSyncInfo(ds, config.MetadataID)
 			if err != nil {
 				if options.loadFromBucket {
-					sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInitSyncInfoError))
+					sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitSyncInfoError))
 				}
 				return nil, err
 			}
@@ -773,7 +774,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config)
 		if err != nil {
 			if options.loadFromBucket {
-				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInitialisationIndexError))
+				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitialisationIndexError))
 			}
 			return nil, err
 		}
@@ -842,7 +843,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	err = validateMetadataStore(ctx, contextOptions.MetadataStore)
 	if err != nil {
 		if options.loadFromBucket {
-			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseInvalidDatastore))
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInvalidDatastore))
 		}
 		return nil, err
 	}
@@ -859,7 +860,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	dbcontext, err = db.NewDatabaseContext(ctx, dbName, bucket, autoImport, contextOptions)
 	if err != nil {
 		if options.loadFromBucket {
-			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseCreateDatabaseContextError))
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseCreateDatabaseContextError))
 		}
 		return nil, err
 	}
@@ -906,7 +907,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	cfgReplications, err := dbcontext.SGReplicateMgr.GetReplications()
 	if err != nil {
 		if options.loadFromBucket {
-			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseSGRClusterError))
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseSGRClusterError))
 		}
 		return nil, err
 	}
@@ -922,7 +923,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	replicationErr := dbcontext.SGReplicateMgr.PutReplications(ctx, newReplications)
 	if replicationErr != nil {
 		if options.loadFromBucket {
-			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, NewDatabaseError(DatabaseCreateReplicationError))
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseCreateReplicationError))
 		}
 		return nil, replicationErr
 	}
@@ -947,8 +948,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		atomic.StoreUint32(&dbcontext.State, db.DBStarting)
 	}
 
-	// TODO: Errors for online processes should be handled on dbcontext as its been loaded into server context below (CBG-4511)
-
 	// Register it so HTTP handlers can find it:
 	sc.databases_[dbcontext.Name] = dbcontext
 	sc.dbConfigs[dbcontext.Name] = &RuntimeDatabaseConfig{DatabaseConfig: config}
@@ -968,6 +967,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		if dbInitDoneChan != nil {
 			initError := <-dbInitDoneChan
 			if initError != nil {
+				// report error in building/creating indexes
+				dbcontext.DatabaseStartupError = db.NewDatabaseError(db.DatabaseInitialisationIndexError)
 				atomic.StoreUint32(&dbcontext.State, db.DBOffline)
 				_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(ctx, dbName, "offline", dbLoadedStateChangeMsg, &sc.Config.API.AdminInterface)
 				return nil, initError
@@ -1002,6 +1003,7 @@ func (sc *ServerContext) asyncDatabaseOnline(nonCancelCtx base.NonCancellableCon
 		initError := <-doneChan
 		if initError != nil {
 			base.WarnfCtx(ctx, "Async database init returned error: %v", initError)
+			dbc.DatabaseStartupError = db.NewDatabaseError(db.DatabaseInitialisationIndexError)
 			atomic.CompareAndSwapUint32(&dbc.State, db.DBStarting, db.DBOffline)
 			return
 		}


### PR DESCRIPTION
CBG-4511

- Add database error type to dbcontext
- Move databse error file to db package for dependency reasons (changes include change to db package file for online processes function) 
- Generic error code and message for failure in online processes. 
- Extend existing test for this functionality
- Have error on done chan for database init bubble up a Index init error

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2950/
