### PR TITLE
CBG-4552 switch go mod to include major.minor.patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.23
+go 1.23.0
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
CBG-4552 switch go mod to include major.minor.patch

This allows us to pull in new dependencies for golang.org/x/crypto updates https://github.com/couchbase/sync_gateway/pull/7393