### PR TITLE
CBG-4676: add stats around the public all docs endpoint

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -1843,6 +1843,9 @@ func (d *DbStats) initDatabaseStats() error {
 		return err
 	}
 	resUtil.NumDocsPostFilterPublicAllDocs, err = NewIntStat(SubsystemDatabaseKey, "num_docs_post_filter_public_all_docs", StatUnitNoUnits, NumDocsPostFilterPublicAllDocsDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityInternal, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}

--- a/base/stats.go
+++ b/base/stats.go
@@ -686,6 +686,12 @@ type DatabaseStats struct {
 	TotalInitFatalErrors *SgwIntStat `json:"total_init_fatal_errors"`
 	// The total number of errors that occurred that prevented the database from being brought online.
 	TotalOnlineFatalErrors *SgwIntStat `json:"total_online_fatal_errors"`
+	// NumPublicAllDocsRequests is the total number of requests to /_all_docs on the public interface.
+	NumPublicAllDocsRequests *SgwIntStat `json:"num_public_all_docs_requests"`
+	// NumDocsPostFilterPublicAllDocs is the total number of documents returned after filtering for /_all_docs on the public interface.
+	NumDocsPostFilterPublicAllDocs *SgwIntStat `json:"num_docs_post_filter_public_all_docs"`
+	// NumDocsPreFilterPublicAllDocs is the total number of documents returned before filtering for /_all_docs on the public interface.
+	NumDocsPreFilterPublicAllDocs *SgwIntStat `json:"num_docs_pre_filter_public_all_docs"`
 }
 
 // This wrapper ensures that an expvar.Map type can be marshalled into JSON. The expvar.Map has no method to go direct to
@@ -1828,6 +1834,15 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.NumPublicAllDocsRequests, err = NewIntStat(SubsystemDatabaseKey, "num_public_all_docs_requests", StatUnitNoUnits, NumPublicAllDocsRequestsDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityInternal, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.NumDocsPreFilterPublicAllDocs, err = NewIntStat(SubsystemDatabaseKey, "num_docs_pre_filter_public_all_docs", StatUnitNoUnits, NumDocsPreFilterPublicAllDocsDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityInternal, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.NumDocsPostFilterPublicAllDocs, err = NewIntStat(SubsystemDatabaseKey, "num_docs_post_filter_public_all_docs", StatUnitNoUnits, NumDocsPostFilterPublicAllDocsDesc, StatAddedVersion3dot3dot0, StatDeprecatedVersionNotDeprecated, StatStabilityInternal, labelKeys, labelVals, prometheus.CounterValue, 0)
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
@@ -1881,6 +1896,9 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.PublicRestBytesRead)
 	prometheus.Unregister(d.DatabaseStats.TotalInitFatalErrors)
 	prometheus.Unregister(d.DatabaseStats.TotalOnlineFatalErrors)
+	prometheus.Unregister(d.DatabaseStats.NumPublicAllDocsRequests)
+	prometheus.Unregister(d.DatabaseStats.NumDocsPreFilterPublicAllDocs)
+	prometheus.Unregister(d.DatabaseStats.NumDocsPostFilterPublicAllDocs)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -328,6 +328,12 @@ const (
 
 	CorruptSequenceCountDesc = "The total number of corrupt sequences detected at the sequence allocator. Documents that have a corrupt " +
 		"sequence that trigger release of sequences above the MaxSequenceToRelease threshold will have their update cancelled."
+
+	NumPublicAllDocsRequestsDesc = "The total number of requests sent over the public REST api for /_all_docs."
+
+	NumDocsPreFilterPublicAllDocsDesc = "The total number of documents returned on all public /_all_docs requests before filtering"
+
+	NumDocsPostFilterPublicAllDocsDesc = "The total number of documents returned on all public /_all_docs requests after filtering"
 )
 
 // Delta Sync stats descriptions

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2857,7 +2857,7 @@ func TestPublicAllDocsApiStats(t *testing.T) {
 
 	resp := rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/_all_docs", "", "user1")
 	RequireStatus(t, resp, http.StatusOK)
-	// two docs in the db but use only has access to one of them, ensure stats are correct in that assessment
+	// two docs in the db but user only has access to one of them, ensure stats are correct in that assessment
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DatabaseStats.NumPublicAllDocsRequests.Value())
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Value())
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Value())
@@ -2867,7 +2867,7 @@ func TestPublicAllDocsApiStats(t *testing.T) {
 	resp = rt.SendUserRequest(http.MethodPost, "/{{.keyspace}}/_all_docs", body, "user1")
 	RequireStatus(t, resp, http.StatusOK)
 	// docs that don't exist or the user doesn't have access to are returned in result but with errors when a key filter applies, so these
-	// should still count in post filter count as they;re still returned to teh user in some capacity
+	// should still count in post filter count as they're still returned to the user in some capacity
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DatabaseStats.NumPublicAllDocsRequests.Value())
 	assert.Equal(t, int64(5), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Value())
 	assert.Equal(t, int64(4), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Value())

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2839,3 +2839,51 @@ func TestBufferFlush(t *testing.T) {
 	// assert that the response is a flushed response
 	assert.True(t, resp.Flushed)
 }
