### PR TITLE
CBG-4652: add missing unused sequence flag for unused sequences in DocChanged

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -425,9 +425,10 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	for _, seq := range syncData.UnusedSequences {
 		base.InfofCtx(ctx, base.KeyCache, "Received unused #%d in unused_sequences property for (%q / %q)", seq, base.UD(docID), syncData.CurrentRev)
 		change := &LogEntry{
-			Sequence:     seq,
-			TimeReceived: timeReceived,
-			CollectionID: event.CollectionID,
+			Sequence:       seq,
+			TimeReceived:   timeReceived,
+			CollectionID:   event.CollectionID,
+			UnusedSequence: true,
 		}
 		changedChannels := c.processEntry(ctx, change)
 		changedChannelsCombined = changedChannelsCombined.Update(changedChannels)


### PR DESCRIPTION

CBG-4652

Missed in #7529

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3127/ (unrelated test failures)
