### PR TITLE
Make `MgmtRequest` tolerant to request failures and not panic

### DIFF
--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -181,7 +181,7 @@ func MgmtRequest(client *http.Client, mgmtEp, method, uri, contentType, username
 	}
 	response, err := client.Do(req)
 	if err != nil {
-		return nil, response.StatusCode, err
+		return nil, 0, err
 	}
 	defer func() { _ = response.Body.Close() }()
 


### PR DESCRIPTION
`Do()` only returns an error if the request could not be made. If that is the case, `response` is not usable and will cause a nil pointer panic on this line.

Hit the following panic only due to environment setup (port 9102 was not exposed), but it could do with being handled better with this PR.

## before
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x101cb0e]

goroutine 192 [running]:
testing.tRunner.func1.2({0x1608280, 0x26706e0})
	/usr/lib/go/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1737 +0x35e
panic({0x1608280?, 0x26706e0?})
	/usr/lib/go/src/runtime/panic.go:792 +0x132
github.com/couchbase/sync_gateway/base.MgmtRequest(0xc005bfa2d0, {0xc000046540?, 0x1?}, {0x184e5b9, 0x3}, {0x185debe?, 0x0?}, {0x185f8e7, 0x10}, {0x185acb2, ...}, ...)
	/home/bbrks/dev/cb/sg/base/gocb_utils.go:184 +0x28e
github.com/couchbase/sync_gateway/db.GetIndexPartitionCount({0x1bf1940, 0xc000795500}, 0xc000796620, {0x1bd8138, 0xc000695758}, {0xc013574670, 0xc})
	/home/bbrks/dev/cb/sg/db/util_testing.go:747 +0x26f
github.com/couchbase/sync_gateway/rest/indextest.assertNumSGIndexPartitions({0x1bf1940, 0xc000795500}, 0x2, 0xc0000e9808)
	/home/bbrks/dev/cb/sg/rest/indextest/index_init_api_test.go:100 +0xfaf
github.com/couchbase/sync_gateway/rest/indextest.TestChangeIndexPartitions(0xc000795500)
	/home/bbrks/dev/cb/sg/rest/indextest/index_init_api_test.go:43 +0x23e
testing.tRunner(0xc000795500, 0x18f8cf0)
	/usr/lib/go/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 1
	/usr/lib/go/src/testing/testing.go:1851 +0x413
```


## after
```
    util_testing.go:748: 
        	Error Trace:	/home/bbrks/dev/cb/sg/db/util_testing.go:748
        	            				/home/bbrks/dev/cb/sg/rest/indextest/index_init_api_test.go:100
        	            				/home/bbrks/dev/cb/sg/rest/indextest/index_init_api_test.go:43
        	Error:      	Received unexpected error:
        	            	Get "http://localhost:9102/getIndexStatus": dial tcp [::1]:9102: connect: connection refused
        	Test:       	TestChangeIndexPartitions
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a