### PR TITLE
CBG-4538 do not expect revSeqNo as a particular value

### DIFF
--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -623,10 +623,8 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
-	xattrs, cas, err := dataStore.GetXattrs(rt.Context(), mobileKey, []string{base.MouXattrName, base.VirtualXattrRevSeqNo})
+	_, cas, err := dataStore.GetXattrs(rt.Context(), mobileKey, []string{base.MouXattrName, base.VirtualXattrRevSeqNo})
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), db.RetrieveDocRevSeqNo(t, xattrs[base.VirtualXattrRevSeqNo]))
-	require.Equal(t, uint64(1), getMou(t, xattrs[base.MouXattrName]).PreviousRevSeqNo)
 
 	// Modify the document via the SDK to add a new, non-mobile xattr
 	xattrVal := make(map[string]interface{})


### PR DESCRIPTION
CBG-4538 do not expect revSeqNo as a particular value

revSeqNo starts at the max deleted revSeqNo for a vbucket, which is not necessarily one https://github.com/couchbase/kv_engine/blob/3318fd7bb87772f8368b0c12075318b113742afd/engines/ep/src/vbucket.cc#L3747

Removed revSeqNo checking in rest/importtest/import_test.go because I don't think it's adding value, this is tested in db package, and some of the revSeqNo values aren't public.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
