### PR TITLE
CBG-4473: Reset Resync on resume when changing collections

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1727,3 +1727,20 @@ func removeAllWhitespace(s string) string {
 		return r
 	}, s)
 }
+
+// SlicesEqualIgnoreOrder checks if two slices are equal, ignoring order.
+func SlicesEqualIgnoreOrder[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aLookup := make(map[T]struct{}, len(a))
+	for _, aItem := range a {
+		aLookup[aItem] = struct{}{}
+	}
+	for _, bItem := range b {
+		if _, ok := aLookup[bItem]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/base/util.go
+++ b/base/util.go
@@ -1733,14 +1733,15 @@ func SlicesEqualIgnoreOrder[T comparable](a, b []T) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	aLookup := make(map[T]struct{}, len(a))
+	aCount := make(map[T]int, len(a))
 	for _, aItem := range a {
-		aLookup[aItem] = struct{}{}
+		aCount[aItem]++
 	}
 	for _, bItem := range b {
-		if _, ok := aLookup[bItem]; !ok {
+		if count, ok := aCount[bItem]; !ok || count == 0 {
 			return false
 		}
+		aCount[bItem]--
 	}
 	return true
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1735,3 +1735,31 @@ func TestCASToLittleEndianHex(t *testing.T) {
 	littleEndianHex := Uint64CASToLittleEndianHex(casValue)
 	require.Equal(t, expHexValue, string(littleEndianHex))
 }
+
+func TestSlicesEqualUnordered(t *testing.T) {
+	tests := []struct {
+		name          string
+		a, b          []any
+		expectedMatch bool
+	}{
+		// matched cases
+		{"empty slices", []any{}, []any{}, true},
+		{"same elements in same order", []any{1, 2, 3}, []any{1, 2, 3}, true},
+		{"same elements in different order", []any{1, 2, 3}, []any{3, 2, 1}, true},
+		{"same elements with duplicates", []any{1, 2, 2}, []any{2, 1, 2}, true},
+		{"nil elements", []any{1, nil, 2}, []any{2, nil, 1}, true},
+		{"nil in both slices", []any{1, nil}, []any{nil, 1}, true},
+		{"different types", []any{1, "2"}, []any{"2", 1}, true}, // the two slices themselves must have the same type (which could be any - with mixed values)
+		{"mixed types", []any{1, 2.0, "3"}, []any{"3", 2.0, 1}, true},
+		// mismatched cases
+		{"different elements", []any{1, 2, 3}, []any{4, 5, 6}, false},
+		{"different lengths", []any{1, 2}, []any{1, 2, 3}, false},
+		{"same elements with different duplicates", []any{1, 2, 2}, []any{2, 1, 3}, false},
+		{"nil in one slice", []any{1, nil}, []any{1, 2}, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedMatch, SlicesEqualIgnoreOrder(test.a, test.b))
+		})
+	}
+}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1747,14 +1747,21 @@ func TestSlicesEqualUnordered(t *testing.T) {
 		{"same elements in same order", []any{1, 2, 3}, []any{1, 2, 3}, true},
 		{"same elements in different order", []any{1, 2, 3}, []any{3, 2, 1}, true},
 		{"same elements with duplicates", []any{1, 2, 2}, []any{2, 1, 2}, true},
+		{"multiple duplicates", []any{1, 2, 2, 2, 3}, []any{2, 3, 2, 1, 2}, true},
+		{"all same element", []any{1, 1, 1}, []any{1, 1, 1}, true},
 		{"nil elements", []any{1, nil, 2}, []any{2, nil, 1}, true},
 		{"nil in both slices", []any{1, nil}, []any{nil, 1}, true},
 		{"different types", []any{1, "2"}, []any{"2", 1}, true}, // the two slices themselves must have the same type (which could be any - with mixed values)
 		{"mixed types", []any{1, 2.0, "3"}, []any{"3", 2.0, 1}, true},
 		// mismatched cases
 		{"different elements", []any{1, 2, 3}, []any{4, 5, 6}, false},
-		{"different lengths", []any{1, 2}, []any{1, 2, 3}, false},
+		{"different lengths a<b", []any{1, 2}, []any{1, 2, 3}, false},
+		{"different lengths a>b", []any{1, 2, 3}, []any{1, 2}, false},
 		{"same elements with different duplicates", []any{1, 2, 2}, []any{2, 1, 3}, false},
+		{"different duplicate counts", []any{1, 2, 2, 2}, []any{2, 2, 1}, false},
+		{"extra duplicates", []any{1, 2, 2}, []any{2, 1, 2, 2}, false},
+		{"unique vs duplicate", []any{1, 2, 3}, []any{1, 2, 2}, false},
+		{"duplicate vs unique", []any{1, 2, 2}, []any{1, 2, 3}, false},
 		{"nil in one slice", []any{1, nil}, []any{1, 2}, false},
 	}
 	for _, test := range tests {

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -86,6 +86,8 @@ func (r *ResyncManagerDCP) Init(ctx context.Context, options map[string]interfac
 		resetMsg = "failed to unmarshal cluster status"
 	} else if statusDoc.State == BackgroundProcessStateCompleted {
 		resetMsg = "previous run completed"
+	} else if !base.SlicesEqualIgnoreOrder(r.collectionIDs, statusDoc.CollectionIDs) {
+		resetMsg = "collection IDs have changed"
 	} else {
 		// use the resync ID from the status doc to resume
 		r.ResyncID = statusDoc.ResyncID
@@ -357,8 +359,9 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus) ([]b
 		CollectionsProcessing:   r.ResyncedCollections,
 	}
 
-	meta := AttachmentManagerMeta{
-		VBUUIDs: r.VBUUIDs,
+	meta := ResyncManagerMeta{
+		VBUUIDs:       r.VBUUIDs,
+		CollectionIDs: r.collectionIDs,
 	}
 
 	statusJSON, err := base.JSONMarshal(response)
@@ -374,7 +377,8 @@ func (r *ResyncManagerDCP) GetProcessStatus(status BackgroundManagerStatus) ([]b
 }
 
 type ResyncManagerMeta struct {
-	VBUUIDs []uint64 `json:"vbuuids"`
+	VBUUIDs       []uint64 `json:"vbuuids"`
+	CollectionIDs []uint32 `json:"collection_ids,omitempty"`
 }
 
 type ResyncManagerStatusDocDCP struct {

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -49,11 +49,31 @@ func TestResyncDCPInit(t *testing.T) {
 					DocsProcessed: 20,
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
-					VBUUIDs: []uint64{1},
+					VBUUIDs:       []uint64{1},
+					CollectionIDs: []uint32{1},
 				},
 			},
 			forceReset:         false,
 			shouldCreateNewRun: false,
+		},
+		{
+			title: "Restart existing run new Collection",
+			initialClusterState: ResyncManagerStatusDocDCP{
+				ResyncManagerResponseDCP: ResyncManagerResponseDCP{
+					BackgroundManagerStatus: BackgroundManagerStatus{
+						State: BackgroundProcessStateStopped,
+					},
+					ResyncID:      uuid.NewString(),
+					DocsChanged:   10,
+					DocsProcessed: 20,
+				},
+				ResyncManagerMeta: ResyncManagerMeta{
+					VBUUIDs:       []uint64{1},
+					CollectionIDs: []uint32{1, 2},
+				},
+			},
+			forceReset:         false,
+			shouldCreateNewRun: true,
 		},
 		{
 			title: "Reinitialize completed run",

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -494,6 +494,9 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, col)
 
+		// required to avoid missing audit fields in PUT
+		ctx := col.AddCollectionContext(ctx)
+
 		_, err = col.UpdateSyncFun(ctx, `function sync(doc){channel("channel.ABC");}`)
 		require.NoError(t, err)
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -13,6 +13,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"maps"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -25,11 +27,6 @@ import (
 )
 
 func TestResyncDCPInit(t *testing.T) {
-
-	defaultCollectionID := uint32(0)
-	if base.UnitTestUrlIsWalrus() {
-		defaultCollectionID = 1 // Rosmar collection IDs start at 1 ...
-	}
 
 	testCases := []struct {
 		title               string
@@ -54,8 +51,7 @@ func TestResyncDCPInit(t *testing.T) {
 					DocsProcessed: 20,
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
-					VBUUIDs:       []uint64{1},
-					CollectionIDs: []uint32{defaultCollectionID},
+					VBUUIDs: []uint64{1},
 				},
 			},
 			forceReset:         false,
@@ -74,7 +70,7 @@ func TestResyncDCPInit(t *testing.T) {
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
 					VBUUIDs:       []uint64{1},
-					CollectionIDs: []uint32{defaultCollectionID, 123},
+					CollectionIDs: []uint32{123},
 				},
 			},
 			forceReset:         false,
@@ -92,8 +88,7 @@ func TestResyncDCPInit(t *testing.T) {
 					DocsProcessed: 20,
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
-					VBUUIDs:       []uint64{1},
-					CollectionIDs: []uint32{defaultCollectionID},
+					VBUUIDs: []uint64{1},
 				},
 			},
 			forceReset:         false,
@@ -111,8 +106,7 @@ func TestResyncDCPInit(t *testing.T) {
 					DocsProcessed: 20,
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
-					VBUUIDs:       []uint64{1},
-					CollectionIDs: []uint32{defaultCollectionID},
+					VBUUIDs: []uint64{1},
 				},
 			},
 			forceReset:         true,
