### PR TITLE
[3.2.5 Backport] CBG-4655: Make `MgmtRequest` tolerant to request failures and not panic

### DIFF
--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -181,7 +181,7 @@ func MgmtRequest(client *http.Client, mgmtEp, method, uri, contentType, username
 	}
 	response, err := client.Do(req)
 	if err != nil {
-		return nil, response.StatusCode, err
+		return nil, 0, err
 	}
 	defer func() { _ = response.Body.Close() }()
 


### PR DESCRIPTION
CBG-4655

Clean cherry-pick of #7486 for 3.2.5

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a