### PR TITLE
CBG-4713 wait for stat for import

### DIFF
--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -357,6 +357,7 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 
 	defer db.SuspendSequenceBatching()()
 	base.SkipImportTestsIfNotEnabled(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
 
@@ -401,7 +402,7 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 	// Wait for auto-import to work
 	rt.WaitForChanges(docCount, "/{{.keyspace1}}/_changes", "", true)
 	rt.WaitForChanges(docCount, "/{{.keyspace2}}/_changes", "", true)
-	require.Equal(t, int64(docCount*2), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, int64(docCount*2))
 
 	oneScopeConfig := rest.GetCollectionsConfig(t, testBucket, 1)
 	oneScopeConfigJSON, err := json.Marshal(oneScopeConfig)


### PR DESCRIPTION
CBG-4713 wait for stat for import

I believe that the error comes because the changes can be seen slightly before the `ImportCount` happens.

The `ImportCount` doesn't get incremented until the new doc with metadata has been written. It is possible that the caching feed and changes feed see this value before this stat is incremented.

Add logging for the case that this analysis might not be correct.
