### PR TITLE
CBG-4565 re-implement post_upgrade

### DIFF
--- a/db/indexes.go
+++ b/db/indexes.go
@@ -528,7 +528,7 @@ func GetOnlinePrincipalIndexes(ctx context.Context, collection base.N1QLStore, u
 	return onlineIndexes, nil
 }
 
-// RemoveUnusedIndexes removes indexes that are not in use from the bucket given a collection of indexes that are in use. Only datastores which are keys of inUseIndexes are considered, other datastores will be ignored. It returns a list of removed indexes. Running with preview=true will not remove any indexes, but will return the list of indexes that would be removed.
+// RemoveUnusedIndexes removes Sync Gateway indexes that are not in use from the bucket given a collection of indexes that are in use. Only datastores which are keys of inUseIndexes are considered, other datastores will be ignored. It returns a list of removed indexes. Running with preview=true will not remove any indexes, but will return the list of indexes that would be removed.
 func RemoveUnusedIndexes(ctx context.Context, bucket base.Bucket, inUseIndexes CollectionIndexes, preview bool) (removedIndexes []string, err error) {
 	var errs *base.MultiError
 	for dsName, inUseIndexes := range inUseIndexes {

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -85,3 +85,33 @@ func TestShouldUseLegacySyncDocsIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSGIndex(t *testing.T) {
+	validSGIndexes := []string{
+		"sg_access_foo", // this will get marked as a sync gateway index
+		"sg_access_x1",
+		"sg_access_x2",
+		"sg_channels_1",
+		"sg_roleAccess_x1",
+		"sg_syncDocs_x1",
+		"sg_syncDocs_x1_p1",
+		"sg_syncDocs_x2",
+		"sg_tombstones_x1",
+	}
+	for _, indexName := range validSGIndexes {
+		t.Run(indexName, func(t *testing.T) {
+			assert.True(t, isSGIndex(indexName), "expected %s to be a sync gateway index", indexName)
+		})
+	}
+	invalidSGIndexes := []string{
+		"sg_sync_docs_1",
+		"sg_sync_docs",
+		"some_index",
+		"_sg_access_x1",
+	}
+	for _, indexName := range invalidSGIndexes {
+		t.Run(indexName, func(t *testing.T) {
+			assert.False(t, isSGIndex(indexName), "expected %s to not be a sync gateway index", indexName)
+		})
+	}
+}

--- a/db/indextest/post_upgrade_test.go
+++ b/db/indextest/post_upgrade_test.go
@@ -141,6 +141,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 }
 
 func TestPostUpgradeMultipleCollections(t *testing.T) {
+	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyQuery)
 
 	bucket := base.GetTestBucket(t)

--- a/db/indextest/post_upgrade_test.go
+++ b/db/indextest/post_upgrade_test.go
@@ -80,6 +80,12 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 			database, ctx := db.CreateTestDatabase(t, bucket, test.dbOptions)
 			defer database.Close(ctx)
 
+			// add some non SG indexes to the bucket to make sure they aren't removed when running post upgrade
+			n1qlStore, ok := db.GetSingleDatabaseCollection(t, database.DatabaseContext).GetCollectionDatastore().(base.N1QLStore)
+			require.True(t, ok)
+			require.NoError(t, n1qlStore.CreatePrimaryIndex(ctx, "sg_primary", &base.N1qlIndexOptions{}))
+			require.NoError(t, n1qlStore.CreateIndex(ctx, "sg_nonSGIndex", "val", "val > 3", &base.N1qlIndexOptions{}))
+
 			// Preview removing indexes
 			removedIndexes, removeErr := db.RemoveUnusedIndexes(ctx, database.Bucket, database.GetInUseIndexes(), true)
 			require.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in preview mode")

--- a/docs/api/paths/admin/_post_upgrade.yaml
+++ b/docs/api/paths/admin/_post_upgrade.yaml
@@ -18,8 +18,8 @@ post:
       in: query
       description: 'If set, a dry-run will be done to return what would be removed.'
       schema:
-        type: string
-        default: 'false'
+        type: boolean
+        default: false
   responses:
     '200':
       description: Returned results
@@ -46,6 +46,7 @@ post:
                       type: array
                       items:
                         type: string
+                      example: ["`_default`.`_default`.syncDocs_x1`", "`scope`.`collection1`.sg_allDocs_1"]
                   required:
                     - removed_design_docs
                     - removed_indexes

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -35,6 +35,9 @@ func TestChangeIndexPartitions(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test only works against Couchbase Server with GSI enabled")
 	}
+	if !base.TestUseXattrs() {
+		t.Skip("To simplify testing to allow for exact string matching on indexes, skip for xattrs")
+	}
 
 	// requires index init for many subtests
 	base.LongRunningTest(t)
@@ -183,7 +186,7 @@ func TestChangeIndexPartitions(t *testing.T) {
 	}
 }
 
