### PR TITLE
CBG-4678: reject writes when unsupported option is set for skipped sequences

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -630,6 +630,8 @@ type DatabaseStats struct {
 	NumDocReadsRest *SgwIntStat `json:"num_doc_reads_rest"`
 	// The total number of documents written by any means (replication, rest API interaction or imports) since Sync Gateway node startup.
 	NumDocWrites *SgwIntStat `json:"num_doc_writes"`
+	// NumDocWritesRejected is the total number of document writes that were rejected by Sync Gateway.
+	NumDocWritesRejected *SgwIntStat `json:"num_doc_writes_rejected"`
 	// The total number of requests sent over the public REST api
 	NumPublicRestRequests *SgwIntStat `json:"num_public_rest_requests"`
 	// The total number of active replications.
@@ -1732,6 +1734,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.NumDocWritesRejected, err = NewIntStat(SubsystemDatabaseKey, "num_doc_writes_rejected", StatUnitNoUnits, NumDocWritesRejectedDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityInternal, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.NumReplicationsActive, err = NewIntStat(SubsystemDatabaseKey, "num_replications_active", StatUnitNoUnits, NumReplicationsActiveDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
@@ -1856,6 +1862,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumDocReadsBlip)
 	prometheus.Unregister(d.DatabaseStats.NumDocReadsRest)
 	prometheus.Unregister(d.DatabaseStats.NumDocWrites)
+	prometheus.Unregister(d.DatabaseStats.NumDocWritesRejected)
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsActive)
 	prometheus.Unregister(d.DatabaseStats.NumReplicationsTotal)
 	prometheus.Unregister(d.DatabaseStats.NumTombstonesCompacted)

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -271,6 +271,9 @@ const (
 
 	NumDocWritesDesc = "The total number of documents written by any means (replication, rest API interaction or imports) since Sync Gateway node startup."
 
+	NumDocWritesRejectedDesc = "NumDocWritesRejected is the total number of document writes that were rejected by Sync Gateway when the unsupported option " +
+		"RejectWritesWithSkippedSequences."
+
 	NumReplicationsActiveDesc = "The total number of active replications."
 
 	NumReplicationsTotalDesc = "The total number of replications created since Sync Gateway node startup."

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -965,6 +965,14 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		}
 	}()
 
+	if bh.db.DatabaseContext.Options.UnsupportedOptions != nil && bh.db.DatabaseContext.Options.UnsupportedOptions.RejectWritesWithSkippedSequences {
+		// if we are in slow broadcast mode reject write with 503 and increment rejected writes stat
+		if bh.db.BroadcastSlowMode.Load() {
+			bh.db.DbStats.DatabaseStats.NumDocWritesRejected.Add(1)
+			return base.HTTPErrorf(http.StatusServiceUnavailable, "Database cache is behind and cannot accept writes at this time. Please try again later.")
+		}
+	}
+
 	// throttle concurrent revs
 	if cap(bh.inFlightRevsThrottle) > 0 {
 		select {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -629,7 +629,7 @@ func (c *changeCache) processUnusedRange(ctx context.Context, fromSequence, toSe
 		base.WarnfCtx(ctx, "unused sequence range of #%d to %d contains duplicate sequences, will be ignored", fromSequence, toSequence)
 	}
 	if numSkipped == 0 {
-		c.db.mutationListener.BroadcastSlowMode.CompareAndSwap(true, false)
+		c.db.BroadcastSlowMode.CompareAndSwap(true, false)
 	}
 	return allChangedChannels
 }
@@ -973,7 +973,7 @@ func (c *changeCache) RemoveSkipped(x uint64) error {
 		return err
 	}
 	if numSkipped == 0 {
-		c.db.mutationListener.BroadcastSlowMode.CompareAndSwap(true, false)
+		c.db.BroadcastSlowMode.CompareAndSwap(true, false)
 	}
 	return nil
 }
@@ -988,7 +988,7 @@ func (c *changeCache) PushSkipped(ctx context.Context, startSeq uint64, endSeq u
 		return
 	}
 	c.skippedSeqs.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(startSeq, endSeq))
