### PR TITLE
CBG-4086 add assert to GetDocumentSequence

### DIFF
--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2398,7 +2398,10 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 			t, &RestTesterConfig{
 				LeakyBucketConfig: &base.LeakyBucketConfig{
 					GetWithXattrCallback: func(key string) error {
-						return fmt.Errorf("Leaky Bucket GetWithXattrCallback Error")
+						if throw {
+							return fmt.Errorf("Leaky Bucket GetWithXattrCallback Error")
+						}
+						return nil
 					}, GetRawCallback: func(key string) error {
 						if throw {
 							return fmt.Errorf("Leaky Bucket GetRawCallback Error")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1163,12 +1163,10 @@ type RawResponse struct {
 // Used by tests that need to validate sequences (for grants, etc)
 func (rt *RestTester) GetDocumentSequence(key string) (sequence uint64) {
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/_raw/%s", key), "")
-	if response.Code != 200 {
-		return 0
-	}
+	require.Equal(rt.TB(), http.StatusOK, response.Code, "Error getting raw document %s", response.Body.String())
 
 	var rawResponse RawResponse
-	_ = base.JSONUnmarshal(response.BodyBytes(), &rawResponse)
+	require.NoError(rt.TB(), base.JSONUnmarshal(response.BodyBytes(), &rawResponse))
 	return rawResponse.Sync.Sequence
 }
 


### PR DESCRIPTION
CBG-4086 add assert to GetDocumentSequence

Previously, if it couldn't find the document sequence, it would just return 0. This forces a document sequence to be found. This actually doesn't affect the test other than readability of printing an extra error message, the second pull replication just started at 0.

This corrects the code for the future and makes the test output a bit easier to read.

This _doesn't_ fix the flaky test just improves the assertion. Do not close this ticket when this PR is done.