### PR TITLE
CBG-4637 fix example for /_all_dbs

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3052,13 +3052,27 @@ CollectionNames:
     type: string
     example: ["collection1", "collection2"]
 "All DBs":
+  title: Simple
   description: "The names of all databases."
   type: array
   items:
     type: string
+  example: ["db1", "db2"] # example required to work around https://github.com/Redocly/redoc/issues/2676
 "All DBs Verbose":
+  title: Verbose
   description: "Description of all databases."
   type: array
+  example: # example required to work around https://github.com/Redocly/redoc/issues/2676
+    - db_name: "db1"
+      bucket: "bucket1"
+      state: "Online"
+      require_resync: false
+      init_in_progress: false
+    - db_name: "db2"
+      bucket: "bucket2"
+      state: "Starting"
+      require_resync: true
+      init_in_progress: true
   items:
     type: object
     properties:

--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -64,11 +64,13 @@ post:
                     description: A map of the channels the user is in along with the sequence number the user was granted access.
                     type: object
                     additionalProperties:
-                      oneOf:
-                        - type: number
-                        - type: string
+                      type: number
                       minimum: 1
-                      description: The channel name (as the key) and the channel sequence number the user was granted access to that channel.
+                      description: The sequence number the user was granted access.
+                      title: sequence number
+                    example:
+                      "!": 1
+                      "channelA": 2
                   name:
                     description: The name of the user.
                     type: string
@@ -80,17 +82,6 @@ post:
               - authentication_handlers
               - ok
               - userCtx
-          examples:
-            Example:
-              value:
-                authentication_handlers:
-                  - default
-                  - cookie
-                ok: true
-                userCtx:
-                  channels:
-                    '!': 1
-                  name: Bob
     '400':
       $ref: ../../components/responses.yaml#/Invalid-CORS
     '404':


### PR DESCRIPTION
CBG-4637 fix example for /_all_dbs

Analyzed use of `oneOf` in our documentation. 
- removed oneOf in `userCtx` since it always returns a sequence number, never compound sequence
- oneOf bug only hits arrays https://github.com/Redocly/redoc/issues/2676 and not objects in getting db audit configuration