### PR TITLE
CBG-4594: Move key filtering on mutation feed higher up stack

### DIFF
--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -42,30 +42,30 @@ var ErrVbUUIDMismatch = errors.New("VbUUID mismatch when failOnRollback set")
 
 type DCPClient struct {
 	ctx                        context.Context
-	ID                         string                         // unique ID for DCPClient - used for DCP stream name, must be unique
-	agent                      *gocbcore.DCPAgent             // SDK DCP agent, manages connections and calls back to DCPClient stream observer implementation
-	callback                   sgbucket.FeedEventCallbackFunc // Callback invoked on DCP mutations/deletions
-	MetadataKeys               *sgbucket.FeedMetadataKeys
-	workers                    []*DCPWorker              // Workers for concurrent processing of incoming mutations and callback.  vbuckets are partitioned across workers
-	workersWg                  sync.WaitGroup            // Active workers WG - used for signaling when the DCPClient workers have all stopped so the doneChannel can be closed
-	spec                       BucketSpec                // Bucket spec for the target data store
-	supportsCollections        bool                      // Whether the target data store supports collections
-	numVbuckets                uint16                    // number of vbuckets on target data store
-	terminator                 chan bool                 // Used to close worker goroutines spawned by the DCPClient
-	doneChannel                chan error                // Returns nil on successful completion of one-shot feed or external close of feed, error otherwise
-	metadata                   DCPMetadataStore          // Implementation of DCPMetadataStore for metadata persistence
-	activeVbuckets             map[uint16]struct{}       // vbuckets that have an open stream
-	activeVbucketLock          sync.Mutex                // Synchronization for activeVbuckets
-	oneShot                    bool                      // Whether DCP feed should be one-shot
-	closing                    AtomicBool                // Set when the client is closing (either due to internal or external request)
-	closeError                 error                     // Will be set to a non-nil value for unexpected error
-	closeErrorLock             sync.Mutex                // Synchronization on close error
-	failOnRollback             bool                      // When true, close when rollback detected
-	checkpointPrefix           string                    // DCP checkpoint key prefix
-	checkpointPersistFrequency *time.Duration            // Used to override the default checkpoint persistence frequency
-	dbStats                    *expvar.Map               // Stats for database
-	agentPriority              gocbcore.DcpAgentPriority // agentPriority specifies the priority level for a dcp stream
-	collectionIDs              []uint32                  // collectionIDs used by gocbcore, if empty, uses default collections
+	ID                         string                                       // unique ID for DCPClient - used for DCP stream name, must be unique
+	agent                      *gocbcore.DCPAgent                           // SDK DCP agent, manages connections and calls back to DCPClient stream observer implementation
+	callback                   sgbucket.FeedEventCallbackFunc               // Callback invoked on DCP mutations/deletions
+	workers                    []*DCPWorker                                 // Workers for concurrent processing of incoming mutations and callback.  vbuckets are partitioned across workers
+	workersWg                  sync.WaitGroup                               // Active workers WG - used for signaling when the DCPClient workers have all stopped so the doneChannel can be closed
+	spec                       BucketSpec                                   // Bucket spec for the target data store
+	supportsCollections        bool                                         // Whether the target data store supports collections
+	numVbuckets                uint16                                       // number of vbuckets on target data store
+	terminator                 chan bool                                    // Used to close worker goroutines spawned by the DCPClient
+	doneChannel                chan error                                   // Returns nil on successful completion of one-shot feed or external close of feed, error otherwise
+	metadata                   DCPMetadataStore                             // Implementation of DCPMetadataStore for metadata persistence
+	activeVbuckets             map[uint16]struct{}                          // vbuckets that have an open stream
+	activeVbucketLock          sync.Mutex                                   // Synchronization for activeVbuckets
+	oneShot                    bool                                         // Whether DCP feed should be one-shot
+	closing                    AtomicBool                                   // Set when the client is closing (either due to internal or external request)
+	closeError                 error                                        // Will be set to a non-nil value for unexpected error
+	closeErrorLock             sync.Mutex                                   // Synchronization on close error
+	failOnRollback             bool                                         // When true, close when rollback detected
+	checkpointPrefix           string                                       // DCP checkpoint key prefix
+	checkpointPersistFrequency *time.Duration                               // Used to override the default checkpoint persistence frequency
+	dbStats                    *expvar.Map                                  // Stats for database
+	agentPriority              gocbcore.DcpAgentPriority                    // agentPriority specifies the priority level for a dcp stream
+	collectionIDs              []uint32                                     // collectionIDs used by gocbcore, if empty, uses default collections
+	FilterFunc                 func([]byte) (bool, sgbucket.FeedFilterType) // Filter function to filter out unwanted events
 }
 
 type DCPClientOptions struct {
@@ -80,7 +80,7 @@ type DCPClientOptions struct {
 	AgentPriority              gocbcore.DcpAgentPriority // agentPriority specifies the priority level for a dcp stream
 	CollectionIDs              []uint32                  // CollectionIDs used by gocbcore, if empty, uses default collections
 	CheckpointPrefix           string
-	MetadataKeys               *sgbucket.FeedMetadataKeys // Metadata keys to use for DCP metadata
+	FilterFunc                 func([]byte) (bool, sgbucket.FeedFilterType) // Filter function to filter out unwanted events
 }
 
 func NewDCPClient(ctx context.Context, ID string, callback sgbucket.FeedEventCallbackFunc, options DCPClientOptions, bucket *GocbV2Bucket) (*DCPClient, error) {
@@ -123,7 +123,7 @@ func newDCPClientWithForBuckets(ctx context.Context, ID string, callback sgbucke
 		dbStats:             options.DbStats,
 		agentPriority:       options.AgentPriority,
 		collectionIDs:       options.CollectionIDs,
-		MetadataKeys:        options.MetadataKeys,
+		FilterFunc:          options.FilterFunc,
 	}
 
 	// Initialize active vbuckets

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -50,7 +50,8 @@ type mutationEvent struct {
 	expiry     uint32
 	collection uint32
 	streamEventCommon
-	datatype uint8
+	DCPDocEventType sgbucket.FeedItemDocType
+	datatype        uint8
 }
 
 // asFeedEvent converts a mutationEvent to a sgbucket.FeedEvent.
@@ -67,18 +68,20 @@ func (e mutationEvent) asFeedEvent() sgbucket.FeedEvent {
 		RevNo:        e.revNo,
 		VbNo:         e.vbID,
 		TimeReceived: time.Now(),
+		ItemType:     e.DCPDocEventType,
 	}
 }
 
 // deletionEvent represents a DCP deletion event (opcode 0x58).
 type deletionEvent struct {
-	key        []byte
-	value      []byte
-	seq        uint64
-	cas        uint64
-	revNo      uint64
-	collection uint32
-	datatype   uint8
+	key             []byte
+	value           []byte
+	seq             uint64
+	cas             uint64
+	revNo           uint64
+	collection      uint32
+	datatype        uint8
+	DCPDocEventType sgbucket.FeedItemDocType
 	streamEventCommon
 }
 
@@ -94,6 +97,7 @@ func (e deletionEvent) asFeedEvent() sgbucket.FeedEvent {
 		RevNo:        e.revNo,
 		VbNo:         e.vbID,
 		TimeReceived: time.Now(),
+		ItemType:     e.DCPDocEventType,
 	}
 }
 

