### PR TITLE
Improvements for ISGR docs.

### DIFF
--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -325,6 +325,8 @@ replicationid:
   required: true
   schema:
     type: string
+    minimum: 1
+    maximum: 160
   description: What replication to target based on its replication ID.
 replicator2:
   name: replicator2

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -732,9 +732,7 @@ Replication:
       default: false
     enable_delta_sync:
       description: |-
-        If the field is omitted, this will use the delta-sync setting of the database configuration `delta_sync.enabled`.
-
-        If it is set to false, then delta-sync will not be used for this replication.
+        This will turn on delta-sync for the replication. In order to enable delta-sync for a replication, the database level setting `delta_sync.enabled` must also be set to true.
 
         Using delta-sync is an Enterprise Edition only feature.
       type: boolean

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -599,236 +599,44 @@ HTTP-Error:
     - error
     - reason
   title: HTTP-Error
+ISGRReplicationState:
+  description: This is the state that the replicator is in or that trying to transition in to.
+  type: string
+  enum:
+    - running
+    - stopped
+    - resetting
+    - error
+    - starting
+    - reconnecting
+  x-enumDescriptions:
+    running: Currently running replication.
+    stopped: Not running replication.
+    resetting: The replication is resetting its state.
+    error: The replication is stopped due to an error.
+    starting: The replication is starting up.
+    reconnecting: The replication is reconnecting to the remote database.
+  title: Replication Status
 Retrieved-replication:
   description: Properties of a replication
