### PR TITLE
Needs rework: `/_post_upgrade` cleanup handling for `num_partitions`

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -758,6 +758,7 @@ func (dbCtx *DatabaseContext) getDataStores() []sgbucket.DataStore {
 }
 
 // Removes previous versions of Sync Gateway's indexes found on the server. Returns a map of indexes removed by collection name.
+// FIXME: This does not take into account indexes being used by other databases on the same bucket (e.g. metadata indexes)
 func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, previewOnly bool) ([]string, error) {
 
 	if !dbCtx.Bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql) {
@@ -774,7 +775,7 @@ func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, preview
 			errs = errs.Append(errors.New(err))
 			continue
 		}
-		collectionRemovedIndexes, err := removeObsoleteIndexes(ctx, n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), dbCtx.numIndexPartitions(), sgIndexes)
+		collectionRemovedIndexes, err := removeObsoleteIndexes(ctx, n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), dbCtx.numIndexPartitions(), sgIndexesBySimpleName)
 		if err != nil {
 			errs = errs.Append(err)
 			continue

--- a/db/database.go
+++ b/db/database.go
@@ -774,7 +774,7 @@ func (dbCtx *DatabaseContext) RemoveObsoleteIndexes(ctx context.Context, preview
 			errs = errs.Append(errors.New(err))
 			continue
 		}
-		collectionRemovedIndexes, err := removeObsoleteIndexes(ctx, n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), sgIndexes)
+		collectionRemovedIndexes, err := removeObsoleteIndexes(ctx, n1qlStore, previewOnly, dbCtx.UseXattrs(), dbCtx.UseViews(), dbCtx.numIndexPartitions(), sgIndexes)
 		if err != nil {
 			errs = errs.Append(err)
 			continue

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -436,7 +436,8 @@ func isIndexerError(err error) bool {
 // Iterates over the index set, removing obsolete indexes:
 //   - indexes based on the inverse value of xattrs being used by the database
 //   - indexes associated with previous versions of the index, for either xattrs=true or xattrs=false
-func removeObsoleteIndexes(ctx context.Context, bucket base.N1QLStore, previewOnly bool, useXattrs bool, useViews bool, indexMap map[SGIndexType]SGIndex) (removedIndexes []string, err error) {
+//   - indexes with a different number of partitions than the current database configuration
+func removeObsoleteIndexes(ctx context.Context, bucket base.N1QLStore, previewOnly bool, useXattrs bool, useViews bool, numIndexPartitions uint32, indexMap map[SGIndexType]SGIndex) (removedIndexes []string, err error) {
 	removedIndexes = make([]string, 0)
 
 	// Build set of candidates for cleanup

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -388,3 +388,52 @@ func TestIsIndexerError(t *testing.T) {
 	err = errors.New("err:[5000]  MCResponse status=KEY_ENOENT, opcode=0x89, opaque=0")
 	assert.True(t, isIndexerError(err))
 }
+
+func TestSgIndexParamsFromName(t *testing.T) {
+	tests := []struct {
+		idxName            string
+		expectedName       string
+		expectedXattrs     bool
+		expectedVersion    int64
+		expectedPartitions uint32
+	}{
+		{
+			idxName:            "sg_roleAccess_1",
+			expectedName:       "roleAccess",
+			expectedXattrs:     false,
+			expectedVersion:    1,
+			expectedPartitions: 1,
+		},
+		{
+			idxName:            "sg_roleAccess_x1",
+			expectedName:       "roleAccess",
+			expectedXattrs:     true,
+			expectedVersion:    1,
+			expectedPartitions: 1,
+		},
+		{
+			idxName:            "sg_roleAccess_x1_p2",
+			expectedName:       "roleAccess",
+			expectedXattrs:     true,
+			expectedVersion:    1,
+			expectedPartitions: 2,
+		},
+		{
+			idxName:            "sg_roleAccess_1_p2",
+			expectedName:       "roleAccess",
+			expectedXattrs:     false,
+			expectedVersion:    1,
+			expectedPartitions: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.idxName, func(t *testing.T) {
+			gotName, gotXattrs, gotVersion, gotPartitions, err := sgIndexParamsFromName(test.idxName)
+			require.NoError(t, err)
+			assert.Equalf(t, test.expectedName, gotName, "sgIndexParamsFromName(%v)", test.idxName)
+			assert.Equalf(t, test.expectedXattrs, gotXattrs, "sgIndexParamsFromName(%v)", test.idxName)
+			assert.Equalf(t, test.expectedVersion, gotVersion, "sgIndexParamsFromName(%v)", test.idxName)
+			assert.Equalf(t, test.expectedPartitions, gotPartitions, "sgIndexParamsFromName(%v)", test.idxName)
+		})
+	}
+}

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -136,13 +136,13 @@ func TestChangeIndexPartitions(t *testing.T) {
 			rest.RequireStatus(t, rt.ReplaceDbConfig(dbName, dbConfig), http.StatusCreated)
 
 			// CBG-4565 cleanup old indexes
-			//resp = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade", "")
-			//rest.RequireStatus(t, resp, http.StatusOK)
-			//var body rest.PostUpgradeResponse
-			//err := base.JSONUnmarshal(resp.BodyBytes(), &body)
-			//require.NoError(t, err)
-			//require.Lenf(t, body.Result, 1, "expected one database in post upgrade response")
-			//require.Lenf(t, body.Result[dbName].RemovedIndexes, 2, "expected two indexes to be removed")
+			resp = rt.SendAdminRequest(http.MethodPost, "/_post_upgrade", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+			var body rest.PostUpgradeResponse
+			err := base.JSONUnmarshal(resp.BodyBytes(), &body)
+			require.NoError(t, err)
+			require.Lenf(t, body.Result, 1, "expected one database in post upgrade response")
+			require.Lenf(t, body.Result[dbName].RemovedIndexes, 2, "expected two indexes to be removed")
 		})
 	}
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -475,6 +475,7 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 
 	postUpgradeResults = make(map[string]PostUpgradeDatabaseResult, len(sc.databases_))
 
+	// FIXME: For partitions cleanup - this loop should be removed and instead this function should query all database indexes simultaneously to build the list of indexes to remove.
 	for name, database := range sc.databases_ {
 		// View cleanup
 		removedDDocs, _ := database.RemoveObsoleteDesignDocs(ctx, preview)


### PR DESCRIPTION
During development of this feature, I realized this approach is not going to work and will introduce more edge cases for `/_post_upgrade` that seems unacceptable.

We may need to change how `ServerContext.PostUpgrade()` operates, such that it can consider all database configurations during its evaluation of which indexes to cleanup. Doing this in a per-database loop is not enough to prevent accidental removal of in-use indexes for databases with varying configurations.

This was also a bug with xattrs, but was far less likely to happen than differing numbers of `num_partitions`.

See `FIXME` in code to see thought process and where the current approach started to unravel.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a