### PR TITLE
CBG-4634: remove mutex around initial sequence inside getInitialSequence()

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -947,12 +947,9 @@ func (c *changeCache) getNextSequence() (nextSequence uint64) {
 	return nextSequence
 }
 
-// Concurrent-safe get value of initialSequence
-func (c *changeCache) getInitialSequence() (initialSequence uint64) {
-	c.lock.RLock()
-	initialSequence = c.initialSequence
-	c.lock.RUnlock()
-	return initialSequence
+// Gets value of initialSequence on the change cache, this value will not change once db is up running so no need for mutex
+func (c *changeCache) getInitialSequence() uint64 {
+	return c.initialSequence
 }
 
 // ////// LOG PRIORITY QUEUE -- container/heap callbacks that should not be called directly.   Use heap.Init/Push/etc()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -921,8 +921,6 @@ func TestChannelQueryCancellation(t *testing.T) {
 	assert.NoError(t, err, "Put failed with error: %v", err)
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 4, base.DefaultWaitForSequence))
 
-	// Flush the cache, to ensure view query on subsequent changes requests
-
 	// Issue two one-shot since=0 changes request.  Both will attempt a view query.  The first will block based on queryWg,
 	// the second will block waiting for the view lock
 	initialQueryCount := db.DbStats.Cache().ViewQueries.Value()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -922,7 +922,6 @@ func TestChannelQueryCancellation(t *testing.T) {
 	require.NoError(t, db.changeCache.waitForSequence(ctx, 4, base.DefaultWaitForSequence))
 
 	// Flush the cache, to ensure view query on subsequent changes requests
-	// require.NoError(t, db.FlushChannelCache(ctx))
 
 	// Issue two one-shot since=0 changes request.  Both will attempt a view query.  The first will block based on queryWg,
 	// the second will block waiting for the view lock


### PR DESCRIPTION
CBG-4634

- Was expecting to have to move this around a bit but seems that race detectors don't complain so kept it simple. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3109/