+
+func TestPublicAllDocsApiStats(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
+	})
+	defer rt.Close()
+
+	rt.CreateUser("user1", []string{"ABC"})
+
+	rt.PutDoc("doc1", `{"channels": ["ABC"]}`)
+	rt.PutDoc("doc2", `{"channels": ["DEF"]}`)
+
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.DatabaseStats.NumPublicAllDocsRequests.Value())
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Value())
+	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Value())
+
+	resp := rt.SendUserRequest(http.MethodGet, "/{{.keyspace}}/_all_docs", "", "user1")
+	RequireStatus(t, resp, http.StatusOK)
+	// two docs in the db but use only has access to one of them, ensure stats are correct in that assessment
+	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DatabaseStats.NumPublicAllDocsRequests.Value())
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Value())
+	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Value())
+
+	// add a doc ID that doesn't exist into the mix here
+	body := `{"keys": ["doc2", "doc1", "fakeDoc"]}`
+	resp = rt.SendUserRequest(http.MethodPost, "/{{.keyspace}}/_all_docs", body, "user1")
+	RequireStatus(t, resp, http.StatusOK)
+	// docs that don't exist or the user doesn't have access to are returned in result but with errors when a key filter applies, so these
+	// should still count in post filter count as they;re still returned to teh user in some capacity
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DatabaseStats.NumPublicAllDocsRequests.Value())
+	assert.Equal(t, int64(5), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Value())
+	assert.Equal(t, int64(4), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Value())
+
+	// try admin port _all_docs call and assert that stats are unchanged
+	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_all_docs", "")
+	RequireStatus(t, resp, http.StatusOK)
+	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DatabaseStats.NumPublicAllDocsRequests.Value())
+	assert.Equal(t, int64(5), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Value())
+	assert.Equal(t, int64(4), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Value())
+
+	// try make error case request and assert that the number of request count increments but other stats remain unchanged
+	body = `{"keys": [1]}`
+	resp = rt.SendUserRequest(http.MethodPost, "/{{.keyspace}}/_all_docs", body, "user1")
+	RequireStatus(t, resp, http.StatusBadRequest)
+	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.DatabaseStats.NumPublicAllDocsRequests.Value())
+	assert.Equal(t, int64(5), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Value())
+	assert.Equal(t, int64(4), rt.GetDatabase().DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Value())
+}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -50,9 +50,9 @@ type allDocsRow struct {
 func (h *handler) handleAllDocs() error {
 
 	var numDocsPreFilter, numDocsPostFilter uint64
-	defer func() {
-		// increment public all docs stats here
-		if h.privs != adminPrivs {
+	if h.privs != adminPrivs {
+		defer func() {
+			// public _all_docs stats
 			h.db.DbStats.DatabaseStats.NumPublicAllDocsRequests.Add(1)
 			if numDocsPreFilter > 0 {
 				h.db.DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Add(int64(numDocsPreFilter))
@@ -60,8 +60,8 @@ func (h *handler) handleAllDocs() error {
 			if numDocsPostFilter > 0 {
 				h.db.DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Add(int64(numDocsPostFilter))
 			}
-		}
-	}()
+		}()
+	}
 
 	if h.privs != adminPrivs && h.db.DatabaseContext.Options.DisablePublicAllDocs {
 		return base.HTTPErrorf(http.StatusForbidden, "public access to _all_docs is disabled for this database")

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -254,8 +254,7 @@ func (h *handler) handleAllDocs() error {
 
 		}
 	} else {
-		var err error
-		if err = h.collection.ForEachDocID(h.ctx(), writeDoc, options); err != nil {
+		if err := h.collection.ForEachDocID(h.ctx(), writeDoc, options); err != nil {
 			return err
 		}
 	}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -48,6 +48,21 @@ type allDocsRow struct {
 
 // HTTP handler for _all_docs
 func (h *handler) handleAllDocs() error {
+
+	var numDocsPreFilter, numDocsPostFilter uint64
+	defer func() {
+		// increment public all docs stats here
+		if h.privs != adminPrivs {
+			h.db.DbStats.DatabaseStats.NumPublicAllDocsRequests.Add(1)
+			if numDocsPreFilter > 0 {
+				h.db.DbStats.DatabaseStats.NumDocsPreFilterPublicAllDocs.Add(int64(numDocsPreFilter))
+			}
+			if numDocsPostFilter > 0 {
+				h.db.DbStats.DatabaseStats.NumDocsPostFilterPublicAllDocs.Add(int64(numDocsPostFilter))
+			}
+		}
+	}()
+
 	if h.privs != adminPrivs && h.db.DatabaseContext.Options.DisablePublicAllDocs {
 		return base.HTTPErrorf(http.StatusForbidden, "public access to _all_docs is disabled for this database")
 	}
@@ -184,6 +199,8 @@ func (h *handler) handleAllDocs() error {
 
 	// Subroutine that writes a response entry for a document:
 	writeDoc := func(doc db.IDRevAndSequence, channels []string) (bool, error) {
+		// increment num docs pre-filter, this callback in invoked for each doc returned by query result
+		numDocsPreFilter++
 		row := createRow(doc, channels)
 		if row != nil {
 			if row.Status >= 300 {
@@ -237,10 +254,14 @@ func (h *handler) handleAllDocs() error {
 
 		}
 	} else {
-		if err := h.collection.ForEachDocID(h.ctx(), writeDoc, options); err != nil {
+		var err error
+		if err = h.collection.ForEachDocID(h.ctx(), writeDoc, options); err != nil {
 			return err
 		}
 	}
+	// set total number of docs post filter to number of rows included in response note this may include docs that
+	// have errors associated with them.
+	numDocsPostFilter = uint64(totalRows)
 
 	_, _ = h.response.Write([]byte(fmt.Sprintf("],\n"+`"total_rows":%d,"update_seq":%d}`,
 		totalRows, lastSeq)))


### PR DESCRIPTION
CBG-4676

- adds three new stats around the public all docs endpoint 
- Number of requests (this includes any that aren't successful due to some error)
- Number of docs pre filtering 
- Number of docs post filtering (this will include docs the user doesn't have access to for example when you specify the document id in the "keys" property. This is because these docs will be included in the response on this case but will have an error associated with them). 
- All stats added have been tagged as internal - I don't believe the customer learns much from these

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3146/
