### PR TITLE
CBG-4547: send deletions on blip test client

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2060,8 +2060,8 @@ func TestBlipClientSendDelete(t *testing.T) {
 		rt.WaitForVersion(docID, docVersion)
 
 		// delete doc and wait for deletion at rest tester
-		_ = btcRunner.DeleteRev(client.id, docID, &docVersion)
-		rt.WaitForDeletion(docID)
+		deleteVersion := btcRunner.DeleteRev(client.id, docID, &docVersion)
+		rt.WaitForTombstoneVersion(docID, deleteVersion)
 	})
 }
 

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -143,26 +143,12 @@ func (rt *RestTester) WaitForTombstoneVersion(docID string, deleteVersion DocVer
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
-		if ! assert.NoError(c, err) {
+		if !assert.NoError(c, err) {
 			return
 		}
-		assert.True(c, doc.Deleted)
+		assert.NotEqual(c, int64(0), doc.TombstonedAt)
 		assert.Equal(c, deleteVersion.RevID, doc.SyncData.CurrentRev)
 	}, time.Second*10, time.Millisecond*100)
-}
-
-func getDocVersion(xattrs map[string][]byte) (DocVersion, error) {
-	docVersion := DocVersion{}
-	sync, ok := xattrs[base.SyncXattrName]
-	if ok {
-		var syncData *db.SyncData
-		err := json.Unmarshal(sync, &syncData)
-		if err != nil {
-			return docVersion, err
-		}
-		docVersion.RevID = syncData.CurrentRev
-	}
-	return docVersion, nil
 }
 
 func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string, error) {

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -139,6 +139,14 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 	}, time.Second*10, time.Millisecond*10)
 }
 
+func (rt *RestTester) WaitForDeletion(docID string) {
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
+		rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")
+		assert.Equal(c, 404, rawResponse.Code, "Expected 404 status code but got %d for %s", rawResponse.Code, docID)
+		assert.Contains(c, rawResponse.Body.String(), "deleted")
+	}, time.Second*10, time.Millisecond*100)
+}
+
 func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string, error) {
 	var lastSeq string
 	successFunc := func() bool {

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -139,7 +139,7 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 	}, time.Second*10, time.Millisecond*10)
 }
 
-func (rt *RestTester) WaitForDeletion(docID string) {
+func (rt *RestTester) WaitForTombstoneVersion(docID string, deleteVersion DocVersion) {
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")
 		assert.Equal(c, 404, rawResponse.Code, "Expected 404 status code but got %d for %s", rawResponse.Code, docID)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -142,12 +142,12 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 func (rt *RestTester) WaitForTombstoneVersion(docID string, deleteVersion DocVersion) {
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
-		doc, rawDoc, err := collection.GetDocWithXattr(ctx, docID, db.DocUnmarshalAll)
-		assert.NoError(c, err)
+		doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+		if ! assert.NoError(c, err) {
+			return
+		}
 		assert.True(c, doc.Deleted)
-		docVersion, err := getDocVersion(rawDoc.Xattrs)
-		assert.NoError(c, err)
-		assert.Equal(c, deleteVersion.RevID, docVersion.RevID, "Unexpected revision for %s, got: %s expected: %s", doc.ID, docVersion.RevID, deleteVersion.RevID)
+		assert.Equal(c, deleteVersion.RevID, doc.SyncData.CurrentRev)
 	}, time.Second*10, time.Millisecond*100)
 }
 


### PR DESCRIPTION
CBG-4547

- Blip tester client doesn't set the rev delete property + sends currently a zero length byte array as body (which causes issues on sync gateway when we try unmarshal this). Found this on topology tests.
- Adds an api to delete a doc on blip client 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2984/
