### PR TITLE
CBG-4674 mark DropIndex error as retryable

### DIFF
--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -419,8 +419,16 @@ func IsIndexerRetryIndexError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if strings.Contains(err.Error(), "will retry") || strings.Contains(err.Error(), "will be retried") {
-		return true
+	retryableStrings := []string{
+		"will retry",
+		"will be retried",
+		// [{\"code\":5000,\"message\":\"GSI Drop() - cause: Fail to Drop Index due to internal errors. Cleanup may happen in the background.  Error=DeleteScheduleCreateToken:*:Rev mismatch.\"}]
+		"Drop Index due to internal errors. Cleanup may happen in the background",
+	}
+	for _, s := range retryableStrings {
+		if strings.Contains(err.Error(), s) {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
CBG-4674 mark DropIndex error as retryable

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3175/
