### PR TITLE
CBG-4633 avoid reconstructing channel map

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -742,7 +742,7 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channe
 	var changedChannels channels.Set
 	if sequence == c.nextSequence || c.nextSequence == 0 {
 		// This is the expected next sequence so we can add it now:
-		changedChannels = channels.SetFromArrayNoValidate(c._addToCache(ctx, change))
+		changedChannels = c._addToCache(ctx, change)
 		// Also add any pending sequences that are now contiguous:
 		changedChannels = changedChannels.Update(c._addPendingLogs(ctx))
 	} else if sequence > c.nextSequence {
@@ -774,7 +774,7 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channe
 			change.Skipped = true
 		}
 
-		changedChannels = changedChannels.UpdateWithSlice(c._addToCache(ctx, change))
+		changedChannels = changedChannels.Update(c._addToCache(ctx, change))
 		// Add to cache before removing from skipped, to ensure lowSequence doesn't get incremented until results are available
 		// in cache
 		err := c.RemoveSkipped(sequence)
@@ -787,7 +787,7 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channe
 
 // Adds an entry to the appropriate channels' caches, returning the affected channels.  lateSequence
 // flag indicates whether it was a change arriving out of sequence
-func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) []channels.ID {
+func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) channels.Set {
 
 	if change.Sequence >= c.nextSequence {
 		c.nextSequence = change.Sequence + 1
@@ -837,7 +837,7 @@ func (c *changeCache) _addPendingLogs(ctx context.Context) channels.Set {
 
 		if isNext {
 			oldestPending = c._popPendingLog(ctx)
-			changedChannels = changedChannels.UpdateWithSlice(c._addToCache(ctx, oldestPending))
+			changedChannels = changedChannels.Update(c._addToCache(ctx, oldestPending))
 		} else if oldestPending.Sequence < c.nextSequence {
 			// oldest pending is lower than next sequence, should be ignored
 			base.InfofCtx(ctx, base.KeyCache, "Oldest entry in pending logs %v (%d, %d) is earlier than cache next sequence (%d), ignoring as sequence has already been cached", base.UD(oldestPending.DocID), oldestPending.Sequence, oldestPending.EndSequence, c.nextSequence)

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -39,7 +39,7 @@ type ChannelCache interface {
 	Init(initialSequence uint64)
 
 	// Adds an entry to the cache, returns set of channels it was added to
-	AddToCache(ctx context.Context, change *LogEntry) []channels.ID
+	AddToCache(ctx context.Context, change *LogEntry) channels.Set
 
 	// Notifies the cache of a principal update.  Updates the cache's high sequence
 	AddPrincipal(change *LogEntry)
@@ -197,14 +197,14 @@ func (c *channelCacheImpl) AddUnusedSequence(change *LogEntry) {
 
 // Adds an entry to the appropriate channels' caches, returning the affected channels.  lateSequence
 // flag indicates whether it was a change arriving out of sequence
-func (c *channelCacheImpl) AddToCache(ctx context.Context, change *LogEntry) (updatedChannels []channels.ID) {
+func (c *channelCacheImpl) AddToCache(ctx context.Context, change *LogEntry) channels.Set {
 
 	ch := change.Channels
 	change.Channels = nil // not needed anymore, so free some memory
 
 	// updatedChannels tracks the set of channels that should be notified of the change.  This includes
 	// the change's active channels, as well as any channel removals for the active revision.
-	updatedChannels = make([]channels.ID, 0, len(ch))
+	updatedChannels := make(channels.Set, len(ch))
 
 	// If it's a late sequence, we want to add to all channel late queues within a single write lock,
 	// to avoid a changes feed seeing the same late sequence in different iteration loops (and sending
@@ -234,7 +234,7 @@ func (c *channelCacheImpl) AddToCache(ctx context.Context, change *LogEntry) (up
 				}
 			}
 			// Need to notify even if channel isn't active, for case where number of connected changes channels exceeds cache capacity
-			updatedChannels = append(updatedChannels, channels.NewID(channelName, change.CollectionID))
+			updatedChannels.Add(channels.NewID(channelName, change.CollectionID))
 		}
 	}
 
@@ -246,7 +246,7 @@ func (c *channelCacheImpl) AddToCache(ctx context.Context, change *LogEntry) (up
 				channelCache.AddLateSequence(change)
 			}
 		}
-		updatedChannels = append(updatedChannels, channels.NewID(channels.UserStarChannel, change.CollectionID))
+		updatedChannels.Add(channels.NewID(channels.UserStarChannel, change.CollectionID))
 	}
 
 	c.updateHighCacheSequence(change.Sequence)


### PR DESCRIPTION
CBG-4633 avoid reconstructing channel map

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3106/
