### PR TITLE
fix processEntry mode on caching tool

### DIFF
--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -211,7 +211,7 @@ func main() {
 		dcpGen.vBucketCreation(ctx)
 	} else if *mode == processEntry {
 		p := &processEntryGen{t: t, dbCtx: dbContext, delays: delayList, seqAlloc: seqAllocator, numNodes: *nodes,
-			batchSize: *batchSize, numChans: *numChannelsPerDoc}
+			batchSize: *batchSize, numChansPerDoc: *numChannelsPerDoc, totalChans: *totalNumberOfChans}
 		// create new sgw node abstraction and spawn write goroutines
 		p.spawnDocCreationGoroutine(ctx)
 	} else {

--- a/tools/cache_perf_tool/processEntry.go
+++ b/tools/cache_perf_tool/processEntry.go
@@ -50,8 +50,8 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 	if delay.Nanoseconds() == 0 {
 		// mutate as fast as possible
 		for {
-			chanMap = make(channels.ChannelMap)
-			for i := 0; i < p.numChansPerDoc; i++ {
+			chanMap = make(channels.ChannelMap, p.numChansPerDoc)
+			for range p.numChansPerDoc {
 				if chanCountZeroWait == p.totalChans {
 					// when count gets to total number configured channels we rest index to 0
 					chanCountZeroWait = 0
@@ -60,11 +60,11 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 				chanMap[chanName] = nil
 				chanCountZeroWait++
 			}
-			timeStamp := time.Now()
 			select {
 			case <-ctx.Done():
 				return
 			default:
+				timeStamp := time.Now()
 				sgwSeqno := node.seqAlloc.nextSeq()
 				docCount++
 				logEntry := &db.LogEntry{
@@ -85,8 +85,8 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 	ticker := time.NewTicker(delay)
 	defer ticker.Stop()
 	for {
-		chanMap = make(channels.ChannelMap)
-		for i := 0; i < p.numChansPerDoc; i++ {
+		chanMap = make(channels.ChannelMap, p.numChansPerDoc)
+		for range p.numChansPerDoc {
 			if chanCountWait == p.totalChans {
 				// when count gets to total number configured channels we rest index to 0
 				chanCountWait = 0
@@ -95,11 +95,11 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 			chanMap[chanName] = nil
 			chanCountWait++
 		}
-		timeStamp := time.Now()
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			timeStamp := time.Now()
 			docCount++
 			sgwSeqno := node.seqAlloc.nextSeq()
 			logEntry := &db.LogEntry{

--- a/tools/cache_perf_tool/processEntry.go
+++ b/tools/cache_perf_tool/processEntry.go
@@ -19,13 +19,14 @@ import (
 )
 
 type processEntryGen struct {
-	seqAlloc  *syncSeqMock
-	delays    []time.Duration
-	dbCtx     *db.DatabaseContext
-	t         *testing.T
-	numNodes  int
-	batchSize int
-	numChans  int
+	seqAlloc       *syncSeqMock
+	delays         []time.Duration
+	dbCtx          *db.DatabaseContext
+	t              *testing.T
+	numNodes       int
+	batchSize      int
+	numChansPerDoc int
+	totalChans     int
 }
 
 func (p *processEntryGen) spawnDocCreationGoroutine(ctx context.Context) {
@@ -41,14 +42,24 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 	docCount := uint64(0)
 	numGoroutines.Add(1)
 	defer numGoroutines.Add(-1)
-	// create map of configured channels
-	chanMap := make(channels.ChannelMap)
-	for i := 0; i < p.numChans; i++ {
-		chanMap["test-"+strconv.Itoa(i)] = nil
-	}
+	// create map of configured channels, initialised channels are names test-x where x is integer between 0 and total
+	// number of system channels. Thus to assign to channels we can increment through channels initialised
+	chanCountZeroWait := 0
+	chanCountWait := 0
+	var chanMap channels.ChannelMap
 	if delay.Nanoseconds() == 0 {
 		// mutate as fast as possible
 		for {
+			chanMap = make(channels.ChannelMap)
+			for i := 0; i < p.numChansPerDoc; i++ {
+				if chanCountZeroWait == p.totalChans {
+					// when count gets to total number configured channels we rest index to 0
+					chanCountZeroWait = 0
+				}
+				chanName := "test-" + strconv.Itoa(chanCountZeroWait)
+				chanMap[chanName] = nil
+				chanCountZeroWait++
+			}
 			timeStamp := time.Now()
 			select {
 			case <-ctx.Done():
@@ -74,6 +85,16 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 	ticker := time.NewTicker(delay)
 	defer ticker.Stop()
 	for {
+		chanMap = make(channels.ChannelMap)
+		for i := 0; i < p.numChansPerDoc; i++ {
+			if chanCountWait == p.totalChans {
+				// when count gets to total number configured channels we rest index to 0
+				chanCountWait = 0
+			}
+			chanName := "test-" + strconv.Itoa(chanCountWait)
+			chanMap[chanName] = nil
+			chanCountWait++
+		}
 		timeStamp := time.Now()
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION

After #7483 got merged processEnrty mode was broken due to some changes. Also needed to add ability to add configured number of channels per doc from system channels. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
