### PR TITLE
CBG-4662: Rescope log collection context to avoid deep context value nesting

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -142,17 +142,17 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 
 		r.DocsProcessed.Add(1)
 		databaseCollection := db.CollectionByID[event.CollectionID]
-		ctx = databaseCollection.AddCollectionContext(ctx)
+		collectionCtx := databaseCollection.AddCollectionContext(ctx)
 		_, unusedSequences, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
-		}).resyncDocument(ctx, docID, key, regenerateSequences, []uint64{})
+		}).resyncDocument(collectionCtx, docID, key, regenerateSequences, []uint64{})
 
-		databaseCollection.releaseSequences(ctx, unusedSequences)
+		databaseCollection.releaseSequences(collectionCtx, unusedSequences)
 
 		if err == nil {
 			r.DocsChanged.Add(1)
 		} else if err != base.ErrUpdateCancel {
-			base.WarnfCtx(ctx, "[%s] Error updating doc %q: %v", resyncLoggingID, base.UD(docID), err)
+			base.WarnfCtx(collectionCtx, "[%s] Error updating doc %q: %v", resyncLoggingID, base.UD(docID), err)
 		}
 		return true
 	}


### PR DESCRIPTION
CBG-4662

Rescope log collection context to avoid deep context value nesting.
I found it preferable to rename the context rather than shadow the existing `ctx` variable to make it more obvious.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a