### PR TITLE
CBG-3811 do not assert on processed DCP docs

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -729,8 +729,18 @@ func TestResyncUsingDCPStream(t *testing.T) {
 			resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
 			assert.Equal(t, testCase.docsCreated, int(rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value()))
-
-			assert.Equal(t, testCase.docsCreated, int(resyncManagerStatus.DocsProcessed))
+			if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
+				// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
+				// test.
+				// 1. doc1 mutation
+				// 2. doc1 deletion
+				//
+				// In a test, these will not be resynced but docsProcessed is incremented. Relax
+				// the assertion to greater than the number of documents.
+				assert.GreaterOrEqual(t, int(resyncManagerStatus.DocsProcessed), testCase.docsCreated)
+			} else {
+				assert.Equal(t, testCase.docsCreated, int(resyncManagerStatus.DocsProcessed))
+			}
 			assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
 		})
 	}
@@ -784,8 +794,19 @@ func TestResyncUsingDCPStreamReset(t *testing.T) {
 	assert.NotEqual(t, resyncID, resyncManagerStatus.ResyncID)
 
 	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-	assert.Equal(t, int64(numDocs), resyncManagerStatus.DocsProcessed)
+	if !base.UnitTestUrlIsWalrus() && !base.TestsDisableGSI() {
+		// It is possible for Couchbase Server GSI runs which use DCP purge to two DCP events from a previous
+		// test.
+		// 1. doc1 mutation
+		// 2. doc1 deletion
+		//
+		// In a test, these will not be resynced but docsProcessed is incremented. Relax
+		// the assertion to greater than the number of documents.
+		assert.GreaterOrEqual(t, int(resyncManagerStatus.DocsProcessed), numDocs)
+	} else {
 
+		assert.Equal(t, int64(numDocs), resyncManagerStatus.DocsProcessed)
+	}
 }
 
 func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
@@ -804,12 +825,14 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 
 	rt := rest.NewRestTesterMultipleCollections(t,
 		&rest.RestTesterConfig{
-			SyncFn: syncFn,
+			SyncFn:           syncFn,
+			PersistentConfig: true,
 		},
 		numCollections,
 	)
 	defer rt.Close()
 
+	rest.RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 	// put a docs in both collections
 	for i := 1; i <= 10; i++ {
 		resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/{{.keyspace1}}/1000%d", i), `{"type":"test_doc"}`)
@@ -821,6 +844,8 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 
 	rt.TakeDbOffline()
 
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/_config/sync", `function(doc){channel("A")}`), http.StatusOK)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/_config/sync", `function(doc){channel("A")}`), http.StatusOK)
 	dataStore1, err := rt.TestBucket.GetNamedDataStore(0)
 	require.NoError(t, err)
 	// Run resync for single collection // Request body {"scopes": "scopeName": ["collection1Name", "collection2Name"]}}
@@ -833,16 +858,17 @@ func TestResyncUsingDCPStreamForNamedCollection(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusOK)
 	resyncManagerStatus := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-	assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
-	assert.LessOrEqual(t, 10, int(resyncManagerStatus.DocsProcessed))
+	assert.Equal(t, 10, int(resyncManagerStatus.DocsChanged))
+
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace1}}/_config/sync", `function(doc){channel("B")}`), http.StatusOK)
+	rest.RequireStatus(t, rt.SendAdminRequest(http.MethodPut, "/{{.keyspace2}}/_config/sync", `function(doc){channel("B")}`), http.StatusOK)
 
 	// Run resync for all collections
 	resp = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 	resyncManagerStatus = rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
-	assert.Equal(t, 0, int(resyncManagerStatus.DocsChanged))
-	assert.LessOrEqual(t, 20, int(resyncManagerStatus.DocsProcessed))
+	assert.Equal(t, 20, int(resyncManagerStatus.DocsChanged))
 }
 
 func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
@@ -1230,6 +1256,7 @@ func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
 //   - persist that db config to another bucket
 //   - assert that is picked up as an invalid db config
 func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
 
 	ctx := base.TestCtx(t)
 	tb1 := base.GetTestBucket(t)
@@ -3742,12 +3769,14 @@ func TestDeleteDatabaseCBGTTeardown(t *testing.T) {
 
 func TestDatabaseCreationErrorCode(t *testing.T) {
 	for _, persistentConfig := range []bool{true, false} {
-		rt := rest.NewRestTester(t, &rest.RestTesterConfig{PersistentConfig: persistentConfig})
-		defer rt.Close()
+		t.Run(fmt.Sprintf("persistent_config=%t", persistentConfig), func(t *testing.T) {
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{PersistentConfig: persistentConfig})
+			defer rt.Close()
 
-		rt.CreateDatabase("db", rt.NewDbConfig())
-		resp := rt.SendAdminRequest(http.MethodPut, "/db/", `{"bucket": "irrelevant"}`)
-		rest.RequireStatus(t, resp, http.StatusPreconditionFailed)
+			rt.CreateDatabase("db", rt.NewDbConfig())
+			resp := rt.SendAdminRequest(http.MethodPut, "/db/", `{"bucket": "irrelevant"}`)
+			rest.RequireStatus(t, resp, http.StatusPreconditionFailed)
+		})
 	}
 }
 

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -359,7 +359,6 @@ function sync(doc, oldDoc){
 	resp = rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_resync?action=start", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 	status := rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-	assert.Equal(t, int64(1), status.DocsProcessed)
 	assert.Equal(t, int64(1), status.DocsChanged)
 
 	// ensure doc body remains unchanged after resync


### PR DESCRIPTION
CBG-3811 do not assert on processed DCP docs

The way the bucket pool works for Couchbase Server + GSI is to create a bucket and the beginning of a test and then run `db.purgeWithDCPFeed` between each test which removes the document and the xattrs.

However, it doesn't remove the fact that these mutations and deletions once existed, so if you are looking for the documents that are processed via a DCP feed as in attachment compaction and resync tests, you might find relevant documents from an earlier test, causing these tests to fail.

1. test1 start
2. create doc1 <-- flushed to disk by kv
3. test1 ends
4. delete doc1 <-- not flushed to disk by kv
5. run test2
6. see mutation event for create of doc1
7. see mutation event for deletion of doc1

Seeing the duplicate events is only possible if not all the CRUD operations are flushed to disk by kv. If they are all in memory, or all on disk, they will be deduplicated by kv on the DCP feed. Since these tests can run reasonably quickly this error can occur.

This was reproducible by running tests with `env SG_TEST_BUCKET_POOL_SIZE=1 SG_TEST_BACKING_STORE=couchbase go test -tags cb_sg_enterprise,cb_sg_devmode ./rest/adminapitest -run '(TestDCPResyncCollectionsStatus|TestResyncUsingDCPStream$)'` but other tests are susceptible to the same problem. I found additional tests by running with `SG_TEST_BUCKET_POOL_SIZE=1` and `-shuffle=on` as well as code analysis.

Fixes: CBG-3811 CBG-2686 CBG-4577

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3205/
