### PR TITLE
CBG-4603 Send 422 on delta sync for _removed in body

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1065,6 +1065,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Unable to unmarshal mutable body for doc %s deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
 		}
 
+		if deltaSrcBody[BodyRemoved] != nil {
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't use delta. Found _removed property for doc %s deltaSrc=%s", base.UD(docID), deltaSrcRevID)
+		}
 		// Stamp attachments so we can patch them
 		if len(deltaSrcRev.Attachments) > 0 {
 			deltaSrcBody[BodyAttachments] = map[string]interface{}(deltaSrcRev.Attachments)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -12,6 +12,7 @@ package rest
 
 import (
 	"encoding/base64"
+	"net/http"
 	"testing"
 
 	"github.com/couchbase/go-blip"
@@ -958,5 +959,36 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 
 		body := rt.GetDocVersion("doc1", version2)
 		require.Equal(t, "bob", body["greetings"].([]interface{})[2].(map[string]interface{})["howdy"])
+	})
+}
+
+func TestBlipDeltaNoAccessPush(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeySyncMsg, base.KeyWebSocket, base.KeySGTest)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {}`, PersistentConfig: true})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.DeltaSync = &DeltaSyncConfig{Enabled: base.BoolPtr(true)}
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	const (
+		username = "alice"
+		docID    = "doc1"
+	)
+	rt.CreateUser(username, nil)
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, Username: username, ClientDeltas: true}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		btcRunner.StartPush(client.id)
+
+		version1 := btcRunner.AddRev(client.id, docID, nil, []byte(`{"foo": "bar", "version": "1"}`))
+		rt.WaitForVersion(docID, version1)
+
+		version2 := btcRunner.AddRev(client.id, docID, &version1, []byte(`{"foo": "bar", "version": "2"}`))
+		rt.WaitForVersion(docID, version2)
+
 	})
 }

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -1054,6 +1054,12 @@ func (btcc *BlipTesterCollectionClient) sendRev(ctx context.Context, change prop
 	base.DebugfCtx(ctx, base.KeySGTest, "sent doc %s / %v", change.docID, change.version)
 	// block until remote has actually processed the rev and sent a response
 	revResp := revRequest.Response()
+	errorCode := revResp.Properties["Error-Code"]
+	// if there is something wrong with the delta, resend as a non delta
+	if errorCode == strconv.Itoa(http.StatusUnprocessableEntity) && deltasSupported {
+		btcc.sendRev(ctx, change, false)
+		return
+	}
 	require.NotContains(btcc.TB(), revResp.Properties, "Error-Domain", "unexpected error response from rev %v: %s", revResp)
 	base.DebugfCtx(ctx, base.KeySGTest, "peer acked rev %s / %v", change.docID, change.version)
 	btcc.updateLastReplicatedRev(change.docID, change.version, revRequest)


### PR DESCRIPTION
CBG-4603: Send 422 on delta sync for _removed in body

- implement logic in blip test code to resend rev without delta

- [ ] TODO: write test for ISGR


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3026/
