### PR TITLE
CBG-4705: Branch release/3.3.0 and disable main

### DIFF
--- a/manifest/3.3.xml
+++ b/manifest/3.3.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2016-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+-->
+
+<manifest>
+
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
+
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
+        <annotation name="VERSION" value="3.3.0"     keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
+
+
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.3.0" />
+
+</manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -2,13 +2,14 @@
     "product": "sync_gateway",
     "manifests": {
         "manifest/default.xml": {
+            "do-build": false,
             "release": "3.3.0",
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
             "go_version": "1.24.4",
             "trigger_blackduck": true,
-            "start_build": 11
+            "start_build": 1
         },
         "manifest/1.4.0.xml": {
             "do-build": false,
@@ -717,6 +718,15 @@
             "go_version": "1.24.4",
             "trigger_blackduck": true,
             "start_build": 1
+        },
+        "manifest/3.3.xml": {
+            "release": "3.3.0",
+            "release_name": "Couchbase Sync Gateway 3.3.0",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.24.4",
+            "trigger_blackduck": true,
+            "start_build": 285
         },
         "manifest/4.0.xml": {
             "release": "4.0.0",


### PR DESCRIPTION
CBG-4705

Disables `main` from building until 4.0 is merged on top and we promote to 4.0

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- n/a