### PR TITLE
CBG-4222: add unused sequence flag to log entry

### DIFF
--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -29,18 +29,19 @@ const (
 )
 
 type LogEntry struct {
-	Sequence     uint64     // Sequence number
-	EndSequence  uint64     // End sequence on range of sequences that have been released by the sequence allocator (0 if entry is single sequence)
-	DocID        string     // Document ID
-	RevID        string     // Revision ID
-	Flags        uint8      // Deleted/Removed/Hidden flags
-	TimeSaved    time.Time  // Time doc revision was saved (just used for perf metrics)
-	TimeReceived time.Time  // Time received from tap feed
-	Channels     ChannelMap // Channels this entry is in or was removed from
-	Skipped      bool       // Late arriving entry
-	PrevSequence uint64     // Sequence of previous active revision
-	IsPrincipal  bool       // Whether the log-entry is a tracking entry for a principal doc
-	CollectionID uint32     // Collection ID
+	Sequence       uint64     // Sequence number
+	EndSequence    uint64     // End sequence on range of sequences that have been released by the sequence allocator (0 if entry is single sequence)
+	DocID          string     // Document ID
+	RevID          string     // Revision ID
+	Flags          uint8      // Deleted/Removed/Hidden flags
+	TimeSaved      time.Time  // Time doc revision was saved (just used for perf metrics)
+	TimeReceived   time.Time  // Time received from tap feed
+	Channels       ChannelMap // Channels this entry is in or was removed from
+	Skipped        bool       // Late arriving entry
+	PrevSequence   uint64     // Sequence of previous active revision
+	IsPrincipal    bool       // Whether the log-entry is a tracking entry for a principal doc
+	CollectionID   uint32     // Collection ID
+	UnusedSequence bool       // Whether the log-entry is a tracking entry for a unused sequence(s)
 }
 
 func (l LogEntry) String() string {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -126,7 +126,7 @@ func (entry *LogEntry) SetDeleted() {
 }
 
 func (entry *LogEntry) IsUnusedRange() bool {
-	return entry.DocID == "" && entry.EndSequence > 0
+	return entry.UnusedSequence && entry.EndSequence > 0
 }
 
 type LogEntries []*LogEntry
@@ -562,8 +562,9 @@ func (c *changeCache) processUnusedSequence(ctx context.Context, docID string, t
 
 func (c *changeCache) releaseUnusedSequence(ctx context.Context, sequence uint64, timeReceived time.Time) {
 	change := &LogEntry{
-		Sequence:     sequence,
-		TimeReceived: timeReceived,
+		Sequence:       sequence,
+		TimeReceived:   timeReceived,
+		UnusedSequence: true,
 	}
 	base.InfofCtx(ctx, base.KeyCache, "Received #%d (unused sequence)", sequence)
 
@@ -593,8 +594,9 @@ func (c *changeCache) releaseUnusedSequenceRange(ctx context.Context, fromSequen
 	// if range is single value, just run sequence through process entry and return early
 	if fromSequence == toSequence {
 		change := &LogEntry{
-			Sequence:     toSequence,
-			TimeReceived: timeReceived,
+			Sequence:       toSequence,
+			TimeReceived:   timeReceived,
+			UnusedSequence: true,
 		}
 		changedChannels := c.processEntry(ctx, change)
 		allChangedChannels = allChangedChannels.Update(changedChannels)
@@ -643,9 +645,10 @@ func (c *changeCache) processUnusedRange(ctx context.Context, fromSequence, toSe
 func (c *changeCache) _pushRangeToPending(ctx context.Context, startSeq, endSeq uint64, timeReceived time.Time) {
 
 	entry := &LogEntry{
-		TimeReceived: timeReceived,
-		Sequence:     startSeq,
-		EndSequence:  endSeq,
+		TimeReceived:   timeReceived,
+		Sequence:       startSeq,
+		EndSequence:    endSeq,
+		UnusedSequence: true,
 	}
 	heap.Push(&c.pendingLogs, entry)
 
@@ -800,7 +803,7 @@ func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) channel
 	delete(c.receivedSeqs, change.Sequence)
 
 	// If unused sequence, notify the cache and return
-	if change.DocID == "" {
+	if change.UnusedSequence {
 		c.channelCache.AddUnusedSequence(change)
 		return nil
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -641,7 +641,7 @@ func (c *changeCache) processUnusedRange(ctx context.Context, fromSequence, toSe
 	return allChangedChannels
 }
 
-// _pushRangeToPending will push a sequence range to pendingLogs
+// _pushRangeToPending will push an unused sequence range to pendingLogs
 func (c *changeCache) _pushRangeToPending(ctx context.Context, startSeq, endSeq uint64, timeReceived time.Time) {
 
 	entry := &LogEntry{


### PR DESCRIPTION
CBG-4222

- Instead of relying on empty doc ID on log entry have an explicit boolean to signify an unused sequence change

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3110/
