### PR TITLE
CBG-4613 switch option from serverless to principal index specific

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -173,7 +173,8 @@ type DatabaseContextOptions struct {
 	BcryptCost                    int
 	GroupID                       string
 	JavascriptTimeout             time.Duration // Max time the JS functions run for (ie. sync fn, import filter)
-	Serverless                    bool          // If running in serverless mode
+	UseLegacySyncDocsIndex        bool
+	Serverless                    bool // If running in serverless mode
 	Scopes                        ScopesOptions
 	MetadataStore                 base.DataStore // If set, use this location/connection for SG metadata storage - if not set, metadata is stored using the same location/connection as the bucket used for data storage.
 	MetadataID                    string         // MetadataID used for metadata storage
@@ -885,6 +886,10 @@ func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authent
 
 func (context *DatabaseContext) IsServerless() bool {
 	return context.Options.Serverless
+}
+
+func (context *DatabaseContext) UseLegacySyncDocsIndex() bool {
+	return true // switch in CBG-4614
 }
 
 // Makes a Database object given its name and bucket.

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -40,10 +40,10 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 
 	// construct indexes as the test expects
 	options := InitializeIndexOptions{
-		NumReplicas:   0,
-		Serverless:    db.IsServerless(),
-		UseXattrs:     db.UseXattrs(),
-		NumPartitions: DefaultNumIndexPartitions,
+		NumReplicas:         0,
+		LegacySyncDocsIndex: db.UseLegacySyncDocsIndex(),
+		UseXattrs:           db.UseXattrs(),
+		NumPartitions:       DefaultNumIndexPartitions,
 	}
 	if db.OnlyDefaultCollection() {
 		options.MetadataIndexes = IndexesAll
@@ -101,10 +101,10 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	defer func() {
 		// Restore indexes after test
 		options := InitializeIndexOptions{
-			NumReplicas:   0,
-			Serverless:    db.IsServerless(),
-			UseXattrs:     db.UseXattrs(),
-			NumPartitions: DefaultNumIndexPartitions,
+			NumReplicas:         0,
+			LegacySyncDocsIndex: db.UseLegacySyncDocsIndex(),
+			UseXattrs:           db.UseXattrs(),
+			NumPartitions:       DefaultNumIndexPartitions,
 		}
 		err := InitializeIndexes(ctx, n1qlStore, options)
 		assert.NoError(t, err)
@@ -166,10 +166,10 @@ func TestPostUpgradeMultipleCollections(t *testing.T) {
 	}
 	useXattrs := false
 	options := InitializeIndexOptions{
-		NumReplicas:   0,
-		Serverless:    false,
-		UseXattrs:     useXattrs,
-		NumPartitions: DefaultNumIndexPartitions,
+		NumReplicas:         0,
+		LegacySyncDocsIndex: db.UseLegacySyncDocsIndex(),
+		UseXattrs:           useXattrs,
+		NumPartitions:       DefaultNumIndexPartitions,
 	}
 
 	for _, dataStore := range db.getDataStores() {
@@ -229,9 +229,9 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 		err = InitializeViews(ctx, collection.dataStore)
 		assert.NoError(t, err)
 		options := InitializeIndexOptions{
-			NumReplicas: 0,
-			Serverless:  db.IsServerless(),
-			UseXattrs:   base.TestUseXattrs(),
+			NumReplicas:         0,
+			LegacySyncDocsIndex: db.UseLegacySyncDocsIndex(),
+			UseXattrs:           base.TestUseXattrs(),
 		}
 		if db.OnlyDefaultCollection() {
 			options.MetadataIndexes = IndexesAll
@@ -249,10 +249,10 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, err)
 
 	options := InitializeIndexOptions{
-		NumReplicas:   0,
-		Serverless:    db.IsServerless(),
-		UseXattrs:     db.UseXattrs(),
-		NumPartitions: DefaultNumIndexPartitions,
+		NumReplicas:         0,
+		LegacySyncDocsIndex: db.UseLegacySyncDocsIndex(),
+		UseXattrs:           db.UseXattrs(),
+		NumPartitions:       DefaultNumIndexPartitions,
 	}
 	if db.OnlyDefaultCollection() {
 		options.MetadataIndexes = IndexesAll
@@ -290,10 +290,10 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 		n1qlStore, ok := base.AsN1QLStore(dataStore)
 		assert.True(t, ok)
 		options := InitializeIndexOptions{
-			NumReplicas:   0,
-			Serverless:    db.IsServerless(),
-			UseXattrs:     db.UseXattrs(),
-			NumPartitions: DefaultNumIndexPartitions,
+			NumReplicas:         0,
+			LegacySyncDocsIndex: db.UseLegacySyncDocsIndex(),
+			UseXattrs:           db.UseXattrs(),
+			NumPartitions:       DefaultNumIndexPartitions,
 		}
 		err := InitializeIndexes(ctx, n1qlStore, options)
 		assert.NoError(t, err)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -375,7 +375,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			UseXattrs:                  base.TestUseXattrs(),
 			NumReplicas:                0,
 			WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
-			Serverless:                 false,
+			LegacySyncDocsIndex:        true, // Change in CBG-4614
 			MetadataIndexes:            IndexesWithoutMetadata,
 			NumPartitions:              DefaultNumIndexPartitions,
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -770,8 +770,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		// If database has been requested to start offline, or there's an active async initialization, use async initialization
 		isAsync = startOffline || sc.DatabaseInitManager.HasActiveInitialization(dbName)
 
+		useLegacySyncDocsIndex := true // decide in CBG-4615
 		// Initialize indexes using DatabaseInitManager.
-		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config)
+		dbInitDoneChan, err = sc.DatabaseInitManager.InitializeDatabase(ctx, sc.Config, &config, useLegacySyncDocsIndex)
 		if err != nil {
 			if options.loadFromBucket {
 				sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError(db.DatabaseInitializationIndexError))


### PR DESCRIPTION
CBG-4613 switch option from serverless to principal index specific

This should unblock being able to configure building the new indexes. They won't be used in a db until a subsequent commit.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3040/
