### PR TITLE
CBG-603: have broadcast goroutine with ticker value to broadcast changes

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -946,10 +946,13 @@ func (h *LogPriorityQueue) Pop() interface{} {
 
 func (c *changeCache) RemoveSkipped(x uint64) error {
 	numSkipped, err := c.skippedSeqs.removeSeq(x)
+	if err != nil {
+		return err
+	}
 	if numSkipped == 0 {
 		c.db.mutationListener.BroadcastSlowMode.CompareAndSwap(true, false)
 	}
-	return err
+	return nil
 }
 
 func (c *changeCache) WasSkipped(x uint64) bool {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -610,7 +610,7 @@ func (c *changeCache) processUnusedRange(ctx context.Context, fromSequence, toSe
 		base.WarnfCtx(ctx, "unused sequence range of #%d to %d contains duplicate sequences, will be ignored", fromSequence, toSequence)
 	}
 	if numSkipped == 0 {
-		c.db.mutationListener.SkippedSequenceBroadcast.CompareAndSwap(true, false)
+		c.db.mutationListener.BroadcastSlowMode.CompareAndSwap(true, false)
 	}
 	return allChangedChannels
 }
@@ -947,7 +947,7 @@ func (h *LogPriorityQueue) Pop() interface{} {
 func (c *changeCache) RemoveSkipped(x uint64) error {
 	numSkipped, err := c.skippedSeqs.removeSeq(x)
 	if numSkipped == 0 {
-		c.db.mutationListener.SkippedSequenceBroadcast.CompareAndSwap(true, false)
+		c.db.mutationListener.BroadcastSlowMode.CompareAndSwap(true, false)
 	}
 	return err
 }
@@ -962,7 +962,7 @@ func (c *changeCache) PushSkipped(ctx context.Context, startSeq uint64, endSeq u
 		return
 	}
 	c.skippedSeqs.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(startSeq, endSeq))
-	c.db.mutationListener.SkippedSequenceBroadcast.CompareAndSwap(false, true)
+	c.db.mutationListener.BroadcastSlowMode.CompareAndSwap(false, true)
 }
 
 // waitForSequence blocks up to maxWaitTime until the given sequence has been received.

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -3004,6 +3004,9 @@ func TestAddPendingLogs(t *testing.T) {
 }
 
 func TestChangeInBroadcastForSkipped(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("Skipped test as it requires xattrs")
+	}
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache)
 
 	opts := DefaultCacheOptions()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -3003,6 +3003,43 @@ func TestAddPendingLogs(t *testing.T) {
 
 }
 
