### PR TITLE
[3.2.5 Backport] CBG-4660: remove warnings for null document bodies

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2685,7 +2685,7 @@ func (db *DatabaseCollectionWithUser) RevDiff(ctx context.Context, docid string,
 
 	doc, err := db.GetDocSyncDataNoImport(ctx, docid, DocUnmarshalHistory)
 	if err != nil {
-		if !base.IsDocNotFoundError(err) && !errors.Is(err, base.ErrXattrNotFound) {
+		if !base.IsDocNotFoundError(err) && !base.IsXattrNotFoundError(err) {
 			base.WarnfCtx(ctx, "RevDiff(%q) --> %T %v", base.UD(docid), err, err)
 		}
 		missing = revids
@@ -2747,7 +2747,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedRev(ctx context.Context, doci
 	}
 	doc, err := db.GetDocSyncDataNoImport(ctx, docid, level)
 	if err != nil {
-		if !base.IsDocNotFoundError(err) && !errors.Is(err, base.ErrXattrNotFound) {
+		if !base.IsDocNotFoundError(err) && !base.IsXattrNotFoundError(err) {
 			base.WarnfCtx(ctx, "CheckProposedRev(%q) --> %T %v", base.UD(docid), err, err)
 			return ProposedRev_Error, ""
 		}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1806,3 +1806,24 @@ func TestDocUpdateCorruptSequence(t *testing.T) {
 		return db.DbStats.Database().CorruptSequenceCount.Value()
 	}, 1)
 }
+
+func TestPutResurrection(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	const docID = "doc1"
+	_, _, err := collection.Put(ctx, docID, Body{"foo": "bar"})
+	require.NoError(t, err)
+
+	require.NoError(t, collection.Purge(ctx, docID, false))
+	// assert no warnings when re-pushing a resurrection
+	_, _, err = collection.Put(ctx, docID, Body{"resurrect": true})
+	require.NoError(t, err)
+
+	require.Equal(t, startWarnCount, base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value())
+}

--- a/db/document.go
+++ b/db/document.go
@@ -272,7 +272,6 @@ func (doc *Document) Body(ctx context.Context) Body {
 	}
 
 	if doc._rawBody == nil {
-		base.WarnfCtx(ctx, "Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return nil
 	}
 
@@ -319,17 +318,11 @@ func (doc *Document) HasBody() bool {
 }
 
 func (doc *Document) BodyBytes(ctx context.Context) ([]byte, error) {
-	var caller string
-	if base.ConsoleLogLevel().Enabled(base.LevelTrace) {
-		caller = base.GetCallersName(1, true)
-	}
-
 	if doc._rawBody != nil {
 		return doc._rawBody, nil
 	}
 
 	if doc._body == nil {
-		base.WarnfCtx(ctx, "Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return nil, nil
 	}
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3271,7 +3271,7 @@ func TestBlipPushRevOnResurrection(t *testing.T) {
 
 				docVersion, err := btcRunner.PushRev(btc.id, docID, EmptyDocVersion(), []byte(`{"resurrect":true}`))
 				require.NoError(t, err)
-				rt.WaitForVersion(docID, docVersion)
+				require.NoError(t, rt.WaitForVersion(docID, docVersion))
 				require.Equal(t, startWarnCount, base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value())
 			})
 		})

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3243,3 +3243,37 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 		}, time.Second*10, time.Millisecond*100)
 	})
 }
+
+func TestBlipPushRevOnResurrection(t *testing.T) {
+	for _, allowConflicts := range []bool{true, false} {
+		t.Run(fmt.Sprintf("allowConflicts=%t", allowConflicts), func(t *testing.T) {
+			btcRunner := NewBlipTesterClientRunner(t)
+			btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+				rt := NewRestTester(t, &RestTesterConfig{
+					PersistentConfig: true,
+				})
+				defer rt.Close()
+
+				dbConfig := rt.NewDbConfig()
+				dbConfig.AllowConflicts = base.Ptr(allowConflicts)
+				RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+				startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
+				docID := "doc1"
+				rt.CreateTestDoc(docID)
+
+				rt.PurgeDoc(docID)
+
+				RequireStatus(t, rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, ""), http.StatusNotFound)
+
+				opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, Username: "alice"}
+				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+				defer btc.Close()
+
+				btcRunner.StartPush(btc.id)
+				docVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"resurrect":true}`))
+				rt.WaitForVersion(docID, docVersion)
+				require.Equal(t, startWarnCount, base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value())
+			})
+		})
+	}
+}

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3269,8 +3269,8 @@ func TestBlipPushRevOnResurrection(t *testing.T) {
 				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 				defer btc.Close()
 
-				btcRunner.StartPush(btc.id)
-				docVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"resurrect":true}`))
+				docVersion, err := btcRunner.PushRev(btc.id, docID, EmptyDocVersion(), []byte(`{"resurrect":true}`))
+				require.NoError(t, err)
 				rt.WaitForVersion(docID, docVersion)
 				require.Equal(t, startWarnCount, base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value())
 			})


### PR DESCRIPTION
CBG-4660

Unclean cherry-pick of #7538 for 3.2.5

- Resolved conflicts in BLIP test code
- Changed test to use older version of BLIP tester

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3125/
  - `TestLateSequenceHandlingDuringCompact` unrelated