### PR TITLE
Always use ClusterOnlyN1QLStore in tests

### DIFF
--- a/db/indextest/main_test.go
+++ b/db/indextest/main_test.go
@@ -8,6 +8,7 @@ be governed by the Apache License, Version 2.0, included in the file
 licenses/APL2.txt.
 */
 
+// Package indextest runs tests which add or remove GSI tests. These exist in a separate package from db to avoid index churn, and the bucket pool function will drop all indexes in the bucket pool before running tests.
 package indextest
 
 import (
@@ -25,6 +26,6 @@ func TestMain(m *testing.M) {
 	}
 
 	ctx := context.Background() // start of test process
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048, NumCollectionsPerBucket: 1}
 	db.TestBucketPoolEnsureNoIndexes(ctx, m, tbpOptions)
 }

--- a/db/indextest/util.go
+++ b/db/indextest/util.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"testing"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/require"
@@ -33,9 +34,6 @@ func setupN1QLStore(ctx context.Context, t *testing.T, bucket base.Bucket, isSer
 
 	hasOnlyDefaultDataStore := len(testBucket.GetNonDefaultDatastoreNames()) == 0
 
-	defaultDataStore := bucket.DefaultDataStore()
-	defaultN1QLStore, ok := base.AsN1QLStore(defaultDataStore)
-	require.True(t, ok, "Unable to get n1QLStore for defaultDataStore")
 	options := db.InitializeIndexOptions{
 		NumReplicas: 0,
 		Serverless:  isServerless,
@@ -46,8 +44,7 @@ func setupN1QLStore(ctx context.Context, t *testing.T, bucket base.Bucket, isSer
 	} else {
 		options.MetadataIndexes = db.IndexesMetadataOnly
 	}
-	ctx = base.CollectionLogCtx(ctx, defaultDataStore.ScopeName(), defaultDataStore.CollectionName())
-	require.NoError(t, db.InitializeIndexes(ctx, defaultN1QLStore, options))
+	initializeIndexes(ctx, t, testBucket, bucket.DefaultDataStore(), options)
 	if hasOnlyDefaultDataStore {
 		return
 	}
@@ -61,13 +58,18 @@ func setupN1QLStore(ctx context.Context, t *testing.T, bucket base.Bucket, isSer
 	dataStore, err := testBucket.GetNamedDataStore(0)
 	require.NoError(t, err)
 
-	var n1qlStore base.N1QLStore
+	initializeIndexes(ctx, t, testBucket, dataStore, options)
+}
+
+// initializeIndexes initializes the indexes for a data store like rest.DatabaseInitManager's DatabaseInitWorker
+func initializeIndexes(ctx context.Context, t *testing.T, testBucket base.Bucket, dsName sgbucket.DataStoreName, options db.InitializeIndexOptions) {
 	gocbBucket, err := base.AsGocbV2Bucket(testBucket)
 	require.NoError(t, err)
 
-	n1qlStore, err = base.NewClusterOnlyN1QLStore(gocbBucket.GetCluster(), gocbBucket.BucketName(), dataStore.ScopeName(), dataStore.CollectionName())
+	n1qlStore, err := base.NewClusterOnlyN1QLStore(gocbBucket.GetCluster(), gocbBucket.BucketName(), dsName.ScopeName(), dsName.CollectionName())
 	require.NoError(t, err)
 
+	ctx = base.CollectionLogCtx(ctx, dsName.ScopeName(), dsName.CollectionName())
 	require.NoError(t, db.InitializeIndexes(ctx, n1qlStore, options))
 }
 

--- a/db/indextest/util.go
+++ b/db/indextest/util.go
@@ -27,7 +27,7 @@ func getDatabaseContextOptions(isServerless bool) db.DatabaseContextOptions {
 }
 
 // setupN1QLStore initializes the indexes for a database. This is normally done by the rest package
-func setupN1QLStore(ctx context.Context, t *testing.T, bucket base.Bucket, isServerless, useN1qlCluster bool) {
+func setupN1QLStore(ctx context.Context, t *testing.T, bucket base.Bucket, isServerless bool) {
 	testBucket, ok := bucket.(*base.TestBucket)
 	require.True(t, ok)
 
@@ -62,17 +62,11 @@ func setupN1QLStore(ctx context.Context, t *testing.T, bucket base.Bucket, isSer
 	require.NoError(t, err)
 
 	var n1qlStore base.N1QLStore
-	if useN1qlCluster {
-		gocbBucket, err := base.AsGocbV2Bucket(testBucket)
-		require.NoError(t, err)
+	gocbBucket, err := base.AsGocbV2Bucket(testBucket)
+	require.NoError(t, err)
 
-		n1qlStore, err = base.NewClusterOnlyN1QLStore(gocbBucket.GetCluster(), gocbBucket.BucketName(), dataStore.ScopeName(), dataStore.CollectionName())
-		require.NoError(t, err)
-	} else {
-		var ok bool
-		n1qlStore, ok = base.AsN1QLStore(dataStore)
-		require.True(t, ok)
-	}
+	n1qlStore, err = base.NewClusterOnlyN1QLStore(gocbBucket.GetCluster(), gocbBucket.BucketName(), dataStore.ScopeName(), dataStore.CollectionName())
+	require.NoError(t, err)
 
 	require.NoError(t, db.InitializeIndexes(ctx, n1qlStore, options))
 }


### PR DESCRIPTION
- Always use ClusterOnlyN1QLStore in tests since this is the only code pathway after 7c03a5d3d37bb1da02961775773bfb1357e611a9 was implemented.
- force only 1 collection to be used since that is all that is necessary and this speeds up testing

Drops test time from 4:20 to 2:50 on my computer.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2990/