-	c.db.mutationListener.BroadcastSlowMode.CompareAndSwap(false, true)
+	c.db.BroadcastSlowMode.CompareAndSwap(false, true)
 }
 
 // waitForSequence blocks up to maxWaitTime until the given sequence has been received.

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -3038,7 +3038,7 @@ func TestChangeInBroadcastForSkipped(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		db.UpdateCalculatedStats(ctx)
 		assert.Equal(c, int64(1), db.DbStats.CacheStats.SkippedSeqLen.Value())
-		assert.True(t, db.mutationListener.BroadcastSlowMode.Load())
+		assert.True(t, db.BroadcastSlowMode.Load())
 	}, time.Second*10, time.Millisecond*100)
 
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2677,6 +2677,10 @@ func TestDocChannelSetPruning(t *testing.T) {
 }
 
 func TestRejectWritesWhenInBroadcastSlowMode(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("Test requires xattrs to be enabled")
+	}
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			CacheConfig: &CacheConfig{
@@ -2692,7 +2696,7 @@ func TestRejectWritesWhenInBroadcastSlowMode(t *testing.T) {
 	defer rt.Close()
 
 	docID := t.Name() + "_doc1"
-	ctx := t.Context()
+	ctx := base.TestCtx(t)
 
 	docVrs := rt.PutDoc(docID, `{"test": "value"}`)
 

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -69,11 +69,10 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 		require.NoError(t, err)
 
 		// wait for value to move from pending to cache and skipped list to fill
-		listener := rt.GetDatabase().GetMutationListener(t)
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			rt.GetDatabase().UpdateCalculatedStats(ctx)
 			assert.Equal(c, int64(1), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
-			assert.True(c, listener.BroadcastSlowMode.Load())
+			assert.True(c, rt.GetDatabase().BroadcastSlowMode.Load())
 		}, time.Second*10, time.Millisecond*100)
 
 		// assert new change added still replicates to client
@@ -88,7 +87,7 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			rt.GetDatabase().UpdateCalculatedStats(ctx)
 			assert.Equal(c, int64(0), rt.GetDatabase().DbStats.CacheStats.SkippedSeqLen.Value())
-			assert.False(c, listener.BroadcastSlowMode.Load())
+			assert.False(c, rt.GetDatabase().BroadcastSlowMode.Load())
 		}, time.Second*10, time.Millisecond*100)
 	})
 }

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -491,6 +491,14 @@ func (h *handler) handleBulkGet() error {
 // HTTP handler for a POST to _bulk_docs
 func (h *handler) handleBulkDocs() error {
 
+	if h.db.DatabaseContext.Options.UnsupportedOptions != nil && h.db.DatabaseContext.Options.UnsupportedOptions.RejectWritesWithSkippedSequences {
+		// if we are in slow broadcast mode reject write with 503 and increment rejected writes stat
+		if h.db.BroadcastSlowMode.Load() {
+			h.db.DbStats.DatabaseStats.NumDocWritesRejected.Add(1)
+			return base.HTTPErrorf(http.StatusServiceUnavailable, "Database cache is behind and cannot accept writes at this time. Please try again later.")
+		}
+	}
+
 	startTime := time.Now()
 	defer func() {
 		h.db.DbStats.CBLReplicationPush().WriteProcessingTime.Add(time.Since(startTime).Nanoseconds())

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -442,6 +442,14 @@ func (h *handler) handlePutDoc() error {
 		return base.HTTPErrorf(http.StatusForbidden, auth.GuestUserReadOnly)
 	}
 
+	if h.db.DatabaseContext.Options.UnsupportedOptions != nil && h.db.DatabaseContext.Options.UnsupportedOptions.RejectWritesWithSkippedSequences {
+		// if we are in slow broadcast mode reject write with 503 and increment rejected writes stat
+		if h.db.BroadcastSlowMode.Load() {
+			h.db.DbStats.DatabaseStats.NumDocWritesRejected.Add(1)
+			return base.HTTPErrorf(http.StatusServiceUnavailable, "Database cache is behind and cannot accept writes at this time. Please try again later.")
+		}
+	}
+
 	startTime := time.Now()
 	defer func() {
 		h.db.DbStats.CBLReplicationPush().WriteProcessingTime.Add(time.Since(startTime).Nanoseconds())


### PR DESCRIPTION
CBG-4678

- Reject writes from rest api and blip writes when unsupported option is enabled together with the slow broadcast boolean being set on the node. 
- Test for api pathway, testing with blip tester client not possible as test wil fail as the write will be rejected at sync gateway 
- Tested with new doc pusher and pusher doesn't stop with this error code
- Moved atomic boolean to db context and had to include db context on change listener 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3145/
