### PR TITLE
CBG-2835 add wait for stat

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -543,7 +543,7 @@ func getLocalStatus(ctx context.Context, metadataStore base.DataStore, statusKey
 
 // setLocalStatus updates replication status.
 func setLocalStatus(ctx context.Context, metadataStore base.DataStore, statusKey string, status *ReplicationStatus, localDocExpirySecs int) (err error) {
-	base.TracefCtx(ctx, base.KeyReplicate, "setLocalStatus for %q (%v)", statusKey, status)
+	base.TracefCtx(ctx, base.KeyReplicate, "setLocalStatus for %q (%#+v)", statusKey, status)
 
 	// obtain current rev
 	currentStatus, err := getLocalStatusDoc(ctx, metadataStore, statusKey)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2217,9 +2217,9 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	rt1.WaitForVersion(docID1, doc1Version)
 
 	require.NoError(t, ar.Stop())
-	assert.Equal(t, int64(1), pullCheckpointer.Stats().ExpectedSequenceCount)
+	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 1)
 	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
-	assert.Equal(t, int64(1), pullCheckpointer.Stats().ProcessedSequenceCount)
+	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 1)
 
 	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
 	assert.Equal(t, int64(1), dbstats.ProcessedSequenceLen.Value())
@@ -2248,9 +2248,9 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	require.Len(t, changesResults.Results, 3)
 
 	require.NoError(t, ar.Stop())
-	assert.Equal(t, int64(2), pullCheckpointer.Stats().ExpectedSequenceCount)
+	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 2)
 	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
-	assert.Equal(t, int64(2), pullCheckpointer.Stats().ProcessedSequenceCount)
+	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 2)
 
 	assert.Equal(t, int64(2), dbstats.ExpectedSequenceLen.Value())
 	assert.Equal(t, int64(2), dbstats.ProcessedSequenceLen.Value())
@@ -2271,9 +2271,9 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	require.Len(t, changesResults.Results, 4)
 
 	require.NoError(t, ar.Stop())
-	assert.Equal(t, int64(1), pullCheckpointer.Stats().ExpectedSequenceCount)
+	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 1)
 	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
-	assert.Equal(t, int64(1), pullCheckpointer.Stats().ProcessedSequenceCount)
+	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 1)
 
 	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
 	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())


### PR DESCRIPTION
CBG-2835 add wait for stat for `TestActiveReplicatorPullSkippedSequence`

The fundamental problem is that `WaitForVersion` queries the bucket for the presence of the document but this does not mean the stats have processed yet which happens after the end of the write.

I can't reproduce this failure even with -cover and -race and large -count but mobile jenkins can.
