### PR TITLE
CBG-4546: Detect loading non-xattr config document in xattr bootstrap mode

### DIFF
--- a/base/config_persistence.go
+++ b/base/config_persistence.go
@@ -108,7 +108,7 @@ func (xbp *XattrBootstrapPersistence) loadRawConfig(ctx context.Context, c *gocb
 		xattrContErr := res.ContentAt(0, &rawValue)
 		if xattrContErr != nil {
 			SyncGatewayStats.GlobalStats.ConfigStat.XattrFormatMismatches.Add(1)
-			WarnfCtx(ctx, "Found config document but No xattr config found for key=%s, path=%s: %v", key, cfgXattrConfigPath, xattrContErr)
+			DebugfCtx(ctx, KeyCRUD, "Found config document but No xattr config found for key=%s, path=%s: %v", key, cfgXattrConfigPath, xattrContErr)
 			return rawValue, 0, ErrNotFound
 		}
 		return rawValue, res.Cas(), nil
@@ -183,7 +183,7 @@ func (xbp *XattrBootstrapPersistence) loadConfig(ctx context.Context, c *gocb.Co
 		xattrContErr := res.ContentAt(0, valuePtr)
 		if xattrContErr != nil {
 			SyncGatewayStats.GlobalStats.ConfigStat.XattrFormatMismatches.Add(1)
-			WarnfCtx(ctx, "Found config document but No xattr config found for key=%s, path=%s: %v", key, cfgXattrConfigPath, xattrContErr)
+			DebugfCtx(ctx, KeyCRUD, "Found config document but No xattr config found for key=%s, path=%s: %v", key, cfgXattrConfigPath, xattrContErr)
 			return 0, ErrNotFound
 		}
 		casOut := res.Cas()

--- a/base/config_persistence.go
+++ b/base/config_persistence.go
@@ -107,7 +107,8 @@ func (xbp *XattrBootstrapPersistence) loadRawConfig(ctx context.Context, c *gocb
 		// config
 		xattrContErr := res.ContentAt(0, &rawValue)
 		if xattrContErr != nil {
-			DebugfCtx(ctx, KeyCRUD, "No xattr config found for key=%s, path=%s: %v", key, cfgXattrConfigPath, xattrContErr)
+			SyncGatewayStats.GlobalStats.ConfigStat.XattrFormatMismatches.Add(1)
+			WarnfCtx(ctx, "Found config document but No xattr config found for key=%s, path=%s: %v", key, cfgXattrConfigPath, xattrContErr)
 			return rawValue, 0, ErrNotFound
 		}
 		return rawValue, res.Cas(), nil
@@ -181,7 +182,8 @@ func (xbp *XattrBootstrapPersistence) loadConfig(ctx context.Context, c *gocb.Co
 		// config
 		xattrContErr := res.ContentAt(0, valuePtr)
 		if xattrContErr != nil {
-			DebugfCtx(ctx, KeyCRUD, "No xattr config found for key=%s, path=%s: %v", key, cfgXattrConfigPath, xattrContErr)
+			SyncGatewayStats.GlobalStats.ConfigStat.XattrFormatMismatches.Add(1)
+			WarnfCtx(ctx, "Found config document but No xattr config found for key=%s, path=%s: %v", key, cfgXattrConfigPath, xattrContErr)
 			return 0, ErrNotFound
 		}
 		casOut := res.Cas()

--- a/base/stats.go
+++ b/base/stats.go
@@ -203,6 +203,10 @@ func (g *GlobalStat) initConfigStats() error {
 	if err != nil {
 		return err
 	}
+	configStat.XattrFormatMismatches, err = NewIntStat(ConfigSubsystem, "xattr_format_mismatches", StatUnitBytes, XattrFormatMismatchesDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	g.ConfigStat = configStat
 	return nil
 }
@@ -402,6 +406,8 @@ type ConfigStat struct {
 	DatabaseBucketMismatches *SgwIntStat `json:"database_config_bucket_mismatches"`
 	// The number of times the config was rolled back to an invalid state (conflicting collections)
 	DatabaseRollbackCollectionCollisions *SgwIntStat `json:"database_config_rollback_collection_collisions"`
+	// The number of times a non-xattr config or registry document was loaded in xattr mode
+	XattrFormatMismatches *SgwIntStat `json:"xattr_format_mismatches"`
 }
 
 type AuditStat struct {

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -74,6 +74,7 @@ const (
 const (
 	DatabaseBucketMismatchesDesc   = "The total number of times a database config is polled from a bucket that doesn't match the bucket specified in the database config."
 	DatabaseCollectionConflictDesc = "The total number of times a database config is rolled back to an invalid state (collection conflicts)."
+	XattrFormatMismatchesDesc      = "The total number of times a non-xattr config or registry document was loaded in xattr mode."
 )
 
 // audit stat


### PR DESCRIPTION
CBG-4546

- Add stat to track loading non-xattr config document in xattr bootstrap mode
- Change debug to warning and make slightly more descriptive (retain original message for grep)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3024/
