### PR TITLE
refactor blip test client

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2428,9 +2428,7 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		btcRunner.WaitForVersion(btc.id, docID, version)
 
 		// Add an attachment to client
-		btcRunner.AttachmentsLock(btc.id).Lock()
-		btcRunner.Attachments(btc.id)["sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="] = []byte("goodbye cruel world")
-		btcRunner.AttachmentsLock(btc.id).Unlock()
+		btcRunner.saveAttachment(btc.id, base64.StdEncoding.EncodeToString([]byte("goodbye cruel world")))
 
 		// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
 		updatedVersion, err := btcRunner.PushRevWithHistory(btc.id, docID, &version, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1948,7 +1948,7 @@ func TestSendReplacementRevision(t *testing.T) {
 
 				// one shot or else we'll carry on to send rev 2-... normally, and we can't assert correctly on the final state of the client
 				rt.WaitForPendingChanges()
-				btcRunner.StartOneshotPullFiltered(btc.id, replicationChannels)
+				btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Channels: replicationChannels, Continuous: false})
 
 				// block until we've written the update and got the new version to use in assertions
 				version2 := <-updatedVersion
@@ -2270,7 +2270,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
-		btcRunner.StartOneshotPullFiltered(btc.id, "A")
+		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Channels: "A", Continuous: false})
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
 		_ = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
@@ -2285,7 +2285,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		assert.Equal(t, "doc", changes.Results[0].ID)
 		assert.Equal(t, markerID, changes.Results[1].ID)
 
-		btcRunner.StartOneshotPullFiltered(btc.id, "A")
+		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Channels: "A", Continuous: false})
 		_ = btcRunner.WaitForVersion(btc.id, markerID, markerVersion)
 
 		messages := btc.pullReplication.GetMessages()
@@ -2879,7 +2879,7 @@ func TestRequestPlusPull(t *testing.T) {
 		caughtUpStart := database.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Value()
 
 		// Start a regular one-shot pull
-		btcRunner.StartOneshotPullRequestPlus(client.id)
+		btcRunner.StartPullSince(client.id, BlipTesterPullOptions{Continuous: true, RequestPlus: true})
 
 		// Wait for the one-shot changes feed to go into wait mode before releasing the slow sequence
 		require.NoError(t, database.WaitForTotalCaughtUp(caughtUpStart+1))


### PR DESCRIPTION
This is an intended noop refactor in prep for more work on this code.

- separate each handler function into its method to make logical refactoring easier
- consistently name pointer recievers to make it easier to match different layers of blip tester when readinghte code
- remove perilous attachments lock function

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2964/
