### PR TITLE
CBG-4513 make sure db is online before running new requests

### DIFF
--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -909,6 +909,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/sync", `function(doc) {access("alice", "beta");channel("beta");}`), http.StatusOK)
 	resyncStatus := rt.RunResync()
 	require.Equal(t, int64(9), resyncStatus.DocsChanged)
+	rt.TakeDbOnline()
 	expectedIDs := []string{"beta", "delta", "gamma", "a1", "b1", "d1", "g1", "alpha", "epsilon"}
 	changes, err = rt.WaitForChanges(len(expectedIDs), "/{{.keyspace}}/_changes", "alice", false)
 	assert.NoError(t, err, "Unexpected error")


### PR DESCRIPTION
I screwed this up in https://github.com/couchbase/sync_gateway/commit/f4494979479cbdfb86e167f291549238aa9368f9

