### PR TITLE
CBG-4658: Uptake Otto stack depth limit with tests

### DIFF
--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -663,3 +663,12 @@ func TestGetDefaultSyncFunction(t *testing.T) {
 		})
 	}
 }
+
+// TestSyncFunctionRecursion ensures that an infinite recursion in the sync function does not cause a stack overflow.
+func TestSyncFunctionRecursion(t *testing.T) {
+	ctx := base.TestCtx(t)
+	mapper := NewChannelMapper(ctx, `function access(doc) { access("foo", "bar"); }`, 0)
+	res, err := mapper.MapToChannelsAndAccess(ctx, parse(t, `{"blank": "doc"}`), `{}`, emptyMetaMap(), noUser)
+	require.ErrorContains(t, err, "Maximum call stack size exceeded")
+	require.Nil(t, res)
+}

--- a/channels/main_test.go
+++ b/channels/main_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	teardownFuncs := make([]func(), 0)
 	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestLogging(ctx))
 	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestProfiling(m))
-	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 128))
+	teardownFuncs = append(teardownFuncs, base.SetUpGlobalTestMemoryWatermark(m, 256))
 
 	base.SkipPrometheusStatsRegistration = true
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.5.4
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be
+	github.com/couchbase/sg-bucket v0.0.0-20250522094013-53622a23aa0c
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/couchbase/gocbcore/v10 v10.5.4
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
-	github.com/couchbase/sg-bucket v0.0.0-20250522094013-53622a23aa0c
+	github.com/couchbase/sg-bucket v0.0.0-20250522135601-8c9a5acda2c2
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/couchbase/goprotostellar v1.0.2 h1:yoPbAL9sCtcyZ5e/DcU5PRMOEFaJrF9awX
 github.com/couchbase/goprotostellar v1.0.2/go.mod h1:5/yqVnZlW2/NSbAWu1hPJCFBEwjxgpe0PFFOlRixnp4=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20250522094013-53622a23aa0c h1:VlWWQdmXw5RMmXkMIpRZ1Qr5L3z2IPHWwKH32jHnHpw=
-github.com/couchbase/sg-bucket v0.0.0-20250522094013-53622a23aa0c/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
+github.com/couchbase/sg-bucket v0.0.0-20250522135601-8c9a5acda2c2 h1:K8PMVrRNknzTMo+Blg1d0kVhyZzcdcmKpFb6scp/0NA=
+github.com/couchbase/sg-bucket v0.0.0-20250522135601-8c9a5acda2c2/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/couchbase/goprotostellar v1.0.2 h1:yoPbAL9sCtcyZ5e/DcU5PRMOEFaJrF9awX
 github.com/couchbase/goprotostellar v1.0.2/go.mod h1:5/yqVnZlW2/NSbAWu1hPJCFBEwjxgpe0PFFOlRixnp4=
 github.com/couchbase/goutils v0.1.2 h1:gWr8B6XNWPIhfalHNog3qQKfGiYyh4K4VhO3P2o9BCs=
 github.com/couchbase/goutils v0.1.2/go.mod h1:h89Ek/tiOxxqjz30nPPlwZdQbdB8BwgnuBxeoUe/ViE=
-github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be h1:QM2afa9Xhbhy1ywVEVCRV0vEQvHIPplDkc6NsNug78Y=
-github.com/couchbase/sg-bucket v0.0.0-20241018143914-45ef51a0c1be/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
+github.com/couchbase/sg-bucket v0.0.0-20250522094013-53622a23aa0c h1:VlWWQdmXw5RMmXkMIpRZ1Qr5L3z2IPHWwKH32jHnHpw=
+github.com/couchbase/sg-bucket v0.0.0-20250522094013-53622a23aa0c/go.mod h1:Tw3QSBP+nkDjw1cpHwMFP4pBORs0UOP+KbF2hXBVwqM=
 github.com/couchbase/tools-common/cloud v1.0.0 h1:SQZIccXoedbrThehc/r9BJbpi/JhwJ8X00PDjZ2gEBE=
 github.com/couchbase/tools-common/cloud v1.0.0/go.mod h1:6KVlRpbcnDWrvickUJ+xpqCWx1vgYYlEli/zL4xmZAg=
 github.com/couchbase/tools-common/fs v1.0.0 h1:HFA4xCF/r3BtZShFJUxzVvGuXtDkqGnaPzYJP3Kp1mw=

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -74,32 +74,24 @@ func TestImportFeed(t *testing.T) {
 }
 
 func TestImportFeedWithRecursiveSyncFunction(t *testing.T) {
-
 	base.SkipImportTestsIfNotEnabled(t)
-
-	rtConfig := rest.RestTesterConfig{
-		SyncFn:     `function access(doc) { access("foo", "bar"); }`,
-		AutoImport: base.Ptr(true),
-	}
-
-	rt := rest.NewRestTester(t, &rtConfig)
-	defer rt.Close()
-	dataStore := rt.GetSingleDataStore()
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
 
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn:     `function access(doc) { access("foo", "bar"); }`,
+		AutoImport: base.Ptr(true),
+	})
+	defer rt.Close()
+
 	// Create doc via the SDK
 	mobileKey := t.Name()