--- a/base/dcp_client_stream_event.go
+++ b/base/dcp_client_stream_event.go
@@ -41,17 +41,17 @@ type snapshotEvent struct {
 
 // mutationEvent represents a DCP mutation event (opcode 0x57).
 type mutationEvent struct {
-	key        []byte
-	value      []byte
-	seq        uint64
-	cas        uint64
-	revNo      uint64
-	flags      uint32
-	expiry     uint32
-	collection uint32
+	FeedFilterDocType sgbucket.FeedFilterType
+	key               []byte
+	value             []byte
+	seq               uint64
+	cas               uint64
+	revNo             uint64
+	flags             uint32
+	expiry            uint32
+	collection        uint32
 	streamEventCommon
-	DCPDocEventType sgbucket.FeedItemDocType
-	datatype        uint8
+	datatype uint8
 }
 
 // asFeedEvent converts a mutationEvent to a sgbucket.FeedEvent.
@@ -68,20 +68,20 @@ func (e mutationEvent) asFeedEvent() sgbucket.FeedEvent {
 		RevNo:        e.revNo,
 		VbNo:         e.vbID,
 		TimeReceived: time.Now(),
-		ItemType:     e.DCPDocEventType,
+		FilterType:   e.FeedFilterDocType,
 	}
 }
 
 // deletionEvent represents a DCP deletion event (opcode 0x58).
 type deletionEvent struct {
-	key             []byte
-	value           []byte
-	seq             uint64
-	cas             uint64
-	revNo           uint64
-	collection      uint32
-	datatype        uint8
-	DCPDocEventType sgbucket.FeedItemDocType
+	FeedFilterDocType sgbucket.FeedFilterType
+	key               []byte
+	value             []byte
+	seq               uint64
+	cas               uint64
+	revNo             uint64
+	collection        uint32
+	datatype          uint8
 	streamEventCommon
 }
 
