### PR TITLE
[3.2.4 Backport] CBG-4551: Skip revcache insertion for all imports

### DIFF
--- a/db/import.go
+++ b/db/import.go
@@ -146,8 +146,8 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		existingDoc.Expiry = *expiry
 	}
 
-	// do not update rev cache for on-demand imports
-	updateRevCache := mode == ImportFromFeed
+	// do not update rev cache for any imports (CBG-4494 and CBG-4550)
+	const updateRevCache = false
 	docOut, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, true, expiry, mutationOptions, existingDoc, true, updateRevCache, func(doc *Document) (resultDocument *Document, resultAttachmentData updatedAttachments, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.


### PR DESCRIPTION
CBG-4551

Clean 3.2.4 cherry-pick of #7431

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3008/
