### PR TITLE
CBG-4570: stop audit events logging when no audit config is provided at db level

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -896,10 +896,6 @@ func IntPtr(i int) *int {
 	return &i
 }
 
-func UintSlicePtr(u []uint) *[]uint {
-	return &u
-}
-
 // IntDefault returns ifNil if i is nil, or else returns dereferenced value of i
 func IntDefault(i *int, ifNil int) int {
 	if i != nil {

--- a/base/util.go
+++ b/base/util.go
@@ -896,6 +896,10 @@ func IntPtr(i int) *int {
 	return &i
 }
 
+func UintSlicePtr(u []uint) *[]uint {
+	return &u
+}
+
 // IntDefault returns ifNil if i is nil, or else returns dereferenced value of i
 func IntDefault(i *int, ifNil int) int {
 	if i != nil {

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -561,7 +561,7 @@ func TestAuditDatabaseUpdate(t *testing.T) {
 	dbConfig.Logging = &DbLoggingConfig{
 		Audit: &DbAuditLoggingConfig{
 			Enabled: base.BoolPtr(true),
-			EnabledEvents: base.UintSlicePtr([]uint{
+			EnabledEvents: base.Ptr([]uint{
 				uint(base.AuditIDUpdateDatabaseConfig),
 			}),
 		},
@@ -764,7 +764,7 @@ func TestAuditDocumentRead(t *testing.T) {
 	dbConfig.Logging = &DbLoggingConfig{
 		Audit: &DbAuditLoggingConfig{
 			Enabled: base.BoolPtr(true),
-			EnabledEvents: base.UintSlicePtr([]uint{
+			EnabledEvents: base.Ptr([]uint{
 				uint(base.AuditIDDocumentRead),
 				uint(base.AuditIDDocumentMetadataRead),
 			}),
@@ -979,7 +979,7 @@ func TestAuditAttachmentEvents(t *testing.T) {
 	dbConfig.Logging = &DbLoggingConfig{
 		Audit: &DbAuditLoggingConfig{
 			Enabled: base.BoolPtr(true),
-			EnabledEvents: base.UintSlicePtr([]uint{
+			EnabledEvents: base.Ptr([]uint{
 				uint(base.AuditIDAttachmentCreate),
 				uint(base.AuditIDAttachmentRead),
 				uint(base.AuditIDAttachmentDelete),
@@ -1140,7 +1140,7 @@ func TestAuditDocumentCreateUpdateEvents(t *testing.T) {
 	dbConfig.Logging = &DbLoggingConfig{
 		Audit: &DbAuditLoggingConfig{
 			Enabled: base.BoolPtr(true),
-			EnabledEvents: base.UintSlicePtr([]uint{
+			EnabledEvents: base.Ptr([]uint{
 				uint(base.AuditIDDocumentCreate),
 				uint(base.AuditIDDocumentUpdate),
 			}),
@@ -1229,7 +1229,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 		dbConfig.Logging = &DbLoggingConfig{
 			Audit: &DbAuditLoggingConfig{
 				Enabled: base.BoolPtr(true),
-				EnabledEvents: base.UintSlicePtr([]uint{
+				EnabledEvents: base.Ptr([]uint{
 					uint(base.AuditIDChangesFeedStarted),
 				}),
 			},
@@ -1581,7 +1581,7 @@ func TestAuditBlipCRUD(t *testing.T) {
 		dbConfig.Logging = &DbLoggingConfig{
 			Audit: &DbAuditLoggingConfig{
 				Enabled: base.BoolPtr(true),
-				EnabledEvents: base.UintSlicePtr([]uint{
+				EnabledEvents: base.Ptr([]uint{
 					uint(base.AuditIDAttachmentCreate),
 					uint(base.AuditIDAttachmentRead),
 					uint(base.AuditIDAttachmentDelete),

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -990,8 +990,6 @@ func TestAuditAttachmentEvents(t *testing.T) {
 
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
-	rt.WaitForDBOnline()
-
 	testCases := []struct {
 		name                  string
 		setupCode             func(t testing.TB, docID string) DocVersion
@@ -1528,6 +1526,9 @@ func requireChangesStartEvent(t testing.TB, output []byte, expectedFields map[st
 }
 
 func createAuditLoggingRestTester(t *testing.T) *RestTester {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Audit logging only works in EE")
+	}
 	// get tempdir before resetting global loggers, since the logger cleanup needs to happen before deletion
 	tempdir := t.TempDir()
 	base.ResetGlobalTestLogging(t)

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -990,6 +990,8 @@ func TestAuditAttachmentEvents(t *testing.T) {
 
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
+	rt.WaitForDBOnline()
+
 	testCases := []struct {
 		name                  string
 		setupCode             func(t testing.TB, docID string) DocVersion
@@ -1614,6 +1616,9 @@ func TestAuditBlipCRUD(t *testing.T) {
 					btcRunner.StartPushWithOpts(btc.id, BlipTesterPushOptions{Continuous: false})
 					// wait for the doc to be replicated, since that's what we're actually auditing
 					rt.WaitForVersion(docID, version)
+					base.RequireWaitForStat(t, func() int64 {
+						return rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value()
+					}, 1)
 				},
 				attachmentCreateCount: 1,
 			},

--- a/rest/config.go
+++ b/rest/config.go
@@ -2300,7 +2300,7 @@ func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 	if l == nil || (l.Console == nil && l.Audit == nil) {
 		return &base.DbLogConfig{
 			Audit: &base.DbAuditLogConfig{
-				Enabled: false,
+				Enabled: base.DefaultDbAuditEnabled,
 			},
 		}
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -2298,7 +2298,11 @@ func RegisterSignalHandler(ctx context.Context) {
 func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 	l := c.Logging
 	if l == nil || (l.Console == nil && l.Audit == nil) {
-		return nil
+		return &base.DbLogConfig{
+			Audit: &base.DbAuditLogConfig{
+				Enabled: false,
+			},
+		}
 	}
 
 	var con *base.DbConsoleLogConfig


### PR DESCRIPTION
CBG-4570

- When not providing a db level audit log config and you have global audit enabled you will get all audit events logged for that db
- To fix we should explicitly set enabled to false in audit log config on database when no config is povided
- This PR incudes a lot of test fixes too, found that some tests were wrongly asserting on events 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/2999/
