### PR TITLE
Speed up tests that include sleep

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3324,7 +3324,6 @@ func TestUpdateCalculatedStatsPanic(t *testing.T) {
 }
 
 func Test_waitForBackgroundManagersToStop(t *testing.T) {
-	base.LongRunningTest(t)
 	t.Run("single unstoppable process", func(t *testing.T) {
 		bgMngr := &BackgroundManager{
 			name:    "test_unstoppable_runner",
@@ -3337,7 +3336,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		deadline := 10 * time.Second
+		deadline := 10 * time.Millisecond
 		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{bgMngr})
 		assert.Greater(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopping, bgMngr.GetRunState())
@@ -3355,7 +3354,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		deadline := 10 * time.Second
+		deadline := 10 * time.Millisecond
 		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{bgMngr})
 		assert.Less(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopped, bgMngr.GetRunState())
@@ -3383,7 +3382,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		deadline := 10 * time.Second
+		deadline := 10 * time.Millisecond
 		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{stoppableBgMngr, unstoppableBgMngr})
 		assert.Greater(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopped, stoppableBgMngr.GetRunState())

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2184,45 +2184,25 @@ func TestHandlePprofsCmdlineAndSymbol(t *testing.T) {
 }
 
 func TestHandlePprofs(t *testing.T) {
-	base.LongRunningTest(t)
-
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
+	// only test endpoints that do not require time based sampling to make this test fast, net/http/pprof package is itself tested
 	tests := []struct {
 		inputProfile  string
 		inputResource string
 	}{
 		{
 			inputProfile:  "heap",
-			inputResource: "/_debug/pprof/heap?seconds=1",
-		},
-		{
-			inputProfile:  "profile",
-			inputResource: "/_debug/pprof/profile?seconds=1",
-		},
-		{
-			inputProfile:  "block",
-			inputResource: "/_debug/pprof/block?seconds=1",
+			inputResource: "/_debug/pprof/heap",
 		},
 		{
 			inputProfile:  "threadcreate",
 			inputResource: "/_debug/pprof/threadcreate",
 		},
 		{
-			inputProfile:  "mutex",
-			inputResource: "/_debug/pprof/mutex?seconds=1",
-		},
-		{
 			inputProfile:  "goroutine",
 			inputResource: "/_debug/pprof/goroutine?debug=0&gc=1",
-		},
-		{
-			inputProfile:  "trace",
-			inputResource: "/_debug/pprof/trace?seconds=1",
 		},
 	}
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -835,13 +835,13 @@ func TestOfflineDatabaseStartup(t *testing.T) {
 	_, _, err = collection.Put(ctx, "doc2", db.Body{"type": "doc2"})
 	require.NoError(t, err)
 
-	// wait long enough to be confident that import isn't running...
-	time.Sleep(time.Second * 5)
+	require.Nil(t, rt.GetDatabase().ImportListener)
 
 	// ensure doc1 is not imported - since we started the database offline
 	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
 	rt.ServerContext().TakeDbOnline(base.NewNonCancelCtx(), rt.GetDatabase())
+	require.NotNil(t, rt.GetDatabase().ImportListener)
 
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc3", `{"type":"doc3"}`)
 	RequireStatus(t, resp, http.StatusCreated)


### PR DESCRIPTION
The background manager tests do not require 10s to wait for sleep to happen. The pprof code is just utilizing net/http/pprof which we can assume works OK. Any API that requires sampling (cpuprofile, mutex) can not occur in parallel and takes a minimum of 1s.

| test | old time | new time     |
| ---- | -------- | ----------- |
| TestHandlePprofs |  15s  |  0.7s |
| Test_waitForBackgroundManagersToStop | 20s | 0.7s |
| TestOfflineDatabaseStartup | 7.5s | 2.5s |


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2991/
