### PR TITLE
CBG-4616 make WaitForChanges more strict

### DIFF
--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -147,8 +147,7 @@ func TestStarAccess(t *testing.T) {
 
 	// Ensure docs have been processed before issuing changes requests
 	expectedSeq := uint64(6)
-	err = rt.WaitForSequence(expectedSeq)
-	require.NoError(t, err)
+	rt.WaitForSequence(expectedSeq)
 
 	// GET /db/_changes
 	changes := rt.GetChanges("/{{.keyspace}}/_changes", "bernard")
@@ -805,7 +804,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	RequireStatus(t, rt.SendRequest("PUT", "/{{.keyspace}}/d1", `{"channel":"delta"}`), 201)
 	RequireStatus(t, rt.SendRequest("PUT", "/{{.keyspace}}/g1", `{"channel":"gamma"}`), 201)
 
-	rt.MustWaitForDoc("g1", t)
+	rt.WaitForDoc("g1")
 
 	changes := rt.GetChanges("/{{.keyspace}}/_changes", "zegpold")
 	require.Len(t, changes.Results, 1)
@@ -875,7 +874,7 @@ func TestChannelAccessChanges(t *testing.T) {
 			"gamma": channels.NewVbSimpleSequence(gammaGrantDocSeq),
 		}, zegpold.CollectionChannels(s, c))
 
-	rt.MustWaitForDoc("alpha", t)
+	rt.WaitForDoc("alpha")
 
 	// Look at alice's _changes feed:
 	changes = rt.GetChanges("/{{.keyspace}}/_changes", "alice")
@@ -903,7 +902,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Must wait for sequence to arrive in cache, since the cache processor will be paused when UpdateSyncFun() is called
 	// below, which could lead to a data race if the cache processor is paused while it's processing a change
-	rt.MustWaitForDoc("epsilon", t)
+	rt.WaitForDoc("epsilon")
 
 	// Finally, throw a wrench in the works by changing the sync fn.
 	RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/sync", `function(doc) {access("alice", "beta");channel("beta");}`), http.StatusOK)
@@ -911,8 +910,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	require.Equal(t, int64(9), resyncStatus.DocsChanged)
 	rt.TakeDbOnline()
 	expectedIDs := []string{"beta", "delta", "gamma", "a1", "b1", "d1", "g1", "alpha", "epsilon"}
-	changes, err = rt.WaitForChanges(len(expectedIDs), "/{{.keyspace}}/_changes", "alice", false)
-	assert.NoError(t, err, "Unexpected error")
+	changes = rt.WaitForChanges(len(expectedIDs), "/{{.keyspace}}/_changes", "alice", false)
 	log.Printf("_changes looks like: %+v", changes)
 	assert.Equal(t, len(expectedIDs), len(changes.Results))
 

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1721,8 +1721,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	rest.RequireStatus(t, rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"foo":"bar", "channels": ["abc", "def"]}`), http.StatusCreated)
 	rest.RequireStatus(t, rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc2", `{"moo":"car", "channels": ["abc"]}`), http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
-	require.NoError(t, err, "Error waiting for changes")
+	changes := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	base.RequireAllAssertions(t,
 		assert.Equal(t, "doc1", changes.Results[0].ID),
 		assert.Equal(t, "doc2", changes.Results[1].ID),
@@ -1735,8 +1734,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}}, body)
 
-	changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
-	require.NoError(t, err, "Error waiting for changes")
+	changes = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	assert.Equal(t, "doc2", changes.Results[0].ID)
 
 }

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -224,7 +224,7 @@ func TestSingleCollectionDCP(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, rt.WaitForDoc(docID))
+	rt.WaitForDoc(docID)
 }
 
 func TestMultiCollectionDCP(t *testing.T) {
@@ -255,8 +255,7 @@ func TestMultiCollectionDCP(t *testing.T) {
 	rt.WaitForPendingChanges()
 
 	for _, ks := range rt.GetKeyspaces() {
-		_, err = rt.WaitForChanges(1, fmt.Sprintf("/%s/_changes", ks), "", true)
-		require.NoError(t, err)
+		rt.WaitForChanges(1, fmt.Sprintf("/%s/_changes", ks), "", true)
 	}
 }
 
@@ -588,8 +587,7 @@ func TestCollectionsSGIndexQuery(t *testing.T) {
 	resp = rt.SendUserRequestWithHeaders(http.MethodGet, "/{{.keyspace}}/"+invalidDocID, ``, nil, username, password)
 	RequireStatus(t, resp, http.StatusForbidden)
 
-	_, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", username, false)
-	require.NoError(t, err)
+	rt.WaitForChanges(1, "/{{.keyspace}}/_changes", username, false)
 }
 
 func TestCollectionsPutDBInexistentCollection(t *testing.T) {

--- a/rest/api_test_helpers.go
+++ b/rest/api_test_helpers.go
@@ -72,10 +72,3 @@ func (rt *RestTester) PutNewEditsFalse(docID string, newVersion DocVersion, pare
 
 	return base.Ptr(DocVersionFromPutResponse(rt.TB(), resp))
 }
-
-func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) ChangesResults {
-	changesResults, err := rt.WaitForChanges(numChangesExpected, "/{{.keyspace}}/_changes?since="+since, "", true)
-	require.NoError(rt.TB(), err)
-	require.Len(rt.TB(), changesResults.Results, numChangesExpected)
-	return changesResults
-}

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2174,9 +2174,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		const docID = "doc"
 		version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
-		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, 1)
+		changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
@@ -2185,9 +2183,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		version = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
 
-		changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, 1)
+		changes = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
@@ -2198,9 +2194,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		const docMarker = "docmarker"
 		docMarkerVersion := rt.PutDoc(docMarker, `{"channels": ["!"]}`)
 
-		changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, 2)
+		changes = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 		assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
@@ -2265,9 +2259,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		)
 		version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
-		changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, 1)
+		changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
@@ -2277,9 +2269,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
 		rt.WaitForPendingChanges()
 		// At this point changes should send revocation, as document isn't in any of the user's channels
-		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, 1)
+		changes = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
 		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
 
@@ -2292,9 +2282,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		rt.WaitForPendingChanges()
 
 		// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
-		changes, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, 2) // _changes still gets two results, as we don't support 3.0 removal handling over REST API
+		changes = rt.WaitForChanges(2, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
 		assert.Equal(t, markerID, changes.Results[1].ID)
 
@@ -2575,8 +2563,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 
 				// Wait for rev to be received on RT
 				rt.WaitForPendingChanges()
-				changes, err = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "", true)
-				require.NoError(t, err)
+				changes = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "", true)
 
 				var bucketDoc map[string]interface{}
 				_, err = rt.GetSingleDataStore().Get(docID, &bucketDoc)

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -17,8 +17,11 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestBlipPusherUpdateDatabase starts a push replication and updates the database underneath the replication.
@@ -74,7 +77,10 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 		}()
 
 		// and wait for a few to be done before we proceed with updating database config underneath replication
-		rt.WaitForChanges(5, "/{{.keyspace}}/_changes", "", true)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			changes := rt.GetChanges("/{{.keyspace}}/_changes", "")
+			assert.GreaterOrEqual(c, 5, changes.Results)
+		}, time.Second*5, time.Millisecond*100)
 
 		// just change the sync function to cause the database to reload
 		dbConfig := *rt.ServerContext().GetDbConfig("db")

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -18,8 +18,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -76,8 +74,7 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 		}()
 
 		// and wait for a few to be done before we proceed with updating database config underneath replication
-		_, err := rt.WaitForChanges(5, "/{{.keyspace}}/_changes", "", true)
-		require.NoError(t, err)
+		rt.WaitForChanges(5, "/{{.keyspace}}/_changes", "", true)
 
 		// just change the sync function to cause the database to reload
 		dbConfig := *rt.ServerContext().GetDbConfig("db")

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -111,24 +111,18 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	}
 
 	limit := 50
-	changesResults, err := rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user1", false)
-	assert.NoError(t, err, "Unexpected error")
-	require.Len(t, changesResults.Results, 50)
+	changesResults := rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user1", false)
 	since := changesResults.Results[49].Seq
 	assert.Equal(t, "doc48", changesResults.Results[49].ID)
 
 	// // Check the _changes feed with  since and limit, to get second half of feed
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
-	assert.NoError(t, err, "Unexpected error")
-	require.Len(t, changesResults.Results, 50)
+	changesResults = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
 	assert.Equal(t, "doc98", changesResults.Results[49].ID)
 
 	rt.CreateUser("user2", []string{"alpha"})
 
 	// Retrieve all changes for user2 with no limits
-	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/{{.keyspace}}/_changes"), "user2", false)
-	assert.NoError(t, err, "Unexpected error")
-	require.Len(t, changesResults.Results, 101)
+	changesResults = rt.WaitForChanges(101, fmt.Sprintf("/{{.keyspace}}/_changes"), "user2", false)
 	assert.Equal(t, "doc99", changesResults.Results[99].ID)
 
 	rt.CreateUser("user3", []string{"alpha"})
@@ -142,35 +136,28 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	userSequence := user3.Sequence()
 
 	// Get first 50 document changes.
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user3", false)
-	assert.NoError(t, err, "Unexpected error")
-	require.Len(t, changesResults.Results, 50)
+	changesResults = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user3", false)
 	since = changesResults.Results[49].Seq
 	assert.Equal(t, "doc49", changesResults.Results[49].ID)
 	assert.Equal(t, userSequence, since.TriggeredBy)
 
 	// // Get remainder of changes i.e. no limit parameter
-	changesResults, err = rt.WaitForChanges(51, fmt.Sprintf("/{{.keyspace}}/_changes?since=\"%s\"", since), "user3", false)
-	assert.NoError(t, err, "Unexpected error")
-	require.Len(t, changesResults.Results, 51)
+	changesResults = rt.WaitForChanges(51, fmt.Sprintf("/{{.keyspace}}/_changes?since=\"%s\"", since), "user3", false)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 	rt.CreateUser("user4", []string{"alpha"})
 	// Get the sequence from the user doc to validate against the triggered by value in the changes results
-	user4, _ := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")
+	user4, err := rt.GetDatabase().Authenticator(base.TestCtx(t)).GetUser("user4")
+	require.NoError(t, err)
 	user4Sequence := user4.Sequence()
 
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user4", false)
-	assert.NoError(t, err, "Unexpected error")
-	require.Len(t, changesResults.Results, 50)
+	changesResults = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?limit=%d", limit), "user4", false)
 	since = changesResults.Results[49].Seq
 	assert.Equal(t, "doc49", changesResults.Results[49].ID)
 	assert.Equal(t, user4Sequence, since.TriggeredBy)
 
 	// // Check the _changes feed with  since and limit, to get second half of feed
-	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&limit=%d", since, limit), "user4", false)
-	assert.Equal(t, nil, err)
-	require.Len(t, changesResults.Results, 50)
+	changesResults = rt.WaitForChanges(50, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&limit=%d", since, limit), "user4", false)
 	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 }
@@ -330,8 +317,7 @@ func TestJumpInSequencesAtAllocatorSkippedSequenceFill(t *testing.T) {
 
 	doc1Vrs := rt.PutDoc("doc1", `{"prop":true}`)
 
-	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err)
+	changes := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
 	changes.RequireDocIDs(t, []string{"doc1", "doc"})
 	changes.RequireRevID(t, []string{docVrs.RevID, doc1Vrs.RevID})
 }
@@ -401,8 +387,7 @@ func TestJumpInSequencesAtAllocatorRangeInPending(t *testing.T) {
 
 	doc1Vrs := rt.PutDoc("doc1", `{"prop":true}`)
 
-	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err)
+	changes := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
 	changes.RequireDocIDs(t, []string{"doc1", "doc"})
 	changes.RequireRevID(t, []string{docVrs.RevID, doc1Vrs.RevID})
 }

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -180,9 +180,7 @@ func TestChangesFeedOnInheritedChannelsFromRoles(t *testing.T) {
 	}
 
 	// Start changes feed as the user filtered to channel A, expect 6 changes (5 docs + user doc)
-	changes, err := rt.WaitForChanges(6, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A", "alice", false)
-	require.NoError(t, err)
-	assert.Len(t, changes.Results, 6)
+	rt.WaitForChanges(6, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A", "alice", false)
 }
 
 // TestChangesFeedOnInheritedChannelsFromRolesDefaultCollection:
@@ -212,9 +210,7 @@ func TestChangesFeedOnInheritedChannelsFromRolesDefaultCollection(t *testing.T) 
 	}
 
 	// Start changes feed as the user filtered to channel A, expect 6 changes (5 docs + user doc)
-	changes, err := rt.WaitForChanges(6, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A", "alice", false)
-	require.NoError(t, err)
-	assert.Len(t, changes.Results, 6)
+	rt.WaitForChanges(6, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A", "alice", false)
 }
 
 func TestPostChanges(t *testing.T) {
@@ -241,9 +237,7 @@ func TestPostChanges(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/{{.keyspace}}/pbs3", `{"value":3, "channel":["PBS"]}`)
 	rest.RequireStatus(t, response, 201)
 
-	changes, err := rt.WaitForChanges(3, "/{{.keyspace}}/_changes?style=all_docs&heartbeat=300000&feed=longpoll&limit=50&since=0", "bernard", false)
-	assert.NoError(t, err)
-	assert.Len(t, changes.Results, 3)
+	rt.WaitForChanges(3, "/{{.keyspace}}/_changes?style=all_docs&heartbeat=300000&feed=longpoll&limit=50&since=0", "bernard", false)
 }
 
 // Tests race between waking up the changes feed, and detecting that the user doc has changed
@@ -587,8 +581,7 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":26,"id":"abc-2","deleted":true,"removed":["ABC"],"changes":[{"rev":"2-6055be21d970eb690f48452505ea02ed"}]}`,
 		`{"seq":27,"id":"abc-3","removed":["ABC"],"changes":[{"rev":"2-09b89154aa9a0e1620da0d86528d406a"}]}`,
 	}
