### PR TITLE
CBG-2835: TestActiveReplicatorPullSkippedSequence stop after WaitForStat

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2198,10 +2198,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	// wait for the documents originally written to rt2 to arrive at rt1
 	rt1.WaitForVersion(docID1, doc1Version)
 
-	require.NoError(t, ar.Stop())
 	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 1)
-	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
 	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 1)
+	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
+	require.NoError(t, ar.Stop())
 
 	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
 	assert.Equal(t, int64(1), dbstats.ProcessedSequenceLen.Value())
@@ -2227,10 +2227,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 
 	rt1.WaitForChanges(3, "/{{.keyspace}}/_changes?since=0", "", true)
 
-	require.NoError(t, ar.Stop())
 	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 2)
-	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
 	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 2)
+	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
+	require.NoError(t, ar.Stop())
 
 	assert.Equal(t, int64(2), dbstats.ExpectedSequenceLen.Value())
 	assert.Equal(t, int64(2), dbstats.ProcessedSequenceLen.Value())
@@ -2248,10 +2248,10 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 
 	rt1.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
 
-	require.NoError(t, ar.Stop())
 	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ExpectedSequenceCount }, 1)
-	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
 	base.RequireWaitForStat(t, func() int64 { return pullCheckpointer.Stats().ProcessedSequenceCount }, 1)
+	assert.Equal(t, int64(0), pullCheckpointer.Stats().AlreadyKnownSequenceCount)
+	require.NoError(t, ar.Stop())
 
 	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
 	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2254,7 +2254,7 @@ func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
 	require.NoError(t, ar.Stop())
 
 	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
-	assert.Equal(t, int64(1), dbstats.ExpectedSequenceLen.Value())
+	assert.Equal(t, int64(1), dbstats.ProcessedSequenceLen.Value())
 	assert.Equal(t, int64(0), dbstats.ExpectedSequenceLenPostCleanup.Value())
 	assert.Equal(t, int64(0), dbstats.ProcessedSequenceLenPostCleanup.Value())
 }


### PR DESCRIPTION
CBG-2835

Rearrange test code so that `ar.Stop()` runs after the `WaitForStat`s have finished.

My current theory about this flaky test is that the replicator is being stopped after the doc has been sent (i.e. written to the other side and passed `WaitForVersion`, but before the replicator has actually had the ack or properly checkpointed this sequence)

The final synchronous `CheckpointNow()` is potentially still working on information that hasn't yet been fully processed so the stats never get the final update.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3184/
- [ ] `count=100/race` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3186/
