### PR TITLE
CBG-3561 make --sync-gateway-password obsolete

### DIFF
--- a/tools/sgcollect.py
+++ b/tools/sgcollect.py
@@ -27,7 +27,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from typing import List, NoReturn, Optional
+from typing import List, Literal, NoReturn, Optional, Union
 
 import password_remover
 from tasks import (
@@ -118,7 +118,7 @@ class HelpFormatter(optparse.IndentedHelpFormatter):
         indent_increment: int = 2,
         max_help_position: int = 24,
         width: Optional[int] = None,
-        short_first: int = 1,
+        short_first: Union[bool, Literal[0, 1]] = 1,
     ):
         # match width from argparse implementation
         width = shutil.get_terminal_size().columns - 2
@@ -148,6 +148,7 @@ def create_option_parser():
         "-r",
         dest="root",
         help=optparse.SUPPRESS_HELP,
+        default=os.path.abspath(os.path.join(mydir, "..")),
     )
     parser.add_option(
         "--log-redaction-level",

--- a/tools/sgcollect.py
+++ b/tools/sgcollect.py
@@ -82,7 +82,6 @@ SGCOLLECT_INFO_OPTIONS_LOG = "sgcollect_info_options.log"
 SG_USERNAME_ENV = "SG_USERNAME"
 SG_PASSWORD_ENV = "SG_PASSWORD"
 SG_PASSWORD_ERROR = f"--sync-gateway-password is no longer functional. --sync-gateway-username will ask for an interactive password or use environment variable {SG_PASSWORD_ENV}=<password>."
-DEFAULT_ADMIN_URL = "https://127.0.0.1:4985"
 
 
 def delete_zip(filename):

--- a/tools/sgcollect.py
+++ b/tools/sgcollect.py
@@ -80,7 +80,7 @@ SGCOLLECT_INFO_OPTIONS_LOG = "sgcollect_info_options.log"
 
 SG_USERNAME_ENV = "SG_USERNAME"
 SG_PASSWORD_ENV = "SG_PASSWORD"
-SG_PASSWORD_ERROR = f"--sync-gateway-password is no longer functional. --sync-gateway-username will ask for an interactive password or use environment variable {SG_PASSWORD_ENV}=<username>."
+SG_PASSWORD_ERROR = f"--sync-gateway-password is no longer functional. --sync-gateway-username will ask for an interactive password or use environment variable {SG_PASSWORD_ENV}=<password>."
 
 
 def delete_zip(filename):

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -535,6 +535,11 @@ def make_os_tasks(processes):
         WindowsTask("Computer system", "wmic computersystem"),
         WindowsTask("Computer OS", "wmic os"),
         LinuxTask("System Hardware", "lshw -json || lshw"),
+        LinuxTask("Process list snapshot", "export TERM=''; top -Hb -n1 || top -H n1"),
+        LinuxTask(
+            "Process list",
+            "ps -AwwL -o user,pid,lwp,ppid,nlwp,pcpu,maj_flt,min_flt,pri,nice,vsize,rss,tty,stat,wchan:12,start,bsdtime,command",
+        ),
         LinuxTask("Raw /proc/vmstat", "cat /proc/vmstat"),
         LinuxTask("Raw /proc/mounts", "cat /proc/mounts"),
         LinuxTask("Raw /proc/partitions", "cat /proc/partitions"),
@@ -572,6 +577,7 @@ def make_os_tasks(processes):
         LinuxTask("LVM info", "lvdisplay"),
         LinuxTask("LVM info", "vgdisplay"),
         LinuxTask("LVM info", "pvdisplay"),
+        MacOSXTask("Process list snapshot", "top -l 1"),
         MacOSXTask("Disk activity", "iostat 1 10"),
         MacOSXTask(
             "Process list",


### PR DESCRIPTION
CBG-3561 make --sync-gateway-password obsolete

- `--sync-gateway-password=arg` is going to return `SG_PASSWORD_ERROR` explaining what to do.
- `SG_USERNAME` and `SG_PASSWORD` are supported for headless access
- remove hidden argument `--watch-stdin` since if you called this, `getpass` would fail since `--watch-stdin` would exit sgcollect_info as soon as the password was typed.
- always prompt for a password if we have a username.

Precedence (last wins):

- SG_USERNAME, --sync-gateway-username
- SG_PASSWORD, --sync-gateway-password

For future consideration, CBG-3562 which would require passing this variable or answering that we can't provide it. It would be good to try to get SG URL, and then ask for username/password. I thought this was scoped a bit outside of this review.

It would be more idiomatic to allow `--sync-gateway-password` if it has no arguments to prompt for a password, but this isn't possible using the long deprecated `optparse` cmdline parsing library.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
