### PR TITLE
CBG-4581 - Add sequence value stats for last allocated and last reserved

### DIFF
--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -276,13 +276,17 @@ const (
 
 	SequenceAssignedCountDesc = "The total number of sequence numbers assigned."
 
+	LastSequenceAssignedValueDesc = "The value of the last sequence number assigned."
+
 	SequenceGetCountDesc = "The total number of high sequence lookups."
 
 	SequenceIncrCountDesc = "The total number of times the sequence counter document has been incremented."
 
-	SequenceReleasedCountDesc = "The total number of unused, reserved sequences released by Sync Gateway."
+	SequenceReleasedCountDesc = "The total number of unused, reserved sequences released."
 
-	SequenceReservedCountDesc = "The total number of sequences reserved by Sync Gateway."
+	SequenceReservedCountDesc = "The total number of sequences reserved."
+
+	LastSequenceReservedValueDesc = "The value of the last sequence number reserved (which may not yet be assigned)"
 
 	WarnChannelNameSizeCountDesc = "The total number of warnings relating to the channel name size."
 

--- a/base/util.go
+++ b/base/util.go
@@ -1234,10 +1234,12 @@ type AtomicInt struct {
 	val int64
 }
 
+// Set sets the value of the atomic int. Callers must ensure that invocations of this are protected by a mutex or are otherwise safe to call concurrently, since value can overwrite any previous value.
 func (ai *AtomicInt) Set(value int64) {
 	atomic.StoreInt64(&ai.val, value)
 }
 
+// SetIfMax sets the value of the atomic int to the given value if the given value is greater than the current value.
 func (ai *AtomicInt) SetIfMax(value int64) {
 	for {
 		cur := atomic.LoadInt64(&ai.val)
@@ -1251,6 +1253,7 @@ func (ai *AtomicInt) SetIfMax(value int64) {
 	}
 }
 
+// Add adds the given value to the atomic int.
 func (ai *AtomicInt) Add(value int64) {
 	atomic.AddInt64(&ai.val, value)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -618,7 +618,9 @@ func GetSingleDatabaseCollection(tb testing.TB, database *DatabaseContext) *Data
 
 // AllocateTestSequence allocates a sequence via the sequenceAllocator.  For use by non-db tests
 func AllocateTestSequence(database *DatabaseContext) (uint64, error) {
-	return database.sequences.incrementSequence(1)
+	database.sequences.mutex.Lock()
+	defer database.sequences.mutex.Unlock()
+	return database.sequences._incrementSequence(1)
 }
 
 // ReleaseTestSequence releases a sequence via the sequenceAllocator.  For use by non-db tests


### PR DESCRIPTION
CBG-4581

Add new stats to track last allocated and last reserved sequence values
- Centralized sequence stat updates into the two main functions `_incrementSequence` and `_nextSequence`
  - Additional locking required for new value stats to ensure concurrent sequence allocations do not overwrite previous values, so stat updates moved inside the mutex guarded methods.
  - Deduplicates stat updates by moving them down one level.
- Extended existing test assertion helper `assertNewAllocatorStats` to cover new seq value stats.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3019/
