### PR TITLE
CBG-4578: have maximum threshold for releasing sequences in nextSequenceGreaterThan

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -77,6 +77,9 @@ var (
 
 	// ErrSkippedSequencesMissing is returned when attempting to remove a sequence range form the skipped sequence list and at least one sequence in that range is not present
 	ErrSkippedSequencesMissing = &sgError{"Sequence range has sequences that aren't present in skipped list"}
+
+	// ErrMaxSequenceReleasedExceeded is returned when the maximum number of sequences to be released as part of nextSequenceGreaterThan is exceeded
+	ErrMaxSequenceReleasedExceeded = &sgError{"Maximum number of sequences to release to catch up with document sequence exceeded"}
 )
 
 func (e *sgError) Error() string {

--- a/base/stats.go
+++ b/base/stats.go
@@ -1756,7 +1756,7 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.CorruptSequenceCount, err = NewIntStat(SubsystemDatabaseKey, "corrupt_sequence_count", StatUnitNoUnits, CorruptSequenceCountDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.CorruptSequenceCount, err = NewIntStat(SubsystemDatabaseKey, "corrupt_sequence_count", StatUnitNoUnits, CorruptSequenceCountDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -645,6 +645,8 @@ type DatabaseStats struct {
 	SequenceReleasedCount *SgwIntStat `json:"sequence_released_count"`
 	// The total number of sequences reserved by Sync Gateway.
 	SequenceReservedCount *SgwIntStat `json:"sequence_reserved_count"`
+	// The total number of corrupt sequences above the MaxSequencesToRelease threshold seen at the sequence allocator
+	CorruptSequenceCount *SgwIntStat `json:"corrupt_sequence_count"`
 	// The total number of warnings relating to the channel name size.
 	WarnChannelNameSizeCount *SgwIntStat `json:"warn_channel_name_size_count"`
 	// The total number of warnings relating to the channel count exceeding the channel count threshold.
@@ -1754,6 +1756,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.CorruptSequenceCount, err = NewIntStat(SubsystemDatabaseKey, "corrupt_sequence_count", StatUnitNoUnits, CorruptSequenceCountDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.WarnChannelNameSizeCount, err = NewIntStat(SubsystemDatabaseKey, "warn_channel_name_size_count", StatUnitNoUnits, WarnChannelNameSizeCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1839,6 +1845,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.SequenceIncrCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceReleasedCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceReservedCount)
+	prometheus.Unregister(d.DatabaseStats.CorruptSequenceCount)
 	prometheus.Unregister(d.DatabaseStats.WarnChannelNameSizeCount)
 	prometheus.Unregister(d.DatabaseStats.WarnChannelsPerDocCount)
 	prometheus.Unregister(d.DatabaseStats.WarnGrantsPerDocCount)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -320,6 +320,9 @@ const (
 
 	TotalInitFatalErrorsDesc   = "The total number of errors that occurred that prevented the database from being initialized."
 	TotalOnlineFatalErrorsDesc = "The total number of errors that occurred that prevented the database from being brought online."
+
+	CorruptSequenceCountDesc = "The total number of corrupt sequences detected at the sequence allocator. Documents that have a corrupt " +
+		"sequence that trigger release of sequences above the MaxSequenceToRelease threshold will have their update cancelled."
 )
 
 // Delta Sync stats descriptions

--- a/db/crud.go
+++ b/db/crud.go
@@ -1883,7 +1883,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, d
 	unusedSequences, err = col.assignSequence(ctx, previousDocSequenceIn, doc, unusedSequences)
 	if err != nil {
 		if errors.Is(err, base.ErrMaxSequenceReleasedExceeded) {
-			base.WarnfCtx(ctx, "Doc %s / %s had an existing sequence %d that is more than %d larger than expected. Document update will be cancelled. This may indicate documents being migrated between databases by an external process.", base.UD(newDoc.ID), prevCurrentRev, doc.Sequence, MaxSequencesToRelease)
+			base.ErrorfCtx(ctx, "Doc %s / %s had a much larger sequence (%d) than the current sequence number. Document update will be cancelled, since we don't want to allocate sequences to fill a gap this large. This may indicate document metadata being migrated between databases where it should've been stripped and re-imported.", base.UD(newDoc.ID), prevCurrentRev, doc.Sequence)
 		}
 		return
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1882,6 +1882,9 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, d
 
 	unusedSequences, err = col.assignSequence(ctx, previousDocSequenceIn, doc, unusedSequences)
 	if err != nil {
+		if errors.Is(err, base.ErrMaxSequenceReleasedExceeded) {
+			base.WarnfCtx(ctx, "Doc %s / %s had an existing sequence %d that is more than %d larger than expected. Document update will be cancelled. This may indicate documents being migrated between databases by an external process.", base.UD(newDoc.ID), prevCurrentRev, doc.Sequence, MaxSequencesToRelease)
+		}
 		return
 	}
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1761,3 +1761,46 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 		assert.Equal(t, int64(1), db.DbStats.Database().SequenceReleasedCount.Value())
 	}, time.Second*10, time.Millisecond*100)
 }
+
+func TestDocUpdateCorruptSequence(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyChanges, base.KeyCRUD, base.KeyDCP)
+
+	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{})
+	defer db.Close(ctx)
+
+	// create a sequence much higher than _syc:seqs value
+	const corruptSequence = MaxSequencesToRelease + 1000
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	rev, doc, err := collection.Put(ctx, "doc1", Body{"foo": "bar"})
+	require.NoError(t, err)
+	docRev := doc.RevID
+	t.Logf("doc sequence: %d", doc.Sequence)
+
+	// but we can fiddle with the sequence in the metadata of the doc write to simulate a doc from a different cluster (with a higher sequence)
+	_, xattrs, _, err := collection.dataStore.GetWithXattrs(ctx, "doc1", []string{base.SyncXattrName})
+	require.NoError(t, err)
+	var newSyncData map[string]interface{}
+	err = json.Unmarshal(xattrs[base.SyncXattrName], &newSyncData)
+	require.NoError(t, err)
+	newSyncData["sequence"] = corruptSequence
+	_, err = collection.dataStore.UpdateXattrs(ctx, doc.ID, 0, doc.Cas, map[string][]byte{base.SyncXattrName: base.MustJSONMarshal(t, newSyncData)}, DefaultMutateInOpts())
+	require.NoError(t, err)
+
+	_, _, err = collection.Put(ctx, "doc1", Body{"foo": "buzz", BodyRev: rev})
+	require.Error(t, err)
+	require.ErrorIs(t, err, base.ErrMaxSequenceReleasedExceeded)
+
+	// assert update to doc was cancelled thus doc1 is its original version
+	doc, err = collection.GetDocument(ctx, "doc1", DocUnmarshalAll)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(corruptSequence), doc.Sequence)
+	assert.Equal(t, docRev, doc.RevID)
+
+	base.RequireWaitForStat(t, func() int64 {
+		return db.DbStats.Database().CorruptSequenceCount.Value()
+	}, 1)
+}

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -292,7 +292,6 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 
 	// if sequences to release are above the max allowed, return error to cancel update
 	if numberToRelease > MaxSequencesToRelease {
-		base.WarnfCtx(ctx, "Number of sequences to release (%d) to catch up with doc current sequence (%d) exceeds MaxSequencesToRelease (%d). Doc update will be cancelled.", numberToRelease, existingSequence, MaxSequencesToRelease)
 		s.mutex.Unlock()
 		s.dbStats.CorruptSequenceCount.Add(1) // increment corrupt sequence count
 		return 0, 0, base.ErrMaxSequenceReleasedExceeded

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -290,7 +290,7 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 	numberToAllocate := s.sequenceBatchSize
 	incrVal := numberToRelease + numberToAllocate
 
-	// here
+	// if sequences to release are above the max allowed, return error to cancel update
 	if numberToRelease > MaxSequencesToRelease {
 		base.WarnfCtx(ctx, "Number of sequences to release (%d) to catch up with doc current sequence (%d) exceeds MaxSequencesToRelease (%d). Doc update will be cancelled.", numberToRelease, existingSequence, MaxSequencesToRelease)
 		s.mutex.Unlock()

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -114,7 +114,7 @@ func TestResyncRegenerateSequencesCorruptDocumentSequence(t *testing.T) {
 
 	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-	_, xattrs, cas, err = ds.GetWithXattrs(ctx, "doc0", []string{base.SyncXattrName})
+	_, xattrs, _, err = ds.GetWithXattrs(ctx, "doc0", []string{base.SyncXattrName})
 	require.NoError(t, err)
 	// assert doc sequence wasn't changed
 	var bucketSync map[string]interface{}


### PR DESCRIPTION
CBG-4578

- New error type to be returned for when number of sequcnes to release is above a threshold 
- Tests for doc update, resync, import feed and on demand import 
- New stat for when we encounter this, this will be used for capella alerting 
- Will log at warning level when this is encountered at teh sequcne allocator and document update level (this can be changed if this is too mcuh warning logging) 


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3005/
