### PR TITLE
CBG-4553 fix race condition in TestBlipProveAttachmentV2Push

### DIFF
--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -268,7 +268,8 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 		doc2Version := btcRunner.AddRev(btc.id, doc2ID, nil, []byte(doc2Body))
 		btc.rt.WaitForVersion(doc2ID, doc2Version)
 
-		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value())
+		// use RequireWaitForStat since document exists on Server very slightly before the stat is updated
+		base.RequireWaitForStat(t, btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushCount.Value, 2)
 		assert.Equal(t, int64(0), btc.rt.GetDatabase().DbStats.CBLReplicationPush().DocPushErrorCount.Value())
 		assert.Equal(t, int64(2), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
 		assert.Equal(t, int64(2*len(attachmentData)), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())


### PR DESCRIPTION
CBG-4553 fix race condition in TestBlipProveAttachmentV2Push

This is a cousin of the fix in https://github.com/couchbase/sync_gateway/pull/7375 (pull side) vs this PR as push side. 

I wonder if making this more robust would be to have function to do synchronous and blocking push, but I'm not sure that the caller would remember to do this, or why you would remember to do this. I'm interested in other thoughts for how to avoid this problem in the future.

In this case, the stat is incremented here https://github.com/couchbase/sync_gateway/blob/65abcd8a005dc09482fe92801a401347a8c2d4e7/db/blip_handler.go#L962 but the rev is written here https://github.com/couchbase/sync_gateway/blob/65abcd8a005dc09482fe92801a401347a8c2d4e7/db/blip_handler.go#L1227
