### PR TITLE
CBG-4636: have check for skipped sequences on recent sequence handling

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -449,7 +449,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		for _, seq := range syncData.RecentSequences {
 			// seq < currentSequence means the sequence is not the latest allocated to this document
 			// seq >= nextSequence means this sequence is a pending sequence to be expected in the cache
-			// the two conditions above together means that the cache expect ue to run processEntry on this sequence as its pending
+			// the two conditions above together means that the cache expects us to run processEntry on this sequence as its pending
 			// If seq < current sequence allocated to the doc and seq is in skipped list this means that this sequence
 			// never arrived over the caching feed due to deduplication and was pushed to a skipped sequence list
 			isSkipped := (seq < currentSequence && seq < nextSequence) && c.WasSkipped(seq)
@@ -710,8 +710,8 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channe
 	// We can cancel processing early in these scenarios.
 	// Check if this is a duplicate of an already processed sequence
 	if sequence < c.nextSequence && !change.Skipped {
-		// check for presence in skippedSeqs, it's possible that change.skipped can be false but subsequently change
-		// is pushed to skipped before hitting this point
+		// check for presence in skippedSeqs, it's possible that change.skipped can be marked false in recent sequence handling
+		// but this change is subsequently pushed to skipped before acquiring cache mutex in this function
 		if !c.WasSkipped(sequence) {
 			base.DebugfCtx(ctx, base.KeyCache, "  Ignoring duplicate of #%d", sequence)
 			return nil

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -453,7 +453,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 			// the two conditions above together means that the cache expect ue to run processEntry on this sequence as its pending
 			// If seq >= c.getOldestSkippedSequence(ctx) and seq < current sequence allocated to the doc this means
 			// that this sequence never arrived over the caching feed due to deduplication and was pushed to a skipped sequence list
-			isSkipped := seq < currentSequence && seq >= oldestSkipped
+			isSkipped := (seq < currentSequence && seq >= oldestSkipped) && oldestSkipped != 0
 			if (seq >= nextSequence && seq < currentSequence) || isSkipped {
 				base.InfofCtx(ctx, base.KeyCache, "Received deduplicated #%d in recent_sequences property for (%q / %q)", seq, base.UD(docID), syncData.CurrentRev)
 				change := &LogEntry{
@@ -468,6 +468,8 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 					change.DocID = docID
 					change.RevID = atRevId
 					change.Channels = channelRemovals
+				} else {
+					// Todo: add unused seq flag here (needs rebase)
 				}
 
 				changedChannels := c.processEntry(ctx, change)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -447,7 +447,9 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		nextSequence := c.getNextSequence()
 
 		for _, seq := range syncData.RecentSequences {
-			if seq >= nextSequence && seq < currentSequence {
+			// we need to check if it's possible that one of the recent sequences has been pushed to skipped
+			isSkipped := seq < currentSequence && seq >= c.getOldestSkippedSequence(ctx)
+			if (seq >= nextSequence && seq < currentSequence) || isSkipped {
 				base.InfofCtx(ctx, base.KeyCache, "Received deduplicated #%d in recent_sequences property for (%q / %q)", seq, base.UD(docID), syncData.CurrentRev)
 				change := &LogEntry{
 					Sequence:     seq,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -453,6 +453,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 			// the two conditions above together means that the cache expect ue to run processEntry on this sequence as its pending
 			// If seq >= c.getOldestSkippedSequence(ctx) and seq < current sequence allocated to the doc this means
 			// that this sequence never arrived over the caching feed due to deduplication and was pushed to a skipped sequence list
+			// We need check for 0 oldestSkipped because if the skipped list is empty 0 is returned
 			isSkipped := (seq < currentSequence && seq >= oldestSkipped) && oldestSkipped != 0
 			if (seq >= nextSequence && seq < currentSequence) || isSkipped {
 				base.InfofCtx(ctx, base.KeyCache, "Received deduplicated #%d in recent_sequences property for (%q / %q)", seq, base.UD(docID), syncData.CurrentRev)
@@ -469,7 +470,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 					change.RevID = atRevId
 					change.Channels = channelRemovals
 				} else {
-					// Todo: add unused seq flag here (needs rebase)
+					change.UnusedSequence = true // treat as unused sequence when sequence is not channel removal
 				}
 
 				changedChannels := c.processEntry(ctx, change)


### PR DESCRIPTION
CBG-4636

We need to check if its possible that a recent_sequence got pushed to skipped on recent sequence handing, when pending gets to max or is flushed due to age we move the next expected sequence at the cache to the oldest pending sequence. Hence this loop was not running on some sequences that were in recent sequences on a doc but were also present in skipped sequences. This meant skipped would grow exponentially with no prospect of ever removing the sequences until we abandoned them. This lead to high sequence stable being stuck until abandoned sequences job was run. 

I chose not to do an actual check in skipped given this is done inside `processEntry` and it would be less expensive to just check if seq in recent sequence is less than current sequence and it is greater than or equal to the oldest skipped sequence.

Before changes high_seq_stable:
![high_seq_stable_pre](https://github.com/user-attachments/assets/97d5c344-ad28-4186-bff8-c252186d006b)

After changes high_seq_stable:
![high_seq_stable_post](https://github.com/user-attachments/assets/b7d72196-5b62-49d6-805b-5dea6994dade)


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3114/
