### PR TITLE
CBG-4661: Pass doc type down from ProcessFeedEvent to avoid extra key filtering

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -36,6 +36,18 @@ const (
 	unusedSeqCollectionID         = 0                // Collection ID used by ChangeWaiter to mark unused sequences
 )
 
+// DocumentType indicates the type of document being processed in the change cache (e.g. User doc etc).
+type DocumentType uint8
+
+const (
+	DocTypeDocument       DocumentType = iota // Customer data document type
+	DocTypeUser                               // User document
+	DocTypeRole                               // Role document
+	DocTypeUnusedSeq                          // Unused sequence notification
+	DocTypeUnusedSeqRange                     // Unused sequence range notification
+	DocTypeSGConfig                           // Sync Gateway config document
+)
+
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
 // someone has access to "*" (e.g. admin-party) and tracks its changes feed.
 var EnableStarChannelLog = true
@@ -291,17 +303,6 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 	base.InfofCtx(ctx, base.KeyCache, "CleanSkippedSequenceQueue complete.  Cleaned %d sequences from skipped list for database %s.", compactedSequences, base.MD(c.db.Name))
 	return nil
 }
-
-type DocumentType uint8
-
-const (
-	DocTypeDocument       DocumentType = iota // Unknown document type
-	DocTypeUser                               // User document
-	DocTypeRole                               // Role document
-	DocTypeUnusedSeq                          // Unused sequence notification
-	DocTypeUnusedSeqRange                     // Unused sequence range notification
-	DocTypeSGConfig                           // Sync Gateway config document
-)
 
 // ////// ADDING CHANGES:
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1406,7 +1406,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 		CollectionID: collectionID,
 		DataType:     dataType,
 	}
-	db.changeCache.DocChanged(feedEventDoc2, 0)
+	db.changeCache.DocChanged(feedEventDoc2, DocTypeDocument)
 
 	// Send feed event for doc1. This should trigger caching for doc2, and trigger notifyChange for channel ABC.
 	feedEventDoc1 := sgbucket.FeedEvent{
@@ -1415,7 +1415,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 		Value:        doc1DCPBytes,
 		CollectionID: collectionID,
 	}
-	db.changeCache.DocChanged(feedEventDoc1, 0)
+	db.changeCache.DocChanged(feedEventDoc1, DocTypeDocument)
 
 	// -------- Wait for waitgroup ----------------
 
@@ -1958,7 +1958,7 @@ func BenchmarkDocChanged(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				feedEntry := bm.feed.Next()
-				changeCache.DocChanged(feedEntry, 0)
+				changeCache.DocChanged(feedEntry, DocTypeDocument)
 			}
 
 			// log.Printf("maxNumPending: %v", changeCache.context.DbStats.StatsCblReplicationPull().Get(base.StatKeyMaxPending))

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1406,7 +1406,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 		CollectionID: collectionID,
 		DataType:     dataType,
 	}
-	db.changeCache.DocChanged(feedEventDoc2)
+	db.changeCache.DocChanged(feedEventDoc2, 0)
 
 	// Send feed event for doc1. This should trigger caching for doc2, and trigger notifyChange for channel ABC.
 	feedEventDoc1 := sgbucket.FeedEvent{
@@ -1415,7 +1415,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 		Value:        doc1DCPBytes,
 		CollectionID: collectionID,
 	}
-	db.changeCache.DocChanged(feedEventDoc1)
+	db.changeCache.DocChanged(feedEventDoc1, 0)
 
 	// -------- Wait for waitgroup ----------------
 
@@ -1958,7 +1958,7 @@ func BenchmarkDocChanged(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				feedEntry := bm.feed.Next()
-				changeCache.DocChanged(feedEntry)
+				changeCache.DocChanged(feedEntry, 0)
 			}
 
 			// log.Printf("maxNumPending: %v", changeCache.context.DbStats.StatsCblReplicationPull().Get(base.StatKeyMaxPending))

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -157,7 +157,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 	}
 
 	// Cfg callback supports both mutation and deletion events
