### PR TITLE
CBG-4519 wait for database online to prevent test panic

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1956,7 +1956,7 @@ func TestDBOnlineSingle(t *testing.T) {
 	rt.SendAdminRequest("POST", "/db/_online", "")
 	rest.RequireStatus(t, response, 200)
 
-	time.Sleep(500 * time.Millisecond)
+	rt.WaitForDBOnline()
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1038,8 +1038,7 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 	rest.RequireStatus(t, response, http.StatusOK)
 
 	// wait for db to be offline
-	err := rt.WaitForDBState(db.RunStateString[db.DBOffline])
-	require.NoError(t, err)
+	rt.WaitForDBState(db.RunStateString[db.DBOffline])
 
 	// start a resync run
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
@@ -1437,9 +1436,6 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 	resp := rt.CreateDatabase("db1", dbConfig)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
-	// wait for db to come online
-	require.NoError(t, rt.WaitForDBOnline())
-
 	// grab the persisted db config from the bucket
 	databaseConfig := rest.DatabaseConfig{}
 	_, err := rt.ServerContext().BootstrapContext.GetConfig(rt.Context(), rt.CustomTestBucket.GetName(), rt.ServerContext().Config.Bootstrap.ConfigGroupID, "db1", &databaseConfig)
@@ -1573,7 +1569,7 @@ func TestMismatchedBucketNameOnDbConfigUpdate(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// wait for db to come online
-	require.NoError(t, rt.WaitForDBOnline())
+	rt.WaitForDBOnline()
 	badName := tb1.GetName()
 	dbConfig.Bucket = &badName
 
@@ -2007,10 +2003,7 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	// They may not have been processed at this point
 	wg.Wait()
 
-	// Wait for DB to come online (retry loop)
-	errDbOnline := rt.WaitForDBOnline()
-	assert.NoError(t, errDbOnline, "Error waiting for db to come online")
-
+	rt.WaitForDBOnline()
 }
 
 // Test bring DB online with delay of 1 second
@@ -2046,10 +2039,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 	// Wait until after the 1 second delay, since the online request explicitly asked for a delay
 	time.Sleep(1500 * time.Millisecond)
 
-	// Wait for DB to come online (retry loop)
-	errDbOnline := rt.WaitForDBOnline()
-	assert.NoError(t, errDbOnline, "Error waiting for db to come online")
-
+	rt.WaitForDBOnline()
 }
 
 // Test bring DB online with delay of 2 seconds
@@ -2068,7 +2058,6 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 		defer rt.Close()
 
 		var response *rest.TestResponse
-		var errDBState error
 
 		log.Printf("Taking DB offline")
 		require.Equal(t, "Online", rt.GetDBState())
@@ -2086,16 +2075,12 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 		response = rt.SendAdminRequest("POST", "/db/_online", "")
 		rest.RequireStatus(t, response, 200)
 
-		// Wait for DB to come online (retry loop)
-		errDBState = rt.WaitForDBOnline()
-		assert.NoError(t, errDBState)
+		rt.WaitForDBOnline()
 
 		// Wait until after the 1 second delay, since the online request explicitly asked for a delay
 		time.Sleep(1500 * time.Millisecond)
 