-	changes, err := rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes", "bernard", false)
-	require.NoError(t, err, "Error retrieving changes results")
+	changes := rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes", "bernard", false)
 
 	for index, result := range changes.Results {
 		var expectedChange db.ChangeEntry
@@ -615,9 +608,8 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":"28:22","id":"mix-5","changes":[{"rev":"3-8192afec7aa6986420be1d57f1677960"}]}`,
 		`{"seq":28,"id":"_user/bernard","changes":[]}`,
 	}
-	changes, err = rt.WaitForChanges(len(expectedResults),
+	changes = rt.WaitForChanges(len(expectedResults),
 		fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "bernard", false)
-	require.NoError(t, err, "Error retrieving changes results")
 
 	for index, result := range changes.Results {
 		var expectedChange db.ChangeEntry
@@ -650,9 +642,8 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		`{"seq":31,"id":"hbo-3","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":32,"id":"mix-7","changes":[{"rev":"1-32f69cdbf1772a8e064f15e928a18f85"}]}`,
 	}
-	changes, err = rt.WaitForChanges(len(expectedResults),
+	changes = rt.WaitForChanges(len(expectedResults),
 		fmt.Sprintf("/{{.keyspace}}/_changes?since=28:5"), "bernard", false)
-	require.NoError(t, err, "Error retrieving changes results")
 
 	for index, result := range changes.Results {
 		var expectedChange db.ChangeEntry
@@ -711,18 +702,14 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 	cacheWaiter.AddAndWait(3)
 
 	// Issue changes request with limit less than 5.  Expect to get pbs-5, user doc, and abc-1
-	changes, err := rt.WaitForChanges(0, "/{{.keyspace}}/_changes?limit=3", "bernard", false)
-	assert.NoError(t, err)
-	require.Equal(t, len(changes.Results), 3)
+	changes := rt.WaitForChanges(3, "/{{.keyspace}}/_changes?limit=3", "bernard", false)
 	assert.Equal(t, "pbs-5", changes.Results[0].ID)
 	assert.Equal(t, "_user/bernard", changes.Results[1].ID)
 	assert.Equal(t, "abc-1", changes.Results[2].ID)
 	lastSeq := changes.Last_Seq
 
 	// Issue a second changes request, expect to see last 2 documents.
-	moreChanges, err := rt.WaitForChanges(0, fmt.Sprintf("/{{.keyspace}}/_changes?limit=3&since=%s", lastSeq), "bernard", false)
-	assert.NoError(t, err)
-	require.Len(t, moreChanges.Results, 2)
+	moreChanges := rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?limit=3&since=%s", lastSeq), "bernard", false)
 	assert.Equal(t, "abc-2", moreChanges.Results[0].ID)
 	assert.Equal(t, "abc-3", moreChanges.Results[1].ID)
 }
@@ -778,8 +765,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	expectedResults := []string{
 		`{"seq":7,"id":"abc-1","changes":[{"rev":"1-0143105976caafbda3b90cf82948dc64"}]}`,
 	}
-	changes, err := rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes", "bernard", false)
-	require.NoError(t, err, "Error retrieving changes results")
+	changes := rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes", "bernard", false)
 	for index, result := range changes.Results {
 		var expectedChange db.ChangeEntry
 		require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
@@ -797,9 +783,8 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 		`{"seq":"8:2","id":"hbo-1","changes":[{"rev":"1-46f8c67c004681619052ee1a1cc8e104"}]}`,
 		`{"seq":8,"id":"grant-1","changes":[{"rev":"1-c5098bb14d12d647c901850ff6a6292a"}]}`,
 	}
-	changes, err = rt.WaitForChanges(1,
+	changes = rt.WaitForChanges(3,
 		fmt.Sprintf("/{{.keyspace}}/_changes?since=%s", changes.Last_Seq), "bernard", false)
-	require.NoError(t, err, "Error retrieving changes results")
 	for index, result := range changes.Results {
 		var expectedChange db.ChangeEntry
 		require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
@@ -820,8 +805,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	}
 
 	rt.Run("grant via existing channel", func(t *testing.T) {
-		changes, err = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "alice", false)
-		require.NoError(t, err, "Error retrieving changes results for alice")
+		changes = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "alice", false)
 		for index, result := range changes.Results {
 			var expectedChange db.ChangeEntry
 			require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
@@ -830,8 +814,7 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	})
 
 	rt.Run("grant via new channel", func(t *testing.T) {
-		changes, err = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "bernard", false)
-		require.NoError(t, err, "Error retrieving changes results for bernard")
+		changes = rt.WaitForChanges(len(expectedResults), "/{{.keyspace}}/_changes?since=8:1", "bernard", false)
 		for index, result := range changes.Results {
 			var expectedChange db.ChangeEntry
 			require.NoError(t, base.JSONUnmarshal([]byte(expectedResults[index]), &expectedChange))
@@ -898,8 +881,7 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 			// Create a doc and send an initial changes
 			resp := sendRequestFn(rt, test.username, http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar"}`)
 			rest.RequireStatus(t, resp, http.StatusCreated)
-			c, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			require.NoError(t, err)
+			c := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 
 			lastSeq := c.Last_Seq.String()
 
@@ -973,7 +955,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 	// Send a missing doc - low sequence should move to 3
 	db.WriteDirect(t, collection, []string{"PBS"}, 3)
-	require.NoError(t, rt.WaitForSequence(3))
+	rt.WaitForSequence(3)
 
 	// WaitForSequence doesn't wait for low sequence to be updated on each channel - additional delay to ensure
 	// low is updated before making the next changes request.
@@ -1069,7 +1051,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
 	db.WriteDirect(t, collection, []string{"PBS"}, 13)
 	db.WriteDirect(t, collection, []string{"PBS"}, 6)
-	require.NoError(t, rt.WaitForSequence(13))
+	rt.WaitForSequence(13)
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
@@ -1187,7 +1169,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
 	db.WriteDirect(t, collection, []string{"PBS"}, 13)
 	db.WriteDirect(t, collection, []string{"PBS"}, 6)
-	require.NoError(t, rt.WaitForSequence(13))
+	rt.WaitForSequence(13)
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
@@ -3107,9 +3089,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	// Get pre-delete changes
-	changes, err := rt.WaitForChanges(5, "/{{.keyspace}}/_changes?style=all_docs", "bernard", false)
-	require.NoError(t, err, "Error retrieving changes results")
-	require.Len(t, changes.Results, 5)
+	rt.WaitForChanges(5, "/{{.keyspace}}/_changes?style=all_docs", "bernard", false)
 
 	// Delete
 	response = rt.SendAdminRequest("DELETE", "/{{.keyspace}}/deletedDoc?rev="+deletedRev, "")
@@ -3136,9 +3116,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	rest.RequireStatus(t, response, 201)
 
 	// Normal changes
-	changes, err = rt.WaitForChanges(10, "/{{.keyspace}}/_changes?style=all_docs", "bernard", false)
-	require.NoError(t, err, "Error retrieving changes results")
-	require.Len(t, changes.Results, 10)
+	changes := rt.WaitForChanges(10, "/{{.keyspace}}/_changes?style=all_docs", "bernard", false)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1402,13 +1402,11 @@ func TestDbConfigEnvVarsToggle(t *testing.T) {
 			rt.WaitForPendingChanges()
 
 			// ensure doc is in expected channel and is not in the unexpected channels
-			changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels="+test.expectedChannel, "", true)
-			require.NoError(t, err)
+			changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels="+test.expectedChannel, "", true)
 			changes.RequireDocIDs(t, []string{docID})
 
 			channels := strings.Join(test.unexpectedChannels, ",")
-			changes, err = rt.WaitForChanges(0, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels="+channels, "", true)
-			require.NoError(t, err)
+			changes = rt.WaitForChanges(0, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels="+channels, "", true)
 			changes.RequireDocIDs(t, []string{})
 		})
 	}

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -262,6 +262,7 @@ const collectionsDbConfigUpsertScopes = `{
 
 func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	base.SkipImportTestsIfNotEnabled(t)
 	base.RequireNumTestDataStores(t, 2)
 
@@ -310,8 +311,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	require.Equal(t, strings.ReplaceAll(dataStore1.GetName(), testBucket.GetName(), dbName), rt.GetSingleKeyspace())
 
 	// Wait for auto-import to work
-	_, err = rt.WaitForChanges(docCount, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err)
+	rt.WaitForChanges(docCount, "/{{.keyspace}}/_changes", "", true)
 
 	for _, dataStore := range dataStores {
 		for j := 0; j < docCount; j++ {
@@ -337,8 +337,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	require.Len(t, rt.GetDbCollections(), 2)
 
 	// Wait for auto-import to work
-	_, err = rt.WaitForChanges(docCount, "/{{.keyspace2}}/_changes", "", true)
-	require.NoError(t, err)
+	rt.WaitForChanges(docCount, "/{{.keyspace2}}/_changes", "", true)
 
 	for _, dataStore := range dataStores {
 		for j := 0; j < docCount; j++ {
@@ -400,10 +399,8 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 	require.Len(t, rt.GetDbCollections(), 2)
 
 	// Wait for auto-import to work
-	_, err = rt.WaitForChanges(docCount, "/{{.keyspace1}}/_changes", "", true)
-	require.NoError(t, err)
-	_, err = rt.WaitForChanges(docCount, "/{{.keyspace2}}/_changes", "", true)
-	require.NoError(t, err)
+	rt.WaitForChanges(docCount, "/{{.keyspace1}}/_changes", "", true)
+	rt.WaitForChanges(docCount, "/{{.keyspace2}}/_changes", "", true)
 	require.Equal(t, int64(docCount*2), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
 	oneScopeConfig := rest.GetCollectionsConfig(t, testBucket, 1)
@@ -424,8 +421,7 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 		}
 	}
 
-	_, err = rt.WaitForChanges(docCount*2, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err)
+	rt.WaitForChanges(docCount*2, "/{{.keyspace}}/_changes", "", true)
 	// there should be 10 documents datastore1_{10..19}
 	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1056,8 +1056,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	assert.NoError(t, err, "Error writing SDK doc")
 
 	// Wait until the change appears on the changes feed to ensure that it's been imported by this point
-	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err, "Error waiting for changes")
+	changes := rt.WaitForChanges(2, "/{{.keyspace}}/_changes", "", true)
 
 	log.Printf("changes: %+v", changes)
 	changeEntry := changes.Results[0]
@@ -1108,8 +1107,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	// Wait for doc to appear on changes feed
 	// Wait until the change appears on the changes feed to ensure that it's been imported by this point
 	now := time.Now()
-	changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err, "Error waiting for changes")
+	changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
 	changeEntry := changes.Results[0]
 	assert.Equal(t, key, changeEntry.ID)
 	log.Printf("Saw doc on changes feed after %v", time.Since(now))
@@ -1273,8 +1271,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 
 			// Wait until the change appears on the changes feed to ensure that it's been imported by this point.
 			// This is probably unnecessary in the case of on-demand imports, but it doesn't hurt to leave it in as a double check.
-			changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
-			require.NoError(t, err, "Error waiting for changes")
+			changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "", true)
 			changeEntry := changes.Results[0]
 			assert.Equal(t, key, changeEntry.ID)
 
@@ -1481,9 +1478,7 @@ func TestImportZeroValueDecimalPlaces(t *testing.T) {
 		t.Logf("Inserting doc %s: %s", docID, string(docBody))
 	}
 
-	changes, err := rt.WaitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/{{.keyspace}}/_changes", "", true)
-	assert.NoError(t, err, "Error waiting for changes")
-	require.Lenf(t, changes.Results, maxDecimalPlaces+1-minDecimalPlaces, "Expected %d changes in: %#v", (maxDecimalPlaces+1)-minDecimalPlaces, changes.Results)
+	rt.WaitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/{{.keyspace}}/_changes", "", true)
 	ctx := base.TestCtx(t)
 
 	for i := minDecimalPlaces; i <= maxDecimalPlaces; i++ {
@@ -1547,9 +1542,7 @@ func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 		t.Logf("Inserting doc %s: %s", docID, string(docBody))
 	}
 
-	changes, err := rt.WaitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/{{.keyspace}}/_changes", "", true)
-	assert.NoError(t, err, "Error waiting for changes")
-	require.Lenf(t, changes.Results, maxDecimalPlaces+1-minDecimalPlaces, "Expected %d changes in: %#v", (maxDecimalPlaces+1)-minDecimalPlaces, changes.Results)
+	rt.WaitForChanges((maxDecimalPlaces+1)-minDecimalPlaces, "/{{.keyspace}}/_changes", "", true)
 
 	ctx := base.TestCtx(t)
 	for i := minDecimalPlaces; i <= maxDecimalPlaces; i++ {
@@ -2265,8 +2258,7 @@ func TestImportRollback(t *testing.T) {
 			require.NoError(t, err)
 
 			// wait for doc to be imported
-			changes, err := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			require.NoError(t, err)
+			changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 			lastSeq := changes.Last_Seq.String()
 
 			// Close db while we mess with checkpoints
@@ -2313,8 +2305,7 @@ func TestImportRollback(t *testing.T) {
 			require.NoError(t, err)
 
 			// wait for doc update to be imported
-			_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
-			require.NoError(t, err)
+			rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
 		})
 	}
 }
@@ -2362,8 +2353,7 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 	}
 
 	// wait for docs to be imported
-	changes, err := rt.WaitForChanges(20, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
+	changes := rt.WaitForChanges(20, "/{{.keyspace}}/_changes?since=0", "", true)
 	lastSeq := changes.Last_Seq.String()
 
 	// Close db while we alter checkpoints to force rollback
@@ -2436,8 +2426,7 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 	require.True(t, added)
 
 	// wait for doc update to be imported
-	_, err = rt2.WaitForChanges(21, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
-	require.NoError(t, err)
+	rt2.WaitForChanges(21, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
 }
 
 func TestImportUpdateExpiry(t *testing.T) {

--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -81,8 +81,7 @@ func TestUserXattrRevCache(t *testing.T) {
 	_, err = dataStore.UpdateXattrs(ctx, docKey, 0, cas, map[string][]byte{xattrKey: base.MustJSONMarshal(t, "DEF")}, nil)
 	require.NoError(t, err)
 
-	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
-	assert.NoError(t, err)
+	rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
 
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -96,10 +95,8 @@ func TestUserXattrRevCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for import of the xattr change on both nodes
-	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userABC", false)
-	assert.NoError(t, err)
-	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "userABC", false)
-	assert.NoError(t, err)
+	rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userABC", false)
+	rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "userABC", false)
 
 	// GET the doc with userABC to ensure it is accessible on both nodes
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userABC")
@@ -168,13 +165,11 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	_, err = dataStore.UpdateXattrs(ctx, docKey, 0, cas, map[string][]byte{xattrKey: base.MustJSONMarshal(t, "DEF")}, nil)
 	assert.NoError(t, err)
 
-	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
-	assert.NoError(t, err)
+	rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
 
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")
 	rest.RequireStatus(t, resp, http.StatusOK)
 
-	// FIXME, why is cas different after import?
 	cas, err = rt.GetSingleDataStore().Get(docKey, nil)
 	require.NoError(t, err)
 
@@ -183,10 +178,8 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for import of the xattr change on both nodes
-	_, err = rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
-	assert.NoError(t, err)
-	_, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
-	assert.NoError(t, err)
+	rt.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
+	rt2.WaitForChanges(1, "/{{.keyspace}}/_changes", "userDEF", false)
 
 	// GET the doc with userDEF on both nodes to ensure userDEF no longer has access
 	resp = rt2.SendUserRequest("GET", "/{{.keyspace}}/"+docKey, ``, "userDEF")

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -175,14 +175,10 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 		}
 
 		localKeyspace := rt1DbName + "." + localCollection
-		changes, err := rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, expectedNumDocs)
+		rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
 
 		remoteKeyspace := rt2DbName + "." + remoteCollection
-		changes, err = rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, expectedNumDocs)
+		rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
 
 		for j := 1; j <= numDocsPerCollection; j++ {
 			expectedStatus := http.StatusOK
@@ -259,14 +255,10 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 		}
 
 		localKeyspace := rt1DbName + "." + localCollection
-		changes, err := rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, expectedNumDocs)
+		rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
 
 		remoteKeyspace := rt2DbName + "." + remoteCollection
-		changes, err = rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, expectedNumDocs)
+		rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
 
 		// check rt1 for passive docs (pull)
 		resp = rt1.SendAdminRequest(http.MethodGet,
@@ -295,18 +287,14 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 		expectedNumDocs := numDocsPerCollection + 1 // we created a set of 3 docs (plus one later), but didn't replicate any in or out of here...
 
 		localKeyspace := rt1DbName + "." + localCollection
-		changes, err := rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, expectedNumDocs)
+		rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
 	}
 	for _, remoteCollection := range nonReplicatedRemoteCollections {
 
 		expectedNumDocs := numDocsPerCollection + 1 // we created a set of 3 docs (plus one later), but didn't replicate any in or out of here...
 
 		remoteKeyspace := rt2DbName + "." + remoteCollection
-		changes, err := rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
-		require.NoError(t, err)
-		assert.Len(t, changes.Results, expectedNumDocs)
+		rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
 	}
 }
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -485,7 +485,7 @@ func TestPushReplicationAPI(t *testing.T) {
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults := rt2.RequireWaitChanges(1, "0")
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID1, changesResults.Results[0].ID)
 
 	// Validate doc1 contents on remote
@@ -497,7 +497,7 @@ func TestPushReplicationAPI(t *testing.T) {
 	_ = rt2.PutDoc(docID2, `{"source":"rt1","channels":["alice"]}`)
 
 	// wait for doc2 to arrive at rt2
-	changesResults = rt2.RequireWaitChanges(1, changesResults.Last_Seq.String())
+	changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
 	assert.Equal(t, docID2, changesResults.Results[0].ID)
 
 	// Validate doc2 contents
@@ -528,7 +528,7 @@ func TestPullReplicationAPI(t *testing.T) {
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// wait for document originally written to rt2 to arrive at rt1
-	changesResults := rt1.RequireWaitChanges(1, "0")
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	changesResults.RequireDocIDs(t, []string{docID1})
 
 	// Validate doc1 contents
@@ -540,7 +540,7 @@ func TestPullReplicationAPI(t *testing.T) {
 	_ = rt2.PutDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
 
 	// wait for new document to arrive at rt1
-	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.String())
+	changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
 	changesResults.RequireDocIDs(t, []string{docID2})
 
 	// Validate doc2 contents
@@ -726,7 +726,7 @@ func TestReplicationStatusActions(t *testing.T) {
 	}()
 
 	// wait for document originally written to rt2 to arrive at rt1
-	changesResults := rt1.RequireWaitChanges(1, "0")
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	changesResults.RequireDocIDs(t, []string{docID1})
 
 	// Validate doc1 contents
@@ -738,7 +738,7 @@ func TestReplicationStatusActions(t *testing.T) {
 	_ = rt2.PutDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
 
 	// wait for new document to arrive at rt1
-	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.String())
+	changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
 	changesResults.RequireDocIDs(t, []string{docID2})
 
 	// Validate doc2 contents
@@ -838,7 +838,7 @@ func TestReplicationRebalancePull(t *testing.T) {
 	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// wait for documents originally written to remoteRT to arrive at activeRT
-	changesResults := activeRT.RequireWaitChanges(2, "0")
+	changesResults := activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
 	changesResults.RequireDocIDs(t, []string{docABC1, docDEF1})
 
 	// Validate doc contents
@@ -864,7 +864,7 @@ func TestReplicationRebalancePull(t *testing.T) {
 	_ = remoteRT.PutDoc(docDEF2, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at activeRT
-	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.String())
+	changesResults = activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
 	changesResults.RequireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents
@@ -945,7 +945,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// wait for documents to be pushed to remote
-	changesResults := remoteRT.RequireWaitChanges(2, "0")
+	changesResults := remoteRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
 	changesResults.RequireDocIDs(t, []string{docABC1, docDEF1})
 
 	// Validate doc contents
@@ -969,7 +969,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 	_ = activeRT.PutDoc(docDEF2, `{"source":"activeRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at remote
-	changesResults = remoteRT.RequireWaitChanges(2, changesResults.Last_Seq.String())
+	changesResults = remoteRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
 	changesResults.RequireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents
@@ -1048,7 +1048,7 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 	activeRT.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// wait for documents originally written to rt2 to arrive at rt1
-	changesResults := activeRT.RequireWaitChanges(docCount, "0")
+	changesResults := activeRT.WaitForChanges(docCount, "/{{.keyspace}}/_changes?since=0", "", true)
 	changesResults.RequireDocIDs(t, docIDs)
 
 	// Validate sample doc contents
@@ -1111,7 +1111,7 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	_ = activeRT.PutDoc(docAllChannels2, `{"source":"activeRT2","channels":["ABC","DEF"]}`)
 
 	// wait for documents to be pushed to remote
-	changesResults := remoteRT.RequireWaitChanges(2, "0")
+	changesResults := remoteRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
 	changesResults.RequireDocIDs(t, []string{docAllChannels1, docAllChannels2})
 
 	// wait for both replications to have pushed, and total pushed to equal 2
@@ -1620,9 +1620,7 @@ func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
 
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-	changesResults, err := rt2.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 4)
+	rt2.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	resp = rt1.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -1646,9 +1644,7 @@ func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-	changesResults, err = rt2.WaitForChanges(8, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 8)
+	rt2.WaitForChanges(8, "/{{.keyspace}}/_changes?since=0", "", true)
 }
 
 func TestReplicationConfigChange(t *testing.T) {
@@ -1699,9 +1695,7 @@ func TestReplicationConfigChange(t *testing.T) {
 
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-	changesResults, err := rt2.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 4)
+	rt2.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	resp = rt1.SendAdminRequest("PUT", "/{{.db}}/_replicationStatus/"+replicationID+"?action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -1724,9 +1718,7 @@ func TestReplicationConfigChange(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
-	changesResults, err = rt2.WaitForChanges(8, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 8)
+	rt2.WaitForChanges(8, "/{{.keyspace}}/_changes?since=0", "", true)
 }
 
 // TestReplicationHeartbeatRemoval
@@ -1767,8 +1759,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	activeRT.WaitForReplicationStatus("rep_DEF", db.ReplicationStateRunning)
 
 	// wait for documents originally written to remoteRT to arrive at activeRT
-	changesResults := activeRT.RequireWaitChanges(2, "0")
-	changesResults.RequireDocIDs(t, []string{docABC1, docDEF1})
+	changesResults := activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	// Validate doc replication
 	_ = activeRT.GetDocBody(docABC1)
@@ -1789,7 +1780,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	_ = remoteRT.PutDoc(docDEF2, `{"source":"remoteRT","channels":["DEF"]}`)
 
 	// wait for new documents to arrive at activeRT
-	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.String())
+	changesResults = activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
 	changesResults.RequireDocIDs(t, []string{docABC2, docDEF2})
 
 	// Validate doc contents via both active nodes
@@ -1827,7 +1818,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	docDEF3 := t.Name() + "DEF3"
 	_ = remoteRT.PutDoc(docDEF3, `{"source":"remoteRT","channels":["DEF"]}`)
 
-	changesResults = activeRT.RequireWaitChanges(2, changesResults.Last_Seq.String())
+	changesResults = activeRT.WaitForChanges(2, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
 	changesResults.RequireDocIDs(t, []string{docABC3, docDEF3})
 
 	// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
@@ -1934,7 +1925,7 @@ func TestTakeDbOfflineOngoingPushReplication(t *testing.T) {
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults := rt2.RequireWaitChanges(1, "0")
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID1, changesResults.Results[0].ID)
 
 	resp := rt2.SendAdminRequest("POST", "/{{.db}}/_offline", "")
@@ -1967,7 +1958,7 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 	rt1.WaitForReplicationStatus(replicationID, db.ReplicationStateRunning)
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults := rt2.RequireWaitChanges(1, "0")
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	require.Equal(t, docID, changesResults.Results[0].ID)
 
 	var lastDocID atomic.Value
@@ -1993,8 +1984,7 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 	}()
 
 	// and wait for a few to be done before we proceed with updating database config underneath replication
-	_, err := rt2.WaitForChanges(5, "/db/_changes", "", true)
-	require.NoError(t, err)
+	rt2.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	// just change the sync function to cause the database to reload
 	dbConfig := *rt2.ServerContext().GetDbConfig("db")
@@ -2124,9 +2114,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 
 	// wait for the document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
@@ -2243,9 +2231,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	// restarted replicator has a new checkpointer
 	pullCheckpointer = ar.Pull.GetSingleCollection(t).Checkpointer
 
-	changesResults, err := rt1.WaitForChanges(3, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 3)
+	rt1.WaitForChanges(3, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	require.NoError(t, ar.Stop())
 	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 2)
@@ -2266,9 +2252,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	// restarted replicator has a new checkpointer
 	pullCheckpointer = ar.Pull.GetSingleCollection(t).Checkpointer
 
-	changesResults, err = rt1.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 4)
+	rt1.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	require.NoError(t, ar.Stop())
 	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 1)
@@ -2411,8 +2395,7 @@ func TestReconnectReplicator(t *testing.T) {
 				response := remoteRT.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+fmt.Sprint(i), `{"source": "remote"}`)
 				rest.RequireStatus(t, response, http.StatusCreated)
 			}
-			_, err := activeRT.WaitForChanges(10, "/{{.keyspace}}/_changes", "", true)
-			require.NoError(t, err)
+			activeRT.WaitForChanges(10, "/{{.keyspace}}/_changes", "", true)
 		})
 	}
 