-// assertNumSGIndexPartitions ensures that the number of partitions for SG indexes is as expected. Some indexes aren't partitioned.
+// requireNumSGIndexPartitions ensures that the number of partitions for SG indexes is as expected. Some indexes aren't partitioned.
 func assertNumSGIndexPartitions(t testing.TB, database *db.DatabaseContext) {
 	gocbBucket, err := base.AsGocbV2Bucket(database.Bucket)
 	require.NoError(t, err)

--- a/rest/indextest/index_test.go
+++ b/rest/indextest/index_test.go
@@ -954,7 +954,7 @@ func requireActiveChannel(t *testing.T, dataStore base.DataStore, key string, ch
 }
 
 func TestPartitionedIndexes(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test requires Couchbase Server for GSI")
 	}
 	if !base.TestUseXattrs() {
@@ -987,7 +987,8 @@ func TestPartitionedIndexes(t *testing.T) {
 	}
 	if !base.TestsUseNamedCollections() {
 		// metadata index, unpartitioned
-		expectedIndexNames = append(expectedIndexNames, "sg_syncDocs_x1")
+		expectedIndexNames = append(expectedIndexNames, "sg_users_x1")
+		expectedIndexNames = append(expectedIndexNames, "sg_roles_x1")
 	}
 	require.ElementsMatch(t, expectedIndexNames, indexNames)
 

--- a/rest/indextest/post_upgrade_test.go
+++ b/rest/indextest/post_upgrade_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestPostUpgrade(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("rosmar doesn't support N1QLStore")
+	}
 	base.RequireNumTestDataStores(t, 2)
 
 	ctx := base.TestCtx(t)

--- a/rest/indextest/post_upgrade_test.go
+++ b/rest/indextest/post_upgrade_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package indextest
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostUpgrade(t *testing.T) {
+	base.RequireNumTestDataStores(t, 2)
+
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	defaultDataStore, ok := bucket.DefaultDataStore().(base.N1QLStore)
+	require.True(t, ok, "Default data store should be N1QLDataStore")
+	// create legacy syncDocs index + all non metadata indexes
+	require.NoError(t, db.InitializeIndexes(ctx, defaultDataStore, db.InitializeIndexOptions{
+		NumReplicas:         0,
+		UseXattrs:           base.TestUseXattrs(),
+		NumPartitions:       db.DefaultNumIndexPartitions,
+		LegacySyncDocsIndex: true,
+		MetadataIndexes:     db.IndexesAll,
+	}))
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+		CustomTestBucket: bucket.NoCloseClone(),
+	})
+	defer rt.Close()
+
+	const (
+		db1Name = "db1"
+		db2Name = "db2"
+		db3Name = "db3"
+	)
+	// create a database with the default collection
+	db1Config := rt.NewDbConfig()
+	db1Config.Scopes = nil
+	rest.RequireStatus(t, rt.CreateDatabase(db1Name, db1Config), http.StatusCreated)
+	db1 := rt.ServerContext().AllDatabases()[db1Name]
+	require.True(t, db1.UseLegacySyncDocsIndex())
+
+	// create sg_users_x1 and sg_roles_x1 indexes
+	require.NoError(t, db.InitializeIndexes(ctx, defaultDataStore, db.InitializeIndexOptions{
+		NumReplicas:         0,
+		UseXattrs:           base.TestUseXattrs(),
+		NumPartitions:       db.DefaultNumIndexPartitions,
+		LegacySyncDocsIndex: false,
+		MetadataIndexes:     db.IndexesMetadataOnly,
+	}))
+
+	// create two databases with the same scope but different collections
+	ds2Name := bucket.GetNonDefaultDatastoreNames()[0]
+	db2Config := rt.NewDbConfig()
+	db2Config.Scopes = rest.ScopesConfig{
+		ds2Name.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				ds2Name.CollectionName(): {},
+			},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(db2Name, db2Config), http.StatusCreated)
+	db2 := rt.ServerContext().AllDatabases()[db2Name]
+	require.False(t, db2.UseLegacySyncDocsIndex())
+
+	ds3Name := bucket.GetNonDefaultDatastoreNames()[1]
+	db3Config := rt.NewDbConfig()
+	db3Config.Scopes = rest.ScopesConfig{
+		ds2Name.ScopeName(): rest.ScopeConfig{
+			Collections: rest.CollectionsConfig{
+				ds3Name.CollectionName(): {},
+			},
+		},
+	}
+	rest.RequireStatus(t, rt.CreateDatabase(db3Name, db3Config), http.StatusCreated)
+	db3 := rt.ServerContext().AllDatabases()[db3Name]
+	require.False(t, db3.UseLegacySyncDocsIndex())
+
+	t.Run("no-op post-upgrade", func(t *testing.T) {
+		for _, preview := range []bool{true, false} {
+			t.Run("preview="+strconv.FormatBool(preview), func(t *testing.T) {
+				url := "/_post_upgrade"
+				if preview {
+					url += "?preview=true"
+				}
+				resp := rt.SendAdminRequest(http.MethodPost, url, "")
+				rest.RequireStatus(t, resp, http.StatusOK)
+				var output rest.PostUpgradeResponse
+				require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &output))
+			})
+		}
+	})
+
+	// delete the database with the default collection, which will allow sg_syncDocs_x1 and all non-metadata indexes from default collection to be removed
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, "/"+db1Name+"/", ""), http.StatusOK)
+	for _, preview := range []bool{true, false} {
+		t.Run("preview="+strconv.FormatBool(preview), func(t *testing.T) {
+			url := "/_post_upgrade"
+			if preview {
+				url += "?preview=true"
+			}
+			resp := rt.SendAdminRequest(http.MethodPost, url, "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+			var output rest.PostUpgradeResponse
+			require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &output))
+			// unused indexes created by InitializeIndexes, like a database that was targeting a default collection
+			expectedRemovedIndexes := []string{
+				"`_default`.`_default`.sg_access_x1",
+				"`_default`.`_default`.sg_allDocs_x1",
+				"`_default`.`_default`.sg_channels_x1",
+				"`_default`.`_default`.sg_roleAccess_x1",
+				"`_default`.`_default`.sg_syncDocs_x1",
+				"`_default`.`_default`.sg_tombstones_x1",
+			}
+			if !base.TestUseXattrs() {
+				expectedRemovedIndexes = []string{
+					"`_default`.`_default`.sg_access_1",
+					"`_default`.`_default`.sg_allDocs_1",
+					"`_default`.`_default`.sg_channels_1",
+					"`_default`.`_default`.sg_roleAccess_1",
+					"`_default`.`_default`.sg_syncDocs_1",
+				}
+
+			}
+			require.Equal(t, rest.PostUpgradeResponse{
+				Result: rest.PostUpgradeResult{
+					db2Name: rest.PostUpgradeDatabaseResult{
+						RemovedDDocs:   []string{},
+						RemovedIndexes: expectedRemovedIndexes,
+					},
+					db3Name: rest.PostUpgradeDatabaseResult{
+						RemovedDDocs:   []string{},
+						RemovedIndexes: expectedRemovedIndexes,
+					},
+				},
+				Preview: preview,
+			}, output)
+
+		})
+	}
+}

