### PR TITLE
CBG-4602: benchmarking for procesEntry

### DIFF
--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -67,19 +67,19 @@ func main() {
 		cpuProfBuf := bytes.Buffer{}
 		err = pprof.StartCPUProfile(&cpuProfBuf)
 		if err != nil {
-			log.Println("Error starting CPU profile: %v", err)
+			log.Printf("Error starting CPU profile: %v", err)
 			return
 		}
 		defer func() {
 			pprof.StopCPUProfile()
 			cpuProfileBuffer, err := io.ReadAll(&cpuProfBuf)
 			if err != nil {
-				log.Println("error reading cpuProfBuf: %v", err)
+				log.Printf("error reading cpuProfBuf: %v", err)
 				return
 			}
 			err = os.WriteFile("cpu.prof", cpuProfileBuffer, os.ModePerm)
 			if err != nil {
-				log.Println("error writing cpu profile to file: %v", err)
+				log.Printf("error writing cpu profile to file: %v", err)
 				return
 			}
 		}()
@@ -104,7 +104,7 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Println("Error creating database context: %v", err)
+		log.Printf("Error creating database context: %v", err)
 		return
 	}
 	defer dbContext.Close(ctx)
@@ -124,7 +124,7 @@ func main() {
 			}
 			// need to have a delay for each node defined so we have variable write throughput
 			if len(delayList) != *nodes-1 {
-				log.Println("invalid number of delays: %d", len(delayList))
+				log.Printf("invalid number of delays: %d", len(delayList))
 				return
 			}
 		}
@@ -132,7 +132,7 @@ func main() {
 		// create new sgw node abstraction and spawn write goroutines
 		p.spawnDocCreationGoroutine(ctx)
 	} else {
-		log.Println("Invalid mode: %s", *mode)
+		log.Printf("Invalid mode: %s", *mode)
 		return
 	}
 
@@ -209,13 +209,13 @@ func heapProfiling(ctx context.Context) {
 			heapProfBuf := bytes.Buffer{}
 			err := pprof.WriteHeapProfile(&heapProfBuf)
 			if err != nil {
-				log.Println("Error writing heap profile: %v", err)
+				log.Printf("Error writing heap profile: %v", err)
 				return
 			}
 
 			err = os.WriteFile(fileName, heapProfBuf.Bytes(), os.ModePerm)
 			if err != nil {
-				log.Println("Error writing heap profile to file: %v", err)
+				log.Printf("Error writing heap profile to file: %v", err)
 				return
 			}
 		}
@@ -236,12 +236,12 @@ func mutexProfiling(ctx context.Context) {
 			mutexProfBuf := bytes.Buffer{}
 			err := pprof.Lookup("mutex").WriteTo(&mutexProfBuf, 0)
 			if err != nil {
-				log.Println("Error writing mutex profile: %v", err)
+				log.Printf("Error writing mutex profile: %v", err)
 				return
 			}
 			err = os.WriteFile(fileName, mutexProfBuf.Bytes(), os.ModePerm)
 			if err != nil {
-				log.Println("Error writing mutex profile to file: %v", err)
+				log.Printf("Error writing mutex profile to file: %v", err)
 				return
 			}
 		}
@@ -262,13 +262,13 @@ func blockProfiling(ctx context.Context) {
 			blockProfBuf := bytes.Buffer{}
 			err := pprof.Lookup("block").WriteTo(&blockProfBuf, 0)
 			if err != nil {
-				log.Println("Error writing block profile: %v", err)
+				log.Printf("Error writing block profile: %v", err)
 				return
 			}
 
 			err = os.WriteFile(fileName, blockProfBuf.Bytes(), os.ModePerm)
 			if err != nil {
-				log.Println("Error writing block profile to file: %v", err)
+				log.Printf("Error writing block profile to file: %v", err)
 				return
 			}
 		}
