### PR TITLE
[3.2.4 Backport] CBG-4585: Return Invalid JSON error via OIDC discovery

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -517,6 +517,7 @@ func (op *OIDCProvider) fetchCustomProviderConfig(ctx context.Context, discovery
 	}
 
 	if err := base.JSONUnmarshal(bodyBytes, &metadata); err != nil {
+		err = base.ErrInvalidJSON
 		base.InfofCtx(ctx, base.KeyAuth, "Error parsing body during discovery sync: %v", err)
 		return ProviderMetadata{}, MaxProviderConfigSyncInterval, false, err
 	}

--- a/base/error.go
+++ b/base/error.go
@@ -77,6 +77,9 @@ var (
 
 	// ErrMaxSequenceReleasedExceeded is returned when the maximum number of sequences to be released as part of nextSequenceGreaterThan is exceeded
 	ErrMaxSequenceReleasedExceeded = &sgError{"Maximum number of sequences to release to catch up with document sequence exceeded"}
+
+	// ErrInvalidJSON is returned when the JSON being unmarshalled cannot be parsed.
+	ErrInvalidJSON = HTTPErrorf(http.StatusBadRequest, "Invalid JSON")
 )
 
 func (e *sgError) Error() string {
@@ -249,7 +252,8 @@ func IsTemporaryKvError(err error) bool {
 		gocb.ErrTimeout,            // SDK op timeout.  Wrapped by gocb.ErrAmbiguousTimeout, gocb.ErrUnambiguousTimeout,
 		gocb.ErrOverload,           // SDK client-side pipeline queue full, request was not submitted to server
 		gocb.ErrTemporaryFailure,   // Couchbase Server returned temporary failure error
-		gocb.ErrCircuitBreakerOpen} // SDK client-side circuit breaker blocked request
+		gocb.ErrCircuitBreakerOpen, // SDK client-side circuit breaker blocked request
+	}
 
 	// iterate through to check incoming error is one of them
 	for _, tempKVErr := range temporaryKVError {


### PR DESCRIPTION
CBG-4585

Clean cherry-pick of #7438 for 3.2.4

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a