### PR TITLE
Allow RetryLoop to be type safe

### DIFF
--- a/base/collection_view.go
+++ b/base/collection_view.go
@@ -104,7 +104,7 @@ func (c *Collection) PutDDoc(ctx context.Context, docname string, sgDesignDoc *s
 	}
 
 	// Retry for all errors (The view service sporadically returns 500 status codes with Erlang errors (for unknown reasons) - E.g: 500 {"error":"case_clause","reason":"false"})
-	var worker RetryWorker = func() (bool, error, interface{}) {
+	worker := func() (bool, error, interface{}) {
 		err := manager.UpsertDesignDocument(gocbDesignDoc, gocb.DesignDocumentNamespaceProduction, nil)
 		if err != nil {
 			WarnfCtx(ctx, "Got error from UpsertDesignDocument: %v - Retrying...", err)

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -450,7 +450,7 @@ func (tbp *TestBucketPool) setXDCRBucketSetting(ctx context.Context, bucket Buck
 
 	url := fmt.Sprintf("/pools/default/buckets/%s", store.GetName())
 	// retry for 1 minute to get this bucket setting, MB-63675
-	_, err := RetryLoop(ctx, "setXDCRBucketSetting", func() (bool, error, interface{}) {
+	err, _ := RetryLoop(ctx, "setXDCRBucketSetting", func() (bool, error, interface{}) {
 		output, statusCode, err := store.MgmtRequest(ctx, http.MethodPost, url, "application/x-www-form-urlencoded", strings.NewReader(posts.Encode()))
 		if err != nil {
 			tbp.Fatalf(ctx, "request to mobile XDCR bucket setting failed, status code: %d error: %w output: %s", statusCode, err, string(output))

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -486,11 +486,9 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	assert.True(t, sent)
 
 	// Get all docs and attachment via subChanges request
-	allDocs, ok := bt.WaitForNumDocsViaChanges(1)
-	require.True(t, ok)
+	allDocs := bt.WaitForNumDocsViaChanges(1)
 
 	// make assertions on allDocs -- make sure attachment is present w/ expected body
-	require.Len(t, allDocs, 1)
 	retrievedDoc := allDocs[input.docId]
 
 	// doc assertions

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1843,9 +1843,7 @@ func TestMissingNoRev(t *testing.T) {
 	}
 
 	// Pull docs, expect to pull 5 docs since none of them has purged yet.
-	docs, ok := bt.WaitForNumDocsViaChanges(5)
-	require.True(t, ok)
-	assert.Len(t, docs, 5)
+	bt.WaitForNumDocsViaChanges(5)
 
 	// Purge one doc
 	doc0Id := fmt.Sprintf("doc-%d", 0)
@@ -1857,9 +1855,7 @@ func TestMissingNoRev(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// Pull docs, expect to pull 4 since one was purged.  (also expect to NOT get stuck)
-	docs, ok = bt.WaitForNumDocsViaChanges(4)
-	assert.True(t, ok)
-	assert.Len(t, docs, 4)
+	bt.WaitForNumDocsViaChanges(4)
 
 }
 

--- a/rest/utilities_testing_user.go
+++ b/rest/utilities_testing_user.go
@@ -54,7 +54,7 @@ func MakeUser(t *testing.T, httpClient *http.Client, serverURL, username, passwo
 }
 
 func DeleteUser(t *testing.T, httpClient *http.Client, serverURL, username string) {
-	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
+	retryWorker := func() (shouldRetry bool, err error, value *http.Response) {
 		req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/settings/rbac/users/local/%s", serverURL, username), nil)
 		require.NoError(t, err)
 
@@ -71,9 +71,9 @@ func DeleteUser(t *testing.T, httpClient *http.Client, serverURL, username strin
 	err, resp := base.RetryLoop(base.TestCtx(t), "Admin Auth testing DeleteUser", retryWorker, base.CreateSleeperFunc(10, 100))
 	require.NoError(t, err)
 
-	require.Equal(t, http.StatusOK, resp.(*http.Response).StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	require.NoError(t, resp.(*http.Response).Body.Close(), "Error closing response body")
+	require.NoError(t, resp.Body.Close(), "Error closing response body")
 }
 
 func getBasicAuthHeader(username, password string) string {


### PR DESCRIPTION
- Use generics to allow use of type safe RetryLoops
- Drop need in tests to always assert on errr != nil for some rest utility test functions

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3096/ (known independent flake)