--- a/rest/indextest/post_upgrade_test.go
+++ b/rest/indextest/post_upgrade_test.go
@@ -39,6 +39,10 @@ func TestPostUpgrade(t *testing.T) {
 		LegacySyncDocsIndex: true,
 		MetadataIndexes:     db.IndexesAll,
 	}))
+	// create non SG indexes to make sure they aren't removed by post upgrade
+	require.NoError(t, defaultDataStore.CreatePrimaryIndex(ctx, "sg_primary", &base.N1qlIndexOptions{}))
+	require.NoError(t, defaultDataStore.CreateIndex(ctx, "sg_nonSGIndex", "val", "val > 3", &base.N1qlIndexOptions{}))
+
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		PersistentConfig: true,
 		CustomTestBucket: bucket.NoCloseClone(),

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -70,7 +70,11 @@ func TestResyncWithoutIndexes(t *testing.T) {
 			numIndexes, err := n1qlStore.GetIndexes()
 			require.NoError(t, err)
 			if collection.IsDefaultCollection() {
-				require.Len(t, numIndexes, 1, "Expected 1 index for default collection")
+				if rt.GetDatabase().UseLegacySyncDocsIndex() {
+					require.Len(t, numIndexes, 1) // sg_syncDocs
+				} else {
+					require.Len(t, numIndexes, 2) // sg_roles, sg_syncDocs
+				}
 			} else {
 				require.Len(t, numIndexes, 0, "Expected 0 indexes for non-default collection")
 			}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -512,6 +512,11 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 			errs = errs.Append(fmt.Errorf("Error getting bucket %q for index cleanup: %v", bucketName, err))
 			continue
 		}
