### PR TITLE
[3.2.5 backport] CBG-4620: skip assigning nil body attachments to _attachments property if _attachments is uses as json value

### DIFF
--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -739,12 +739,12 @@ func TestPushDocWithNonRootAttachmentProperty(t *testing.T) {
 			// parent doc for attachment keys too, this is where the issue arose of assigning nil to _attachments key in the body
 			docVersion, err := btcRunner.PushRev(btc.id, tc.docID, EmptyDocVersion(), tc.initialBody)
 			require.NoError(t, err)
-			rt.WaitForVersion(tc.docID, docVersion)
+			require.NoError(t, rt.WaitForVersion(tc.docID, docVersion))
 
 			// add rev2 for each doc and wait to be replicated to SGW
 			docVersion, err = btcRunner.PushRev(btc.id, tc.docID, docVersion, tc.bodyUpdate)
 			require.NoError(t, err)
-			rt.WaitForVersion(tc.docID, docVersion)
+			require.NoError(t, rt.WaitForVersion(tc.docID, docVersion))
 		}
 	})
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -90,6 +90,99 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	})
 }
 
+// TestDeltaWithAttachmentJsonProperty tests pushing a delta when _attachments is present in either delta or existing doc
+func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+		}},
+		GuestEnabled: true,
+	}
+
+	doc1ID := t.Name() + "_doc1"
+	doc2ID := t.Name() + "_doc2"
+	doc3ID := t.Name() + "_doc3"
+	doc4ID := t.Name() + "_doc4"
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, ClientDeltas: true}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+
+		collection, ctx := rt.GetSingleTestDatabaseCollection()
+
+		btcRunner.StartPush(btc.id)
+
+		attData := base64.StdEncoding.EncodeToString([]byte("attach"))
+
+		testcases := []struct {
+			initialBody   []byte
+			bodyUpdate    []byte
+			expBody       []byte
+			docID         string
+			hasAttachment bool
+		}{
+			// test case: pushing delta with key update onto doc with _attachment in json value
+			{
+				docID:         doc1ID,
+				initialBody:   []byte(`{"data":"_attachments"}`),
+				bodyUpdate:    []byte(`{"data1":"_attachments"}`),
+				hasAttachment: false,
+			},
+			{
+				// test case: pushing delta with key update onto doc with _attachment in json value and attachment defined
+				docID:         doc2ID,
+				initialBody:   []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				bodyUpdate:    []byte(`{"key1":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				hasAttachment: true,
+			},
+			{
+				// test case: pushing delta with attachment defined onto doc with _attachment in json value
+				docID:         doc3ID,
+				initialBody:   []byte(`{"key":"_attachments"}`),
+				bodyUpdate:    []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				hasAttachment: true,
+			},
+			{
+				// test case: pushing delta with _attachment json value onto doc with attachment defined
+				docID:         doc4ID,
+				initialBody:   []byte(`{"key":"val","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				bodyUpdate:    []byte(`{"key":"_attachments","_attachments":{"myAttachment":{"data":"` + attData + `"}}}`),
+				hasAttachment: true,
+			},
+		}
+		for _, tc := range testcases {
+
+			// Push first rev
+			version := btcRunner.AddRev(btc.id, tc.docID, EmptyDocVersion(), tc.initialBody)
+			rt.WaitForVersion(tc.docID, version)
+
+			// Push second rev
+			version = btcRunner.AddRev(btc.id, tc.docID, &version, tc.bodyUpdate)
+			rt.WaitForVersion(tc.docID, version)
+
+			if tc.hasAttachment {
+				syncData, err := collection.GetDocSyncData(ctx, tc.docID)
+				require.NoError(t, err)
+				assert.Len(t, syncData.Attachments, 1)
+				_, found := syncData.Attachments["myAttachment"]
+				assert.True(t, found)
+			}
+		}
+	})
+}
+
 // Test pushing and pulling new attachments through delta sync
 // 1. Create test client that have deltas enabled
 // 2. Start continuous push and pull replication in client

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -165,14 +165,14 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 			// Push first rev
 			version, err := btcRunner.PushRev(btc.id, tc.docID, EmptyDocVersion(), tc.initialBody)
 			require.NoError(t, err)
-			rt.WaitForVersion(tc.docID, version)
+			require.NoError(t, rt.WaitForVersion(tc.docID, version))
 
 			btc.ClientDeltas = true
 
 			// Push second rev
 			version, err = btcRunner.PushRev(btc.id, tc.docID, version, tc.bodyUpdate)
 			require.NoError(t, err)
-			rt.WaitForVersion(tc.docID, version)
+			require.NoError(t, rt.WaitForVersion(tc.docID, version))
 
 			if tc.hasAttachment {
 				syncData, err := collection.GetDocSyncData(ctx, tc.docID)


### PR DESCRIPTION
CBG-4620

-Backports #7507 

Note to reviewer, not a clean backport required conflict merge in processRev where revPos handling seems to differ between main and 3.2.5 branch quite a bit. Also required changes to tests as we have different blip client tester on main to this branch. 


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3092/