-		// Wait for DB to come online (retry loop)
-		errDBState = rt.WaitForDBOnline()
-		assert.NoError(t, errDBState)
+		rt.WaitForDBOnline()
 	}, "CBG-1513: panicked when the walrus bucket was closed and still used")
 }
 

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -246,7 +246,7 @@ func TestRequireResync(t *testing.T) {
 	// The online call is async, but subsequent get to status should remain offline
 	onlineResponse := rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
 	rest.RequireStatus(t, onlineResponse, http.StatusOK)
-	require.NoError(t, rt.WaitForDatabaseState(db2Name, db.DBOffline))
+	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOffline])
 
 	needsResync := []string{scope + "." + collection1}
 	rest.WaitAndAssertCondition(t, func() bool {
@@ -276,7 +276,7 @@ func TestRequireResync(t *testing.T) {
 	resyncPayload, marshalErr := base.JSONMarshal(resyncCollections)
 	require.NoError(t, marshalErr)
 
-	require.NoError(t, rt.WaitForDatabaseState(db2Name, db.DBOffline))
+	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOffline])
 
 	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", string(resyncPayload))
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -310,7 +310,7 @@ func TestRequireResync(t *testing.T) {
 	// Attempt online again, should now succeed
 	onlineResponse = rt.SendAdminRequest("POST", "/"+db2Name+"/_online", "")
 	rest.RequireStatus(t, onlineResponse, http.StatusOK)
-	require.NoError(t, rt.WaitForDatabaseState(db2Name, db.DBOnline))
+	rt.WaitForDatabaseState(db2Name, db.RunStateString[db.DBOnline])
 
 	resp = rt.SendAdminRequest("GET", "/"+db2Name+"/", "")
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -40,7 +40,7 @@ func TestResyncRollback(t *testing.T) {
 
 	response := rt.SendAdminRequest("POST", "/{{.db}}/_offline", "")
 	rest.RequireStatus(t, response, http.StatusOK)
-	require.NoError(t, rt.WaitForDBState(db.RunStateString[db.DBOffline]))
+	rt.WaitForDBState(db.RunStateString[db.DBOffline])
 
 	// we need to wait for the resync to start and not finish so we get a partial completion
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_resync", "")

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -851,9 +851,6 @@ func TestCollectionStats(t *testing.T) {
 	rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
 	defer rt.Close()
 
-	// Wait for the DB to be ready before attempting to get initial error count
-	require.NoError(t, rt.WaitForDBOnline())
-
 	collection1Stats, err := rt.GetDatabase().DbStats.CollectionStat(scope1Name, collection1Name)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), collection1Stats.SyncFunctionCount.Value())

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1838,8 +1838,6 @@ func TestMissingNoRev(t *testing.T) {
 	require.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
-	require.NoError(t, rt.WaitForDBOnline())
-
 	// Create 5 docs
 	for i := 0; i < 5; i++ {
 		docID := fmt.Sprintf("doc-%d", i)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -3481,7 +3481,7 @@ func TestResyncAllTombstones(t *testing.T) {
 
 			resp := rt.SendAdminRequest(http.MethodPost, fmt.Sprintf("/%s/_offline", rt.GetDatabase().Name), "")
 			rest.RequireStatus(t, resp, http.StatusOK)
-			require.NoError(t, rt.WaitForDBState(db.RunStateString[db.DBOffline]))
+			rt.WaitForDBState(db.RunStateString[db.DBOffline])
 
 			resp = rt.SendAdminRequest(http.MethodPost, fmt.Sprintf("/%s/_resync?action=start", rt.GetDatabase().Name), "")
 			rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2960,7 +2960,7 @@ func TestInvalidDbConfigNoLongerPresentInBucket(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// wait for db to come online
-	require.NoError(t, rt.WaitForDBOnline())
+	rt.WaitForDBOnline()
 
 	// grab the persisted db config from the bucket
 	databaseConfig := DatabaseConfig{}

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -243,14 +243,12 @@ func TestPersistentDbConfigAsyncOnlineWithInvalidConfig(t *testing.T) {
 
 	// simulate regular startup
 	atomic.StoreUint32(&rt.GetDatabase().State, db.DBStarting)
-	err := rt.WaitForDBState(db.RunStateString[db.DBStarting])
-	require.NoError(t, err)
+	rt.WaitForDBState(db.RunStateString[db.DBStarting])
 
 	// Can't trigger error case from REST API - requires incompatible or difficult to test configurations (persistent config, offline, active async init)
 	rt.ServerContext().asyncDatabaseOnline(base.NewNonCancelCtx(), rt.GetDatabase(), nil, rt.ServerContext().GetDbVersion("db"))
 
 	// Error should cause db to stay offline - originally a bug caused it to go offline then back to online.
 	// Since we're not running asyncDatabaseOnline inside a goroutine, we don't see the Starting->Offline->Online transition, only the final state
-	err = rt.WaitForDBState(db.RunStateString[db.DBOffline])
-	require.NoError(t, err)
+	rt.WaitForDBState(db.RunStateString[db.DBOffline])
 }

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -982,7 +982,7 @@ func TestDatabaseStartupFailure(t *testing.T) {
 	// assert that you can attempt again to bring db back online again after failure
 	resp := rt.SendAdminRequest(http.MethodPost, "/"+invalDb.Bucket+"/_online", "")
 	RequireStatus(t, resp, http.StatusOK)
-	require.NoError(t, rt.WaitForDBOnline())
+	rt.WaitForDBOnline()
 }
 
 func TestDatabaseCollectionDeletedErrorState(t *testing.T) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -982,6 +982,7 @@ func TestDatabaseStartupFailure(t *testing.T) {
 	// assert that you can attempt again to bring db back online again after failure
 	resp := rt.SendAdminRequest(http.MethodPost, "/"+invalDb.Bucket+"/_online", "")
 	RequireStatus(t, resp, http.StatusOK)
+	require.NoError(t, rt.WaitForDBOnline())
 }
 
 func TestDatabaseCollectionDeletedErrorState(t *testing.T) {

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -304,7 +304,7 @@ func TestSyncFunctionErrorLogging(t *testing.T) {
 	defer rt.Close()
 
 	// Wait for the DB to be ready before attempting to get initial error count
-	assert.NoError(t, rt.WaitForDBOnline())
+	rt.WaitForDBOnline()
 
 	numErrors, err := strconv.Atoi(base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().ErrorCount.String())
 	assert.NoError(t, err)
@@ -345,7 +345,7 @@ func TestSyncFunctionException(t *testing.T) {
 	defer rt.Close()
 
 	// Wait for the DB to be ready before attempting to get initial error count
-	assert.NoError(t, rt.WaitForDBOnline())
+	rt.WaitForDBOnline()
 
 	numDBSyncExceptionsStart := rt.GetDatabase().DbStats.Database().SyncFunctionExceptionCount.Value()
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1053,38 +1053,21 @@ func (rt *RestTester) GetDBState() string {
 	return body["state"].(string)
 }
 
-func (rt *RestTester) WaitForDBOnline() (err error) {
-	return rt.WaitForDBState("Online")
+// WaitForDBOnline waits for the database to be in the Online state.
+func (rt *RestTester) WaitForDBOnline() {
+	rt.WaitForDBState("Online")
 }
 
-func (rt *RestTester) WaitForDBState(stateWant string) (err error) {
-	var stateCurr string
-	maxTries := 20
-
-	for i := 0; i < maxTries; i++ {
-		if stateCurr = rt.GetDBState(); stateCurr == stateWant {
-			return nil
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-	return fmt.Errorf("given up waiting for DB state, want: %s, current: %s, attempts: %d", stateWant, stateCurr, maxTries)
+// WaitForDBState waits for the database to be in the specified state.
+func (rt *RestTester) WaitForDBState(stateWant string) {
+	rt.WaitForDatabaseState(rt.GetDatabase().Name, stateWant)
 }
 
-func (rt *RestTester) WaitForDatabaseState(dbName string, targetState uint32) error {
-	var stateCurr string
-	maxTries := 50
-	for i := 0; i < maxTries; i++ {
-		dbRootResponse := DatabaseRoot{}
-		resp := rt.SendAdminRequest("GET", "/"+dbName+"/", "")
-		RequireStatus(rt.TB(), resp, 200)
-		require.NoError(rt.TB(), base.JSONUnmarshal(resp.Body.Bytes(), &dbRootResponse))
-		stateCurr = dbRootResponse.State
-		if stateCurr == db.RunStateString[targetState] {
-			return nil
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	return fmt.Errorf("given up waiting for DB state, want: %s, current: %s, attempts: %d", db.RunStateString[targetState], stateCurr, maxTries)
+// WaitForDatabaseState waits for the specified database to be in the specified state.
+func (rt *RestTester) WaitForDatabaseState(dbName string, targetState string) {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		assert.Equal(c, targetState, rt.GetDatabaseRoot(dbName).State)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func (rt *RestTester) SendAdminRequestWithHeaders(method, resource string, body string, headers map[string]string) *TestResponse {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1053,17 +1053,17 @@ func (rt *RestTester) GetDBState() string {
 	return body["state"].(string)
 }
 
-// WaitForDBOnline waits for the database to be in the Online state.
+// WaitForDBOnline waits for the database to be in the Online state. Fail the test harness if the state is not reached within the timeout.
 func (rt *RestTester) WaitForDBOnline() {
 	rt.WaitForDBState("Online")
 }
 
-// WaitForDBState waits for the database to be in the specified state.
+// WaitForDBState waits for the database to be in the specified state. Fails the test harness if the state is not reached within the timeout.
 func (rt *RestTester) WaitForDBState(stateWant string) {
 	rt.WaitForDatabaseState(rt.GetDatabase().Name, stateWant)
 }
 
-// WaitForDatabaseState waits for the specified database to be in the specified state.
+// WaitForDatabaseState waits for the specified database to be in the specified state. Fails the test harness if the state is not reached within the timeout.
 func (rt *RestTester) WaitForDatabaseState(dbName string, targetState string) {
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		assert.Equal(c, targetState, rt.GetDatabaseRoot(dbName).State)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -115,6 +115,7 @@ func (rt *RestTester) DeleteDocRev(docID, revID string) {
 	rt.DeleteDoc(docID, DocVersion{RevID: revID})
 }
 
+// GetDatabaseRoot returns the DatabaseRoot for a given dtabase. This will fail the test harness if the database is not available.
 func (rt *RestTester) GetDatabaseRoot(dbname string) DatabaseRoot {
 	var dbroot DatabaseRoot
 	resp := rt.SendAdminRequest("GET", "/"+dbname+"/", "")


### PR DESCRIPTION
CBG-4519 wait for database online to prevent test panic

This started in 5088a15ac09bc8ad0eae3e0f1402fd101433b1d6.

- The first commit is the only one required to fix the test, and I could scale back this PR to only include that one. 
- More changes were added to refactor `WaitForDBOnline` to not require checking for errors, and just fail the test harness.

This is reproducible with -race and -cover and running this single test many times.

The bug occurs because the reloading the configuration is happening at the same time as `ServerContext.Close` is happening. `ServerContext.Close` is only called in test code, so this can't happen in prod code.

Looked for other places where /db/_online is called without waiting, but I didn't spot any. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2952/
