### PR TITLE
CBG-4557 document endpoints for partitioned indexes

### DIFF
--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -105,8 +105,14 @@ paths:
     $ref: './paths/admin/keyspace-_config-sync.yaml'
   '/{keyspace}/_config/import_filter':
     $ref: './paths/admin/keyspace-_config-import_filter.yaml'
+  '/{db}/':
+    $ref: './paths/admin/db-.yaml'
+  /_all_dbs:
+    $ref: ./paths/admin/_all_dbs.yaml
   '/{db}/_resync':
     $ref: './paths/admin/db-_resync.yaml'
+  '/{db}/_index_init':
+    $ref: './paths/admin/db-_index_init.yaml'
   '/{keyspace}/_purge':
     $ref: './paths/admin/keyspace-_purge.yaml'
   '/{db}/_flush':
@@ -123,12 +129,8 @@ paths:
     $ref: './paths/admin/keyspace-_dumpchannel-channel.yaml'
   '/{db}/_repair':
     $ref: './paths/admin/db-_repair.yaml'
-  /_all_dbs:
-    $ref: ./paths/admin/_all_dbs.yaml
   '/{db}/_compact':
     $ref: './paths/admin/db-_compact.yaml'
-  '/{db}/':
-    $ref: './paths/admin/db-.yaml'
   '/{keyspace}/':
     $ref: './paths/admin/keyspace-.yaml'
   /_expvar:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3088,13 +3088,17 @@ IndexInitStatus:
       description: The status of the current operation.
       type: string
       enum:
-        - running
         - completed
         - error
+        - running
+        - stopped
+        - stopping
       x-enumDescriptions:
         running: Indexes are being created.
         completed: All indexes were created.
         error: The index initialization operation has failed.
+        stopped: The index initialization operation has been stopped. These indexes may still on Couchbase Server.
+        stopping: The index initialization operation is in the process of being stopped.
     start_time:
       description: The ISO-8601 date and time the index initialization operation was started.
       type: string
@@ -3105,8 +3109,18 @@ IndexInitStatus:
       description: 'scope name with one or more collection names and the status of their index creation'
       type: object
       additionalProperties:
-        $ref: '#/CollectionNames'
-      example: {"scopeName": ["collection1", "collection2"]}
+        x-additionalPropertiesName: scopename
+        description: An object keyed by scope, containing a set of collections and the status of their index creation.
+        type: object
+        additionalProperties:
+          x-additionalPropertiesName: collectionname
+          type: string
+          enum:
+            - "completed"
+            - "in progress"
+          x-enumDescriptions:
+            completed: All indexes were created.
+            "in progress": Indexes are being created.
     settings:
       allOf:
         - $ref: '#/IndexSettings'
@@ -3114,6 +3128,4 @@ IndexInitStatus:
     - status
     - start_time
     - last_error
-    - docs_changed
-    - docs_processed
   title: IndexInitStatus

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1725,17 +1725,8 @@ Database:
       type: number
       default: 1
     index:
-      type: object
-      description: Settings for Global Secondary Indexes (GSI).
-      properties:
-        num_replicas:
-          description: This is the number of Global Secondary Indexes (GSI) to use for core indexes.
-          type: number
-          default: 1
-        num_partitions:
-          description: The number of partitions to use for the large indexes created by Sync Gateway. It is not recommended to set this unless you require additional horizontal scalability for individual indexes and have appropriately scaled your Query nodes to handle the increased query parallelism. If set, the recommended number is 8 and does not need to be directly related to the number of your Query nodes. Ensure documentation is read to understand the performance tradeoffs and instructions for migration if you have previously run with only one partition.
-          type: number
-          default: 1
+      allOf:
+        - $ref: '#/IndexSettings'
     use_views:
       description: Force the use of views instead of GSI.
       type: boolean
@@ -2999,6 +2990,7 @@ CollectionNames:
   type: array
   items:
     type: string
+    example: ["collection1", "collection2"]
 "All DBs":
   description: "The names of all databases."
   type: array
@@ -3075,3 +3067,53 @@ doc_access_spans:
             entries:
               type: array
               description: Start sequence to end sequence. If the channel is currently granted, the end sequence will be zero.
