### PR TITLE
CBG-4306: Log a warning when we're abandoning each skipped sequence entry

### DIFF
--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -532,6 +532,8 @@ func BenchmarkInsertSkippedItem(b *testing.B) {
 //   - Run compact and assert that each item is compacted apart from the last added item
 //   - Assert on number sequences removed
 func TestCompactSkippedList(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+
 	testCases := []struct {
 		name       string
 		inputList  [][]uint64


### PR DESCRIPTION
CBG-4306

I don't think we anticipate any expected scenarios that would result in abandoned sequences now, so decided to put this at warn level.

Example test output:
```go
=== RUN   TestCompactSkippedList
2025-06-04T15:27:17.068+01:00 [INF] db.TestCompactSkippedList: Setup logging: level: info - keys: [*]
=== RUN   TestCompactSkippedList/single_items
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/single_items Abandoning previously skipped sequence entry: #2 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/single_items Abandoning previously skipped sequence entry: #6 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/single_items Abandoning previously skipped sequence entry: #100 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/single_items Abandoning previously skipped sequence entry: #200 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/single_items Abandoning previously skipped sequence entry: #500 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
--- PASS: TestCompactSkippedList/single_items (0.00s)
=== RUN   TestCompactSkippedList/range_items
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/range_items Abandoning previously skipped sequence entry: #5-#10 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/range_items Abandoning previously skipped sequence entry: #15-#20 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/range_items Abandoning previously skipped sequence entry: #25-#30 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/range_items Abandoning previously skipped sequence entry: #35-#40 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/range_items Abandoning previously skipped sequence entry: #45-#50 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
2025-06-04T15:27:17.069+01:00 [WRN] t:TestCompactSkippedList/range_items Abandoning previously skipped sequence entry: #55-#60 after 16m40s -- db.(*SkippedSequenceSlice).SkippedSequenceCompact() at skipped_sequence.go:174
--- PASS: TestCompactSkippedList/range_items (0.00s)
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a