### PR TITLE
CBG-4528 remove PushRevWithHistory

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2431,10 +2431,10 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 		btcRunner.saveAttachment(btc.id, base64.StdEncoding.EncodeToString([]byte("goodbye cruel world")))
 
 		// Put doc with an erroneous revpos 1 but with a different digest, referring to the above attachment
-		updatedVersion, err := btcRunner.PushRevWithHistory(btc.id, docID, &version, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`), 1, 0)
-		require.NoError(t, err)
+		updatedVersion := btcRunner.AddRev(btc.id, docID, &version, []byte(`{"_attachments": {"hello.txt": {"revpos":1,"stub":true,"length": 19,"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc="}}}`))
 
-		rt.WaitForVersion(docID, *updatedVersion)
+		btcRunner.StartPush(btc.id)
+		rt.WaitForVersion(docID, updatedVersion)
 
 		// Get the attachment and ensure the data is updated
 		resp := btc.rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc/hello.txt", "")


### PR DESCRIPTION
CBG-4528 remove PushRevWithHistory/PushUnsolicitedRev

This was used to push unsolicited rev and check failure of the message. Instead of wrapping this in blip code, send the message separately and check the actual error.

This is also an intermediate commit for full CBG-4528 but allows removing a large code pathway. The problem with `PushRevWithHistory` was that it called `upsertDoc` so an outgoing pull replication would see the changes. So this had to avoid being called at the same time as a pull replication to avoid a data race.

Additionally, the error `TestBlipDeltaSyncPush` was wrapped as followed `fmt.Errorf("error %s %s from revResponse: %s", revResponse.Properties["Error-Domain"], revResponse.Properties["Error-Code"], rspBody)` so the assertion was indirect at best since the verfication is on `deltaSrc`.

The test doesn't actually set the correct body for the delta but that is OK since the assertion is set on `deltaRev
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2968/
