### PR TITLE
CBG-4465: [3.2.3 backport] Add Database Init and Online fatal error stats

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -88,6 +88,7 @@ const (
 	StatAddedVersion3dot2dot0     = "3.2.0"
 	StatAddedVersion3dot2dot1     = "3.2.1"
 	StatAddedVersion3dot2dot2     = "3.2.2"
+	StatAddedVersion3dot2dot3     = "3.2.3"
 	StatAddedVersion3dot3dot0     = "3.3.0"
 
 	StatDeprecatedVersionNotDeprecated = ""

--- a/base/stats.go
+++ b/base/stats.go
@@ -662,6 +662,11 @@ type DatabaseStats struct {
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
 	CacheFeedMapStats  *ExpVarMapWrapper `json:"cache_feed"`
 	ImportFeedMapStats *ExpVarMapWrapper `json:"import_feed"`
+
+	// The total number of errors that occurred that prevented the database from being initialized.
+	TotalInitFatalErrors *SgwIntStat `json:"total_init_fatal_errors"`
+	// The total number of errors that occurred that prevented the database from being brought online.
+	TotalOnlineFatalErrors *SgwIntStat `json:"total_online_fatal_errors"`
 }
 
 // This wrapper ensures that an expvar.Map type can be marshalled into JSON. The expvar.Map has no method to go direct to
@@ -1782,6 +1787,14 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.TotalInitFatalErrors, err = NewIntStat(SubsystemDatabaseKey, "total_init_fatal_errors", StatUnitNoUnits, TotalInitFatalErrorsDesc, StatAddedVersion3dot2dot3, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.TotalOnlineFatalErrors, err = NewIntStat(SubsystemDatabaseKey, "total_online_fatal_errors", StatUnitNoUnits, TotalOnlineFatalErrorsDesc, StatAddedVersion3dot2dot3, StatDeprecatedVersionNotDeprecated, StatStabilityVolatile, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
@@ -1830,6 +1843,8 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumPublicRestRequests)
 	prometheus.Unregister(d.DatabaseStats.TotalSyncTime)
 	prometheus.Unregister(d.DatabaseStats.PublicRestBytesRead)
+	prometheus.Unregister(d.DatabaseStats.TotalInitFatalErrors)
+	prometheus.Unregister(d.DatabaseStats.TotalOnlineFatalErrors)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -316,6 +316,9 @@ const (
 
 	NumIdleKvOpsDesc    = "The total number of idle kv operations."
 	NumIdleQueryOpsDesc = "The total number of idle query operations."
+
+	TotalInitFatalErrorsDesc   = "The total number of errors that occurred that prevented the database from being initialized."
+	TotalOnlineFatalErrorsDesc = "The total number of errors that occurred that prevented the database from being brought online."
 )
 
 // Delta Sync stats descriptions


### PR DESCRIPTION
CBG-4465

Backports #7369

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