@@ -289,13 +289,13 @@ func goroutineProfiling(ctx context.Context) {
 			goroutineProfBuf := bytes.Buffer{}
 			err := pprof.Lookup("goroutine").WriteTo(&goroutineProfBuf, 1)
 			if err != nil {
-				log.Println("Error writing goroutine profile: %v", err)
+				log.Printf("Error writing goroutine profile: %v", err)
 				return
 			}
 
 			err = os.WriteFile(fileName, goroutineProfBuf.Bytes(), os.ModePerm)
 			if err != nil {
-				log.Println("Error writing goroutine profile to file: %v", err)
+				log.Printf("Error writing goroutine profile to file: %v", err)
 				return
 			}
 		}

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -1,0 +1,281 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package main // main.go
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"runtime/pprof"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbaselabs/rosmar"
+)
+
+var numGoroutines atomic.Int32
+
+func main() {
+	mode := flag.String("mode", "processEntry", "Mode for the tool to run in, either dcp or processEntry.")
+	nodes := flag.Int("sgwNodes", 1, "Number of sgw nodes to abstract.")
+	bachSize := flag.Int("batchSize", 10, "Batch size for the sequence allocator.")
+	timeToRun := flag.Int("duration", 5, "Duration to run the test for in minutes.")
+	dalays := flag.String("writeDelay", "150", "Delay between writes in milliseconds. Must be entered in format <delayMS>,<delayMS>,<delayMS>.")
+	profile := flag.Bool("profile", false, "Enable profiling.")
+	flag.Parse()
+
+	if *nodes < 1 {
+		log.Fatalf("Invalid number of nodes: %d", *nodes)
+	}
+	if *bachSize < 1 {
+		log.Fatalf("Invalid batch size: %d", *bachSize)
+	}
+	if *timeToRun < 1 {
+		log.Fatalf("Invalid duration: %d", *timeToRun)
+	}
+
+	parentCtx := context.Background()
+	ctx, cancelFunc := context.WithCancel(parentCtx)
+
+	// Need a bucket type for creating the database context
+	var walrusBucket *rosmar.Bucket
+	bucketName := "cahceTest" + "rosmar_"
+	url := rosmar.InMemoryURL
+	walrusBucket, err := rosmar.OpenBucket(url, bucketName, rosmar.CreateOrOpen)
+	if err != nil {
+		log.Fatalf("Error opening walrus bucket: %v", err)
+	}
+	defer walrusBucket.Close(parentCtx)
+
+	if *profile {
+		// start CPU profiling here
+		cpuProfBuf := bytes.Buffer{}
+		err = pprof.StartCPUProfile(&cpuProfBuf)
+		if err != nil {
+			log.Fatalf("Error starting CPU profile: %v", err)
+		}
+		defer func() {
+			pprof.StopCPUProfile()
+			cpuProfileBuffer, err := io.ReadAll(&cpuProfBuf)
+			if err != nil {
+				log.Fatalf("error reading cpuProfBuf: %v", err)
+			}
+			err = os.WriteFile("cpu.prof", cpuProfileBuffer, os.ModePerm)
+			if err != nil {
+				log.Fatalf("error writing cpu profile to file: %v", err)
+			}
+		}()
+		go heapProfiling(ctx)
+		go mutexProfiling(ctx)
+		go blockProfiling(ctx)
+		go goroutineProfiling(ctx)
+	}
+
+	// new syncSeqMock to be used for the sequence allocator
+	seqAllocator := newSyncSeq()
+	_ = seqAllocator.nextBatch(1) // init atomic on syncSeqMock to 1
+
+	var t *testing.T
+	dbContext, err := db.NewDatabaseContext(ctx, "db", walrusBucket, false, db.DatabaseContextOptions{
+		Scopes: map[string]db.ScopeOptions{
+			base.DefaultScope: {
+				Collections: map[string]db.CollectionOptions{
+					base.DefaultCollection: {},
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Error creating database context: %v", err)
+	}
+	defer dbContext.Close(ctx)
+
+	// init change cache and unlock mutex for the test
+	dbContext.StartChangeCache(t, parentCtx)
+
+	// mode selection logic
+	if *mode == "dcp" {
+		// todo: add dcp mode code
+	} else if *mode == "processEntry" {
+		var delayList []time.Duration
+		if *nodes > 1 { // if we have one node then we don't have a delay (node will write as fast as possible)
+			delayList = extractDelays(*dalays)
+			// need to have a delay for each node defined so we have variable write throughput
+			if len(delayList) != *nodes-1 {
+				log.Fatalf("invalid number of delays: %d", len(delayList))
+			}
+		}
+		p := &processEntryGen{t: t, dbCtx: dbContext, delays: delayList, seqAlloc: seqAllocator, numNodes: *nodes, batchSize: *bachSize}
+		// create new sgw node abstraction and spawn write goroutines
+		p.spawnDocCreationGoroutine(ctx)
+	} else {
+		log.Fatalf("Invalid mode: %s", *mode)
+	}
+
+	defer func() {
+		fmt.Println("-------------------------------------")
+		fmt.Println("end of test stats")
+		dbContext.UpdateCalculatedStats(ctx)
+		fmt.Println("high seq of cache", dbContext.DbStats.Database().HighSeqFeed.Value())
+		fmt.Println("pending seq length", dbContext.DbStats.Cache().PendingSeqLen.Value())
+		fmt.Println("high seq stable", dbContext.DbStats.Cache().HighSeqStable.Value())
+		fmt.Println("num current skipped", dbContext.DbStats.Cache().NumCurrentSeqsSkipped.Value())
+		fmt.Println("cumulative skipped", dbContext.DbStats.Cache().NumSkippedSeqs.Value())
+		fmt.Println("skipped length", dbContext.DbStats.Cache().SkippedSeqLen.Value())
+		fmt.Println("skipped capacity", dbContext.DbStats.Cache().SkippedSeqCap.Value())
+		fmt.Println("dcp cache count", dbContext.DbStats.Database().DCPCachingCount.Value())
+		fmt.Println("dcp cache time", dbContext.DbStats.Database().DCPCachingTime.Value())
+	}()
+
+	// duration of test logic
+	ticker := time.NewTicker(time.Duration(*timeToRun) * time.Minute)
+	defer ticker.Stop()
+
+outerloop:
+	for {
+		select {
+		case <-ticker.C:
+			cancelFunc()
+			break outerloop
+		}
+	}
+
+	workerFunc := func() (shouldRetry bool, err error, val interface{}) {
+		return numGoroutines.Load() != int32(0), nil, val
+	}
+	err, _ = base.RetryLoop(parentCtx, "wait for writing goroutines to stop", workerFunc, base.CreateSleeperFunc(200, 100))
+	if err != nil {
+		log.Printf("Error waiting for stat value (%d) to reach 0: %v", numGoroutines.Load(), err)
+	}
+
+}
+
+func extractDelays(delayStr string) []time.Duration {
+	var delays []time.Duration
+	if delayStr == "" {
+		return delays
+	}
+	delayList := strings.Split(delayStr, ",")
+	for _, delay := range delayList {
+		delayInt, err := strconv.Atoi(delay)
+		if err != nil {
+			log.Fatalf("Error parsing delay: %v", err)
+		}
+		delays = append(delays, time.Duration(delayInt)*time.Millisecond)
+	}
+	return delays
+}
+
+func heapProfiling(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	numGoroutines.Add(1)
+	defer numGoroutines.Add(-1)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fileName := fmt.Sprintf("heap-%s.prof", time.Now().Format(time.RFC3339))
+			heapProfBuf := bytes.Buffer{}
+			err := pprof.WriteHeapProfile(&heapProfBuf)
+			if err != nil {
+				log.Fatalf("Error writing heap profile: %v", err)
+			}
+
+			err = os.WriteFile(fileName, heapProfBuf.Bytes(), os.ModePerm)
+			if err != nil {
+				log.Fatalf("Error writing heap profile to file: %v", err)
+			}
+		}
+	}
+}
+
+func mutexProfiling(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	numGoroutines.Add(1)
+	defer numGoroutines.Add(-1)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fileName := fmt.Sprintf("mutex-%s.prof", time.Now().Format(time.RFC3339))
+			mutexProfBuf := bytes.Buffer{}
+			err := pprof.Lookup("mutex").WriteTo(&mutexProfBuf, 0)
+			if err != nil {
+				log.Fatalf("Error writing mutex profile: %v", err)
+			}
+			err = os.WriteFile(fileName, mutexProfBuf.Bytes(), os.ModePerm)
+			if err != nil {
+				log.Fatalf("Error writing mutex profile to file: %v", err)
+			}
+		}
+	}
+}
+
+func blockProfiling(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	numGoroutines.Add(1)
+	defer numGoroutines.Add(-1)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fileName := fmt.Sprintf("block-%s.prof", time.Now().Format(time.RFC3339))
+			blockProfBuf := bytes.Buffer{}
+			err := pprof.Lookup("block").WriteTo(&blockProfBuf, 0)
+			if err != nil {
+				log.Fatalf("Error writing block profile: %v", err)
+			}
+
+			err = os.WriteFile(fileName, blockProfBuf.Bytes(), os.ModePerm)
+			if err != nil {
+				log.Fatalf("Error writing block profile to file: %v", err)
+			}
+		}
+	}
+}
+
+func goroutineProfiling(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	numGoroutines.Add(1)
+	defer numGoroutines.Add(-1)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fileName := fmt.Sprintf("goroutine-%s.prof", time.Now().Format(time.RFC3339))
+			goroutineProfBuf := bytes.Buffer{}
+			err := pprof.Lookup("goroutine").WriteTo(&goroutineProfBuf, 1)
+			if err != nil {
+				log.Fatalf("Error writing goroutine profile: %v", err)
+			}
+
+			err = os.WriteFile(fileName, goroutineProfBuf.Bytes(), os.ModePerm)
+			if err != nil {
+				log.Fatalf("Error writing goroutine profile to file: %v", err)
+			}
+		}
+	}
+}

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -38,7 +38,7 @@ func main() {
 	batchSize := flag.Int("batchSize", 10, "Batch size for the sequence allocator.")
 	timeToRun := flag.Duration("duration", 5*time.Minute, "Duration to run the test for in minutes. Examples:  3m for 3 minutes, 30s for 30 seconds etc")
 	delays := flag.String("writeDelay", "0", "Delay between writes in milliseconds. Must be entered in format <delayMS>,<delayMS>,<delayMS>.")
-	profileInterval := flag.Duration("profileInterval", 30*time.Second, "Interval for profiling to be triggered on, example 10s would be every 10 seconds.")
+	profileInterval := flag.Duration("profileInterval", 0*time.Second, "Interval for profiling to be triggered on, example 10s would be every 10 seconds.")
 	numChannels := flag.Int("numChannels", 1, "Number of channels to create per document.")
 	flag.Parse()
 
@@ -53,6 +53,9 @@ func main() {
 	}
 	if *numChannels < 1 {
 		log.Fatalf("Invalid number of channels: %d", *numChannels)
+	}
+	if profileInterval.Seconds() != 0 && *profileInterval >= *timeToRun {
+		log.Fatalf("Invalid profile interval: %d, must be less than the duration of test: %d", *profileInterval, *timeToRun)
 	}
 	var delayList []time.Duration
 	delayList, err := extractDelays(*delays)

--- a/tools/cache_perf_tool/processEntry.go
+++ b/tools/cache_perf_tool/processEntry.go
@@ -1,0 +1,101 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+type processEntryGen struct {
+	seqAlloc  *syncSeqMock
+	delays    []time.Duration
+	dbCtx     *db.DatabaseContext
+	t         *testing.T
+	numNodes  int
+	batchSize int
+}
+
+func (p *processEntryGen) spawnDocCreationGoroutine(ctx context.Context) {
+	for i := 0; i < p.numNodes; i++ {
+		// create new sgw node abstraction
+		sgNode := &sgwNode{nodeID: i, seqAlloc: newSequenceAllocator(p.batchSize, p.seqAlloc)}
+		if i == 0 {
+			go p.nodeWrites(ctx, sgNode, 0*time.Second)
+		} else {
+			// delay list will always be length 1 less than the number of nodes
+			// because the first node created has delay 0
+			index := i - 1
+			go p.nodeWrites(ctx, sgNode, p.delays[index])
+		}
+	}
+}
+
+func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay time.Duration) {
+	docCount := uint64(0)
+	numGoroutines.Add(1)
+	defer numGoroutines.Add(-1)
+	log.Printf("node %d has delay of %v ms", node.nodeID, delay.Milliseconds())
+	if delay.Nanoseconds() == 0 {
+		// mutate as fast as possible
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				sgwSeqno := node.seqAlloc.nextSeq()
+				docCount++
+				chanMap := make(channels.ChannelMap)
+				chanMap["test"] = nil
+				logEntry := &db.LogEntry{
+					Sequence:     sgwSeqno,
+					DocID:        fmt.Sprintf("key-%d-%d", docCount, sgwSeqno),
+					RevID:        "1-abc",
+					Flags:        0,
+					TimeReceived: time.Now(),
+					TimeSaved:    time.Now(),
+					Channels:     chanMap,
+					CollectionID: 0,
+				}
+				p.dbCtx.CallProcessEntry(p.t, ctx, logEntry)
+			}
+		}
+	}
+
+	ticker := time.NewTicker(delay)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			docCount++
+			sgwSeqno := node.seqAlloc.nextSeq()
+			chanMap := make(channels.ChannelMap)
+			chanMap["test"] = nil
+			logEntry := &db.LogEntry{
+				Sequence:     sgwSeqno,
+				DocID:        fmt.Sprintf("key-%d-%d", docCount, sgwSeqno),
+				RevID:        "1-abc",
+				Flags:        0,
+				TimeReceived: time.Now(),
+				TimeSaved:    time.Now(),
+				Channels:     chanMap,
+				CollectionID: 0,
+			}
+			p.dbCtx.CallProcessEntry(p.t, ctx, logEntry)
+		}
+	}
+}