-	mobileBody := make(map[string]interface{})
-	mobileBody["channels"] = "ABC"
-	_, err := dataStore.Add(mobileKey, 0, mobileBody)
-	assert.NoError(t, err, "Error writing SDK doc")
+	mobileBody := map[string]any{"channels": "ABC"}
+	added, err := rt.GetSingleDataStore().Add(mobileKey, 0, mobileBody)
+	require.NoError(t, err, "Error writing SDK doc")
+	require.True(t, added)
 
-	// Wait for import
-	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().DbStats.SharedBucketImportStats.ImportErrorCount.Value() == 1
-	})
-	require.NoError(t, err)
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImportStats.ImportErrorCount.Value, 1)
 
 	// Attempt to get the document via Sync Gateway.
 	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+mobileKey, "")

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -73,6 +73,42 @@ func TestImportFeed(t *testing.T) {
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value())
 }
 
+func TestImportFeedWithRecursiveSyncFunction(t *testing.T) {
+
+	base.SkipImportTestsIfNotEnabled(t)
+
+	rtConfig := rest.RestTesterConfig{
+		SyncFn:     `function access(doc) { access("foo", "bar"); }`,
+		AutoImport: base.Ptr(true),
+	}
+
+	rt := rest.NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	dataStore := rt.GetSingleDataStore()
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyCRUD)
+
+	// Create doc via the SDK
+	mobileKey := t.Name()
+	mobileBody := make(map[string]interface{})
+	mobileBody["channels"] = "ABC"
+	_, err := dataStore.Add(mobileKey, 0, mobileBody)
+	assert.NoError(t, err, "Error writing SDK doc")
+
+	// Wait for import
+	err = rt.WaitForCondition(func() bool {
+		return rt.GetDatabase().DbStats.SharedBucketImportStats.ImportErrorCount.Value() == 1
+	})
+	require.NoError(t, err)
+
+	// Attempt to get the document via Sync Gateway.
+	response := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+mobileKey, "")
+	assert.Equal(t, 404, response.Code)
+
+	// Verify this didn't trigger an on-demand import
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value())
+}
+
 // Test import of an SDK delete.
 func TestXattrImportOldDoc(t *testing.T) {
 	rtConfig := rest.RestTesterConfig{

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -99,6 +99,7 @@ func TestImportFeedWithRecursiveSyncFunction(t *testing.T) {
 
 	// Verify this didn't trigger an on-demand import
 	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value())
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImportStats.ImportErrorCount.Value, 2)
 }
 
 // Test import of an SDK delete.


### PR DESCRIPTION
CBG-4658

Prevents SO in the event somebody has screwed up their sync/import function, or is just doing too much recursion.
Limit is set to 10,000 JS stack frames, which aligns with the max Go stdlib JSON nesting depth (golang/go#31789) in case there are legitimate recursion use-cases.

Added unit test and more 'real-world' import feed sync function test:
```
2025-05-22T11:17:33.283+01:00 [DBG] CRUD+: t:TestImportFeedWithRecursiveSyncFunction db:db col:sg_test_0 Invoking sync on doc "<ud>TestImportFeedWithRecursiveSyncFunction</ud>" rev 1-2b2a84503be944f6ba87b49256345b6f
2025-05-22T11:17:33.333+01:00 [WRN] t:TestImportFeedWithRecursiveSyncFunction db:db col:sg_test_0 Sync fn exception: RangeError: Maximum call stack size exceeded; doc "<ud>TestImportFeedWithRecursiveSyncFunction</ud>" / "1-2b2a84503be944f6ba87b49256345b6f" -- db.(*DatabaseCollectionWithUser).getChannelsAndAccess() at crud.go:2522
2025-05-22T11:17:33.333+01:00 [DBG] CRUD+: t:TestImportFeedWithRecursiveSyncFunction db:db col:sg_test_0 Did not update document "<ud>TestImportFeedWithRecursiveSyncFunction</ud>" w/ xattr: 500 Exception in JS sync function
2025-05-22T11:17:33.333+01:00 [INF] Import: t:TestImportFeedWithRecursiveSyncFunction db:db col:sg_test_0 Error importing doc "<ud>TestImportFeedWithRecursiveSyncFunction</ud>": 500 Exception in JS sync function
2025-05-22T11:17:33.333+01:00 [DBG] Import+: t:TestImportFeedWithRecursiveSyncFunction db:db col:sg_test_0 Did not import doc "<ud>TestImportFeedWithRecursiveSyncFunction</ud>" - external update will not be accessible via Sync Gateway.  Reason: 500 Exception in JS sync function
```

## Dependencies
- [x] https://github.com/couchbase/sg-bucket/pull/136

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a