### PR TITLE
CBG-4440: HLC implementation for blip tester client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20250219003541-c8f724802783
+	github.com/couchbaselabs/rosmar v0.0.0-20250226122108-9622e369c5b0
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.0.4

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20250226122108-9622e369c5b0
+	github.com/couchbaselabs/rosmar v0.0.0-20250226134616-3b9ac157a3cd
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.0.4

--- a/go.sum
+++ b/go.sum
@@ -76,10 +76,8 @@ github.com/couchbaselabs/gocbconnstr v1.0.5 h1:e0JokB5qbcz7rfnxEhNRTKz8q1svoRvDo
 github.com/couchbaselabs/gocbconnstr v1.0.5/go.mod h1:KV3fnIKMi8/AzX0O9zOrO9rofEqrRF1d2rG7qqjxC7o=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28 h1:lhGOw8rNG6RAadmmaJAF3PJ7MNt7rFuWG7BHCYMgnGE=
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
-github.com/couchbaselabs/rosmar v0.0.0-20250219003541-c8f724802783 h1:V6N77//HHB1ypgaD0iuvZuSMz7tkeB7LSvSUbXtL/6c=
-github.com/couchbaselabs/rosmar v0.0.0-20250219003541-c8f724802783/go.mod h1:suZBurj14d2YtLOW8pBc8mjQN8MhPFHHgPbqX1fDDlE=
-github.com/couchbaselabs/rosmar v0.0.0-20250226122108-9622e369c5b0 h1:Mg5cAcWRmFo5+FVrrqbET2TEJv5M7d426R0LkQgehTA=
-github.com/couchbaselabs/rosmar v0.0.0-20250226122108-9622e369c5b0/go.mod h1:suZBurj14d2YtLOW8pBc8mjQN8MhPFHHgPbqX1fDDlE=
+github.com/couchbaselabs/rosmar v0.0.0-20250226134616-3b9ac157a3cd h1:kW8rCwAesoUTaTPu/wK5/XhcAAncKKir5zdj0eeHOpE=
+github.com/couchbaselabs/rosmar v0.0.0-20250226134616-3b9ac157a3cd/go.mod h1:suZBurj14d2YtLOW8pBc8mjQN8MhPFHHgPbqX1fDDlE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28 h1:lh
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
 github.com/couchbaselabs/rosmar v0.0.0-20250219003541-c8f724802783 h1:V6N77//HHB1ypgaD0iuvZuSMz7tkeB7LSvSUbXtL/6c=
 github.com/couchbaselabs/rosmar v0.0.0-20250219003541-c8f724802783/go.mod h1:suZBurj14d2YtLOW8pBc8mjQN8MhPFHHgPbqX1fDDlE=
+github.com/couchbaselabs/rosmar v0.0.0-20250226122108-9622e369c5b0 h1:Mg5cAcWRmFo5+FVrrqbET2TEJv5M7d426R0LkQgehTA=
+github.com/couchbaselabs/rosmar v0.0.0-20250226122108-9622e369c5b0/go.mod h1:suZBurj14d2YtLOW8pBc8mjQN8MhPFHHgPbqX1fDDlE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1588,7 +1588,6 @@ func (btc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *Do
 
 	var docVersion DocVersion
 	if btc.UseHLV() {
-		// TODO: CBG-4440 Construct a HLC for Value - UnixNano is not accurate enough on Windows to generate unique values, and seq is not comparable across clients.
 		newVersion := db.Version{SourceID: btc.parent.SourceID, Value: uint64(btc.hlc.Now())}
 		require.NoError(btc.TB(), hlv.AddVersion(newVersion))
 		docVersion = DocVersion{CV: *hlv.ExtractCurrentVersionFromHLV()}

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1124,6 +1124,7 @@ func (btc *BlipTesterClient) createBlipTesterReplications() {
 			_seqCond:      sync.NewCond(&l),
 			_attachments:  make(map[string][]byte),
 			parent:        btc,
+			hlc:           btc.hlc,
 		}
 	}
 

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -447,7 +447,6 @@ func TestPeerImplementation(t *testing.T) {
 			resurrectionVersion := peer.WriteDocument(collectionName, docID, resurrectionBody)
 			require.NotEmpty(t, resurrectionVersion.docMeta.CV(t))
 
-			// need to switch to a HLC so we can have unique versions even in the same timestamp window
 			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), deleteVersion.CV(t))
 			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), updateVersion.docMeta.CV(t))
 			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), createVersion.docMeta.CV(t))

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"iter"
 	"maps"
-	"runtime"
 	"slices"
 	"testing"
 	"time"
@@ -447,13 +446,12 @@ func TestPeerImplementation(t *testing.T) {
 			resurrectionBody := []byte(`{"op": "resurrection"}`)
 			resurrectionVersion := peer.WriteDocument(collectionName, docID, resurrectionBody)
 			require.NotEmpty(t, resurrectionVersion.docMeta.CV(t))
-			// FIXME: CBG-4440 - Windows timestamp resolution not good enough for this test
-			if runtime.GOOS != "windows" {
-				// need to switch to a HLC so we can have unique versions even in the same timestamp window
-				require.NotEqual(t, resurrectionVersion.docMeta.CV(t), deleteVersion.CV(t))
-				require.NotEqual(t, resurrectionVersion.docMeta.CV(t), updateVersion.docMeta.CV(t))
-				require.NotEqual(t, resurrectionVersion.docMeta.CV(t), createVersion.docMeta.CV(t))
-			}
+
+			// need to switch to a HLC so we can have unique versions even in the same timestamp window
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), deleteVersion.CV(t))
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), updateVersion.docMeta.CV(t))
+			require.NotEqual(t, resurrectionVersion.docMeta.CV(t), createVersion.docMeta.CV(t))
+
 			if tc.peerOption.Type == PeerTypeSyncGateway {
 				require.NotEmpty(t, resurrectionVersion.docMeta.RevTreeID)
 				require.NotEqual(t, resurrectionVersion.docMeta.RevTreeID, createVersion.docMeta.RevTreeID)


### PR DESCRIPTION
CBG-4440

- HLC implementation for value in CV for blip tester client
- Using rosmar implementation now, so not ready to merge until rosmar is merged (this PR points to that PR in go mod) 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs: https://github.com/couchbaselabs/rosmar/pull/45
- [x] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2967/
