### PR TITLE
CBG-3838 fix TestAttachmentDeleteOnExpiry flake

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2222,8 +2222,12 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AutoImport = base.BoolPtr(base.TestUseXattrs())
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	dataStore := rt.GetSingleDataStore()
 

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
@@ -2227,25 +2228,29 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 	dataStore := rt.GetSingleDataStore()
 
 	// Create doc with attachment and expiry
-	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}, "_exp": 2}`)
+	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}, "_exp": 1}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// Wait for document to be expired - this bucket get should also trigger the expiry purge interval
-	err := rt.WaitForCondition(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		_, _, err := dataStore.GetRaw(t.Name())
-		return base.IsDocNotFoundError(err)
-	})
-	assert.NoError(t, err)
+		assert.True(c, base.IsDocNotFoundError(err), "expected err %v to be doc not found", err)
+	}, time.Second*10, time.Millisecond*10)
 
-	// Trigger OnDemand Import for that doc to trigger tombstone
-	resp = rt.SendAdminRequest("GET", "/{{.keyspace}}/"+t.Name(), "")
-	RequireStatus(t, resp, http.StatusNotFound)
-
+	if base.TestUseXattrs() {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+		}, time.Second*10, time.Millisecond*5)
+	} else {
+		// Trigger OnDemand Import for that doc to trigger tombstone
+		resp := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+t.Name(), "")
+		RequireStatus(t, resp, http.StatusNotFound)
+	}
 	att2Key := db.MakeAttachmentKey(db.AttVersion2, t.Name(), "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=")
 
 	// With xattrs doc will be imported and will be captured as tombstone and therefore purge attachments
 	// Otherwise attachment will not be purged
-	_, _, err = dataStore.GetRaw(att2Key)
+	_, _, err := dataStore.GetRaw(att2Key)
 	if base.TestUseXattrs() {
 		base.RequireDocNotFoundError(t, err)
 	} else {


### PR DESCRIPTION
CBG-3838 make sure document gets fully imported before next step occurs.

The rare race condition for this test occurred when a document gets imported by import listener and then the on demand import got cancelled, but before the attachments are deleted. Attachments are deleted https://github.com/couchbase/sync_gateway/blob/d764940a42e18a22831c2ebb360b7e8b7be37d61/db/crud.go#L2220 but document is updated https://github.com/couchbase/sync_gateway/blob/d764940a42e18a22831c2ebb360b7e8b7be37d61/db/crud.go#L2121