-  type: object
-  properties:
-    replication_id:
-      description: |-
-        This is the ID of the replication.
-
-        When creating a new replication using a POST request, this will be set to a random UUID if not explicitly set.
-
-        When the replication ID is specified in the URL, this must be set to the same replication ID if specifying it at all.
-      type: string
-    remote:
-      description: |-
-        This is the endpoint of the database for the remote Sync Gateway that is the subject of this replication's `push`, `pull`, or `pushAndPull` action.
-
-        Typically this would include the URI, port, and database name. For example, `http://localhost:4985/db`.
-
-        How this remote is used depends on the `direction` of the replication:
-        * `pull` - this replicator _pulls_ changes from the `remote`
-        * `push` - this replicator _pushes_ changes to this `remote`
-        * `pushAndPull` - this replicator _pushes_ changes to this `remote`, while also pulling receiving changes
-      type: string
-    username:
-      description: |-
-        **This has been deprecated in favour of `remote_username`.**
-
-        This is the username to use to authenticate with the remote.
-
-        This can only be used for a pull replication.
-      type: string
-      deprecated: true
-    password:
-      description: |-
-        **This has been deprecated in favour of `remote_password`.**
-
-        This is the password to use to authenticate with the remote.
-
-        This password will be redacted in the replication config.
-
-        This can only be used for a pull replication.
-      type: string
-      deprecated: true
-    remote_username:
-      description: |-
-        The username to use to authenticate with the remote.
-
-        This can only be used for a pull replication.
-      type: string
-    remote_password:
-      description: |-
-        The password to use to authenticate with the remote.
-
-        This password will be redacted in the replication config.
-
-        This can only be used for a pull replication.
-      type: string
-    direction:
-      description: |-
-        This specifies which direction the replication will be replicating with the `remote` replicator.
-
-        The directions are:
-        * `pull` - changes are pulled from the remote database
-        * `push` - changes are pushed to the remote database
-        * `pushAndPull` - changes are both push-to and pulled-from the remote database
-
-        Replications created prior to Sync Gateway 2.8 derive their `direction` from the source/target URL of the replication.
-      type: string
-      enum:
-        - push
-        - pull
-        - pushAndPull
-    conflict_resolution_type:
-      description: |-
-        This defines what conflict resolution policy Sync Gateway should use to apply when resolving conflicting revisions.
-
-        Changing this is an Enterprise Edition only feature.
-
-        **Behaviour**
-        * *default* - In priority order, this will cause
-          - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
-          - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
-        * *localWins* - This will result in local revisions always being the winner in any conflict.
-        * *remoteWins* - This will result in remote revisions always being the winner in any conflict.
-        * *custom* - This will result in conflicts going through your own custom conflict resolver. You must provide this logic as a Javascript function in the `custom_conflict_resolver` parameter. This is an Enterprise Edition only feature.
-
-
-        Note: replications created prior to Sync Gateway 2.8 will default to `default`.
-      type: string
-      default: default
-      enum:
-        - default
-        - remoteWins
-        - localWins
-        - custom
-    custom_conflict_resolver:
-      description: "This specifies the Javascript function to use to resolve conflicts between conflicting revisions.\n \nThis **must** be used when `conflict_resolution_type=custom`. This property will be ignored when `conflict_resolution_type` is not `custom`.\n\nThe Javascript function to provide this property should be in backticks (like the sync function). The function takes 1 parameter which is a struct that represents the conflict. This struct has 2 properties:\n* `LocalDocument` - The local document. This contains the document ID under the `_id` key.\n* `RemoteDocument` - The remote document\nThe function should return the new document's body. This can be the winning revision (for example, `return conflict.LocalDocument`), a new body, or `nil` to resolve as a delete.\n\nExample:\n```\n\"custom_conflict_resolver\":\\`\n\tfunction(conflict) {\n\t\tconsole.log(\"Doc ID: \"+conflict.LocalDocument._id);\n\t\tconsole.log(\"Full remote doc: \"+JSON.stringify(conflict.RemoteDocument));\n\t\treturn conflict.RemoteDocument;\n\t}\n\\`\n```\n\nUsing complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.\n\nThis is an Enterprise Edition only feature.\n"
-      type: string
-      default: none
-    purge_on_removal:
-      description: |-
-        Specifies whether to purge a document if the remote user loses access to all of the channels on the document when attempting to pull it from the remote.
-
-        If false, documents will not be replicated and not be purged when the user loses access.
-      type: boolean
-      default: false
-    enable_delta_sync:
-      description: |-
-        This will turn on delta- sync for the replication. This works in conjunction with the database level setting `delta_sync.enabled`
-
-        If set to true, delta-sync will be used as long as both databases involved in the replication have delta-sync enabled. If a database does not have delta-sync enabled, then the replication will run without delta-sync.
-
-        Replications created prior to Sync Gateway 2.8 must have delta-sync disabled.
-
-        Enabling this is an Enterprise Edition only feature.
-      type: boolean
-      default: false
-    max_backoff_time:
-      description: |-
-        Specifies the maximum time-period (in minutes) that Sync Gateway will attempt to reconnect to a lost or unreachable remote.
-
-        When a disconnection happens, Sync Gateway will do an exponential backoff up to this specified value. When this value is met, it will attempt to reconnect indefinitely every `max_backoff_time` minutes.
-
-        If this is set to 0, Sync Gateway will do the normal exponential backoff after the disconnect happens but then attempting 10 minutes and stop the replication.
-
-        Note: this defaults to 5 minutes for replications created prior to Sync Gateway 2.8.
-      type: integer
-      default: 5
-    initial_state:
-      description: |-
-        This is what state to start the replication in when creating a new replication.
-
-        This allows you to control if the replication starts in a `stopped` start or `running` state.
-
-        Replications prior to Sync Gateway 2.8 will run in the default state `running`.
-      type: string
-      default: running
-      enum:
-        - running
-        - stopped
-    continuous:
-      description: |-
-        If true, changes will be immediately synced when they happen. This is known as a continuous replication.
-
-        If false, all changes will be synced until they have been processed. The replication will then cease and not process any future changes (unless started again by the user). This is known as a one-shot replication.
-      type: boolean
-      default: false
-    filter:
-      description: |-
-        This defines whether to filter documents by their channels or not.
-
-        If set to `sync_gateway/bychannel` then a **pull** replication will be limited to a specific set of channels specified by the `query_params.channels` property.
-
-        This only can be used with pull replications.
-      type: string
-      enum:
-        - sync_gateway/bychannel
-    query_params:
-      description: |-
-        This is a set of key/value pairs used in the query string of the replication.
-
-        If `filters=sync_gateway/bychannel` then this can be used to set the channels to filter by in a pull replication. To do this, set the `channels` key to a string array of the channels to filter by. For example:
-        ```
-        "filter":"sync_gateway/bychannel",
-        "query_params": {
-          "channels":["chanUser1"]
-        },
-        ```
-      type: array
-      items:
-        type: string
-    adhoc:
-      description: |-
-        Set to true to run the replication as an adhoc replication instead of a persistent one.
-
-        This means that the replication will only last the period of the replication until the status is changed to `stopped` and then it will be removed automatically. It will also be removed if Sync Gateway restarts or if removed due to user action.
-      type: boolean
-      default: false
-    batch_size:
-      description: The amount of changes to be sent in one batch of replications. Changing this is an Enterprise Edition only feature.
-      type: integer
-      default: 200
-    run_as:
-      description: This is used if you want to specify a user to run the replication as. This means that the replication will only be able to replicate what the user  access to what the user has access to.
-      type: string
-    collections_enabled:
-      description: |-
-        If true, the replicator will run with collections, and will replicate all collections, unless otherwise limited by `collections_local`.
-
-        If false, the replicator will only replicate the default collection.
-      type: boolean
-      default: false
-    collections_local:
-      description: |-
-        Limits the set of collections replicated to those listed in this array.
-
-        The replication will use all collections defined on the database if this list is empty.
-      type: array
-      items:
-        type: string
-      example: ["scope1.collection1", "scope1.collection3", "scope1.collection6"]
-      default: []
-    collections_remote:
-      description: |-
-        Remaps the local collection name to the one specified in this array when replicating with the remote.
-
-        If only a subset of collections need remapping, elements in this array can be specified as `null` to preserve the local collection name.
-
-        The same index is used for both `collections_remote` and `collections_local`, and both arrays must be the same length.
-      type: array
-      items:
-        type: string
-      example: ["scope1.collectionA", null, "scope1.collectionF"]
-      default: []
-    assigned_node:
-      description: The unique ID of the node assigned to the replication.
-      type: string
-    target_state:
-      description: This is the state that the replicator is in or that trying to transition in to.
-      type: string
-      enum:
-        - running
-        - stopped
-        - resetting
-        - error
-        - starting
-        - reconnecting
-    cluster_uuid:
-      description: The cluster unique identifier.
-      type: string
+  allOf:
+    - type: object
+      properties:
+        replication_id:
+          description: |-
+            This is the ID of the replication.
+          type: string
+    - $ref: '#/Replication'
+    - type: object
+      properties:
+        assigned_node:
+          description: The unique ID of the node assigned to the replication.
+          type: string
+        target_state:
+          $ref: '#/ISGRReplicationState'
+        cluster_uuid:
+          description: The cluster unique identifier.
+          type: string
   title: Replication
 Replication:
   description: Properties of a replication
