### PR TITLE
CBG-4614 Add toggle for using separate principal indexes

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -431,30 +431,6 @@ func TestGetRemovedAsUser(t *testing.T) {
 	assertHTTPError(t, err, 404)
 }
 
-func TestIsServerless(t *testing.T) {
-	testCases := []struct {
-		title      string
-		serverless bool
-	}{
-		{
-			serverless: true,
-		},
-		{
-			serverless: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(fmt.Sprintf("TestIsServerless with Serverless=%t", testCase.serverless), func(t *testing.T) {
-			db, ctx := setupTestDB(t)
-			defer db.Close(ctx)
-
-			db.Options.Serverless = testCase.serverless
-			assert.Equal(t, testCase.serverless, db.IsServerless())
-		})
-	}
-}
-
 // Test removal handling for unavailable multi-channel revisions.
 func TestGetRemovalMultiChannel(t *testing.T) {
 	db, ctx := setupTestDB(t)

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -141,8 +141,8 @@ var (
 		IndexChannels:   IdxFlagIndexTombstones,
 		IndexAllDocs:    IdxFlagIndexTombstones,
 		IndexSyncDocs:   IdxFlagMetadataOnly | IdxFlagPrincipalDocsOnly,
-		IndexUser:       IdxFlagMetadataOnly,
-		IndexRole:       IdxFlagMetadataOnly,
+		IndexUser:       IdxFlagMetadataOnly | IdxFlagPrincipalDocsOnly,
+		IndexRole:       IdxFlagMetadataOnly | IdxFlagPrincipalDocsOnly,
 		IndexTombstones: IdxFlagXattrOnly | IdxFlagIndexTombstones,
 	}
 
@@ -261,7 +261,7 @@ func (i *SGIndex) isXattrOnly() bool {
 	return i.flags&IdxFlagXattrOnly != 0
 }
 
-// shouldCreate returns if given index should be created based on Serverless mode
+// shouldCreate returns if given index should be created.
 func (i *SGIndex) shouldCreate(options InitializeIndexOptions) bool {
 	if options.LegacySyncDocsIndex {
 		if i.creationMode == SeparatePrincipalIndexes {

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -232,6 +232,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 			NumReplicas:         0,
 			LegacySyncDocsIndex: db.UseLegacySyncDocsIndex(),
 			UseXattrs:           base.TestUseXattrs(),
+			NumPartitions:       DefaultNumIndexPartitions,
 		}
 		if db.OnlyDefaultCollection() {
 			options.MetadataIndexes = IndexesAll

--- a/db/indextest/util.go
+++ b/db/indextest/util.go
@@ -24,7 +24,6 @@ func getDatabaseContextOptions(useLegacySyncDocsIndex bool) db.DatabaseContextOp
 	return db.DatabaseContextOptions{
 		CacheOptions:           &defaultCacheOptions,
 		UseLegacySyncDocsIndex: useLegacySyncDocsIndex,
-		Serverless:             !useLegacySyncDocsIndex, // after CBG-4614, this flag will not be used
 	}
 }
 

--- a/db/query.go
+++ b/db/query.go
@@ -599,7 +599,7 @@ func (context *DatabaseContext) QueryUsers(ctx context.Context, startKey string,
 // query is covering.
 func (context *DatabaseContext) BuildUsersQuery(startKey string, limit int) (string, map[string]interface{}) {
 	var queryStatement string
-	if context.IsServerless() {
+	if !context.UseLegacySyncDocsIndex() {
 		queryStatement = replaceIndexTokensQuery(QueryUsers.statement, sgIndexes[IndexUser], context.UseXattrs(), context.numIndexPartitions())
 	} else {
 		queryStatement = replaceIndexTokensQuery(QueryUsersUsingSyncDocsIdx.statement, sgIndexes[IndexSyncDocs], context.UseXattrs(), context.numIndexPartitions())
@@ -643,7 +643,7 @@ func (context *DatabaseContext) QueryRoles(ctx context.Context, startKey string,
 func (context *DatabaseContext) BuildRolesQuery(startKey string, limit int) (string, map[string]interface{}) {
 
 	var queryStatement string
-	if context.IsServerless() {
+	if !context.UseLegacySyncDocsIndex() {
 		queryStatement = replaceIndexTokensQuery(QueryRolesExcludeDeletedUsingRoleIdx.statement, sgIndexes[IndexRole], context.UseXattrs(), context.numIndexPartitions())
 	} else {
 		queryStatement = replaceIndexTokensQuery(QueryRolesExcludeDeleted.statement, sgIndexes[IndexSyncDocs], context.UseXattrs(), context.numIndexPartitions())
@@ -668,7 +668,7 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 	}
 
 	var queryStatement string
-	if context.IsServerless() {
+	if !context.UseLegacySyncDocsIndex() {
 		queryStatement = replaceIndexTokensQuery(QueryAllRolesUsingRoleIdx.statement, sgIndexes[IndexRole], context.UseXattrs(), context.numIndexPartitions())
 	} else {
 		queryStatement = replaceIndexTokensQuery(QueryAllRolesUsingSyncDocsIdx.statement, sgIndexes[IndexSyncDocs], context.UseXattrs(), context.numIndexPartitions())

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -375,7 +375,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			UseXattrs:                  base.TestUseXattrs(),
 			NumReplicas:                0,
 			WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
-			LegacySyncDocsIndex:        true, // Change in CBG-4614
+			LegacySyncDocsIndex:        false, // Change in CBG-4614
 			MetadataIndexes:            IndexesWithoutMetadata,
 			NumPartitions:              DefaultNumIndexPartitions,
 		}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -375,7 +375,7 @@ var viewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 			UseXattrs:                  base.TestUseXattrs(),
 			NumReplicas:                0,
 			WaitForIndexesOnlineOption: base.WaitForIndexesDefault,
-			LegacySyncDocsIndex:        false, // Change in CBG-4614
+			LegacySyncDocsIndex:        false,
 			MetadataIndexes:            IndexesWithoutMetadata,
 			NumPartitions:              DefaultNumIndexPartitions,
 		}

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -62,19 +62,33 @@ func TestSyncGatewayStartupIndexes(t *testing.T) {
 		// use example indexes to make sure metadata and non metadata are created
 		indexSyncDocs := "sg_syncDocs"
 		indexAccess := "sg_access"
+		indexRoles := "sg_roles"
+		indexUsers := "sg_users"
 		if base.TestUseXattrs() {
 			indexSyncDocs += "_x1"
 			indexAccess += "_x1"
+			indexRoles += "_x1"
+			indexUsers += "_x1"
 		} else {
 			indexSyncDocs += "_1"
 			indexAccess += "_1"
+			indexRoles += "_1"
+			indexUsers += "_1"
 		}
 		metadataCollection, err := base.AsCollection(bucket.DefaultDataStore())
 		require.NoError(t, err)
 		indexNames, err := metadataCollection.GetIndexes()
 		require.NoError(t, err)
 
-		require.Contains(t, indexNames, indexSyncDocs)
+		if rt.GetDatabase().UseLegacySyncDocsIndex() {
+			require.Contains(t, indexNames, indexSyncDocs)
+			require.NotContains(t, indexNames, indexRoles)
+			require.NotContains(t, indexNames, indexUsers)
+		} else {
+			require.NotContains(t, indexNames, indexSyncDocs)
+			require.Contains(t, indexNames, indexRoles)
+			require.Contains(t, indexNames, indexUsers)
+		}
 
 		if base.TestsUseNamedCollections() {
 			require.NotContains(t, indexNames, indexAccess)

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -58,7 +58,11 @@ func TestResyncWithoutIndexes(t *testing.T) {
 		// the sync docs index)
 		numIndexes, err := defaultDataStore.GetIndexes()
 		require.NoError(t, err)
-		require.Len(t, numIndexes, 1)
+		if rt.GetDatabase().UseLegacySyncDocsIndex() {
+			require.Len(t, numIndexes, 1) // sg_syncDocs
+		} else {
+			require.Len(t, numIndexes, 2) // sg_roles, sg_syncDocs
+		}
 
 		for _, collection := range rt.GetDatabase().CollectionByID {
 			n1qlStore, ok := base.AsN1QLStore(collection.GetCollectionDatastore())

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -26,6 +26,7 @@ func TestResyncWithoutIndexes(t *testing.T) {
 
 	dbName := "db"
 
+	// CBG-4615: parametrize test to use legacy sync docs index, or users and roles indexes
 	rest.RequireStatus(t, rt.CreateDatabase(dbName, rt.NewDbConfig()), http.StatusCreated)
 	// create test doc to change sequence number
 	rt.CreateTestDoc("doc1")
@@ -55,7 +56,6 @@ func TestResyncWithoutIndexes(t *testing.T) {
 	require.True(t, ok)
 
 	if !base.TestsDisableGSI() {
-		// the sync docs index)
 		numIndexes, err := defaultDataStore.GetIndexes()
 		require.NoError(t, err)
 		if rt.GetDatabase().UseLegacySyncDocsIndex() {


### PR DESCRIPTION
CBG-4614 Add toggle for using separate principal indexes

- This will force all code to use the new indexes, but there will be a followup PR to actually decide when to use the new indexes. This forced all the
- Removed now used `Serverless` option from `DatabaseContext`. This still exists in rest code, but I don't want to change that code as it is too risky.
- simplified the code that used channels to use waitgroups for easier readability

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3084/