### PR TITLE
CBG-4560 mark always replicator reconnecting

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -218,7 +218,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	blipContext.OnExitCallback = func() {
 		// fall into a reconnect loop only if the connection is unexpectedly closed.
 		if arc.ctx.Err() == nil {
-			go arc.reconnectLoop()
+			arc.reconnect()
 		}
 	}
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -165,7 +165,6 @@ func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
 			defer arc.ctxCancel()
 		} else {
 			base.InfofCtx(arc.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
-			arc.reconnectActive.Set(true)
 			go arc.reconnectLoop()
 		}
 	}
@@ -243,6 +242,7 @@ func (arc *activeReplicatorCommon) reset() error {
 
 // reconnectLoop synchronously calls replicatorConnectFn until successful, or times out trying. Retry loop can be stopped by cancelling ctx
 func (arc *activeReplicatorCommon) reconnectLoop() {
+	arc.reconnectActive.Set(true)
 	base.DebugfCtx(arc.ctx, base.KeyReplicate, "starting reconnector")
 	defer func() {
 		arc.reconnectActive.Set(false)

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -54,7 +54,7 @@ type activeReplicatorCommon struct {
 	ctx                             context.Context
 	ctxCancel                       context.CancelFunc
 	reconnectActive                 base.AtomicBool                                             // Tracks whether reconnect goroutine is active
-	replicatorConnectFn             func() error                                                // the function called inside reconnectLoop.
+	replicatorConnectFn             func() error                                                // the function called inside reconnect.
 	registerCheckpointerCallbacksFn func(*activeReplicatorCollection) error                     // function to register checkpointer callbacks
 	activeSendChanges               atomic.Int32                                                // Tracks whether sendChanges goroutines are active, there is one per collection.
 	namedCollections                map[base.ScopeAndCollectionName]*activeReplicatorCollection // set only if the replicator is running with collections - access with forEachCollection
@@ -165,7 +165,7 @@ func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
 			defer arc.ctxCancel()
 		} else {
 			base.InfofCtx(arc.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
-			go arc.reconnectLoop()
+			arc.reconnect()
 		}
 	}
 	arc._publishStatus()
@@ -240,100 +240,102 @@ func (arc *activeReplicatorCommon) reset() error {
 	return removeLocalStatus(arc.ctx, arc.config.ActiveDB.MetadataStore, arc.statusKey)
 }
 
-// reconnectLoop synchronously calls replicatorConnectFn until successful, or times out trying. Retry loop can be stopped by cancelling ctx
-func (arc *activeReplicatorCommon) reconnectLoop() {
+// reconnect asynchronously calls replicatorConnectFn until successful, or times out trying. Retry loop can be stopped by cancelling ctx
+func (arc *activeReplicatorCommon) reconnect() {
 	arc.reconnectActive.Set(true)
-	base.DebugfCtx(arc.ctx, base.KeyReplicate, "starting reconnector")
-	defer func() {
-		arc.reconnectActive.Set(false)
-	}()
+	go func() {
+		base.DebugfCtx(arc.ctx, base.KeyReplicate, "starting reconnector")
+		defer func() {
+			arc.reconnectActive.Set(false)
+		}()
 
-	initialReconnectInterval := defaultInitialReconnectInterval
-	if arc.config.InitialReconnectInterval != 0 {
-		initialReconnectInterval = arc.config.InitialReconnectInterval
-	}
-	maxReconnectInterval := defaultMaxReconnectInterval
-	if arc.config.MaxReconnectInterval != 0 {
-		maxReconnectInterval = arc.config.MaxReconnectInterval
-	}
-
-	// ctx causes the retry loop to stop if cancelled
-	ctx := arc.ctx
-
-	// if a reconnect timeout is set, we'll wrap the existing so both can stop the retry loop
-	var deadlineCancel context.CancelFunc
-	if arc.config.TotalReconnectTimeout != 0 {
-		ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(arc.config.TotalReconnectTimeout))
-	}
-
-	sleeperFunc := base.SleeperFuncCtx(
-		base.CreateIndefiniteMaxDoublingSleeperFunc(
-			int(initialReconnectInterval.Milliseconds()),
-			int(maxReconnectInterval.Milliseconds())),
-		ctx)
-
-	retryFunc := func() (shouldRetry bool, err error, _ interface{}) {
-		// check before and after acquiring lock to make sure to exit early if ActiveReplicatorCommon.Stop() was called.
-		if ctx.Err() != nil {
-			return false, ctx.Err(), nil
+		initialReconnectInterval := defaultInitialReconnectInterval
+		if arc.config.InitialReconnectInterval != 0 {
+			initialReconnectInterval = arc.config.InitialReconnectInterval
+		}
+		maxReconnectInterval := defaultMaxReconnectInterval
+		if arc.config.MaxReconnectInterval != 0 {
+			maxReconnectInterval = arc.config.MaxReconnectInterval
 		}
 
+		// ctx causes the retry loop to stop if cancelled
+		ctx := arc.ctx
+
+		// if a reconnect timeout is set, we'll wrap the existing so both can stop the retry loop
+		var deadlineCancel context.CancelFunc
+		if arc.config.TotalReconnectTimeout != 0 {
+			ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(arc.config.TotalReconnectTimeout))
+		}
+
+		sleeperFunc := base.SleeperFuncCtx(
+			base.CreateIndefiniteMaxDoublingSleeperFunc(
+				int(initialReconnectInterval.Milliseconds()),
+				int(maxReconnectInterval.Milliseconds())),
+			ctx)
+
+		retryFunc := func() (shouldRetry bool, err error, _ interface{}) {
+			// check before and after acquiring lock to make sure to exit early if ActiveReplicatorCommon.Stop() was called.
+			if ctx.Err() != nil {
+				return false, ctx.Err(), nil
+			}
+
+			arc.lock.Lock()
+			defer arc.lock.Unlock()
+
+			if ctx.Err() != nil {
+				return false, ctx.Err(), nil
+			}
+
+			// preserve lastError from the previous connect attempt
+			arc.setState(ReplicationStateReconnecting)
+
+			// disconnect no-ops if nothing is active, but will close any checkpointer processes, blip contexts, etc, if active.
+			base.TracefCtx(arc.ctx, base.KeyReplicate, "calling disconnect from reconnect")
+			err = arc._disconnect()
+			if err != nil {
+				base.InfofCtx(arc.ctx, base.KeyReplicate, "error stopping replicator on reconnect: %v", err)
+			}
+
+			// set lastError, but don't set an error state inside the reconnect loop
+			err = arc.replicatorConnectFn()
+			arc.setLastError(err)
+			arc._publishStatus()
+
+			if err != nil {
+				base.InfofCtx(arc.ctx, base.KeyReplicate, "error starting replicator on reconnect: %v", err)
+			}
+			return err != nil, err, nil
+		}
+
+		retryErr, _ := base.RetryLoop(ctx, "replicator reconnect", retryFunc, sleeperFunc)
+		// release timer associated with context deadline
+		if deadlineCancel != nil {
+			deadlineCancel()
+		}
+		// Exit early if no error
+		if retryErr == nil {
+			return
+		}
+
+		// replicator was stopped - appropriate state has already been set
+		if errors.Is(ctx.Err(), context.Canceled) {
+			base.DebugfCtx(ctx, base.KeyReplicate, "exiting reconnect loop: %v", retryErr)
+			return
+		}
+
+		base.WarnfCtx(ctx, "aborting reconnect loop: %v", retryErr)
+		arc.replicationStats.NumReconnectsAborted.Add(1)
 		arc.lock.Lock()
 		defer arc.lock.Unlock()
-
-		if ctx.Err() != nil {
-			return false, ctx.Err(), nil
-		}
-
-		// preserve lastError from the previous connect attempt
-		arc.setState(ReplicationStateReconnecting)
-
-		// disconnect no-ops if nothing is active, but will close any checkpointer processes, blip contexts, etc, if active.
-		base.TracefCtx(arc.ctx, base.KeyReplicate, "calling disconnect from reconnectLoop")
-		err = arc._disconnect()
-		if err != nil {
-			base.InfofCtx(arc.ctx, base.KeyReplicate, "error stopping replicator on reconnect: %v", err)
-		}
-
-		// set lastError, but don't set an error state inside the reconnect loop
-		err = arc.replicatorConnectFn()
-		arc.setLastError(err)
+		// use setState to preserve last error from retry loop set by setLastError
+		arc.setState(ReplicationStateError)
 		arc._publishStatus()
-
-		if err != nil {
-			base.InfofCtx(arc.ctx, base.KeyReplicate, "error starting replicator on reconnect: %v", err)
-		}
-		return err != nil, err, nil
-	}
-
-	retryErr, _ := base.RetryLoop(ctx, "replicator reconnect", retryFunc, sleeperFunc)
-	// release timer associated with context deadline
-	if deadlineCancel != nil {
-		deadlineCancel()
-	}
-	// Exit early if no error
-	if retryErr == nil {
-		return
-	}
-
-	// replicator was stopped - appropriate state has already been set
-	if errors.Is(ctx.Err(), context.Canceled) {
-		base.DebugfCtx(ctx, base.KeyReplicate, "exiting reconnect loop: %v", retryErr)
-		return
-	}
-
-	base.WarnfCtx(ctx, "aborting reconnect loop: %v", retryErr)
-	arc.replicationStats.NumReconnectsAborted.Add(1)
-	arc.lock.Lock()
-	defer arc.lock.Unlock()
-	// use setState to preserve last error from retry loop set by setLastError
-	arc.setState(ReplicationStateError)
-	arc._publishStatus()
-	arc._stop()
+		arc._stop()
+	}()
 }
 
-// reconnect will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.
-func (arc *activeReplicatorCommon) reconnect() error {
+// disconnet will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.
+func (arc *activeReplicatorCommon) disconnect() error {
 	arc.lock.Lock()
 	base.TracefCtx(arc.ctx, base.KeyReplicate, "Calling disconnect from reconnect()")
 	err := arc._disconnect()

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -334,10 +334,10 @@ func (arc *activeReplicatorCommon) reconnect() {
 	}()
 }
 
-// disconnet will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.
+// disconnect will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.
 func (arc *activeReplicatorCommon) disconnect() error {
 	arc.lock.Lock()
-	base.TracefCtx(arc.ctx, base.KeyReplicate, "Calling disconnect from reconnect()")
+	base.TracefCtx(arc.ctx, base.KeyReplicate, "Calling disconnect without stopping the replicator")
 	err := arc._disconnect()
 	arc._publishStatus()
 	arc.lock.Unlock()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -218,9 +218,9 @@ func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since Seq
 				base.ErrorfCtx(apr.ctx, "Failed to stop and disconnect replication: %v", err)
 			}
 		} else if strings.Contains(err.Error(), ErrDatabaseWentAway.Message) {
-			err = apr.reconnect()
+			err = apr.disconnect()
 			if err != nil {
-				base.ErrorfCtx(apr.ctx, "Failed to reconnect replication: %v", err)
+				base.ErrorfCtx(apr.ctx, "Failed to disconnect replication after database went away: %v", err)
 			}
 		}
 		// No special handling for error

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -8547,12 +8547,12 @@ func TestExistingConfigEmptyReplicationID(t *testing.T) {
 	}
 }
 
-// TestPanicInCheckpointHash:
+// TestNoDBInCheckpointHash:
 //   - Create two rest testers
 //   - Add active replicator for rt1 to push to rt2
 //   - Remove database context off os rt1
 //   - Call start on active replicator, this would normally hit panic in ticket CBG-4070, should now error instead
-func TestPanicInCheckpointHash(t *testing.T) {
+func TestNoDBInCheckpointHash(t *testing.T) {
 
 	// Create two rest testers
 	rt1 := rest.NewRestTester(t, nil)
@@ -8586,7 +8586,7 @@ func TestPanicInCheckpointHash(t *testing.T) {
 		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
 	})
 	require.NoError(t, err)
-
+	defer func() { assert.NoError(t, ar.Stop()) }()
 	// remove the db context for rt1 off the server context
 	ok := rt1.ServerContext().RemoveDatabase(base.TestCtx(t), "db")
 	require.True(t, ok)


### PR DESCRIPTION
CBG-4560 mark always replicator reconnecting

Addresses a test flake where `TestPanicInCheckpointHash` would panic when reconnect loop is called from https://github.com/couchbase/sync_gateway/blob/main/db/active_replicator.go#L221 

Before this change calling `ActiveReplicator.Stop` would not correctly wait for reconnection if it occurred in the `OnExitCallback`. The panic occurs from the passive side when https://github.com/couchbase/sync_gateway/blob/main/db/active_replicator.go#L261 was called.

Renamed the test to not include the word `Panic` to make it easier to find real panics in test results.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2989/
