### PR TITLE
CBG-4534: Wrap CORS origin warning in err check

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1068,8 +1068,9 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 
 	if dbConfig.CORS != nil {
 		// these values will likely to be ignored by the CORS handler unless browser sends abornmal Origin headers
-		_, err := hostOnlyCORS(dbConfig.CORS.Origin)
-		base.WarnfCtx(ctx, "The cors.origin contains values that may be ignored: %s", err)
+		if _, err := hostOnlyCORS(dbConfig.CORS.Origin); err != nil {
+			base.WarnfCtx(ctx, "The cors.origin contains values that may be ignored: %s", err)
+		}
 	}
 
 	if validateReplications {


### PR DESCRIPTION
CBG-4534

Wrap the CORS origin warning in err check because sometimes (often) it is nil and we shouldn't say anything

```
2025-02-15T23:31:57.028Z [WRN] c:#1234 db:dbname The cors.origin contains values that may be ignored: %!s(<nil>) -- rest.(*DbConfig).validateVersion() at config.go:1066
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a