### PR TITLE
CBG-4456 fix unit test

### DIFF
--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -964,7 +964,7 @@ func TestNoAuditWhenDisabledAtDb(t *testing.T) {
 
 	// test event that is enabled by default on db (when audit is enabled)
 	output = base.AuditLogContents(t, func(t testing.TB) {
-		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", `{"user_xattr_key":"user_xattr_value"}`)
+		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", `{"user_xattr_key":"user_xattr"}`)
 		RequireStatus(t, resp, http.StatusCreated)
 	})
 	events = jsonLines(rt.TB(), output)


### PR DESCRIPTION
mobile jenkins caught this because it runs with `-tags cb_sg_enterprise` but not `-race`. We do not have anything in the test matrix for this.

I would like to move this test out of the no race package but there's still a data race in `AssertLogContains` that I can not quite pin down yet.
