### PR TITLE
CBG-4400 re-enable skipped attachment tests

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -933,6 +933,11 @@ func (db *Database) ReloadUser(ctx context.Context) error {
 	}
 }
 
+// NextSequence returns the new sequence number.
+func (db *DatabaseContext) NextSequence(ctx context.Context) (uint64, error) {
+	return db.sequences.nextSequence(ctx)
+}
+
 // ////// ALL DOCUMENTS:
 
 type IDRevAndSequence struct {

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2673,7 +2673,8 @@ func TestCBLRevposHandling(t *testing.T) {
 }
 
 // Helper_Functions
-func CreateDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) {
+// CreateDocWithLegacyAttachment adds a document with a legacy attachment and returns the version of that document.
+func CreateDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) DocVersion {
 	// Write attachment directly to the datastore.
 	dataStore := rt.GetSingleDataStore()
 	_, err := dataStore.Add(attKey, 0, attBody)
@@ -2690,6 +2691,10 @@ func CreateDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, r
 	// Migrate document metadata from document body to system xattr.
 	attachments := retrieveAttachmentMeta(t, rt, docID)
 	require.Len(t, attachments, 1)
+	// this will do an on demand import
+	docVersion, _ := rt.GetDoc(docID)
+	rt.WaitForPendingChanges()
+	return docVersion
 }
 
 func retrieveAttachmentMeta(t *testing.T, rt *RestTester, docID string) (attMeta map[string]interface{}) {
@@ -2703,9 +2708,9 @@ func rawDocWithAttachmentAndSyncMeta() []byte {
 	return []byte(`{
    "_sync": {
       "rev": "1-5fc93bd36377008f96fdae2719c174ed",
-      "sequence": 2,
+      "sequence": 1,
       "recent_sequences": [
-         2
+         1
       ],
       "history": {
          "revs": [

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2687,9 +2687,8 @@ func retrieveAttachmentMeta(t *testing.T, rt *RestTester, docID string) (attMeta
 
 // rawDocWithAttachmentAndSyncMeta returns a raw document with an attachment and sync metadata inline. RestTester is used to determine the sequence for the document.
 func rawDocWithAttachmentAndSyncMeta(rt *RestTester) []byte {
-	latestSeq, err := rt.GetDatabase().LastSequence(rt.Context())
+	latestSeq, err := rt.GetDatabase().NextSequence(rt.Context())
 	require.NoError(rt.TB(), err)
-	docSeq := latestSeq + 1
 	return []byte(fmt.Sprintf(`{
    "_sync": {
       "rev": "1-5fc93bd36377008f96fdae2719c174ed",
@@ -2721,7 +2720,7 @@ func rawDocWithAttachmentAndSyncMeta(rt *RestTester) []byte {
       "time_saved": "2021-09-01T17:33:03.054227821Z"
    },
   "key": "value"
-}`, docSeq, docSeq))
+}`, latestSeq, latestSeq))
 }
 
 // attachmentHeaders returns the headers needed to store an attachment.

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -578,10 +578,9 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 		attBody := []byte(`hi`)
 		digest := db.Sha1DigestKey(attBody)
 		attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
-		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 		// Create a document with legacy attachment.
-		version1 := CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDoc, attKey, attBody)
+		version1 := CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDocWithAttachmentAndSyncMeta(rt), attKey, attBody)
 
 		// Confirm attachment is in the bucket
 		attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
@@ -630,10 +629,9 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 		digest := db.Sha1DigestKey(attBody)
 		attKey := db.MakeAttachmentKey(db.AttVersion1, docID, digest)
 		attName := "hi.txt"
-		rawDoc := rawDocWithAttachmentAndSyncMeta()
 
 		// Create a document with legacy attachment.
-		version1 := CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDoc, attKey, attBody)
+		version1 := CreateDocWithLegacyAttachment(t, client1.rt, docID, rawDocWithAttachmentAndSyncMeta(rt), attKey, attBody)
 
 		attachmentAKey := db.MakeAttachmentKey(1, "doc", digest)
 		dataStore := client1.rt.GetSingleDataStore()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1686,7 +1686,6 @@ func (bt *BlipTester) SendRevWithHistory(docId, docRev string, revHistory []stri
 	if len(revHistory) > 0 {
 		revRequest.Properties["history"] = strings.Join(revHistory, ",")
 	}
-
 	// Override any properties which have been supplied explicitly
 	for k, v := range properties {
 		revRequest.Properties[k] = v


### PR DESCRIPTION
CBG-4400 enable skipped attachment tests

- Rather than having "fake revs", have real revs.
- Create function to prune old versions out of BlipTesterClient
- Remove versionvector test code on main (since those tests are always skipped)
- changed the test sync metadata to use sequence 1 so it doesn't show up as a skipped sequence in test

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2960/
