### PR TITLE
CBG-4575 switch allowConflicts default to false

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -85,8 +85,8 @@ const (
 	// TestEnvGoroutineDump if set to true will capture a goroutine pprof profile and log the location at the end of each package
 	TestEnvGoroutineDump = "SG_TEST_GOROUTINE_DUMP"
 
-	DefaultUseXattrs      = true // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
-	DefaultAllowConflicts = true // Whether Sync Gateway allows revision conflicts, if not specified in the config
+	DefaultUseXattrs      = true  // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
+	DefaultAllowConflicts = false // Whether Sync Gateway allows revision conflicts, if not specified in the config
 
 	DefaultDropIndexes = false // Whether Sync Gateway drops GSI indexes before each test while running in integration mode
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -129,25 +129,7 @@ func (tb *TestBucket) GetNamedDataStore(count int) (DataStore, error) {
 
 // Return a sorted list of data store names
 func (tb *TestBucket) GetNonDefaultDatastoreNames() []sgbucket.DataStoreName {
-	allDataStoreNames, err := tb.ListDataStores()
-	require.NoError(tb.t, err)
-	var keyspaces []string
-	for _, name := range allDataStoreNames {
-		if IsDefaultCollection(name.ScopeName(), name.CollectionName()) {
-			continue
-		}
-		keyspaces = append(keyspaces, fmt.Sprintf("%s.%s", name.ScopeName(), name.CollectionName()))
-	}
-	sort.Strings(keyspaces)
-	var nonDefaultDataStoreNames []sgbucket.DataStoreName
-	for _, keyspace := range keyspaces {
-		scopeAndCollection := strings.Split(keyspace, ScopeCollectionSeparator)
-		nonDefaultDataStoreNames = append(nonDefaultDataStoreNames,
-			ScopeAndCollectionName{
-				Scope:      scopeAndCollection[0],
-				Collection: scopeAndCollection[1]})
-	}
-	return nonDefaultDataStoreNames
+	return GetNonDefaultDatastoreNames(tb.t, tb)
 }
 
 // GetSingleDataStore returns a DataStore that can be used for testing.
@@ -974,4 +956,27 @@ func numFilesInDir(t *testing.T, dir string, recursive bool) int {
 // CreateTestBucketName will create a test bucket name using the test bucket prefix and the suffix you pass in
 func CreateTestBucketName(suffix string) string {
 	return fmt.Sprintf("%s%s", tbpBucketNamePrefix, suffix)
+}
+
+// GetNonDefaultDatastoreNames returns a list of non-default datastore names from the given bucket.
+func GetNonDefaultDatastoreNames(t testing.TB, bucket Bucket) []sgbucket.DataStoreName {
+	allDataStoreNames, err := bucket.ListDataStores()
+	require.NoError(t, err)
+	var keyspaces []string
+	for _, name := range allDataStoreNames {
+		if IsDefaultCollection(name.ScopeName(), name.CollectionName()) {
+			continue
+		}
+		keyspaces = append(keyspaces, fmt.Sprintf("%s.%s", name.ScopeName(), name.CollectionName()))
+	}
+	sort.Strings(keyspaces)
+	var nonDefaultDataStoreNames []sgbucket.DataStoreName
+	for _, keyspace := range keyspaces {
+		scopeAndCollection := strings.Split(keyspace, ScopeCollectionSeparator)
+		nonDefaultDataStoreNames = append(nonDefaultDataStoreNames,
+			ScopeAndCollectionName{
+				Scope:      scopeAndCollection[0],
+				Collection: scopeAndCollection[1]})
+	}
+	return nonDefaultDataStoreNames
 }

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -90,7 +90,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 func TestAttachments(t *testing.T) {
 
-	db, ctx := setupTestDB(t)
+	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 
 	// Test creating & updating a document:
@@ -543,7 +543,7 @@ func TestSetAttachment(t *testing.T) {
 }
 
 func TestRetrieveAncestorAttachments(t *testing.T) {
-	db, ctx := setupTestDB(t)
+	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -42,12 +42,20 @@ func setupTestDB(t testing.TB) (*Database, context.Context) {
 	return setupTestDBWithCacheOptions(t, DefaultCacheOptions())
 }
 
-func setupTestDBForBucket(t testing.TB, bucket *base.TestBucket) (*Database, context.Context) {
+func setupTestDBAllowConflicts(t testing.TB) (*Database, context.Context) {
+	dbcOptions := DatabaseContextOptions{
+		AllowConflicts: base.Ptr(true),
+		CacheOptions:   base.Ptr(DefaultCacheOptions()),
+	}
+	return SetupTestDBWithOptions(t, dbcOptions)
+}
+
+func setupTestDBForBucket(t testing.TB, bucket base.Bucket) (*Database, context.Context) {
 	cacheOptions := DefaultCacheOptions()
 	dbcOptions := DatabaseContextOptions{
 		CacheOptions: &cacheOptions,
 	}
-	return SetupTestDBForDataStoreWithOptions(t, bucket, dbcOptions)
+	return SetupTestDBForBucketWithOptions(t, bucket, dbcOptions)
 }
 
 func setupTestDBForBucketDefaultCollection(t testing.TB, bucket *base.TestBucket) (*Database, context.Context) {
@@ -56,7 +64,7 @@ func setupTestDBForBucketDefaultCollection(t testing.TB, bucket *base.TestBucket
 		CacheOptions: &cacheOptions,
 		Scopes:       GetScopesOptionsDefaultCollectionOnly(t),
 	}
-	return SetupTestDBForDataStoreWithOptions(t, bucket, dbcOptions)
+	return SetupTestDBForBucketWithOptions(t, bucket, dbcOptions)
 }
 
 func setupTestDBWithOptionsAndImport(t testing.TB, tBucket *base.TestBucket, dbcOptions DatabaseContextOptions) (*Database, context.Context) {
@@ -139,58 +147,12 @@ func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) (*Database, co
 }
 
 func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyOptions base.LeakyBucketConfig) (*Database, context.Context) {
-	ctx := base.TestCtx(t)
 	testBucket := base.GetTestBucket(t)
+	leakyBucket := base.NewLeakyBucket(testBucket, leakyOptions)
 	dbcOptions := DatabaseContextOptions{
 		CacheOptions: &options,
-		Scopes:       GetScopesOptions(t, testBucket, 1),
 	}
-	AddOptionsFromEnvironmentVariables(&dbcOptions)
-	leakyBucket := base.NewLeakyBucket(testBucket, leakyOptions)
-	dbCtx, err := NewDatabaseContext(ctx, "db", leakyBucket, false, dbcOptions)
-	if err != nil {
-		testBucket.Close(ctx)
-		t.Fatalf("Unable to create database context: %v", err)
-	}
-	ctx = dbCtx.AddDatabaseLogContext(ctx)
-	err = dbCtx.StartOnlineProcesses(ctx)
-	if err != nil {
-		dbCtx.Close(ctx)
-		t.Fatalf("Unable to start online processes: %v", err)
-	}
-	db, err := CreateDatabase(dbCtx)
-	if err != nil {
-		dbCtx.Close(ctx)
-		t.Fatalf("Unable to create database: %v", err)
-	}
-	return db, addDatabaseAndTestUserContext(ctx, db)
-}
-
-func setupTestDBWithLeakyBucket(t testing.TB, leakyBucket *base.LeakyBucket) (*Database, context.Context) {
-	ctx := base.TestCtx(t)
-	testBucket, ok := leakyBucket.GetUnderlyingBucket().(*base.TestBucket)
-	require.True(t, ok)
-	dbcOptions := DatabaseContextOptions{
-		Scopes: GetScopesOptions(t, testBucket, 1),
-	}
-	AddOptionsFromEnvironmentVariables(&dbcOptions)
-	dbCtx, err := NewDatabaseContext(ctx, "db", leakyBucket, false, dbcOptions)
-	if err != nil {
-		leakyBucket.Close(ctx)
-		t.Fatalf("Unable to create database context: %v", err)
-	}
-	ctx = dbCtx.AddDatabaseLogContext(ctx)
-	err = dbCtx.StartOnlineProcesses(ctx)
-	if err != nil {
-		dbCtx.Close(ctx)
-		t.Fatalf("Unable to start online processes: %v", err)
-	}
-	db, err := CreateDatabase(dbCtx)
-	if err != nil {
-		dbCtx.Close(ctx)
-		t.Fatalf("Unable to create database: %v", err)
-	}
-	return db, addDatabaseAndTestUserContext(ctx, db)
+	return SetupTestDBForBucketWithOptions(t, leakyBucket, dbcOptions)
 }
 
 func setupTestDBDefaultCollection(t testing.TB) (*Database, context.Context) {
@@ -1105,7 +1067,7 @@ func TestUpdatePrincipalCASRetry(t *testing.T) {
 		IgnoreClose: true,
 	})
 
-	db, ctx := setupTestDBWithLeakyBucket(t, lb)
+	db, ctx := setupTestDBForBucket(t, lb)
 	defer db.Close(ctx)
 
 	// Create a user with access to channel ABC
@@ -1152,7 +1114,7 @@ func TestUpdatePrincipalCASRetry(t *testing.T) {
 // Re-apply one of the conflicting changes to make sure that PutExistingRevWithBody() treats it as a no-op (SG Issue #3048)
 func TestRepeatedConflict(t *testing.T) {
 
-	db, ctx := setupTestDB(t)
+	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -1189,7 +1151,7 @@ func TestRepeatedConflict(t *testing.T) {
 
 func TestConflicts(t *testing.T) {
 
-	db, ctx := setupTestDB(t)
+	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -1312,7 +1274,7 @@ func TestConflicts(t *testing.T) {
 func TestConflictRevLimitDefault(t *testing.T) {
 
 	// Test Default Is the higher of the two
-	db, ctx := setupTestDB(t)
+	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	assert.Equal(t, uint32(DefaultRevsLimitConflicts), db.RevsLimit)
 }
@@ -1418,7 +1380,7 @@ func TestNoConflictsMode(t *testing.T) {
 
 // Test tombstoning of existing conflicts after AllowConflicts is set to false via Put
 func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
-	db, ctx := setupTestDB(t)
+	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -1495,7 +1457,7 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 
 // Test tombstoning of existing conflicts after AllowConflicts is set to false via PutExistingRev
 func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T) {
-	db, ctx := setupTestDB(t)
+	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -2306,24 +2268,24 @@ func TestConcurrentPushSameNewNonWinningRevision(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 	var db *Database
 	var enableCallback bool
-	var ctx context.Context
+	ctx := base.TestCtx(t)
 
-	writeUpdateCallback := func(key string) {
-		if enableCallback {
-			enableCallback = false
-			body := Body{"name": "Emily", "age": 20}
-			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b", "2-b", "1-a"}, false)
-			assert.NoError(t, err, "Adding revision 3-b")
-		}
-	}
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
 
-	// Use leaky bucket to inject callback in query invocation
-	queryCallbackConfig := base.LeakyBucketConfig{
-		UpdateCallback: writeUpdateCallback,
-	}
+	leakyBucket := base.NewLeakyBucket(bucket, base.LeakyBucketConfig{
+		UpdateCallback: func(key string) {
+			if enableCallback {
+				enableCallback = false
+				body := Body{"name": "Emily", "age": 20}
+				collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+				_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b", "2-b", "1-a"}, false)
+				assert.NoError(t, err, "Adding revision 3-b")
+			}
+		},
+	})
 
-	db, ctx = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
+	db, ctx = SetupTestDBForBucketWithOptions(t, leakyBucket, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -2364,24 +2326,21 @@ func TestConcurrentPushSameTombstoneWinningRevision(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 	var db *Database
 	var enableCallback bool
-	var ctx context.Context
-
-	writeUpdateCallback := func(key string) {
-		if enableCallback {
-			enableCallback = false
-			body := Body{"name": "Charlie", "age": 10, BodyDeleted: true}
-			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
-			assert.NoError(t, err, "Couldn't add revision 4-a (tombstone)")
-		}
-	}
-
-	// Use leaky bucket to inject callback in query invocation
-	queryCallbackConfig := base.LeakyBucketConfig{
-		UpdateCallback: writeUpdateCallback,
-	}
-
-	db, ctx = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	leakyBucket := base.NewLeakyBucket(bucket, base.LeakyBucketConfig{
+		UpdateCallback: func(key string) {
+			if enableCallback {
+				enableCallback = false
+				body := Body{"name": "Charlie", "age": 10, BodyDeleted: true}
+				collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+				_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+				assert.NoError(t, err, "Couldn't add revision 4-a (tombstone)")
+			}
+		},
+	})
+	db, ctx = SetupTestDBForBucketWithOptions(t, leakyBucket, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -2422,24 +2381,23 @@ func TestConcurrentPushDifferentUpdateNonWinningRevision(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 	var db *Database
 	var enableCallback bool
-	var ctx context.Context
 
-	writeUpdateCallback := func(key string) {
-		if enableCallback {
-			enableCallback = false
-			body := Body{"name": "Joshua", "age": 11}
-			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-			_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b1", "2-b", "1-a"}, false)
-			assert.NoError(t, err, "Couldn't add revision 3-b1")
-		}
-	}
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	leakyBucket := base.NewLeakyBucket(bucket, base.LeakyBucketConfig{
+		UpdateCallback: func(key string) {
+			if enableCallback {
+				enableCallback = false
+				body := Body{"name": "Joshua", "age": 11}
+				collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+				_, _, err := collection.PutExistingRevWithBody(ctx, "doc1", body, []string{"3-b1", "2-b", "1-a"}, false)
+				assert.NoError(t, err, "Couldn't add revision 3-b1")
+			}
+		},
+	})
 
-	// Use leaky bucket to inject callback in query invocation
-	queryCallbackConfig := base.LeakyBucketConfig{
-		UpdateCallback: writeUpdateCallback,
-	}
-
-	db, ctx = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
+	db, ctx = SetupTestDBForBucketWithOptions(t, leakyBucket, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
@@ -2638,7 +2596,7 @@ func TestTombstoneCompactionStopWithManager(t *testing.T) {
 
 	bucket := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
 	zero := time.Duration(0)
-	db, ctx := SetupTestDBForDataStoreWithOptions(t, bucket, DatabaseContextOptions{
+	db, ctx := SetupTestDBForBucketWithOptions(t, bucket, DatabaseContextOptions{
 		PurgeInterval: &zero,
 	})
 	defer db.Close(ctx)
@@ -2822,10 +2780,8 @@ func Test_updateAllPrincipalsSequences(t *testing.T) {
 }
 
 func Test_invalidateAllPrincipalsCache(t *testing.T) {
-	bucket := base.GetTestBucket(t)
-	defer bucket.Close(base.TestCtx(t))
-
-	db, ctx := setupTestDBForBucket(t, bucket)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
 	defer db.Close(ctx)
 	db.Options.QueryPaginationLimit = 100
 
@@ -2887,13 +2843,13 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 		for i := 0; i < 1; i++ {
 			raw, _, err := db.MetadataStore.GetRaw(db.MetadataKeys.RoleKey(fmt.Sprintf("role%d", i)))
 			assert.NoError(t, err)
-			err = json.Unmarshal(raw, &invalPrinc)
-			assert.NoError(t, err)
-			assert.Equal(t, endSeq, invalPrinc.CollectionAccess[scopeName][collectionName].ChannelInvalSeq)
+			require.NoError(t, json.Unmarshal(raw, &invalPrinc))
+			fmt.Printf("raw=%s invalPrinc: %#+v\n", raw, invalPrinc)
+			assert.Equal(t, int(endSeq), int(invalPrinc.CollectionAccess[scopeName][collectionName].ChannelInvalSeq))
 			assert.Equal(t, fmt.Sprintf("role%d", i), invalPrinc.Name)
 
 			raw, _, err = db.MetadataStore.GetRaw(db.MetadataKeys.UserKey(fmt.Sprintf("user%d", i)))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = json.Unmarshal(raw, &invalPrinc)
 			assert.NoError(t, err)
 			assert.Equal(t, endSeq, invalPrinc.CollectionAccess[scopeName][collectionName].ChannelInvalSeq)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -961,7 +961,7 @@ func TestImportConflictWithTombstone(t *testing.T) {
 	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport, base.KeyCRUD)
-	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
+	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
 	defer db.Close(ctx)
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
@@ -1076,7 +1076,7 @@ func TestImportCancelOnDocWithCorruptSequenceOndemand(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyImport, base.KeyCRUD)
 	tb := base.GetTestBucket(t)
 	defer tb.Close(base.TestCtx(t))
-	db, ctx := SetupTestDBForDataStoreWithOptions(t, tb, DatabaseContextOptions{})
+	db, ctx := setupTestDBForBucket(t, tb)
 	key := t.Name()
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -155,7 +155,7 @@ func TestPostUpgradeMultipleCollections(t *testing.T) {
 		dbOptions.Scopes = GetScopesOptions(t, tb, numCollections)
 	}
 
-	db, ctx := SetupTestDBForDataStoreWithOptions(t, tb, dbOptions)
+	db, ctx := SetupTestDBForBucketWithOptions(t, tb, dbOptions)
 	defer db.Close(ctx)
 
 	// make sure RemoveObsoleteIndexes is a no-op before adding obsolete indexes

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -355,7 +355,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db, ctx := setupTestDB(t)
+	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	collection.ChannelMapper = channels.NewChannelMapper(ctx, channels.DocChannelsSyncFunction, db.Options.JavascriptTimeout)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1027,7 +1027,7 @@ func TestRevCacheHitMultiCollection(t *testing.T) {
 	dbOptions := DatabaseContextOptions{}
 	dbOptions.Scopes = GetScopesOptions(t, tb, 2)
 
-	db, ctx := SetupTestDBForDataStoreWithOptions(t, tb, dbOptions)
+	db, ctx := SetupTestDBForBucketWithOptions(t, tb, dbOptions)
 	defer db.Close(ctx)
 
 	var collectionList []*DatabaseCollectionWithUser
@@ -1081,7 +1081,7 @@ func TestRevCacheHitMultiCollectionLoadFromBucket(t *testing.T) {
 	}
 	dbOptions.Scopes = GetScopesOptions(t, tb, 2)
 
-	db, ctx := SetupTestDBForDataStoreWithOptions(t, tb, dbOptions)
+	db, ctx := SetupTestDBForBucketWithOptions(t, tb, dbOptions)
 	defer db.Close(ctx)
 
 	var collectionList []*DatabaseCollectionWithUser

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -556,10 +556,10 @@ func AddOptionsFromEnvironmentVariables(dbcOptions *DatabaseContextOptions) {
 // override somedbcOptions properties.
 func SetupTestDBWithOptions(t testing.TB, dbcOptions DatabaseContextOptions) (*Database, context.Context) {
 	tBucket := base.GetTestBucket(t)
-	return SetupTestDBForDataStoreWithOptions(t, tBucket, dbcOptions)
+	return SetupTestDBForBucketWithOptions(t, tBucket, dbcOptions)
 }
 
-func SetupTestDBForDataStoreWithOptions(t testing.TB, tBucket *base.TestBucket, dbcOptions DatabaseContextOptions) (*Database, context.Context) {
+func SetupTestDBForBucketWithOptions(t testing.TB, tBucket base.Bucket, dbcOptions DatabaseContextOptions) (*Database, context.Context) {
 	ctx := base.TestCtx(t)
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 	if dbcOptions.Scopes == nil {
@@ -585,7 +585,7 @@ func addDatabaseAndTestUserContext(ctx context.Context, db *Database) context.Co
 }
 
 // GetScopesOptions sets up a ScopesOptions from a TestBucket. This will set up default or non default collections depending on the test harness use of SG_TEST_USE_DEFAULT_COLLECTION and whether the backing store supports collections.
-func GetScopesOptions(t testing.TB, testBucket *base.TestBucket, numCollections int) ScopesOptions {
+func GetScopesOptions(t testing.TB, bucket base.Bucket, numCollections int) ScopesOptions {
 	if !base.TestsUseNamedCollections() {
 		if numCollections != 1 {
 			t.Fatal("Setting numCollections on a test that can't use collections is invalid")
@@ -593,8 +593,8 @@ func GetScopesOptions(t testing.TB, testBucket *base.TestBucket, numCollections 
 		return GetScopesOptionsDefaultCollectionOnly(t)
 	}
 	// Get a datastore as provided by the test
-	stores := testBucket.GetNonDefaultDatastoreNames()
-	require.True(t, len(stores) >= numCollections, "Requested more collections %d than found on testBucket %d", numCollections, len(stores))
+	stores := base.GetNonDefaultDatastoreNames(t, bucket)
+	require.GreaterOrEqual(t, len(stores), numCollections, "Requested more collections %d than found on testBucket %d", numCollections, len(stores))
 
 	scopesConfig := ScopesOptions{}
 	for i := 0; i < numCollections; i++ {

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1715,9 +1715,9 @@ Database:
       type: boolean
       default: false
     allow_conflicts:
-      description: This controls whether to allow conflicting document revisions.
+      description: This controls whether to allow conflicting document revisions. This option is going to be removed from sync gateway, and conflicts will not be allowed.
       type: boolean
-      default: true
+      default: false
       deprecated: true
     num_index_replicas:
       description: |-

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2114,8 +2114,13 @@ func TestHandleGetConfig(t *testing.T) {
 }
 
 func TestHandleGetRevTree(t *testing.T) {
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AllowConflicts = base.Ptr(true)
+
+	rest.RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	// Create three revisions of the user foo with different status and updated_at values;
 	reqBodyJson := `{"new_edits": false, "docs": [

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -685,9 +685,12 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 }
 
 func TestConflictWithInvalidAttachment(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
 
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AllowConflicts = base.Ptr(true)
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 	// Create Doc
 	version := rt.CreateTestDoc("doc1")
 
@@ -779,8 +782,12 @@ func TestAttachmentRevposPre25Metadata(t *testing.T) {
 }
 
 func TestConflictingBranchAttachments(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AllowConflicts = base.Ptr(true)
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	// Create a document
 	version := rt.CreateTestDoc("doc1")
@@ -830,8 +837,12 @@ func TestConflictingBranchAttachments(t *testing.T) {
 }
 
 func TestAttachmentsWithTombstonedConflict(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AllowConflicts = base.Ptr(true)
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	version := rt.CreateTestDoc("doc1")
 
@@ -2132,8 +2143,12 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 func TestAttachmentsMissing(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AllowConflicts = base.Ptr(true)
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	docID := t.Name()
 	version1 := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
@@ -2151,8 +2166,12 @@ func TestAttachmentsMissing(t *testing.T) {
 func TestAttachmentsMissingNoBody(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AllowConflicts = base.Ptr(true)
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	docID := t.Name()
 	version1 := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
@@ -2386,10 +2405,13 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 
 // CBG-2004: Test that prove attachment over Blip works correctly when receiving a ErrAttachmentNotFound
 func TestProveAttachmentNotFound(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
-		GuestEnabled: true,
-	})
+	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.AllowConflicts = base.Ptr(true)
+	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	require.NoError(t, rt.SetAdminParty(true))
 
 	bt, err := NewBlipTesterFromSpecWithRT(t, nil, rt)
 	assert.NoError(t, err, "Error creating BlipTester")

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -48,10 +48,9 @@ import (
 //
 // Replication Spec: https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#proposechanges
 func TestBlipPushRevisionInspectChanges(t *testing.T) {
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	bt, err := NewBlipTester(t)
+	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{allowConflicts: true, GuestEnabled: true})
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
@@ -67,7 +66,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	body, err := changesResponse.Body()
 	assert.NoError(t, err, "Error reading changes response body")
 	err = base.JSONUnmarshal(body, &changeList)
-	assert.NoError(t, err, "Error unmarshalling response body")
+	require.NoError(t, err, "Error unmarshalling response body: %s", body)
 	require.Len(t, changeList, 1) // Should be 1 row, corresponding to the single doc that was queried in changes
 	changeRow := changeList[0]
 	assert.Len(t, changeRow, 0) // Should be empty, meaning the server is saying it doesn't have the revision yet
@@ -603,8 +602,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noConflictsMode: true,
-		GuestEnabled:    true,
+		GuestEnabled: true,
 	})
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -643,8 +641,7 @@ func TestProposedChangesIncludeConflictingRev(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noConflictsMode: true,
-		GuestEnabled:    true,
+		GuestEnabled: true,
 	})
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -1666,7 +1663,6 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noConflictsMode:    true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
@@ -1691,12 +1687,11 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 }
 
 func TestPutRevConflictsMode(t *testing.T) {
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noConflictsMode:    false,
+		allowConflicts:     true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
@@ -2648,8 +2643,7 @@ func TestSendRevAsReadOnlyGuest(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noConflictsMode: true,
-		GuestEnabled:    true,
+		GuestEnabled: true,
 	})
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -218,6 +218,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 					},
 				},
 			},
+			AllowConflicts: base.Ptr(true),
 		},
 		}}
 	rt := NewRestTester(t, rtConfig)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1246,6 +1246,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	skippedMaxWait := uint32(120000)
 
 	shortWaitConfig := &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+		AllowConflicts: base.Ptr(true),
 		CacheConfig: &rest.CacheConfig{
 			ChannelCacheConfig: &rest.ChannelCacheConfig{
 				MaxWaitPending: &pendingMaxWait,
@@ -1509,7 +1510,7 @@ func _testConcurrentNewEditsFalseDelete(t *testing.T) {
 func TestChangesActiveOnlyInteger(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`, AllowConflicts: true})
 	defer rt.Close()
 
 	// Create user:
@@ -1627,6 +1628,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 				channel(doc.channels)
 			}
 		}`,
+		AllowConflicts: true,
 	}
 	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig)
 	defer rt.Close()
@@ -1751,7 +1753,8 @@ func TestChangesIncludeDocs(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rtConfig := rest.RestTesterConfig{
-		SyncFn: `function(doc) {channel(doc.channels)}`,
+		SyncFn:         `function(doc) {channel(doc.channels)}`,
+		AllowConflicts: true,
 	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	testDB := rt.GetDatabase()
@@ -2725,10 +2728,9 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 }
 
 func TestChangesActiveOnlyWithLimit(t *testing.T) {
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`, AllowConflicts: true})
 	defer rt.Close()
 
 	ctx := rt.Context()
@@ -2891,7 +2893,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`, AllowConflicts: true})
 	defer rt.Close()
 
 	// Create user:
@@ -3053,6 +3055,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 
 	cacheSize := 2
 	shortWaitConfig := &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+		AllowConflicts: base.Ptr(true),
 		CacheConfig: &rest.CacheConfig{
 			ChannelCacheConfig: &rest.ChannelCacheConfig{
 				MinLength: &cacheSize,
@@ -3194,12 +3197,13 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 
 // Test _changes returning conflicts
 func TestChangesIncludeConflicts(t *testing.T) {
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)
 
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc,oldDoc) {
 			 channel(doc.channel)
-		 }`}
+		 }`,
+		AllowConflicts: true,
+	}
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -258,7 +258,7 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 		}
 	}`
 
-	rtConfig := RestTesterConfig{SyncFn: syncFn}
+	rtConfig := RestTesterConfig{SyncFn: syncFn, AllowConflicts: true}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 


### PR DESCRIPTION
CBG-4575 switch allowConflicts default to false

The only substaintive changes in the docs and in `base/constants.go`. The rest of the changes are necessary to allow tests with conflicts to pass. There is already a warning for this setting in 3.2 https://github.com/couchbase/sync_gateway/blob/bec2afd648bbc7cef7873edef883bec0dff264cc/rest/server_context.go#L1257

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3045/
