### PR TITLE
CBG-4667: Return role-inherited channels in the userCtx.channels part of the session response

### DIFF
--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -331,6 +331,9 @@ func (h *handler) formatSessionResponse(user auth.User) db.Body {
 			name = &userName
 		}
 		allChannels = user.Channels()
+		for _, role := range user.GetRoles() {
+			allChannels.Add(role.Channels())
+		}
 	}
 
 	// Return a JSON struct similar to what CouchDB returns:


### PR DESCRIPTION
CBG-4667

Return role-inherited channels in the userCtx.channels part of the session response

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a - No Couchbase Server specific changes