### PR TITLE
Test only: Use DefaultQueryPaginationLimit in as fallback in Principal queries

### DIFF
--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -439,7 +439,6 @@ func TestResycnManagerDCPResumeStoppedProcess(t *testing.T) {
 // helper function to insert documents equals to docsToCreate, and update sync function if updateResyncFuncAfterDocsAdded set to true
 func setupTestDBForResyncWithDocs(t testing.TB, docsToCreate int, updateResyncFuncAfterDocsAdded bool) (*Database, context.Context) {
 	db, ctx := setupTestDB(t)
-	db.Options.QueryPaginationLimit = 100
 	syncFn := `
 function sync(doc, oldDoc){
 	channel("channel.ABC");
@@ -489,8 +488,6 @@ func TestResyncMou(t *testing.T) {
 	if !db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
 		t.Skip("Test requires multi-xattr subdoc operations, CBS 7.6 or higher")
 	}
-
-	db.Options.QueryPaginationLimit = 100 // Required for principal ID query to not deadlock
 
 	initialImportCount := db.DbStats.SharedBucketImport().ImportCount.Value()
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)

--- a/db/database.go
+++ b/db/database.go
@@ -1051,6 +1051,9 @@ func (db *DatabaseContext) GetUserNames(ctx context.Context) (users []string, er
 	dbUserPrefix := db.MetadataKeys.UserKeyPrefix()
 	startKey := dbUserPrefix
 	limit := db.Options.QueryPaginationLimit
+	if limit == 0 {
+		limit = DefaultQueryPaginationLimit
+	}
 
 	userRe, err := regexp.Compile(`^` + dbUserPrefix + `[^:]*$`)
 	if err != nil {
@@ -1117,6 +1120,9 @@ func (db *DatabaseContext) getAllPrincipalIDsSyncDocs(ctx context.Context) (user
 
 	startKey := ""
 	limit := db.Options.QueryPaginationLimit
+	if limit == 0 {
+		limit = DefaultQueryPaginationLimit
+	}
 
 	dbUserPrefix := db.MetadataKeys.UserKeyPrefix()
 	dbRolePrefix := db.MetadataKeys.RoleKeyPrefix()
@@ -1325,6 +1331,9 @@ func (db *DatabaseContext) getRoleIDsUsingIndex(ctx context.Context, includeDele
 	}
 	startKey := dbRoleIDPrefix
 	limit := db.Options.QueryPaginationLimit
+	if limit == 0 {
+		limit = DefaultQueryPaginationLimit
+	}
 
 	roles = []string{}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2750,7 +2750,6 @@ func TestGetAllUsers(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 	db, ctx := setupTestDB(t)
-	db.Options.QueryPaginationLimit = 100
 	defer db.Close(ctx)
 
 	log.Printf("Creating users...")
@@ -2788,7 +2787,6 @@ func TestGetRoleIDs(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	db.Options.QueryPaginationLimit = 100
 	authenticator := db.Authenticator(ctx)
 
 	rolename1 := uuid.NewString()
@@ -2833,8 +2831,6 @@ func Test_updateAllPrincipalsSequences(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	db.Options.QueryPaginationLimit = 100
-
 	auth := db.Authenticator(ctx)
 	roleSequences := [5]uint64{}
 	userSequences := [5]uint64{}
@@ -2874,7 +2870,6 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
 	defer db.Close(ctx)
-	db.Options.QueryPaginationLimit = 100
 
 	sequenceAllocator, err := newSequenceAllocator(base.DatabaseLogCtx(base.TestCtx(t), db.Name, nil), db.MetadataStore, db.DbStats.DatabaseStats, db.MetadataKeys)
 	assert.NoError(t, err)
@@ -2990,7 +2985,6 @@ func Test_resyncDocument(t *testing.T) {
 			defer db.Close(ctx)
 
 			db.Options.EnableXattr = testCase.useXattr
-			db.Options.QueryPaginationLimit = 100
 			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 			syncFn := `
@@ -3047,7 +3041,6 @@ func Test_getUpdatedDocument(t *testing.T) {
 		db, ctx := setupTestDB(t)
 		defer db.Close(ctx)
 
-		db.Options.QueryPaginationLimit = 100
 		docID := "testDoc"
 
 		body := `{"val": "nonsyncdoc"}`
@@ -3068,7 +3061,6 @@ func Test_getUpdatedDocument(t *testing.T) {
 	t.Run("Sync Document", func(t *testing.T) {
 		db, ctx := setupTestDB(t)
 		defer db.Close(ctx)
-		db.Options.QueryPaginationLimit = 100
 		collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 		syncFn := `
 	function sync(doc, oldDoc){

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -144,7 +144,6 @@ func TestAllPrincipalIDs(t *testing.T) {
 				requireCoveredQuery(t, database, userStatement, !testCase.useLegacySyncDocsIndex)
 			})
 
-			database.Options.QueryPaginationLimit = 100
 			authenticator := database.Authenticator(ctx)
 
 			rolename1 := uuid.NewString()
@@ -208,7 +207,6 @@ func TestGetRoleIDs(t *testing.T) {
 			})
 
 			ctx := database.AddDatabaseLogContext(base.TestCtx(t))
-			database.Options.QueryPaginationLimit = 100
 			authenticator := database.Authenticator(ctx)
 
 			rolename1 := uuid.NewString()


### PR DESCRIPTION
Use default query pagination limit value as a fallback in principal queries when unset (which is expected in db package tests) - removes requirement for deadlock workaround from tests.

This has been an issue for a while and has always had test-side workarounds applied instead of providing a sane default value.

https://github.com/couchbase/sync_gateway/pull/6834#discussion_r1610596800 

This value is _always_ being passed in from `rest` so this change affects `db` package and its tests only.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3158/
