### PR TITLE
[3.2.4 backport] CBG-4571: stop audit events logging when no audit config is provided at db level

### DIFF
--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -557,8 +557,18 @@ func TestAuditDatabaseUpdate(t *testing.T) {
 	rt := createAuditLoggingRestTester(t)
 	defer rt.Close()
 
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Logging = &DbLoggingConfig{
+		Audit: &DbAuditLoggingConfig{
+			Enabled: base.BoolPtr(true),
+			EnabledEvents: base.Ptr([]uint{
+				uint(base.AuditIDUpdateDatabaseConfig),
+			}),
+		},
+	}
+
 	// initialize RestTester
-	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	testCases := []struct {
 		name   string
@@ -756,7 +766,18 @@ func TestAuditDocumentRead(t *testing.T) {
 	rt := createAuditLoggingRestTester(t)
 	defer rt.Close()
 
-	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Logging = &DbLoggingConfig{
+		Audit: &DbAuditLoggingConfig{
+			Enabled: base.BoolPtr(true),
+			EnabledEvents: base.Ptr([]uint{
+				uint(base.AuditIDDocumentRead),
+				uint(base.AuditIDDocumentMetadataRead),
+			}),
+		},
+	}
+
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	const docID = "doc1"
 	docVersion := rt.CreateTestDoc(docID)
@@ -923,11 +944,58 @@ func TestAuditDocumentRead(t *testing.T) {
 	}
 }
 
+// TestNoAuditWhenDisabledAtDb tests to ensure when audit logging is disabled at the db that you will not get any events
+// associated with the db in the audit log
+func TestNoAuditWhenDisabledAtDb(t *testing.T) {
+	rt := createAuditLoggingRestTester(t)
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
+	// test create/view doc events and assert they don't show in audit log
+	output := base.AuditLogContents(t, func(t testing.TB) {
+		resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"key":"value"}`)
+		RequireStatus(t, resp, http.StatusCreated)
+	})
+	events := jsonLines(rt.TB(), output)
+	require.Len(t, events, 0)
+
+	output = base.AuditLogContents(t, func(t testing.TB) {
+		resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/doc1", "")
+		RequireStatus(t, resp, http.StatusOK)
+	})
+	events = jsonLines(rt.TB(), output)
+	require.Len(t, events, 0)
+
+	// test event that is enabled by default on db (when audit is enabled)
+	output = base.AuditLogContents(t, func(t testing.TB) {
+		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", `{"user_xattr_key":"user_xattr_value"}`)
+		RequireStatus(t, resp, http.StatusCreated)
+	})
+	events = jsonLines(rt.TB(), output)
+	require.Len(t, events, 0)
+}
+
 func TestAuditAttachmentEvents(t *testing.T) {
 	rt := createAuditLoggingRestTester(t)
 	defer rt.Close()
 
-	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Logging = &DbLoggingConfig{
+		Audit: &DbAuditLoggingConfig{
+			Enabled: base.BoolPtr(true),
+			EnabledEvents: base.Ptr([]uint{
+				uint(base.AuditIDAttachmentCreate),
+				uint(base.AuditIDAttachmentRead),
+				uint(base.AuditIDAttachmentDelete),
+				uint(base.AuditIDAttachmentUpdate),
+			}),
+		},
+	}
+
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+
 	testCases := []struct {
 		name                  string
 		setupCode             func(t testing.TB, docID string) DocVersion
@@ -1061,7 +1129,11 @@ func TestAuditAttachmentEvents(t *testing.T) {
 			})
 			postAttachmentVersion, _ := rt.GetDoc(docID)
 
+			requireAttachmentEvents(rt, base.AuditIDAttachmentCreate, output, docID, postAttachmentVersion.RevID, attachmentName, testCase.attachmentCreateCount)
+			requireAttachmentEvents(rt, base.AuditIDAttachmentRead, output, docID, postAttachmentVersion.RevID, attachmentName, testCase.attachmentReadCount)
+			requireAttachmentEvents(rt, base.AuditIDAttachmentUpdate, output, docID, postAttachmentVersion.RevID, attachmentName, testCase.attachmentUpdateCount)
 			requireAttachmentEvents(rt, base.AuditIDAttachmentDelete, output, docID, postAttachmentVersion.RevID, attachmentName, testCase.attachmentDeleteCount)
+
 		})
 	}
 }
@@ -1071,10 +1143,20 @@ func TestAuditDocumentCreateUpdateEvents(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := rt.NewDbConfig()
+	dbConfig.Logging = &DbLoggingConfig{
+		Audit: &DbAuditLoggingConfig{
+			Enabled: base.BoolPtr(true),
+			EnabledEvents: base.Ptr([]uint{
+				uint(base.AuditIDDocumentCreate),
+				uint(base.AuditIDDocumentUpdate),
+			}),
+		},
+	}
 	if base.TestUseXattrs() {
 		// this is not set automatically for CE
 		dbConfig.AutoImport = base.BoolPtr(true)
 	}
+
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 	type testCase struct {
 		name                string
@@ -1149,7 +1231,17 @@ func TestAuditChangesFeedStart(t *testing.T) {
 		rt := createAuditLoggingRestTester(t)
 		defer rt.Close()
 
-		RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+		dbConfig := rt.NewDbConfig()
+		dbConfig.Logging = &DbLoggingConfig{
+			Audit: &DbAuditLoggingConfig{
+				Enabled: base.BoolPtr(true),
+				EnabledEvents: base.Ptr([]uint{
+					uint(base.AuditIDChangesFeedStarted),
+				}),
+			},
+		}
+
+		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
@@ -1445,6 +1537,9 @@ func requireChangesStartEvent(t testing.TB, output []byte, expectedFields map[st
 }
 
 func createAuditLoggingRestTester(t *testing.T) *RestTester {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Audit logging only works in EE")
+	}
 	// get tempdir before resetting global loggers, since the logger cleanup needs to happen before deletion
 	tempdir := t.TempDir()
 	base.ResetGlobalTestLogging(t)
@@ -1493,7 +1588,20 @@ func TestAuditBlipCRUD(t *testing.T) {
 		rt := createAuditLoggingRestTester(t)
 		defer rt.Close()
 
-		RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
+		dbConfig := rt.NewDbConfig()
+		dbConfig.Logging = &DbLoggingConfig{
+			Audit: &DbAuditLoggingConfig{
+				Enabled: base.BoolPtr(true),
+				EnabledEvents: base.Ptr([]uint{
+					uint(base.AuditIDAttachmentCreate),
+					uint(base.AuditIDAttachmentRead),
+					uint(base.AuditIDAttachmentDelete),
+					uint(base.AuditIDAttachmentUpdate),
+				}),
+			},
+		}
+
+		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
@@ -1517,7 +1625,11 @@ func TestAuditBlipCRUD(t *testing.T) {
 
 					version, err := btcRunner.PushRev(btc.id, docID, EmptyDocVersion(), []byte(`{"key":"val","_attachments":{"attachment1":{"data":"`+attData+`"}}}`))
 					require.NoError(t, err)
-					btcRunner.WaitForVersion(btc.id, docID, version)
+					// wait for the doc to be replicated, since that's what we're actually auditing
+					require.NoError(t, rt.WaitForVersion(docID, version))
+					base.RequireWaitForStat(t, func() int64 {
+						return rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value()
+					}, 1)
 				},
 				attachmentCreateCount: 1,
 			},

--- a/rest/config.go
+++ b/rest/config.go
@@ -2298,7 +2298,11 @@ func RegisterSignalHandler(ctx context.Context) {
 func (c *DbConfig) toDbLogConfig(ctx context.Context) *base.DbLogConfig {
 	l := c.Logging
 	if l == nil || (l.Console == nil && l.Audit == nil) {
-		return nil
+		return &base.DbLogConfig{
+			Audit: &base.DbAuditLogConfig{
+				Enabled: base.DefaultDbAuditEnabled,
+			},
+		}
 	}
 
 	var con *base.DbConsoleLogConfig


### PR DESCRIPTION
[3.2.4 backport] CBG-4571: stop audit events logging when no audit config is provided at db level

cherry-pick of 45cbed032132e11d793af4ce224c25e9090b5946

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