@@ -2626,9 +2609,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	assert.NoError(t, ar.Start(ctx1))
 
 	// wait for the document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
@@ -2646,9 +2627,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	version = rt2.PutDoc(docID, `{"source":"rt2","doc_num":2,`+attachment+`,"channels":["alice"]}`)
 
 	// wait for the new document written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 2)
+	changesResults = rt1.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[1].ID)
 
 	doc2, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
@@ -2811,9 +2790,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			version1 := rt2.PutDoc(docID, test.initialRevBody)
 
 			// wait for the document originally written to rt2 to arrive at rt1
-			changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			require.NoError(t, err)
-			require.Len(t, changesResults.Results, 1)
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
 			lastSeq := changesResults.Last_Seq.String()
 
@@ -2825,9 +2802,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			resp = rt1.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID+"?rev="+version1.RevID, test.localConflictingRevBody)
 			rest.RequireStatus(t, resp, http.StatusCreated)
 
-			changesResults, err = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
-			require.NoError(t, err)
-			assert.Len(t, changesResults.Results, 1)
+			changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
 			lastSeq = changesResults.Last_Seq.String()
 
@@ -2839,9 +2814,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 
 			rt1.WaitForReplicationStatus("repl1", db.ReplicationStateRunning)
 
-			changesResults, err = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
-			require.NoError(t, err)
-			assert.Len(t, changesResults.Results, 1)
+			changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
 			_ = changesResults.Last_Seq.String()
 