@@ -150,6 +144,11 @@ func TestResyncDCPInit(t *testing.T) {
 			// otherwise clusterData is zero value of ResyncManagerStatusDocDCP
 			// which make `Init` to reinitialize run from existing cluster data
 			if testCase.initialClusterState.ResyncID != "" {
+				// if this is unset from the test case, stamp the collection ID we have - difficult to reliably predict this ahead of time
+				if len(testCase.initialClusterState.CollectionIDs) == 0 {
+					testCase.initialClusterState.CollectionIDs = slices.Collect(maps.Keys(db.CollectionByID))
+				}
+
 				clusterData, err = json.Marshal(testCase.initialClusterState)
 				require.NoError(t, err)
 			}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -26,6 +26,11 @@ import (
 
 func TestResyncDCPInit(t *testing.T) {
 
+	defaultCollectionID := uint32(0)
+	if base.UnitTestUrlIsWalrus() {
+		defaultCollectionID = 1 // Rosmar collection IDs start at 1 ...
+	}
+
 	testCases := []struct {
 		title               string
 		initialClusterState ResyncManagerStatusDocDCP
@@ -50,7 +55,7 @@ func TestResyncDCPInit(t *testing.T) {
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
 					VBUUIDs:       []uint64{1},
-					CollectionIDs: []uint32{1},
+					CollectionIDs: []uint32{defaultCollectionID},
 				},
 			},
 			forceReset:         false,
@@ -69,7 +74,7 @@ func TestResyncDCPInit(t *testing.T) {
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
 					VBUUIDs:       []uint64{1},
-					CollectionIDs: []uint32{1, 2},
+					CollectionIDs: []uint32{defaultCollectionID, 123},
 				},
 			},
 			forceReset:         false,
@@ -87,7 +92,8 @@ func TestResyncDCPInit(t *testing.T) {
 					DocsProcessed: 20,
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
-					VBUUIDs: []uint64{1},
+					VBUUIDs:       []uint64{1},
+					CollectionIDs: []uint32{defaultCollectionID},
 				},
 			},
 			forceReset:         false,
@@ -105,7 +111,8 @@ func TestResyncDCPInit(t *testing.T) {
 					DocsProcessed: 20,
 				},
 				ResyncManagerMeta: ResyncManagerMeta{
-					VBUUIDs: []uint64{1},
+					VBUUIDs:       []uint64{1},
+					CollectionIDs: []uint32{defaultCollectionID},
 				},
 			},
 			forceReset:         true,


### PR DESCRIPTION
CBG-4473

- Store collection IDs in resync meta
- Reset resync ID/checkpoints when collection set changes

## Dependencies
- [x] #7585 
- [x] #7586 
- [x] Rebase for above

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3163/
