### PR TITLE
CBG-4533 track blip replication goroutines

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -78,7 +78,8 @@ type TestBucketPoolOptions struct {
 	UseDefaultScope         bool
 	RequireXDCR             bool // Test buckets will be performing XDCR, requires Server > 7 for integration test robustness
 	ParallelBucketInit      bool
-	NumCollectionsPerBucket int // setting this value in main_test.go will override the default
+	NumCollectionsPerBucket int      // setting this value in main_test.go will override the default
+	TeardownFuncs           []func() // functions to be run after Main is completed but before standard teardown functions run
 }
 
 func NewTestBucketPool(ctx context.Context, bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TBPBucketInitFunc) *TestBucketPool {
@@ -666,7 +667,7 @@ func TestBucketPoolMain(ctx context.Context, m *testing.M, bucketReadierFunc TBP
 	teardownFuncs = append(teardownFuncs, SetUpGlobalTestLogging(ctx))
 	teardownFuncs = append(teardownFuncs, SetUpGlobalTestProfiling(m))
 	teardownFuncs = append(teardownFuncs, SetUpGlobalTestMemoryWatermark(m, options.MemWatermarkThresholdMB))
-
+	teardownFuncs = append(teardownFuncs, options.TeardownFuncs...)
 	SkipPrometheusStatsRegistration = true
 
 	GTestBucketPool = NewTestBucketPoolWithOptions(ctx, bucketReadierFunc, bucketInitFunc, options)

--- a/rest/adminapitest/main_test.go
+++ b/rest/adminapitest/main_test.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
 )
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 3}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/attachmentcompactiontest/main_test.go
+++ b/rest/attachmentcompactiontest/main_test.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
 )
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3165,6 +3165,7 @@ func TestBlipDatabaseClose(t *testing.T) {
 		const username = "alice"
 		rt.CreateUser(username, []string{"*"})
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: username})
+		defer btc.Close()
 		var blipContextClosed atomic.Bool
 		btcRunner.clients[btc.id].pullReplication.bt.blipContext.OnExitCallback = func() {
 			log.Printf("on exit callback invoked")
@@ -3214,6 +3215,7 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 		const username = "alice"
 		rt.CreateUser(username, []string{"*"})
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: username})
+		defer btc.Close()
 		var blipContextClosed atomic.Bool
 		btcRunner.clients[btc.id].pullReplication.bt.blipContext.OnExitCallback = func() {
 			blipContextClosed.Store(true)

--- a/rest/changestest/main_test.go
+++ b/rest/changestest/main_test.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
 )
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/functionsapitest/main_test.go
+++ b/rest/functionsapitest/main_test.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
 )
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 18192}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/importtest/main_test.go
+++ b/rest/importtest/main_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
 )
 
 func TestMain(m *testing.M) {
@@ -25,5 +25,5 @@ func TestMain(m *testing.M) {
 
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048, NumCollectionsPerBucket: 3}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/importuserxattrtest/main_test.go
+++ b/rest/importuserxattrtest/main_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
 )
 
 func TestMain(m *testing.M) {
@@ -26,5 +26,5 @@ func TestMain(m *testing.M) {
 
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +22,7 @@ import (
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 3}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }
 
 func TestConfigOverwritesLegacyFlags(t *testing.T) {

--- a/rest/replicatortest/main_test.go
+++ b/rest/replicatortest/main_test.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
 )
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 3}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/upgradetest/main_test.go
+++ b/rest/upgradetest/main_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
 )
 
 func TestMain(m *testing.M) {
@@ -24,5 +24,5 @@ func TestMain(m *testing.M) {
 		MemWatermarkThresholdMB: 8192,
 		UseDefaultScope:         true,
 	}
-	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
+	rest.TestBucketPoolRestWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -110,7 +110,7 @@ func (a *activeBlipTesterClients) add(name string) {
 	a.m[name]++
 }
 
-// removeincrements the count of a blip tester client for a particular test
+// remove decrements the count of a blip tester client for a particular test
 func (a *activeBlipTesterClients) remove(tb testing.TB, name string) {
 	a.lock.Lock()
 	defer a.lock.Unlock()


### PR DESCRIPTION
CBG-4533 track blip replication goroutines

- Addresses a test failure when `TestHTTPLoggingRedaction` is called after `TestChangesFeedExitDisconnect` since blipsync logging occurs after the test is finished.
- Added missing btc.Close() functions
- Added global tracking to be able to discover if BlipTesterClient is not closed

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2959/
