### PR TITLE
CBG-4517: [3.2.3 backport] pick up gocb fix for bucket names with . in 

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -972,3 +972,8 @@ func numFilesInDir(t *testing.T, dir string, recursive bool) int {
 	require.NoError(t, err)
 	return numFiles
 }
+
+// CreateTestBucketName will create a test bucket name using the test bucket prefix and the suffix you pass in
+func CreateTestBucketName(suffix string) string {
+	return fmt.Sprintf("%s%s", tbpBucketNamePrefix, suffix)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/couchbase/clog v0.1.0
 	github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd
 	github.com/couchbase/gocb/v2 v2.9.4-0.20250206113323-8ef6d9010511
-    github.com/couchbase/gocbcore/v10 v10.5.4-0.20250107135314-f4c4becdca29
+	github.com/couchbase/gocbcore/v10 v10.5.4-0.20250107135314-f4c4becdca29
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/couchbase/cbgt v1.3.10-0.20250128173458-04138cb9d33d
 	github.com/couchbase/clog v0.1.0
 	github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd
-	github.com/couchbase/gocb/v2 v2.9.1
-	github.com/couchbase/gocbcore/v10 v10.5.2
+	github.com/couchbase/gocb/v2 v2.9.4-0.20250206113323-8ef6d9010511
+    github.com/couchbase/gocbcore/v10 v10.5.4-0.20250107135314-f4c4becdca29
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,10 @@ github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd h1:ERQXaXuX1eix3
 github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd/go.mod h1:Dz8Keu17/4cjF7hvKYqOjH4pRXOh1CCnzsKlBOJaoJE=
 github.com/couchbase/go-couchbase v0.1.1 h1:ClFXELcKj/ojyoTYbsY34QUrrYCBi/1G749sXSCkdhk=
 github.com/couchbase/go-couchbase v0.1.1/go.mod h1:+/bddYDxXsf9qt0xpDUtRR47A2GjaXmGGAqQ/k3GJ8A=
-github.com/couchbase/gocb/v2 v2.9.1 h1:yB2ZhRLk782Y9sZlATaUwglZe9+2QpvFmItJXTX4stQ=
-github.com/couchbase/gocb/v2 v2.9.1/go.mod h1:TMAeK34yUdcASdV4mGcYuwtkAWckRBYN5uvMCEgPfXo=
-github.com/couchbase/gocbcore/v10 v10.5.2 h1:DHK042E1RfhPBR3b14CITl5XHRsLjH3hpERuwUc5UIg=
-github.com/couchbase/gocbcore/v10 v10.5.2/go.mod h1:rulbgUK70EuyRUiLQ0LhQAfSI/Rl+jWws8tTbHzvB6M=
+github.com/couchbase/gocb/v2 v2.9.4-0.20250206113323-8ef6d9010511 h1:5TNKEA0AgZcih7e3h26PmuIBRscsx+PLVmDnAOstxO8=
+github.com/couchbase/gocb/v2 v2.9.4-0.20250206113323-8ef6d9010511/go.mod h1:cYjNi8djFZ3plKNHzkDQ4URoEAdBsGJUAeLksL5LspA=
+github.com/couchbase/gocbcore/v10 v10.5.4-0.20250107135314-f4c4becdca29 h1:IWTk7tS7HnQFszIRv+b0SwpnBV3QjbP9HDiTvT6ksxI=
+github.com/couchbase/gocbcore/v10 v10.5.4-0.20250107135314-f4c4becdca29/go.mod h1:xtcM+sfxVB6p7ZPoFFH2t/PmZHV7+4HT+LTy9ZvMG2Y=
 github.com/couchbase/gocbcoreps v0.1.3 h1:fILaKGCjxFIeCgAUG8FGmRDSpdrRggohOMKEgO9CUpg=
 github.com/couchbase/gocbcoreps v0.1.3/go.mod h1:hBFpDNPnRno6HH5cRXExhqXYRmTsFJlFHQx7vztcXPk=
 github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUlhv9I2U=
@@ -74,8 +74,8 @@ github.com/couchbase/tools-common/utils v1.0.0 h1:6mWXqWWj7aM0Kp2LWpSKEu9pLAYm7i
 github.com/couchbase/tools-common/utils v1.0.0/go.mod h1:i6cN5Z5hB9vQRLxe2j1v6Nu8bv+pKl9BFXjbQUHSah8=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
-github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259 h1:2TXy68EGEzIMHOx9UvczR5ApVecwCfQZ0LjkmwMI6g4=
-github.com/couchbaselabs/gocaves/client v0.0.0-20230404095311-05e3ba4f0259/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
+github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8 h1:MQfvw4BiLTuyR69FuA5Kex+tXUeLkH+/ucJfVL1/hkM=
+github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8/go.mod h1:AVekAZwIY2stsJOMWLAS/0uA/+qdp7pjO8EHnl61QkY=
 github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDoZihsiwNigA=
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28 h1:lhGOw8rNG6RAadmmaJAF3PJ7MNt7rFuWG7BHCYMgnGE=

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -10,10 +10,12 @@ package rest
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -81,4 +83,49 @@ func TestDbConfigUpdatedAtField(t *testing.T) {
 	// assert that registry timestamps are as expected
 	assert.Equal(t, registry.CreatedAt.UnixNano(), registryCreated.UnixNano())
 	assert.Greater(t, registry.UpdatedAt.UnixNano(), registryUpdated.UnixNano())
+}
+
+func TestConfigToBucketPointName(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Need cbs bucket for this test")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTPResp, base.KeyHTTP)
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+	testBucketName := base.CreateTestBucketName(fmt.Sprintf(".%d", time.Now().Unix()))
+
+	// create db config to point to bucket with . in the name
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Bucket = base.StringPtr(testBucketName)
+	dbConfig.Username = base.TestClusterUsername()
+	dbConfig.Password = base.TestClusterPassword()
+	dbConfig.Scopes = nil
+
+	// create bucket with . in the name
+	v2Bucket, err := base.AsGocbV2Bucket(rt.TestBucket)
+	require.NoError(t, err)
+	cluster := v2Bucket.GetCluster()
+	settings := gocb.CreateBucketSettings{
+		BucketSettings: gocb.BucketSettings{
+			Name:       testBucketName,
+			RAMQuotaMB: uint64(256),
+			BucketType: gocb.CouchbaseBucketType,
+		},
+	}
+	require.NoError(t, v2Bucket.GetCluster().Buckets().CreateBucket(settings, nil))
+	// cleanup this bucket
+	defer func() {
+		require.NoError(t, v2Bucket.GetCluster().Buckets().DropBucket(testBucketName, nil))
+	}()
+	// wait till bucket is ready
+	bucket := cluster.Bucket(testBucketName)
+	require.NoError(t, bucket.WaitUntilReady(10*time.Second, nil))
+
+	// create db pointing to bucket with . in it
+	RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+
+	// assert that we can create a user (pre CBG-4512 access query fails)
+	resp := rt.SendAdminRequest(http.MethodPost, "/db1/_user/", `{"name":"user1", "password":"password", "admin_channels":["ABC"]}`)
+	RequireStatus(t, resp, http.StatusCreated)
 }


### PR DESCRIPTION
CBG-4517

Backports #7376

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2955/
