### PR TITLE
unit test: increase time slightly to account for slow machines

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3354,7 +3354,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		deadline := 10 * time.Millisecond
+		deadline := 100 * time.Millisecond
 		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{bgMngr})
 		assert.Less(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopped, bgMngr.GetRunState())
@@ -3382,7 +3382,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		deadline := 10 * time.Millisecond
+		deadline := 100 * time.Millisecond
 		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{stoppableBgMngr, unstoppableBgMngr})
 		assert.Greater(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopped, stoppableBgMngr.GetRunState())


### PR DESCRIPTION
Unfortunately 1fb9f8e1d3e2fc6d5699ce01176c3476ab7b015f was too aggressive on slow machines. Bump to 100ms to as order of magnitude but there's a chance it will still be too short. I'd rather tune the number up conservatively to find sweet spot between running quick interactively and not failing CI. There's a chance these numbers will have to be increased again, but I'm OK with that.

```
--- FAIL: Test_waitForBackgroundManagersToStop (0.02s)
    --- FAIL: Test_waitForBackgroundManagersToStop/one_stoppable_process_and_one_unstoppable_process (0.01s)
        database_test.go:3387: 
            	Error Trace:	C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/db/database_test.go:3387
            	Error:      	"10ms" is not greater than "10ms"
            	Test:       	Test_waitForBackgroundManagersToStop/one_stoppable_process_and_one_unstoppable_process
```

```
    database_test.go:3359: 
        	Error Trace:	/Users/runner/work/sync_gateway/sync_gateway/db/database_test.go:3359
        	Error:      	"23.986625ms" is not less than "10ms"
        	Test:       	Test_waitForBackgroundManagersToStop/single_stoppable_process            	
```

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`