### PR TITLE
CBG-4006: Default log retention of 90 days for stats

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -197,7 +197,7 @@ func NewAuditLogger(ctx context.Context, config *AuditLoggerConfig, logFilePath 
 		config.CollationBufferSize = Ptr(defaultFileLoggerCollateBufferSize)
 	}
 
-	fl, err := NewFileLogger(ctx, &config.FileLoggerConfig, LevelNone, auditLogName, logFilePath, minAge, buffer)
+	fl, err := NewFileLogger(ctx, &config.FileLoggerConfig, LevelNone, auditLogName, logFilePath, minAge, nil, buffer)
 	if err != nil {
 		return nil, err
 	}

--- a/base/logger_audit_test.go
+++ b/base/logger_audit_test.go
@@ -298,7 +298,7 @@ func BenchmarkAuditFieldwork(b *testing.B) {
 			Output:              buf,
 			CollationBufferSize: Ptr(0),
 		},
-	}, b.TempDir(), auditMinage, nil, map[string]any{"foo": "bar", "buzz": 1234})
+	}, b.TempDir(), auditMinAge, nil, map[string]any{"foo": "bar", "buzz": 1234})
 	require.NoError(b, err)
 	auditLogger.Store(al)
 

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -190,7 +190,7 @@ func (lcc *ConsoleLoggerConfig) init(ctx context.Context) (chan struct{}, error)
 		return nil, errors.New("nil LogConsoleConfig")
 	}
 
