### PR TITLE
Force golangci-lint to flag all errcheck issues

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -85,11 +85,6 @@ linters:
         - -ST1023 # Redundant type in variable declaration.
   exclusions:
     generated: strict
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
     rules:
       # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
       - linters:
@@ -100,6 +95,18 @@ linters:
       - linters:
           - unused
         path: rest/debug.go
+      - text: "ST1000:" # at least one file in a package should have a package comment
+        linters:
+          - staticcheck
+      - text: "ST1020:" # comment on exported method should be of the form "MethodName ..."
+        linters:
+          - staticcheck
+      - text: "ST1021:" # comment on exported type should be of the form "TypeName ..."
+        linters:
+          - staticcheck
+      - text: "ST1022:" # comment on exported type should be of the form "TypeName ..."
+        linters:
+          - staticcheck
 formatters:
   enable:
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,11 +34,6 @@ linters:
         - fieldalignment
   exclusions:
     generated: strict
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
     rules:
       - linters:
           # Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.


### PR DESCRIPTION
Removing `presets: std-error-handling` fixes the long standing issue where jenkins errcheck executable could find more bugs than golangci-lint.

Removed all the presets for specific exclusions for staticcheck from `presets: common` so we'll be able to make a decision if new presets get added on whether to adopt or not adopt. This code comes from an automated migration from golangci v1 -> golangci v2, but the issue with errcheck and golangci-lint predated that.
