### PR TITLE
CBG-4563 add import_feed_processed_count stat

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -868,6 +868,8 @@ type SharedBucketImportStats struct {
 	ImportHighSeq *SgwIntStat `json:"import_high_seq"`
 	// The total number of import partitions.
 	ImportPartitions *SgwIntStat `json:"import_partitions"`
+	// The total number of documents processed by the import feed.
+	ImportFeedProcessedCount *SgwIntStat `json:"import_feed_processed_count"`
 }
 
 type SgwStatWrapper interface {
@@ -2303,7 +2305,10 @@ func (d *DbStats) InitSharedBucketImportStats() error {
 		if err != nil {
 			return err
 		}
-
+		resUtil.ImportFeedProcessedCount, err = NewIntStat(SubsystemSharedBucketImport, "import_processed_count", StatUnitNoUnits, ImportFeedProcessedCountDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+		if err != nil {
+			return err
+		}
 		d.SharedBucketImportStats = resUtil
 	}
 	return nil
@@ -2316,6 +2321,7 @@ func (d *DbStats) unregisterSharedBucketImportStats() {
 	prometheus.Unregister(d.SharedBucketImportStats.ImportProcessingTime)
 	prometheus.Unregister(d.SharedBucketImportStats.ImportHighSeq)
 	prometheus.Unregister(d.SharedBucketImportStats.ImportPartitions)
+	prometheus.Unregister(d.SharedBucketImportStats.ImportFeedProcessedCount)
 }
 
 func (d *DbStats) SharedBucketImport() *SharedBucketImportStats {

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -381,6 +381,8 @@ const (
 	ImportPartitionsDesc = "The total number of import partitions."
 
 	ImportProcessingTimeDesc = "The total time taken to process a document import."
+
+	ImportFeedProcessedCountDesc = "The total number of documents processed by import feed."
 )
 
 // DB Replicators stats descriptions (ISGR Specific)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -164,6 +164,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 	}
 
 	il.ImportFeedEvent(ctx, &collection, event)
+	il.importStats.ImportFeedProcessedCount.Add(1)
 	return true
 }
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -45,6 +45,7 @@ func TestFeedImport(t *testing.T) {
 	assert.NoError(t, err, "Error unmarshalling body")
 
 	initialImportCount := db.DbStats.SharedBucketImport().ImportCount.Value()
+	initialImportFeedProcessedCount := db.DbStats.SharedBucketImport().ImportFeedProcessedCount.Value()
 
 	// Create via the SDK
 	writeCas, err := collection.dataStore.WriteCas(key, 0, 0, bodyBytes, 0)
@@ -53,6 +54,10 @@ func TestFeedImport(t *testing.T) {
 	base.RequireWaitForStat(t, func() int64 {
 		return db.DbStats.SharedBucketImport().ImportCount.Value()
 	}, initialImportCount+1)
+	// processed twice:
+	// - initial write
+	// - after import
+	base.RequireWaitForStat(t, db.DbStats.SharedBucketImport().ImportFeedProcessedCount.Value, initialImportFeedProcessedCount+2)
 
 	// fetch the xattrs directly doc to confirm import (to avoid triggering on-demand import)
 	var syncData SyncData


### PR DESCRIPTION
CBG-4563 add import_feed_processed_count stat

Add a stat to parallel `dcp_received_count` stat that only tracks mutations or deletions of non binary documents. `dcp_received_count` only increments when something is added to cache. https://github.com/couchbase/sync_gateway/blob/cf72677a71c62ab1185e34f60c0d15cebac3ff84/db/change_cache.go#L422

I count see an argument for adding this stat to the top of `importListener.ProcessFeedEvent` but it feels like having it increment for _sync docs might be misleading.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3134/ (unrelated intermittent failure)
