### PR TITLE
[3.2.2.1 backport] CBG-4595: have maximum threshold for releasing sequences

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -74,6 +74,9 @@ var (
 
 	// ErrReplicationLimitExceeded is returned when then replication connection threshold is exceeded
 	ErrReplicationLimitExceeded = &sgError{"Replication limit exceeded. Try again later."}
+
+	// ErrMaxSequenceReleasedExceeded is returned when the maximum number of sequences to be released as part of nextSequenceGreaterThan is exceeded
+	ErrMaxSequenceReleasedExceeded = &sgError{"Maximum number of sequences to release to catch up with document sequence exceeded"}
 )
 
 func (e *sgError) Error() string {

--- a/base/stats.go
+++ b/base/stats.go
@@ -88,6 +88,7 @@ const (
 	StatAddedVersion3dot2dot0     = "3.2.0"
 	StatAddedVersion3dot2dot1     = "3.2.1"
 	StatAddedVersion3dot2dot2     = "3.2.2"
+	StatAddedVersion3dot2dot2dot1 = "3.2.2.1"
 	StatAddedVersion3dot3dot0     = "3.3.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
@@ -638,6 +639,8 @@ type DatabaseStats struct {
 	SequenceReleasedCount *SgwIntStat `json:"sequence_released_count"`
 	// The total number of sequences reserved by Sync Gateway.
 	SequenceReservedCount *SgwIntStat `json:"sequence_reserved_count"`
+	// The total number of corrupt sequences above the MaxSequencesToRelease threshold seen at the sequence allocator
+	CorruptSequenceCount *SgwIntStat `json:"corrupt_sequence_count"`
 	// The total number of warnings relating to the channel name size.
 	WarnChannelNameSizeCount *SgwIntStat `json:"warn_channel_name_size_count"`
 	// The total number of warnings relating to the channel count exceeding the channel count threshold.
@@ -1742,6 +1745,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.CorruptSequenceCount, err = NewIntStat(SubsystemDatabaseKey, "corrupt_sequence_count", StatUnitNoUnits, CorruptSequenceCountDesc, StatAddedVersion3dot2dot2dot1, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.WarnChannelNameSizeCount, err = NewIntStat(SubsystemDatabaseKey, "warn_channel_name_size_count", StatUnitNoUnits, WarnChannelNameSizeCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1819,6 +1826,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.SequenceIncrCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceReleasedCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceReservedCount)
+	prometheus.Unregister(d.DatabaseStats.CorruptSequenceCount)
 	prometheus.Unregister(d.DatabaseStats.WarnChannelNameSizeCount)
 	prometheus.Unregister(d.DatabaseStats.WarnChannelsPerDocCount)
 	prometheus.Unregister(d.DatabaseStats.WarnGrantsPerDocCount)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -316,6 +316,9 @@ const (
 
 	NumIdleKvOpsDesc    = "The total number of idle kv operations."
 	NumIdleQueryOpsDesc = "The total number of idle query operations."
+
+	CorruptSequenceCountDesc = "The total number of corrupt sequences detected at the sequence allocator. Documents that have a corrupt " +
+		"sequence that trigger release of sequences above the MaxSequenceToRelease threshold will have their update cancelled."
 )
 
 // Delta Sync stats descriptions

--- a/db/crud.go
+++ b/db/crud.go
@@ -1875,6 +1875,9 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(ctx context.Context, d
 
 	unusedSequences, err = col.assignSequence(ctx, previousDocSequenceIn, doc, unusedSequences)
 	if err != nil {
+		if errors.Is(err, base.ErrMaxSequenceReleasedExceeded) {
+			base.ErrorfCtx(ctx, "Doc %s / %s had a much larger sequence (%d) than the current sequence number. Document update will be cancelled, since we don't want to allocate sequences to fill a gap this large. This may indicate document metadata being migrated between databases where it should've been stripped and re-imported.", base.UD(newDoc.ID), prevCurrentRev, doc.Sequence)
+		}
 		return
 	}
 

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -39,6 +39,9 @@ const (
 	// Accounts for a maximum SG cluster size of 50 nodes, each allocating a full batch size of 10
 	// if this value is too low and this correction has potential to allocate sequences that other nodes have already reserved a batch for
 	syncSeqCorrectionValue = 500
+
+	// Maximum number of sequences to release as part of nextSequenceGreaterThan
+	MaxSequencesToRelease = 10000000
 )
 
 // MaxSequenceIncrFrequency is the maximum frequency we want to perform incr operations.
@@ -286,6 +289,14 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 	numberToRelease := existingSequence - syncSeq
 	numberToAllocate := s.sequenceBatchSize
 	incrVal := numberToRelease + numberToAllocate
+
+	// if sequences to release are above the max allowed, return error to cancel update
+	if numberToRelease > MaxSequencesToRelease {
+		s.mutex.Unlock()
+		s.dbStats.CorruptSequenceCount.Add(1) // increment corrupt sequence count
+		return 0, 0, base.ErrMaxSequenceReleasedExceeded
+	}
+
 	allocatedToSeq, err := s.incrementSequence(incrVal)
 	if err != nil {
 		base.WarnfCtx(ctx, "Error from incrementSequence in nextSequenceGreaterThan(%d): %v", existingSequence, err)

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -9,6 +9,7 @@
 package adminapitest
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -67,6 +68,64 @@ func TestResyncRollback(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, response, http.StatusOK)
 	status = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+}
+
+func TestResyncRegenerateSequencesCorruptDocumentSequence(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test doesn't works with walrus")
+	}
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCRUD, base.KeyChanges, base.KeyAccess)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		AutoImport: base.BoolPtr(false),
+	})
+
+	defer rt.Close()
+	ctx := base.TestCtx(t)
+	ds := rt.GetSingleDataStore()
+
+	// create a sequence much higher than _syc:seqs value
+	const corruptSequence = db.MaxSequencesToRelease + 1000
+
+	numDocs := 10
+	for i := 0; i < numDocs; i++ {
+		rt.CreateTestDoc(fmt.Sprintf("doc%v", i))
+	}
+
+	// corrupt doc0 sequence
+	_, xattrs, cas, err := ds.GetWithXattrs(ctx, "doc0", []string{base.SyncXattrName})
+	require.NoError(t, err)
+
+	// corrupt the document sequence
+	var newSyncData map[string]interface{}
+	err = json.Unmarshal(xattrs[base.SyncXattrName], &newSyncData)
+	require.NoError(t, err)
+	newSyncData["sequence"] = corruptSequence
+	_, err = ds.UpdateXattrs(ctx, "doc0", 0, cas, map[string][]byte{base.SyncXattrName: base.MustJSONMarshal(t, newSyncData)}, nil)
+	require.NoError(t, err)
+
+	response := rt.SendAdminRequest("POST", "/{{.db}}/_offline", "")
+	rest.RequireStatus(t, response, http.StatusOK)
+	rt.WaitForDBState(db.RunStateString[db.DBOffline])
+
+	// we need to wait for the resync to start and not finish
+	resp := rt.SendAdminRequest("POST", "/{{.db}}/_resync?action=start&regenerate_sequences=true", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateRunning)
+
+	_ = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+
+	_, xattrs, _, err = ds.GetWithXattrs(ctx, "doc0", []string{base.SyncXattrName})
+	require.NoError(t, err)
+	// assert doc sequence wasn't changed
+	var bucketSync map[string]interface{}
+	err = json.Unmarshal(xattrs[base.SyncXattrName], &bucketSync)
+	require.NoError(t, err)
+	seq := newSyncData["sequence"].(int)
+	require.Equal(t, uint64(corruptSequence), uint64(seq))
+
+	base.RequireWaitForStat(t, func() int64 {
+		return rt.GetDatabase().DbStats.Database().CorruptSequenceCount.Value()
+	}, 1)
 }
 
 func TestResyncRegenerateSequencesPrincipals(t *testing.T) {

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -105,7 +105,7 @@ func TestResyncRegenerateSequencesCorruptDocumentSequence(t *testing.T) {
 
 	response := rt.SendAdminRequest("POST", "/{{.db}}/_offline", "")
 	rest.RequireStatus(t, response, http.StatusOK)
-	rt.WaitForDBState(db.RunStateString[db.DBOffline])
+	require.NoError(t, rt.WaitForDBState(db.RunStateString[db.DBOffline]))
 
 	// we need to wait for the resync to start and not finish
 	resp := rt.SendAdminRequest("POST", "/{{.db}}/_resync?action=start&regenerate_sequences=true", "")


### PR DESCRIPTION
[3.2.2.1 backport] CBG-4595: have maximum threshold for releasing sequences

cherry-picks 0afb8086976709c9dfbc318dfa6a0a8fdcd56229

I will update 3.2.4/3.3 branches with this stat appearing on 3.2.2.1 now.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3016/
