### PR TITLE
CBG-4669: Silence resync-specific logging (move to trace)

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -1652,7 +1652,7 @@ func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, d
 		return nil, false, nil, doc.Sequence, unusedSequences, base.ErrUpdateCancel
 	}
 
-	base.DebugfCtx(ctx, base.KeyCRUD, "\tRe-syncing document %q", base.UD(docid))
+	base.TracefCtx(ctx, base.KeyCRUD, "\tRe-syncing document %q", base.UD(docid))
 
 	// Run the sync fn over each current/leaf revision, in case there are conflicts:
 	changed := 0
@@ -1728,7 +1728,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 			if !shouldUpdate {
 				return sgbucket.UpdatedDoc{}, base.ErrUpdateCancel
 			}
-			base.InfofCtx(ctx, base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
+			base.TracefCtx(ctx, base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
 			if updatedExpiry != nil {
 				updatedDoc.UpdateExpiry(*updatedExpiry)
 			}
@@ -1775,7 +1775,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 				return nil, nil, false, err
 			}
 			if shouldUpdate {
-				base.InfofCtx(ctx, base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
+				base.TracefCtx(ctx, base.KeyAccess, "Saving updated channels and access grants of %q", base.UD(docid))
 				if updatedExpiry != nil {
 					updatedDoc.UpdateExpiry(*updatedExpiry)
 				}

--- a/db/document.go
+++ b/db/document.go
@@ -910,7 +910,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 		}
 	}
 	if changed != nil {
-		base.DebugfCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
+		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)
 	}
 	return
@@ -991,7 +991,7 @@ func (accessMap *UserAccessMap) updateAccess(ctx context.Context, doc *Document,
 		if accessMap == &doc.RoleAccess {
 			what = "role"
 		}
-		base.DebugfCtx(ctx, base.KeyAccess, "Doc %q grants %s access: %v", base.UD(doc.ID), what, base.UD(*accessMap))
+		base.InfofCtx(ctx, base.KeyAccess, "Doc %q grants %s access: %v", base.UD(doc.ID), what, base.UD(*accessMap))
 	}
 	return changedUsers
 }

--- a/db/document.go
+++ b/db/document.go
@@ -910,7 +910,7 @@ func (doc *Document) updateChannels(ctx context.Context, newChannels base.Set) (
 		}
 	}
 	if changed != nil {
-		base.InfofCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
+		base.DebugfCtx(ctx, base.KeyCRUD, "\tDoc %q / %q in channels %q", base.UD(doc.ID), doc.CurrentRev, base.UD(newChannels))
 		changedChannels, err = channels.SetFromArray(changed, channels.KeepStar)
 	}
 	return
@@ -991,7 +991,7 @@ func (accessMap *UserAccessMap) updateAccess(ctx context.Context, doc *Document,
 		if accessMap == &doc.RoleAccess {
 			what = "role"
 		}
-		base.InfofCtx(ctx, base.KeyAccess, "Doc %q grants %s access: %v", base.UD(doc.ID), what, base.UD(*accessMap))
+		base.DebugfCtx(ctx, base.KeyAccess, "Doc %q grants %s access: %v", base.UD(doc.ID), what, base.UD(*accessMap))
 	}
 	return changedUsers
 }


### PR DESCRIPTION
CBG-4669

- Resync logging moved to trace since we have regular logging already present via `updateChannels` and `updateAccess`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a