@@ -842,82 +650,38 @@ Replication:
 
         When the replication ID is specified in the URL, this must be set to the same replication ID if specifying it at all.
       type: string
+      maximum: 160
     remote:
       description: |-
         This is the endpoint of the database for the remote Sync Gateway that is the subject of this replication's `push`, `pull`, or `pushAndPull` action.
 
-        Typically this would include the URI, port, and database name. For example, `http://localhost:4985/db`.
-
-        How this remote is used depends on the `direction` of the replication:
-        * `pull` - this replicator _pulls_ changes from the `remote`
-        * `push` - this replicator _pushes_ changes to this `remote`
-        * `pushAndPull` - this replicator _pushes_ changes to this `remote`, while also pulling receiving changes
+        Typically this would include the URI, port, and database name. For example, `https://localhost:4985/db`.
       type: string
-    username:
-      description: |-
-        **This has been deprecated in favour of `remote_username`.**
-
-        This is the username to use to authenticate with the remote.
-
-        This can only be used for a pull replication.
-      type: string
-      deprecated: true
-    password:
-      description: |-
-        **This has been deprecated in favour of `remote_password`.**
-
-        This is the password to use to authenticate with the remote.
-
-        This password will be redacted in the replication config.
-
-        This can only be used for a pull replication.
-      type: string
-      deprecated: true
     remote_username:
       description: |-
-        The username to use to authenticate with the remote.
-
-        This can only be used for a pull replication.
+       The username to use to authenticate with the remote.
       type: string
     remote_password:
       description: |-
-        The password to use to authenticate with the remote.
-
-        This password will be redacted in the replication config.
-
-        This can only be used for a pull replication.
+        The password to use to authenticate with the remote. This password will be redacted in the replication config.
       type: string
     direction:
       description: |-
         This specifies which direction the replication will be replicating with the `remote` replicator.
-
-        The directions are:
-        * `pull` - changes are pulled from the remote database
-        * `push` - changes are pushed to the remote database
-        * `pushAndPull` - changes are both push-to and pulled-from the remote database
-
-        Replications created prior to Sync Gateway 2.8 derive their `direction` from the source/target URL of the replication.
       type: string
       enum:
         - push
         - pull
         - pushAndPull