+func TestChangeInBroadcastForSkipped(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache)
+
+	opts := DefaultCacheOptions()
+	opts.CachePendingSeqMaxWait = 10 * time.Nanosecond
+	db, ctx := setupTestDBWithCacheOptions(t, opts)
+	defer db.Close(ctx)
+
+	docID := t.Name()
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	_, _, err := collection.Put(ctx, docID, Body{"test": "doc"})
+	require.NoError(t, err)
+
+	// create some skipped sequences
+	xattrs, cas, err := collection.dataStore.GetXattrs(ctx, docID, []string{base.SyncXattrName})
+	require.NoError(t, err)
+
+	var retrievedXattr map[string]interface{}
+	require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &retrievedXattr))
+	retrievedXattr["sequence"] = uint64(20)
+	newXattrVal := map[string][]byte{
+		base.SyncXattrName: base.MustJSONMarshal(t, retrievedXattr),
+	}
+	_, err = collection.dataStore.UpdateXattrs(ctx, docID, 0, cas, newXattrVal, nil)
+	require.NoError(t, err)
+
+	// wait for seqs to be pushed skipped
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		db.UpdateCalculatedStats(ctx)
+		assert.Equal(c, int64(1), db.DbStats.CacheStats.SkippedSeqLen.Value())
+		assert.True(t, db.mutationListener.SkippedSequenceBroadcast.Load())
+	}, time.Second*10, time.Millisecond*100)
+
+}
+
 type sequenceRange struct {
 	start uint64
 	end   uint64

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -3038,7 +3038,7 @@ func TestChangeInBroadcastForSkipped(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		db.UpdateCalculatedStats(ctx)
 		assert.Equal(c, int64(1), db.DbStats.CacheStats.SkippedSeqLen.Value())
-		assert.True(t, db.mutationListener.SkippedSequenceBroadcast.Load())
+		assert.True(t, db.mutationListener.BroadcastSlowMode.Load())
 	}, time.Second*10, time.Millisecond*100)
 
 }

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -229,11 +229,12 @@ func (listener *changeListener) BroadcastChanges(ctx context.Context) {
 	// boolean to indicate whether ticker is using the default value, this is needed so we don't call reset on ticker
 	// for a value it already has
 	defaultTickerValue := true
+	terminator := listener.terminator // take copy of this to avoid race when restarting change listener in tests
 	go func() {
 		var currCount uint64
 		for {
 			select {
-			case <-listener.terminator:
+			case <-terminator:
 				ticker.Stop()
 				return
 			case <-ticker.C:

--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -215,9 +215,9 @@ func binarySearchFunc(a *SkippedSequenceListEntry, seq uint64) int {
 }
 
 // _removeSeqRange will remove sequence between x and y from the skipped sequence slice
-func (s *SkippedSequenceSlice) _removeSeqRange(ctx context.Context, startSeq, endSeq uint64) error {
+func (s *SkippedSequenceSlice) _removeSeqRange(ctx context.Context, startSeq, endSeq uint64) (bool, error) {
 	if len(s.list) == 0 {
-		return fmt.Errorf("skipped sequence list is empty, unable to remove sequence range %d to %d", startSeq, endSeq)
+		return true, fmt.Errorf("skipped sequence list is empty, unable to remove sequence range %d to %d", startSeq, endSeq)
 	}
 
 	startIndex, found := s._findSequence(startSeq)
@@ -226,13 +226,13 @@ func (s *SkippedSequenceSlice) _removeSeqRange(ctx context.Context, startSeq, en
 	// if startSeq and endSeq are in different elements there is at least one sequence between these values not in the list
 	if !found {
 		base.DebugfCtx(ctx, base.KeyCache, "sequence range %d to %d specified has sequences in that are not present in skipped list", startSeq, endSeq)
-		return base.ErrSkippedSequencesMissing
+		return false, base.ErrSkippedSequencesMissing
 	}
 	// put this below a check for !found to avoid out of bound error
 	rangeElem := s.list[startIndex]
 	if endSeq > rangeElem.getLastSeq() {
 		base.DebugfCtx(ctx, base.KeyCache, "sequence range %d to %d specified has sequences in that are not present in skipped list", startSeq, endSeq)
-		return base.ErrSkippedSequencesMissing
+		return false, base.ErrSkippedSequencesMissing
 	}
 
 	// handle sequence range removal
@@ -240,44 +240,48 @@ func (s *SkippedSequenceSlice) _removeSeqRange(ctx context.Context, startSeq, en
 	numCurrSkippedSequences := (endSeq - startSeq) + 1
 	s.NumCurrentSkippedSequences -= int64(numCurrSkippedSequences)
 
+	isEmpty := s.NumCurrentSkippedSequences == 0
+
 	// if single sequence element
 	if rangeElem.getStartSeq() == startSeq && rangeElem.getLastSeq() == endSeq {
 		// simply remove the element
 		s.list = slices.Delete(s.list, startIndex, startIndex+1)
-		return nil
+		return isEmpty, nil
 	}
 	// check if one of x or y is equal to start or end seq
 	if rangeElem.getStartSeq() == startSeq {
 		rangeElem.setStartSeq(endSeq + 1)
-		return nil
+		return isEmpty, nil
 	}
 	if rangeElem.getLastSeq() == endSeq {
 		rangeElem.setLastSeq(startSeq - 1)
-		return nil
+		return isEmpty, nil
 	}
 	// assume we are removing from middle of the range
 	newElem := NewSkippedSequenceRangeEntryAt(endSeq+1, rangeElem.getLastSeq(), rangeElem.getTimestamp())
 	s._insert(startIndex+1, newElem)
 	rangeElem.setLastSeq(startSeq - 1)
-	return nil
+	return isEmpty, nil
 
 }
 
 // removeSeq will remove a given sequence from the slice if it exists
-func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
+func (s *SkippedSequenceSlice) removeSeq(x uint64) (bool, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	if len(s.list) == 0 {
-		return fmt.Errorf("skipped sequence list is empty, unable to remove sequence %d", x)
+		return true, fmt.Errorf("skipped sequence list is empty, unable to remove sequence %d", x)
 	}
 
 	index, found := s._findSequence(x)
 	if !found {
-		return fmt.Errorf("sequence %d not found in the skipped list", x)
+		return false, fmt.Errorf("sequence %d not found in the skipped list", x)
 	}
 	// if found we need to decrement the current num skipped sequences stat
 	s.NumCurrentSkippedSequences -= 1
+
+	listNowEmpty := s.NumCurrentSkippedSequences == 0
 
 	// take the element at the index and handle cases required to removal of a sequence
 	rangeElem := s.list[index]
@@ -286,18 +290,18 @@ func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 	if numSequences == 1 {
 		// if not a range, we can just remove the single entry from the slice
 		s.list = slices.Delete(s.list, index, index+1)
-		return nil
+		return listNowEmpty, nil
 	}
 
 	// range entry handling
 	// if x == startSeq set startSeq+1, if x == lastSeq set lastSeq-1
 	if rangeElem.getStartSeq() == x {
 		rangeElem.setStartSeq(x + 1)
-		return nil
+		return listNowEmpty, nil
 	}
 	if rangeElem.getLastSeq() == x {
 		rangeElem.setLastSeq(x - 1)
-		return nil
+		return listNowEmpty, nil
 	}
 
 	if numSequences == 3 {
@@ -308,7 +312,7 @@ func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 		s._insert(index+1, newElem)
 		// make rangeElem a single entry
 		rangeElem.setLastSeq(rangeElem.getStartSeq())
-		return nil
+		return listNowEmpty, nil
 	}
 
 	// if we get here we can assume that startSeq < x < lastSeq
@@ -317,7 +321,7 @@ func (s *SkippedSequenceSlice) removeSeq(x uint64) error {
 	s._insert(index+1, newElem)
 	rangeElem.setLastSeq(x - 1)
 
-	return nil
+	return listNowEmpty, nil
 }
 
 // _insert will insert element in middle of slice maintaining order of rest of slice
@@ -381,17 +385,17 @@ func (s *SkippedSequenceSlice) getStats() SkippedSequenceStats {
 
 // processUnusedSequenceRangeAtSkipped will batch remove unused sequence range form skipped sequences, if duplicate
 // sequences are present, we will iterate through skipped list removing the non-duplicate sequences
-func (s *SkippedSequenceSlice) processUnusedSequenceRangeAtSkipped(ctx context.Context, fromSequence, toSequence uint64) {
+func (s *SkippedSequenceSlice) processUnusedSequenceRangeAtSkipped(ctx context.Context, fromSequence, toSequence uint64) bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	// batch remove from skipped
-	err := s._removeSeqRange(ctx, fromSequence, toSequence)
+	isEmpty, err := s._removeSeqRange(ctx, fromSequence, toSequence)
 	if err != nil && err == base.ErrSkippedSequencesMissing {
 		base.DebugfCtx(ctx, base.KeyCache, err.Error())
 		// we have sequences (possibly duplicate sequences) in the unused range that don't exist in skipped list
 		// handle any potential duplicate sequences between the unused range and the skipped list
-		err = s._removeSubsetOfRangeFromSkipped(ctx, fromSequence, toSequence)
+		isEmpty, err = s._removeSubsetOfRangeFromSkipped(ctx, fromSequence, toSequence)
 		if err != nil {
 			base.WarnfCtx(ctx, "error processing subset of unused sequences in skipped list: %v", err)
 		}
@@ -399,15 +403,16 @@ func (s *SkippedSequenceSlice) processUnusedSequenceRangeAtSkipped(ctx context.C
 		// if we get here then the skipped list must be empty
 		base.InfofCtx(ctx, base.KeyCache, "error attempting to remove unused sequence range form skipped: %v", err)
 	}
+	return isEmpty
 }
 
 // _removeSubsetOfRangeFromSkipped will be called if we get error removing the unused sequence range indicating we have duplicate sequence in the unused sequence range
 // in the unused sequence range. This function will iterate through each skipped list element from the minimum index that has overlap with unused range
 // and remove any sequences within the unused sequence range
-func (s *SkippedSequenceSlice) _removeSubsetOfRangeFromSkipped(ctx context.Context, startSeq, endSeq uint64) error {
+func (s *SkippedSequenceSlice) _removeSubsetOfRangeFromSkipped(ctx context.Context, startSeq, endSeq uint64) (bool, error) {
 	if len(s.list) == 0 {
 		base.DebugfCtx(ctx, base.KeyCache, "unused sequence range of #%d to %d is a duplicate sequence range", startSeq, endSeq)
-		return nil
+		return true, nil
 	}
 	var indexStart *int // the minimum index that has overlap from unused sequence range (thus index to start iterating from)
 
@@ -434,6 +439,8 @@ func (s *SkippedSequenceSlice) _removeSubsetOfRangeFromSkipped(ctx context.Conte
 		return 1
 	})
 
+	var isEmpty bool
+	var err error
 	skippedLen := len(s.list)
 	if indexStart != nil {
 		// We have found the lowest elem in skipped list with overlap with unused range
@@ -457,9 +464,9 @@ func (s *SkippedSequenceSlice) _removeSubsetOfRangeFromSkipped(ctx context.Conte
 			} else if skippedElem.getLastSeq() >= endSeq {
 				removeEndSequence = endSeq
 			}
-			err := s._removeSeqRange(ctx, removeStartSequence, removeEndSequence)
+			isEmpty, err = s._removeSeqRange(ctx, removeStartSequence, removeEndSequence)
 			if err != nil {
-				return err
+				return isEmpty, err
 			}
 			// if above operation removes an entire element, list length wil need updating and index
 			// needs to be reprocessed
@@ -477,5 +484,5 @@ func (s *SkippedSequenceSlice) _removeSubsetOfRangeFromSkipped(ctx context.Conte
 			}
 		}
 	}
-	return nil
+	return isEmpty, nil
 }

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -309,7 +309,7 @@ func TestRemoveSeqFromSkipped(t *testing.T) {
 				}
 			}
 
-			err := skippedSlice.removeSeq(testCase.remove)
+			_, err := skippedSlice.removeSeq(testCase.remove)
 			require.NoError(t, err)
 
 			for i := 0; i < len(skippedSlice.list); i++ {
@@ -332,7 +332,7 @@ func TestRemoveSeqFromSkipped(t *testing.T) {
 			}
 
 			// attempt remove on non existent sequence
-			err = skippedSlice.removeSeq(testCase.errorRemove)
+			_, err = skippedSlice.removeSeq(testCase.errorRemove)
 			require.Error(t, err)
 		})
 	}
@@ -365,7 +365,7 @@ func TestRemoveSeqFromThreeSequenceRange(t *testing.T) {
 	timestampAtSequence := skippedSlice.list[i].getTimestamp()
 
 	// remove seq in middle of above range
-	err := skippedSlice.removeSeq(61)
+	_, err := skippedSlice.removeSeq(61)
 	require.NoError(t, err)
 
 	skippedLen := len(skippedSlice.list)
@@ -394,10 +394,10 @@ func TestRemoveSeqFromThreeSequenceRange(t *testing.T) {
 	skippedSlice.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(85, 87))
 
 	// remove start seq from range 80-32
-	err = skippedSlice.removeSeq(80)
+	_, err = skippedSlice.removeSeq(80)
 	require.NoError(t, err)
 	// remove last seq from range 85-87
-	err = skippedSlice.removeSeq(87)
+	_, err = skippedSlice.removeSeq(87)
 	require.NoError(t, err)
 
 	skippedLen = len(skippedSlice.list)
@@ -425,7 +425,7 @@ func BenchmarkRemoveSeqFromSkippedList(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = bm.inputSlice.removeSeq(uint64(i * 2))
+				_, _ = bm.inputSlice.removeSeq(uint64(i * 2))
 			}
 		})
 	}
@@ -435,7 +435,7 @@ func BenchmarkRemoveSeqRangeFromSkippedList(b *testing.B) {
 	ctx := base.TestCtx(b)
 	skipedSlice := setupBenchmark(true, true, DefaultClipCapacityHeadroom)
 	for i := 0; i < b.N; i++ {
-		_ = skipedSlice._removeSeqRange(ctx, uint64(i*2), uint64(i*2)+5)
+		_, _ = skipedSlice._removeSeqRange(ctx, uint64(i*2), uint64(i*2)+5)
 	}
 }
 
@@ -820,7 +820,7 @@ func TestRemoveSequenceRange(t *testing.T) {
 				}
 			}
 
-			err := skippedSlice._removeSeqRange(ctx, testCase.rangeToRemove[0], testCase.rangeToRemove[1])
+			_, err := skippedSlice._removeSeqRange(ctx, testCase.rangeToRemove[0], testCase.rangeToRemove[1])
 			if testCase.errorCase {
 				require.Error(t, err)
 			} else {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -96,6 +96,9 @@ func (db *DatabaseContext) StartChangeCache(t *testing.T, ctx context.Context) {
 	}
 	db.mutationListener.OnChangeCallback = db.changeCache.DocChanged
 	db.changeCache.lock.Unlock()
+
+	// start broadcast goroutine
+	db.mutationListener.BroadcastChanges(ctx)
 }
 
 // CallProcessEntry allows the cache benchmarking tool to call directly into processEntry, not to
@@ -777,8 +780,8 @@ func GetIndexPartitionCount(t testing.TB, bucket *base.GocbV2Bucket, dsName sgbu
 }
 
 // GetMutationListener retrieves mutation listener form database context, to be used only for testing purposes.
-func (db *DatabaseContext) GetMutationListener(t *testing.T) changeListener {
-	return db.mutationListener
+func (db *DatabaseContext) GetMutationListener(t *testing.T) *changeListener {
+	return &db.mutationListener
 }
 
 // InitChannel is a test-only function to initialize a channel in the channel cache.

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -98,7 +98,7 @@ func (db *DatabaseContext) StartChangeCache(t *testing.T, ctx context.Context) {
 	db.changeCache.lock.Unlock()
 
 	// start broadcast goroutine
-	db.mutationListener.BroadcastChanges(ctx)
+	db.mutationListener.StartNotifierBroadcaster(ctx)
 }
 
 // CallProcessEntry allows the cache benchmarking tool to call directly into processEntry, not to

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -73,7 +73,7 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			rt.GetDatabase().UpdateCalculatedStats(ctx)
 			assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
-			assert.True(c, listener.SkippedSequenceBroadcast.Load())
+			assert.True(c, listener.BroadcastSlowMode.Load())
 		}, time.Second*10, time.Millisecond*100)
 
 		// assert new change added still replicates to client
@@ -88,7 +88,7 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			rt.GetDatabase().UpdateCalculatedStats(ctx)
 			assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
-			assert.False(c, listener.SkippedSequenceBroadcast.Load())
+			assert.False(c, listener.BroadcastSlowMode.Load())
 		}, time.Second*10, time.Millisecond*100)
 	})
 }

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -10,10 +10,88 @@ package rest
 
 import (
 	"testing"
+	"time"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReplicationBroadcastTickerChange(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("Skipping test that requires xattrs")
+	}
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			CacheConfig: &CacheConfig{
+				ChannelCacheConfig: &ChannelCacheConfig{
+					MaxWaitPending: base.Ptr(uint32(100)),
+				},
+			},
+		}},
+		GuestEnabled: true,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	docID := t.Name() + "_doc1"
+	docID2 := t.Name() + "_doc2"
+
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t,
+			&rtConfig)
+		defer rt.Close()
+		ctx := base.TestCtx(t)
+
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		btcRunner.StartPull(client.id)
+
+		// create doc1 on SG and wait to replicate to client
+		versionDoc1 := rt.PutDoc(docID, `{"test": "value"}`)
+		btcRunner.WaitForVersion(client.id, docID, versionDoc1)
+
+		// alter sync data of this doc to artificially create skipped sequences
+		ds := rt.GetSingleDataStore()
+		xattrs, cas, err := ds.GetXattrs(ctx, docID, []string{base.SyncXattrName})
+		require.NoError(t, err)
+
+		var retrievedXattr map[string]interface{}
+		require.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &retrievedXattr))
+		retrievedXattr["sequence"] = uint64(20)
+		newXattrVal := map[string][]byte{
+			base.SyncXattrName: base.MustJSONMarshal(t, retrievedXattr),
+		}
+
+		_, err = ds.UpdateXattrs(ctx, docID, 0, cas, newXattrVal, nil)
+		require.NoError(t, err)
+
+		// wait for value to move from pending to cache and skipped list to fill
+		listener := rt.GetDatabase().GetMutationListener(t)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			rt.GetDatabase().UpdateCalculatedStats(ctx)
+			assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+			assert.True(c, listener.SkippedSequenceBroadcast.Load())
+		}, time.Second*10, time.Millisecond*100)
+
+		// assert new change added still replicates to client
+		versionDoc2 := rt.PutDoc(docID2, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
+		btcRunner.WaitForVersion(client.id, docID2, versionDoc2)
+
+		// update doc1 that will trigger unused seq release to clear skipped and assert that update is received
+		versionDoc1 = rt.UpdateDoc(docID, versionDoc1, `{"test": "new value"}`)
+		btcRunner.WaitForVersion(client.id, docID, versionDoc1)
+
+		// assert skipped is cleared and skipped sequence broadcast is not sent
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			rt.GetDatabase().UpdateCalculatedStats(ctx)
+			assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
+			assert.False(c, listener.SkippedSequenceBroadcast.Load())
+		}, time.Second*10, time.Millisecond*100)
+	})
+}
 
 // TestBlipClientPushAndPullReplication sets up a bidi replication for a BlipTesterClient, writes documents on SG and the client and ensures they replicate.
 func TestBlipClientPushAndPullReplication(t *testing.T) {


### PR DESCRIPTION
CBG-603

- Have `BroadcastChanges` function that spawns a goroutine to call Broadcast if the change listener count changes
- Adds a few tests to assert the boolean is correctly changed when skipped sequences are present and replication works as expected 
- Use pushing and removing from skipped to return whether the skipped list is empty or not, this will avoid any extra contention on skipped list mutex 
- Note: new skipped list data structure to go in soon so code to return whether or not skipped is empty will change very soon

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3128/
