### PR TITLE
CBG-4587: Add async index init REST API to allow partitioned index creation without downtime

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -348,9 +348,6 @@ func (b *BackgroundManager) resetStatus() {
 }
 
 func (b *BackgroundManager) Stop() error {
-	if b == nil {
-		return nil
-	}
 	if err := b.markStop(); err != nil {
 		return err
 	}

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -348,8 +348,10 @@ func (b *BackgroundManager) resetStatus() {
 }
 
 func (b *BackgroundManager) Stop() error {
-	err := b.markStop()
-	if err != nil {
+	if b == nil {
+		return nil
+	}
+	if err := b.markStop(); err != nil {
 		return err
 	}
 

--- a/db/background_mgr_async_index_init.go
+++ b/db/background_mgr_async_index_init.go
@@ -1,0 +1,84 @@
+//  Copyright 2025-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package db
+
+import (
+	"context"
+	"sync"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// AsyncIndexInitManager is a background manager process that manages the cross-node job state and status of an async invocation of DatabaseInitManager (via /db/_index_init)
+// This manager does not do the actual work to initialize indexes, due to go package boundaries and import-cycles, but is being fed status updates from callbacks passed into rest.DatabaseInitManager
+// This status can be viewed cross-node, and similarly the start/stop actions can be used cross-node with this AsyncIndexInitManager layer.
+type AsyncIndexInitManager struct {
+	lock      sync.Mutex
+	statusMap *map[string]map[string]string
+	doneChan  chan error
+}
+
+// Init is called synchronously to set up a run for the background manager process. See Run() for the async part.
+func (a *AsyncIndexInitManager) Init(ctx context.Context, options map[string]interface{}, clusterStatus []byte) error {
+	a.statusMap = options["statusMap"].(*map[string]map[string]string)
+	a.doneChan = options["doneChan"].(chan error)
+	return nil
+}
+
+// Run is called inside a goroutine to perform the job of the job. This function should block until the job is complete.
+func (a *AsyncIndexInitManager) Run(ctx context.Context, options map[string]interface{}, persistClusterStatusCallback updateStatusCallbackFunc, terminator *base.SafeTerminator) error {
+	return <-a.doneChan
+}
+
+type AsyncIndexInitManagerResponse struct {
+	BackgroundManagerStatus
+	IndexStatus map[string]map[string]string `json:"index_status"` // scope->collection->status
+}
+
+type AsyncIndexInitManagerStatusDoc struct {
+	AsyncIndexInitManagerResponse `json:"status"`
+}
+
+func (a *AsyncIndexInitManager) GetProcessStatus(status BackgroundManagerStatus) (statusOut []byte, meta []byte, err error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	var statusMap map[string]map[string]string
+	if a.statusMap != nil {
+		statusMap = *a.statusMap
+	}
+
+	retStatus := AsyncIndexInitManagerResponse{
+		BackgroundManagerStatus: status,
+		IndexStatus:             statusMap,
+	}
+
+	statusJSON, err := base.JSONMarshal(retStatus)
+	return statusJSON, nil, err
+}
+
+func (a *AsyncIndexInitManager) ResetStatus() {
+	a.statusMap = nil
+	return
+}
+
+var _ BackgroundManagerProcessI = &AsyncIndexInitManager{}
+
+func NewAsyncIndexInitManager(metadataStore base.DataStore, metaKeys *base.MetadataKeys) *BackgroundManager {
+	return &BackgroundManager{
+		name:    "index_init",
+		Process: &AsyncIndexInitManager{},
+		clusterAwareOptions: &ClusterAwareBackgroundManagerOptions{
+			metadataStore: metadataStore,
+			metaKeys:      metaKeys,
+			processSuffix: "index_init",
+		},
+		terminator: base.NewSafeTerminator(),
+	}
+}

--- a/db/database.go
+++ b/db/database.go
@@ -647,7 +647,7 @@ func (dbCtx *DatabaseContext) stopBackgroundManagers() (stopped []*BackgroundMan
 		dbCtx.TombstoneCompactionManager,
 		dbCtx.AsyncIndexInitManager,
 	} {
-		if manager.Stop() == nil {
+		if manager != nil && !isBackgroundManagerStopped(manager.GetRunState()) && manager.Stop() == nil {
 			stopped = append(stopped, manager)
 		}
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -640,42 +640,18 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 
 // stopBackgroundManagers stops any running BackgroundManager.
 // Returns a list of BackgroundManager it signalled to stop
-func (context *DatabaseContext) stopBackgroundManagers() []*BackgroundManager {
-	bgManagers := make([]*BackgroundManager, 0)
-
-	if context.ResyncManager != nil {
-		if !isBackgroundManagerStopped(context.ResyncManager.GetRunState()) {
-			if err := context.ResyncManager.Stop(); err == nil {
-				bgManagers = append(bgManagers, context.ResyncManager)
-			}
+func (dbCtx *DatabaseContext) stopBackgroundManagers() (stopped []*BackgroundManager) {
+	for _, manager := range []*BackgroundManager{
+		dbCtx.ResyncManager,
+		dbCtx.AttachmentCompactionManager,
+		dbCtx.TombstoneCompactionManager,
+		dbCtx.AsyncIndexInitManager,
+	} {
+		if manager.Stop() == nil {
+			stopped = append(stopped, manager)
 		}
 	}
-
-	if context.AttachmentCompactionManager != nil {
-		if !isBackgroundManagerStopped(context.AttachmentCompactionManager.GetRunState()) {
-			if err := context.AttachmentCompactionManager.Stop(); err == nil {
-				bgManagers = append(bgManagers, context.AttachmentCompactionManager)
-			}
-		}
-	}
-
-	if context.TombstoneCompactionManager != nil {
-		if !isBackgroundManagerStopped(context.TombstoneCompactionManager.GetRunState()) {
-			if err := context.TombstoneCompactionManager.Stop(); err == nil {
-				bgManagers = append(bgManagers, context.TombstoneCompactionManager)
-			}
-		}
-	}
-
-	if context.AsyncIndexInitManager != nil {
-		if !isBackgroundManagerStopped(context.AsyncIndexInitManager.GetRunState()) {
-			if err := context.AsyncIndexInitManager.Stop(); err == nil {
-				bgManagers = append(bgManagers, context.AsyncIndexInitManager)
-			}
-		}
-	}
-
-	return bgManagers
+	return stopped
 }
 
 // waitForBackgroundManagersToStop wait for given BackgroundManagers to stop within given time

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -233,7 +233,7 @@ func (il *importListener) Stop() {
 	}
 }
 
-func (db *DatabaseContext) PartitionCount() int {
+func (db *DatabaseContext) ImportPartitionCount() int {
 	il := db.ImportListener
 	_, pindexes := il.cbgtContext.Manager.CurrentMaps()
 	return len(pindexes)

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -323,7 +323,7 @@ func TestInitializeIndexesConcurrentMultiNode(t *testing.T) {
 		ctx := base.CorrelationIDLogCtx(context.Background(), fmt.Sprintf("test-node-%d", i))
 		go func() {
 			defer wg.Done()
-			setupN1QLStore(ctx, t, bucket, false, db.DefaultNumIndexPartitions)
+			setupN1QLStore(ctx, t, bucket, true, db.DefaultNumIndexPartitions)
 		}()
 	}
 	wg.Wait()
@@ -334,12 +334,12 @@ func TestPartitionedIndexes(t *testing.T) {
 		t.Skip("TestPartitionedIndexes only works with UseXattrs=true")
 	}
 	numPartitions := uint32(13)
-	serverless := false
+	useLegacySyncDocsIndex := true // CBG-4615
 
 	database, ctx := db.SetupTestDBWithOptions(t, db.DatabaseContextOptions{NumIndexPartitions: base.Ptr(numPartitions)})
 	defer database.Close(ctx)
 
-	setupN1QLStore(ctx, t, database.Bucket, serverless, numPartitions)
+	setupN1QLStore(ctx, t, database.Bucket, useLegacySyncDocsIndex, numPartitions)
 	gocbBucket, err := base.AsGocbV2Bucket(database.Bucket)
 	require.NoError(t, err)
 	for _, dsName := range []sgbucket.DataStoreName{db.GetSingleDatabaseCollection(t, database.DatabaseContext).GetCollectionDatastore(), database.MetadataStore} {

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -107,10 +107,6 @@ paths:
     $ref: './paths/admin/keyspace-_config-sync.yaml'
   '/{keyspace}/_config/import_filter':
     $ref: './paths/admin/keyspace-_config-import_filter.yaml'
-  '/{db}/':
-    $ref: './paths/admin/db-.yaml'
-  /_all_dbs:
-    $ref: ./paths/admin/_all_dbs.yaml
   '/{db}/_resync':
     $ref: './paths/admin/db-_resync.yaml'
   '/{db}/_index_init':

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -107,8 +107,14 @@ paths:
     $ref: './paths/admin/keyspace-_config-sync.yaml'
   '/{keyspace}/_config/import_filter':
     $ref: './paths/admin/keyspace-_config-import_filter.yaml'
+  '/{db}/':
+    $ref: './paths/admin/db-.yaml'
+  /_all_dbs:
+    $ref: ./paths/admin/_all_dbs.yaml
   '/{db}/_resync':
     $ref: './paths/admin/db-_resync.yaml'
+  '/{db}/_index_init':
+    $ref: './paths/admin/db-_index_init.yaml'
   '/{keyspace}/_purge':
     $ref: './paths/admin/keyspace-_purge.yaml'
   '/{db}/_flush':

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3164,7 +3164,7 @@ IndexInitStatus:
         running: Indexes are being created.
         completed: All indexes were created.
         error: The index initialization operation has failed.
-        stopped: The index initialization operation has been stopped. These indexes may still on Couchbase Server.
+        stopped: The index initialization operation has been stopped. These indexes may still exist on Couchbase Server.
         stopping: The index initialization operation is in the process of being stopped.
     start_time:
       description: The ISO-8601 date and time the index initialization operation was started.

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1726,17 +1726,8 @@ Database:
       type: number
       default: 1
     index:
-      type: object
-      description: Settings for Global Secondary Indexes (GSI).
-      properties:
-        num_replicas:
-          description: This is the number of Global Secondary Indexes (GSI) to use for core indexes.
-          type: number
-          default: 1
-        num_partitions:
-          description: The number of partitions to use for the large indexes created by Sync Gateway. It is not recommended to set this unless you require additional horizontal scalability for individual indexes and have appropriately scaled your Query nodes to handle the increased query parallelism. If set, the recommended number is 8 and does not need to be directly related to the number of your Query nodes. Ensure documentation is read to understand the performance tradeoffs and instructions for migration if you have previously run with only one partition.
-          type: number
-          default: 1
+      allOf:
+        - $ref: '#/IndexSettings'
     use_views:
       description: Force the use of views instead of GSI.
       type: boolean
@@ -3062,6 +3053,7 @@ CollectionNames:
   type: array
   items:
     type: string
+    example: ["collection1", "collection2"]
 "All DBs":
   description: "The names of all databases."
   type: array

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3147,3 +3147,65 @@ DatabaseState:
     Starting: The database is in the process of going online.
     Stopping: The database is no longer accepting connections and is being taken offline or deleted.
     Resyncing: The database is offline and performing a resync operation.
+IndexSettings:
+  type: object
+  description: Settings for Global Secondary Indexes (GSI).
+  properties:
+    num_partitions:
+      description: The number of partitions to use for the large indexes created by Sync Gateway. It is not recommended to set this unless you require additional horizontal scalability for individual indexes and have appropriately scaled your Query nodes to handle the increased query parallelism. If set, the recommended number is 8 and does not need to be directly related to the number of your Query nodes. Ensure documentation is read to understand the performance tradeoffs and instructions for migration if you have previously run with only one partition. See [/{db}/_index_init](#operation/post_db-_index_init) for more information.
+      type: number
+      default: 1
+IndexInitStatus:
+  description: The status of an asynchronous indexes initialization operation.
+  type: object
+  properties:
+    status:
+      description: The status of the current operation.
+      type: string
+      enum:
+        - completed
+        - error
+        - running
+        - stopped
+        - stopping
+      x-enumDescriptions:
+        running: Indexes are being created.
+        completed: All indexes were created.
+        error: The index initialization operation has failed.
+        stopped: The index initialization operation has been stopped. These indexes may still on Couchbase Server.
+        stopping: The index initialization operation is in the process of being stopped.
+    start_time:
+      description: The ISO-8601 date and time the index initialization operation was started.
+      type: string
+    last_error:
+      description: The last error that occurred in the index initialization operation (if any).
+      type: string
+    index_status:
+      description: 'scope name with one or more collection names and the status of their index creation'
+      type: object
+      additionalProperties:
+        x-additionalPropertiesName: scopename
+        description: An object keyed by scope, containing a set of collections and the status of their index creation.
+        type: object
+        additionalProperties:
+          x-additionalPropertiesName: collectionname
+          type: string
+          enum:
+            - "queued"
+            - "in progress"
+            - "ready"
+            - "error"
+          x-enumDescriptions:
+            "queued": Indexes are queued for creation.
+            "in progress": Indexes are being created.
+            "ready": All indexes were created.
+            "error": The index creation operation has failed.
+    settings:
+      allOf:
+        - $ref: '#/IndexSettings'
+  required:
+    - status
+    - start_time
+    - last_error
+    - index_status
+  title: IndexInitStatus

--- a/docs/api/paths/admin/db-_config.yaml
+++ b/docs/api/paths/admin/db-_config.yaml
@@ -55,7 +55,7 @@ put:
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Architect
-    * Sync Gateway Application
+    * Sync Gateway Application (sync function only)
   parameters:
     - $ref: ../../components/parameters.yaml#/DB-config-If-Match
     - $ref: ../../components/parameters.yaml#/disable_oidc_validation
@@ -87,7 +87,7 @@ post:
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Architect
-    * Sync Gateway Application
+    * Sync Gateway Application (sync function only)
   parameters:
     - $ref: ../../components/parameters.yaml#/DB-config-If-Match
   requestBody:

--- a/docs/api/paths/admin/db-_index_init.yaml
+++ b/docs/api/paths/admin/db-_index_init.yaml
@@ -1,0 +1,79 @@
+# Copyright 2022-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+parameters:
+  - $ref: ../../components/parameters.yaml#/db
+post:
+  summary: Start asynchronous index initialization
+  description: |
+    This can be used to start index initialization with different parameters from a running database. The typical workflow is:
+
+    1. Start the process of creating new indexes with [POST /{db}/_index_init](#operation/post-db_index_init).
+    2. Wait for index initialization to complete with [GET /{db}/_index_init](#operation/get_db-_index_init).
+    3. Update the database configuration to use these new indexes with [POST /{db}/_config](#operation/post_db-_config).
+    4. Call [POST /_post_upgrade](#operation/post__post_upgrade) to remove the original indexes.
+
+    This operation will start creation of indexes, and the creation of indexes can not be stopped on Couchbase Server once it has been started.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Architect
+  parameters:
+    - name: action
+      in: query
+      description: Defines whether the index creation operation is being started or stopped.
+      schema:
+        type: string
+        default: start
+        enum:
+          - start
+          - stop
+        x-enumDescriptions:
+          start: Starts the creation of indexes.
+          stop: Stops tracking the indexes by Sync Gateway. These indexes will still be created on Couchbase Server.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          allOf:
+            - $ref: ../../components/schemas.yaml#/IndexSettings
+  responses:
+    '200':
+      description: successfully changed the status of the resync operation
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/IndexInitStatus
+    '503':
+      description: Service Unavailable
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/HTTP-Error
+  tags:
+    - Database Management
+  operationId: post_db-_index_init
+get:
+  summary: Get status of index initialization.
+  description: |-
+    This will retrieve the status of last index initialization operation (whether it is running or not) in the Sync Gateway cluster.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Architect
+  responses:
+    '200':
+      description: successfully retrieved the most recent index initialization
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas.yaml#/IndexInitStatus
+    '404':
+      $ref: ../../components/responses.yaml#/Not-found
+  tags:
+    - Database Management
+  operationId: get_db-_index_init

--- a/docs/api/paths/admin/db-_index_init.yaml
+++ b/docs/api/paths/admin/db-_index_init.yaml
@@ -34,7 +34,7 @@ post:
           - stop
         x-enumDescriptions:
           start: Starts the creation of indexes.
-          stop: Stops tracking the indexes by Sync Gateway. These indexes will still be created on Couchbase Server.
+          stop: Stops tracking the index creation by Sync Gateway. These indexes will still be created on Couchbase Server.
   requestBody:
     content:
       application/json:
@@ -43,7 +43,7 @@ post:
             - $ref: ../../components/schemas.yaml#/IndexSettings
   responses:
     '200':
-      description: successfully changed the status of the resync operation
+      description: successfully changed the status of the index initialization operation
       content:
         application/json:
           schema:

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -330,7 +330,7 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 			// assertRespStatus changes behaviour depending on if forcing forbidden errors
 			assertRespStatus := func(resp *TestResponse, statusIfForbiddenErrorsFalse int) {
 				if test.forceForbiddenErrors {
-					assertHTTPErrorReason(t, resp, http.StatusForbidden, "forbidden")
+					AssertHTTPErrorReason(t, resp, http.StatusForbidden, "forbidden")
 					return
 				}
 				AssertStatus(t, resp, statusIfForbiddenErrorsFalse)
@@ -443,11 +443,11 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 
 			// PUT with access but no rev
 			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc", `{}`, nil, "Perms", "password")
-			assertHTTPErrorReason(t, resp, http.StatusConflict, "Document exists")
+			AssertHTTPErrorReason(t, resp, http.StatusConflict, "Document exists")
 
 			// PUT with access but wrong rev
 			resp = rt.SendUserRequestWithHeaders(http.MethodPut, "/{{.keyspace}}/doc?rev=1-abc", `{}`, nil, "Perms", "password")
-			assertHTTPErrorReason(t, resp, http.StatusConflict, "Document revision conflict")
+			AssertHTTPErrorReason(t, resp, http.StatusConflict, "Document revision conflict")
 
 			// Confirm no access grants where granted
 			resp = rt.SendAdminRequest(http.MethodGet, "/db/_user/NoPerms", ``)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -300,11 +300,11 @@ func (h *handler) handlePostIndexInit() error {
 		if err := h.db.AsyncIndexInitManager.Stop(); err != nil {
 			return err
 		}
-		status, err := h.db.AsyncIndexInitManager.GetStatus(h.ctx())
+		b, err := h.db.AsyncIndexInitManager.GetStatus(h.ctx())
 		if err != nil {
 			return err
 		}
-		h.writeRawJSON(status)
+		h.writeRawJSON(b)
 		return nil
 	}
 
@@ -360,7 +360,17 @@ func (h *handler) handlePostIndexInit() error {
 		"statusMap": &statusMap,
 		"doneChan":  done,
 	}
-	return h.db.AsyncIndexInitManager.Start(h.ctx(), opts)
+	err = h.db.AsyncIndexInitManager.Start(h.ctx(), opts)
+	if err != nil {
+		return err
+	}
+
+	b, err := h.db.AsyncIndexInitManager.GetStatus(h.ctx())
+	if err != nil {
+		return err
+	}
+	h.writeRawJSON(b)
+	return nil
 }
 
 // Get admin database info

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -321,8 +321,12 @@ func (h *handler) handlePostIndexInit() error {
 	}
 
 	currentDbConfig := h.server.GetDatabaseConfig(h.db.Name)
-	if currentDbConfig.Index.NumPartitions == req.NumPartitions {
+	if currentDbConfig.NumIndexPartitions() == *req.NumPartitions {
 		return base.HTTPErrorf(http.StatusBadRequest, "num_partitions is already %d", *req.NumPartitions)
+	}
+
+	if h.db.UseViews() {
+		return base.HTTPErrorf(http.StatusBadRequest, "_index_init is a GSI-only feature and is not supported when using views")
 	}
 
 	var newDbConfig DatabaseConfig

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -805,7 +805,7 @@ func TestCollectionsChangeConfigScopeFromImplicitDefault(t *testing.T) {
 			newCollection.CollectionName(): {},
 		}},
 	}})
-	assertHTTPErrorReason(t, resp, http.StatusBadRequest, "1 errors:\ncannot change scopes after database creation")
+	AssertHTTPErrorReason(t, resp, http.StatusBadRequest, "1 errors:\ncannot change scopes after database creation")
 }
 
 // TestCollecitonStats ensures that stats are specific to each collection.

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2765,18 +2765,6 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	}
 }
 
-func assertHTTPErrorReason(t testing.TB, response *TestResponse, expectedStatus int, expectedReason string) {
-	var httpError struct {
-		Reason string `json:"reason"`
-	}
-	err := base.JSONUnmarshal(response.BodyBytes(), &httpError)
-	require.NoError(t, err, "Failed to unmarshal HTTP error: %v", response.BodyBytes())
-
-	AssertStatus(t, response, expectedStatus)
-
-	assert.Equal(t, expectedReason, httpError.Reason)
-}
-
 // TestPing ensures that /_ping is accessible on all APIs for GET and HEAD without authentication.
 func TestPing(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp)

--- a/rest/config.go
+++ b/rest/config.go
@@ -2404,8 +2404,8 @@ func (c *DbConfig) numIndexReplicas() uint {
 	return DefaultNumIndexReplicas
 }
 
-// numIndexPartitions returns the number of index partitions for the database, populating the default value if necessary.
-func (c *DbConfig) numIndexPartitions() uint32 {
+// NumIndexPartitions returns the number of index partitions for the database, populating the default value if necessary.
+func (c *DbConfig) NumIndexPartitions() uint32 {
 	if c.Index != nil && c.Index.NumPartitions != nil {
 		return *c.Index.NumPartitions
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3121,7 +3121,7 @@ func TestRevCacheMemoryLimitConfig(t *testing.T) {
 	}
 	resp = rt.UpsertDbConfig("db1", dbConfig)
 	if base.IsEnterpriseEdition() {
-		assertHTTPErrorReason(t, resp, http.StatusInternalServerError, "Internal error: maximum rev cache memory size cannot be lower than 50 MB")
+		AssertHTTPErrorReason(t, resp, http.StatusInternalServerError, "Internal error: maximum rev cache memory size cannot be lower than 50 MB")
 	} else {
 		// CE will roll back to no memory limit as it's an EE ony feature
 		RequireStatus(t, resp, http.StatusCreated)

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -33,24 +33,32 @@ type DatabaseInitManager struct {
 	workers     map[string]*DatabaseInitWorker
 	workersLock sync.Mutex
 
-	// collectionCompleteCallback is defined for testability only.
+	// testCollectionCompleteCallback is defined for testability only.
 	// Invoked after collection initialization is complete for each collection
-	collectionCompleteCallback collectionCallbackFunc
+	testCollectionCompleteCallback CollectionCallbackFunc
 
-	// databaseCompleteCallback is defined for testability only.
+	// testDatabaseCompleteCallback is defined for testability only.
 	// Invoked after worker completes, but before worker is removed from workers set
-	databaseCompleteCallback func(databaseName string) // Callback for testability only
+	testDatabaseCompleteCallback func(databaseName string) // Callback for testability only
 }
 
-type collectionCallbackFunc func(dbName, collectionName string)
+type CollectionIndexStatus string
+
+const (
+	CollectionIndexStatusQueued     CollectionIndexStatus = "queued"
+	CollectionIndexStatusInProgress CollectionIndexStatus = "in progress"
+	CollectionIndexStatusReady      CollectionIndexStatus = "ready"
+	CollectionIndexStatusError      CollectionIndexStatus = "error"
+)
+
+// CollectionCallbackFunc is called when the initialization has completed for each collection on the database.
+type CollectionCallbackFunc func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus)
 
 // CollectionInitData defines the set of collections being created (by ScopeAneCollectionName), and the set of
 // indexes required for each collection.
 type CollectionInitData map[base.ScopeAndCollectionName]db.CollectionIndexesType
 
-// Initializes the database.  Will establish a new cluster connection using the provided server config.  Establishes a new
-// cluster-only N1QLStore based on the startup config to perform initialization.
-func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool) (doneChan chan error, err error) {
+func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, statusCallback CollectionCallbackFunc, useLegacySyncDocsIndex bool) (doneChan chan error, err error) {
 	m.workersLock.Lock()
 	defer m.workersLock.Unlock()
 	if m.workers == nil {
@@ -106,10 +114,15 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 		return nil, err
 	}
 
-	indexOptions := m.BuildIndexOptions(dbConfig, useLegacySyncDocsIndex)
+	indexOptions := m.buildIndexOptions(dbConfig, useLegacySyncDocsIndex)
+
+	// allow the test callback to be overridden by the caller if desired
+	if statusCallback == nil {
+		statusCallback = m.testCollectionCompleteCallback
+	}
 
 	// Create new worker and add this caller as a watcher
-	worker := NewDatabaseInitWorker(ctx, dbConfig.Name, n1qlStore, collectionSet, indexOptions, m.collectionCompleteCallback)
+	worker := NewDatabaseInitWorker(ctx, dbConfig.Name, n1qlStore, collectionSet, indexOptions, statusCallback)
 	m.workers[dbConfig.Name] = worker
 	doneChan = worker.addWatcher()
 
@@ -119,8 +132,8 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 		defer couchbaseCluster.Close()
 		// worker.Run blocks until completion, and returns any error on doneChan.
 		worker.Run()
-		if m.databaseCompleteCallback != nil {
-			m.databaseCompleteCallback(dbConfig.Name)
+		if m.testDatabaseCompleteCallback != nil {
+			m.testDatabaseCompleteCallback(dbConfig.Name)
 		}
 		// On success, remove worker
 		m.workersLock.Lock()
@@ -128,6 +141,12 @@ func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupCon
 		m.workersLock.Unlock()
 	}()
 	return doneChan, nil
+}
+
+// Initializes the database.  Will establish a new cluster connection using the provided server config.  Establishes a new
+// cluster-only N1QLStore based on the startup config to perform initialization.
+func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool) (doneChan chan error, err error) {
+	return m.InitializeDatabaseWithStatusCallback(ctx, startupConfig, dbConfig, nil, useLegacySyncDocsIndex)
 }
 
 func (m *DatabaseInitManager) HasActiveInitialization(dbName string) bool {
@@ -140,7 +159,7 @@ func (m *DatabaseInitManager) HasActiveInitialization(dbName string) bool {
 	return ok
 }
 
-func (m *DatabaseInitManager) BuildIndexOptions(dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool) db.InitializeIndexOptions {
+func (m *DatabaseInitManager) buildIndexOptions(dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool) db.InitializeIndexOptions {
 	return db.InitializeIndexOptions{
 		WaitForIndexesOnlineOption: base.WaitForIndexesInfinite,
 		NumReplicas:                dbConfig.numIndexReplicas(),
@@ -151,9 +170,9 @@ func (m *DatabaseInitManager) BuildIndexOptions(dbConfig *DatabaseConfig, useLeg
 }
 
 // Intended for test usage.  Updates to callback function aren't synchronized
-func (m *DatabaseInitManager) SetCallbacks(collectionComplete collectionCallbackFunc, databaseComplete func(dbName string)) {
-	m.collectionCompleteCallback = collectionComplete
-	m.databaseCompleteCallback = databaseComplete
+func (m *DatabaseInitManager) SetTestCallbacks(collectionCallback CollectionCallbackFunc, databaseComplete func(dbName string)) {
+	m.testCollectionCompleteCallback = collectionCallback
+	m.testDatabaseCompleteCallback = databaseComplete
 }
 
 func (m *DatabaseInitManager) Cancel(dbName string) {
@@ -195,13 +214,13 @@ func buildCollectionIndexData(config *DatabaseConfig) CollectionInitData {
 // DatabaseInitWorker performs async database initialization tasks that should be performed in the background,
 // independent of the database being reloaded for config changes
 type DatabaseInitWorker struct {
-	dbName                     string
-	n1qlStore                  *base.ClusterOnlyN1QLStore
-	options                    DatabaseInitOptions
-	ctx                        context.Context        // On close, terminates any goroutines associated with the worker
-	cancelFunc                 context.CancelFunc     // Cancel function for context, invoked if Cancel is called
-	collections                CollectionInitData     // The set of collections associated with the worker, mapped by name to their index set
-	collectionCompleteCallback collectionCallbackFunc // Callback for testability
+	dbName                   string
+	n1qlStore                *base.ClusterOnlyN1QLStore
+	options                  DatabaseInitOptions
+	ctx                      context.Context        // On close, terminates any goroutines associated with the worker
+	cancelFunc               context.CancelFunc     // Cancel function for context, invoked if Cancel is called
+	collections              CollectionInitData     // The set of collections associated with the worker, mapped by name to their index set
+	collectionStatusCallback CollectionCallbackFunc // Callback for status observability
 
 	// Multiple goroutines (watchers) may be waiting for database initialization.  To support sending error information to
 	// every goroutine, we maintain a channel for each of these watching goroutines.  On success, all channels are
@@ -217,21 +236,20 @@ type DatabaseInitOptions struct {
 	indexOptions db.InitializeIndexOptions // Options used for index initialization
 }
 
-func NewDatabaseInitWorker(ctx context.Context, dbName string, n1qlStore *base.ClusterOnlyN1QLStore, collections CollectionInitData, indexOptions db.InitializeIndexOptions, callback collectionCallbackFunc) *DatabaseInitWorker {
+func NewDatabaseInitWorker(ctx context.Context, dbName string, n1qlStore *base.ClusterOnlyN1QLStore, collections CollectionInitData, indexOptions db.InitializeIndexOptions, callback CollectionCallbackFunc) *DatabaseInitWorker {
 	cancelCtx, cancelFunc := context.WithCancel(ctx)
 	return &DatabaseInitWorker{
-		dbName:                     dbName,
-		options:                    DatabaseInitOptions{indexOptions: indexOptions},
-		ctx:                        cancelCtx,
-		cancelFunc:                 cancelFunc,
-		collections:                collections,
-		n1qlStore:                  n1qlStore,
-		collectionCompleteCallback: callback,
+		dbName:                   dbName,
+		options:                  DatabaseInitOptions{indexOptions: indexOptions},
+		ctx:                      cancelCtx,
+		cancelFunc:               cancelFunc,
+		collections:              collections,
+		n1qlStore:                n1qlStore,
+		collectionStatusCallback: callback,
 	}
 }
 
 func (w *DatabaseInitWorker) Run() {
-
 	// Ensure cancelFunc resources are released on normal completion
 	defer func() {
 		if w.cancelFunc != nil {
@@ -239,8 +257,18 @@ func (w *DatabaseInitWorker) Run() {
 		}
 	}()
 
+	if w.collectionStatusCallback != nil {
+		for scName := range w.collections {
+			w.collectionStatusCallback(w.dbName, scName, CollectionIndexStatusQueued)
+		}
+	}
+
 	var indexErr error
 	for scName, indexSet := range w.collections {
+		if w.collectionStatusCallback != nil {
+			w.collectionStatusCallback(w.dbName, scName, CollectionIndexStatusInProgress)
+		}
+
 		// Add the index set to the common indexOptions
 		collectionIndexOptions := w.options.indexOptions
 		collectionIndexOptions.MetadataIndexes = indexSet
@@ -250,6 +278,9 @@ func (w *DatabaseInitWorker) Run() {
 		keyspaceCtx := base.KeyspaceLogCtx(w.ctx, w.n1qlStore.BucketName(), scName.ScopeName(), scName.CollectionName())
 		indexErr = db.InitializeIndexes(keyspaceCtx, w.n1qlStore, collectionIndexOptions)
 		if indexErr != nil {
+			if w.collectionStatusCallback != nil {
+				w.collectionStatusCallback(w.dbName, scName, CollectionIndexStatusError)
+			}
 			break
 		}
 
@@ -264,8 +295,8 @@ func (w *DatabaseInitWorker) Run() {
 			break
 		}
 
-		if w.collectionCompleteCallback != nil {
-			w.collectionCompleteCallback(w.dbName, scName.CollectionName())
+		if w.collectionStatusCallback != nil {
+			w.collectionStatusCallback(w.dbName, scName, CollectionIndexStatusReady)
 		}
 	}
 

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -42,17 +42,8 @@ type DatabaseInitManager struct {
 	testDatabaseCompleteCallback func(databaseName string) // Callback for testability only
 }
 
-type CollectionIndexStatus string
-
-const (
-	CollectionIndexStatusQueued     CollectionIndexStatus = "queued"
-	CollectionIndexStatusInProgress CollectionIndexStatus = "in progress"
-	CollectionIndexStatusReady      CollectionIndexStatus = "ready"
-	CollectionIndexStatusError      CollectionIndexStatus = "error"
-)
-
 // CollectionCallbackFunc is called when the initialization has completed for each collection on the database.
-type CollectionCallbackFunc func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus)
+type CollectionCallbackFunc func(dbName string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus)
 
 // CollectionInitData defines the set of collections being created (by ScopeAneCollectionName), and the set of
 // indexes required for each collection.
@@ -259,14 +250,14 @@ func (w *DatabaseInitWorker) Run() {
 
 	if w.collectionStatusCallback != nil {
 		for scName := range w.collections {
-			w.collectionStatusCallback(w.dbName, scName, CollectionIndexStatusQueued)
+			w.collectionStatusCallback(w.dbName, scName, db.CollectionIndexStatusQueued)
 		}
 	}
 
 	var indexErr error
 	for scName, indexSet := range w.collections {
 		if w.collectionStatusCallback != nil {
-			w.collectionStatusCallback(w.dbName, scName, CollectionIndexStatusInProgress)
+			w.collectionStatusCallback(w.dbName, scName, db.CollectionIndexStatusInProgress)
 		}
 
 		// Add the index set to the common indexOptions
@@ -279,7 +270,7 @@ func (w *DatabaseInitWorker) Run() {
 		indexErr = db.InitializeIndexes(keyspaceCtx, w.n1qlStore, collectionIndexOptions)
 		if indexErr != nil {
 			if w.collectionStatusCallback != nil {
-				w.collectionStatusCallback(w.dbName, scName, CollectionIndexStatusError)
+				w.collectionStatusCallback(w.dbName, scName, db.CollectionIndexStatusError)
 			}
 			break
 		}
@@ -296,7 +287,7 @@ func (w *DatabaseInitWorker) Run() {
 		}
 
 		if w.collectionStatusCallback != nil {
-			w.collectionStatusCallback(w.dbName, scName, CollectionIndexStatusReady)
+			w.collectionStatusCallback(w.dbName, scName, db.CollectionIndexStatusReady)
 		}
 	}
 

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -156,7 +156,7 @@ func (m *DatabaseInitManager) buildIndexOptions(dbConfig *DatabaseConfig, useLeg
 		NumReplicas:                dbConfig.numIndexReplicas(),
 		LegacySyncDocsIndex:        useLegacySyncDocsIndex,
 		UseXattrs:                  dbConfig.UseXattrs(),
-		NumPartitions:              dbConfig.numIndexPartitions(),
+		NumPartitions:              dbConfig.NumIndexPartitions(),
 	}
 }
 

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -33,9 +33,9 @@ type DatabaseInitManager struct {
 	workers     map[string]*DatabaseInitWorker
 	workersLock sync.Mutex
 
-	// testCollectionCompleteCallback is defined for testability only.
+	// testCollectionStatusUpdateCallback is defined for testability only.
 	// Invoked after collection initialization is complete for each collection
-	testCollectionCompleteCallback CollectionCallbackFunc
+	testCollectionStatusUpdateCallback CollectionCallbackFunc
 
 	// testDatabaseCompleteCallback is defined for testability only.
 	// Invoked after worker completes, but before worker is removed from workers set
@@ -118,7 +118,7 @@ func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.C
 
 	// allow the test callback to be overridden by the caller if desired
 	if statusCallback == nil {
-		statusCallback = m.testCollectionCompleteCallback
+		statusCallback = m.testCollectionStatusUpdateCallback
 	}
 
 	// Create new worker and add this caller as a watcher
@@ -171,7 +171,7 @@ func (m *DatabaseInitManager) buildIndexOptions(dbConfig *DatabaseConfig, useLeg
 
 // Intended for test usage.  Updates to callback function aren't synchronized
 func (m *DatabaseInitManager) SetTestCallbacks(collectionCallback CollectionCallbackFunc, databaseComplete func(dbName string)) {
-	m.testCollectionCompleteCallback = collectionCallback
+	m.testCollectionStatusUpdateCallback = collectionCallback
 	m.testDatabaseCompleteCallback = databaseComplete
 }
 

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -94,8 +94,8 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	expectedCollectionCount := int64(3) // default, collection1, collection2
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus) {
-		if status != CollectionIndexStatusReady {
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
@@ -184,8 +184,8 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus) {
-		if status != CollectionIndexStatusReady {
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
@@ -271,8 +271,8 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus) {
-		if status != CollectionIndexStatusReady {
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
@@ -362,8 +362,8 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus) {
-		if status != CollectionIndexStatusReady {
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
@@ -447,8 +447,8 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionStatusUpdateCallback = func(_ string, _ base.ScopeAndCollectionName, status CollectionIndexStatus) {
-		if status != CollectionIndexStatusReady {
+	initMgr.testCollectionStatusUpdateCallback = func(_ string, _ base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		atomic.AddInt64(&collectionCount, 1)

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -94,12 +94,12 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	expectedCollectionCount := int64(3) // default, collection1, collection2
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
-		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+	initMgr.testCollectionCompleteCallback = func(dbName string, scName base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
-			notifyChannel(t, singleCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
-			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))             // wait for the test to unblock before proceeding to the next collection
+			notifyChannel(t, singleCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", scName)) // notify the test that indexes have been created for this collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", scName))             // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -181,12 +181,12 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
-		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+	initMgr.testCollectionCompleteCallback = func(dbName string, scName base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
-			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
-			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", scName.CollectionName())) // notify the test that indexes have been created for this collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", scName.CollectionName()))            // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -265,12 +265,12 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
-		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+	initMgr.testCollectionCompleteCallback = func(dbName string, scName base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
-			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
-			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", scName)) // notify the test that indexes have been created for this collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", scName))            // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
@@ -353,16 +353,16 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
-		log.Printf("Collection complete callback invoked for %s %s", dbName, collectionName)
+	initMgr.testCollectionCompleteCallback = func(dbName string, scName base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
-			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", collectionName)) // notify the test that indexes have been created for this collection
-			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", collectionName))            // wait for the test to unblock before proceeding to the next collection
+			notifyChannel(t, firstCollectionInitChannel, fmt.Sprintf("singleCollectionInit-%s", scName)) // notify the test that indexes have been created for this collection
+			WaitForChannel(t, testSignalChannel, fmt.Sprintf("testSignalChannel-%s", scName))            // wait for the test to unblock before proceeding to the next collection
 		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
-	initMgr.databaseCompleteCallback = func(dbName string) {
+	initMgr.testDatabaseCompleteCallback = func(dbName string) {
 		notifyChannel(t, databaseCompleteChannel, "database complete")
 	}
 
@@ -435,7 +435,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.collectionCompleteCallback = func(dbName, collectionName string) {
+	initMgr.testCollectionCompleteCallback = func(_ string, _ base.ScopeAndCollectionName, _ CollectionIndexStatus) {
 		atomic.AddInt64(&collectionCount, 1)
 	}
 	dbName := "dbName"
@@ -446,7 +446,7 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	databaseCompleteCount := int64(0)
-	initMgr.databaseCompleteCallback = func(dbName string) {
+	initMgr.testDatabaseCompleteCallback = func(dbName string) {
 		// On first completion, invoke InitializeDatabase with the same collection set post-completion
 		currentCount := atomic.LoadInt64(&databaseCompleteCount)
 		if currentCount == 0 {

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -94,7 +94,10 @@ func TestDatabaseInitConfigChangeSameCollections(t *testing.T) {
 	expectedCollectionCount := int64(3) // default, collection1, collection2
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionCompleteCallback = func(dbName string, scName base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus) {
+		if status != CollectionIndexStatusReady {
+			return
+		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
@@ -181,7 +184,10 @@ func TestDatabaseInitConfigChangeDifferentCollections(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionCompleteCallback = func(dbName string, scName base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus) {
+		if status != CollectionIndexStatusReady {
+			return
+		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
@@ -265,7 +271,10 @@ func TestDatabaseInitConcurrentDatabasesSameBucket(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionCompleteCallback = func(dbName string, scName base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus) {
+		if status != CollectionIndexStatusReady {
+			return
+		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
@@ -353,7 +362,10 @@ func TestDatabaseInitConcurrentDatabasesDifferentBuckets(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionCompleteCallback = func(dbName string, scName base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+	initMgr.testCollectionStatusUpdateCallback = func(dbName string, scName base.ScopeAndCollectionName, status CollectionIndexStatus) {
+		if status != CollectionIndexStatusReady {
+			return
+		}
 		log.Printf("Collection complete callback invoked for %s %s", dbName, scName)
 		currentCount := atomic.LoadInt64(&collectionCount)
 		if currentCount == 0 {
@@ -435,7 +447,10 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
 	collectionCount := int64(0)
-	initMgr.testCollectionCompleteCallback = func(_ string, _ base.ScopeAndCollectionName, _ CollectionIndexStatus) {
+	initMgr.testCollectionStatusUpdateCallback = func(_ string, _ base.ScopeAndCollectionName, status CollectionIndexStatus) {
+		if status != CollectionIndexStatusReady {
+			return
+		}
 		atomic.AddInt64(&collectionCount, 1)
 	}
 	dbName := "dbName"

--- a/rest/importtest/import_partition_test.go
+++ b/rest/importtest/import_partition_test.go
@@ -64,7 +64,7 @@ func TestImportPartitionsOnConcurrentStart(t *testing.T) {
 		balancedPartitions := true
 		currentPartitions := make([]int, len(restTesters))
 		for i, rt := range restTesters {
-			rtPartitions := rt.GetDatabase().PartitionCount()
+			rtPartitions := rt.GetDatabase().ImportPartitionCount()
 			currentPartitions[i] = rtPartitions
 			totalPartitions = totalPartitions + uint16(rtPartitions)
 			if rtPartitions != expectedPartitions {

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -1,3 +1,11 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
 package indextest
 
 import (

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -123,7 +123,7 @@ func TestChangeIndexPartitions(t *testing.T) {
 						assert.Equal(c, db.CollectionIndexStatusReady, status)
 					}
 				}
-			}, 30*time.Second, 1*time.Second)
+			}, 1*time.Minute, 1*time.Second)
 			assertNumSGIndexPartitions(t, database)
 
 			// update db config with new partition count - shouldn't create indexes at this point since they already exist
@@ -222,7 +222,6 @@ func TestChangeIndexPartitionsErrors(t *testing.T) {
 			require.NoError(t, err, "Failed to unmarshal HTTP error: %v", resp.BodyBytes())
 			rest.AssertStatus(t, resp, http.StatusBadRequest)
 			assert.Contains(t, httpError.Reason, test.expectedError)
-
 		})
 	}
 }
@@ -267,7 +266,7 @@ func TestChangeIndexPartitionsDbOffline(t *testing.T) {
 		err := base.JSONUnmarshal(resp.BodyBytes(), &body)
 		require.NoError(c, err)
 		require.Equal(c, db.BackgroundProcessStateCompleted, body.State)
-	}, 30*time.Second, 1*time.Second)
+	}, 1*time.Minute, 1*time.Second)
 }
 
 func TestChangeIndexPartitionsStartStopAndRestart(t *testing.T) {
@@ -295,7 +294,7 @@ func TestChangeIndexPartitionsStartStopAndRestart(t *testing.T) {
 		err := base.JSONUnmarshal(resp.BodyBytes(), &body)
 		require.NoError(c, err)
 		require.Equal(c, db.BackgroundProcessStateStopped, body.State)
-	}, 30*time.Second, 1*time.Second)
+	}, 1*time.Minute, 1*time.Second)
 
 	// restart with new params
 	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":3}`)
@@ -309,7 +308,7 @@ func TestChangeIndexPartitionsStartStopAndRestart(t *testing.T) {
 		err := base.JSONUnmarshal(resp.BodyBytes(), &body)
 		require.NoError(c, err)
 		require.Equal(c, db.BackgroundProcessStateCompleted, body.State)
-	}, 30*time.Second, 1*time.Second)
+	}, 1*time.Minute, 1*time.Second)
 }
 
 func TestChangeIndexPartitionsWithViews(t *testing.T) {

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -35,8 +35,8 @@ func TestChangeIndexPartitions(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig, base.KeyQuery)
 	require.False(t, base.TestsDisableGSI(), "Test requires GSI to be enabled")
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig, base.KeyQuery)
 	const (
 		dbName            = "db"
 		initialPartitions = uint32(2)

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -79,15 +79,14 @@ func TestChangeIndexPartitions(t *testing.T) {
 	// update db config - shouldn't create indexes at this point since they already exist
 	dbConfig.Index.NumPartitions = base.Ptr(newPartitions)
 	rt.UpsertDbConfig(dbName, dbConfig)
-	// TODO: stat to check if we tried rebuilding the indexes?
 
 	// cleanup old indexes
-	resp = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade", "")
-	rest.RequireStatus(t, resp, http.StatusOK)
-	var body rest.PostUpgradeResponse
-	err := base.JSONUnmarshal(resp.BodyBytes(), &body)
-	require.NoError(t, err)
-	require.Lenf(t, body.Result, 1, "expected one database in post upgrade response")
+	//resp = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade", "")
+	//rest.RequireStatus(t, resp, http.StatusOK)
+	//var body rest.PostUpgradeResponse
+	//err := base.JSONUnmarshal(resp.BodyBytes(), &body)
+	//require.NoError(t, err)
+	//require.Lenf(t, body.Result, 1, "expected one database in post upgrade response")
 	//require.Lenf(t, body.Result[dbName].RemovedIndexes, 2, "expected two indexes to be removed")
 }
 

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -188,6 +188,11 @@ func TestChangeIndexPartitionsErrors(t *testing.T) {
 			expectedError: `action "invalid" not supported... must be either 'start' or 'stop'`,
 		},
 		{
+			name:          "invalid num_partitions",
+			body:          `{"num_partitions":0}`,
+			expectedError: `num_partitions must be greater than 0`,
+		},
+		{
 			name:          "bad json",
 			body:          `{num_partitions:2}`,
 			expectedError: `Bad JSON: invalid character 'n' looking for beginning of object key string`,
@@ -224,6 +229,24 @@ func TestChangeIndexPartitionsSameNumber(t *testing.T) {
 	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":2}`)
 	rest.RequireStatus(t, resp, http.StatusBadRequest)
 	rest.AssertHTTPErrorReason(t, resp, http.StatusBadRequest, "num_partitions is already 2")
+}
+
+func TestChangeIndexPartitionsStartAndStop(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
+		t.Skip("This test only works against Couchbase Server with GSI enabled")
+	}
+
+	// requires index init
+	base.LongRunningTest(t)
+
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{Index: &rest.IndexConfig{NumPartitions: base.Ptr(uint32(2))}}}})
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":2}`)
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init?action=stop", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
 }
 
 func TestChangeIndexPartitionsWithViews(t *testing.T) {

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -32,11 +32,12 @@ import (
 //  4. Ensure the database starts up using the indexes created in step 2 without any delay.
 //  5. Use the _post_upgrade endpoint to clean up the old set of indexes.
 func TestChangeIndexPartitions(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
+		t.Skip("This test only works against Couchbase Server with GSI enabled")
 	}
-	require.False(t, base.TestsDisableGSI(), "Test requires GSI to be enabled")
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig, base.KeyQuery)
+
 	const (
 		dbName            = "db"
 		initialPartitions = uint32(2)

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -1,0 +1,116 @@
+package indextest
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChangeIndexPartitions ensures that users can change the number of partitions without any downtime using the documented steps.
+//  1. Have a database already running with an undesired number of partitions.
+//  2. Use Index Init API to initialize a new set of indexes with different partitions.
+//  3. Use the regular db config API to change the number of partitions to match the set created.
+//  4. Ensure the database starts up using the indexes created in step 2 without any delay.
+//  5. Use the _post_upgrade endpoint to clean up the old set of indexes.
+func TestChangeIndexPartitions(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig, base.KeyQuery)
+	require.False(t, base.TestsDisableGSI(), "Test requires GSI to be enabled")
+	const (
+		dbName            = "db"
+		initialPartitions = uint32(2)
+		newPartitions     = uint32(4)
+	)
+
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.Index.NumPartitions = base.Ptr(initialPartitions)
+	rest.RequireStatus(t, rt.CreateDatabase(dbName, dbConfig), http.StatusCreated)
+
+	database := rt.GetDatabase()
+	assertNumSGIndexPartitions(t, database)
+
+	// init new indexes with different partitions
+	resp := rt.SendAdminRequest(http.MethodPost, fmt.Sprintf("/%s/_index_init", dbName), fmt.Sprintf(`{"num_partitions":%d}`, newPartitions))
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	// wait for indexes to be ready using init api
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/%s/_index_init", dbName), "")
+		rest.AssertStatus(t, resp, http.StatusOK)
+		var body db.AsyncIndexInitManagerResponse
+		err := base.JSONUnmarshal(resp.BodyBytes(), &body)
+		require.NoError(c, err)
+		require.Empty(c, body.LastErrorMessage)
+		require.Equal(c, db.BackgroundProcessStateCompleted, body.State)
+		require.GreaterOrEqual(c, len(body.IndexStatus), 1, "expected at least one scope (maybe two if `_default` plu a named scope)")
+		require.LessOrEqual(c, len(body.IndexStatus), 2, "expected at most two scopes (maybe one if `_default` only)")
+		for _, collections := range body.IndexStatus {
+			for _, status := range collections {
+				assert.Equal(c, "ready", status)
+			}
+		}
+	}, 10*time.Second, 1*time.Second)
+	assertNumSGIndexPartitions(t, database)
+
+	// update db config - shouldn't create indexes at this point since they already exist
+	dbConfig.Index.NumPartitions = base.Ptr(newPartitions)
+	rt.UpsertDbConfig(dbName, dbConfig)
+	// TODO: stat to check if we tried rebuilding the indexes?
+
+	// cleanup old indexes
+	resp = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	var body rest.PostUpgradeResponse
+	err := base.JSONUnmarshal(resp.BodyBytes(), &body)
+	require.NoError(t, err)
+	require.Lenf(t, body.Result, 1, "expected one database in post upgrade response")
+	//require.Lenf(t, body.Result[dbName].RemovedIndexes, 2, "expected two indexes to be removed")
+}
+
+// assertNumSGIndexPartitions ensures that the number of partitions for SG indexes is as expected. Some indexes aren't partitioned.
+func assertNumSGIndexPartitions(t testing.TB, database *db.DatabaseContext) {
+	gocbBucket, err := base.AsGocbV2Bucket(database.Bucket)
+	require.NoError(t, err)
+	for _, dsName := range []sgbucket.DataStoreName{db.GetSingleDatabaseCollection(t, database).GetCollectionDatastore(), database.MetadataStore} {
+		allIndexes, err := gocbBucket.GetCluster().Bucket(gocbBucket.BucketName()).Scope(dsName.ScopeName()).Collection(dsName.CollectionName()).QueryIndexes().GetAllIndexes(nil)
+		require.NoError(t, err)
+		require.Greaterf(t, len(allIndexes), 0, "expected at least one index for datastore %s", dsName)
+		for _, index := range allIndexes {
+			if !strings.HasPrefix(index.Name, "sg_") {
+				t.Logf("skipping non-SG index %s", index.Name)
+				continue
+			}
+			// only two SG indexes are partitioned currently
+			re, err := regexp.Compile(`sg_(?:allDocs|channels)_x1(?:_p(\d+))?$`)
+			require.NoError(t, err)
+			partitionsFromNameStrs := re.FindStringSubmatch(index.Name)
+			if len(partitionsFromNameStrs) > 1 {
+				expectedPartitionsFromName, err := strconv.ParseInt(partitionsFromNameStrs[1], 10, 64)
+				require.NoError(t, err)
+				require.Greaterf(t, int(expectedPartitionsFromName), 1, "expected at least one partition for %s", index.Name)
+				assert.NotEqualf(t, "", index.Partition, "expected partition clause for %s", index.Name)
+				assert.Equal(t, int(expectedPartitionsFromName), int(db.GetIndexPartitionCount(t, gocbBucket, dsName, index.Name)))
+			} else {
+				assert.Equal(t, "", index.Partition)
+				assert.True(t, strings.HasSuffix(index.Name, "_x1"), "expected no partitions for %+v", index)
+				assert.Equal(t, 1, int(db.GetIndexPartitionCount(t, gocbBucket, dsName, index.Name)))
+			}
+		}
+	}
+}

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -39,6 +39,8 @@ func TestChangeIndexPartitions(t *testing.T) {
 	// requires index init for many subtests
 	base.LongRunningTest(t)
 
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyQuery, base.KeyHTTP)
+
 	const (
 		dbName = "db"
 	)
@@ -131,10 +133,9 @@ func TestChangeIndexPartitions(t *testing.T) {
 				dbConfig.Index = &rest.IndexConfig{}
 			}
 			dbConfig.Index.NumPartitions = base.Ptr(test.newPartitions)
-			t.Logf("dbconfig: %+v", dbConfig)
 			rest.RequireStatus(t, rt.ReplaceDbConfig(dbName, dbConfig), http.StatusCreated)
 
-			// cleanup old indexes
+			// CBG-4565 cleanup old indexes
 			//resp = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade", "")
 			//rest.RequireStatus(t, resp, http.StatusOK)
 			//var body rest.PostUpgradeResponse

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -132,8 +132,8 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
-		if status != rest.CollectionIndexStatusReady {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		count := atomic.AddInt64(&collectionCount, 1)
@@ -271,8 +271,8 @@ func TestAsyncInitWithResync(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
-		if status != rest.CollectionIndexStatusReady {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		count := atomic.AddInt64(&collectionCount, 1)
@@ -354,8 +354,8 @@ func TestAsyncOnlineOffline(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
-		if status != rest.CollectionIndexStatusReady {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		count := atomic.AddInt64(&collectionCount, 1)
@@ -475,8 +475,8 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
-		if status != rest.CollectionIndexStatusReady {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		count := atomic.AddInt64(&collectionCount, 1)
@@ -625,8 +625,8 @@ func TestAsyncInitConfigUpdates(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
-		if status != rest.CollectionIndexStatusReady {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		count := atomic.AddInt64(&collectionCount, 1)
@@ -742,8 +742,8 @@ func TestAsyncInitRemoteConfigUpdates(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
-		if status != rest.CollectionIndexStatusReady {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
+		if status != db.CollectionIndexStatusReady {
 			return
 		}
 		count := atomic.AddInt64(&collectionCount, 1)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -132,7 +132,10 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(dbName, collectionName string) {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
+		if status != rest.CollectionIndexStatusReady {
+			return
+		}
 		count := atomic.AddInt64(&collectionCount, 1)
 		// On first collection, close initStarted channel
 		log.Printf("collection callback count: %v", count)
@@ -142,7 +145,7 @@ func TestAsyncInitializeIndexes(t *testing.T) {
 		}
 		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
 	}
-	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 
 	ctx := base.TestCtx(t)
 	// Get a test bucket, and use it to create the database.
@@ -268,7 +271,10 @@ func TestAsyncInitWithResync(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(dbName, collectionName string) {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
+		if status != rest.CollectionIndexStatusReady {
+			return
+		}
 		count := atomic.AddInt64(&collectionCount, 1)
 		// On first collection, close initStarted channel
 		log.Printf("collection callback count: %v", count)
@@ -278,7 +284,7 @@ func TestAsyncInitWithResync(t *testing.T) {
 		}
 		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
 	}
-	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 	// Recreate the database with offline=true and a modified sync function
 	syncFunc = "function(doc){ channel(doc.channel2);}"
 	dbConfig = makeDbConfig(t, tb, syncFunc, "")
@@ -348,7 +354,10 @@ func TestAsyncOnlineOffline(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(dbName, collectionName string) {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
+		if status != rest.CollectionIndexStatusReady {
+			return
+		}
 		count := atomic.AddInt64(&collectionCount, 1)
 		// On first collection, close initStarted channel
 		log.Printf("collection callback count: %v", count)
@@ -358,7 +367,7 @@ func TestAsyncOnlineOffline(t *testing.T) {
 		}
 		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
 	}
-	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 
 	ctx := base.TestCtx(t)
 	// Get a test bucket, and use it to create the database.
@@ -466,7 +475,10 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(dbName, collectionName string) {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
+		if status != rest.CollectionIndexStatusReady {
+			return
+		}
 		count := atomic.AddInt64(&collectionCount, 1)
 		// On first collection, close initStarted channel
 		log.Printf("collection callback count: %v", count)
@@ -485,7 +497,7 @@ func TestAsyncCreateThenDelete(t *testing.T) {
 			close(firstDatabaseComplete)
 		}
 	}
-	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, databaseCompleteCallback)
+	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, databaseCompleteCallback)
 
 	ctx := base.TestCtx(t)
 	// Get a test bucket, and use it to create the database.
@@ -613,7 +625,10 @@ func TestAsyncInitConfigUpdates(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(dbName, collectionName string) {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
+		if status != rest.CollectionIndexStatusReady {
+			return
+		}
 		count := atomic.AddInt64(&collectionCount, 1)
 		// On first collection, close initStarted channel
 		log.Printf("collection callback count: %v", count)
@@ -623,7 +638,7 @@ func TestAsyncInitConfigUpdates(t *testing.T) {
 		}
 		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
 	}
-	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 
 	ctx := base.TestCtx(t)
 	// Get a test bucket, and use it to create the database.
@@ -727,7 +742,10 @@ func TestAsyncInitRemoteConfigUpdates(t *testing.T) {
 	collectionCount := int64(0)
 	initStarted := make(chan error)
 	unblockInit := make(chan error)
-	collectionCompleteCallback := func(dbName, collectionName string) {
+	collectionCompleteCallback := func(_ string, _ base.ScopeAndCollectionName, status rest.CollectionIndexStatus) {
+		if status != rest.CollectionIndexStatusReady {
+			return
+		}
 		count := atomic.AddInt64(&collectionCount, 1)
 		// On first collection, close initStarted channel
 		log.Printf("collection callback count: %v", count)
@@ -737,7 +755,7 @@ func TestAsyncInitRemoteConfigUpdates(t *testing.T) {
 		}
 		rest.WaitForChannel(t, unblockInit, "waiting for test to unblock initialization")
 	}
-	sc.DatabaseInitManager.SetCallbacks(collectionCompleteCallback, nil)
+	sc.DatabaseInitManager.SetTestCallbacks(collectionCompleteCallback, nil)
 
 	ctx := base.TestCtx(t)
 	// Get a test bucket, and use it to create the database.

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -249,6 +249,11 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	dbr.Handle("/_repair",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleRepair)).Methods("POST")
 
+	dbr.Handle("/_index_init",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetIndexInit)).Methods("GET")
+	dbr.Handle("/_index_init",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePostIndexInit)).Methods("POST")
+
 	r.Handle("/_logging",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetLogging)).Methods("GET")
 	r.Handle("/_logging",

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -250,9 +250,9 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleRepair)).Methods("POST")
 
 	dbr.Handle("/_index_init",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetIndexInit)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetIndexInit)).Methods("GET")
 	dbr.Handle("/_index_init",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePostIndexInit)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePostIndexInit)).Methods("POST")
 
 	r.Handle("/_logging",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetLogging)).Methods("GET")

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -677,7 +677,7 @@ func TestServerlessUnsuspendAdminAuth(t *testing.T) {
 
 	// Attempt to get DB that does not exist
 	resp = rt.SendAdminRequestWithAuth(http.MethodGet, "/invaliddb/doc", "", base.TestClusterUsername(), base.TestClusterPassword())
-	assertHTTPErrorReason(t, resp, http.StatusForbidden, "")
+	AssertHTTPErrorReason(t, resp, http.StatusForbidden, "")
 }
 
 func TestImportPartitionsServerless(t *testing.T) {

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -397,7 +397,7 @@ func TestSyncFnTimeout(t *testing.T) {
 	syncFnFinishedWG.Add(1)
 	go func() {
 		response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/doc", `{"foo": "bar"}`)
-		assertHTTPErrorReason(t, response, 500, "JS sync function timed out")
+		AssertHTTPErrorReason(t, response, 500, "JS sync function timed out")
 		syncFnFinishedWG.Done()
 	}()
 	timeoutErr := WaitWithTimeout(&syncFnFinishedWG, time.Second*15)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -150,12 +150,18 @@ func NewRestTester(tb testing.TB, restConfig *RestTesterConfig) *RestTester {
 	return newRestTester(tb, restConfig, useSingleCollection, 1)
 }
 
-// NewRestTesterPersistentConfig returns a rest tester with persistent config setup and a single database. A convenience function for NewRestTester.
-func NewRestTesterPersistentConfig(tb testing.TB) *RestTester {
+// NewRestTesterPersistentConfigNoDB returns a rest tester with persistent config setup and no database. A convenience function for NewRestTester.
+func NewRestTesterPersistentConfigNoDB(tb testing.TB) *RestTester {
 	config := &RestTesterConfig{
 		PersistentConfig: true,
 	}
 	rt := newRestTester(tb, config, useSingleCollection, 1)
+	return rt
+}
+
+// NewRestTesterPersistentConfig returns a rest tester with persistent config setup and a single database. A convenience function for NewRestTester.
+func NewRestTesterPersistentConfig(tb testing.TB) *RestTester {
+	rt := NewRestTesterPersistentConfigNoDB(tb)
 	RequireStatus(tb, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 	return rt
 }


### PR DESCRIPTION
CBG-4587

Add async index init REST API to allow partitioned index creation without downtime
- `GET`/`POST` `/db/_index_init`
- Supports cross-node start/stop and status reporting with the `AsyncIndexInitManager` wrapper
- Uses the existing `DatabaseInitManager` to integrate with existing index init code and support index creation request deduplication
- Index creation states can be one of `queued`, `in progress`, `ready`, `error`
- No `/_post_upgrade` cleanup support yet - will be in a follow-up ticket/PR
- "E2E" type test that covers the expected and documented user steps to do a no-downtime migration to partitioned indexes

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3047/
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3064/
