### PR TITLE
CBG-4536 prevent status goroutine leak if there is a fatal error

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -62,16 +62,16 @@ type activeReplicatorCommon struct {
 }
 
 // GetSingleCollection returns the single collection for the replication.
-func (apr *activeReplicatorCommon) GetSingleCollection(tb testing.TB) *activeReplicatorCollection {
-	if apr.config.CollectionsEnabled {
-		if len(apr.namedCollections) != 1 {
-			tb.Fatalf("Can only use GetSingleCollection with 1 collection, had %d", len(apr.namedCollections))
+func (arc *activeReplicatorCommon) GetSingleCollection(tb testing.TB) *activeReplicatorCollection {
+	if arc.config.CollectionsEnabled {
+		if len(arc.namedCollections) != 1 {
+			tb.Fatalf("Can only use GetSingleCollection with 1 collection, had %d", len(arc.namedCollections))
 		}
-		for _, collection := range apr.namedCollections {
+		for _, collection := range arc.namedCollections {
 			return collection
 		}
 	}
-	return apr.defaultCollection
+	return arc.defaultCollection
 }
 
 // activeReplicatorCollection stores data about a single collection for the replication.
@@ -114,7 +114,7 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 		metakeys = config.ActiveDB.MetadataKeys
 	}
 
-	apr := activeReplicatorCommon{
+	arc := activeReplicatorCommon{
 		config:           config,
 		state:            ReplicationStateStopped,
 		replicationStats: replicationStats,
@@ -125,70 +125,68 @@ func newActiveReplicatorCommon(ctx context.Context, config *ActiveReplicatorConf
 	}
 
 	if config.CollectionsEnabled {
-		apr.namedCollections = make(map[base.ScopeAndCollectionName]*activeReplicatorCollection)
+		arc.namedCollections = make(map[base.ScopeAndCollectionName]*activeReplicatorCollection)
 	} else {
 		defaultDatabaseCollection, err := config.ActiveDB.GetDefaultDatabaseCollection()
 		if err != nil {
 			return nil, err
 		}
-		apr.defaultCollection = &activeReplicatorCollection{
+		arc.defaultCollection = &activeReplicatorCollection{
 			metadataStore:       config.ActiveDB.MetadataStore,
 			collectionDataStore: defaultDatabaseCollection.dataStore,
 		}
 	}
 
-	return &apr, nil
+	return &arc, nil
 }
 
 // Start starts the replicator, setting the state to ReplicationStateStarting and starting the status reporter.
-func (apr *activeReplicatorCommon) Start(ctx context.Context) error {
-	apr.lock.Lock()
-	defer apr.lock.Unlock()
+func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
+	arc.lock.Lock()
+	defer arc.lock.Unlock()
 
-	if apr.ctx != nil && apr.ctx.Err() == nil {
+	if arc.ctx != nil && arc.ctx.Err() == nil {
 		return fmt.Errorf("Replicator is already running")
 	}
 
-	apr.setState(ReplicationStateStarting)
+	arc.setState(ReplicationStateStarting)
 	logCtx := base.CorrelationIDLogCtx(ctx,
-		apr.config.ID+"-"+string(apr.direction))
-	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
+		arc.config.ID+"-"+string(arc.direction))
+	arc.ctx, arc.ctxCancel = context.WithCancel(logCtx)
 
-	if err := apr.startStatusReporter(apr.ctx); err != nil {
-		return err
-	}
+	arc.startStatusReporter(arc.ctx)
 
-	err := apr.replicatorConnectFn()
+	err := arc.replicatorConnectFn()
 	if err != nil {
-		apr.setError(err)
-		base.WarnfCtx(apr.ctx, "Couldn't connect: %s", err)
+		arc.setError(err)
+		base.WarnfCtx(arc.ctx, "Couldn't connect: %s", err)
 		if errors.Is(err, fatalReplicatorConnectError) {
-			base.WarnfCtx(apr.ctx, "Stopping replication connection attempt")
-			defer apr.ctxCancel()
+			base.WarnfCtx(arc.ctx, "Stopping replication connection attempt")
+			defer arc.ctxCancel()
 		} else {
-			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
-			apr.reconnectActive.Set(true)
-			go apr.reconnectLoop()
+			base.InfofCtx(arc.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
+			arc.reconnectActive.Set(true)
+			go arc.reconnectLoop()
 		}
 	}
-	apr._publishStatus()
+	arc._publishStatus()
 	return err
 }
 
 // initCheckpointer starts a checkpointer. The remoteCheckpoints are only for collections and indexed by the blip collectionIdx. If using default collection only, replicationCheckpoints is an empty array.
-func (apr *activeReplicatorCommon) _initCheckpointer(remoteCheckpoints []replicationCheckpoint) error {
+func (arc *activeReplicatorCommon) _initCheckpointer(remoteCheckpoints []replicationCheckpoint) error {
 	// wrap the replicator context with a cancelFunc that can be called to abort the checkpointer from _disconnect
-	apr.checkpointerCtx, apr.checkpointerCtxCancel = context.WithCancel(apr.ctx)
+	arc.checkpointerCtx, arc.checkpointerCtxCancel = context.WithCancel(arc.ctx)
 
-	err := apr.forEachCollection(func(c *activeReplicatorCollection) error {
-		checkpointHash, hashErr := apr.config.CheckpointHash(c.collectionIdx)
+	err := arc.forEachCollection(func(c *activeReplicatorCollection) error {
+		checkpointHash, hashErr := arc.config.CheckpointHash(c.collectionIdx)
 		if hashErr != nil {
 			return hashErr
 		}
 
-		c.Checkpointer = NewCheckpointer(apr.checkpointerCtx, c.metadataStore, c.collectionDataStore, apr.CheckpointID, checkpointHash, apr.blipSender, apr.config, c.collectionIdx)
+		c.Checkpointer = NewCheckpointer(arc.checkpointerCtx, c.metadataStore, c.collectionDataStore, arc.CheckpointID, checkpointHash, arc.blipSender, arc.config, c.collectionIdx)
 
-		if apr.config.CollectionsEnabled {
+		if arc.config.CollectionsEnabled {
 			err := c.Checkpointer.setLastCheckpointSeq(&remoteCheckpoints[*c.collectionIdx])
 			if err != nil {
 				return err
@@ -200,7 +198,7 @@ func (apr *activeReplicatorCommon) _initCheckpointer(remoteCheckpoints []replica
 			}
 		}
 
-		if err := apr.registerCheckpointerCallbacksFn(c); err != nil {
+		if err := arc.registerCheckpointerCallbacksFn(c); err != nil {
 			return err
 		}
 
@@ -215,23 +213,23 @@ func (apr *activeReplicatorCommon) _initCheckpointer(remoteCheckpoints []replica
 }
 
 // GetStatus is used to retrieve replication status. Combines current running stats with initialStatus.
-func (apr *activeReplicatorCommon) GetStatus() *ReplicationStatus {
-	apr.lock.RLock()
-	defer apr.lock.RUnlock()
-	return apr._getStatusCallback()
+func (arc *activeReplicatorCommon) GetStatus() *ReplicationStatus {
+	arc.lock.RLock()
+	defer arc.lock.RUnlock()
+	return arc._getStatusCallback()
 }
 
 // reset performs a reset on the replication by removing the local checkpoint document.
-func (apr *activeReplicatorCommon) reset() error {
-	if apr.state != ReplicationStateStopped {
-		return fmt.Errorf("reset invoked for replication %s when the replication was not stopped", apr.config.ID)
+func (arc *activeReplicatorCommon) reset() error {
+	if arc.state != ReplicationStateStopped {
+		return fmt.Errorf("reset invoked for replication %s when the replication was not stopped", arc.config.ID)
 	}
 
-	apr.lock.Lock()
-	defer apr.lock.Unlock()
+	arc.lock.Lock()
+	defer arc.lock.Unlock()
 
-	if err := apr.forEachCollection(func(c *activeReplicatorCollection) error {
-		if err := resetLocalCheckpoint(c.collectionDataStore, apr.CheckpointID); err != nil {
+	if err := arc.forEachCollection(func(c *activeReplicatorCollection) error {
+		if err := resetLocalCheckpoint(c.collectionDataStore, arc.CheckpointID); err != nil {
 			return err
 		}
 		c.Checkpointer = nil
@@ -240,32 +238,32 @@ func (apr *activeReplicatorCommon) reset() error {
 		return err
 	}
 
-	return removeLocalStatus(apr.ctx, apr.config.ActiveDB.MetadataStore, apr.statusKey)
+	return removeLocalStatus(arc.ctx, arc.config.ActiveDB.MetadataStore, arc.statusKey)
 }
 
 // reconnectLoop synchronously calls replicatorConnectFn until successful, or times out trying. Retry loop can be stopped by cancelling ctx
-func (a *activeReplicatorCommon) reconnectLoop() {
-	base.DebugfCtx(a.ctx, base.KeyReplicate, "starting reconnector")
+func (arc *activeReplicatorCommon) reconnectLoop() {
+	base.DebugfCtx(arc.ctx, base.KeyReplicate, "starting reconnector")
 	defer func() {
-		a.reconnectActive.Set(false)
+		arc.reconnectActive.Set(false)
 	}()
 
 	initialReconnectInterval := defaultInitialReconnectInterval
-	if a.config.InitialReconnectInterval != 0 {
-		initialReconnectInterval = a.config.InitialReconnectInterval
+	if arc.config.InitialReconnectInterval != 0 {
+		initialReconnectInterval = arc.config.InitialReconnectInterval
 	}
 	maxReconnectInterval := defaultMaxReconnectInterval
-	if a.config.MaxReconnectInterval != 0 {
-		maxReconnectInterval = a.config.MaxReconnectInterval
+	if arc.config.MaxReconnectInterval != 0 {
+		maxReconnectInterval = arc.config.MaxReconnectInterval
 	}
 
 	// ctx causes the retry loop to stop if cancelled
-	ctx := a.ctx
+	ctx := arc.ctx
 
 	// if a reconnect timeout is set, we'll wrap the existing so both can stop the retry loop
 	var deadlineCancel context.CancelFunc
-	if a.config.TotalReconnectTimeout != 0 {
-		ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(a.config.TotalReconnectTimeout))
+	if arc.config.TotalReconnectTimeout != 0 {
+		ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(arc.config.TotalReconnectTimeout))
 	}
 
 	sleeperFunc := base.SleeperFuncCtx(
@@ -281,26 +279,26 @@ func (a *activeReplicatorCommon) reconnectLoop() {
 		default:
 		}
 
-		a.lock.Lock()
-		defer a.lock.Unlock()
+		arc.lock.Lock()
+		defer arc.lock.Unlock()
 
 		// preserve lastError from the previous connect attempt
-		a.setState(ReplicationStateReconnecting)
+		arc.setState(ReplicationStateReconnecting)
 
 		// disconnect no-ops if nothing is active, but will close any checkpointer processes, blip contexts, etc, if active.
-		base.TracefCtx(a.ctx, base.KeyReplicate, "calling disconnect from reconnectLoop")
-		err = a._disconnect()
+		base.TracefCtx(arc.ctx, base.KeyReplicate, "calling disconnect from reconnectLoop")
+		err = arc._disconnect()
 		if err != nil {
-			base.InfofCtx(a.ctx, base.KeyReplicate, "error stopping replicator on reconnect: %v", err)
+			base.InfofCtx(arc.ctx, base.KeyReplicate, "error stopping replicator on reconnect: %v", err)
 		}
 
 		// set lastError, but don't set an error state inside the reconnect loop
-		err = a.replicatorConnectFn()
-		a.setLastError(err)
-		a._publishStatus()
+		err = arc.replicatorConnectFn()
+		arc.setLastError(err)
+		arc._publishStatus()
 
 		if err != nil {
-			base.InfofCtx(a.ctx, base.KeyReplicate, "error starting replicator on reconnect: %v", err)
+			base.InfofCtx(arc.ctx, base.KeyReplicate, "error starting replicator on reconnect: %v", err)
 		}
 		return err != nil, err, nil
 	}
@@ -322,139 +320,139 @@ func (a *activeReplicatorCommon) reconnectLoop() {
 	}
 
 	base.WarnfCtx(ctx, "aborting reconnect loop: %v", retryErr)
-	a.replicationStats.NumReconnectsAborted.Add(1)
-	a.lock.Lock()
-	defer a.lock.Unlock()
+	arc.replicationStats.NumReconnectsAborted.Add(1)
+	arc.lock.Lock()
+	defer arc.lock.Unlock()
 	// use setState to preserve last error from retry loop set by setLastError
-	a.setState(ReplicationStateError)
-	a._publishStatus()
-	a._stop()
+	arc.setState(ReplicationStateError)
+	arc._publishStatus()
+	arc._stop()
 }
 
 // reconnect will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.
-func (a *activeReplicatorCommon) reconnect() error {
-	a.lock.Lock()
-	base.TracefCtx(a.ctx, base.KeyReplicate, "Calling disconnect from reconnect()")
-	err := a._disconnect()
-	a._publishStatus()
-	a.lock.Unlock()
+func (arc *activeReplicatorCommon) reconnect() error {
+	arc.lock.Lock()
+	base.TracefCtx(arc.ctx, base.KeyReplicate, "Calling disconnect from reconnect()")
+	err := arc._disconnect()
+	arc._publishStatus()
+	arc.lock.Unlock()
 	return err
 }
 
 // stopAndDisconnect runs _disconnect and _stop on the replicator, and sets the Stopped replication state.
-func (a *activeReplicatorCommon) stopAndDisconnect() error {
-	a.lock.Lock()
-	a._stop()
-	base.TracefCtx(a.ctx, base.KeyReplicate, "Calling _stop and _disconnect from stopAndDisconnect()")
-	err := a._disconnect()
-	a.setState(ReplicationStateStopped)
-	a._publishStatus()
-	a.lock.Unlock()
+func (arc *activeReplicatorCommon) stopAndDisconnect() error {
+	arc.lock.Lock()
+	arc._stop()
+	base.TracefCtx(arc.ctx, base.KeyReplicate, "Calling _stop and _disconnect from stopAndDisconnect()")
+	err := arc._disconnect()
+	arc.setState(ReplicationStateStopped)
+	arc._publishStatus()
+	arc.lock.Unlock()
 
 	// Wait for up to 10s for reconnect goroutine to exit
 	teardownStart := time.Now()
-	for a.reconnectActive.IsTrue() && (time.Since(teardownStart) < time.Second*10) {
+	for arc.reconnectActive.IsTrue() && (time.Since(teardownStart) < time.Second*10) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	return err
 }
 
 // _disconnect aborts any replicator processes used during a connected/running replication (checkpointing, blip contexts, etc.)
-func (a *activeReplicatorCommon) _disconnect() error {
-	if a == nil {
+func (arc *activeReplicatorCommon) _disconnect() error {
+	if arc == nil {
 		// noop
 		return nil
 	}
 
-	if a.checkpointerCtx != nil {
-		base.TracefCtx(a.ctx, base.KeyReplicate, "cancelling checkpointer context inside _disconnect")
-		a.checkpointerCtxCancel()
-		_ = a.forEachCollection(func(c *activeReplicatorCollection) error {
+	if arc.checkpointerCtx != nil {
+		base.TracefCtx(arc.ctx, base.KeyReplicate, "cancelling checkpointer context inside _disconnect")
+		arc.checkpointerCtxCancel()
+		_ = arc.forEachCollection(func(c *activeReplicatorCollection) error {
 			c.Checkpointer.closeWg.Wait()
 			c.Checkpointer.CheckpointNow()
 			return nil
 		})
 	}
-	a.checkpointerCtx = nil
+	arc.checkpointerCtx = nil
 
-	if a.blipSender != nil {
-		base.TracefCtx(a.ctx, base.KeyReplicate, "closing blip sender")
-		a.blipSender.Close()
-		a.blipSender = nil
+	if arc.blipSender != nil {
+		base.TracefCtx(arc.ctx, base.KeyReplicate, "closing blip sender")
+		arc.blipSender.Close()
+		arc.blipSender = nil
 	}
 
-	if a.blipSyncContext != nil {
-		base.TracefCtx(a.ctx, base.KeyReplicate, "closing blip sync context")
-		a.blipSyncContext.Close()
-		a.blipSyncContext = nil
+	if arc.blipSyncContext != nil {
+		base.TracefCtx(arc.ctx, base.KeyReplicate, "closing blip sync context")
+		arc.blipSyncContext.Close()
+		arc.blipSyncContext = nil
 	}
 
 	return nil
 }
 
 // _stop aborts any replicator processes that run outside of a running replication connection (e.g: async reconnect handling, statsreporter)
-func (a *activeReplicatorCommon) _stop() {
-	if a.ctxCancel != nil {
-		base.TracefCtx(a.ctx, base.KeyReplicate, "cancelling context on activeReplicatorCommon in _stop()")
-		a.ctxCancel()
+func (arc *activeReplicatorCommon) _stop() {
+	if arc.ctxCancel != nil {
+		base.TracefCtx(arc.ctx, base.KeyReplicate, "cancelling context on activeReplicatorCommon in _stop()")
+		arc.ctxCancel()
 	}
 }
 
 type ReplicatorCompleteFunc func()
 
 // setError updates state to ReplicationStateError and sets the last error.
-func (a *activeReplicatorCommon) setError(err error) {
-	base.InfofCtx(a.ctx, base.KeyReplicate, "ActiveReplicator had error state set with err: %v", err)
-	a.stateErrorLock.Lock()
-	a.state = ReplicationStateError
-	a.lastError = err
-	a.stateErrorLock.Unlock()
+func (arc *activeReplicatorCommon) setError(err error) {
+	base.InfofCtx(arc.ctx, base.KeyReplicate, "ActiveReplicator had error state set with err: %v", err)
+	arc.stateErrorLock.Lock()
+	arc.state = ReplicationStateError
+	arc.lastError = err
+	arc.stateErrorLock.Unlock()
 }
 
 // setLastError updates the lastError field for the replicator without updating the replicator state.
-func (a *activeReplicatorCommon) setLastError(err error) {
-	a.stateErrorLock.Lock()
-	a.lastError = err
-	a.stateErrorLock.Unlock()
+func (arc *activeReplicatorCommon) setLastError(err error) {
+	arc.stateErrorLock.Lock()
+	arc.lastError = err
+	arc.stateErrorLock.Unlock()
 }
 
 // setState updates replicator state and resets lastError to nil.  Expects callers
-// to be holding a.lock
-func (a *activeReplicatorCommon) setState(state string) {
-	a.stateErrorLock.Lock()
-	a.state = state
+// to be holding activeReplicatorCommon.lock
+func (arc *activeReplicatorCommon) setState(state string) {
+	arc.stateErrorLock.Lock()
+	arc.state = state
 	if state == ReplicationStateRunning {
-		a.lastError = nil
+		arc.lastError = nil
 	}
-	a.stateErrorLock.Unlock()
+	arc.stateErrorLock.Unlock()
 }
 
-func (a *activeReplicatorCommon) getState() string {
-	a.stateErrorLock.RLock()
-	defer a.stateErrorLock.RUnlock()
-	return a.state
+func (arc *activeReplicatorCommon) getState() string {
+	arc.stateErrorLock.RLock()
+	defer arc.stateErrorLock.RUnlock()
+	return arc.state
 }
 
 // getStateWithErrorMessage returns the current state and last error message for the replicator.
-func (a *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastErrorMessage string) {
-	a.stateErrorLock.RLock()
-	defer a.stateErrorLock.RUnlock()
-	if a.lastError == nil {
-		return a.state, ""
+func (arc *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastErrorMessage string) {
+	arc.stateErrorLock.RLock()
+	defer arc.stateErrorLock.RUnlock()
+	if arc.lastError == nil {
+		return arc.state, ""
 	}
-	return a.state, a.lastError.Error()
+	return arc.state, arc.lastError.Error()
 }
 
-func (a *activeReplicatorCommon) GetStats() *BlipSyncStats {
-	a.lock.RLock()
-	defer a.lock.RUnlock()
-	return a.replicationStats
+func (arc *activeReplicatorCommon) GetStats() *BlipSyncStats {
+	arc.lock.RLock()
+	defer arc.lock.RUnlock()
+	return arc.replicationStats
 }
 
 // getCheckpointHighSeq returns the highest sequence number that has been processed by the replicator across all collections.
-func (a *activeReplicatorCommon) getCheckpointHighSeq() string {
+func (arc *activeReplicatorCommon) getCheckpointHighSeq() string {
 	var highSeq SequenceID
-	err := a.forEachCollection(func(c *activeReplicatorCollection) error {
+	err := arc.forEachCollection(func(c *activeReplicatorCollection) error {
 		if c.Checkpointer != nil {
 			safeSeq := c.Checkpointer.calculateSafeProcessedSeq()
 			if highSeq.Before(safeSeq) {
@@ -464,7 +462,7 @@ func (a *activeReplicatorCommon) getCheckpointHighSeq() string {
 		return nil
 	})
 	if err != nil {
-		base.WarnfCtx(a.ctx, "Error calculating high sequence: %v", err)
+		base.WarnfCtx(arc.ctx, "Error calculating high sequence: %v", err)
 		return ""
 	}
 
@@ -476,22 +474,22 @@ func (a *activeReplicatorCommon) getCheckpointHighSeq() string {
 }
 
 // publishStatus updates the replication status document in the metadata store.
-func (a *activeReplicatorCommon) publishStatus() {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-	a._publishStatus()
+func (arc *activeReplicatorCommon) publishStatus() {
+	arc.lock.Lock()
+	defer arc.lock.Unlock()
+	arc._publishStatus()
 }
 
-// _publishStatus updates the replication status document in the metadata store. Requires holding a.lock before calling.
-func (a *activeReplicatorCommon) _publishStatus() {
-	status := a._getStatusCallback()
-	err := setLocalStatus(a.ctx, a.config.ActiveDB.MetadataStore, a.statusKey, status, int(a.config.ActiveDB.Options.LocalDocExpirySecs))
+// _publishStatus updates the replication status document in the metadata store. Requires holding activeReplicatorCommon.lock before calling.
+func (arc *activeReplicatorCommon) _publishStatus() {
+	status := arc._getStatusCallback()
+	err := setLocalStatus(arc.ctx, arc.config.ActiveDB.MetadataStore, arc.statusKey, status, int(arc.config.ActiveDB.Options.LocalDocExpirySecs))
 	if err != nil {
-		base.WarnfCtx(a.ctx, "Couldn't set status for replication: %v", err)
+		base.WarnfCtx(arc.ctx, "Couldn't set status for replication: %v", err)
 	}
 }
 
-func (arc *activeReplicatorCommon) startStatusReporter(ctx context.Context) error {
+func (arc *activeReplicatorCommon) startStatusReporter(ctx context.Context) {
 	go func() {
 		ticker := time.NewTicker(arc.config.CheckpointInterval)
 		defer ticker.Stop()
@@ -509,7 +507,6 @@ func (arc *activeReplicatorCommon) startStatusReporter(ctx context.Context) erro
 			}
 		}
 	}()
-	return nil
 }
 
 // getLocalStatusDoc retrieves replication status document for a given client ID from the given metadataStore
@@ -583,8 +580,8 @@ func removeLocalStatus(ctx context.Context, metadataStore base.DataStore, status
 }
 
 // registerFunctions must be called once after immediately after newActiveReplicatorCommon to set the functions that require a circular definition from parent (ActiveReplicatorPush/ActiveReplicatorPull) and activeReplicatorCommon.
-func (apr *activeReplicatorCommon) registerFunctions(getStatusFn func() *ReplicationStatus, connectFn func() error, registerCheckpointerCallbacksFn func(*activeReplicatorCollection) error) {
-	apr._getStatusCallback = getStatusFn
-	apr.replicatorConnectFn = connectFn
-	apr.registerCheckpointerCallbacksFn = registerCheckpointerCallbacksFn
+func (arc *activeReplicatorCommon) registerFunctions(getStatusFn func() *ReplicationStatus, connectFn func() error, registerCheckpointerCallbacksFn func(*activeReplicatorCollection) error) {
+	arc._getStatusCallback = getStatusFn
+	arc.replicatorConnectFn = connectFn
+	arc.registerCheckpointerCallbacksFn = registerCheckpointerCallbacksFn
 }

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -21,6 +21,7 @@ type ActivePullReplicator struct {
 	*activeReplicatorCommon
 }
 
+// NewPullReplicator creates an ISGR pull replicator.
 func NewPullReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*ActivePullReplicator, error) {
 	replicator, err := newActiveReplicatorCommon(ctx, config, ActiveReplicatorTypePull)
 	if err != nil {
@@ -148,7 +149,7 @@ func (apr *ActivePullReplicator) Complete() {
 	}
 }
 
-// requires apr.lock
+// _getStatus returns current replicator status. Requires holding ActivePullReplicator.lock as a read lock.
 func (apr *ActivePullReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{
 		ID: apr.CheckpointID,

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -12,8 +12,6 @@ package db
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -31,41 +29,8 @@ func NewPullReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*Ac
 	apr := ActivePullReplicator{
 		activeReplicatorCommon: replicator,
 	}
-	replicator._getStatusCallback = apr._getStatus
-	apr.replicatorConnectFn = apr._connect
+	replicator.registerFunctions(apr._getStatus, apr._connect, apr.registerCheckpointerCallbacks)
 	return &apr, nil
-}
-
-func (apr *ActivePullReplicator) Start(ctx context.Context) error {
-	apr.lock.Lock()
-	defer apr.lock.Unlock()
-
-	if apr.ctx != nil && apr.ctx.Err() == nil {
-		return fmt.Errorf("ActivePullReplicator already running")
-	}
-
-	apr.setState(ReplicationStateStarting)
-	logCtx := base.CorrelationIDLogCtx(ctx, apr.config.ID+"-"+string(ActiveReplicatorTypePull))
-	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
-
-	if err := apr.startStatusReporter(apr.ctx); err != nil {
-		return err
-	}
-
-	err := apr._connect()
-	if err != nil {
-		_ = apr.setError(err)
-		base.WarnfCtx(apr.ctx, "Couldn't connect: %v", err)
-		if errors.Is(err, fatalReplicatorConnectError) {
-			base.WarnfCtx(apr.ctx, "Stopping replication connection attempt")
-		} else {
-			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
-			apr.reconnectActive.Set(true)
-			go apr.reconnectLoop()
-		}
-	}
-	apr._publishStatus()
-	return err
 }
 
 func (apr *ActivePullReplicator) _connect() error {
@@ -183,44 +148,6 @@ func (apr *ActivePullReplicator) Complete() {
 	}
 }
 
-func (apr *ActivePullReplicator) _initCheckpointer(remoteCheckpoints []replicationCheckpoint) error {
-	// wrap the replicator context with a cancelFunc that can be called to abort the checkpointer from _disconnect
-	apr.checkpointerCtx, apr.checkpointerCtxCancel = context.WithCancel(apr.ctx)
-
-	err := apr.forEachCollection(func(c *activeReplicatorCollection) error {
-		checkpointHash, hashErr := apr.config.CheckpointHash(c.collectionIdx)
-		if hashErr != nil {
-			return hashErr
-		}
-
-		c.Checkpointer = NewCheckpointer(apr.checkpointerCtx, c.metadataStore, c.collectionDataStore, apr.CheckpointID, checkpointHash, apr.blipSender, apr.config, c.collectionIdx)
-
-		if apr.config.CollectionsEnabled {
-			err := c.Checkpointer.setLastCheckpointSeq(&remoteCheckpoints[*c.collectionIdx])
-			if err != nil {
-				return err
-			}
-		} else {
-			err := c.Checkpointer.fetchDefaultCollectionCheckpoints()
-			if err != nil {
-				return err
-			}
-		}
-
-		if err := apr.registerCheckpointerCallbacks(c); err != nil {
-			return err
-		}
-
-		c.Checkpointer.Start()
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // requires apr.lock
 func (apr *ActivePullReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{
@@ -241,35 +168,6 @@ func (apr *ActivePullReplicator) _getStatus() *ReplicationStatus {
 		status.PullReplicationStatus.Add(apr.initialStatus.PullReplicationStatus)
 	}
 	return status
-}
-
-// GetStatus is used externally to retrieve pull replication status.  Combines current running stats with
-// initialStatus.
-func (apr *ActivePullReplicator) GetStatus() *ReplicationStatus {
-	apr.lock.RLock()
-	defer apr.lock.RUnlock()
-	return apr._getStatus()
-}
-
-func (apr *ActivePullReplicator) reset() error {
-	if apr.state != ReplicationStateStopped {
-		return fmt.Errorf("reset invoked for replication %s when the replication was not stopped", apr.config.ID)
-	}
-
-	apr.lock.Lock()
-	defer apr.lock.Unlock()
-
-	if err := apr.forEachCollection(func(c *activeReplicatorCollection) error {
-		if err := resetLocalCheckpoint(c.collectionDataStore, apr.CheckpointID); err != nil {
-			return err
-		}
-		c.Checkpointer = nil
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	return removeLocalStatus(apr.ctx, apr.config.ActiveDB.MetadataStore, apr.statusKey)
 }
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -13,7 +13,6 @@ package db
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -35,42 +34,8 @@ func NewPushReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*Ac
 	apr := ActivePushReplicator{
 		activeReplicatorCommon: replicator,
 	}
-	replicator._getStatusCallback = apr._getStatus
-	apr.replicatorConnectFn = apr._connect
+	replicator.registerFunctions(apr._getStatus, apr._connect, apr.registerCheckpointerCallbacks)
 	return &apr, nil
-}
-
-func (apr *ActivePushReplicator) Start(ctx context.Context) error {
-	apr.lock.Lock()
-	defer apr.lock.Unlock()
-
-	if apr.ctx != nil && apr.ctx.Err() == nil {
-		return fmt.Errorf("ActivePushReplicator already running")
-	}
-
-	apr.setState(ReplicationStateStarting)
-	logCtx := base.CorrelationIDLogCtx(ctx,
-		apr.config.ID+"-"+string(ActiveReplicatorTypePush))
-	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
-
-	if err := apr.startStatusReporter(apr.ctx); err != nil {
-		return err
-	}
-
-	err := apr._connect()
-	if err != nil {
-		_ = apr.setError(err)
-		base.WarnfCtx(apr.ctx, "Couldn't connect: %s", err)
-		if errors.Is(err, fatalReplicatorConnectError) {
-			base.WarnfCtx(apr.ctx, "Stopping replication connection attempt")
-		} else {
-			base.InfofCtx(apr.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
-			apr.reconnectActive.Set(true)
-			go apr.reconnectLoop()
-		}
-	}
-	apr._publishStatus()
-	return err
 }
 
 var PreHydrogenTargetAllowConflictsError = errors.New("cannot run replication to target with allow_conflicts=false. Change to allow_conflicts=true or upgrade to 2.8")
@@ -139,45 +104,6 @@ func (apr *ActivePushReplicator) Complete() {
 	}
 }
 
-// initCheckpointer starts a checkpointer. The remoteCheckpoints are only for collections and indexed by the blip collectionIdx. If using default collection only, replicationCheckpoints is an empty array.
-func (apr *ActivePushReplicator) _initCheckpointer(remoteCheckpoints []replicationCheckpoint) error {
-	// wrap the replicator context with a cancelFunc that can be called to abort the checkpointer from _disconnect
-	apr.checkpointerCtx, apr.checkpointerCtxCancel = context.WithCancel(apr.ctx)
-
-	err := apr.forEachCollection(func(c *activeReplicatorCollection) error {
-		checkpointHash, hashErr := apr.config.CheckpointHash(c.collectionIdx)
-		if hashErr != nil {
-			return hashErr
-		}
-
-		c.Checkpointer = NewCheckpointer(apr.checkpointerCtx, c.metadataStore, c.collectionDataStore, apr.CheckpointID, checkpointHash, apr.blipSender, apr.config, c.collectionIdx)
-
-		if apr.config.CollectionsEnabled {
-			err := c.Checkpointer.setLastCheckpointSeq(&remoteCheckpoints[*c.collectionIdx])
-			if err != nil {
-				return err
-			}
-		} else {
-			err := c.Checkpointer.fetchDefaultCollectionCheckpoints()
-			if err != nil {
-				return err
-			}
-		}
-
-		if err := apr.registerCheckpointerCallbacks(c); err != nil {
-			return err
-		}
-
-		c.Checkpointer.Start()
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // requires apr.lock
 func (apr *ActivePushReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{}
@@ -195,36 +121,6 @@ func (apr *ActivePushReplicator) _getStatus() *ReplicationStatus {
 		status.PushReplicationStatus.Add(apr.initialStatus.PushReplicationStatus)
 	}
 	return status
-}
-
-// GetStatus is used externally to retrieve pull replication status.  Combines current running stats with
-// initialStatus.
-func (apr *ActivePushReplicator) GetStatus() *ReplicationStatus {
-	apr.lock.RLock()
-	defer apr.lock.RUnlock()
-	return apr._getStatus()
-}
-
-// reset performs a reset on the replication by removing the local checkpoint document.
-func (apr *ActivePushReplicator) reset() error {
-	if apr.state != ReplicationStateStopped {
-		return fmt.Errorf("reset invoked for replication %s when the replication was not stopped", apr.config.ID)
-	}
-
-	apr.lock.Lock()
-	defer apr.lock.Unlock()
-
-	if err := apr.forEachCollection(func(c *activeReplicatorCollection) error {
-		if err := resetLocalCheckpoint(c.collectionDataStore, apr.CheckpointID); err != nil {
-			return err
-		}
-		c.Checkpointer = nil
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	return removeLocalStatus(apr.ctx, apr.config.ActiveDB.MetadataStore, apr.statusKey)
 }
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
@@ -315,7 +211,7 @@ func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since Seq
 	apr.blipSyncContext.fatalErrorCallback = func(err error) {
 		if strings.Contains(err.Error(), ErrUseProposeChanges.Message) {
 			err = ErrUseProposeChanges
-			_ = apr.setError(PreHydrogenTargetAllowConflictsError)
+			apr.setError(PreHydrogenTargetAllowConflictsError)
 			err = apr.stopAndDisconnect()
 			if err != nil {
 				base.ErrorfCtx(apr.ctx, "Failed to stop and disconnect replication: %v", err)
@@ -347,7 +243,7 @@ func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since Seq
 		if err != nil {
 			base.InfofCtx(apr.ctx, base.KeyReplicate, "Terminating blip connection due to changes feed error: %v", err)
 			bh.ctxCancelFunc()
-			_ = apr.setError(err)
+			apr.setError(err)
 			apr.publishStatus()
 			return
 		}

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -26,6 +26,7 @@ type ActivePushReplicator struct {
 	*activeReplicatorCommon
 }
 
+// NewPushReplicator creates an ISGR push replicator.
 func NewPushReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*ActivePushReplicator, error) {
 	replicator, err := newActiveReplicatorCommon(ctx, config, ActiveReplicatorTypePush)
 	if err != nil {
@@ -104,7 +105,7 @@ func (apr *ActivePushReplicator) Complete() {
 	}
 }
 
-// requires apr.lock
+// _getStatus returns current replicator status. Requires holding ActivePushReplicator.lock as a read lock.
 func (apr *ActivePushReplicator) _getStatus() *ReplicationStatus {
 	status := &ReplicationStatus{}
 	status.Status, status.ErrorMessage = apr.getStateWithErrorMessage()


### PR DESCRIPTION
The only structural change I made was to add `defer apr.ctxCancel()` to `Start`. I couldn't think of a way to test this since it involves counting goroutines, but verified by eye.

I did consolidate `Start`, `GetStatus`, `reset`, `_initCheckpointer` into `activeReplicatorCommon` since they were duplicated exactly between the Push and Pull. In order to do this, add a`activeReplicatorCommon.registerFunctions` to resolve circular references.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2983/