+      x-enumDescriptions:
+        pull: changes are pulled from the remote database
+        push: changes are pushed to the remote database
+        pushAndPull: changes are both push-to and pulled-from the remote database
     conflict_resolution_type:
       description: |-
         This defines what conflict resolution policy Sync Gateway should use to apply when resolving conflicting revisions.
 
         Changing this is an Enterprise Edition only feature.
-
-        **Behaviour**
-        * *default* - In priority order, this will cause
-          - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
-          - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
-        * *localWins* - This will result in local revisions always being the winner in any conflict.
-        * *remoteWins* - This will result in remote revisions always being the winner in any conflict.
-        * *custom* - This will result in conflicts going through your own custom conflict resolver. You must provide this logic as a Javascript function in the `custom_conflict_resolver` parameter. This is an Enterprise Edition only feature.
-
-
-        Note: replications created prior to Sync Gateway 2.8 will default to `default`.
       type: string
       default: default
       enum:
@@ -925,10 +689,40 @@ Replication:
         - remoteWins
         - localWins
         - custom
+      x-enumDescriptions:
+        default: |-
+          In priority order, this will cause
+            - Deletes to always win (the delete with the longest revision history wins if both revisions are deletes)
+            - The revision with the longest revision history to win. This means the the revision with the most changes and therefore the highest revision ID will win.
+        localWins: This will result in local revisions always being the winner in any conflict.
+        remoteWins: This will result in remote revisions always being the winner in any conflict.
+        custom: This will result in conflicts going through your own custom conflict resolver. You must provide this logic as a Javascript function in the `custom_conflict_resolver` parameter.
     custom_conflict_resolver:
-      description: "This specifies the Javascript function to use to resolve conflicts between conflicting revisions.\n \nThis **must** be used when `conflict_resolution_type=custom`. This property will be ignored when `conflict_resolution_type` is not `custom`.\n\nThe Javascript function to provide this property should be in backticks (like the sync function). The function takes 1 parameter which is a struct that represents the conflict. This struct has 2 properties:\n* `LocalDocument` - The local document. This contains the document ID under the `_id` key.\n* `RemoteDocument` - The remote document\nThe function should return the new document's body. This can be the winning revision (for example, `return conflict.LocalDocument`), a new body, or `nil` to resolve as a delete.\n\nExample:\n```\n\"custom_conflict_resolver\":\\`\n\tfunction(conflict) {\n\t\tconsole.log(\"Doc ID: \"+conflict.LocalDocument._id);\n\t\tconsole.log(\"Full remote doc: \"+JSON.stringify(conflict.RemoteDocument));\n\t\treturn conflict.RemoteDocument;\n\t}\n\\`\n```\n\nUsing complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.\n\nThis is an Enterprise Edition only feature.\n"
+      description: |-
+        This specifies the Javascript function to use to resolve conflicts between conflicting revisions.
+
+        This **must** be used when `conflict_resolution_type=custom`. This property will be ignored when `conflict_resolution_type` is not `custom`.
+
+        The Javascript function to provide this property should be in backticks (like the sync function). The function takes 1 parameter which is a struct that represents the conflict. This struct has 2 properties:
+          * `LocalDocument` - The local document. This contains the document ID under the `_id` key.
+          * `RemoteDocument` - The remote document
+        The function should return the new document's body. This can be the winning revision (for example, `return conflict.LocalDocument`), a new body, or `nil` to resolve as a delete.
+
+        Example:
+
+        ```javascript
+        function(conflict) {
+          console.log("Doc ID: "+conflict.LocalDocument._id);
+          console.log("Full remote doc: "+JSON.stringify(conflict.RemoteDocument));
+          return conflict.RemoteDocument;
+        }
+        ```
+
+        Using complex `custom_conflict_resolver` functions can noticeably degrade performance. Use a built-in resolver whenever possible.
+
+        This is an Enterprise Edition only feature.
       type: string
-      default: none
+      default: ""
     purge_on_removal:
       description: |-
         Specifies whether to purge a document if the remote user loses access to all of the channels on the document when attempting to pull it from the remote.
@@ -938,13 +732,11 @@ Replication:
       default: false
     enable_delta_sync:
       description: |-
-        This will turn on delta- sync for the replication. This works in conjunction with the database level setting `delta_sync.enabled`
+        If the field is omitted, this will use the delta-sync setting of the database configuration `delta_sync.enabled`.
 
