### PR TITLE
Don't cancel builds on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'release/')}}
+  cancel-in-progress: ${{ !contains(github.ref, 'release/') && !contains(github.ref, 'main') }}
 
 jobs:
   build:


### PR DESCRIPTION
Cancelled jobs should up as red, and this is confusing when judging whether builds pass or fail. Don't collapse multiple commits merged in short order into one build, since the earlier commit CI will show up as red.
