### PR TITLE
CBG-4599 update to golanci-lint v2 configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
         with:
           go-version: 1.24.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.8
+          version: v2.0.2
           args: --config=.golangci-strict.yml
 
   test:

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -1,3 +1,11 @@
+# Copyright 2025-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 version: "2"
 linters:
   enable:
@@ -38,6 +46,43 @@ linters:
         ruleguard:
           failOn: all
           rules: ${base-path}/ruleguard/rules-*.go
+    staticcheck:
+      checks:
+        - all # enable all
+        # disable some checks until fixed
+        - -QF1001 # Apply De Morgan's law.
+        - -QF1003 # could use tagged switch
+        - -QF1004 # Use 'strings.ReplaceAll' instead of 'strings.Replace' with 'n == -1'.
+        - -QF1007 # could merge conditional assignment into variable declaration
+        - -QF1008 # Omit embedded fields from selector expression.
+        - -QF1010 # Convert slice of bytes to string when printing it.
+        - -QF1011 # Omit redundant type from variable declaration.
+        - -QF1012 # Use 'fmt.Fprintf(x, ...)' instead of 'x.Write(fmt.Sprintf(...))'.
+        - -S1000 # Use plain channel send or receive instead of single-case select.
+        - -S1002 # Omit comparison with boolean constant.
+        - -S1005 # unnecssary assignment to the blank identifier
+        - -S1007 # Simplify regular expression by using raw string literal.
+        - -S1008 # Simplify returning boolean expression.
+        - -S1009 # Omit redundant nil check on slices, maps, and channels.
+        - -S1011 # Use a single 'append' to concatenate two slices.
+        - -S1012 # Replace 'time.Now().Sub(x)' with 'time.Since(x)'.
+        - -S1021 # Merge variable declaration and assignment.
+        - -S1023 # redundant return statement
+        - -S1024 # Replace 'x.Sub(time.Now())' with 'time.Until(x)'.
+        - -S1025 # Don't use 'fmt.Sprintf("%s", x)' unnecessarily.
+        - -S1028 # Simplify error construction with 'fmt.Errorf'.
+        - -S1030 # Use 'bytes.Buffer.String' or 'bytes.Buffer.Bytes'.
+        - -S1031 # unnecessary nil check around range
+        - -S1039 # Unnecessary use of 'fmt.Sprint'.
+        - -ST1003 # Poorly chosen identifier.
+        - -ST1005 # errors strings should not end with punctuation or newlines
+        - -ST1006 # Poorly chosen receiver name.
+        - -ST1008 # A function's error value should be its last return value.
+        - -ST1011 # Poorly chosen name for variable of type 'time.Duration'.
+        - -ST1012 # Poorly chosen name for error variable.
+        - -ST1016 # methods on the same type should have the same receiver name
+        - -ST1017 # Don't use Yoda conditions.
+        - -ST1023 # Redundant type in variable declaration.
   exclusions:
     generated: strict
     presets:

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -1,26 +1,9 @@
-# Copyright 2020-Present Couchbase, Inc.
-#
-# Use of this software is governed by the Business Source License included in
-# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
-# file, in accordance with the Business Source License, use of this software
-# will be governed by the Apache License, Version 2.0, included in the file
-# licenses/APL2.txt.
-
-# config file for golangci-lint
-
-run:
-  timeout: 3m
-
+version: "2"
 linters:
   enable:
-    - bodyclose # checks whether HTTP response body is closed successfully
-    #- dupl # Tool for code clone detection
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
-    #- goconst # Finds repeated strings that could be replaced by a constant
     - gocritic # The most opinionated Go source code linter
-    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
     #- goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    #- gosec # (gas) Inspects source code for security problems
+    #- gosec # Inspects source code for security problems
     #- gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
     - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # Detects when assignments to existing variables are not used
@@ -29,81 +12,51 @@ linters:
     #- prealloc # Finds slice declarations that could potentially be preallocated
     #- revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
     - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert # Remove unnecessary type conversions
     #- unparam # Reports unused function parameters
     - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
