### PR TITLE
CBG-4670: only update xattr on import

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2062,8 +2062,9 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			doc.SetCrc32cUserXattrHash()
 			var rawSyncXattr, rawMouXattr, rawDocBody []byte
 			rawDocBody, rawSyncXattr, rawMouXattr, err = doc.MarshalWithXattrs()
-			// if isImport is true, we don't want to update the document body, only the xattrs
-			if !isImport && len(rawDocBody) > 0 {
+			// If isImport is true, we don't generally want to update the document body, only the xattrs. One exception
+			// being when a import is resurrecting a document then we need a body to write back
+			if (!isImport && len(rawDocBody) > 0) || (isImport && doc.Deleted && len(rawDocBody) > 0) {
 				updatedDoc.Doc = rawDocBody
 				docBytes = len(updatedDoc.Doc)
 			}

--- a/db/crud.go
+++ b/db/crud.go
@@ -2064,7 +2064,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			rawDocBody, rawSyncXattr, rawMouXattr, err = doc.MarshalWithXattrs()
 			// If isImport is true, we don't generally want to update the document body, only the xattrs. One exception
 			// being when a import is resurrecting a document then we need a body to write back
-			if (!isImport && len(rawDocBody) > 0) || (isImport && doc.Deleted && len(rawDocBody) > 0) {
+			if (!isImport && len(rawDocBody) > 0) || (isImport && doc.Deleted) {
 				updatedDoc.Doc = rawDocBody
 				docBytes = len(updatedDoc.Doc)
 			}

--- a/db/crud.go
+++ b/db/crud.go
@@ -2062,7 +2062,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			doc.SetCrc32cUserXattrHash()
 			var rawSyncXattr, rawMouXattr, rawDocBody []byte
 			rawDocBody, rawSyncXattr, rawMouXattr, err = doc.MarshalWithXattrs()
-			if len(rawDocBody) > 0 {
+			// if isImport is true, we don't want to update the document body, only the xattrs
+			if !isImport && len(rawDocBody) > 0 {
 				updatedDoc.Doc = rawDocBody
 				docBytes = len(updatedDoc.Doc)
 			}

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -339,9 +339,11 @@ func TestResyncDoesNotWriteDocBody(t *testing.T) {
 	_, err := ds.WriteCas(docID, 0, 0, specBody, 0)
 	require.NoError(t, err)
 
+	// trigger import
 	_, err = collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
 
+	// update sync function to have resync process the doc
 	syncFn := `
 function sync(doc, oldDoc){
 	channel("resync_channel");
@@ -350,12 +352,14 @@ function sync(doc, oldDoc){
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/sync", syncFn)
 	rest.RequireStatus(t, resp, http.StatusOK)
 
+	// take db offline and start resync, assert that the doc is processed
 	rt.TakeDbOffline()
 
 	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 	status := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 	assert.Equal(t, int64(1), status.DocsProcessed)
+	assert.Equal(t, int64(1), status.DocsChanged)
 
 	// ensure doc body remains unchanged after resync
 	collection, _ = rt.GetSingleTestDatabaseCollectionWithUser()

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -315,3 +315,52 @@ func TestResyncInvalidatePrincipals(t *testing.T) {
 	_, ok = roles["roleDEF"]
 	require.True(t, ok, "user should have role roleDEF")
 }
+
+func TestResyncDoesNotWriteDocBody(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+	docID := t.Name()
+
+	cfg := rt.NewDbConfig()
+	cfg.AutoImport = base.Ptr(false)
+	rest.RequireStatus(t, rt.CreateDatabase("db", cfg), http.StatusCreated)
+
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+	ds := collection.GetCollectionDatastore()
+
+	specBody := []byte(`{"test":"<>"}`) // use a special character that is currently escaped to ensure it is not modified by the import process
+	_, err := ds.WriteCas(docID, 0, 0, specBody, 0)
+	require.NoError(t, err)
+
+	_, err = collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+
+	syncFn := `
+function sync(doc, oldDoc){
+	channel("resync_channel");
+}`
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/_config/sync", syncFn)
+	rest.RequireStatus(t, resp, http.StatusOK)
+
+	rt.TakeDbOffline()
+
+	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", "")
+	rest.RequireStatus(t, resp, http.StatusOK)
+	status := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+	assert.Equal(t, int64(1), status.DocsProcessed)
+
+	// ensure doc body remains unchanged after resync
+	collection, ctx = rt.GetSingleTestDatabaseCollectionWithUser()
+	ds = collection.GetCollectionDatastore()
+	bodyGet, _, err := ds.GetRaw(docID)
+	require.NoError(t, err)
+	assert.Equal(t, string(bodyGet), string(specBody))
+}

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -358,7 +358,7 @@ function sync(doc, oldDoc){
 	assert.Equal(t, int64(1), status.DocsProcessed)
 
 	// ensure doc body remains unchanged after resync
-	collection, ctx = rt.GetSingleTestDatabaseCollectionWithUser()
+	collection, _ = rt.GetSingleTestDatabaseCollectionWithUser()
 	ds = collection.GetCollectionDatastore()
 	bodyGet, _, err := ds.GetRaw(docID)
 	require.NoError(t, err)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2296,7 +2296,7 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server - needs cbgt and import checkpointing")
 	}
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyDCP, base.KeyCluster)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyDCP, base.KeyCluster, base.KeyCRUD)
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
@@ -2386,11 +2386,11 @@ func TestImportRollbackMultiplePartitions(t *testing.T) {
 	defer rt2.Close()
 
 	for _, v := range vb0DocIDs {
-		err := rt2.GetSingleDataStore().SetRaw(v, 0, nil, []byte(fmt.Sprintf(`{"star": "6"}`)))
+		err := rt2.GetSingleDataStore().SetRaw(v, 0, nil, []byte(fmt.Sprintf(`{"star": "7"}`)))
 		require.NoError(t, err)
 	}
 	for _, v := range vb800DocIDs {
-		err := rt2.GetSingleDataStore().SetRaw(v, 0, nil, []byte(fmt.Sprintf(`{"star": "6"}`)))
+		err := rt2.GetSingleDataStore().SetRaw(v, 0, nil, []byte(fmt.Sprintf(`{"star": "7"}`)))
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
CBG-4670

- This code was incorrectly changed as part of the mou updates. We should only update xattr on import. This code reverst back to how we used to handle this.
- Resync is fine as is.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3142/
