### PR TITLE
CBG-4621 add wait for stat update

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -4589,7 +4589,12 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := rt2.GetDatabase().DbStats.CBLReplicationPull().RevSendCount.Value()
 	assert.Equal(t, startNumRevsSentTotal+1, numRevsSentTotal)
-	assert.Equal(t, int64(1), pullCheckpointer.Stats().ProcessedSequenceCount)
+	// the checkpointer will be updated after the rev is sent
+	// , so we need to wait for it to be updated
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), pullCheckpointer.Stats().ProcessedSequenceCount)
+	}, 10*time.Second, 10*time.Millisecond)
+
 	assert.Equal(t, int64(1), pullCheckpointer.Stats().ExpectedSequenceCount)
 
 	// checkpoint assertions


### PR DESCRIPTION
I think the checkpoint update can happen after the caching feed in a slow circumstance. By waiting for the stat, this prevents a potential race condition like:

```
2025-04-28T12:17:20.4233751Z 2025-04-28T12:15:22.586Z [INF] Replicate: t:TestActiveReplicatorRecoverFromLocalFlush c:TestActiveReplicatorRecoverFromLocalFlush-pull db:db using checkpointed seq: "0"
2025-04-28T12:17:20.4234072Z 2025-04-28T12:15:22.586Z [INF] SyncMsg: c:[1839a0ea] db:db col:sg_test_0 #3: Type:subChanges Since:0 Collection:0 Continuous:true 
2025-04-28T12:17:20.4234294Z 2025-04-28T12:15:22.586Z [INF] Sync: c:[1839a0ea] db:db col:sg_test_0 Sending changes since 0
2025-04-28T12:17:20.4234636Z 2025-04-28T12:15:22.612Z [INF] HTTP: c:#939 db:db col:sg_test_0 GET http://localhost/db.sg_test_0.sg_test_0/_changes?since=0 (as ADMIN)
2025-04-28T12:17:20.4234856Z 2025-04-28T12:15:22.613Z [INF] HTTP+: c:#939 db:db col:sg_test_0 #939:     --> 200 OK  (0.4 ms)
2025-04-28T12:17:20.4235186Z 2025-04-28T12:15:22.614Z [INF] HTTP: c:#940 db:db col:sg_test_0 GET http://localhost/db.sg_test_0.sg_test_0/_changes?since=0 (as ADMIN)
2025-04-28T12:17:20.4235390Z 2025-04-28T12:15:22.614Z [INF] HTTP+: c:#940 db:db col:sg_test_0 #940:     --> 200 OK  (0.3 ms)
2025-04-28T12:17:20.4235709Z 2025-04-28T12:15:22.620Z [INF] HTTP: c:#941 db:db col:sg_test_0 GET http://localhost/db.sg_test_0.sg_test_0/_changes?since=0 (as ADMIN)
2025-04-28T12:17:20.4235916Z 2025-04-28T12:15:22.621Z [INF] HTTP+: c:#941 db:db col:sg_test_0 #941:     --> 200 OK  (0.8 ms)
2025-04-28T12:17:20.4236053Z 2025/04/28 12:15:22 SG-Bucket: 	... view returned 0 rows
2025-04-28T12:17:20.4236183Z 2025/04/28 12:15:22 SG-Bucket: 	... view returned 1 rows
2025-04-28T12:17:20.4236679Z 2025-04-28T12:15:22.624Z [INF] SyncMsg: c:TestActiveReplicatorRecoverFromLocalFlush-pull db:db col:sg_test_0 #1: Type:changes #Changes:1
2025-04-28T12:17:20.4236994Z 2025-04-28T12:15:22.625Z [INF] Sync: c:[1839a0ea] db:db col:sg_test_0 Sent 1 changes to client, from seq 2
2025-04-28T12:17:20.4237225Z 2025-04-28T12:15:22.625Z [INF] Sync: c:[1839a0ea] db:db col:sg_test_0 Sent all changes to client
2025-04-28T12:17:20.4237630Z 2025-04-28T12:15:22.625Z [INF] SyncMsg: c:TestActiveReplicatorRecoverFromLocalFlush-pull db:db col:sg_test_0 #2: Type:changes #Changes:0
2025-04-28T12:17:20.4237953Z 2025-04-28T12:15:22.627Z [INF] HTTP: c:#942 db:db col:sg_test_0 GET http://localhost/db.sg_test_0.sg_test_0/_changes?since=0 (as ADMIN)
2025-04-28T12:17:20.4238157Z 2025-04-28T12:15:22.628Z [INF] HTTP+: c:#942 db:db col:sg_test_0 #942:     --> 200 OK  (0.4 ms)
2025-04-28T12:17:20.4238303Z     replicator_test.go:4592: 
2025-04-28T12:17:20.4238819Z         	Error Trace:	/home/runner/work/sync_gateway/sync_gateway/rest/replicatortest/replicator_test.go:4592
2025-04-28T12:17:20.4238974Z         	Error:      	Not equal: 
2025-04-28T12:17:20.4239162Z         	            	expected: 1
2025-04-28T12:17:20.4239350Z         	            	actual  : 0
2025-04-28T12:17:20.4239615Z         	Test:       	TestActiveReplicatorRecoverFromLocalFlush
2025-04-28T12:17:20.4239740Z     replicator_test.go:4602: 
2025-04-28T12:17:20.4240251Z         	Error Trace:	/home/runner/work/sync_gateway/sync_gateway/rest/replicatortest/replicator_test.go:4602
2025-04-28T12:17:20.4240393Z         	Error:      	Not equal: 
2025-04-28T12:17:20.4240576Z         	            	expected: 1
2025-04-28T12:17:20.4240756Z         	            	actual  : 0
2025-04-28T12:17:20.4241015Z         	Test:       	TestActiveReplicatorRecoverFromLocalFlush
```