-	if !bytes.HasPrefix(event.Key, []byte(listener.sgCfgPrefix)) {
+	if bytes.HasPrefix(event.Key, []byte(listener.sgCfgPrefix)) {
 		listener.OnDocChanged(event, DocTypeSGCfg)
 		return true
 	}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -11,10 +11,10 @@ licenses/APL2.txt.
 package db
 
 import (
+	"bytes"
 	"context"
 	"expvar"
 	"math"
-	"strings"
 	"sync"
 	"time"
 
@@ -121,43 +121,60 @@ func (listener *changeListener) StartMutationFeed(ctx context.Context, bucket ba
 	return bucket.StartDCPFeed(ctx, listener.FeedArgs, listener.ProcessFeedEvent, dbStats)
 }
 
+// DocumentType returns the type of document received over mutation feed based on its key prefix.
+func (listener *changeListener) DocumentType(key []byte) DocumentType {
+	if bytes.HasPrefix(key, []byte(listener.metaKeys.UserKeyPrefix())) {
+		return DocTypeUser
+	} else if bytes.HasPrefix(key, []byte(listener.metaKeys.RoleKeyPrefix())) {
+		return DocTypeRole
+	} else if bytes.HasPrefix(key, []byte(listener.metaKeys.UnusedSeqPrefix())) {
+		return DocTypeUnusedSeq
+	} else if bytes.HasPrefix(key, []byte(listener.metaKeys.UnusedSeqRangePrefix())) {
+		return DocTypeUnusedSeqRange
+	}
+	return DocTypeUnknown
+}
+
 // ProcessFeedEvent is invoked for each mutate or delete event seen on the server's mutation feed (TAP or DCP).  Uses document
 // key to determine handling, based on whether the incoming mutation is an internal Sync Gateway document.
 func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool {
-	requiresCheckpointPersistence := true
 	if event.Opcode == sgbucket.FeedOpMutation || event.Opcode == sgbucket.FeedOpDeletion {
-		key := string(event.Key)
-		if !strings.HasPrefix(key, base.SyncDocPrefix) { // Anything other than internal SG docs can go straight to OnDocChanged
+		if !bytes.HasPrefix(event.Key, []byte(base.SyncDocPrefix)) {
 			listener.OnDocChanged(event, DocTypeDocument)
-		} else if strings.HasPrefix(key, listener.metaKeys.UserKeyPrefix()) {
-			if event.Opcode == sgbucket.FeedOpMutation {
-				listener.OnDocChanged(event, DocTypeUser)
-			}
-			listener.notifyKey(listener.ctx, key)
-		} else if strings.HasPrefix(key, listener.metaKeys.RoleKeyPrefix()) { // SG users and roles
-			if event.Opcode == sgbucket.FeedOpMutation {
-				listener.OnDocChanged(event, DocTypeRole)
-			}
-			listener.notifyKey(listener.ctx, key)
-		} else if strings.HasPrefix(key, listener.metaKeys.UnusedSeqPrefix()) { // SG unused sequence marker docs
-			if event.Opcode == sgbucket.FeedOpMutation {
-				listener.OnDocChanged(event, DocTypeUnusedSeq)
-			}
-		} else if strings.HasPrefix(key, listener.metaKeys.UnusedSeqRangePrefix()) {
-			if event.Opcode == sgbucket.FeedOpMutation {
-				listener.OnDocChanged(event, DocTypeUnusedSeqRange)
-			}
-		} else if strings.HasPrefix(key, base.DCPCheckpointRootPrefix) { // SG DCP checkpoint docs (including other config group IDs)
-			// Do not require checkpoint persistence when DCP checkpoint docs come back over DCP - otherwise
-			// we'll end up in a feedback loop for their vbucket if persistence is enabled
-			// NOTE: checkpoint persistence is disabled altogether for the caching feed.  Leaving this check in place
-			// defensively.
-			requiresCheckpointPersistence = false
-		} else if strings.HasPrefix(key, listener.sgCfgPrefix) {
-			listener.OnDocChanged(event, DocTypeSGConfig)
+			return true
 		}
+	} else {
+		// backfill or unknown opcodes
+		return true
 	}
-	return requiresCheckpointPersistence
+	// SG DCP checkpoint docs (including other config group IDs)
+	if bytes.HasPrefix(event.Key, []byte(base.DCPCheckpointRootPrefix)) {
+		// Do not require checkpoint persistence when DCP checkpoint docs come back over DCP - otherwise
+		// we'll end up in a feedback loop for their vbucket if persistence is enabled
+		// NOTE: checkpoint persistence is disabled altogether for the caching feed.  Leaving this check in place
+		// defensively.
+		return false
+	}
+
+	// Cfg callback supports both mutation and deletion events
+	if !bytes.HasPrefix(event.Key, []byte(listener.sgCfgPrefix)) {
+		listener.OnDocChanged(event, DocTypeSGCfg)
+		return true
+	}
+
+	if event.Opcode != sgbucket.FeedOpMutation {
+		// nothing more to handle and this point if the event is not a mutation
+		return true
+	}
+
+	docType := listener.DocumentType(event.Key)
+	if docType == DocTypeUser || docType == DocTypeRole {
+		// defer to notify after callback completion
+		defer listener.notifyKey(listener.ctx, string(event.Key))
+	}
+
+	listener.OnDocChanged(event, docType)
+	return true
 }
 
 // MutationFeedStopMaxWait is the maximum amount of time to wait for


### PR DESCRIPTION
CBG-4661

- Passing a doc type parameter down stack into `DocChanged` from the filtering we do in `PorocessFeedEvent` to avoid the same key filtering being done twice

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3129/
- [x] https://jenkins.sgwdev.com/job/SyncGateway-Integration/3132/
  - unrelated flakes