-	if err := lcc.initRotationConfig("console", 0, 0, false); err != nil {
+	if err := lcc.initRotationConfig("console", 0, 0, nil, false); err != nil {
 		return nil, err
 	}
 

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -89,7 +89,7 @@ type logRotationConfig struct {
 }
 
 // NewFileLogger returns a new FileLogger from a config.
-func NewFileLogger(ctx context.Context, config *FileLoggerConfig, level LogLevel, name string, logFilePath string, minAge int, buffer *strings.Builder) (*FileLogger, error) {
+func NewFileLogger(ctx context.Context, config *FileLoggerConfig, level LogLevel, name string, logFilePath string, minAge int, defaultMaxAgeOverride *int, buffer *strings.Builder) (*FileLogger, error) {
 	if config == nil {
 		config = &FileLoggerConfig{}
 	}
@@ -97,7 +97,7 @@ func NewFileLogger(ctx context.Context, config *FileLoggerConfig, level LogLevel
 	cancelCtx, cancelFunc := context.WithCancel(ctx)
 
 	// validate and set defaults
-	rotationDoneChan, err := config.init(cancelCtx, level, name, logFilePath, minAge)
+	rotationDoneChan, err := config.init(cancelCtx, level, name, logFilePath, minAge, defaultMaxAgeOverride)
 	if err != nil {
 		cancelFunc()
 		return nil, err
@@ -242,7 +242,7 @@ func (l *FileLogger) getFileLoggerConfig() *FileLoggerConfig {
 	return &fileLoggerConfig
 }
 
-func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name string, logFilePath string, minAge int) (chan struct{}, error) {
+func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name string, logFilePath string, minAge int, defaultMaxAgeOverride *int) (chan struct{}, error) {
 	if lfc == nil {
 		return nil, errors.New("nil LogFileConfig")
 	}
@@ -252,7 +252,7 @@ func (lfc *FileLoggerConfig) init(ctx context.Context, level LogLevel, name stri
 		lfc.Enabled = Ptr(level < LevelDebug)
 	}
 
-	if err := lfc.initRotationConfig(name, defaultMaxSize, minAge, true); err != nil {
+	if err := lfc.initRotationConfig(name, defaultMaxSize, minAge, defaultMaxAgeOverride, true); err != nil {
 		return nil, err
 	}
 
@@ -331,7 +331,7 @@ func (lfc *FileLoggerConfig) initLumberjack(ctx context.Context, name string, lu
 }
 
 // initRotationConfig will validate the log rotation settings and set defaults where necessary.
-func (lfc *FileLoggerConfig) initRotationConfig(name string, defaultMaxSize, minAge int, compress bool) error {
+func (lfc *FileLoggerConfig) initRotationConfig(name string, defaultMaxSize, minAge int, defaultMaxAgeOverride *int, compress bool) error {
 	if lfc.Rotation.MaxSize == nil {
 		lfc.Rotation.MaxSize = &defaultMaxSize
 	} else if *lfc.Rotation.MaxSize == 0 {
@@ -341,8 +341,14 @@ func (lfc *FileLoggerConfig) initRotationConfig(name string, defaultMaxSize, min
 	}
 
 	if lfc.Rotation.MaxAge == nil {
-		defaultMaxAge := minAge * defaultMaxAgeMultiplier
-		lfc.Rotation.MaxAge = &defaultMaxAge
+		if defaultMaxAgeOverride != nil {
+			// allows loggers to specify a custom default max age that isn't based on a multiple of minAge
+			lfc.Rotation.MaxAge = defaultMaxAgeOverride
+		} else {
+			// determine based on multiplier of minAge
+			defaultMaxAge := minAge * defaultMaxAgeMultiplier
+			lfc.Rotation.MaxAge = &defaultMaxAge
+		}
 	} else if *lfc.Rotation.MaxAge == 0 {
 		// A value of zero disables the age-based log cleanup in Lumberjack.
 	} else if *lfc.Rotation.MaxAge < minAge {

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -23,13 +23,17 @@ import (
 )
 
 const (
+	// hard limits for log levels - do not allow maxAge to be configured below this value.
 	errorMinAge = 180
 	warnMinAge  = 90
 	infoMinAge  = 3
 	debugMinAge = 1
 	traceMinAge = 1
-	statsMinAge = 90
+	statsMinAge = 3
 	auditMinAge = 3
+
+	// statsDefaultMaxAgeOverride tells the stats logger to not determine default max age based on minAge, but instead uses this fixed value.
+	statsDefaultMaxAgeOverride = 90
 
 	// defaultConsoleLoggerCollateBufferSize is the number of console logs we'll
 	// buffer and collate, before flushing the buffer to the output.
@@ -88,38 +92,38 @@ func InitLogging(ctx context.Context, logFilePath string,
 		ConsolefCtx(ctx, LevelInfo, KeyNone, "Logging: Audit to %v", auditLogFilePath)
 	}
 
-	rawErrorlogger, err := NewFileLogger(ctx, error, LevelError, LevelError.String(), logFilePath, errorMinAge, &errorLogger.Load().buffer)
+	rawErrorlogger, err := NewFileLogger(ctx, error, LevelError, LevelError.String(), logFilePath, errorMinAge, nil, &errorLogger.Load().buffer)
 	if err != nil {
 		return err
 	}
 	errorLogger.Store(rawErrorlogger)
 
-	rawWarnLogger, err := NewFileLogger(ctx, warn, LevelWarn, LevelWarn.String(), logFilePath, warnMinAge, &warnLogger.Load().buffer)
+	rawWarnLogger, err := NewFileLogger(ctx, warn, LevelWarn, LevelWarn.String(), logFilePath, warnMinAge, nil, &warnLogger.Load().buffer)
 	if err != nil {
 		return err
 	}
 	warnLogger.Store(rawWarnLogger)
 
-	rawInfoLogger, err := NewFileLogger(ctx, info, LevelInfo, LevelInfo.String(), logFilePath, infoMinAge, &infoLogger.Load().buffer)
+	rawInfoLogger, err := NewFileLogger(ctx, info, LevelInfo, LevelInfo.String(), logFilePath, infoMinAge, nil, &infoLogger.Load().buffer)
 	if err != nil {
 		return err
 	}
 	infoLogger.Store(rawInfoLogger)
 
-	rawDebugLogger, err := NewFileLogger(ctx, debug, LevelDebug, LevelDebug.String(), logFilePath, debugMinAge, &debugLogger.Load().buffer)
+	rawDebugLogger, err := NewFileLogger(ctx, debug, LevelDebug, LevelDebug.String(), logFilePath, debugMinAge, nil, &debugLogger.Load().buffer)
 	if err != nil {
 		return err
 	}
 	debugLogger.Store(rawDebugLogger)
 
-	rawTraceLogger, err := NewFileLogger(ctx, trace, LevelTrace, LevelTrace.String(), logFilePath, traceMinAge, &traceLogger.Load().buffer)
+	rawTraceLogger, err := NewFileLogger(ctx, trace, LevelTrace, LevelTrace.String(), logFilePath, traceMinAge, nil, &traceLogger.Load().buffer)
 	if err != nil {
 		return err
 	}
 	traceLogger.Store(rawTraceLogger)
 
 	// Since there is no level checking in the stats logging, use LevelNone for the level.
-	rawStatsLogger, err := NewFileLogger(ctx, stats, LevelNone, "stats", logFilePath, statsMinAge, &statsLogger.Load().buffer)
+	rawStatsLogger, err := NewFileLogger(ctx, stats, LevelNone, "stats", logFilePath, statsMinAge, Ptr(statsDefaultMaxAgeOverride), &statsLogger.Load().buffer)
 	if err != nil {
 		return err
 	}

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -28,8 +28,8 @@ const (
 	infoMinAge  = 3
 	debugMinAge = 1
 	traceMinAge = 1
-	statsMinage = 3
-	auditMinage = 3
+	statsMinAge = 90
+	auditMinAge = 3
 
 	// defaultConsoleLoggerCollateBufferSize is the number of console logs we'll
 	// buffer and collate, before flushing the buffer to the output.
@@ -119,7 +119,7 @@ func InitLogging(ctx context.Context, logFilePath string,
 	traceLogger.Store(rawTraceLogger)
 
 	// Since there is no level checking in the stats logging, use LevelNone for the level.
-	rawStatsLogger, err := NewFileLogger(ctx, stats, LevelNone, "stats", logFilePath, statsMinage, &statsLogger.Load().buffer)
+	rawStatsLogger, err := NewFileLogger(ctx, stats, LevelNone, "stats", logFilePath, statsMinAge, &statsLogger.Load().buffer)
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func InitLogging(ctx context.Context, logFilePath string,
 	if prevAuditLogger != nil {
 		auditLoggerBuffer = &prevAuditLogger.buffer
 	}
-	rawAuditLogger, err := NewAuditLogger(ctx, audit, auditLogFilePath, auditMinage, auditLoggerBuffer, auditLogGlobalFields)
+	rawAuditLogger, err := NewAuditLogger(ctx, audit, auditLogFilePath, auditMinAge, auditLoggerBuffer, auditLogGlobalFields)
 	if err != nil {
 		return err
 	}

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -82,7 +82,7 @@ func TestLogRotationInterval(t *testing.T) {
 	t.Logf("countBefore: %d", countBefore)
 
 	ctx := TestCtx(t)
-	fl, err := NewFileLogger(ctx, config, LevelTrace, "test", logPath, 0, nil)
+	fl, err := NewFileLogger(ctx, config, LevelTrace, "test", logPath, 0, nil, nil)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, fl.Close())


### PR DESCRIPTION
CBG-4006

Override the default value of `MaxAge` for the stats logger to 90 days.
- Doing this instead of simply increasing `statsMinAge` because existing users may have already configured a value >= 3 but < 45 and we don't want that to now fail. Min age 3 still seems like a reasonable limit to configuration without affecting the default value of `MaxAge`.
- Size limit of 1GB (per level) is still in effect, so the new default of 90 days is safe enough.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3043/
