### PR TITLE
CBG-4650 Use /db/_config offline= for persistent config in tests

### DIFF
--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -220,6 +220,7 @@ func TestResyncRegenerateSequencesPrincipals(t *testing.T) {
 				require.NotEqual(t, originalUserSeq, user.Sequence())
 			}
 
+			collection, ctx = rt.GetSingleTestDatabaseCollection()
 			// regular doc will always change sequence
 			doc, err = collection.GetDocument(ctx, standardDoc, db.DocUnmarshalSync)
 			require.NoError(t, err)

--- a/rest/indextest/resync_test.go
+++ b/rest/indextest/resync_test.go
@@ -44,7 +44,6 @@ func TestResyncWithoutIndexes(t *testing.T) {
 		}
 	}
 
-	rt.TakeDbOffline()
 	// gocb pipeline bootstrap errors can occur before this stage
 	warningsBeforeResync := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
 	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", ""), http.StatusOK)


### PR DESCRIPTION
Calling `/db/_offline` doesn't actually stop all the processes like setting `{"offline": true}` does https://github.com/couchbase/sync_gateway/blob/c109db310a7ad121a12363f2b0b10c3eb631f3d6/db/database.go#L810

I keep getting burned by this in tests because notably import is still running. In addition, pull ISGR would be running, since only the changes feeds are shut down. Any active push replication can also continue while the database is offline. But any new connections will receive a 503, so the problem might be more limited in scope?

I think this change makes more sense as a default, and I had previously improved logging to suggest not to use the offline endpoints. https://github.com/couchbase/sync_gateway/commit/a82bd9305da18cc361e9786c56cef8335d5d6dc7 It might be worth changing https://docs.couchbase.com/sync-gateway/current/resync.html#updating-the-sync-function documentation as well.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3113/
