### PR TITLE
[3.2.4 Backport] CBG-4590 - Add sequence value stats for last allocated and last reserved

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -636,6 +636,8 @@ type DatabaseStats struct {
 	PublicRestBytesWritten *SgwIntStat `json:"public_rest_bytes_written"`
 	// The total amount of bytes read over the public REST api
 	PublicRestBytesRead *SgwIntStat `json:"public_rest_bytes_read"`
+	// The value of the last sequence number assigned. Callers using Set should be holding a mutex or ensure concurrent updates to this value are otherwise safe.
+	LastSequenceAssignedValue *SgwIntStat `json:"last_sequence_assigned_value"` // TODO: CBG-4579 - Replace with SgwUintStat stat
 	// The total number of sequence numbers assigned.
 	SequenceAssignedCount *SgwIntStat `json:"sequence_assigned_count"`
 	// The total number of high sequence lookups.
@@ -644,6 +646,8 @@ type DatabaseStats struct {
 	SequenceIncrCount *SgwIntStat `json:"sequence_incr_count"`
 	// The total number of unused, reserved sequences released by Sync Gateway.
 	SequenceReleasedCount *SgwIntStat `json:"sequence_released_count"`
+	// The value of the last sequence number reserved (which may not yet be assigned). Callers using Set should be holding a mutex or ensure concurrent updates to this value are otherwise safe.
+	LastSequenceReservedValue *SgwIntStat `json:"last_sequence_reserved_value"` // TODO: CBG-4579 - Replace with SgwUintStat stat
 	// The total number of sequences reserved by Sync Gateway.
 	SequenceReservedCount *SgwIntStat `json:"sequence_reserved_count"`
 	// The total number of corrupt sequences above the MaxSequencesToRelease threshold seen at the sequence allocator
@@ -1741,6 +1745,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.LastSequenceAssignedValue, err = NewIntStat(SubsystemDatabaseKey, "last_sequence_assigned_value", StatUnitNoUnits, LastSequenceAssignedValueDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.SequenceGetCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_get_count", StatUnitNoUnits, SequenceGetCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
@@ -1754,6 +1762,10 @@ func (d *DbStats) initDatabaseStats() error {
 		return err
 	}
 	resUtil.SequenceReservedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", StatUnitNoUnits, SequenceReservedCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.LastSequenceReservedValue, err = NewIntStat(SubsystemDatabaseKey, "last_sequence_reserved_value", StatUnitNoUnits, LastSequenceReservedValueDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1842,10 +1854,12 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumTombstonesCompacted)
 	prometheus.Unregister(d.DatabaseStats.PublicRestBytesWritten)
 	prometheus.Unregister(d.DatabaseStats.SequenceAssignedCount)
+	prometheus.Unregister(d.DatabaseStats.LastSequenceAssignedValue)
 	prometheus.Unregister(d.DatabaseStats.SequenceGetCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceIncrCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceReleasedCount)
 	prometheus.Unregister(d.DatabaseStats.SequenceReservedCount)
+	prometheus.Unregister(d.DatabaseStats.LastSequenceReservedValue)
 	prometheus.Unregister(d.DatabaseStats.CorruptSequenceCount)
 	prometheus.Unregister(d.DatabaseStats.WarnChannelNameSizeCount)
 	prometheus.Unregister(d.DatabaseStats.WarnChannelsPerDocCount)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -276,13 +276,17 @@ const (
 
 	SequenceAssignedCountDesc = "The total number of sequence numbers assigned."
 
+	LastSequenceAssignedValueDesc = "The value of the last sequence number assigned."
+
 	SequenceGetCountDesc = "The total number of high sequence lookups."
 
 	SequenceIncrCountDesc = "The total number of times the sequence counter document has been incremented."
 
-	SequenceReleasedCountDesc = "The total number of unused, reserved sequences released by Sync Gateway."
+	SequenceReleasedCountDesc = "The total number of unused, reserved sequences released."
 
-	SequenceReservedCountDesc = "The total number of sequences reserved by Sync Gateway."
+	SequenceReservedCountDesc = "The total number of sequences reserved."
+
+	LastSequenceReservedValueDesc = "The value of the last sequence number reserved (which may not yet be assigned)"
 
 	WarnChannelNameSizeCountDesc = "The total number of warnings relating to the channel name size."
 

--- a/base/util.go
+++ b/base/util.go
@@ -1226,10 +1226,12 @@ type AtomicInt struct {
 	val int64
 }
 
+// Set sets the value of the atomic int. Callers must ensure that invocations of this are protected by a mutex or are otherwise safe to call concurrently, since value can overwrite any previous value.
 func (ai *AtomicInt) Set(value int64) {
 	atomic.StoreInt64(&ai.val, value)
 }
 
+// SetIfMax sets the value of the atomic int to the given value if the given value is greater than the current value.
 func (ai *AtomicInt) SetIfMax(value int64) {
 	for {
 		cur := atomic.LoadInt64(&ai.val)
@@ -1243,6 +1245,7 @@ func (ai *AtomicInt) SetIfMax(value int64) {
 	}
 }
 
+// Add adds the given value to the atomic int.
 func (ai *AtomicInt) Add(value int64) {
 	atomic.AddInt64(&ai.val, value)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -780,7 +780,9 @@ func GetSingleDatabaseCollection(tb testing.TB, database *DatabaseContext) *Data
 
 // AllocateTestSequence allocates a sequence via the sequenceAllocator.  For use by non-db tests
 func AllocateTestSequence(database *DatabaseContext) (uint64, error) {
-	return database.sequences.incrementSequence(1)
+	database.sequences.mutex.Lock()
+	defer database.sequences.mutex.Unlock()
+	return database.sequences._incrementSequence(1)
 }
 
 // ReleaseTestSequence releases a sequence via the sequenceAllocator.  For use by non-db tests


### PR DESCRIPTION
CBG-4590

Clean cherry-pick of #7458 for 3.2.4

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a