### PR TITLE
CBG-4619: skip assigning nil body attachments to _attachments property if _attachments is uses as json value

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1127,9 +1127,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// Pull out attachments
 	if injectedAttachmentsForDelta || bytes.Contains(bodyBytes, []byte(BodyAttachments)) {
 		body := newDoc.Body(bh.loggingCtx)
-		// The above check for presence of _attachments in the json body will pass even if _attachments is
-		// used for json value rather than json key. So we need to perform a nil check on _attachments body property
-		// and if it returns nil we should skip any processing below on the document body.
+		// The bytes.Contains([]byte(BodyAttachments)) check will pass even if _attachments is not a toplevel key but rather a nested key or subkey. That check is an optimization to avoid having to unmarshal the document if there are no attachments. Therefore, check again that the unmarshalled body contains BodyAttachments.
 		if body[BodyAttachments] != nil {
 
 			var currentBucketDoc *Document

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -715,11 +715,6 @@ func TestPushDocWithNonRootAttachmentProperty(t *testing.T) {
 			// add rev2 for each doc and wait to be replicated to SGW
 			docVersion = btcRunner.AddRev(btc.id, tc.docID, &docVersion, tc.bodyUpdate)
 			rt.WaitForVersion(tc.docID, docVersion)
-
-			// assert that the bodies that are replicated are as expected
-			body, _, err := rt.GetSingleDataStore().GetRaw(tc.docID)
-			require.NoError(t, err)
-			assert.Equal(t, tc.bodyUpdate, body)
 		}
 	})
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -143,7 +143,6 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 				initialBody:   []byte(`{"data":"_attachments"}`),
 				bodyUpdate:    []byte(`{"data1":"_attachments"}`),
 				hasAttachment: false,
-				expBody:       []byte(`{"data1":"_attachments"}`),
 			},
 			{
 				// test case: pushing delta with key update onto doc with _attachment in json value and attachment defined
@@ -151,7 +150,6 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 				initialBody:   []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
 				bodyUpdate:    []byte(`{"key1":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
 				hasAttachment: true,
-				expBody:       []byte(`{"key1":"_attachments"}`),
 			},
 			{
 				// test case: pushing delta with attachment defined onto doc with _attachment in json value
@@ -159,7 +157,6 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 				initialBody:   []byte(`{"key":"_attachments"}`),
 				bodyUpdate:    []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
 				hasAttachment: true,
-				expBody:       []byte(`{"key":"_attachments"}`),
 			},
 			{
 				// test case: pushing delta with _attachment json value onto doc with attachment defined
@@ -167,7 +164,6 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 				initialBody:   []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
 				bodyUpdate:    []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
 				hasAttachment: true,
-				expBody:       []byte(`{"key":"_attachments"}`),
 			},
 		}
 		for _, tc := range testcases {
@@ -187,10 +183,6 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 				_, found := syncData.Attachments["myAttachment"]
 				assert.True(t, found)
 			}
-			// assert that the bodies that are replicated are as expected
-			body, _, err := rt.GetSingleDataStore().GetRaw(tc.docID)
-			require.NoError(t, err)
-			assert.Equal(t, tc.expBody, body)
 		}
 	})
 }

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -94,6 +94,107 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	})
 }
 
+// TestDeltaWithAttachmentJsonProperty tests pushing a delta when _attachments is present in either delta or existing doc
+func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+		}},
+		GuestEnabled: true,
+	}
+
+	doc1ID := t.Name() + "_doc1"
+	doc2ID := t.Name() + "_doc2"
+	doc3ID := t.Name() + "_doc3"
+	doc4ID := t.Name() + "_doc4"
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, ClientDeltas: true}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+
+		collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+		btcRunner.StartPush(btc.id)
+
+		attData := base64.StdEncoding.EncodeToString([]byte("attach"))
+
+		testcases := []struct {
+			initialBody   []byte
+			bodyUpdate    []byte
+			expBody       []byte
+			docID         string
+			hasAttachment bool
+		}{
+			// test case: pushing delta with key update onto doc with _attachment in json value
+			{
+				docID:         doc1ID,
+				initialBody:   []byte(`{"data":"_attachments"}`),
+				bodyUpdate:    []byte(`{"data1":"_attachments"}`),
+				hasAttachment: false,
+				expBody:       []byte(`{"data1":"_attachments"}`),
+			},
+			{
+				// test case: pushing delta with key update onto doc with _attachment in json value and attachment defined
+				docID:         doc2ID,
+				initialBody:   []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				bodyUpdate:    []byte(`{"key1":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				hasAttachment: true,
+				expBody:       []byte(`{"key1":"_attachments"}`),
+			},
+			{
+				// test case: pushing delta with attachment defined onto doc with _attachment in json value
+				docID:         doc3ID,
+				initialBody:   []byte(`{"key":"_attachments"}`),
+				bodyUpdate:    []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				hasAttachment: true,
+				expBody:       []byte(`{"key":"_attachments"}`),
+			},
+			{
+				// test case: pushing delta with _attachment json value onto doc with attachment defined
+				docID:         doc4ID,
+				initialBody:   []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				bodyUpdate:    []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				hasAttachment: true,
+				expBody:       []byte(`{"key":"_attachments"}`),
+			},
+		}
+		for _, tc := range testcases {
+
+			// Push first rev
+			version := btcRunner.AddRev(btc.id, tc.docID, EmptyDocVersion(), tc.initialBody)
+			rt.WaitForVersion(tc.docID, version)
+
+			// Push second rev
+			version = btcRunner.AddRev(btc.id, tc.docID, &version, tc.bodyUpdate)
+			rt.WaitForVersion(tc.docID, version)
+
+			if tc.hasAttachment {
+				syncData, err := collection.GetDocSyncData(ctx, tc.docID)
+				require.NoError(t, err)
+				assert.Len(t, syncData.Attachments, 1)
+				_, found := syncData.Attachments["myAttachment"]
+				assert.True(t, found)
+			}
+			// assert that the bodies that are replicated are as expected
+			body, _, err := rt.GetSingleDataStore().GetRaw(tc.docID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expBody, body)
+		}
+	})
+}
+
 // Test pushing and pulling new attachments through delta sync
 // 1. Create test client that have deltas enabled
 // 2. Start continuous push and pull replication in client


### PR DESCRIPTION
CBG-4619

We currently do a check for the presence of _attachment in byte array of the incoming body on replication as optimisation to avoid attachment processing if its not needed. Issue is this will pick up the presence of _attachments if the key word is used as value in json document not the key. 
When using _attachments as json value in a document body and there is a previous version of the doc available we do some extra processing and attempt to fetch the attachment metadata from the body. When doing so and there is no attachment meta available the `GetBodyAttachments` function will return nil AttachmentMeta type and further down we will assign a nil `bodyAtts` to the _attachments property in the body object. This causes the `downloadOrVerifyAttachments` function to fail as _attachments property is in the body but is nil thus is invalid. See example error below:
```
2025-04-28T11:53:03.831+01:00 [ERR] c:[636a9852] db:db col:sg_test_0 Error during downloadOrVerifyAttachments for doc <ud>doc1</ud>/2-abc: 400 Invalid _attachments -- db.(*blipHandler).processRev() at blip_handler.go:1203
```
This fix here is to perform a nil check on body[BodyAttachments] and if nil skip all the attachment processing.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3079/
