### PR TITLE
CBG-4065: ISGR and Blipsync User-Agent support

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -182,6 +182,10 @@ const (
 	EmptyDocument = `{}`
 )
 
+const (
+	HTTPHeaderUserAgent = "User-Agent"
+)
+
 var (
 	SyncFnAccessErrors = []string{
 		HTTPErrorf(403, SyncFnErrorMissingRole).Error(),

--- a/base/constants.go
+++ b/base/constants.go
@@ -182,10 +182,6 @@ const (
 	EmptyDocument = `{}`
 )
 
-const (
-	HTTPHeaderUserAgent = "User-Agent"
-)
-
 var (
 	SyncFnAccessErrors = []string{
 		HTTPErrorf(403, SyncFnErrorMissingRole).Error(),

--- a/base/user_agent.go
+++ b/base/user_agent.go
@@ -14,6 +14,10 @@ import (
 	"strings"
 )
 
+const (
+	HTTPHeaderUserAgent = "User-Agent"
+)
+
 // NewSGProcessUserAgent returns a new user agent string for the given process name.
 // A process may be something like "ISGR" and is used in place of "Platform" when compared with CBL user agents.
 //

--- a/base/user_agent.go
+++ b/base/user_agent.go
@@ -1,0 +1,32 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package base
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// NewSGProcessUserAgent returns a new user agent string for the given process name.
+// A process may be something like "ISGR" and is used in place of "Platform" when compared with CBL user agents.
+//
+// Additional information may be provided which will be appended to the comments section of the UA string.
+// Example: "CouchbaseSyncGateway/3.2.1.4@33-EE (ISGR; darwin/arm64)"
+func NewSGProcessUserAgent(process string, extraComments ...string) string {
+	productName := removeAllWhitespace(ProductNameString)
+	productVersion := removeAllWhitespace(ProductVersion.String())
+
+	comment := fmt.Sprintf("%s; %s/%s", process, runtime.GOOS, runtime.GOARCH)
+	if len(extraComments) > 0 {
+		comment += "; " + strings.Join(extraComments, "; ")
+	}
+
+	return fmt.Sprintf(`%s/%s (%s)`, productName, productVersion, comment)
+}

--- a/base/util.go
+++ b/base/util.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/couchbase/gomemcached"
 	"github.com/gorilla/mux"
@@ -1715,4 +1716,14 @@ func EfficientBytesClone(b []byte) []byte {
 	nb := make([]byte, len(b))
 	copy(nb, b)
 	return nb
+}
+
+// removeAllWhitespace removes all whitespace characters from the input string.
+func removeAllWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/base/version_comparable_build.go
+++ b/base/version_comparable_build.go
@@ -148,6 +148,8 @@ func (a *ComparableBuildVersion) AtLeastMinorDowngrade(b *ComparableBuildVersion
 	return a.minor > b.minor
 }
 
+// String returns the full string representation of the ComparableBuildVersion.
+// e.g. "1:22-3-25@33-EE"
 func (pv ComparableBuildVersion) String() string {
 	return pv.str
 }

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -22,6 +22,8 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+var ISGRUserAgent = base.NewSGProcessUserAgent("ISGR")
+
 // ActiveReplicator is a wrapper to encapsulate separate push and pull active replicators.
 type ActiveReplicator struct {
 	ID     string
@@ -302,12 +304,13 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 	config := blip.DialOptions{
 		URL:        target.String() + "/_blipsync?" + BLIPSyncClientTypeQueryParam + "=" + string(BLIPClientTypeSGR2),
 		HTTPClient: client,
+		HTTPHeader: http.Header{
+			base.HTTPHeaderUserAgent: []string{ISGRUserAgent},
+		},
 	}
 
 	if basicAuthCreds != nil {
-		config.HTTPHeader = http.Header{
-			"Authorization": []string{"Basic " + base64UserInfo(basicAuthCreds)},
-		}
+		config.HTTPHeader.Add("Authorization", "Basic "+base64UserInfo(basicAuthCreds))
 	}
 
 	return blipContext.DialConfig(&config)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -862,7 +862,7 @@ func TestBulkGetEfficientBodyCompression(t *testing.T) {
 	bulkGetBody += `]}`
 
 	bulkGetHeaders := map[string]string{
-		"User-Agent":   "CouchbaseLite/1.2",
+		base.HTTPHeaderUserAgent:   "CouchbaseLite/1.2",
 		"Content-Type": "application/json",
 	}
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -862,8 +862,8 @@ func TestBulkGetEfficientBodyCompression(t *testing.T) {
 	bulkGetBody += `]}`
 
 	bulkGetHeaders := map[string]string{
-		base.HTTPHeaderUserAgent:   "CouchbaseLite/1.2",
-		"Content-Type": "application/json",
+		base.HTTPHeaderUserAgent: "CouchbaseLite/1.2",
+		"Content-Type":           "application/json",
 	}
 
 	// request an uncompressed _bulk_get

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -94,7 +94,7 @@ func (h *handler) handleBLIPSync() error {
 		// ActiveSubprotocol only available after handshake via ServeHTTP(), so have to get go-blip to invoke callback between handshake and serving BLIP messages
 		subprotocol := blipContext.ActiveSubprotocol()
 		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s%s", blipContext.ID, blip.WebSocketSubProtocolPrefix, subprotocol, h.formattedEffectiveUserName()))
-		base.DebugfCtx(h.ctx(), base.KeyHTTP, "BLIP Client had User-Agent: %s", h.rq.Header.Get(base.HTTPHeaderUserAgent))
+		base.DebugfCtx(h.ctx(), base.KeyHTTP, "BLIP Client had User-Agent: %s", base.UD(h.rq.Header.Get(base.HTTPHeaderUserAgent)))
 		err = bsc.SetActiveCBMobileSubprotocol(subprotocol)
 		if err != nil {
 			base.WarnfCtx(h.ctx(), "Couldn't set active CB Mobile Subprotocol: %v", err)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -93,8 +93,7 @@ func (h *handler) handleBLIPSync() error {
 		}
 		// ActiveSubprotocol only available after handshake via ServeHTTP(), so have to get go-blip to invoke callback between handshake and serving BLIP messages
 		subprotocol := blipContext.ActiveSubprotocol()
-		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s%s", blipContext.ID, blip.WebSocketSubProtocolPrefix, subprotocol, h.formattedEffectiveUserName()))
-		base.DebugfCtx(h.ctx(), base.KeyHTTP, "BLIP Client had User-Agent: %s", base.UD(h.rq.Header.Get(base.HTTPHeaderUserAgent)))
+		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s from %q %s", blipContext.ID, blip.WebSocketSubProtocolPrefix, subprotocol, base.UD(h.rq.UserAgent()), h.formattedEffectiveUserName()))
 		err = bsc.SetActiveCBMobileSubprotocol(subprotocol)
 		if err != nil {
 			base.WarnfCtx(h.ctx(), "Couldn't set active CB Mobile Subprotocol: %v", err)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -94,6 +94,7 @@ func (h *handler) handleBLIPSync() error {
 		// ActiveSubprotocol only available after handshake via ServeHTTP(), so have to get go-blip to invoke callback between handshake and serving BLIP messages
 		subprotocol := blipContext.ActiveSubprotocol()
 		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s%s", blipContext.ID, blip.WebSocketSubProtocolPrefix, subprotocol, h.formattedEffectiveUserName()))
+		base.DebugfCtx(h.ctx(), base.KeyHTTP, "BLIP Client had User-Agent: %s", h.rq.Header.Get(base.HTTPHeaderUserAgent))
 		err = bsc.SetActiveCBMobileSubprotocol(subprotocol)
 		if err != nil {
 			base.WarnfCtx(h.ctx(), "Couldn't set active CB Mobile Subprotocol: %v", err)

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -386,7 +386,7 @@ func (h *handler) handleBulkGet() error {
 	// Exception: if the user agent is empty or earlier than 1.2, and X-Accept-Part-Encoding=gzip, then we actually
 	// DO want to compress the parts since the full response will not be gzipped, since those clients can't handle it.
 	// See https://github.com/couchbase/sync_gateway/issues/1419 and encoded_response_writer.go
-	userAgentVersion := NewUserAgentVersion(h.rq.Header.Get("User-Agent"))
+	userAgentVersion := NewUserAgentVersion(h.rq.Header.Get(base.HTTPHeaderUserAgent))
 	if userAgentVersion.IsBefore(1, 2) && acceptGzipPartEncoding {
 		canCompressParts = true
 	}

--- a/rest/encoded_response_writer.go
+++ b/rest/encoded_response_writer.go
@@ -50,7 +50,7 @@ func NewEncodedResponseWriter(response http.ResponseWriter, rq *http.Request, st
 	// the entire response for requests to the _bulk_get endpoint, since the clients
 	// are not equipped to handle that.
 	if strings.Contains(rq.URL.Path, "_bulk_get") {
-		userAgentVersion := NewUserAgentVersion(rq.Header.Get("User-Agent"))
+		userAgentVersion := NewUserAgentVersion(rq.Header.Get(base.HTTPHeaderUserAgent))
 		if userAgentVersion.IsBefore(1, 2) {
 			return nil
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1224,7 +1224,7 @@ func (h *handler) getJSONStringArrayQuery(param string) ([]string, error) {
 }
 
 func (h *handler) userAgentIs(agent string) bool {
-	userAgent := h.rq.Header.Get("User-Agent")
+	userAgent := h.rq.Header.Get(base.HTTPHeaderUserAgent)
 	return len(userAgent) > len(agent) && userAgent[len(agent)] == '/' && strings.HasPrefix(userAgent, agent)
 }
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2055,7 +2055,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
 	// Passive
 	const (


### PR DESCRIPTION
CBG-4065

- Defines a Sync Gateway `User-Agent` header for use by ISGR on `/_blipsync` requests
- Blipsync logs UA at debug for now (tagged as `<UD>` until we're capable of parsing elements)

## Example test output (official builds will also contain build number)
```go
2025-06-06T15:50:56.097+01:00 [INF] HTTP+: c:[310fafbf] db:db #004:     --> 101 [310fafbf] Upgraded to WebSocket protocol BLIP_3+CBMobile_4 (as <ud>AL_1c.e-@</ud>)  (0.0 ms)
2025-06-06T15:50:56.097+01:00 [DBG] HTTP+: c:[310fafbf] db:db BLIP Client had User-Agent: <ud>CouchbaseSyncGateway/3.3.0-EE (ISGR; darwin/arm64)</ud>
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a