### PR TITLE
CBG-4520 wait for stat to avoid test flake

### DIFF
--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -217,7 +217,8 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 		bodyTextExpected = fmt.Sprintf(`{"greetings":[{"howdy":"bob"}],"_attachments":{"%s":{"revpos":1,"length":%d,"stub":true,"digest":"%s"}}}`, attachmentName, len(attachmentData), attachmentDigest)
 		require.JSONEq(t, bodyTextExpected, string(data))
 
-		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value())
+		// use RequireWaitForStat since rev is sent slightly before the stats are incremented
+		base.RequireWaitForStat(t, btc.rt.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value, 2)
 		assert.Equal(t, int64(0), btc.rt.GetDatabase().DbStats.CBLReplicationPull().RevErrorCount.Value())
 		assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullCount.Value())
 		assert.Equal(t, int64(len(attachmentData)), btc.rt.GetDatabase().DbStats.CBLReplicationPull().AttachmentPullBytes.Value())


### PR DESCRIPTION
CBG-4520 wait for stat to avoid test flake

The stat gets incremented https://github.com/couchbase/sync_gateway/blob/dab84da353f3189be5f2ce2025a568e08c5dd8ef/db/blip_handler.go#L962 which is in the defer after the rev is sent. In an unlucky race, the rev will be sent before the stat is incremented.

