### PR TITLE
Make tests work with views=true,xattrs=false

### DIFF
--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -452,6 +452,9 @@ func TestResyncMou(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
+	if !base.TestUseXattrs() {
+		t.Skip("_mou is written to xattrs only")
+	}
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -191,8 +191,6 @@ func purgeWithDCPFeed(ctx context.Context, dataStore sgbucket.DataStore, tbp *ba
 	}
 
 	purgeCallback := func(event sgbucket.FeedEvent) bool {
-		var purgeErr error
-
 		processedDocCount.Add(1)
 		// We only need to purge mutations/deletions
 		if event.Opcode != sgbucket.FeedOpMutation && event.Opcode != sgbucket.FeedOpDeletion {
@@ -206,11 +204,7 @@ func purgeWithDCPFeed(ctx context.Context, dataStore sgbucket.DataStore, tbp *ba
 
 		key := string(event.Key)
 
-		if base.TestUseXattrs() {
-			purgeErr = dataStore.DeleteWithXattrs(ctx, key, []string{base.SyncXattrName})
-		} else {
-			purgeErr = dataStore.Delete(key)
-		}
+		purgeErr := dataStore.DeleteWithXattrs(ctx, key, []string{base.SyncXattrName})
 		if base.IsDocNotFoundError(purgeErr) {
 			// If key no longer exists, need to add and remove to trigger removal from view
 			_, addErr := dataStore.Add(key, 0, purgeBody)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -204,6 +204,7 @@ func purgeWithDCPFeed(ctx context.Context, dataStore sgbucket.DataStore, tbp *ba
 
 		key := string(event.Key)
 
+		// always delete with xattrs, since sometimes even SG_TEST_USE_XATTRS=false write xattrs to test for migration
 		purgeErr := dataStore.DeleteWithXattrs(ctx, key, []string{base.SyncXattrName})
 		if base.IsDocNotFoundError(purgeErr) {
 			// If key no longer exists, need to add and remove to trigger removal from view

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2902,7 +2902,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	defer tb2.Close(ctx)
 
 	resp = rest.BootstrapAdminRequest(t, sc, http.MethodPut, "/db2/", fmt.Sprintf(
-		`{"bucket": "%s", "num_index_replicas": 0, "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t, "unsupported": {"disable_clean_skipped_query": true}}`, tb2.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t, "unsupported": {"disable_clean_skipped_query": true}}`, tb2.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
 	))
 	resp.RequireStatus(http.StatusCreated)
 

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -964,7 +964,7 @@ func TestNoAuditWhenDisabledAtDb(t *testing.T) {
 
 	// test event that is enabled by default on db (when audit is enabled)
 	output = base.AuditLogContents(t, func(t testing.TB) {
-		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", `{"user_xattr_key":"user_xattr"}`)
+		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", `{"changes_request_plus":true}`)
 		RequireStatus(t, resp, http.StatusCreated)
 	})
 	events = jsonLines(rt.TB(), output)

--- a/rest/config.go
+++ b/rest/config.go
@@ -2419,6 +2419,5 @@ func (c *DbConfig) useGSI() bool {
 	if c.UseViews == nil {
 		return true
 	}
-	fmt.Printf("UseViews: %t\n", *c.UseViews)
 	return !*c.UseViews
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -1120,9 +1120,6 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 	}
 	if dbConfig.Index != nil {
 		if dbConfig.Index.NumPartitions != nil {
-			if !dbConfig.useGSI() {
-				multiError = multiError.Append(fmt.Errorf("index.num_partitions is incompatible with use_views=true"))
-			}
 			if *dbConfig.Index.NumPartitions < 1 {
 				multiError = multiError.Append(fmt.Errorf("index.num_partitions must be greater than 0"))
 			} else if !dbConfig.UseXattrs() {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1032,7 +1032,7 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 	if len(dbConfig.Scopes) > 1 {
 		multiError = multiError.Append(fmt.Errorf("only one named scope is supported, but had %d (%v)", len(dbConfig.Scopes), dbConfig.Scopes))
 	} else {
-		if len(dbConfig.Scopes) != 0 && dbConfig.UseViews != nil && *dbConfig.UseViews {
+		if len(dbConfig.Scopes) != 0 && !dbConfig.useGSI() {
 			multiError = multiError.Append(fmt.Errorf("use_views=true is incompatible with collections which requires GSI"))
 		}
 
@@ -1118,11 +1118,16 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 			multiError = multiError.Append(fmt.Errorf("num_index_replicas and index.num_replicas are mutually exclusive. Remove num_index_replicas deprecated option."))
 		}
 	}
-	if dbConfig.Index != nil && dbConfig.Index.NumPartitions != nil {
-		if *dbConfig.Index.NumPartitions < 1 {
-			multiError = multiError.Append(fmt.Errorf("index.num_partitions must be greater than 0"))
-		} else if !dbConfig.UseXattrs() {
-			multiError = multiError.Append(fmt.Errorf("index.num_partitions is incompatible with enable_shared_bucket_access=false"))
+	if dbConfig.Index != nil {
+		if dbConfig.Index.NumPartitions != nil {
+			if !dbConfig.useGSI() {
+				multiError = multiError.Append(fmt.Errorf("index.num_partitions is incompatible with use_views=true"))
+			}
+			if *dbConfig.Index.NumPartitions < 1 {
+				multiError = multiError.Append(fmt.Errorf("index.num_partitions must be greater than 0"))
+			} else if !dbConfig.UseXattrs() {
+				multiError = multiError.Append(fmt.Errorf("index.num_partitions is incompatible with enable_shared_bucket_access=false"))
+			}
 		}
 	}
 	if dbConfig.UserXattrKey != nil && len(*dbConfig.UserXattrKey) > 15 {
@@ -2410,4 +2415,13 @@ func (c *DbConfig) numIndexPartitions() uint32 {
 		return *c.Index.NumPartitions
 	}
 	return db.DefaultNumIndexPartitions
+}
+
+// useGSI returns whether to use GSI for the database.
+func (c *DbConfig) useGSI() bool {
+	if c.UseViews == nil {
+		return true
+	}
+	fmt.Printf("UseViews: %t\n", *c.UseViews)
+	return !*c.UseViews
 }

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -991,9 +991,6 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 			},
 			EnableXattrs: &xattrs,
 			UseViews:     base.Ptr(base.TestsDisableGSI()),
-			Index: &IndexConfig{
-				NumReplicas: base.Ptr(uint(0)),
-			},
 		},
 		"db2": {
 			BucketConfig: BucketConfig{
@@ -1004,9 +1001,6 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 			},
 			EnableXattrs: &xattrs,
 			UseViews:     base.Ptr(base.TestsDisableGSI()),
-			Index: &IndexConfig{
-				NumReplicas: base.Ptr(uint(0)),
-			},
 		},
 		"db3": {
 			BucketConfig: BucketConfig{
@@ -1017,17 +1011,17 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 			},
 			EnableXattrs: &xattrs,
 			UseViews:     base.Ptr(base.TestsDisableGSI()),
-			Index: &IndexConfig{
-				NumReplicas: base.Ptr(uint(0)),
-			},
 		},
 	}
 
-	require.Nil(t, SetupAndValidateDatabases(ctx, databases), "Unexpected error while validating databases")
+	require.NoError(t, SetupAndValidateDatabases(ctx, databases), "Unexpected error while validating databases")
 
 	sc := NewServerContext(ctx, config, false)
 	defer sc.Close(ctx)
 	for _, dbConfig := range databases {
+		if !base.TestsDisableGSI() {
+			dbConfig.Index = &IndexConfig{NumReplicas: base.Ptr(uint(0))}
+		}
 		_, err := sc.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: *dbConfig})
 		require.NoError(t, err, "Couldn't add database from config")
 	}

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -23,6 +23,7 @@ import (
 const accessControlAllowOrigin = "Access-Control-Allow-Origin"
 
 func TestCORSDynamicSet(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,
 	})
@@ -38,21 +39,15 @@ func TestCORSDynamicSet(t *testing.T) {
 	const username = "alice"
 	rt.CreateUser(username, nil)
 
-	invalidDatabaseName := "invalid database name"
 	reqHeaders := map[string]string{
 		"Origin": "http://example.com",
 	}
 
 	for _, method := range []string{http.MethodGet, http.MethodOptions} {
-		response := rt.SendRequestWithHeaders(method, "/{{.keyspace}}/", "", reqHeaders)
+		response := rt.SendRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders)
 		require.Equal(t, "http://example.com", response.Header().Get(accessControlAllowOrigin))
 		if method == http.MethodGet {
-			if base.TestsUseNamedCollections() {
-				RequireStatus(t, response, http.StatusBadRequest)
-				require.Contains(t, response.Body.String(), invalidDatabaseName)
-			} else { // CBG-2978, should not be different from GSI/collections
-				RequireStatus(t, response, http.StatusUnauthorized)
-			}
+			RequireStatus(t, response, http.StatusUnauthorized)
 		} else {
 			RequireStatus(t, response, http.StatusNoContent)
 		}
@@ -99,12 +94,7 @@ func TestCORSDynamicSet(t *testing.T) {
 		response := rt.SendRequestWithHeaders(method, "/{{.keyspace}}/", "", reqHeaders)
 		if method == http.MethodGet {
 			require.Equal(t, "http://example.com", response.Header().Get(accessControlAllowOrigin))
-			if base.TestsUseNamedCollections() {
-				RequireStatus(t, response, http.StatusBadRequest)
-				require.Contains(t, response.Body.String(), invalidDatabaseName)
-			} else { // CBG-2978, should not be different from GSI/collections
-				RequireStatus(t, response, http.StatusUnauthorized)
-			}
+			RequireStatus(t, response, http.StatusUnauthorized)
 		} else {
 			// information leak: the options request knows about the database and knows it doesn't match
 			require.Equal(t, "", response.Header().Get(accessControlAllowOrigin))

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -91,7 +91,7 @@ func TestCORSDynamicSet(t *testing.T) {
 
 	// this falls back to the server config CORS without the user being authenticated
 	for _, method := range []string{http.MethodGet, http.MethodOptions} {
-		response := rt.SendRequestWithHeaders(method, "/{{.keyspace}}/", "", reqHeaders)
+		response := rt.SendRequestWithHeaders(method, "/{{.db}}/", "", reqHeaders)
 		if method == http.MethodGet {
 			require.Equal(t, "http://example.com", response.Header().Get(accessControlAllowOrigin))
 			RequireStatus(t, response, http.StatusUnauthorized)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1493,18 +1493,15 @@ func persistentConfigTestCases() []persistentConfigTestCase {
 				xattrConfig: false,
 			},
 		}
+	} else {
+		return []persistentConfigTestCase{
+			{
+				name:        "xattr_persistence",
+				xattrConfig: true,
+			}, {
+				name:        "document_persistence",
+				xattrConfig: false,
+			},
+		}
 	}
-	testCases := []persistentConfigTestCase{
-		{
-			name:        "document_persistence",
-			xattrConfig: false,
-		},
-	}
-	if base.TestUseXattrs() {
-		testCases = append(testCases, persistentConfigTestCase{
-			name:        "xattr_persistence",
-			xattrConfig: true,
-		})
-	}
-	return testCases
 }

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1493,15 +1493,18 @@ func persistentConfigTestCases() []persistentConfigTestCase {
 				xattrConfig: false,
 			},
 		}
-	} else {
-		return []persistentConfigTestCase{
-			{
-				name:        "xattr_persistence",
-				xattrConfig: true,
-			}, {
-				name:        "document_persistence",
-				xattrConfig: false,
-			},
-		}
 	}
+	testCases := []persistentConfigTestCase{
+		{
+			name:        "document_persistence",
+			xattrConfig: false,
+		},
+	}
+	if base.TestUseXattrs() {
+		testCases = append(testCases, persistentConfigTestCase{
+			name:        "xattr_persistence",
+			xattrConfig: true,
+		})
+	}
+	return testCases
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -1856,21 +1856,15 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 		db2 = "db2"
 		db1 = "db1"
 	)
-	resp := rt.SendAdminRequest(http.MethodPut, "/"+db2+"/", fmt.Sprintf(`{
-				"bucket": "%s",
-				"use_views": %t,
-				"num_index_replicas": 0
-	}`, tb.GetName(), base.TestsDisableGSI()))
-	rest.RequireStatus(t, resp, http.StatusCreated)
+	db2Config := rt.NewDbConfig()
+	db2Config.Bucket = base.Ptr(tb.GetName())
+	rest.RequireStatus(t, rt.CreateDatabase(db2, db2Config), http.StatusCreated)
 
 	tb2 := base.GetTestBucket(t)
 	defer tb2.Close(ctx)
-	resp = rt.SendAdminRequest(http.MethodPut, "/"+db1+"/", fmt.Sprintf(`{
-				"bucket": "%s",
-				"use_views": %t,
-				"num_index_replicas": 0
-	}`, tb2.GetName(), base.TestsDisableGSI()))
-	rest.RequireStatus(t, resp, http.StatusCreated)
+	db1Config := rt.NewDbConfig()
+	db1Config.Bucket = base.Ptr(tb2.GetName())
+	rest.RequireStatus(t, rt.CreateDatabase(db1, db1Config), http.StatusCreated)
 
 	rt.CreateReplicationForDB("{{.db1}}", "repl1", db2Url.String(), db.ActiveReplicatorTypePush, nil, true, db.ConflictResolverDefault)
 	rt.WaitForReplicationStatusForDB("{{.db1}}", "repl1", db.ReplicationStateRunning)
@@ -1886,7 +1880,7 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 	require.NoError(t, err)
 
 	// Force DB reload by modifying config
-	resp = rt.SendAdminRequest(http.MethodPost, "/"+db1+"/_config", `{"import_docs": false}`)
+	resp := rt.SendAdminRequest(http.MethodPost, "/"+db1+"/_config", `{"import_docs": false}`)
 	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// If CE, recreate the replication

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -202,7 +202,7 @@ func TestLegacyMetadataID(t *testing.T) {
 	defer persistentRT.Close()
 
 	resp = persistentRT.SendAdminRequest("PUT", "/db/", dbConfigString)
-	assert.Equal(t, http.StatusCreated, resp.Code)
+	rest.RequireStatus(t, resp, http.StatusCreated)
 
 	// check if database is online
 	dbRoot := persistentRT.GetDatabaseRoot("db")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2678,15 +2678,19 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 		BucketConfig: BucketConfig{
 			Bucket: base.Ptr(rt.Bucket().GetName()),
 		},
-		Index: &IndexConfig{
-			NumReplicas: base.Ptr(uint(0)),
-		},
 		EnableXattrs: base.Ptr(base.TestUseXattrs()),
 	}
-	// Walrus is peculiar in that it needs to run with views, but can run most GSI tests, including collections
-	if !base.UnitTestUrlIsWalrus() {
-		config.UseViews = base.Ptr(base.TestsDisableGSI())
+	if base.TestsDisableGSI() {
+		// Walrus is peculiar in that it needs to run with views, but can run most GSI tests, including collections
+		if !base.UnitTestUrlIsWalrus() {
+			config.UseViews = base.Ptr(true)
+		}
+	} else {
+		config.Index = &IndexConfig{
+			NumReplicas: base.Ptr(uint(0)),
+		}
 	}
+
 	// Setup scopes.
 	if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (base.UnitTestUrlIsWalrus() || (config.UseViews != nil && !*config.UseViews)) {
 		config.Scopes = GetCollectionsConfigWithFiltering(rt.TB(), rt.TestBucket, rt.numCollections, stringPtrOrNil(rt.SyncFn), stringPtrOrNil(rt.ImportFilter))

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -335,7 +335,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		if rt.DatabaseConfig.UseViews == nil {
 			rt.DatabaseConfig.UseViews = base.Ptr(base.TestsDisableGSI())
 		}
-		if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (!*rt.DatabaseConfig.UseViews || base.UnitTestUrlIsWalrus()) {
+		if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (rt.DatabaseConfig.useGSI() || base.UnitTestUrlIsWalrus()) {
 			// If scopes is already set, assume the caller has a plan
 			if rt.DatabaseConfig.Scopes == nil {
 				// Configure non default collections by default
@@ -2692,7 +2692,7 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 	}
 
 	// Setup scopes.
-	if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (base.UnitTestUrlIsWalrus() || (config.UseViews != nil && !*config.UseViews)) {
+	if base.TestsUseNamedCollections() && rt.collectionConfig != useSingleCollectionDefaultOnly && (base.UnitTestUrlIsWalrus() || config.useGSI()) {
 		config.Scopes = GetCollectionsConfigWithFiltering(rt.TB(), rt.TestBucket, rt.numCollections, stringPtrOrNil(rt.SyncFn), stringPtrOrNil(rt.ImportFilter))
 	} else {
 		config.Sync = stringPtrOrNil(rt.SyncFn)

--- a/rest/xattr_upgrade_test.go
+++ b/rest/xattr_upgrade_test.go
@@ -186,7 +186,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 		t.Skip("Check for upgrade test only runs w/ SG_TEST_USE_XATTRS=false")
 	}
 	if !base.TestsDisableGSI() {
-		// This test is trying to test a non xattr node while a non xattr -> xattr upgrade is occuring.
+		// This test is trying to test a non xattr node while a non xattr -> xattr upgrade is occurring.
 		// Intentionally do not query both xattr and non-xattr when doing channel backfill because of the overhead. The assumption is that during upgrade the older (non-xattrs) nodes would have any new xattr entries resident in their cache.
 		t.Skip("Only views will find both xattr and non xattr documents.")
 	}


### PR DESCRIPTION
- `user_xattr_key` is only available when xattrs are enabled
- `TestResyncRegenerateSequencesCorruptDocumentSequence` could be made to work without xattrs, but this doesn't feel a worthwhile use of time.

- [x] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3076/
- [x] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3081/
- [x] `GSI=false,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3078/ has failures, but they seem to occur only when running a fuller set of tests together and have to do with views service being unhappy
- [x] `GSI=false,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3079/ has failures, but they seem to occur only when running a fuller set of tests together and have to do with views service being unhappy