@@ -97,7 +97,7 @@ func (e deletionEvent) asFeedEvent() sgbucket.FeedEvent {
 		RevNo:        e.revNo,
 		VbNo:         e.vbID,
 		TimeReceived: time.Now(),
-		ItemType:     e.DCPDocEventType,
+		FilterType:   e.FeedFilterDocType,
 	}
 }
 

--- a/base/dcp_client_stream_observer.go
+++ b/base/dcp_client_stream_observer.go
@@ -9,7 +9,10 @@
 package base
 
 import (
+	"strings"
+
 	"github.com/couchbase/gocbcore/v10"
+	sgbucket "github.com/couchbase/sg-bucket"
 )
 
 // DCPClient implementation of the gocbcore.StreamObserver interface.  Primarily routes events
@@ -32,7 +35,8 @@ func (dc *DCPClient) SnapshotMarker(snapshotMarker gocbcore.DcpSnapshotMarker) {
 
 func (dc *DCPClient) Mutation(mutation gocbcore.DcpMutation) {
 
-	if dc.filteredKey(mutation.Key) {
+	filterKey, dcpEventType := dc.filteredKey(mutation.Key)
+	if filterKey {
 		return
 	}
 
@@ -41,13 +45,14 @@ func (dc *DCPClient) Mutation(mutation gocbcore.DcpMutation) {
 			vbID:     mutation.VbID,
 			streamID: mutation.StreamID,
 		},
-		seq:        mutation.SeqNo,
-		revNo:      mutation.RevNo,
-		flags:      mutation.Flags,
-		expiry:     mutation.Expiry,
-		cas:        mutation.Cas,
-		datatype:   mutation.Datatype,
-		collection: mutation.CollectionID,
+		seq:             mutation.SeqNo,
+		revNo:           mutation.RevNo,
+		flags:           mutation.Flags,
+		expiry:          mutation.Expiry,
+		cas:             mutation.Cas,
+		datatype:        mutation.Datatype,
+		collection:      mutation.CollectionID,
+		DCPDocEventType: dcpEventType,
 
 		// The byte slices must be copied to ensure that memory associated with the underlying memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 		key:   EfficientBytesClone(mutation.Key),
@@ -58,19 +63,22 @@ func (dc *DCPClient) Mutation(mutation gocbcore.DcpMutation) {
 
 func (dc *DCPClient) Deletion(deletion gocbcore.DcpDeletion) {
 
-	if dc.filteredKey(deletion.Key) {
+	filterKey, dcpEventType := dc.filteredKey(deletion.Key)
+	if filterKey {
 		return
 	}
+
 	e := deletionEvent{
 		streamEventCommon: streamEventCommon{
 			vbID:     deletion.VbID,
 			streamID: deletion.StreamID,
 		},
-		seq:        deletion.SeqNo,
-		cas:        deletion.Cas,
-		revNo:      deletion.RevNo,
-		datatype:   deletion.Datatype,
-		collection: deletion.CollectionID,
+		seq:             deletion.SeqNo,
+		cas:             deletion.Cas,
+		revNo:           deletion.RevNo,
+		datatype:        deletion.Datatype,
+		collection:      deletion.CollectionID,
+		DCPDocEventType: dcpEventType,
 
 		// The byte slices must be copied to ensure that memory associated with the underlying memd mutationEvent and Packet are independent and can be released or reused by gocbcore as needed.
 		key:   EfficientBytesClone(deletion.Key),
@@ -136,6 +144,32 @@ func (dc *DCPClient) SeqNoAdvanced(seqNoAdvanced gocbcore.DcpSeqNoAdvanced) {
 	})
 }
 
-func (dc *DCPClient) filteredKey(key []byte) bool {
-	return false
+// filteredKey will filter keys we don't care about off the mutation DCP feed and will return DCP event type on non-filtered docs
+func (dc *DCPClient) filteredKey(key []byte) (bool, sgbucket.FeedItemDocType) {
+	// if not metadata keys are defined then don't filter, this will be nil for non sharded import feed
+	if dc.MetadataKeys == nil {
+		return false, 0
+	}
+	docID := string(key)
+	// any keys that doesn't have _sync prefix need to be processed
+	if !strings.HasPrefix(docID, dc.MetadataKeys.SyncPrefix) {
+		return false, sgbucket.FeedItemTypeCustomerDocument
+	}
+	if strings.HasPrefix(docID, dc.MetadataKeys.UserPrefix) {
+		return false, sgbucket.FeedItemTypeUserDoc
+	}
+	if strings.HasPrefix(docID, dc.MetadataKeys.RolePrefix) {
+		return false, sgbucket.FeedItemTypeRoleDoc
+	}
+	if strings.HasPrefix(docID, dc.MetadataKeys.UnusedSeqPrefix) {
+		return false, sgbucket.FeedItemTypeUnusedSeqDoc
+	}
+	if strings.HasPrefix(docID, dc.MetadataKeys.UnusedSeqRange) {
+		return false, sgbucket.FeedItemTypeUnusedSeqRangeDoc
+	}
+	if strings.HasPrefix(docID, dc.MetadataKeys.SgCFGPrefix) {
+		return false, sgbucket.FeedItemTypeSgCFGDoc
+	}
+
+	return true, 0
 }

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -102,7 +102,7 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 		CollectionIDs:     collectionIDs,
 		AgentPriority:     gocbcore.DcpAgentPriorityMed,
 		CheckpointPrefix:  args.CheckpointPrefix,
-		MetadataKeys:      args.MetadataKeys,
+		FilterFunc:        args.FilterFunc,
 	}
 
 	if args.Backfill == sgbucket.FeedNoBackfill {

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -102,6 +102,7 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 		CollectionIDs:     collectionIDs,
 		AgentPriority:     gocbcore.DcpAgentPriorityMed,
 		CheckpointPrefix:  args.CheckpointPrefix,
+		MetadataKeys:      args.MetadataKeys,
 	}
 
 	if args.Backfill == sgbucket.FeedNoBackfill {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -334,25 +334,25 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// ** This method does not directly access any state of c, so it doesn't lock.
 	// Is this a user/role doc for this database?
-	if event.ItemType == sgbucket.FeedItemTypeUserDoc {
+	if event.FilterType == UserDoc {
 		c.processPrincipalDoc(ctx, docID, docJSON, true, event.TimeReceived)
 		return
-	} else if event.ItemType == sgbucket.FeedItemTypeRoleDoc {
+	} else if event.FilterType == RoleDoc {
 		c.processPrincipalDoc(ctx, docID, docJSON, false, event.TimeReceived)
 		return
 	}
 
 	// Is this an unused sequence notification?
-	if event.ItemType == sgbucket.FeedItemTypeUnusedSeqDoc {
+	if event.FilterType == UnusedSeqDoc {
 		c.processUnusedSequence(ctx, docID, event.TimeReceived)
 		return
 	}
-	if event.ItemType == sgbucket.FeedItemTypeUnusedSeqRangeDoc {
+	if event.FilterType == UnusedSeqRangeDoc {
 		c.processUnusedSequenceRange(ctx, docID)
 		return
 	}
 
-	if event.ItemType == sgbucket.FeedItemTypeSgCFGDoc {
+	if event.FilterType == SGCfgDoc {
 		if c.cfgEventCallback != nil {
 			c.cfgEventCallback(docID, event.Cas, nil)
 		}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -334,25 +334,25 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// ** This method does not directly access any state of c, so it doesn't lock.
 	// Is this a user/role doc for this database?
-	if strings.HasPrefix(docID, c.metaKeys.UserKeyPrefix()) {
+	if event.ItemType == sgbucket.FeedItemTypeUserDoc {
 		c.processPrincipalDoc(ctx, docID, docJSON, true, event.TimeReceived)
 		return
-	} else if strings.HasPrefix(docID, c.metaKeys.RoleKeyPrefix()) {
+	} else if event.ItemType == sgbucket.FeedItemTypeRoleDoc {
 		c.processPrincipalDoc(ctx, docID, docJSON, false, event.TimeReceived)
 		return
 	}
 
 	// Is this an unused sequence notification?
-	if strings.HasPrefix(docID, c.metaKeys.UnusedSeqPrefix()) {
+	if event.ItemType == sgbucket.FeedItemTypeUnusedSeqDoc {
 		c.processUnusedSequence(ctx, docID, event.TimeReceived)
 		return
 	}
-	if strings.HasPrefix(docID, c.metaKeys.UnusedSeqRangePrefix()) {
+	if event.ItemType == sgbucket.FeedItemTypeUnusedSeqRangeDoc {
 		c.processUnusedSequenceRange(ctx, docID)
 		return
 	}
 
-	if strings.HasPrefix(docID, c.sgCfgPrefix) {
+	if event.ItemType == sgbucket.FeedItemTypeSgCFGDoc {
 		if c.cfgEventCallback != nil {
 			c.cfgEventCallback(docID, event.Cas, nil)
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -2185,6 +2185,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	}
 
 	db.mutationListener.OnChangeCallback = db.changeCache.DocChanged
+	db.mutationListener.FeedArgs.FilterFunc = db.changeCache.FilteredKey
 
 	if base.IsEnterpriseEdition() {
 		cfgSG, ok := db.CfgSG.(*base.CfgSG)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -95,6 +95,7 @@ func (db *DatabaseContext) StartChangeCache(t *testing.T, ctx context.Context) {
 		t.Fatal(err)
 	}
 	db.mutationListener.OnChangeCallback = db.changeCache.DocChanged
+	db.mutationListener.FeedArgs.FilterFunc = db.changeCache.FilteredKey
 	db.changeCache.lock.Unlock()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.5.4
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20250515102824-2e9e70c29697
+	github.com/couchbase/sg-bucket v0.0.0-20250515155751-6be4c5654b05
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20250515111626-5372f7a73ae5
+	github.com/couchbaselabs/rosmar v0.0.0-20250515160152-f8accb77965d
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.0.5

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.5.4
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be
+	github.com/couchbase/sg-bucket v0.0.0-20250515102824-2e9e70c29697
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
-	github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78
+	github.com/couchbaselabs/rosmar v0.0.0-20250515111626-5372f7a73ae5
 	github.com/elastic/gosigar v0.14.3
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-jose/go-jose/v4 v4.0.5
@@ -66,7 +66,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9B
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
 github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be h1:QM2afa9Xhbhy1ywVEVCRV0vEQvHIPplDkc6NsNug78Y=
 github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
+github.com/couchbase/sg-bucket v0.0.0-20250515102824-2e9e70c29697 h1:8vCF1w0LZvsFLxvWVzwdjOqnrRImbvh+w8GCxCZI8dU=
+github.com/couchbase/sg-bucket v0.0.0-20250515102824-2e9e70c29697/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=
@@ -78,6 +80,8 @@ github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28 h1:lh
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20240607131231-fb385523de28/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
 github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78 h1:pdMO4naNb0W68OisY0Y7LEE6xOXlrlZow5IWmwow2Wc=
 github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78/go.mod h1:BZgg7zjF7c8e7BR5/JBuSXZ+PLIHgyrNKwE0eLFeglw=
+github.com/couchbaselabs/rosmar v0.0.0-20250515111626-5372f7a73ae5 h1:t6quidGM0uTbFDy6WBtSndiYWRrix0HSmp9NsWiL6Aw=
+github.com/couchbaselabs/rosmar v0.0.0-20250515111626-5372f7a73ae5/go.mod h1:d9HfiCdUCWFeOtryTaSncrtA0zON1hjw8HCmchS0Y8Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -154,6 +158,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be h1:QM2afa9Xhbh
 github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
 github.com/couchbase/sg-bucket v0.0.0-20250515102824-2e9e70c29697 h1:8vCF1w0LZvsFLxvWVzwdjOqnrRImbvh+w8GCxCZI8dU=
 github.com/couchbase/sg-bucket v0.0.0-20250515102824-2e9e70c29697/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
+github.com/couchbase/sg-bucket v0.0.0-20250515155751-6be4c5654b05 h1:GH5eP5yY+I3gqqa67uQDF+vJfeTrFCQxWxa79PXmovI=
+github.com/couchbase/sg-bucket v0.0.0-20250515155751-6be4c5654b05/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=
@@ -82,6 +84,8 @@ github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78 h1:pdMO4naNb0
 github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78/go.mod h1:BZgg7zjF7c8e7BR5/JBuSXZ+PLIHgyrNKwE0eLFeglw=
 github.com/couchbaselabs/rosmar v0.0.0-20250515111626-5372f7a73ae5 h1:t6quidGM0uTbFDy6WBtSndiYWRrix0HSmp9NsWiL6Aw=
 github.com/couchbaselabs/rosmar v0.0.0-20250515111626-5372f7a73ae5/go.mod h1:d9HfiCdUCWFeOtryTaSncrtA0zON1hjw8HCmchS0Y8Q=
+github.com/couchbaselabs/rosmar v0.0.0-20250515160152-f8accb77965d h1:1l6fLMpN2M5xriPk+jpOYLci9Ntl178GwTLIN6ffu+s=
+github.com/couchbaselabs/rosmar v0.0.0-20250515160152-f8accb77965d/go.mod h1:rPuEz7hN1c9+/OLzDV4GR4EQ586ARoa+MEIOeuURz6U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tools/cache_perf_tool/dcpDataGeneration.go
+++ b/tools/cache_perf_tool/dcpDataGeneration.go
@@ -323,7 +323,7 @@ func (dcp *dcpDataGen) mutateWithDedupe(seqs []uint64, chanCount int, casValue u
 	return encodedVal, chanCount, nil
 }
 
-func createDCPClient(t *testing.T, ctx context.Context, bucket *base.GocbV2Bucket, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map, numWorkers, numVBuckets int) (*base.DCPClient, error) {
+func createDCPClient(t *testing.T, ctx context.Context, bucket *base.GocbV2Bucket, callback sgbucket.FeedEventCallbackFunc, filterFunc func(key []byte) (bool, sgbucket.FeedFilterType), dbStats *expvar.Map, numWorkers, numVBuckets int) (*base.DCPClient, error) {
 	options := base.DCPClientOptions{
 		MetadataStoreType: base.DCPMetadataStoreInMemory,
 		GroupID:           "",
@@ -332,6 +332,7 @@ func createDCPClient(t *testing.T, ctx context.Context, bucket *base.GocbV2Bucke
 		AgentPriority:     gocbcore.DcpAgentPriorityMed,
 		CheckpointPrefix:  "",
 		NumWorkers:        numWorkers,
+		FilterFunc:        filterFunc,
 	}
 	// fake client that we want to hook into
 	client, err := base.NewDCPClientForTest(ctx, t, "test", callback, options, bucket, uint16(numVBuckets))

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -200,7 +200,7 @@ func main() {
 			numTotalChannels: *totalNumberOfChans, simRapidUpdate: *rapidUpdateDocs}
 		mutationListener := dbContext.GetMutationListener(t)
 		cacheFeedStatsMap := dbContext.DbStats.Database().CacheFeedMapStats
-		client, err := createDCPClient(t, ctx, bucket, mutationListener.ProcessFeedEvent, cacheFeedStatsMap.Map, *numDCPWorkers, *numVBuckets)
+		client, err := createDCPClient(t, ctx, bucket, mutationListener.ProcessFeedEvent, mutationListener.FeedArgs.FilterFunc, cacheFeedStatsMap.Map, *numDCPWorkers, *numVBuckets)
 		if err != nil {
 			log.Printf("Error creating DCP client: %v", err)
 			return


### PR DESCRIPTION
CBG-4594

- Moves the key filtering higher up stack to avoid sending docs we don't care about to DCP workers 
- Involves adding metadata keys to the dcp client to allow this filtering which meant changes to feed args in sgbucket given we use a shared interface to start the dcp feed for mutation feed between sgw and rosmar, I can't import metadata keys to rosmar given that would create a circular dependency. 
- In doing this change I noticed we were then subsequently filtering on docs on three places, the new DCP level, `ProcessFeedEvent` and then finally in `processEntry`. This felt wasteful to me so I added a doc type field to `FeedEvent` in sgbucket to avoid having to filter on key prefix in multiple places. 


I'm overall I'm not sure if this change will deliver much or a meaningful change and has required more changes than I was anticipating, so I'm interested in hearing others thoughts on whether its still worth having this change.

## Dependencies (if applicable)
- [ ] Link upstream PRs - https://github.com/couchbase/sg-bucket/pull/135 https://github.com/couchbaselabs/rosmar/pull/48
- [ ] Update Go module dependencies when merged

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3117/
