### PR TITLE
CBG-4607: Allow separate principal index creation using the async index REST API

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3144,6 +3144,10 @@ IndexSettings:
       description: The number of partitions to use for the large indexes created by Sync Gateway. It is not recommended to set this unless you require additional horizontal scalability for individual indexes and have appropriately scaled your Query nodes to handle the increased query parallelism. If set, the recommended number is 8 and does not need to be directly related to the number of your Query nodes. Ensure documentation is read to understand the performance tradeoffs and instructions for migration if you have previously run with only one partition. See [/{db}/_index_init](#operation/post_db-_index_init) for more information.
       type: number
       default: 1
+    separate_principal_indexes:
+      description: Whether to create separate indexes for users and roles instead of a single larger syncDocs index.
+      type: boolean
+      default: false
 IndexInitStatus:
   description: The status of an asynchronous indexes initialization operation.
   type: object

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3144,8 +3144,11 @@ IndexSettings:
       description: The number of partitions to use for the large indexes created by Sync Gateway. It is not recommended to set this unless you require additional horizontal scalability for individual indexes and have appropriately scaled your Query nodes to handle the increased query parallelism. If set, the recommended number is 8 and does not need to be directly related to the number of your Query nodes. Ensure documentation is read to understand the performance tradeoffs and instructions for migration if you have previously run with only one partition. See [/{db}/_index_init](#operation/post_db-_index_init) for more information.
       type: number
       default: 1
-    separate_principal_indexes:
-      description: Whether to create separate indexes for users and roles instead of a single larger syncDocs index.
+    create_separate_principal_indexes:
+      description: |-
+        Whether to create separate indexes for users and roles instead of a single larger syncDocs index.
+
+        The separate principal indexes are smaller and used automatically for new database deployments. To remove the syncDocs index, wait for this to complete, restart all Sync Gateway instances and run  [POST /_post_upgrade](#operation/post__post_upgrade).
       type: boolean
       default: false
 IndexInitStatus:

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -322,9 +322,6 @@ func (h *handler) handlePostIndexInit() error {
 	}
 
 	currentDbConfig := h.server.GetDatabaseConfig(h.db.Name)
-	if req.NumPartitions != nil && currentDbConfig.NumIndexPartitions() == *req.NumPartitions {
-		return base.HTTPErrorf(http.StatusBadRequest, "num_partitions is already %d", *req.NumPartitions)
-	}
 
 	if h.db.UseViews() {
 		return base.HTTPErrorf(http.StatusBadRequest, "_index_init is a GSI-only feature and is not supported when using views")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -284,7 +284,7 @@ type PostIndexInitRequest struct {
 
 func (req PostIndexInitRequest) Validate() error {
 	if req.NumPartitions == nil && req.SeparatePrincipalIndexes == nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "at least one of num_partitions or separate_principal_indexes is required")
+		return base.HTTPErrorf(http.StatusBadRequest, "at least one of num_partitions or create_separate_principal_indexes is required")
 	}
 	if req.NumPartitions != nil && *req.NumPartitions < 1 {
 		return base.HTTPErrorf(http.StatusBadRequest, "num_partitions must be greater than 0")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -279,7 +279,7 @@ func (h *handler) handleGetIndexInit() error {
 
 type PostIndexInitRequest struct {
 	NumPartitions            *uint32 `json:"num_partitions"`
-	SeparatePrincipalIndexes *bool   `json:"separate_principal_indexes"`
+	SeparatePrincipalIndexes *bool   `json:"create_separate_principal_indexes"`
 }
 
 func (req PostIndexInitRequest) Validate() error {

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -191,7 +191,7 @@ func TestChangeIndexPartitionsErrors(t *testing.T) {
 		{
 			name:          "empty num_partitions",
 			body:          `{}`,
-			expectedError: `at least one of num_partitions or separate_principal_indexes is required`,
+			expectedError: `at least one of num_partitions or create_separate_principal_indexes is required`,
 		},
 		{
 			name:          "invalid num_partitions",

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -191,7 +191,7 @@ func TestChangeIndexPartitionsErrors(t *testing.T) {
 		{
 			name:          "empty num_partitions",
 			body:          `{}`,
-			expectedError: `at least one of num_partitions or separate_principal_indexes is required" does not contain "num_partitions is required`,
+			expectedError: `at least one of num_partitions or separate_principal_indexes is required`,
 		},
 		{
 			name:          "invalid num_partitions",

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -227,22 +227,6 @@ func TestChangeIndexPartitionsErrors(t *testing.T) {
 	}
 }
 
-func TestChangeIndexPartitionsSameNumber(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
-		t.Skip("This test only works against Couchbase Server with GSI enabled")
-	}
-
-	// requires index init
-	base.LongRunningTest(t)
-
-	rt := rest.NewRestTester(t, &rest.RestTesterConfig{DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{Index: &rest.IndexConfig{NumPartitions: base.Ptr(uint32(2))}}}})
-	defer rt.Close()
-
-	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":2}`)
-	rest.RequireStatus(t, resp, http.StatusBadRequest)
-	rest.AssertHTTPErrorReason(t, resp, http.StatusBadRequest, "num_partitions is already 2")
-}
-
 func TestChangeIndexPartitionsDbOffline(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test only works against Couchbase Server with GSI enabled")

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -78,6 +78,11 @@ func TestChangeIndexPartitions(t *testing.T) {
 			initialPartitions: base.Ptr(uint32(4)),
 			newPartitions:     1,
 		},
+		{
+			name:              "2 to 2",
+			initialPartitions: base.Ptr(uint32(2)),
+			newPartitions:     2,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
CBG-4607

Allow separate principal index creation using the async index REST API
- Make `num_partitions` optional since now users might only care about `separate_principal_indexes` on this API
- Specifying `"separate_principal_indexes": true` will cause the new user and role specific indexes to be created
- Omitting this value will fall back to whatever the database context has for `UseLegacySyncDocsIndex()`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3094/