+IndexSettings:
+  type: object
+  description: Settings for Global Secondary Indexes (GSI).
+  properties:
+    num_replicas:
+      description: This is the number of Global Secondary Indexes (GSI) to use for core indexes. Changing this number after index creation is initiated will not change the value.
+      type: number
+      default: 1
+      minimum: 0
+    num_partitions:
+      description: The number of partitions to use for the large indexes created by Sync Gateway. It is not recommended to set this unless you require additional horizontal scalability for individual indexes and have appropriately scaled your Query nodes to handle the increased query parallelism. If set, the recommended number is 8 and does not need to be directly related to the number of your Query nodes. Ensure documentation is read to understand the performance tradeoffs and instructions for migration if you have previously run with only one partition. See [/{db}/_index_init](#operation/post_db-_index_init) for more information.
+      type: number
+      default: 1
+IndexInitStatus:
+  description: The status of an asynchronous indexes initizational operation.
+  type: object
+  properties:
+    status:
+      description: The status of the current operation.
+      type: string
+      enum:
+        - running
+        - completed
+        - error
+      x-enumDescriptions:
+        running: Indexes are being created.
+        completed: All indexes were created.
+        error: The index initialization operation has failed.
+    start_time:
+      description: The ISO-8601 date and time the index initialization operation was started.
+      type: string
+    last_error:
+      description: The last error that occurred in the index initialization operation (if any).
+      type: string
+    index_status:
+      description: 'scope name with one or more collection names and the status of their index creation'
+      type: object
+      additionalProperties:
+        $ref: '#/CollectionNames'
+      example: {"scopeName": ["collection1", "collection2"]}
+    settings:
+      allOf:
+        - $ref: '#/IndexSettings'
+  required:
+    - status
+    - start_time
+    - last_error
+    - docs_changed
+    - docs_processed
+  title: IndexInitStatus

--- a/docs/api/paths/admin/db-_config.yaml
+++ b/docs/api/paths/admin/db-_config.yaml
@@ -55,7 +55,7 @@ put:
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Architect
-    * Sync Gateway Application
+    * Sync Gateway Application (sync function only)
   parameters:
     - $ref: ../../components/parameters.yaml#/DB-config-If-Match
     - $ref: ../../components/parameters.yaml#/disable_oidc_validation
@@ -87,7 +87,7 @@ post:
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Architect
-    * Sync Gateway Application
+    * Sync Gateway Application (sync function only)
   parameters:
     - $ref: ../../components/parameters.yaml#/DB-config-If-Match
   requestBody:

--- a/docs/api/paths/admin/db-_index_init.yaml
+++ b/docs/api/paths/admin/db-_index_init.yaml
@@ -1,0 +1,79 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+parameters:
+  - $ref: ../../components/parameters.yaml#/db
+post:
+  summary: Start asynchronous index initialization
+  description: |
+    This can be used to start index initialization with different parameters from a running database. The typical workflow is:
+
+    1. Start the process of creating new indexes with [POST /{db}/_index_init](#operation/post-db_index_init).
+    2. Wait for index initialization to complete with [GET /{db}/_index_init](#operation/get_db-_index_init).
+    3. Update the database configuration to use these new indexes with [POST /{db}/_config](#operation/post_db-_config).
+    4. Call [POST /_post_upgrade](#operation/post__post_upgrade) to remove the original indexes.
+
+    This operation will start creation of indexes, and the creation of indexes can not be stopped on Couchbase Server once it has been started.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Architect
+  parameters:
+    - name: action
+      in: query
+      description: Defines whether the index creation operation is being started or stopped.
+      schema:
+        type: string
+        default: start
+        enum:
+          - start
+          - stop
+        x-enumDescriptions:
+          start: Starts the creation of indexes.
+          stop: Stops tracking the indexes by Sync Gateway. These indexes will still be created on Couchbase Server.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: ../../components/schemas.yaml#/IndexSettings
+  responses:
+    '200':
+      description: successfully changed the status of the resync operation
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/IndexInitStatus
+    '503':
+      description: Service Unavailable
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/HTTP-Error
+  tags:
+    - Database Management
+  operationId: post_db-_index_init
+get:
+  summary: Get status of index initialization.
+  description: |-
+    This will retrieve the status of last index initialization operation (whether it is running or not) in the Sync Gateway cluster.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Architect
+  responses:
+    '200':
+      description: successfully retrieved the most recent index initialization
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/IndexInitStatus
+    '404':
+      $ref: ../../components/responses.yaml#/Not-found
+  tags:
+    - Database Management
+  operationId: get_db-_index_init

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -111,7 +111,7 @@ get:
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-    - Database Management
+    - Document
   operationId: get_keyspace-_changes
 post:
   summary: Get changes list
@@ -174,5 +174,5 @@ post:
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-    - Database Management
+    - Document
   operationId: post_keyspace-_changes

--- a/docs/api/paths/admin/keyspace-_revs_diff.yaml
+++ b/docs/api/paths/admin/keyspace-_revs_diff.yaml
@@ -51,5 +51,5 @@ post:
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
-    - Database Management
+    - Document
   operationId: post_keyspace-_revs_diff


### PR DESCRIPTION
This tracks the new endpoints for partitioned indexes.

This doesn't need to be reviewed until the implementation of the indexes is created, but can be used as a reference. I expect the bulk of the documentation is in the API reference but there will be a small amount of text about the new feature and how to do a downtime operation.
