### PR TITLE
[3.2.4 Backport] CBG-4543: Clone byte slices coming over DCP

### DIFF
--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -48,8 +48,10 @@ func (dc *DCPClient) Mutation(mutation gocbcore.DcpMutation) {
 		cas:        mutation.Cas,
 		datatype:   mutation.Datatype,
 		collection: mutation.CollectionID,
-		key:        mutation.Key,
-		value:      mutation.Value,
+
+		// The byte slices must be copied to ensure that memory associated with the underlying memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
+		key:   EfficientBytesClone(mutation.Key),
+		value: EfficientBytesClone(mutation.Value),
 	}
 	dc.workerForVbno(mutation.VbID).Send(dc.ctx, e)
 }
@@ -69,8 +71,10 @@ func (dc *DCPClient) Deletion(deletion gocbcore.DcpDeletion) {
 		revNo:      deletion.RevNo,
 		datatype:   deletion.Datatype,
 		collection: deletion.CollectionID,
-		key:        deletion.Key,
-		value:      deletion.Value,
+
+		// The byte slices must be copied to ensure that memory associated with the underlying memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
+		key:   EfficientBytesClone(deletion.Key),
+		value: EfficientBytesClone(deletion.Value),
 	}
 	dc.workerForVbno(deletion.VbID).Send(dc.ctx, e)
 

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -522,15 +522,13 @@ func dcpKeyFilter(key []byte, metaKeys *MetadataKeys) bool {
 }
 
 // Makes a feedEvent that can be passed to a FeedEventCallbackFunc implementation
+// The byte slices must be copied to ensure that memory associated with the memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 func makeFeedEvent(key []byte, value []byte, dataType uint8, cas uint64, expiry uint32, vbNo uint16, collectionID uint32, opcode sgbucket.FeedOpcode) sgbucket.FeedEvent {
 
-	// not currently doing rq.Extras handling (as in gocouchbase/upr_feed, makeUprEvent) as SG doesn't use
-	// expiry/flags information, and snapshot handling is done by cbdatasource and sent as
-	// SnapshotStart, SnapshotEnd
 	event := sgbucket.FeedEvent{
 		Opcode:       opcode,
-		Key:          key,
-		Value:        value,
+		Key:          EfficientBytesClone(key),
+		Value:        EfficientBytesClone(value),
 		CollectionID: collectionID,
 		DataType:     dataType,
 		Cas:          cas,

--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/cbgt"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,4 +83,27 @@ func TestDCPNameLength(t *testing.T) {
 				len(cbgtIndexDCPName), maxDCPNameLength, cbgtIndexDCPName)
 		})
 	}
+}
+
+// TestFeedEventByteSliceCopy( ensures that the byte slices in the FeedEvent are copies and not the original ones - CBG-4540
+func TestFeedEventByteSliceCopy(t *testing.T) {
+	const (
+		keyData   = "key"
+		valueData = "value"
+	)
+	keySlice := []byte(keyData)
+	valueSlice := []byte(valueData)
+	e := makeFeedEvent(keySlice, valueSlice, 0, 0, 0, 0, 0, sgbucket.FeedOpMutation)
+	require.Equal(t, keyData, string(e.Key))
+	require.Equal(t, valueData, string(e.Value))
+	require.Equal(t, keyData, string(keySlice))
+	require.Equal(t, valueData, string(valueSlice))
+
+	// mutate the originals and ensure the FeedEvent byte slices didn't change with it
+	keySlice[0] = 'x'
+	valueSlice[0] = 'x'
+	assert.Equal(t, keyData, string(e.Key))
+	assert.Equal(t, valueData, string(e.Value))
+	assert.NotEqual(t, keyData, string(keySlice))
+	assert.NotEqual(t, valueData, string(valueSlice))
 }

--- a/base/util.go
+++ b/base/util.go
@@ -1764,3 +1764,14 @@ func WaitForNoError(ctx context.Context, callback func() error) error {
 	}, CreateMaxDoublingSleeperFunc(30, 10, 1000))
 	return err
 }
+
+// EfficientBytesClone will return a copy of the given bytes.
+// This implementation is slightly quicker than bytes.Clone and won't over-allocate (golang/go#55905)
+func EfficientBytesClone(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	nb := make([]byte, len(b))
+	copy(nb, b)
+	return nb
+}


### PR DESCRIPTION
CBG-4543:

Clean 3.2.4 cherry-pick of #7429

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3009/