-  disable:
-    # - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    # - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    # - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
-    # - err113 # Golang linter to check the errors handling expressions
-    # - funlen # Tool for detection of long functions
-    # - gochecknoglobals # Checks that no globals are present in Go code
-    # - gochecknoinits # Checks that no init functions are present in Go code
-    # - gocognit # Computes and checks the cognitive complexity of functions
-    # - gocyclo # Computes and checks the cyclomatic complexity of functions
-    # - godot # Check if comments end in a period
-    # - godox # Tool for detection of FIXME, TODO and other comment keywords
-    # - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    # - gomodguard # Allow and block list linter for direct Go module dependencies.
-    # - lll # Reports long lines
-    # - nestif # Reports deeply nested if statements
-    # - rowserrcheck # checks whether Err of rows is checked successfully
-    # - stylecheck # Stylecheck is a replacement for golint
-    # - testpackage # linter that makes you use a separate _test package
-    # - whitespace # Tool for detection of leading and trailing whitespace
-    # - wsl # Whitespace Linter - Forces you to use empty lines!
-    # Once fixed, should enable
-    # - dupl # Tool for code clone detection
-    # - goconst # Finds repeated strings that could be replaced by a constant
-    # - goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    # - gosec # (gas) Inspects source code for security problems
-    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
-    # - nakedret # Finds naked returns in functions greater than a specified function length
-    # - prealloc # Finds slice declarations that could potentially be preallocated
-    # - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    # - unparam # Reports unused function parameters
-
-# Don't enable fieldalignment, changing the field alignment requires checking to see if anyone uses constructors
-# without names. If there is a memory issue on a specific field, that is best found with a heap profile.
-#linters-settings:
-#  govet:
-#    enable:
-#      - fieldalignment # detect Go structs that would take less memory if their fields were sorted
-
-# Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
-issues:
-  exclude-rules:
-    # cover _testing.go (utility testing files) and _test.go files
-    # base/util_testing.go / rest/utilities_testing\.*.go
-    - path: (_test.*\.go)
-      linters:
-        - goconst
-    - path: rest/debug.go
-      linters:
-        - unused
-
-linters-settings:
-  gocritic:
-    enabled-checks:
-      - ruleguard
-    disabled-checks:
-      - appendAssign
-      - assignOp
-      - badCond
-      - captLocal
-      - commentFormatting
-      - deprecatedComment
-      - elseif
-      - ifElseChain
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - unlambda
-      - valSwap
-      - wrapperFunc
-    settings:
-      ruleguard:
-        rules: '${configDir}/ruleguard/rules-*.go'
-        failOn: all
+  settings:
+    gocritic:
+      enabled-checks:
+        - ruleguard
+      disabled-checks:
+        - appendAssign
+        - assignOp
+        - badCond
+        - captLocal
+        - commentFormatting
+        - deprecatedComment
+        - elseif
+        - ifElseChain
+        - regexpMust
+        - singleCaseSwitch
+        - sloppyLen
+        - unlambda
+        - valSwap
+        - wrapperFunc
+      settings:
+        ruleguard:
+          failOn: all
+          rules: ${base-path}/ruleguard/rules-*.go
+  exclusions:
+    generated: strict
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
+      - linters:
+          - goconst
+        # cover _testing.go (utility testing files) and _test.go files
+        # base/util_testing.go / rest/utilities_testing\.*.go
+        path: (_test.*\.go)
+      - linters:
+          - unused
+        path: rest/debug.go
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: strict

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,11 @@
+# Copyright 2025-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+
 version: "2"
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,82 +1,48 @@
-# Copyright 2020-Present Couchbase, Inc.
-#
-# Use of this software is governed by the Business Source License included in
-# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
-# file, in accordance with the Business Source License, use of this software
-# will be governed by the Apache License, Version 2.0, included in the file
-# licenses/APL2.txt.
-
-# config file for golangci-lint
-
-run:
-  timeout: 3m
-
+version: "2"
 linters:
   enable:
     - bodyclose # checks whether HTTP response body is closed successfully
     - dupl # Tool for code clone detection
-    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - goconst # Finds repeated strings that could be replaced by a constant
     - gocritic # The most opinionated Go source code linter
-    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
     - goprintffuncname # Checks that printf-like functions are named with `f` at the end
-    - gosec # (gas) Inspects source code for security problems
-    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
-    - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign # Detects when assignments to existing variables are not used
+    - gosec # Inspects source code for security problems
     - misspell # Finds commonly misspelled English words in comments
     - nakedret # Finds naked returns in functions greater than a specified function length
     - prealloc # Finds slice declarations that could potentially be preallocated
     - revive # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
-    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert # Remove unnecessary type conversions
     - unparam # Reports unused function parameters
-    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
-    # disable:
-    # - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    # - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    # - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
-    # - err113 # Golang linter to check the errors handling expressions
-    # - funlen # Tool for detection of long functions
-    # - gochecknoglobals # Checks that no globals are present in Go code
-    # - gochecknoinits # Checks that no init functions are present in Go code
-    # - gocognit # Computes and checks the cognitive complexity of functions
-    # - gocyclo # Computes and checks the cyclomatic complexity of functions
-    # - godot # Check if comments end in a period
-    # - godox # Tool for detection of FIXME, TODO and other comment keywords
-    # - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    # - gomodguard # Allow and block list linter for direct Go module dependencies.
-    # - lll # Reports long lines
-    # - nestif # Reports deeply nested if statements
-    # - rowserrcheck # checks whether Err of rows is checked successfully
-    # - stylecheck # Stylecheck is a replacement for golint
-    # - testpackage # linter that makes you use a separate _test package
-    # - whitespace # Tool for detection of leading and trailing whitespace
-    # - wsl # Whitespace Linter - Forces you to use empty lines!
-
-linters-settings:
-  govet:
-    enable:
-      - fieldalignment # detect Go structs that would take less memory if their fields were sorted
-  gocritic:
-    enabled-checks:
-      - ruleguard
-    settings:
-      ruleguard:
-        rules: '${configDir}/ruleguard/rules-*.go'
-        failOn: all
-
-# Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
-issues:
-  exclude-rules:
-    # cover _testing.go (utility testing files) and _test.go files
-    # base/util_testing.go / rest/utilities_testing\.*.go
-    - path: (_test.*\.go)
-      linters:
-        - goconst
-        - prealloc
-    - path: (_test.*\.go)
-      linters:
-        - govet
-      text: fieldalignment
+  settings:
+    gocritic:
+      enabled-checks:
+        - ruleguard
+      settings:
+        ruleguard:
+          failOn: all
+          rules: ${base-path}/ruleguard/rules-*.go
+    govet:
+      enable:
+        - fieldalignment
+  exclusions:
+    generated: strict
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
+          - goconst
+          - prealloc
+        path: (_test.*\.go)
+      - linters:
+          - govet
+        path: (_test.*\.go)
+        text: fieldalignment # detect Go structs that would take less memory if their fields were sorted
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: strict


### PR DESCRIPTION
CBG-4599 update to golanci-lint v2 configs

Don't merge this until devs know to update golangci-lint locally and we update the maintainance release branches also.

- Used `golangci-lint migrate` and then re-added the comments.
- Manually added any staticchecks that fail 
