### PR TITLE
[3.2.4 backport] close goroutines for multiframe messages

### DIFF
--- a/db/main_test.go
+++ b/db/main_test.go
@@ -19,6 +19,6 @@ import (
 
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 4096}
 	TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/couchbase/cbgt v1.3.10-0.20250128173458-04138cb9d33d
 	github.com/couchbase/clog v0.1.0
-	github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd
+	github.com/couchbase/go-blip v0.0.0-20250401141209-2ce2693998ab
 	github.com/couchbase/gocb/v2 v2.9.4-0.20250206113323-8ef6d9010511
 	github.com/couchbase/gocbcore/v10 v10.5.4-0.20250107135314-f4c4becdca29
 	github.com/couchbase/gomemcached v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/couchbase/cbgt v1.3.10-0.20250128173458-04138cb9d33d h1:X80jy41uF1ivq
 github.com/couchbase/cbgt v1.3.10-0.20250128173458-04138cb9d33d/go.mod h1:MImhtmvk0qjJit5HbmA34tnYThZoNtvgjL7jJH/kCAE=
 github.com/couchbase/clog v0.1.0 h1:4Kh/YHkhRjMCbdQuvRVsm39XZh4FtL1d8fAwJsHrEPY=
 github.com/couchbase/clog v0.1.0/go.mod h1:7tzUpEOsE+fgU81yfcjy5N1H6XtbVC8SgOz/3mCjmd4=
-github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd h1:ERQXaXuX1eix3NUqrxQ5VY0hqHH90vcfrWdbEWKzlEY=
-github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd/go.mod h1:Dz8Keu17/4cjF7hvKYqOjH4pRXOh1CCnzsKlBOJaoJE=
+github.com/couchbase/go-blip v0.0.0-20250401141209-2ce2693998ab h1:vxWvmbfTMfuSS1rGnfHA6RH7b8OtYm9owgrnxV/TX18=
+github.com/couchbase/go-blip v0.0.0-20250401141209-2ce2693998ab/go.mod h1:Dz8Keu17/4cjF7hvKYqOjH4pRXOh1CCnzsKlBOJaoJE=
 github.com/couchbase/go-couchbase v0.1.1 h1:ClFXELcKj/ojyoTYbsY34QUrrYCBi/1G749sXSCkdhk=
 github.com/couchbase/go-couchbase v0.1.1/go.mod h1:+/bddYDxXsf9qt0xpDUtRR47A2GjaXmGGAqQ/k3GJ8A=
 github.com/couchbase/gocb/v2 v2.9.4-0.20250206113323-8ef6d9010511 h1:5TNKEA0AgZcih7e3h26PmuIBRscsx+PLVmDnAOstxO8=


### PR DESCRIPTION
Created a branch on go-blip https://github.com/couchbase/go-blip/tree/release/3.2.4 since go-blip has some changes post release/3.2 sync gateway that we don't want to pick up. This should be the same branch point plus 2 cherry-picks for this change.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3021/
