### PR TITLE
CBG-4505 update cbgt to latest

### DIFF
--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -57,7 +57,7 @@ func cbgtRootCAsProvider(bucketName, bucketUUID, sourceParams string) func() *x5
 	}
 
 	if feedParams.DbName == "" {
-		AssertfCtx(ctx, "Database name not specified in dcp params %s during cbgtRootCAsProvider. Continuing without TLS authentication.")
+		AssertfCtx(ctx, "Database name not specified in dcp params %s during cbgtRootCAsProvider. Continuing without TLS authentication.", UD(sourceParams))
 		return nil
 	}
 

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -57,13 +57,15 @@ func cbgtRootCAsProvider(bucketName, bucketUUID, sourceParams string) func() *x5
 	}
 
 	if feedParams.DbName == "" {
-		AssertfCtx(ctx, "Database name not specified in dcp params %s during cbgtRootCAsProvider. Continuing without TLS authentication.", UD(sourceParams))
+		// consider switching to AssertfCtx one CBG-4730 is fixed
+		InfofCtx(ctx, KeyDCP, "Database name not specified in dcp params %s during cbgtRootCAsProvider. Continuing without TLS authentication.")
 		return nil
 	}
 
 	creds, ok := getCbgtCredentials(feedParams.DbName)
 	if !ok {
-		AssertfCtx(ctx, "No feed credentials stored for db %s from sourceParams during cbgtRootCAsProvider. Continuing without TLS authentication.", MD(feedParams.DbName))
+		// consider switching to AssertfCtx one CBG-4730 is fixed
+		InfofCtx(ctx, KeyDCP, "No feed credentials stored for db %s from sourceParams during cbgtRootCAsProvider. Continuing without TLS authentication.", MD(feedParams.DbName))
 		return nil
 	}
 	if !creds.useTLS {
@@ -240,13 +242,15 @@ func addCbgtAuthToDCPParams(ctx context.Context, dcpParams string) string {
 	}
 
 	if feedParams.DbName == "" {
-		AssertfCtx(ctx, "Database name not specified in dcp params, feed credentials not added")
+		// consider switching to AssertfCtx one CBG-4730 is fixed
+		InfofCtx(ctx, KeyDCP, "Database name not specified in dcp params, feed credentials not added, import feed will not be able to authenticate.")
 		return dcpParams
 	}
 
 	creds, ok := getCbgtCredentials(feedParams.DbName)
 	if !ok {
-		AssertfCtx(ctx, "No feed credentials stored for db from sourceParams: %s", MD(feedParams.DbName))
+		// consider switching to AssertfCtx one CBG-4730 is fixed
+		InfofCtx(ctx, KeyDCP, "No feed credentials stored for db from sourceParams: %s, import feed will not be able to authenticate.", MD(feedParams.DbName))
 		return dcpParams
 	}
 
@@ -261,7 +265,7 @@ func addCbgtAuthToDCPParams(ctx context.Context, dcpParams string) string {
 
 	marshalledParamsWithAuth, marshalErr := JSONMarshal(feedParams)
 	if marshalErr != nil {
-		WarnfCtx(ctx, "Unable to marshal updated cbgt dcp params: %v", marshalErr)
+		WarnfCtx(ctx, "Unable to marshal updated cbgt dcp params: %v. Import feed will not be able to authenticate.", marshalErr)
 		return dcpParams
 	}
 

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -29,16 +29,16 @@ var cbgtCredentials map[string]cbgtCreds
 // contexts we only have access to the bucket name.
 var cbgtBucketToDBName map[string]string
 
-// cbgtRootCertPools is a map of bucket UUIDs to cert pools for its CA certs. The documentation comment of
-// cbgtRootCAsProvider describes the behaviour of different values.
-var cbgtRootCertPools map[string]*x509.CertPool
 var cbgtGlobalsLock sync.Mutex
 
+// cbgtCredentials are bucket specific credentials for connecting to Couchbase Server
 type cbgtCreds struct {
-	username       string
-	password       string
-	clientCertPath string
-	clientKeyPath  string
+	username       string         // Couchbase Server username, if using basic authentication
+	password       string         // Couchbase Server username, if using basic authentication
+	clientCertPath string         // Couchbase Server client certificate(public key), if using x509 authentication. If specified, username and password will be ignored.
+	clientKeyPath  string         // Couchbase Server client certificate(private key), if using x509 authentication. If specified, username and password will be ignored.
+	certPool       *x509.CertPool // If using TLS, the root certificates for verifying Couchbase Server. If TLSSkipVerify is set, this value should be nil.
+	useTLS         bool           // If using couchbases:// this should be true.
 }
 
 // This used to be called SOURCE_GOCOUCHBASE_DCP_SG (with the same string value).
@@ -48,18 +48,30 @@ const SOURCE_DCP_SG = "couchbase-dcp-sg"
 // for the given bucket. Edge cases:
 // * If it returns a function that returns nil, TLS is used but certificate validation is disabled.
 // * If it returns a nil function, TLS is disabled altogether.
-func cbgtRootCAsProvider(bucketName, bucketUUID string) func() *x509.CertPool {
-	cbgtGlobalsLock.Lock()
-	pool, ok := cbgtRootCertPools[bucketUUID]
-	cbgtGlobalsLock.Unlock()
-	if ok {
-		return func() *x509.CertPool {
-			return pool
-		}
-	}
+func cbgtRootCAsProvider(bucketName, bucketUUID, sourceParams string) func() *x509.CertPool {
 	ctx := BucketNameCtx(context.Background(), bucketName) // this function is global, so reconstruct context
-	TracefCtx(ctx, KeyDCP, "Bucket %v not found in root cert pools, not using TLS.", MD(bucketName))
-	return nil
+	feedParams, err := getSGFeedSourceParams(sourceParams)
+	if err != nil {
+		AssertfCtx(ctx, "Unable to unmarshal params provided by cbgt inside cbgtRootCAsProvider: %v: %s. Continuing without TLS authentication.", err, UD(sourceParams))
+		return nil
+	}
+
+	if feedParams.DbName == "" {
+		AssertfCtx(ctx, "Database name not specified in dcp params %s during cbgtRootCAsProvider. Continuing without TLS authentication.")
+		return nil
+	}
+
+	creds, ok := getCbgtCredentials(feedParams.DbName)
+	if !ok {
+		AssertfCtx(ctx, "No feed credentials stored for db %s from sourceParams during cbgtRootCAsProvider. Continuing without TLS authentication.", MD(feedParams.DbName))
+		return nil
+	}
+	if !creds.useTLS {
+		return nil
+	}
+	return func() *x509.CertPool {
+		return creds.certPool
+	}
 }
 
 // cbgt's default GetPoolsDefaultForBucket only works with cbauth
@@ -118,7 +130,6 @@ func cbgtGetPoolsDefaultForBucket(server, bucket string, scopes bool) ([]byte, e
 // the credential information to the DCP parameters before calling the underlying method.
 func init() {
 	cbgtCredentials = make(map[string]cbgtCreds)
-	cbgtRootCertPools = make(map[string]*x509.CertPool)
 	cbgtBucketToDBName = make(map[string]string)
 	// NB: we use the same feed type *name* as Lithium nodes, but run it using gocbcore rather than cbdatasource. If only
 	// streaming the default collection, there is no functional difference.
@@ -139,19 +150,12 @@ func init() {
 	cbgt.GetPoolsDefaultForBucket = cbgtGetPoolsDefaultForBucket
 }
 
+// SGFeedSourceParams is a wrapper for cbgt's parameters.
 type SGFeedSourceParams struct {
-	// Used to specify whether the applications are interested
-	// in receiving the xattrs information in a dcp stream.
-	IncludeXAttrs bool `json:"includeXAttrs,omitempty"`
+	cbgt.DCPFeedParams
 
 	// Used to pass the SG database name to SGFeed* shims
 	DbName string `json:"sg_dbname,omitempty"`
-
-	// Scope within the bucket to stream data from.
-	Scope string `json:"scope,omitempty"`
-
-	// Collections within the scope that the feed would cover.
-	Collections []string `json:"collections,omitempty"`
 }
 
 type SGFeedIndexParams struct {
@@ -218,46 +222,44 @@ func SGGocbSourceUUIDLookup(sourceName, sourceParams, serverIn string,
 	return cbgt.CBSourceUUIDLookUp(sourceName, sourceParams, serverIn, options)
 }
 
+// getSGFeedSourceParams unmarshals the feed parameters from cbgt DCP feed sourceParams. Returns an error if the parameters can not be unmarshalled.
+func getSGFeedSourceParams(params string) (SGFeedSourceParams, error) {
+	var sgSourceParams SGFeedSourceParams
+	err := JSONUnmarshal([]byte(params), &sgSourceParams)
+	return sgSourceParams, err
+}
+
 // addCbgtAuthToDCPParams gets the dbName from the incoming dcpParams, and checks for credentials
 // stored in databaseCredentials.  If found, adds those to the params as authUser/authPassword.
 // If dbname is present,
 func addCbgtAuthToDCPParams(ctx context.Context, dcpParams string) string {
-
-	var sgSourceParams SGFeedSourceParams
-
-	unmarshalErr := JSONUnmarshal([]byte(dcpParams), &sgSourceParams)
-	if unmarshalErr != nil {
-		WarnfCtx(ctx, "Unable to unmarshal params provided by cbgt as sgSourceParams: %v", unmarshalErr)
+	feedParams, err := getSGFeedSourceParams(dcpParams)
+	if err != nil {
+		AssertfCtx(ctx, "Unable to unmarshal params provided by cbgt as sgSourceParams: %v: %s", err, UD(dcpParams))
 		return dcpParams
 	}
 
-	if sgSourceParams.DbName == "" {
-		InfofCtx(ctx, KeyImport, "Database name not specified in dcp params, feed credentials not added")
+	if feedParams.DbName == "" {
+		AssertfCtx(ctx, "Database name not specified in dcp params, feed credentials not added")
 		return dcpParams
 	}
 
-	creds, ok := getCbgtCredentials(sgSourceParams.DbName)
+	creds, ok := getCbgtCredentials(feedParams.DbName)
 	if !ok {
-		InfofCtx(ctx, KeyImport, "No feed credentials stored for db from sourceParams: %s", MD(sgSourceParams.DbName))
+		AssertfCtx(ctx, "No feed credentials stored for db from sourceParams: %s", MD(feedParams.DbName))
 		return dcpParams
-	}
-
-	var feedParamsWithAuth cbgt.DCPFeedParams
-	unmarshalDCPErr := JSONUnmarshal([]byte(dcpParams), &feedParamsWithAuth)
-	if unmarshalDCPErr != nil {
-		WarnfCtx(ctx, "Unable to unmarshal params provided by cbgt as dcpFeedParams: %v", unmarshalDCPErr)
 	}
 
 	// Add creds to params
 	if creds.clientCertPath != "" && creds.clientKeyPath != "" {
-		feedParamsWithAuth.ClientCertPath = creds.clientCertPath
-		feedParamsWithAuth.ClientKeyPath = creds.clientKeyPath
+		feedParams.ClientCertPath = creds.clientCertPath
+		feedParams.ClientKeyPath = creds.clientKeyPath
 	} else {
-		feedParamsWithAuth.AuthUser = creds.username
-		feedParamsWithAuth.AuthPassword = creds.password
+		feedParams.AuthUser = creds.username
+		feedParams.AuthPassword = creds.password
 	}
 
-	marshalledParamsWithAuth, marshalErr := JSONMarshal(feedParamsWithAuth)
+	marshalledParamsWithAuth, marshalErr := JSONMarshal(feedParams)
 	if marshalErr != nil {
 		WarnfCtx(ctx, "Unable to marshal updated cbgt dcp params: %v", marshalErr)
 		return dcpParams
@@ -266,14 +268,10 @@ func addCbgtAuthToDCPParams(ctx context.Context, dcpParams string) string {
 	return string(marshalledParamsWithAuth)
 }
 
-func addCbgtCredentials(dbName, bucketName, username, password, clientCertPath, clientKeyPath string) {
+// addCbgtCredentials registers a particular bucket and database name for cbgt's global lookup callbacks.
+func addCbgtCredentials(dbName, bucketName string, creds cbgtCreds) {
 	cbgtGlobalsLock.Lock()
-	cbgtCredentials[dbName] = cbgtCreds{
-		username:       username,
-		password:       password,
-		clientCertPath: clientCertPath,
-		clientKeyPath:  clientKeyPath,
-	}
+	cbgtCredentials[dbName] = creds
 	cbgtBucketToDBName[bucketName] = dbName
 	cbgtGlobalsLock.Unlock()
 }
@@ -294,11 +292,4 @@ func getCbgtCredentials(dbName string) (cbgtCreds, bool) {
 	creds, found := cbgtCredentials[dbName]
 	cbgtGlobalsLock.Unlock() // cbgtCreds is not a pointer type, safe to unlock
 	return creds, found
-}
-
-// setCbgtRootCertsForBucket creates root certificates for a given bucket. If TLS should be used, this function must be called. If tls certificate verification is skipped, then this function should be called with pool as nil. See the comment of cbgtRootCAsProvider for usage details.
-func setCbgtRootCertsForBucket(bucketUUID string, pool *x509.CertPool) {
-	cbgtGlobalsLock.Lock()
-	defer cbgtGlobalsLock.Unlock()
-	cbgtRootCertPools[bucketUUID] = pool
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"io/fs"
 	"log"
-	"maps"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -978,15 +977,4 @@ func numFilesInDir(t *testing.T, dir string, recursive bool) int {
 	})
 	require.NoError(t, err)
 	return numFiles
-}
-
-// ResetCBGTCertPools resets the cert pools used for cbgt in a test.
-func ResetCBGTCertPools(t *testing.T) {
-	// CBG-4394: removing root certs for the bucket should be done, but it is keyed based on the bucket UUID, and multiple dbs can use the same bucket
-	cbgtGlobalsLock.Lock()
-	defer cbgtGlobalsLock.Unlock()
-	oldRootCAs := maps.Clone(cbgtRootCertPools)
-	t.Cleanup(func() {
-		cbgtRootCertPools = oldRootCAs
-	})
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	dario.cat/mergo v1.0.0
 	github.com/KimMachineGun/automemlimit v0.7.0
 	github.com/coreos/go-oidc/v3 v3.12.0
-	github.com/couchbase/cbgt v1.4.2-0.20241112001929-b9fdd9b009b1
+	github.com/couchbase/cbgt v1.4.9
 	github.com/couchbase/clog v0.1.0
 	github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd
 	github.com/couchbase/gocb/v2 v2.10.0
@@ -45,7 +45,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/couchbase/blance v0.1.6 // indirect
-	github.com/couchbase/cbauth v0.1.12 // indirect
+	github.com/couchbase/cbauth v0.1.13 // indirect
 	github.com/couchbase/go-couchbase v0.1.1 // indirect
 	github.com/couchbase/gocbcoreps v0.1.3 // indirect
 	github.com/couchbase/goprotostellar v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,12 @@ github.com/couchbase/blance v0.1.6 h1:zyNew/SN2AheIoJxQ2LqqA1u3bMp03eGCer6hSDMUD
 github.com/couchbase/blance v0.1.6/go.mod h1:2Sa/nsJSieN/r3T9LsrUYWeQ015qDsuHybhz4F4JcHU=
 github.com/couchbase/cbauth v0.1.12 h1:JOAWjjp2BdubvrrggvN4yQo3oEc2ndXcRN1ONCklUOM=
 github.com/couchbase/cbauth v0.1.12/go.mod h1:W7zkNXa0B2cTDg90YmmuTSbu+PlYOvMqzQvmNlNH/Mg=
+github.com/couchbase/cbauth v0.1.13 h1:1MXacfujb5E4g1MabltOjWUz7Ilewbix2mdSADFa358=
+github.com/couchbase/cbauth v0.1.13/go.mod h1:W7zkNXa0B2cTDg90YmmuTSbu+PlYOvMqzQvmNlNH/Mg=
 github.com/couchbase/cbgt v1.4.2-0.20241112001929-b9fdd9b009b1 h1:w8lHraA/oMGQbc0yhu/rsLQbI1pKL2sIQNHRZBmBpJc=
 github.com/couchbase/cbgt v1.4.2-0.20241112001929-b9fdd9b009b1/go.mod h1:lEYqydKcZbXMd9a4+eEvexODYkQ36ku1KxncsjN+Pqw=
+github.com/couchbase/cbgt v1.4.9 h1:NEWoRodD2oWuLnMdtXLsrRl0RX+nsA4LZ13IHaxzAcU=
+github.com/couchbase/cbgt v1.4.9/go.mod h1:uBM6cfeTmdUXTQ8EwFTc3j7hxtXIduu6NGC+axeSkWk=
 github.com/couchbase/clog v0.1.0 h1:4Kh/YHkhRjMCbdQuvRVsm39XZh4FtL1d8fAwJsHrEPY=
 github.com/couchbase/clog v0.1.0/go.mod h1:7tzUpEOsE+fgU81yfcjy5N1H6XtbVC8SgOz/3mCjmd4=
 github.com/couchbase/go-blip v0.0.0-20241014144256-13a798c348fd h1:ERQXaXuX1eix3NUqrxQ5VY0hqHH90vcfrWdbEWKzlEY=

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3140,7 +3140,6 @@ func TestRevCacheMemoryLimitConfig(t *testing.T) {
 }
 
 func TestTLSWithoutCerts(t *testing.T) {
-	base.ResetCBGTCertPools(t) // CBG-4394: removing root certs for the bucket should be done, but it is keyed based on the bucket UUID, and multiple dbs can use the same bucket
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,
 		MutateStartupConfig: func(config *StartupConfig) {


### PR DESCRIPTION
CBG-4505 update cbgt to latest

This updates cbgt to latest (targets anemone branch).

In main, we are using cbgt sg_v139 branch and on anemone this was 1.4.9 branch. These have contradictory APIs. To resolve this merge, this PR can go into release/anemone and then release/anemone can get merged to main.

I have done manual testing with basic auth (no TLS), basic auth (TLS), and x509 auth.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3194/