-        If set to true, delta-sync will be used as long as both databases involved in the replication have delta-sync enabled. If a database does not have delta-sync enabled, then the replication will run without delta-sync.
+        If it is set to false, then delta-sync will not be used for this replication.
 
-        Replications created prior to Sync Gateway 2.8 must have delta-sync disabled.
-
-        Enabling this is an Enterprise Edition only feature.
+        Using delta-sync is an Enterprise Edition only feature.
       type: boolean
       default: false
     max_backoff_time:
@@ -970,6 +762,9 @@ Replication:
       enum:
         - running
         - stopped
+      x-enumDescriptions:
+        running: The replication will immediately start running.
+        stopped: The replication configuration will be created but the replication will not start running until the user explicitly starts it.
     continuous:
       description: |-
         If true, changes will be immediately synced when they happen. This is known as a continuous replication.
@@ -979,20 +774,21 @@ Replication:
       default: false
     filter:
       description: |-
-        This defines whether to filter documents by their channels or not.
-
-        If set to `sync_gateway/bychannel` then a **pull** replication will be limited to a specific set of channels specified by the `query_params.channels` property.
-
-        This only can be used with pull replications.
+        This defines whether to filter documents.
       type: string
       enum:
         - sync_gateway/bychannel
+        - ""
+      x-enumDescriptions:
+        "": Do not filter any documents.
+        sync_gateway/bychannel: |-
+          If set, a pull replication will be limited to a specific set of channels specified by the `query_param.channels` property.
     query_params:
       description: |-
         This is a set of key/value pairs used in the query string of the replication.
 
         If `filters=sync_gateway/bychannel` then this can be used to set the channels to filter by in a pull replication. To do this, set the `channels` key to a string array of the channels to filter by. For example:
-        ```
+        ```json
         "filter":"sync_gateway/bychannel",
         "query_params": {
           "channels":["chanUser1"]
@@ -1041,9 +837,23 @@ Replication:
         The same index is used for both `collections_remote` and `collections_local`, and both arrays must be the same length.
       type: array
       items:
-        type: string
+        type: [string, null]
       example: ["scope1.collectionA", null, "scope1.collectionF"]
       default: []
+    username:
+      description: |-
+        **This has been deprecated in favour of `remote_username`.**
+
+        This is the username to use to authenticate with the remote.
+      type: string
+      deprecated: true
+    password:
+      description: |-
+        **This has been deprecated in favour of `remote_password`.**
+
+        This is the password to use to authenticate with the remote. This password will be redacted in the replication config.
+      type: string
+      deprecated: true
   required:
     - direction
   title: User configurable replication properties
@@ -1063,15 +873,7 @@ Replication-status:
     config:
       $ref: '#/Replication'
     status:
-      description: The status of the replication.
-      type: string
-      enum:
-        - stopped
-        - running
-        - reconnecting
-        - resetting
-        - error
-        - starting
+      $ref: '#/ISGRReplicationState'
     error_message:
       description: The error message of the replication if an error has occurred.
       type: string
@@ -1099,10 +901,10 @@ Replication-status:
       type: integer
     docs_checked_push:
       type: integer
-    docs_write_failures:
+    doc_write_failures:
       description: The number of documents that have failed to be wrote (pushed) to the target database. There will be no attempt to try to push these docs again.
       type: integer
-    docs_write_conflicts:
+    doc_write_conflicts:
       description: The number of documents that had a conflict.
       type: integer
     rejected_by_remote:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -837,7 +837,8 @@ Replication:
         The same index is used for both `collections_remote` and `collections_local`, and both arrays must be the same length.
       type: array
       items:
-        type: [string, null]
+        type: string
+        nullable: true
       example: ["scope1.collectionA", null, "scope1.collectionF"]
       default: []
     username:


### PR DESCRIPTION
- move username/password to bottom of docs to represent that they are deprecated and remote_username/remote_password should be used.
- Deduplicate the GET and POST replication configuration.
- Add descriptions for the ISGR replication state.
- Note that remote_username/remote_password are used for all replications, not just push replications.
- Fix the code sample in `custom_conflict_resolver` to be valid JS
- Modify description of delta_sync to match the fact that "" is use the database and only explicitly setting to false will have an effect.
- Correct name of doc_write_failures and doc_write_conflicts stats

I've uncovered some real confusing copy in the docs DOC-13297 which came from an old version of openapi docs, so I went through to try to validate this for correctness.