+		// if running with rosmar, can not remove indexes
+		_, ok = base.AsN1QLStore(bucket.DefaultDataStore())
+		if !ok {
+			continue
+		}
 		removedIndexes, err := db.RemoveUnusedIndexes(ctx, bucket, indexes, preview)
 		if err != nil {
 			errs = errs.Append(fmt.Errorf("Error removing obsolete indexes for bucket %q: %v", bucketName, err))

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -512,9 +512,7 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 			errs = errs.Append(fmt.Errorf("Error getting bucket %q for index cleanup: %v", bucketName, err))
 			continue
 		}
-		// if running with rosmar, can not remove indexes
-		_, ok = base.AsN1QLStore(bucket.DefaultDataStore())
-		if !ok {
+		if !bucket.IsSupported(sgbucket.BucketStoreFeatureN1ql) {
 			continue
 		}
 		removedIndexes, err := db.RemoveUnusedIndexes(ctx, bucket, indexes, preview)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -491,9 +491,6 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 		}
 		dbDesignDocs[dbName] = removedDDocs
 
-		if database.UseViews() {
-			continue
-		}
 		// Index cleanup
 		inUseIndexes := database.GetInUseIndexes()
 		if _, ok := bucketInUseIndexes[database.Bucket.GetName()]; !ok {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -473,24 +473,64 @@ func (sc *ServerContext) PostUpgrade(ctx context.Context, preview bool) (postUpg
 	sc.lock.RLock()
 	defer sc.lock.RUnlock()
 
-	postUpgradeResults = make(map[string]PostUpgradeDatabaseResult, len(sc.databases_))
-
-	for name, database := range sc.databases_ {
+	var errs *base.MultiError
+	buckets := make(map[string]base.Bucket)                       // map of bucket name to bucket object
+	dbs := make(map[string]string, len(sc.databases_))            // map of db name to bucket name
+	dbDesignDocs := make(map[string][]string, len(sc.databases_)) // map of db name to removed design docs
+	bucketInUseIndexes := make(map[string]db.CollectionIndexes)   // map of buckets to in use index names
+	bucketRemovedIndexes := make(map[string][]string)             // map of bucket name to removed index names
+	for dbName, database := range sc.databases_ {
+		bucketName := database.Bucket.GetName()
+		dbs[dbName] = bucketName
+		buckets[bucketName] = database.Bucket
 		// View cleanup
-		removedDDocs, _ := database.RemoveObsoleteDesignDocs(ctx, preview)
-
-		// Index cleanup
-		var removedIndexes []string
-		if !base.TestsDisableGSI() {
-			removedIndexes, _ = database.RemoveObsoleteIndexes(ctx, preview)
+		removedDDocs, err := database.RemoveObsoleteDesignDocs(ctx, preview)
+		if err != nil {
+			errs = errs.Append(fmt.Errorf("Error removing obsolete design docs for database %q: %v", dbName, err))
+			continue
 		}
+		dbDesignDocs[dbName] = removedDDocs
 
-		postUpgradeResults[name] = PostUpgradeDatabaseResult{
-			RemovedDDocs:   removedDDocs,
-			RemovedIndexes: removedIndexes,
+		if database.UseViews() {
+			continue
+		}
+		// Index cleanup
+		inUseIndexes := database.GetInUseIndexes()
+		if _, ok := bucketInUseIndexes[database.Bucket.GetName()]; !ok {
+			bucketInUseIndexes[database.Bucket.GetName()] = make(db.CollectionIndexes)
+		}
+		for dsName, indexes := range inUseIndexes {
+			if _, ok := bucketInUseIndexes[database.Bucket.GetName()][dsName]; !ok {
+				bucketInUseIndexes[database.Bucket.GetName()][dsName] = make(map[string]struct{})
+			}
+			for indexName := range indexes {
+				bucketInUseIndexes[database.Bucket.GetName()][dsName][indexName] = struct{}{}
+			}
 		}
 	}
-	return postUpgradeResults, nil
+
+	for bucketName, indexes := range bucketInUseIndexes {
+		bucket, ok := buckets[bucketName]
+		if !ok {
+			errs = errs.Append(fmt.Errorf("Error getting bucket %q for index cleanup: %v", bucketName, err))
+			continue
+		}
+		removedIndexes, err := db.RemoveUnusedIndexes(ctx, bucket, indexes, preview)
+		if err != nil {
+			errs = errs.Append(fmt.Errorf("Error removing obsolete indexes for bucket %q: %v", bucketName, err))
+			continue
+		}
+		bucketRemovedIndexes[bucketName] = removedIndexes
+	}
+	postUpgradeResults = make(map[string]PostUpgradeDatabaseResult, len(sc.databases_))
+	for dbName, database := range sc.databases_ {
+		postUpgradeResults[dbName] = PostUpgradeDatabaseResult{
+			RemovedDDocs:   dbDesignDocs[dbName],
+			RemovedIndexes: bucketRemovedIndexes[database.Bucket.GetName()],
+		}
+	}
+	return postUpgradeResults, errs.ErrorOrNil()
+
 }
 
 // Removes and re-adds a database to the ServerContext.
@@ -1354,6 +1394,9 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		NumIndexReplicas:            config.numIndexReplicas(),
 	}
 
+	if config.Index != nil && config.Index.NumPartitions != nil {
+		contextOptions.NumIndexPartitions = config.Index.NumPartitions
+	}
 	// Per-database logging config overrides
 	contextOptions.LoggingConfig = config.toDbLogConfig(ctx)
 


### PR DESCRIPTION
CBG-4565 post-upgrade for partitioned indexes
CBG-4608 post-upgrade for sync docs

PostUpgrade works by iterating over all the databases and assembling a collection of indexes in use. Then, remove all indexes that don't match this.

- the format of `/_post_upgrade` output is wacky ```[]string{"`scope`.`collection`.idx}``` but I preserved it since it is unambiguous

I'd be curious what kinds of tests are missing. I think I can write tests more efficiently by making `N1QLStore.GetIndexes` part of the LeakyDataStore but then I didn't immediately spot if any tests are missing.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3103/
- [x] `GSI=true,xattrs=true,default_collection_only=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3101/ (failing tests, but different issues than this ticket) 
- [x] `GSI=true,xattrs=false` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3102/ (failing tests, but different issues than this ticket)