@@ -2928,9 +2901,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	assert.NoError(t, ar.Start(ctx1))
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(numRT2DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, numRT2DocsInitial)
+	changesResults := rt1.WaitForChanges(numRT2DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
 	docIDsSeen := make(map[string]bool, numRT2DocsInitial)
 	for _, result := range changesResults.Results {
 		docIDsSeen[result.ID] = true
@@ -2987,9 +2958,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	pullCheckpointer = ar.Pull.GetSingleCollection(t).Checkpointer
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(numRT2DocsTotal, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, numRT2DocsTotal)
+	changesResults = rt1.WaitForChanges(numRT2DocsTotal, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	docIDsSeen = make(map[string]bool, numRT2DocsTotal)
 	for _, result := range changesResults.Results {
@@ -3099,9 +3068,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	}, numRT2DocsInitial)
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(numRT2DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, numRT2DocsInitial)
+	changesResults := rt1.WaitForChanges(numRT2DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
 	docIDsSeen := make(map[string]bool, numRT2DocsInitial)
 	for _, result := range changesResults.Results {
 		docIDsSeen[result.ID] = true
@@ -3270,9 +3237,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	assert.NoError(t, ar.Start(ctx1))
 
 	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
@@ -3338,9 +3303,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	assert.NoError(t, ar.Start(ctx1))
 
 	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
@@ -3359,9 +3322,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	version = rt1.PutDoc(docID, `{"source":"rt1","doc_num":2,`+attachment+`,"channels":["alice"]}`)
 
 	// wait for the new document written to rt1 to arrive at rt2
-	changesResults, err = rt2.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 2)
+	changesResults = rt2.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[1].ID)
 
 	doc2, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
@@ -3443,9 +3404,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 
 	// wait for all of the documents originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(numRT1DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, numRT1DocsInitial)
+	changesResults := rt2.WaitForChanges(numRT1DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
 	docIDsSeen := make(map[string]bool, numRT1DocsInitial)
 	for _, result := range changesResults.Results {
 		docIDsSeen[result.ID] = true
@@ -3502,9 +3461,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	pushCheckpointer = ar.Push.GetSingleCollection(t).Checkpointer
 
 	// wait for all of the documents originally written to rt1 to arrive at rt2
-	changesResults, err = rt2.WaitForChanges(numRT1DocsTotal, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, numRT1DocsTotal)
+	changesResults = rt2.WaitForChanges(numRT1DocsTotal, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	docIDsSeen = make(map[string]bool, numRT1DocsTotal)
 	for _, result := range changesResults.Results {
@@ -3609,8 +3566,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	assert.NoError(t, edge1Replicator.Start(ctx1))
 
 	// wait for all of the documents originally written to rt1 to arrive at edge1
-	changesResults, err := edge1.WaitForChanges(numRT1DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
+	changesResults := edge1.WaitForChanges(numRT1DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
 	edge1LastSeq := changesResults.Last_Seq
 	require.Len(t, changesResults.Results, numRT1DocsInitial)
 	docIDsSeen := make(map[string]bool, numRT1DocsInitial)
@@ -3674,8 +3630,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	require.NoError(t, err)
 	assert.NoError(t, edge2Replicator.Start(ctx2))
 
-	changesResults, err = edge2.WaitForChanges(numRT1DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
+	changesResults = edge2.WaitForChanges(numRT1DocsInitial, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	edge2PullCheckpointer := edge2Replicator.Pull.GetSingleCollection(t).Checkpointer
 	edge2PullCheckpointer.CheckpointNow()
@@ -3707,8 +3662,7 @@ func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, edge1Replicator2.Start(ctx1))
 
-	changesResults, err = edge1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", edge1LastSeq), "", true)
-	require.NoErrorf(t, err, "changesResults: %v", changesResults)
+	changesResults = edge1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", edge1LastSeq), "", true)
 	changesResults.RequireDocIDs(t, []string{fmt.Sprintf("%s%d", docIDPrefix, numRT1DocsInitial)})
 
 	edge1Checkpointer2 := edge1Replicator2.Pull.GetSingleCollection(t).Checkpointer
@@ -3840,9 +3794,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	assert.NoError(t, ar.Start(ctx1))
 
 	// wait for the document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
@@ -3859,9 +3811,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	deletedVersion := rt2.DeleteDoc(docID, version)
 
 	// wait for the tombstone written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+strconv.FormatUint(doc.Sequence, 10), "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+strconv.FormatUint(doc.Sequence, 10), "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	doc, err = rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
@@ -3923,7 +3873,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	assert.NoError(t, ar.Start(ctx1))
 
 	// wait for the document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
@@ -4123,9 +4073,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			}
 			// wait for the document originally written to rt2 to arrive at rt1.  Should end up as winner under default conflict resolution
 
-			changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			require.NoError(t, err)
-			require.Len(t, changesResults.Results, 1)
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
 			rest.RequireChangeRevVersion(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
 			t.Logf("Changes response is %+v", changesResults)
@@ -4343,9 +4291,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			t.Logf("========================Replication should be done, checking with changes")
 
 			// Validate results on the local (rt1)
-			changesResults, err := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", localDoc.Sequence), "", true)
-			require.NoError(t, err)
-			require.Len(t, changesResults.Results, 1)
+			changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", localDoc.Sequence), "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
 			rest.RequireChangeRevVersion(t, test.expectedVersion, changesResults.Results[0].Changes[0])
 			t.Logf("Changes response is %+v", changesResults)
@@ -4389,9 +4335,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 				// no changes should have been pushed back up to rt2, because this rev won.
 				rt2Since = 0
 			}
-			changesResults, err = rt2.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", rt2Since), "", true)
-			require.NoError(t, err)
-			require.Len(t, changesResults.Results, 1)
+			changesResults = rt2.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", rt2Since), "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
 			rest.RequireChangeRevVersion(t, test.expectedVersion, changesResults.Results[0].Changes[0])
 			t.Logf("Changes response is %+v", changesResults)
@@ -4482,9 +4426,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 
 	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
@@ -4624,9 +4566,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 
 	// wait for document originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
@@ -4684,9 +4624,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	assert.Equal(t, int64(0), pullCheckpointer.Stats().GetCheckpointHitCount)
 
 	// wait for document originally written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt1collection, rt1ctx = rt1.GetSingleTestDatabaseCollection()
@@ -4787,9 +4725,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	pushCheckpointer := ar.Push.GetSingleCollection(t).Checkpointer
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
@@ -4854,9 +4790,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	assert.Equal(t, int64(0), pushCheckpointer.Stats().GetCheckpointHitCount)
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	rt2collection, rt2ctx = rt2.GetSingleTestDatabaseCollection()
@@ -4963,9 +4897,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	}, 1)
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 	lastSeq := changesResults.Last_Seq.String()
 
@@ -5000,9 +4932,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	}, 2)
 
 	// wait for new document to arrive at rt2
-	changesResults, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
 	assert.Equal(t, docID+"2", changesResults.Results[0].ID)
 
 	rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollectionWithUser()
@@ -5034,9 +4964,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	pushCheckpointer = ar.Push.GetSingleCollection(t).Checkpointer
 
 	// wait for new document to arrive at rt2 again
-	changesResults, err = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+lastSeq, "", true)
 	assert.Equal(t, docID+"2", changesResults.Results[0].ID)
 
 	doc, err = rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
@@ -5133,9 +5061,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	rt1.WaitForPendingChanges()
 
 	// wait for document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	// Create doc2 on rt2
@@ -5145,9 +5071,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	rt2.WaitForPendingChanges()
 
 	// wait for document originally written to rt2 to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=1", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=1", "", true)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
 	pushCheckpointer := ar.Push.GetSingleCollection(t).Checkpointer
@@ -5231,9 +5155,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	assert.NoError(t, ar.Start(ctx1))
 
 	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults, err := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, rt1docID, changesResults.Results[0].ID)
 
 	rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
@@ -5251,9 +5173,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	rt2Version := rt2.PutDoc(rt2docID, `{"source":"rt2","channels":["alice"]}`)
 
 	// ... and wait to arrive at rt1
-	changesResults, err = rt1.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 2)
+	changesResults = rt1.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0", "", true)
 	assert.Equal(t, rt1docID, changesResults.Results[0].ID)
 	assert.Equal(t, rt2docID, changesResults.Results[1].ID)
 
@@ -5348,9 +5268,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	assert.NoError(t, ar.Start(ctx1))
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(numDocsPerChannelInitial, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, numDocsPerChannelInitial)
+	changesResults := rt1.WaitForChanges(numDocsPerChannelInitial, "/{{.keyspace}}/_changes?since=0", "", true)
 	docIDsSeen := make(map[string]bool, numDocsPerChannelInitial)
 	for _, result := range changesResults.Results {
 		docIDsSeen[result.ID] = true
@@ -5405,9 +5323,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	expectedChan1Docs := numDocsPerChannelInitial
 	expectedChan2Docs := numDocsPerChannelTotal
 	expectedTotalDocs := expectedChan1Docs + expectedChan2Docs
-	changesResults, err = rt1.WaitForChanges(expectedTotalDocs, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, expectedTotalDocs)
+	changesResults = rt1.WaitForChanges(expectedTotalDocs, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	docIDsSeen = make(map[string]bool, expectedTotalDocs)
 	for _, result := range changesResults.Results {
@@ -5988,9 +5904,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 			// Wait for the document originally written to rt2 to arrive at rt1.
 			// Should end up as winner under default conflict resolution.
-			changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?&since=0", "", true)
-			require.NoError(t, err)
-			require.Len(t, changesResults.Results, 1)
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?&since=0", "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
 			rest.RequireChangeRevVersion(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
 			t.Logf("Changes response is %+v", changesResults)
@@ -7191,9 +7105,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	activeRT.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
 
 	// Confirm document is replicated
-	changesResults, err := passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	assert.NoError(t, err)
-	assert.Len(t, changesResults.Results, 1)
+	changesResults := passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	passiveRT.WaitForPendingChanges()
 
@@ -7218,9 +7130,7 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 	require.NoError(t, ar.Start(activeCtx))
 	activeRT.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
 
-	changesResults, err = passiveRT.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
-	assert.NoError(t, err)
-	assert.Len(t, changesResults.Results, 1)
+	changesResults = passiveRT.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
 
 	passiveRT.WaitForPendingChanges()
 
@@ -7700,9 +7610,7 @@ function (doc) {
 
 			base.RequireWaitForStat(t, receiverRT.GetDatabase().DbStats.Database().NumDocWrites.Value, 6)
 
-			changesResults, err := receiverRT.WaitForChanges(6, "/{{.keyspace}}/_changes?since=0&include_docs=true", "", true)
-			assert.NoError(t, err)
-			assert.Len(t, changesResults.Results, 6)
+			changesResults := receiverRT.WaitForChanges(6, "/{{.keyspace}}/_changes?since=0&include_docs=true", "", true)
 			// Check the docs are alices docs
 			for _, result := range changesResults.Results {
 				body, err := result.Doc.MarshalJSON()
@@ -8137,9 +8045,7 @@ func TestActiveReplicatorChangesFeedExit(t *testing.T) {
 	shouldChannelQueryError.Store(true)
 	require.NoError(t, ar.Start(activeRT.Context()))
 
-	changesResults, err := passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
+	changesResults := passiveRT.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 	require.Equal(t, docID, changesResults.Results[0].ID)
 	require.Equal(t, int64(2), stats.NumConnectAttemptsPush.Value())
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1984,7 +1984,10 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 	}()
 
 	// and wait for a few to be done before we proceed with updating database config underneath replication
-	rt2.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		changes := rt2.GetChanges("/{{.keyspace}}/_changes", "")
+		assert.GreaterOrEqual(c, 5, changes.Results)
+	}, time.Second*5, time.Millisecond*100)
 
 	// just change the sync function to cause the database to reload
 	dbConfig := *rt2.ServerContext().GetDbConfig("db")

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -890,9 +890,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	resp := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", false)
-	require.NoError(t, err)
-	assert.Len(t, changes.Results, 2)
+	changes := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", false)
 
 	assert.Equal(t, "doc", changes.Results[1].ID)
 	assert.False(t, changes.Results[0].Revoked)
@@ -900,9 +898,7 @@ func TestRevocationWithAdminChannels(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "", "letmein", "", dataStore, []string{}, nil))
 	RequireStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&revocations=true", 2), "user", false)
-	require.NoError(t, err)
-	require.Len(t, changes.Results, 2)
+	changes = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&revocations=true", 2), "user", false)
 
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)
@@ -923,9 +919,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"channels": ["A"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", false)
-	require.NoError(t, err)
-	assert.Len(t, changes.Results, 2)
+	changes := rt.WaitForChanges(2, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", false)
 
 	assert.Equal(t, "doc", changes.Results[1].ID)
 	assert.False(t, changes.Results[1].Revoked)
@@ -933,9 +927,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": []}`)
 	RequireStatus(t, resp, http.StatusOK)
 
-	changes, err = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&revocations=true", 3), "user", false)
-	require.NoError(t, err)
-	require.Len(t, changes.Results, 2)
+	changes = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d&revocations=true", 3), "user", false)
 
 	assert.Equal(t, "doc", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)
@@ -1783,9 +1775,7 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	RequireStatus(t, resp, http.StatusOK)
 
 	// Wait for docs to turn up on local / rt1
-	changesResults, err := rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 5)
+	rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	// Revoke C and ensure docC gets purged from local
 	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A", "B"}))
@@ -1891,9 +1881,7 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 
 	require.NoError(t, ar.Start(ctx1))
 
-	changesResults, err := rt1.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	assert.Len(t, changesResults.Results, 4)
+	rt1.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	require.NoError(t, ar.Stop())
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
@@ -1990,9 +1978,7 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 	}()
 
 	// Wait for docs to turn up on local / rt1
-	changesResults, err := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	assert.Len(t, changesResults.Results, 1)
+	rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	// Revoke A and ensure ABC chanel access and ensure DocA is purged from local
 	resp = rt2.SendAdminRequest("PUT", "/{{.db}}/_user/user", GetUserPayload(t, username, password, "", rt2ds, []string{}, nil))
@@ -2073,9 +2059,7 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 	}()
 
 	// Wait for docs to turn up on local / rt1
-	changesResults, err := rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	assert.Len(t, changesResults.Results, 5)
+	rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	// Revoke A and ensure docA, docAB, docABC get purged from local
 	resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", RestTesterDefaultUserPassword, "", rt2ds, []string{}, nil))
@@ -2162,9 +2146,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 
 	require.NoError(t, ar.Start(ctx1))
 
-	changesResults, err := rt1.WaitForChanges(3, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	assert.Len(t, changesResults.Results, 3)
+	rt1.WaitForChanges(3, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
@@ -2562,9 +2544,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 	require.NoError(t, ar.Start(ctx1))
 
-	changesResults, err := rt1.WaitForChanges(17, "/{{.keyspace}}/_changes?since=0", "", true)
-	require.NoError(t, err)
-	assert.Len(t, changesResults.Results, 17)
+	changesResults := rt1.WaitForChanges(17, "/{{.keyspace}}/_changes?since=0", "", true)
 
 	// Going to stop & start replication between these actions to make out of order seq no's more likely. More likely
 	// to hit CBG-1591
@@ -2585,9 +2565,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	require.NoError(t, ar.Start(ctx1))
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
 
-	changesResults, err = rt1.WaitForChanges(8, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
-	require.NoError(t, err)
-	assert.Len(t, changesResults.Results, 8)
+	changesResults = rt1.WaitForChanges(8, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
 
 	require.NoError(t, ar.Stop())
 	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
@@ -2619,9 +2597,7 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	// Validate none of the documents are purged after flipping option
 	rt2.WaitForPendingChanges()
 
-	changesResults, err = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
-	assert.NoError(t, err)
-	assert.Len(t, changesResults.Results, 1)
+	changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
 
 	for i := 0; i < 10; i++ {
 		resp = rt1.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/docA%d", i), "")

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -847,8 +847,7 @@ func TestOfflineDatabaseStartup(t *testing.T) {
 	RequireStatus(t, resp, http.StatusCreated)
 
 	// ensure doc1 is imported now we're online
-	_, err = rt.WaitForChanges(3, "/{{.keyspace}}/_changes", "", true)
-	require.NoError(t, err)
+	rt.WaitForChanges(3, "/{{.keyspace}}/_changes", "", true)
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 }
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -591,17 +591,10 @@ func (rt *RestTester) GetSingleDataStore() base.DataStore {
 	return ds
 }
 
-func (rt *RestTester) MustWaitForDoc(docid string, t testing.TB) {
-	err := rt.WaitForDoc(docid)
-	assert.NoError(t, err)
-}
-
-func (rt *RestTester) WaitForDoc(docid string) (err error) {
+func (rt *RestTester) WaitForDoc(docid string) {
 	seq, err := rt.SequenceForDoc(docid)
-	if err != nil {
-		return err
-	}
-	return rt.WaitForSequence(seq)
+	require.NoError(rt.TB(), err, "Error getting sequence for doc %s", docid)
+	rt.WaitForSequence(seq)
 }
 
 func (rt *RestTester) SequenceForDoc(docid string) (seq uint64, err error) {
@@ -614,9 +607,9 @@ func (rt *RestTester) SequenceForDoc(docid string) (seq uint64, err error) {
 }
 
 // Wait for sequence to be buffered by the channel cache
-func (rt *RestTester) WaitForSequence(seq uint64) error {
+func (rt *RestTester) WaitForSequence(seq uint64) {
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	return collection.WaitForSequence(ctx, seq)
+	require.NoError(rt.TB(), collection.WaitForSequence(ctx, seq))
 }
 
 func (rt *RestTester) WaitForPendingChanges() {
@@ -857,7 +850,7 @@ type ChangesResults struct {
 }
 
 func (cr ChangesResults) RequireDocIDs(t testing.TB, docIDs []string) {
-	require.Equal(t, len(docIDs), len(cr.Results))
+	require.Len(t, cr.Results, len(docIDs))
 	for _, docID := range docIDs {
 		var found bool
 		for _, changeEntry := range cr.Results {
@@ -884,61 +877,39 @@ func (cr ChangesResults) RequireRevID(t testing.TB, revIDs []string) {
 	}
 }
 
+func (cr ChangesResults) Summary() string {
+	var revs []string
+	for _, changeEntry := range cr.Results {
+		revs = append(revs, fmt.Sprintf("{ID:%s}", changeEntry.ID))
+	}
+	return strings.Join(revs, ", ")
+}
+
 // RequireChangeRevVersion asserts that the given ChangeRev has the expected version for a given entry returned by _changes feed
 func RequireChangeRevVersion(t *testing.T, expected DocVersion, changeRev db.ChangeRev) {
 	RequireDocVersionEqual(t, expected, DocVersion{RevID: changeRev["rev"]})
 }
 
-func (rt *RestTester) CreateWaitForChangesRetryWorker(numChangesExpected int, changesURL, username string, useAdminPort bool) (worker base.RetryWorker) {
-
-	waitForChangesWorker := func() (shouldRetry bool, err error, value interface{}) {
-
-		var changes ChangesResults
+func (rt *RestTester) WaitForChanges(numChangesExpected int, changesURL, username string, useAdminPort bool) ChangesResults {
+	waitTime := 20 * time.Second // some tests rely on cbgt import which can be quite slow if it needs to rollback
+	if base.UnitTestUrlIsWalrus() {
+		// rosmar will never take a long time, so have faster failures
+		waitTime = 1 * time.Second
+	}
+	var changes *ChangesResults
+	url := rt.mustTemplateResource(changesURL)
+	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		var response *TestResponse
 		if useAdminPort {
-			response = rt.SendAdminRequest("GET", changesURL, "")
+			response = rt.SendAdminRequest("GET", url, "")
 
 		} else {
-			response = rt.Send(RequestByUser("GET", changesURL, "", username))
+			response = rt.Send(RequestByUser("GET", url, "", username))
 		}
-		err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
-		if err != nil {
-			return false, err, nil
-		}
-		if len(changes.Results) < numChangesExpected {
-			// not enough results, retry
-			return true, fmt.Errorf("expecting %d changes, got %d", numChangesExpected, len(changes.Results)), nil
-		}
-		// If it made it this far, there is no errors and it got enough changes
-		return false, nil, changes
-	}
-
-	return waitForChangesWorker
-
-}
-
-func (rt *RestTester) WaitForChanges(numChangesExpected int, changesURL, username string, useAdminPort bool) (
-	changes ChangesResults,
-	err error) {
-
-	waitForChangesWorker := rt.CreateWaitForChangesRetryWorker(numChangesExpected, rt.mustTemplateResource(changesURL), username, useAdminPort)
-
-	sleeper := base.CreateSleeperFunc(200, 100)
-
-	err, changesVal := base.RetryLoop(rt.Context(), "Wait for changes", waitForChangesWorker, sleeper)
-	if err != nil {
-		return changes, err
-	}
-
-	if changesVal == nil {
-		return changes, fmt.Errorf("Got nil value for changes")
-	}
-
-	if changesVal != nil {
-		changes = changesVal.(ChangesResults)
-	}
-
-	return changes, nil
+		assert.NoError(c, base.JSONUnmarshal(response.Body.Bytes(), &changes))
+		assert.Len(c, changes.Results, numChangesExpected, "Expected %d changes, got %d changes", numChangesExpected, len(changes.Results))
+	}, waitTime, 10*time.Millisecond)
+	return *changes
 }
 
 // WaitForCondition runs a retry loop that evaluates the provided function, and terminates

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -42,8 +42,7 @@ func TestX509RoundtripUsingIP(t *testing.T) {
 	RequireStatus(t, tr, http.StatusCreated)
 
 	// wait for doc to come back over DCP
-	err := rt.WaitForDoc(t.Name())
-	require.NoError(t, err, "error waiting for doc over DCP")
+	rt.WaitForDoc(t.Name())
 }
 
 // TestX509RoundtripUsingDomain is a happy-path roundtrip write test for SG connecting to CBS using valid X.509 certs for authentication.
@@ -63,8 +62,7 @@ func TestX509RoundtripUsingDomain(t *testing.T) {
 	RequireStatus(t, tr, http.StatusCreated)
 
 	// wait for doc to come back over DCP
-	err := rt.WaitForDoc(t.Name())
-	require.NoError(t, err, "error waiting for doc over DCP")
+	rt.WaitForDoc(t.Name())
 }
 
 func TestX509UnknownAuthorityWrap(t *testing.T) {

--- a/rest/xattr_upgrade_test.go
+++ b/rest/xattr_upgrade_test.go
@@ -153,7 +153,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	// Create via the SDK with sync metadata intact
 	_, err := dataStore.WriteWithXattrs(ctx, key, 0, 0, []byte(bodyString), map[string][]byte{base.SyncXattrName: []byte(xattrString)}, nil, nil)
 	assert.NoError(t, err, "Error writing doc w/ xattr")
-	require.NoError(t, rt.WaitForSequence(5))
+	rt.WaitForSequence(5)
 
 	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/{{.keyspace}}/%s?rev=2-d", key), `{"updated":true}`)
@@ -163,7 +163,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/_raw/"+key, "")
 	assert.Equal(t, 200, rawResponse.Code)
 	log.Printf("raw response:%s", rawResponse.Body.Bytes())
-	require.NoError(t, rt.WaitForSequence(6))
+	rt.WaitForSequence(6)
 
 	// Validate non-xattr document doesn't get upgraded on attempted write
 	nonMobileKey := "TestUpgradeNoXattr"
@@ -222,7 +222,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	// Create via the SDK with sync metadata intact
 	_, err := dataStore.WriteWithXattrs(ctx, key, 0, 0, []byte(bodyString), map[string][]byte{base.SyncXattrName: []byte(xattrString)}, nil, nil)
 	assert.NoError(t, err, "Error writing doc w/ xattr")
-	require.NoError(t, rt.WaitForSequence(1))
+	rt.WaitForSequence(1)
 
 	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
 	changes := rt.PostChangesAdmin("/{{.keyspace}}/_changes", "{}")


### PR DESCRIPTION
CBG-4616 make WaitForChanges more strict

This addresses some subtle race conditions in test where we could be waiting for the wrong number of changes, since `WaitForChanges` would return if there were greater than the expected number of changes.

https://github.com/couchbase/sync_gateway/blob/main/rest/attachment_test.go#L1776 is an example of a problematic test. I changed this test to just do an on demand get, but this number is wrong since there are changes from the previous subtest. I thought about making it do a wait for import check, but an on-demand import seemed more explicit here.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3039/
