### PR TITLE
Require 3 collections to run adminapitest

### DIFF
--- a/rest/adminapitest/main_test.go
+++ b/rest/adminapitest/main_test.go
@@ -20,6 +20,6 @@ import (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 3}
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }


### PR DESCRIPTION
I don't know why this was missed when running 44d6aa5b208f18ff9e247d85eab83a9755406a16 but it obviously was https://jenkins.sgwdev.com/job/MasterIntegration/965/
