### PR TITLE
CBG-4540: Clone byte slices coming over DCP when transforming into `sgbucket.FeedEvent`

### DIFF
--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -54,15 +54,14 @@ type mutationEvent struct {
 }
 
 // asFeedEvent converts a mutationEvent to a sgbucket.FeedEvent.
-// The byte slices must by copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func (e mutationEvent) asFeedEvent() sgbucket.FeedEvent {
 	return sgbucket.FeedEvent{
 		Opcode:       sgbucket.FeedOpMutation,
 		Flags:        e.flags,
 		Expiry:       e.expiry,
 		CollectionID: e.collection,
-		Key:          EfficientBytesClone(e.key),
-		Value:        EfficientBytesClone(e.value),
+		Key:          e.key,
+		Value:        e.value,
 		DataType:     e.datatype,
 		Cas:          e.cas,
 		RevNo:        e.revNo,
@@ -84,13 +83,12 @@ type deletionEvent struct {
 }
 
 // asFeedEvent converts a deletionEvent to a sgbucket.FeedEvent.
-// The byte slices must be copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func (e deletionEvent) asFeedEvent() sgbucket.FeedEvent {
 	return sgbucket.FeedEvent{
 		Opcode:       sgbucket.FeedOpDeletion,
 		CollectionID: e.collection,
-		Key:          EfficientBytesClone(e.key),
-		Value:        EfficientBytesClone(e.value),
+		Key:          e.key,
+		Value:        e.value,
 		DataType:     e.datatype,
 		Cas:          e.cas,
 		RevNo:        e.revNo,

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -54,7 +54,7 @@ type mutationEvent struct {
 }
 
 // asFeedEvent converts a mutationEvent to a sgbucket.FeedEvent.
-// The byte slices are copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
+// The byte slices must by copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func (e mutationEvent) asFeedEvent() sgbucket.FeedEvent {
 	return sgbucket.FeedEvent{
 		Opcode:       sgbucket.FeedOpMutation,
@@ -84,7 +84,7 @@ type deletionEvent struct {
 }
 
 // asFeedEvent converts a deletionEvent to a sgbucket.FeedEvent.
-// The byte slices are copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
+// The byte slices must be copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func (e deletionEvent) asFeedEvent() sgbucket.FeedEvent {
 	return sgbucket.FeedEvent{
 		Opcode:       sgbucket.FeedOpDeletion,

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -54,14 +54,15 @@ type mutationEvent struct {
 }
 
 // asFeedEvent converts a mutationEvent to a sgbucket.FeedEvent.
+// The byte slices are copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func (e mutationEvent) asFeedEvent() sgbucket.FeedEvent {
 	return sgbucket.FeedEvent{
 		Opcode:       sgbucket.FeedOpMutation,
 		Flags:        e.flags,
 		Expiry:       e.expiry,
 		CollectionID: e.collection,
-		Key:          e.key,
-		Value:        e.value,
+		Key:          EfficientBytesClone(e.key),
+		Value:        EfficientBytesClone(e.value),
 		DataType:     e.datatype,
 		Cas:          e.cas,
 		RevNo:        e.revNo,
@@ -83,12 +84,13 @@ type deletionEvent struct {
 }
 
 // asFeedEvent converts a deletionEvent to a sgbucket.FeedEvent.
+// The byte slices are copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func (e deletionEvent) asFeedEvent() sgbucket.FeedEvent {
 	return sgbucket.FeedEvent{
 		Opcode:       sgbucket.FeedOpDeletion,
 		CollectionID: e.collection,
-		Key:          e.key,
-		Value:        e.value,
+		Key:          EfficientBytesClone(e.key),
+		Value:        EfficientBytesClone(e.value),
 		DataType:     e.datatype,
 		Cas:          e.cas,
 		RevNo:        e.revNo,

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -48,8 +48,10 @@ func (dc *DCPClient) Mutation(mutation gocbcore.DcpMutation) {
 		cas:        mutation.Cas,
 		datatype:   mutation.Datatype,
 		collection: mutation.CollectionID,
-		key:        mutation.Key,
-		value:      mutation.Value,
+
+		// The byte slices must be copied to ensure that memory associated with the underlying memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
+		key:   EfficientBytesClone(mutation.Key),
+		value: EfficientBytesClone(mutation.Value),
 	}
 	dc.workerForVbno(mutation.VbID).Send(dc.ctx, e)
 }
@@ -69,8 +71,10 @@ func (dc *DCPClient) Deletion(deletion gocbcore.DcpDeletion) {
 		revNo:      deletion.RevNo,
 		datatype:   deletion.Datatype,
 		collection: deletion.CollectionID,
-		key:        deletion.Key,
-		value:      deletion.Value,
+
+		// The byte slices must be copied to ensure that memory associated with the underlying memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
+		key:   EfficientBytesClone(deletion.Key),
+		value: EfficientBytesClone(deletion.Value),
 	}
 	dc.workerForVbno(deletion.VbID).Send(dc.ctx, e)
 

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -522,12 +522,11 @@ func dcpKeyFilter(key []byte, metaKeys *MetadataKeys) bool {
 }
 
 // Makes a feedEvent that can be passed to a FeedEventCallbackFunc implementation
-// The byte slices are copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
+// The byte slices must be copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func makeFeedEvent(key []byte, value []byte, dataType uint8, cas uint64, expiry uint32, vbNo uint16, collectionID uint32, opcode sgbucket.FeedOpcode) sgbucket.FeedEvent {
 
-	// not currently doing rq.Extras handling (as in gocouchbase/upr_feed, makeUprEvent) as SG doesn't use
-	// expiry/flags information, and snapshot handling is done by cbdatasource and sent as
-	// SnapshotStart, SnapshotEnd
+	// not currently doing rq.Extras handling (as was done in go-couchbase/upr_feed, makeUprEvent) since SG doesn't use
+	// flags information, and snapshot handling is done by cbgt and sent as SnapshotStart, SnapshotEnd
 	event := sgbucket.FeedEvent{
 		Opcode:       opcode,
 		Key:          EfficientBytesClone(key),

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -525,8 +525,6 @@ func dcpKeyFilter(key []byte, metaKeys *MetadataKeys) bool {
 // The byte slices must be copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func makeFeedEvent(key []byte, value []byte, dataType uint8, cas uint64, expiry uint32, vbNo uint16, collectionID uint32, opcode sgbucket.FeedOpcode) sgbucket.FeedEvent {
 
-	// not currently doing rq.Extras handling (as was done in go-couchbase/upr_feed, makeUprEvent) since SG doesn't use
-	// flags information, and snapshot handling is done by cbgt and sent as SnapshotStart, SnapshotEnd
 	event := sgbucket.FeedEvent{
 		Opcode:       opcode,
 		Key:          EfficientBytesClone(key),

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -522,6 +522,7 @@ func dcpKeyFilter(key []byte, metaKeys *MetadataKeys) bool {
 }
 
 // Makes a feedEvent that can be passed to a FeedEventCallbackFunc implementation
+// The byte slices are copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func makeFeedEvent(key []byte, value []byte, dataType uint8, cas uint64, expiry uint32, vbNo uint16, collectionID uint32, opcode sgbucket.FeedOpcode) sgbucket.FeedEvent {
 
 	// not currently doing rq.Extras handling (as in gocouchbase/upr_feed, makeUprEvent) as SG doesn't use
@@ -529,8 +530,8 @@ func makeFeedEvent(key []byte, value []byte, dataType uint8, cas uint64, expiry 
 	// SnapshotStart, SnapshotEnd
 	event := sgbucket.FeedEvent{
 		Opcode:       opcode,
-		Key:          key,
-		Value:        value,
+		Key:          EfficientBytesClone(key),
+		Value:        EfficientBytesClone(value),
 		CollectionID: collectionID,
 		DataType:     dataType,
 		Cas:          cas,

--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -87,59 +87,23 @@ func TestDCPNameLength(t *testing.T) {
 
 // TestFeedEventByteSliceCopy( ensures that the byte slices in the FeedEvent are copies and not the original ones - CBG-4540
 func TestFeedEventByteSliceCopy(t *testing.T) {
-	tests := []struct {
-		name           string
-		getFeedEventFn func(k, v []byte) sgbucket.FeedEvent
-	}{
-		{
-			name: "makeFeedEvent",
-			getFeedEventFn: func(k, v []byte) sgbucket.FeedEvent {
-				return makeFeedEvent(k, v, 0, 0, 0, 0, 0, sgbucket.FeedOpMutation)
-			},
-		},
-		{
-			name: "mutationEvent.asFeedEvent",
-			getFeedEventFn: func(k, v []byte) sgbucket.FeedEvent {
-				me := mutationEvent{
-					key:   k,
-					value: v,
-				}
-				return me.asFeedEvent()
-			},
-		},
-		{
-			name: "deletionEvent.asFeedEvent",
-			getFeedEventFn: func(k, v []byte) sgbucket.FeedEvent {
-				de := deletionEvent{
-					key:   k,
-					value: v,
-				}
-				return de.asFeedEvent()
-			},
-		},
-	}
+	const (
+		keyData   = "key"
+		valueData = "value"
+	)
+	keySlice := []byte(keyData)
+	valueSlice := []byte(valueData)
+	e := makeFeedEvent(keySlice, valueSlice, 0, 0, 0, 0, 0, sgbucket.FeedOpMutation)
+	require.Equal(t, keyData, string(e.Key))
+	require.Equal(t, valueData, string(e.Value))
+	require.Equal(t, keyData, string(keySlice))
+	require.Equal(t, valueData, string(valueSlice))
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			const (
-				keyData   = "key"
-				valueData = "value"
-			)
-			keySlice := []byte(keyData)
-			valueSlice := []byte(valueData)
-			e := test.getFeedEventFn(keySlice, valueSlice)
-			require.Equal(t, keyData, string(e.Key))
-			require.Equal(t, valueData, string(e.Value))
-			require.Equal(t, keyData, string(keySlice))
-			require.Equal(t, valueData, string(valueSlice))
-
-			// mutate the originals and ensure the FeedEvent byte slices didn't change with it
-			keySlice[0] = 'x'
-			valueSlice[0] = 'x'
-			assert.Equal(t, keyData, string(e.Key))
-			assert.Equal(t, valueData, string(e.Value))
-			assert.NotEqual(t, keyData, string(keySlice))
-			assert.NotEqual(t, valueData, string(valueSlice))
-		})
-	}
+	// mutate the originals and ensure the FeedEvent byte slices didn't change with it
+	keySlice[0] = 'x'
+	valueSlice[0] = 'x'
+	assert.Equal(t, keyData, string(e.Key))
+	assert.Equal(t, valueData, string(e.Value))
+	assert.NotEqual(t, keyData, string(keySlice))
+	assert.NotEqual(t, valueData, string(valueSlice))
 }

--- a/base/util.go
+++ b/base/util.go
@@ -1772,3 +1772,14 @@ func WaitForNoError(ctx context.Context, callback func() error) error {
 	}, CreateMaxDoublingSleeperFunc(30, 10, 1000))
 	return err
 }
+
+// EfficientBytesClone will return a copy of the given bytes.
+// This implementation is slightly quicker than bytes.Clone and won't over-allocate (golang/go#55905)
+func EfficientBytesClone(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	nb := make([]byte, len(b))
+	copy(nb, b)
+	return nb
+}


### PR DESCRIPTION
CBG-4540

- Clone the byte slices coming over DCP when building `FeedEvent` to ensure independent memory allocations of data between gocbcore and Sync Gateway.
- Guards against potential cache corruption in the event of gocbcore/memd refactors to reuse the allocated byte slices in the `memd.Packet` `sync.Pool`
- Avoids retaining `memd.Packet` memory when we keep a direct reference to `Key` and/or `Value` byte slices in our caches.
  - Should significantly improve caching feed memory usage since we're only storing `Key`.
  - Should slightly improve revcache usage since we're storing both.
- Overall it's safer to _always_ do this copy, when crossing the gocbcore/memd/sgbucket package boundaries than conditionally when we're about to store things in the SG caches - even though we may be paying for a copy without needing it.
- Performance testing has shown that the bytes copy implementation doesn't significantly impact import throughput (the copy is very cheap compared to JSON unmarshalling for instance) and _improves_ memory usage associated with import because of above reasons for more efficient `sync.Pool` reuse.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2996/
