### PR TITLE
CBG-4635: move getNextSequence() call to outside recent sequence loop

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -472,9 +472,10 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	if len(syncData.RecentSequences) > 0 {
+		nextSequence := c.getNextSequence()
 
 		for _, seq := range syncData.RecentSequences {
-			if seq >= c.getNextSequence() && seq < currentSequence {
+			if seq >= nextSequence && seq < currentSequence {
 				base.InfofCtx(ctx, base.KeyCache, "Received deduplicated #%d in recent_sequences property for (%q / %q)", seq, base.UD(docID), syncData.CurrentRev)
 				change := &LogEntry{
 					Sequence:     seq,

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1779,6 +1779,10 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 }
 
 func TestRecentSequenceHandlingForDeduplication(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("This test requires xattrs because it writes directly to the xattr")
+	}
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	db, ctx := setupTestDB(t)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1793,7 +1793,7 @@ func TestRecentSequenceHandlingForDeduplication(t *testing.T) {
 	err = db.changeCache.waitForSequence(ctx, 1, base.DefaultWaitForSequence)
 	require.NoError(t, err)
 
-	// grab doc and alter syn cdata as if it had been rapidly updated and deduplicated over dcp
+	// grab doc and alter sync data as if it had been rapidly updated and deduplicated over dcp
 	xattrs, cas, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.SyncXattrName})
 	require.NoError(t, err)
 
@@ -1807,7 +1807,7 @@ func TestRecentSequenceHandlingForDeduplication(t *testing.T) {
 	_, err = collection.dataStore.UpdateXattrs(ctx, docID, 0, cas, newXattrVal, nil)
 	require.NoError(t, err)
 
-	// asser that sequence 6 is seen over caching feed, no pending changes or skipped changes
+	// assert that sequence 6 is seen over caching feed, no pending changes or skipped changes
 	err = db.changeCache.waitForSequence(ctx, 6, base.DefaultWaitForSequence)
 	require.NoError(t, err)
 	db.UpdateCalculatedStats(ctx)


### PR DESCRIPTION
CBG-4635

- Moved `getNextSequence()` call to outside the recent sequences loop in `DocChanged`
- There were signs of some contention on the cache mutex so having this function called less times will make contention a little better. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3107/