--- a/tools/cache_perf_tool/processEntry.go
+++ b/tools/cache_perf_tool/processEntry.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"strconv"
 	"testing"
 	"time"
@@ -42,7 +41,6 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 	docCount := uint64(0)
 	numGoroutines.Add(1)
 	defer numGoroutines.Add(-1)
-	log.Printf("node %d has delay of %v ms", node.nodeID, delay.Milliseconds())
 	// create map of configured channels
 	chanMap := make(channels.ChannelMap)
 	for i := 0; i < p.numChans; i++ {

--- a/tools/cache_perf_tool/processEntry.go
+++ b/tools/cache_perf_tool/processEntry.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strconv"
 	"testing"
@@ -61,7 +60,7 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 				docCount++
 				logEntry := &db.LogEntry{
 					Sequence:     sgwSeqno,
-					DocID:        "key-" + strconv.FormatUint(docCount, 10) + "-" + strconv.FormatUint(sgwSeqno, 10), //fmt.Sprintf("key-%d-%d", docCount, sgwSeqno),
+					DocID:        "key-" + strconv.FormatUint(docCount, 10) + "-" + strconv.FormatUint(sgwSeqno, 10),
 					RevID:        "1-abc",
 					Flags:        0,
 					TimeReceived: timeStamp,
@@ -86,7 +85,7 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 			sgwSeqno := node.seqAlloc.nextSeq()
 			logEntry := &db.LogEntry{
 				Sequence:     sgwSeqno,
-				DocID:        fmt.Sprintf("key-%d-%d", docCount, sgwSeqno),
+				DocID:        "key-" + strconv.FormatUint(docCount, 10) + "-" + strconv.FormatUint(sgwSeqno, 10),
 				RevID:        "1-abc",
 				Flags:        0,
 				TimeReceived: timeStamp,

--- a/tools/cache_perf_tool/sgwNodeAbstraction.go
+++ b/tools/cache_perf_tool/sgwNodeAbstraction.go
@@ -1,0 +1,60 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package main
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type sgwNode struct {
+	nodeID   int
+	seqAlloc *sequenceAllocator
+}
+
+type syncSeqMock struct {
+	sequence atomic.Uint64
+}
+
+func newSyncSeq() *syncSeqMock {
+	return &syncSeqMock{}
+}
+
+func (seqAlloc *syncSeqMock) nextBatch(batchSize uint64) uint64 {
+	return seqAlloc.sequence.Add(batchSize)
+}
+
+type sequenceAllocator struct {
+	syncSeqMock   *syncSeqMock
+	batchSize     int
+	lastSeq       uint64
+	maxSeqInBatch uint64
+	lock          sync.Mutex
+}
+
+func newSequenceAllocator(batchSize int, syncSeq *syncSeqMock) *sequenceAllocator {
+	return &sequenceAllocator{
+		syncSeqMock:   syncSeq,
+		batchSize:     batchSize,
+		lastSeq:       0,
+		maxSeqInBatch: 0,
+	}
+}
+
+func (s *sequenceAllocator) nextSeq() uint64 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.lastSeq >= s.maxSeqInBatch {
+		max := s.syncSeqMock.nextBatch(uint64(s.batchSize))
+		s.maxSeqInBatch = max
+		s.lastSeq = max - uint64(s.batchSize)
+	}
+	s.lastSeq++
+	return s.lastSeq
+}

--- a/tools/cache_perf_tool/sgwNodeAbstraction.go
+++ b/tools/cache_perf_tool/sgwNodeAbstraction.go
@@ -36,6 +36,7 @@ type sequenceAllocator struct {
 	lastSeq       uint64
 	maxSeqInBatch uint64
 	lock          sync.Mutex
+	syncSeqEvent  chan struct{}
 }
 
 func newSequenceAllocator(batchSize int, syncSeq *syncSeqMock) *sequenceAllocator {
@@ -44,6 +45,7 @@ func newSequenceAllocator(batchSize int, syncSeq *syncSeqMock) *sequenceAllocato
 		batchSize:     batchSize,
 		lastSeq:       0,
 		maxSeqInBatch: 0,
+		syncSeqEvent:  make(chan struct{}, 1),
 	}
 }
 
@@ -54,6 +56,13 @@ func (s *sequenceAllocator) nextSeq() uint64 {
 		max := s.syncSeqMock.nextBatch(uint64(s.batchSize))
 		s.maxSeqInBatch = max
 		s.lastSeq = max - uint64(s.batchSize)
+		// channel has cap of 1 so to avoid blocking here we need select here
+		// the motivation to have cap 1 on this buffered channel is to sort of siluate dedupe from KV engine upon
+		// rapid updates to _sync:seq doc
+		select {
+		case s.syncSeqEvent <- struct{}{}:
+		default:
+		}
 	}
 	s.lastSeq++
 	return s.lastSeq


### PR DESCRIPTION
CBG-4602

Benchmarking for process entry. This can be an iterative approach but for now we have something in place to generate data and throw at `processEntry`. We can build upon this in future if we find we need more data points. 

High level view is we have a sgw node abstraction each with their own allocator which links to central atomic counter much like sync seq. We batch allocations to nodes and this is configurable, along with number of nodes and the delays associated with nodes (simulating nodes writing at differing speeds. We have a max delay of 150 ms as this is the slowest a nodes can write through 10 sequences without releasing any and reallocating a batch. 

We needed some methods adding to testing files in db package to expose the `processEntry` and init of change cache to the testing tool itself. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
