### PR TITLE
increase timeout for windows

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3336,7 +3336,7 @@ func Test_waitForBackgroundManagersToStop(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		deadline := 10 * time.Millisecond
+		deadline := 50 * time.Millisecond
 		waitForBackgroundManagersToStop(ctx, deadline, []*BackgroundManager{bgMngr})
 		assert.Greater(t, time.Since(startTime), deadline)
 		assert.Equal(t, BackgroundProcessStateStopping, bgMngr.GetRunState())


### PR DESCRIPTION
Increase timeout for slow windows machines. I considered using `GOOS` to switch on this but some jenkins is also slow linux machines and I think 50ms is not going to be noticeable and it is better than 10s it used to be.

https://mobile.jenkins.couchbase.com/blue/rest/organizations/jenkins/pipelines/sgw-windows-wix/runs/7574/log/?start=0
```
2025-04-11T09:33:48.930-07:00 [WRN] t:Test_waitForBackgroundManagersToStop/one_stoppable_process_and_one_unstoppable_process Background Managers [ test_unstoppable_runner] failed to stop within deadline of 100ms. -- db.waitForBackgroundManagersToStop() at database.go:686
--- FAIL: Test_waitForBackgroundManagersToStop (0.11s)
    --- FAIL: Test_waitForBackgroundManagersToStop/single_unstoppable_process (0.01s)
        database_test.go:3341: 
            	Error Trace:	C:/Jenkins/workspace/sgw-windows-wix/sync_gateway/db/database_test.go:3341
            	Error:      	"10ms" is not greater than "10ms"
            	Test:       	Test_waitForBackgroundManagersToStop/single_unstoppable_process
``` 
