### PR TITLE
CBG-560 Remove unused DCP backfill status code

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -32,9 +32,6 @@ const kCheckpointThreshold = 1
 // Only persist checkpoint once per kCheckpointTimeThreshold (per vbucket)
 const kCheckpointTimeThreshold = 1 * time.Minute
 
-// Persist backfill progress every 10s
-const kBackfillPersistInterval = 10 * time.Second
-
 // DCP Feed IDs are used to build unique DCP identifiers
 const DCPCachingFeedID = "SG"
 const DCPImportFeedID = "SGI"

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -29,7 +29,6 @@ func init() {
 
 type SGDest interface {
 	cbgt.Dest
-	initFeed(backfillType uint64) (map[uint16]uint64, error)
 }
 
 // DCPDest implements SGDest (superset of cbgt.Dest) interface to manage updates coming from a
@@ -328,8 +327,4 @@ func (d *DCPLoggingDest) Query(pindex *cbgt.PIndex, req []byte, w io.Writer,
 
 func (d *DCPLoggingDest) Stats(w io.Writer) error {
 	return d.dest.Stats(w)
-}
-
-func (d *DCPLoggingDest) initFeed(backfillType uint64) (map[uint16]uint64, error) {
-	return d.dest.initFeed(backfillType)
 }


### PR DESCRIPTION
- This is not helpful for cbgt sharded code and this is not used by any other DCP feeds.

I identified with `golang.org/x/tools/cmd/deadcode`.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3116/
