### PR TITLE
[3.2.4 backport] CBG-4382 do not redact profiles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.ruff]
 extend-include = ["tools/sgcollect_info"]
+
+[tool.ruff.lint]
+extend-select = ["I"]

--- a/tools-tests/conftest.py
+++ b/tools-tests/conftest.py
@@ -6,9 +6,9 @@
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
 
-from importlib.util import spec_from_loader, module_from_spec
-from importlib.machinery import SourceFileLoader
 import sys
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
 
 module_name = "sgcollect_info"
 spec = spec_from_loader(

--- a/tools-tests/parser_test.py
+++ b/tools-tests/parser_test.py
@@ -11,3 +11,14 @@ import sgcollect_info
 
 def test_parser():
     sgcollect_info.create_option_parser()
+
+
+def test_parser_log_redaction_salt():
+    parser = sgcollect_info.create_option_parser()
+    options, _ = parser.parse_args(["--log-redaction-salt=a", "foo.zip"])
+    assert options.salt_value == "a"
+
+    options, _ = parser.parse_args(["foo.zip"])
+    # assert this is a str repr of uuid4
+    assert isinstance(options.salt_value, str)
+    assert len(options.salt_value) == 36

--- a/tools-tests/password_remover_test.py
+++ b/tools-tests/password_remover_test.py
@@ -9,9 +9,8 @@
 import json
 import unittest
 
-import pytest
-
 import password_remover
+import pytest
 
 
 class TestStripPasswordsFromUrl(unittest.TestCase):

--- a/tools-tests/sgcollect_info_test.py
+++ b/tools-tests/sgcollect_info_test.py
@@ -36,13 +36,10 @@ def test_make_collect_logs_tasks(config, tmpdir):
         rotated_log_file = tmpdir.join("sg_info-01.log.gz")
         rotated_log_file.write("foo")
         tasks = sgcollect_info.make_collect_logs_tasks(
-            tmpdir,
             sg_url="fakeurl",
             sg_config_file_path="",
             sg_username="",
             sg_password="",
-            salt="",
-            should_redact=False,
         )
         assert [t.log_file for t in tasks] == [
             log_file.basename,
@@ -62,12 +59,11 @@ def test_make_collect_logs_heap_profile(tmpdir):
         pprof_file = tmpdir.join("pprof_heap_high_01.pb.gz")
         pprof_file.write("foo")
         tasks = sgcollect_info.make_collect_logs_tasks(
-            tmpdir,
             sg_url="fakeurl",
             sg_config_file_path="",
             sg_username="",
             sg_password="",
-            salt="",
-            should_redact=False,
         )
         assert [tasks[0].log_file] == [pprof_file.basename]
+        # ensure that this is not redacted task
+        assert tasks[0].description.startswith("Contents of")

--- a/tools-tests/sgcollect_info_test.py
+++ b/tools-tests/sgcollect_info_test.py
@@ -6,11 +6,10 @@
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
 
-import unittest
 import io
+import unittest
 
 import pytest
-
 import sgcollect_info
 
 

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -12,9 +12,8 @@ import sys
 import unittest
 
 import password_remover
-import tasks
-
 import pytest
+import tasks
 
 VERBOSE = 2
 

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -6,7 +6,9 @@
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
 
+import gzip
 import json
+import os
 import pathlib
 import sys
 import unittest
@@ -138,3 +140,97 @@ def test_task_logging(verbosity, task_platform, tmp_path):
     # fake the platform for a test
     task.platforms = [task_platform]
     taskrunner.run(task)
+
+
+@pytest.mark.parametrize(
+    "filename,redactable",
+    [
+        (
+            "sync_gateway",
+            False,
+        ),
+        (
+            "sync_gateway.exe",
+            False,
+        ),
+        (
+            "/abs/path/sync_gateway",
+            False,
+        ),
+        (
+            "/abs/path/sync_gateway.exe",
+            False,
+        ),
+        (
+            "pprof_heap_high_01.pb.gz",
+            False,
+        ),
+        (
+            "pprof.pb",
+            False,
+        ),
+        (
+            "/abs/path/pprof.pb",
+            False,
+        ),
+        (
+            "sg_info.log",
+            True,
+        ),
+        (
+            "sg_info-01.log.gz",
+            True,
+        ),
+        (
+            "/abs/path/sg_info.log",
+            True,
+        ),
+        (
+            "/abs/path/sg_info-01.log.gz",
+            True,
+        ),
+        (
+            "expvars.json",
+            False,
+        ),
+        (
+            "/abs/path/expvars.json",
+            False,
+        ),
+    ],
+)
+@pytest.mark.parametrize("use_pathlib", [True, False])
+def test_redactable_filename(use_pathlib, filename, redactable):
+    if use_pathlib:
+        filename = pathlib.Path(filename)
+    assert tasks.redactable_file(filename) is redactable
+
+
+def test_log_redact_file(tmp_path):
+    log_file = tmp_path / "foo.log.gz"
+    input_log_lines = [
+        "logline1: foo",
+        "logline2: <ud>password</ud>",
+        "logline3: log-redaction-salt=AAA",
+        "logline4: bar",
+    ]
+    with gzip.open(log_file, "wt") as fh:
+        for line in input_log_lines:
+            fh.write(line + "\n")
+
+    salt = "AA"
+    redactor = tasks.LogRedactor(salt, tmp_path)
+    redacted_file = redactor.redact_file(log_file.name, log_file)
+
+    output_log_lines = [
+        "RedactLevel:partial,HashOfSalt:e2512172abf8cc9f67fdd49eb6cacf2df71bbad3",
+        "logline1: foo",
+        "logline2: <ud>1700bc8ae71605063ae83d80837fa53988c635ef</ud>",
+        "logline3: log-redaction-salt <redacted>",
+        "logline4: bar",
+        "",  # file has trailing newline
+    ]
+    updated_text = os.linesep.join(output_log_lines).encode("utf-8")
+
+    redacted_text = gzip.open(redacted_file).read()
+    assert redacted_text == updated_text

--- a/tools-tests/tasks_test.py
+++ b/tools-tests/tasks_test.py
@@ -8,6 +8,7 @@
 
 import json
 import pathlib
+import sys
 import unittest
 
 import password_remover
@@ -128,3 +129,13 @@ def test_task_popen_exception(tmp_path):
 
     with open(pathlib.Path(runner.tmpdir) / runner.default_name) as fh:
         assert "Failed to execute ['notacommand']: Boom!" in fh.read()
+
+
+@pytest.mark.parametrize("verbosity", [0, 1, 2])
+@pytest.mark.parametrize("task_platform", [sys.platform, "fakeplatform"])
+def test_task_logging(verbosity, task_platform, tmp_path):
+    taskrunner = tasks.TaskRunner(verbosity=verbosity, tmp_dir=tmp_path)
+    task = tasks.AllOsTask("echo", "echo")
+    # fake the platform for a test
+    task.platforms = [task_platform]
+    taskrunner.run(task)

--- a/tools-tests/upload_test.py
+++ b/tools-tests/upload_test.py
@@ -8,14 +8,13 @@
 
 import os
 import pathlib
-import unittest.mock
 import ssl
+import unittest.mock
 
 import pytest
-import trustme
-
 import sgcollect_info
 import tasks
+import trustme
 
 ZIP_NAME = "foo.zip"
 REDACTED_ZIP_NAME = "foo-redacted.zip"

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -11,11 +11,10 @@ Redacts sensitive data in config files
 """
 
 import json
-import traceback
 import re
-from urllib.parse import urlparse
-
+import traceback
 from typing import Union
+from urllib.parse import urlparse
 
 
 def get_parsed_json(json_text: str) -> dict:

--- a/tools/sg-check.py
+++ b/tools/sg-check.py
@@ -16,9 +16,10 @@
 # be governed by the Apache License, Version 2.0, included in the file
 # licenses/APL2.txt.
 
-import ijson  # `pip install ijson` if you cannot load this module.
 import sys
 from urllib.request import urlopen
+
+import ijson  # `pip install ijson` if you cannot load this module.
 
 previous = 0
 current = 0

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -16,6 +16,7 @@ import glob
 import json
 import optparse
 import os
+import pathlib
 import platform
 import re
 import ssl
@@ -26,14 +27,15 @@ import urllib.parse
 import urllib.request
 import uuid
 from sys import platform as _platform
+from typing import List, Optional
 
 import password_remover
 from tasks import (
     AllOsTask,
     CbcollectInfoOptions,
+    PythonTask,
     TaskRunner,
     add_file_task,
-    add_gzip_file_task,
     do_upload,
     dump_utilities,
     flatten,
@@ -321,8 +323,11 @@ def urlopen_with_basic_auth(url, username, password):
 
 
 def make_collect_logs_tasks(
-    zip_dir, sg_url, sg_config_file_path, sg_username, sg_password, salt, should_redact
-):
+    sg_url: str,
+    sg_config_file_path: Optional[str],
+    sg_username: Optional[str],
+    sg_password: Optional[str],
+) -> List[PythonTask]:
     sg_log_files = {
         "sg_error.log": "sg_error.log",
         "sg_warn.log": "sg_warn.log",
@@ -385,9 +390,19 @@ def make_collect_logs_tasks(
         os_home_dirs.append(guessed_log_path)
 
     # Keep a dictionary of log file paths we've added, to avoid adding duplicates
-    sg_log_file_paths = {}
+    sg_log_file_paths: set[pathlib.Path] = set()
 
-    sg_tasks = []
+    sg_tasks: List[PythonTask] = []
+
+    def add_file_collection_task(filename: pathlib.Path):
+        canonical_filename = pathlib.Path(filename)
+        canonical_filename.resolve()
+        if canonical_filename in sg_log_file_paths:
+            return
+        sg_log_file_paths.add(canonical_filename)
+        task = add_file_task(sourcefile_path=filename)
+        task.no_header = True
+        sg_tasks.append(task)
 
     def lookup_std_log_files(files, dirs):
         for dir in dirs:
@@ -396,23 +411,12 @@ def make_collect_logs_tasks(
                 # Collect active and rotated log files from the default log locations.
                 pattern_rotated = os.path.join(dir, "{0}*{1}".format(name, ext))
                 for std_log_file in glob.glob(pattern_rotated):
-                    if std_log_file not in sg_log_file_paths:
-                        sg_tasks.append(add_file_task(sourcefile_path=std_log_file))
-                        sg_log_file_paths[std_log_file] = std_log_file
+                    add_file_collection_task(std_log_file)
 
                 # Collect archived log files from the default log locations.
                 pattern_archived = os.path.join(dir, "{0}*{1}.gz".format(name, ext))
                 for std_log_file in glob.glob(pattern_archived):
-                    if std_log_file not in sg_log_file_paths:
-                        if should_redact:
-                            task = add_gzip_file_task(
-                                sourcefile_path=std_log_file, salt=salt
-                            )
-                            sg_tasks.append(task)
-                        else:
-                            task = add_file_task(sourcefile_path=std_log_file)
-                            task.no_header = True
-                            sg_tasks.append(task)
+                    add_file_collection_task(std_log_file)
 
     # Lookup each standard SG log files in each standard SG log directories.
     lookup_std_log_files(sg_log_files, os_home_dirs)
@@ -440,13 +444,7 @@ def make_collect_logs_tasks(
         )
         for log_file_item_name in glob.iglob(rotated_logs_pattern):
             log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
-            # As long as a task that monitors this log file path has not already been added, add a new task
-            if log_file_item_path not in sg_log_file_paths:
-                print("Capturing rotated log file {0}".format(log_file_item_path))
-                task = add_file_task(sourcefile_path=log_file_item_path)
-                sg_tasks.append(task)
-                # Track which log file paths have been added so far.
-                sg_log_file_paths[log_file_item_path] = log_file_item_path
+            add_file_collection_task(log_file_item_path)
 
         # Lookup standard SG log files inside the parent directory.
         lookup_std_log_files(sg_log_files, [log_file_parent_dir])
@@ -467,14 +465,7 @@ def make_collect_logs_tasks(
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
-                # As long as a task that monitors this log file path has not already been added, add a new task
-                if log_file_item_path not in sg_log_file_paths:
-                    print("Capturing rotated log file {0}".format(log_file_item_path))
-                    task = add_file_task(sourcefile_path=log_file_item_path)
-                    sg_tasks.append(task)
-
-                    # Track which log file paths have been added so far
-                    sg_log_file_paths[log_file_item_path] = log_file_item_path
+                add_file_collection_task(log_file_item_path)
 
             # try gzipped logs too
             # e.g: sg_info-2018-12-31T13-33-41.055.log.gz
@@ -483,27 +474,7 @@ def make_collect_logs_tasks(
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
-                # As long as a task that monitors this log file path has not already been added, add a new task
-                if log_file_item_path not in sg_log_file_paths:
-                    print(
-                        "Capturing compressed rotated log file {0}".format(
-                            log_file_item_path
-                        )
-                    )
-                    # If we're redacting a gzipped log file, we'll need to extract, redact and recompress it.
-                    # If we're not redacting, we can skip extraction entirely, and use the existing .gz log file.
-                    if should_redact:
-                        task = add_gzip_file_task(
-                            sourcefile_path=log_file_item_path, salt=salt
-                        )
-                        sg_tasks.append(task)
-                    else:
-                        task = add_file_task(sourcefile_path=log_file_item_path)
-                        task.no_header = True
-                        sg_tasks.append(task)
-
-                    # Track which log file paths have been added so far
-                    sg_log_file_paths[log_file_item_path] = log_file_item_path
+                add_file_collection_task(log_file_item_path)
 
     return sg_tasks
 
@@ -531,8 +502,12 @@ def get_db_list(sg_url, sg_username, sg_password):
 #   Server config
 #   Each DB config
 def make_config_tasks(
-    zip_dir, sg_config_path, sg_url, sg_username, sg_password, should_redact
-):
+    sg_config_path: str,
+    sg_url: str,
+    sg_username: Optional[str],
+    sg_password: Optional[str],
+    should_redact: bool,
+) -> List[PythonTask]:
     collect_config_tasks = []
 
     # Here are the "usual suspects" to probe for finding the static config
@@ -699,15 +674,13 @@ def make_download_expvars_task(sg_url, sg_username, sg_password):
 
 
 def make_sg_tasks(
-    zip_dir,
-    sg_url,
-    sg_username,
-    sg_password,
-    sync_gateway_config_path_option,
-    sync_gateway_executable_path,
-    should_redact,
-    salt,
-):
+    sg_url: str,
+    sg_username: Optional[str],
+    sg_password: Optional[str],
+    sync_gateway_config_path_option: Optional[str],
+    sync_gateway_executable_path: Optional[str],
+    should_redact: bool,
+) -> List[PythonTask]:
     # Get path to sg binary (reliable) and config (not reliable)
     sg_binary_path, sg_config_path = get_paths_from_expvars(
         sg_url, sg_username, sg_password
@@ -740,7 +713,10 @@ def make_sg_tasks(
 
     # Collect logs
     collect_logs_tasks = make_collect_logs_tasks(
-        zip_dir, sg_url, sg_config_path, sg_username, sg_password, salt, should_redact
+        sg_url,
+        sg_config_path,
+        sg_username,
+        sg_password,
     )
 
     py_expvar_task = make_download_expvars_task(sg_url, sg_username, sg_password)
@@ -759,7 +735,7 @@ def make_sg_tasks(
 
     # Add a task to collect Sync Gateway config
     config_tasks = make_config_tasks(
-        zip_dir, sg_config_path, sg_url, sg_username, sg_password, should_redact
+        sg_config_path, sg_url, sg_username, sg_password, should_redact
     )
 
     # Curl the /_status
@@ -951,14 +927,12 @@ def main():
 
     # Run SG specific tasks
     for task in make_sg_tasks(
-        zip_dir,
         sg_url,
         sg_username,
         sg_password,
         options.sync_gateway_config,
         options.sync_gateway_executable,
         should_redact,
-        options.salt_value,
     ):
         runner.run(task)
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -28,19 +28,21 @@ import uuid
 from sys import platform as _platform
 
 import password_remover
-from tasks import AllOsTask
-from tasks import CbcollectInfoOptions
-from tasks import TaskRunner
-from tasks import add_file_task
-from tasks import add_gzip_file_task
-from tasks import do_upload
-from tasks import dump_utilities
-from tasks import flatten
-from tasks import generate_upload_url
-from tasks import log
-from tasks import make_curl_task
-from tasks import make_os_tasks
-from tasks import setup_stdin_watcher
+from tasks import (
+    AllOsTask,
+    CbcollectInfoOptions,
+    TaskRunner,
+    add_file_task,
+    add_gzip_file_task,
+    do_upload,
+    dump_utilities,
+    flatten,
+    generate_upload_url,
+    log,
+    make_curl_task,
+    make_os_tasks,
+    setup_stdin_watcher,
+)
 
 try:
     # Don't validate HTTPS by default.

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -16,9 +16,9 @@ import base64
 import glob
 import gzip
 import hashlib
-import io
 import optparse
 import os
+import pathlib
 import re
 import shutil
 import sys
@@ -29,20 +29,11 @@ import traceback
 import urllib.error
 import urllib.parse
 import urllib.request
-
-# The 'latin-1' encoding is being used since we can't guarantee that all bytes that will be
-# processed through sgcollect will be decodable from 'utf-8' (which is the default in Python)
-# and the decoder may fail if it encounters any such byte sequence whilst decoding byte strings.
-# The 'latin-1' encoding belongs to the ISO-8859 family and is capable of decoding any byte sequence.
-ENCODING_LATIN1 = "latin-1"
-
-# Error handler is being used to handle special cases on Windows platforms when the cp1252
-# encoding is  referred to as 'latin-1',  it does not map all possible byte values.
-BACKSLASH_REPLACE = "backslashreplace"
+from typing import Callable, List, Optional, Union
 
 
 class LogRedactor:
-    def __init__(self, salt, tmpdir):
+    def __init__(self, salt: str, tmpdir: Union[str, pathlib.Path]):
         self.target_dir = os.path.join(tmpdir, "redacted")
         os.makedirs(self.target_dir)
 
@@ -51,22 +42,16 @@ class LogRedactor:
 
     def _process_file(self, ifile, ofile, processor):
         try:
-            with open(
+            with get_open_fn(ifile)(
                 ifile,
-                "r",
-                newline="",
-                encoding=ENCODING_LATIN1,
-                errors=BACKSLASH_REPLACE,
+                "rb",
             ) as inp:
-                with open(
+                with get_open_fn(ofile)(
                     ofile,
-                    "w+",
-                    newline="",
-                    encoding=ENCODING_LATIN1,
-                    errors=BACKSLASH_REPLACE,
+                    "wb+",
                 ) as out:
                     # Write redaction header
-                    out.write(self.couchbase_log.do("RedactLevel"))
+                    out.write(self.couchbase_log.do(b"RedactLevel"))
                     for line in inp:
                         out.write(processor.do(line))
         except IOError as e:
@@ -79,55 +64,56 @@ class LogRedactor:
         return ofile
 
     def redact_string(self, istring):
-        ostring = self.couchbase_log.do("RedactLevel")
+        ostring = self.couchbase_log.do(b"RedactLevel")
         ostring += self.regular_log.do(istring)
         return ostring
 
 
 class CouchbaseLogProcessor:
-    def __init__(self, salt):
-        self.salt = salt
+    def __init__(self, salt: str):
+        self.salt = salt.encode("ascii")
 
-    def do(self, line):
-        if "RedactLevel" in line:
+    def do(self, line: bytes) -> bytes:
+        if b"RedactLevel" in line:
             # salt + salt to maintain consistency with other
             # occurrences of hashed salt in the logs.
-            return (
-                "RedactLevel:partial,HashOfSalt:%s\n"
-                % generate_hash(self.salt + self.salt).hexdigest()
-            )
+            return b"RedactLevel:partial,HashOfSalt:%b" % generate_hash(
+                self.salt + self.salt
+            ).hexdigest().encode("utf-8") + os.linesep.encode("ascii")
         else:
             return line
 
 
 class RegularLogProcessor:
-    rexes = [
-        re.compile("(<ud>)(.+?)(</ud>)"),
-        # Redact the rest of the line in the case we encounter
-        # log-redaction-salt. Needed to redact ps output containing sgcollect flags safely.
-        re.compile("(log-redaction-salt)(.+)"),
-    ]
+    def __init__(self, salt: str):
+        self.salt = salt.encode("ascii")
+        self.rexes = [
+            (re.compile(b"(<ud>)(.+?)(</ud>)"), self._redact_userdata),
+            (re.compile(rb"(log-redaction-salt)(.+)"), self.redact_salt),
+        ]
 
-    def __init__(self, salt):
-        self.salt = salt
-
-    def _hash(self, match):
+    def _redact_userdata(self, match: re.Match) -> bytes:
         result = match.group(1)
-        if match.lastindex == 3:
-            h = generate_hash(self.salt + match.group(2)).hexdigest()
-            result += h + match.group(3)
-        elif match.lastindex == 2:
-            result += " <redacted>"
+        h = generate_hash(self.salt + match.group(2)).hexdigest().encode("ascii")
+        result += h + match.group(3)
         return result
 
-    def do(self, line):
-        for rex in self.rexes:
-            line = rex.sub(self._hash, line)
+    def redact_salt(self, match: re.Match) -> bytes:
+        result = match.group(1)
+        result += b" <redacted>"
+        # on windows, make sure we don't lose the \r
+        if match.group(0).endswith(b"\r"):
+            result += b"\r"
+        return result
+
+    def do(self, line: bytes) -> bytes:
+        for rex, func in self.rexes:
+            line = rex.sub(func, line)
         return line
 
 
-def generate_hash(val):
-    return hashlib.sha1(val.encode())
+def generate_hash(val: bytes):
+    return hashlib.sha1(val)
 
 
 class AltExitC(object):
@@ -402,16 +388,20 @@ class TaskRunner(object):
                 % (task.description, command_to_print, sys.platform)
             )
 
-    def redact_and_zip(self, filename, log_type, salt, node):
+    def redact_and_zip(self, filename: str, log_type: str, salt: str, node: str):
+        """
+        Redacts all files defined by writing a copy into a temporary directory. Zips up the directory as filename.
+
+        :param filename: The name of the zip file to be created
+        :param log_type: Prefix for the name of the zipfile
+        :param salt: The salt to be used for redaction
+        :param node: Hostname
+        """
         files = []
         redactor = LogRedactor(salt, self.tmpdir)
 
         for name, fp in self.files.items():
-            if not (
-                ".gz" in name
-                or "expvars.json" in name
-                or os.path.basename(name) == "sync_gateway"
-            ):
+            if redactable_file(name):
                 files.append(redactor.redact_file(name, fp.name))
             else:
                 files.append(fp.name)
@@ -515,41 +505,9 @@ def make_curl_task(
     )
 
 
-def add_gzip_file_task(sourcefile_path, salt, content_postprocessors=[]):
-    """
-    Adds the extracted contents of a file to the output zip
-
-    The content_postprocessors is a list of functions -- see make_curl_task
-    """
-
-    def python_add_file_task():
-        with gzip.open(sourcefile_path, "r") as infile:
-            contents = infile.read().decode("utf-8")
-            for content_postprocessor in content_postprocessors:
-                contents = content_postprocessor(contents)
-            redactor = LogRedactor(salt, tempfile.mkdtemp())
-            contents = redactor.redact_string(contents)
-
-        out = io.BytesIO()
-        with gzip.GzipFile(fileobj=out, mode="w") as f:
-            f.write(contents.encode())
-        return out.getvalue()
-
-    log_file = os.path.basename(sourcefile_path)
-
-    task = PythonTask(
-        description="Extracted contents of {0}".format(sourcefile_path),
-        callable=python_add_file_task,
-        log_file=log_file,
-        log_exception=False,
-    )
-
-    task.no_header = True
-
-    return task
-
-
-def add_file_task(sourcefile_path, content_postprocessors=[]):
+def add_file_task(
+    sourcefile_path, content_postprocessors: Optional[List[Callable]] = None
+) -> PythonTask:
     """
     Adds the contents of a file to the output zip
 
@@ -559,8 +517,9 @@ def add_file_task(sourcefile_path, content_postprocessors=[]):
     def python_add_file_task():
         with open(sourcefile_path, "br") as infile:
             contents = infile.read()
-            for content_postprocessor in content_postprocessors:
-                contents = content_postprocessor(contents)
+            if content_postprocessors:
+                for content_postprocessor in content_postprocessors:
+                    contents = content_postprocessor(contents)
             return contents
 
     task = PythonTask(
@@ -1372,3 +1331,23 @@ def exec_name(name):
     if sys.platform == "win32":
         name += ".exe"
     return name
+
+
+def redactable_file(filename: Union[pathlib.Path, str]) -> bool:
+    """
+    Return True if the file should be redacted, otherwise False.
+    """
+    filename = pathlib.Path(filename)
+    if filename.name.startswith(("pprof", "expvars.json")):
+        return False
+    return filename.stem != "sync_gateway"
+
+
+def get_open_fn(path: Union[pathlib.Path, str]) -> Callable:
+    """
+    Return open function for path. gzip.open if suffixed with .gz, else open.
+    """
+    path = pathlib.Path(path)
+    if path.suffix == ".gz":
+        return gzip.open
+    return open

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -372,12 +372,8 @@ class TaskRunner(object):
 
     def run(self, task):
         """Run a task with a file descriptor corresponding to its log file"""
+        command_to_print = getattr(task, "command_to_print", task.command)
         if task.will_run():
-            if hasattr(task, "command_to_print"):
-                command_to_print = task.command_to_print
-            else:
-                command_to_print = task.command
-
             log("%s (%s) - " % (task.description, command_to_print), end="")
             if task.privileged and os.getuid() != 0:
                 log("skipped (needs root privs)")
@@ -406,7 +402,7 @@ class TaskRunner(object):
         elif self.verbosity >= 2:
             log(
                 'Skipping "%s" (%s): not for platform %s'
-                % (task.description, task.command_to_print, sys.platform)
+                % (task.description, command_to_print, sys.platform)
             )
 
     def redact_and_zip(self, filename, log_type, salt, node):


### PR DESCRIPTION
[3.2.4 backport] CBG-4382 do not redact profiles

Cherry-picks the following commits:

24b96f23275fb61debba8c002e371c25fc933163 (fixes exception with -v)
65c5ae456a553e3018a3ae7ee938eaedde2f017 (lint fixes)
80c5dbcb0410c3c8e4e50b45f7159bac4ea01aab

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`