### PR TITLE
CBG-4441 switch cache to use int64 from time.Time

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2937,7 +2937,7 @@ func TestAddPendingLogs(t *testing.T) {
 					logEntry.TimeReceived = backdatedTimeReceived
 					heap.Push(&testChangeCache.pendingLogs, logEntry)
 				} else {
-					testChangeCache._pushRangeToPending(ctx, incomingRange.start, incomingRange.end, backdatedTimeReceived)
+					testChangeCache._pushRangeToPending(incomingRange.start, incomingRange.end, backdatedTimeReceived)
 				}
 			}
 			// Call _addPendingLogs to trigger eviction from pendingLogs based on age

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -18,6 +18,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 )
 
 // One "changes" row in a channelsViewResult
@@ -44,7 +45,7 @@ func nextChannelViewEntry(ctx context.Context, results sgbucket.QueryResultItera
 		DocID:        viewRow.ID,
 		RevID:        viewRow.Value.Rev,
 		Flags:        viewRow.Value.Flags,
-		TimeReceived: time.Now(),
+		TimeReceived: channels.NewFeedTimestampFromNow(),
 		CollectionID: collectionID,
 	}
 	return entry, true
@@ -63,7 +64,7 @@ func nextChannelQueryEntry(ctx context.Context, results sgbucket.QueryResultIter
 		DocID:        queryRow.Id,
 		RevID:        queryRow.Rev,
 		Flags:        queryRow.Flags,
-		TimeReceived: time.Now(),
+		TimeReceived: channels.NewFeedTimestampFromNow(),
 		CollectionID: collectionID,
 	}
 

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -298,7 +298,7 @@ func (c *singleChannelCacheImpl) pruneCacheAge(ctx context.Context) {
 	pruned := 0
 	// Remove all entries who've been in the cache longer than channelCacheAge, except
 	// those that fit within channelCacheMinLength and therefore not subject to cache age restrictions
-	for len(c.logs) > c.options.ChannelCacheMinLength && time.Since(c.logs[0].TimeReceived) > c.options.ChannelCacheAge {
+	for len(c.logs) > c.options.ChannelCacheMinLength && c.logs[0].TimeReceived.OlderThan(c.options.ChannelCacheAge) {
 		c.validFrom = c.logs[0].Sequence + 1
 		c.UpdateCacheUtilization(c.logs[0], -1)
 		delete(c.cachedDocIDs, c.logs[0].DocID)

--- a/tools/cache_perf_tool/processEntry.go
+++ b/tools/cache_perf_tool/processEntry.go
@@ -64,7 +64,7 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 			case <-ctx.Done():
 				return
 			default:
-				timeStamp := time.Now()
+				timeStamp := channels.NewFeedTimestampFromNow()
 				sgwSeqno := node.seqAlloc.nextSeq()
 				docCount++
 				logEntry := &db.LogEntry{
@@ -73,7 +73,6 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 					RevID:        "1-abc",
 					Flags:        0,
 					TimeReceived: timeStamp,
-					TimeSaved:    timeStamp,
 					Channels:     chanMap,
 					CollectionID: 0,
 				}
@@ -99,7 +98,7 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			timeStamp := time.Now()
+			timeStamp := channels.NewFeedTimestampFromNow()
 			docCount++
 			sgwSeqno := node.seqAlloc.nextSeq()
 			logEntry := &db.LogEntry{
@@ -108,7 +107,6 @@ func (p *processEntryGen) nodeWrites(ctx context.Context, node *sgwNode, delay t
 				RevID:        "1-abc",
 				Flags:        0,
 				TimeReceived: timeStamp,
-				TimeSaved:    timeStamp,
 				Channels:     chanMap,
 				CollectionID: 0,
 			}


### PR DESCRIPTION
CBG-4441 create a timestamp for cache

- Reduce size of `LogEntry` from 136 to 72 bytes. Some of this is replacing the `time.Time` with `FeedTimestamp` and the rest is using `fieldalignment` tool to ensure optimal struct packing. Several unused fields were removed: `TimeSaved`, `PrevSequence`
- The `TimeReceived` is used strictly for counting for the time it takes to cache an item, so it only needs to be relative to the earlier in memory processing time, thus `time.Time` doesn't need to be stored. I considered modifying `sgbucket.FeedEvent` to store a `FeedTimestamp` but decided not to. The `FeedEvent` is already passed through DCP as a copy (112 bytes, mostly pointers and ints) and I didn't think that it needed to be moved too much. It would still need to be converted from `time.Time` from gocbcore to an `sgbucket.FeedEvent` and delaying this later seems fine.
- Created `FeedTimestamp` to represent this new type and use helper methods to avoid accidental integer mishap when computing timestamps. I didn't have tests for the `FeedTimestamp` functions, so those should be verified by eye. In order to write tests, I would have to create a replaceable `time.Now` function at a package level and I'm not sure if this is worthwhile.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3112/
