### PR TITLE
CBG-4497 centralize blip correlation ids

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -220,7 +220,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	cancelCtx, cancelFunc := context.WithCancel(context.WithoutCancel(ctx)) // separate cancel context from parent cancel context
 
 	var originPatterns []string // no origin headers for ISGR
-	blipContext, err := NewSGBlipContext(ctx, arc.config.ID+idSuffix, originPatterns, cancelCtx)
+	ctx, blipContext, err := NewSGBlipContext(ctx, arc.config.ID+idSuffix, originPatterns, cancelCtx)
 	if err != nil {
 		cancelFunc()
 		return nil, nil, err

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -204,12 +204,23 @@ func (ar *ActiveReplicator) GetStatus(ctx context.Context) *ReplicationStatus {
 	return status
 }
 
+// connect establishes a blip connection to a remote host.
 func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sender, bsc *BlipSyncContext, err error) {
 	arc.replicationStats.NumConnectAttempts.Add(1)
 
+	ctx := base.CorrelationIDLogCtx(
+		arc.config.ActiveDB.AddDatabaseLogContext(base.NewNonCancelCtx().Ctx),
+		arc.config.ID+idSuffix)
+	if arc.config.RunAs != "" {
+		ctx = base.UserLogCtx(ctx, arc.config.RunAs, base.UserDomainSyncGateway, nil)
+	} else {
+		ctx = arc.config.ActiveDB.AddBucketUserLogContext(ctx)
+	}
+
+	cancelCtx, cancelFunc := context.WithCancel(context.WithoutCancel(ctx)) // separate cancel context from parent cancel context
+
 	var originPatterns []string // no origin headers for ISGR
-	cancelCtx, cancelFunc := context.WithCancel(context.Background())
-	blipContext, err := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix, originPatterns, cancelCtx)
+	blipContext, err := NewSGBlipContext(ctx, arc.config.ID+idSuffix, originPatterns, cancelCtx)
 	if err != nil {
 		cancelFunc()
 		return nil, nil, err
@@ -217,23 +228,14 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
 	blipContext.OnExitCallback = func() {
 		// fall into a reconnect loop only if the connection is unexpectedly closed.
-		if arc.ctx.Err() == nil {
+		if ctx.Err() == nil {
 			arc.reconnect()
 		}
 	}
 
-	bsc, err = NewBlipSyncContext(arc.ctx, blipContext, arc.config.ActiveDB, blipContext.ID, arc.replicationStats, cancelFunc)
+	bsc, err = NewBlipSyncContext(ctx, blipContext, arc.config.ActiveDB, arc.replicationStats, cancelFunc)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	bsc.loggingCtx = base.CorrelationIDLogCtx(
-		arc.config.ActiveDB.AddDatabaseLogContext(base.NewNonCancelCtx().Ctx),
-		arc.config.ID+idSuffix)
-	if arc.config.RunAs != "" {
-		bsc.loggingCtx = base.UserLogCtx(bsc.loggingCtx, arc.config.RunAs, base.UserDomainSyncGateway, nil)
-	} else {
-		bsc.loggingCtx = arc.config.ActiveDB.AddBucketUserLogContext(bsc.loggingCtx)
 	}
 
 	// NewBlipSyncContext has already set deltas as disabled/enabled based on config.ActiveDB.

--- a/db/active_replicator_test.go
+++ b/db/active_replicator_test.go
@@ -65,7 +65,7 @@ func TestBlipSyncErrorUserinfo(t *testing.T) {
 			srvURL.Path = "/db1"
 			t.Logf("srvURL: %v", srvURL.String())
 
-			blipContext, err := NewSGBlipContext(base.TestCtx(t), t.Name(), nil, nil)
+			_, blipContext, err := NewSGBlipContext(base.TestCtx(t), t.Name(), nil, nil)
 			require.NoError(t, err)
 
 			_, err = blipSync(*srvURL, blipContext, false)

--- a/db/blip.go
+++ b/db/blip.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strings"
 

--- a/db/blip.go
+++ b/db/blip.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -35,29 +36,39 @@ var (
 	badFilenames = regexp.MustCompile(`(?i)\.(zip|t?gz|rar|7z|jpe?g|png|gif|svgz|mp3|m4a|ogg|wav|aiff|mp4|mov|avi|theora)$`)
 )
 
-// NewSGBlipContext returns a go-blip context with the given ID, initialized for use in Sync Gateway.
-func NewSGBlipContext(ctx context.Context, id string, origin []string, cancelCtx context.Context) (bc *blip.Context, err error) {
+// NewSGBlipContext returns a go-blip context with the given ID, initialized for use in Sync Gateway. Returns a new context updating the correlation ID.
+func NewSGBlipContext(ctx context.Context, id string, origin []string, cancelCtx context.Context) (context.Context, *blip.Context, error) {
 	return NewSGBlipContextWithProtocols(ctx, id, origin, supportedSubprotocols(), cancelCtx)
 }
 
-func NewSGBlipContextWithProtocols(ctx context.Context, id string, origin []string, protocols []string, cancelCtx context.Context) (bc *blip.Context, err error) {
+// NewSGBlipContextWithProtocols returns a go-blip context with the given ID, initialized for use in Sync Gateway allowing specification of custom protocols. Returns a new context updating the correlation ID.
+func NewSGBlipContextWithProtocols(ctx context.Context, id string, origin []string, protocols []string, cancelCtx context.Context) (context.Context, *blip.Context, error) {
 	opts := blip.ContextOptions{
 		Origin:      origin,
 		ProtocolIds: protocols,
 		CancelCtx:   cancelCtx,
 	}
+	// for backwards compatibility, the correlation ID is formatted slightly differently:
+	// - /ks/_blipsync uses a correlation id like c:[1234] since id == ""
+	// - active replicator code uses a correlation id like but the active replicator uses an id like c:replname-pull
+	var bc *blip.Context
+	var err error
 	if id == "" {
 		bc, err = blip.NewContext(opts)
+		fmt.Printf("HONK base.FormatBlipContextID(bc.ID) %s\n", base.FormatBlipContextID(bc.ID))
+		ctx = base.CorrelationIDLogCtx(ctx, base.FormatBlipContextID(bc.ID))
 	} else {
 		bc, err = blip.NewContextCustomID(id, opts)
+		ctx = base.CorrelationIDLogCtx(ctx, bc.ID)
 	}
-	ctx = base.CorrelationIDLogCtx(ctx, bc.ID)
-
+	if err != nil {
+		return nil, nil, err
+	}
 	bc.LogMessages = base.LogTraceEnabled(ctx, base.KeyWebSocket)
 	bc.LogFrames = base.LogTraceEnabled(ctx, base.KeyWebSocketFrame)
 	bc.Logger = defaultBlipLogger(ctx)
 
-	return bc, err
+	return ctx, bc, nil
 }
 
 // defaultBlipLogger returns a function that can be set as the blip.Context.Logger for Sync Gateway integrated go-blip logging.

--- a/db/blip.go
+++ b/db/blip.go
@@ -51,6 +51,7 @@ func NewSGBlipContextWithProtocols(ctx context.Context, id string, origin []stri
 	} else {
 		bc, err = blip.NewContextCustomID(id, opts)
 	}
+	ctx = base.CorrelationIDLogCtx(ctx, bc.ID)
 
 	bc.LogMessages = base.LogTraceEnabled(ctx, base.KeyWebSocket)
 	bc.LogFrames = base.LogTraceEnabled(ctx, base.KeyWebSocketFrame)

--- a/db/blip.go
+++ b/db/blip.go
@@ -55,7 +55,6 @@ func NewSGBlipContextWithProtocols(ctx context.Context, id string, origin []stri
 	var err error
 	if id == "" {
 		bc, err = blip.NewContext(opts)
-		fmt.Printf("HONK base.FormatBlipContextID(bc.ID) %s\n", base.FormatBlipContextID(bc.ID))
 		ctx = base.CorrelationIDLogCtx(ctx, base.FormatBlipContextID(bc.ID))
 	} else {
 		bc, err = blip.NewContextCustomID(id, opts)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -36,8 +36,6 @@ var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 
 // NewBlipSyncContext creates a new BlipSyncContext for a given database and register the handlers. This does not make a connection.
 func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, replicationStats *BlipSyncStats, ctxCancelFunc context.CancelFunc) (*BlipSyncContext, error) {
-	// reset ctx to contain correlation id from blip
-	ctx = base.CorrelationIDLogCtx(ctx, bc.ID)
 	if ctxCancelFunc == nil {
 		return nil, errors.New("cancelCtxFunc is required")
 	}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -34,7 +34,10 @@ const (
 
 var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 
-func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, contextID string, replicationStats *BlipSyncStats, ctxCancelFunc context.CancelFunc) (*BlipSyncContext, error) {
+// NewBlipSyncContext creates a new BlipSyncContext for a given database and register the handlers. This does not make a connection.
+func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, replicationStats *BlipSyncStats, ctxCancelFunc context.CancelFunc) (*BlipSyncContext, error) {
+	// reset ctx to contain correlation id from blip
+	ctx = base.CorrelationIDLogCtx(ctx, bc.ID)
 	if ctxCancelFunc == nil {
 		return nil, errors.New("cancelCtxFunc is required")
 	}
@@ -46,7 +49,6 @@ func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, con
 	if db.Options.MaxConcurrentRevs != nil {
 		maxInFlightRevs = *db.Options.MaxConcurrentRevs
 	}
-
 	bsc := &BlipSyncContext{
 		blipContext:             bc,
 		blipContextDb:           db,
@@ -76,7 +78,7 @@ func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, con
 	// Register default handlers
 	bc.DefaultHandler = bsc.NotFoundHandler
 	bc.FatalErrorHandler = func(err error) {
-		base.InfofCtx(ctx, base.KeyHTTP, "%s:     --> BLIP+WebSocket connection error: %v", contextID, err)
+		base.InfofCtx(ctx, base.KeyHTTP, "%s:     --> BLIP+WebSocket connection error: %v", bc.ID, err)
 	}
 
 	// Register 2.x replicator handlers
@@ -84,7 +86,7 @@ func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, con
 		bsc.register(profile, handlerFn)
 	}
 
-	if db.Options.UnsupportedOptions.ConnectedClient {
+	if db.Options.UnsupportedOptions != nil && db.Options.UnsupportedOptions.ConnectedClient {
 		// Register Connected Client handlers
 		for profile, handlerFn := range kConnectedClientHandlersByProfile {
 			bsc.register(profile, handlerFn)

--- a/db/blip_test.go
+++ b/db/blip_test.go
@@ -41,12 +41,12 @@ func TestBlipCorrelationID(t *testing.T) {
 			if !explicitTestID {
 				testID = ""
 			}
-			bc, err := NewSGBlipContext(ctx, testID, nil, nil)
+			ctx, bc, err := NewSGBlipContext(ctx, testID, nil, nil)
 			require.NoError(t, err)
 			if !explicitTestID {
 				require.NotEqual(t, testID, bc.ID)
 				require.NotEmpty(t, bc.ID)
-				testID = bc.ID
+				testID = "[" + bc.ID + "]"
 			}
 			base.AssertLogContains(t, "c:"+testID, func() {
 				bc.Logger(blip.LogGeneral, "Sample log message")

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -63,7 +63,7 @@ func (h *handler) handleBLIPSync() error {
 	h.rqCtx = base.CorrelationIDLogCtx(h.ctx(), base.FormatBlipContextID(blipContext.ID))
 	h.response.Header().Set(db.BLIPCorrelationIDResponseHeader, blipContext.ID)
 	// Create a new BlipSyncContext attached to the given blipContext.
-	ctx, err := db.NewBlipSyncContext(h.rqCtx, blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats), cancelCtxFunc)
+	ctx, err := db.NewBlipSyncContext(h.rqCtx, blipContext, h.db, db.BlipSyncStatsForCBL(h.db.DbStats), cancelCtxFunc)
 	if err != nil {
 		return err
 	}

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -53,7 +53,7 @@ func (h *handler) handleBLIPSync() error {
 
 	cancelCtx, cancelCtxFunc := context.WithCancel(h.db.DatabaseContext.CancelContext)
 	// Create a BLIP context:
-	blipContext, err := db.NewSGBlipContext(h.ctx(), "", originPatterns, cancelCtx)
+	ctx, blipContext, err := db.NewSGBlipContext(h.ctx(), "", originPatterns, cancelCtx)
 	if err != nil {
 		cancelCtxFunc()
 		return err
@@ -63,19 +63,19 @@ func (h *handler) handleBLIPSync() error {
 	h.rqCtx = base.CorrelationIDLogCtx(h.ctx(), base.FormatBlipContextID(blipContext.ID))
 	h.response.Header().Set(db.BLIPCorrelationIDResponseHeader, blipContext.ID)
 	// Create a new BlipSyncContext attached to the given blipContext.
-	ctx, err := db.NewBlipSyncContext(h.rqCtx, blipContext, h.db, db.BlipSyncStatsForCBL(h.db.DbStats), cancelCtxFunc)
+	bsc, err := db.NewBlipSyncContext(ctx, blipContext, h.db, db.BlipSyncStatsForCBL(h.db.DbStats), cancelCtxFunc)
 	if err != nil {
 		return err
 	}
-	defer ctx.Close()
+	defer bsc.Close()
 
 	auditFields := base.AuditFields{base.AuditFieldReplicationID: base.FormatBlipContextID(blipContext.ID)}
 	if string(db.BLIPClientTypeSGR2) == h.getQuery(db.BLIPSyncClientTypeQueryParam) {
-		ctx.SetClientType(db.BLIPClientTypeSGR2)
+		bsc.SetClientType(db.BLIPClientTypeSGR2)
 		auditFields["client_type"] = db.BLIPClientTypeSGR2
 	} else {
 		// we could pull the exact CBL client and version from User-Agent
-		ctx.SetClientType(db.BLIPClientTypeCBL2)
+		bsc.SetClientType(db.BLIPClientTypeCBL2)
 		auditFields["client_type"] = db.BLIPClientTypeCBL2
 	}
 	base.Audit(h.rqCtx, base.AuditIDReplicationConnect, auditFields)
@@ -94,7 +94,7 @@ func (h *handler) handleBLIPSync() error {
 		// ActiveSubprotocol only available after handshake via ServeHTTP(), so have to get go-blip to invoke callback between handshake and serving BLIP messages
 		subprotocol := blipContext.ActiveSubprotocol()
 		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s%s", blipContext.ID, blip.WebSocketSubProtocolPrefix, subprotocol, h.formattedEffectiveUserName()))
-		err = ctx.SetActiveCBMobileSubprotocol(subprotocol)
+		err = bsc.SetActiveCBMobileSubprotocol(subprotocol)
 		if err != nil {
 			base.WarnfCtx(h.ctx(), "Couldn't set active CB Mobile Subprotocol: %v", err)
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1499,7 +1499,7 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 	}
 	// Make BLIP/Websocket connection.  Not specifying cancellation context here as this is a
 	// client blip context that doesn't require cancellation-based close
-	bt.blipContext, err = db.NewSGBlipContextWithProtocols(base.TestCtx(tb), "", origin, protocols, nil)
+	_, bt.blipContext, err = db.NewSGBlipContextWithProtocols(base.TestCtx(tb), "", origin, protocols, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CBG-4497 centralize blip correlation ids

Force assignment of blip correlation IDs to match the blip context for _blipsync and ISGR. The important change is in `NewSGBlipContextWithProtocols` to have `bc.Logger = defaultBlipLogger(ctx)` use the right correlation id.

ISGR and _blipsync did reset the context on `BlipSyncContext` after its construction, but this seems confusing and error prone, so I just forced setting the correlation id in `NewBlipSyncContext` constructor. I could leave the this part of the code alone and just do the change in `NewSGBlipContextWithProtocols`
  
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3063/
