### PR TITLE
CBG-4472 remove warnings for null document bodies

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2685,7 +2685,7 @@ func (db *DatabaseCollectionWithUser) RevDiff(ctx context.Context, docid string,
 
 	doc, err := db.GetDocSyncDataNoImport(ctx, docid, DocUnmarshalHistory)
 	if err != nil {
-		if !base.IsDocNotFoundError(err) && !errors.Is(err, base.ErrXattrNotFound) {
+		if !base.IsDocNotFoundError(err) && !base.IsXattrNotFoundError(err) {
 			base.WarnfCtx(ctx, "RevDiff(%q) --> %T %v", base.UD(docid), err, err)
 		}
 		missing = revids
@@ -2747,7 +2747,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 	}
 	doc, err := db.GetDocSyncDataNoImport(ctx, docid, level)
 	if err != nil {
-		if !base.IsDocNotFoundError(err) && !errors.Is(err, base.ErrXattrNotFound) {
+		if !base.IsDocNotFoundError(err) && !base.IsXattrNotFoundError(err) {
 			base.WarnfCtx(ctx, "CheckProposedRev(%q) --> %T %v", base.UD(docid), err, err)
 			return ProposedRev_Error, ""
 		}

--- a/db/document.go
+++ b/db/document.go
@@ -272,7 +272,6 @@ func (doc *Document) Body(ctx context.Context) Body {
 	}
 
 	if doc._rawBody == nil {
-		base.WarnfCtx(ctx, "Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return nil
 	}
 
@@ -319,17 +318,11 @@ func (doc *Document) HasBody() bool {
 }
 
 func (doc *Document) BodyBytes(ctx context.Context) ([]byte, error) {
-	var caller string
-	if base.ConsoleLogLevel().Enabled(base.LevelTrace) {
-		caller = base.GetCallersName(1, true)
-	}
-
 	if doc._rawBody != nil {
 		return doc._rawBody, nil
 	}
 
 	if doc._body == nil {
-		base.WarnfCtx(ctx, "Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return nil, nil
 	}
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3195,3 +3195,37 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 		}, time.Second*10, time.Millisecond*100)
 	})
 }
+
+func TestBlipPushRevOnResurrection(t *testing.T) {
+	for _, allowConflicts := range []bool{true, false} {
+		t.Run(fmt.Sprintf("allowConflicts=%t", allowConflicts), func(t *testing.T) {
+			btcRunner := NewBlipTesterClientRunner(t)
+			btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+				rt := NewRestTester(t, &RestTesterConfig{
+					PersistentConfig: true,
+				})
+				defer rt.Close()
+
+				dbConfig := rt.NewDbConfig()
+				dbConfig.AllowConflicts = base.Ptr(allowConflicts)
+				RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+				startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
+				docID := "doc1"
+				rt.CreateTestDoc(docID)
+
+				rt.PurgeDoc(docID)
+
+				RequireStatus(t, rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, ""), http.StatusNotFound)
+
+				opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, Username: "alice"}
+				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+				defer btc.Close()
+
+				btcRunner.StartPush(btc.id)
+				docVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"resurrect":true}`))
+				rt.WaitForVersion(docID, docVersion)
+				require.Equal(t, startWarnCount, base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value())
+			})
+		})
+	}
+}

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -1060,7 +1060,9 @@ func (btcc *BlipTesterCollectionClient) sendRev(ctx context.Context, change prop
 		btcc.sendRev(ctx, change, false)
 		return
 	}
-	require.NotContains(btcc.TB(), revResp.Properties, "Error-Domain", "unexpected error response from rev %v: %s", revResp)
+	body, err := revResp.Body()
+	require.NoError(btcc.TB(), err)
+	require.NotContains(btcc.TB(), revResp.Properties, "Error-Domain", "unexpected error response from rev %v: %s", change.version, string(body))
 	base.DebugfCtx(ctx, base.KeySGTest, "peer acked rev %s / %v", change.docID, change.version)
 	btcc.updateLastReplicatedRev(change.docID, change.version, revRequest)
 }


### PR DESCRIPTION
CBG-4472 remove warnings for null document bodies

When writing this test, discovered that rosmar returns `sgbucket.XattrMissingError` rather than `ErrXattrNotFound` for these two cases, and so swapped to use `base.IsXattrNotFoundError`. I think this code could be dropped for a 3.2.5 backport if it is too risky, but I do not think it is.

The tests use the new blip test handling code in 3.3, so might be a bit tricky to backport, but I do not think that's critical.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3121/
