### PR TITLE
CBG-4280 Improve test assertions for attachments

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -203,6 +203,8 @@ const (
 	ContentTypeJSON = "application/json"
 	// ContentTypeFormEncoded is the content type for form-encoded requests.
 	ContentTypeFormEncoded = "application/x-www-form-urlencoded"
+	// ContentTypeOctetStream is for binary data
+	ContentTypeOctetStream = "application/octet-stream"
 )
 
 // UnitTestUrl returns the configured test URL.

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -19,11 +19,13 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"maps"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1002,4 +1004,16 @@ func GetNonDefaultDatastoreNames(t testing.TB, bucket Bucket) []sgbucket.DataSto
 // TestClusterSpec returns the cluster spec for the test bucket pool.
 func TestClusterSpec(t *testing.T) CouchbaseClusterSpec {
 	return GTestBucketPool.clusterSpec
+}
+
+// RequireKeysEqual asserts that a map has the expected keys.
+func RequireKeysEqual[T any](t testing.TB, expectedKeys []string, actual map[string]T, msgAndArgs ...any) {
+	require.ElementsMatch(t, expectedKeys, slices.Collect(maps.Keys(actual)), msgAndArgs...)
+}
+
+// RequireXattrNotFound asserts that the given xattr is not found on the document.
+func RequireXattrNotFound(t testing.TB, dataStore sgbucket.DataStore, docID string, xattrName string) {
+	xattrs, _, err := dataStore.GetXattrs(TestCtx(t), docID, []string{xattrName})
+	require.Error(t, err, fmt.Sprintf("Expected xattr %q to not be found on document %q but has contents %s", xattrName, docID, xattrs[xattrName]))
+	RequireXattrNotFoundError(t, err)
 }

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -46,8 +46,12 @@ type updatedAttachment struct {
 // updatedAttachments holds the user facing attachment name and raw contents
 type updatedAttachments map[string]updatedAttachment
 
-// A map of keys -> DocAttachments.
-type AttachmentMap map[string]*DocAttachment
+// AttachmentMap can represent:
+//   - _sync.attachments
+//   - _globalSync.attachments_meta
+//   - inline body `_attachments` from blip rev messages
+//   - inline body `_attachments`from pre Sync Gateway 2.5
+type AttachmentMap map[string]DocAttachment
 
 // A struct which models an attachment.  Currently only used by test code, however
 // new code or refactoring in the main codebase should try to use where appropriate.
@@ -58,7 +62,7 @@ type DocAttachment struct {
 	Revpos      int    `json:"revpos,omitempty"`
 	Stub        bool   `json:"stub,omitempty"`
 	Version     int    `json:"ver,omitempty"`
-	Data        []byte `json:"-"` // tell json marshal/unmarshal to ignore this field
+	Data        []byte `json:"data,omitempty"` // tell json marshal/unmarshal to ignore this field
 }
 
 // ErrAttachmentTooLarge is returned when an attempt to attach an oversize attachment is made.

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -53,8 +53,10 @@ type updatedAttachments map[string]updatedAttachment
 //   - inline body `_attachments`from pre Sync Gateway 2.5
 type AttachmentMap map[string]DocAttachment
 
-// A struct which models an attachment.  Currently only used by test code, however
-// new code or refactoring in the main codebase should try to use where appropriate.
+// DocAttachment models an attachment. This could be attachment metadata or the full body of an attachment.
+//   - `_sync.attachments` : Data field should not be present
+//   - `_globalSync.attachments_meta` : Data field should not be present
+//   - `_attachments` body from blip or REST input/output: Data field could be present if Stub: false
 type DocAttachment struct {
 	ContentType string `json:"content_type,omitempty"`
 	Digest      string `json:"digest,omitempty"`
@@ -62,7 +64,7 @@ type DocAttachment struct {
 	Revpos      int    `json:"revpos,omitempty"`
 	Stub        bool   `json:"stub,omitempty"`
 	Version     int    `json:"ver,omitempty"`
-	Data        []byte `json:"data,omitempty"` // tell json marshal/unmarshal to ignore this field
+	Data        []byte `json:"data,omitempty"` // this field is present for unmarshalling data but typically should not be marshalled for output.
 }
 
 // ErrAttachmentTooLarge is returned when an attempt to attach an oversize attachment is made.

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -35,7 +35,6 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	deltasEnabled := base.IsEnterpriseEdition()
-	xattrsEnabled := base.TestUseXattrs()
 
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{DeltaSyncOptions: DeltaSyncOptions{
 		Enabled:          deltasEnabled,
@@ -49,13 +48,13 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal([]byte(rev1Data), &rev1Body))
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-	rev1ID, docRev1, err := collection.Put(ctx, docID, rev1Body)
+	revid1, docRev1, err := collection.Put(ctx, docID, rev1Body)
 	require.NoError(t, err)
-	assert.Equal(t, "1-12ff9ce1dd501524378fe092ce9aee8f", rev1ID)
+	assert.Equal(t, "1-12ff9ce1dd501524378fe092ce9aee8f", revid1)
 
 	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 	rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
-	if deltasEnabled && xattrsEnabled {
+	if deltasEnabled {
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	} else {
@@ -68,7 +67,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	var rev2Body Body
 	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
-	docRev2, _, err := collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", rev1ID}, true, ExistingVersionWithUpdateToHLV)
+	docRev2, _, err := collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", revid1}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
 	// now in any case - we'll have rev 1 backed up
@@ -80,7 +79,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	// and rev 2 should be present only for the xattrs and deltas case
 	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 	rev2OldBody, err := collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
-	if deltasEnabled && xattrsEnabled {
+	if deltasEnabled {
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 	} else {
@@ -103,92 +102,95 @@ func TestAttachments(t *testing.T) {
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev1input), &body))
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-	revid, docRev1, err := collection.Put(ctx, "doc1", body)
-	rev1id := revid
-	assert.NoError(t, err, "Couldn't create document")
+	rev1id, docRev1, err := collection.Put(ctx, "doc1", body)
+	require.NoError(t, err)
 
 	log.Printf("Retrieve doc...")
 	gotbody, err := collection.Get1xRevBody(ctx, "doc1", "", false, []string{})
-	assert.NoError(t, err, "Couldn't get document")
-	atts := gotbody[BodyAttachments].(AttachmentsMeta)
-
-	hello := atts["hello.txt"].(map[string]interface{})
-	assert.Equal(t, "hello world", string(hello["data"].([]byte)))
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, 11, hello["length"])
-	assert.Equal(t, 1, hello["revpos"])
-
-	bye := atts["bye.txt"].(map[string]interface{})
-	assert.Equal(t, "goodbye cruel world", string(bye["data"].([]byte)))
-	assert.Equal(t, "sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=", bye["digest"])
-	assert.Equal(t, 19, bye["length"])
-	assert.Equal(t, 1, bye["revpos"])
-
+	require.NoError(t, err)
+	atts := GetAttachmentsFrom1xBody(t, gotbody)
+	require.Equal(t, AttachmentMap{
+		"hello.txt": DocAttachment{
+			Data:   []byte("hello world"),
+			Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length: 11,
+			Revpos: 1,
+		},
+		"bye.txt": DocAttachment{
+			Data:   []byte("goodbye cruel world"),
+			Digest: "sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=",
+			Length: 19,
+			Revpos: 1,
+		},
+	}, atts)
 	log.Printf("Create rev 2...")
 	rev2str := `{"_attachments": {"hello.txt": {"stub":true, "revpos":1}, "bye.txt": {"data": "YnllLXlh"}}}`
 	var body2 Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev2str), &body2))
-	body2[BodyRev] = revid
-	revid, _, err = collection.Put(ctx, "doc1", body2)
-	assert.NoError(t, err, "Couldn't update document")
-	assert.Equal(t, "2-5d3308aae9930225ed7f6614cf115366", revid)
+	body2[BodyRev] = rev1id
+	rev2id, _, err := collection.Put(ctx, "doc1", body2)
+	require.NoError(t, err, "Couldn't update document")
+	assert.Equal(t, "2-5d3308aae9930225ed7f6614cf115366", rev2id)
 
 	log.Printf("Retrieve doc...")
 	gotbody, err = collection.Get1xRevBody(ctx, "doc1", "", false, []string{})
-	assert.NoError(t, err, "Couldn't get document")
-	atts = gotbody[BodyAttachments].(AttachmentsMeta)
-
-	hello = atts["hello.txt"].(map[string]interface{})
-	assert.Equal(t, "hello world", string(hello["data"].([]byte)))
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, float64(11), hello["length"])
-	assert.Equal(t, float64(1), hello["revpos"])
-
-	bye = atts["bye.txt"].(map[string]interface{})
-	assert.Equal(t, "bye-ya", string(bye["data"].([]byte)))
-	assert.Equal(t, "sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=", bye["digest"])
-	assert.Equal(t, 6, bye["length"])
-	assert.Equal(t, 2, bye["revpos"])
-
+	require.NoError(t, err)
+	atts = GetAttachmentsFrom1xBody(t, gotbody)
+	require.Equal(t, AttachmentMap{
+		"hello.txt": DocAttachment{
+			Data:   []byte("hello world"),
+			Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length: 11,
+			Revpos: 1,
+		},
+		"bye.txt": DocAttachment{
+			Data:   []byte("bye-ya"),
+			Digest: "sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=",
+			Length: 6,
+			Revpos: 2,
+		},
+	}, atts)
 	log.Printf("Retrieve doc with atts_since...")
 	gotbody, err = collection.Get1xRevBody(ctx, "doc1", "", false, []string{"1-ca9ad22802b66f662ff171f226211d5c", "1-foo", "993-bar"})
-	assert.NoError(t, err, "Couldn't get document")
-	atts = gotbody[BodyAttachments].(AttachmentsMeta)
-
-	hello = atts["hello.txt"].(map[string]interface{})
-	assert.Nil(t, hello["data"])
-
-	bye = atts["bye.txt"].(map[string]interface{})
-	require.NotNil(t, bye["data"])
-	assert.Equal(t, "bye-ya", string(bye["data"].([]byte)))
-	require.NotNil(t, bye["digest"])
-	assert.Equal(t, "sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=", bye["digest"])
-	require.NotNil(t, bye["length"])
-	assert.Equal(t, 6, bye["length"])
-	require.NotNil(t, bye["revpos"])
-	assert.Equal(t, 2, bye["revpos"])
+	require.NoError(t, err, "Couldn't get document")
+	atts = GetAttachmentsFrom1xBody(t, gotbody)
+	require.Equal(t, AttachmentMap{
+		"hello.txt": DocAttachment{
+			Stub:   true,
+			Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length: 11,
+			Revpos: 1,
+		},
+		"bye.txt": DocAttachment{
+			Stub:   false,
+			Data:   []byte("bye-ya"),
+			Digest: "sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=",
+			Length: 6,
+			Revpos: 2,
+		},
+	}, atts)
 
 	log.Printf("Create rev 3...")
 	rev3str := `{"_attachments": {"bye.txt": {"stub":true,"revpos":2}}}`
 	var body3 Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev3str), &body3))
-	body3[BodyRev] = revid
-	revid, _, err = collection.Put(ctx, "doc1", body3)
+	body3[BodyRev] = rev2id
+	rev3id, _, err := collection.Put(ctx, "doc1", body3)
 	assert.NoError(t, err, "Couldn't update document")
-	assert.Equal(t, "3-aa3ff4ca3aad12e1479b65cb1e602676", revid)
+	assert.Equal(t, "3-aa3ff4ca3aad12e1479b65cb1e602676", rev3id)
 
 	log.Printf("Retrieve doc...")
 	gotbody, err = collection.Get1xRevBody(ctx, "doc1", "", false, []string{})
-	assert.NoError(t, err, "Couldn't get document")
-	atts = gotbody[BodyAttachments].(AttachmentsMeta)
-
-	assert.Nil(t, atts["hello.txt"])
-
-	bye = atts["bye.txt"].(map[string]interface{})
-	assert.Equal(t, "bye-ya", string(bye["data"].([]byte)))
-	assert.Equal(t, "sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=", bye["digest"])
-	assert.Equal(t, float64(6), bye["length"])
-	assert.Equal(t, float64(2), bye["revpos"])
+	require.NoError(t, err, "Couldn't get document")
+	atts = GetAttachmentsFrom1xBody(t, gotbody)
+	require.Equal(t, AttachmentMap{
+		"bye.txt": DocAttachment{
+			Data:   []byte("bye-ya"),
+			Digest: "sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=",
+			Length: 6,
+			Revpos: 2,
+		},
+	}, atts)
 
 	log.Printf("Expire body of rev 1, then add a child...") // test fix of #498
 	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
@@ -238,32 +240,32 @@ func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 	require.NoError(t, countErr, "Couldn't retrieve document_gets expvar")
 	gotbody, err := collection.Get1xRevBody(ctx, "doc1", "1-ca9ad22802b66f662ff171f226211d5c", false, []string{})
 	require.NoError(t, err, "Couldn't get document")
-	atts := gotbody[BodyAttachments].(AttachmentsMeta)
 
-	assertAttachments := func(atts AttachmentsMeta) {
-		hello := atts["hello.txt"].(map[string]interface{})
-		assert.Equal(t, "hello world", string(hello["data"].([]byte)))
-		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-		assert.Equal(t, 11, hello["length"])
-		assert.Equal(t, 1, hello["revpos"])
-
-		bye := atts["bye.txt"].(map[string]interface{})
-		assert.Equal(t, "goodbye cruel world", string(bye["data"].([]byte)))
-		assert.Equal(t, "sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=", bye["digest"])
-		assert.Equal(t, 19, bye["length"])
-		assert.Equal(t, 1, bye["revpos"])
+	assertAttachments := func(atts AttachmentMap) {
+		require.Equal(t, AttachmentMap{
+			"hello.txt": DocAttachment{
+				Data:   []byte("hello world"),
+				Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+				Length: 11,
+				Revpos: 1,
+			},
+			"bye.txt": DocAttachment{
+				Data:   []byte("goodbye cruel world"),
+				Digest: "sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=",
+				Length: 19,
+				Revpos: 1,
+			},
+		}, atts)
 		getCount, countErr := base.GetExpvarAsInt("syncGateway_db", "document_gets")
 		require.NoError(t, countErr, "Couldn't retrieve document_gets expvar")
 		require.Equal(t, initCount, getCount)
 	}
-	assertAttachments(atts)
+	assertAttachments(GetAttachmentsFrom1xBody(t, gotbody))
 
 	// Repeat, validate no additional get operations
 	gotbody, err = collection.Get1xRevBody(ctx, "doc1", "1-ca9ad22802b66f662ff171f226211d5c", false, []string{})
 	require.NoError(t, err, "Couldn't get document")
-	atts = gotbody[BodyAttachments].(AttachmentsMeta)
-
-	assertAttachments(atts)
+	assertAttachments(GetAttachmentsFrom1xBody(t, gotbody))
 }
 
 func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
@@ -320,13 +322,14 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 	// 4. Get the document, check attachments
 	finalDoc, err := collection.Get1xBody(ctx, "doc1")
 	require.NoError(t, err)
-	attachments := GetBodyAttachments(finalDoc)
-	assert.True(t, attachments != nil, "_attachments should be present in GET response")
-	attachment, attachmentOk := attachments["hello.txt"].(map[string]interface{})
-	assert.True(t, attachmentOk, "hello.txt attachment should be present in GET response")
-	_, digestOk := attachment["digest"]
-	assert.True(t, digestOk, "digest should be set for attachment hello.txt in GET response")
-
+	require.Equal(t, AttachmentMap{
+		"hello.txt": DocAttachment{
+			Stub:   true,
+			Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length: 11,
+			Revpos: 2,
+		},
+	}, GetAttachmentsFrom1xBody(t, finalDoc))
 }
 
 func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
@@ -383,15 +386,15 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 	// 4. Get the document, check attachments
 	finalDoc, err := collection.Get1xBody(ctx, "doc1")
 	require.NoError(t, err)
-	log.Printf("get doc attachments: %v", finalDoc)
 
-	attachments := GetBodyAttachments(finalDoc)
-	assert.True(t, attachments != nil, "_attachments should be present in GET response")
-	attachment, attachmentOk := attachments["hello.txt"].(map[string]interface{})
-	assert.True(t, attachmentOk, "hello.txt attachment should be present in GET response")
-	_, digestOk := attachment["digest"]
-	assert.True(t, digestOk, "digest should be set for attachment hello.txt in GET response")
-
+	require.Equal(t, AttachmentMap{
+		"hello.txt": DocAttachment{
+			Stub:   true,
+			Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length: 11,
+			Revpos: 3,
+		},
+	}, GetAttachmentsFrom1xBody(t, finalDoc))
 }
 
 func TestForEachStubAttachmentErrors(t *testing.T) {
@@ -678,18 +681,19 @@ func TestStoreAttachments(t *testing.T) {
 	revText = `{"key1": "value1", "_attachments": {"att1.txt": {"data": "YXR0MS50eHQ=", "content_type": "text/plain"}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(revText), &revBody))
 	revId, doc, err = collection.Put(ctx, "doc3", revBody)
-	assert.NoError(t, err, "Couldn't update document")
+	require.NoError(t, err)
 	assert.NotEmpty(t, revId, "Document revision id should be generated")
 	require.NotNil(t, doc)
-	assert.NotEmpty(t, doc.Attachments, "Attachment metadata should be populated")
-	attachment = doc.Attachments["att1.txt"].(map[string]interface{})
-	assert.Equal(t, "text/plain", attachment["content_type"])
-	assert.Equal(t, "sha1-crv3IVNxp3JXbP6bizTHt3GB3O0=", attachment["digest"])
-	assert.Empty(t, attachment["encoded_length"])
-	assert.Equal(t, int(8), attachment["length"])
-	assert.Empty(t, attachment["encoding"])
-	assert.NotEmpty(t, attachment["revpos"])
-	assert.True(t, attachment["stub"].(bool))
+	require.Equal(t, AttachmentsMeta{
+		"att1.txt": map[string]any{
+			"content_type": "text/plain",
+			"digest":       "sha1-crv3IVNxp3JXbP6bizTHt3GB3O0=",
+			"length":       8,
+			"revpos":       1,
+			"stub":         true,
+			"ver":          2,
+		},
+	}, doc.Attachments)
 
 	// Simulate error scenario for attachment without data; stub is not provided; If the data is
 	// empty in attachment, the attachment must be a stub that repeats a parent attachment.
@@ -722,29 +726,6 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		db, ctx = setupTestDB(t)
 
 		collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-		// Put a document with hello.txt attachment, to write attachment to the bucket
-		rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
-		var body Body
-		assert.NoError(t, base.JSONUnmarshal([]byte(rev1input), &body))
-		_, _, err := collection.Put(ctx, "doc1", body)
-		assert.NoError(t, err, "Couldn't create document")
-
-		gotbody, err := collection.Get1xRevBody(ctx, "doc1", "", false, []string{})
-		assert.NoError(t, err, "Couldn't get document")
-		atts, ok := gotbody[BodyAttachments].(AttachmentsMeta)
-		assert.True(t, ok)
-
-		hello, ok := atts["hello.txt"].(map[string]interface{})
-		assert.True(t, ok)
-
-		helloData, ok := hello["data"].([]byte)
-		assert.True(t, ok)
-
-		assert.Equal(t, "hello world", string(helloData))
-		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-		assert.Equal(t, 11, hello["length"])
-		assert.Equal(t, 1, hello["revpos"])
 
 		// Create 2.1 style document - metadata in sync data, _attachments in body, referencing attachment created above
 		bodyPre25 := `{
@@ -793,22 +774,13 @@ func TestMigrateBodyAttachments(t *testing.T) {
   }
 }`
 
-		if base.TestUseXattrs() {
-			_, err = collection.dataStore.WriteWithXattrs(ctx, docKey, 0, 0, []byte(bodyPre25), map[string][]byte{base.SyncXattrName: []byte(syncData)}, nil, DefaultMutateInOpts())
-			assert.NoError(t, err)
-		} else {
-			newBody, err := base.InjectJSONPropertiesFromBytes([]byte(bodyPre25), base.KVPairBytes{Key: base.SyncPropertyName, Val: []byte(syncData)})
-			assert.NoError(t, err)
-			ok, err := collection.dataStore.Add(docKey, 0, newBody)
-			assert.NoError(t, err)
-			assert.True(t, ok)
-		}
+		_, err := collection.dataStore.WriteWithXattrs(ctx, docKey, 0, 0, []byte(bodyPre25), map[string][]byte{base.SyncXattrName: []byte(syncData)}, nil, DefaultMutateInOpts())
+		require.NoError(t, err)
 
 		// Fetch the raw doc sync data from the bucket to make sure we didn't store pre-2.5 attachments in syncData.
-		docSyncData, err := collection.GetDocSyncData(ctx, docKey)
-		assert.NoError(t, err)
+		docSyncData := GetRawSyncXattr(t, collection.dataStore, docKey)
 		assert.Empty(t, docSyncData.Attachments)
-
+		base.RequireXattrNotFound(t, collection.dataStore, docKey, base.GlobalXattrName)
 		return db, ctx
 	}
 
@@ -837,9 +809,9 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
 
 		// Fetch the raw doc sync data from the bucket to see if this read-only op unintentionally persisted the migrated meta.
-		syncData, err := collection.GetDocSyncData(ctx, docKey)
-		assert.NoError(t, err)
+		syncData := GetRawSyncXattr(t, collection.dataStore, docKey)
 		assert.Empty(t, syncData.Attachments)
+		base.RequireXattrNotFound(t, collection.dataStore, docKey, base.GlobalXattrName)
 	})
 
 	// Reading a non-active revision shouldn't perform an upgrade, but should transform the metadata in memory for the returned rev.
@@ -867,9 +839,9 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
 
 		// Fetch the raw doc sync data from the bucket to see if this read-only op unintentionally persisted the migrated meta.
-		syncData, err := collection.GetDocSyncData(ctx, docKey)
-		assert.NoError(t, err)
+		syncData := GetRawSyncXattr(t, collection.dataStore, docKey)
 		assert.Empty(t, syncData.Attachments)
+		base.RequireXattrNotFound(t, collection.dataStore, docKey, base.GlobalXattrName)
 	})
 
 	// Writing a new rev should migrate the metadata and write that upgrade back to the bucket.
@@ -907,13 +879,13 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		// It will be stamped in for 1.x clients that require it further up the stack.
 		body1, err := rev.Body()
 		require.NoError(t, err)
-		bodyAtts, foundBodyAtts := body1[BodyAttachments]
-		assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
+		require.NotContains(t, body1, BodyAttachments)
 
 		// Fetch the raw doc sync data from the bucket to make sure we actually moved attachments on write.
-		syncData, err := collection.GetDocSyncData(ctx, docKey)
-		assert.NoError(t, err)
-		assert.Len(t, syncData.Attachments, 1)
+		syncData := GetRawSyncXattr(t, collection.dataStore, docKey)
+		require.Empty(t, syncData.Attachments)
+		globalSyncAttachments := GetRawGlobalSyncAttachments(t, collection.dataStore, docKey)
+		base.RequireKeysEqual(t, []string{"hello.txt"}, globalSyncAttachments)
 	})
 
 	// Adding a new attachment should migrate existing attachments, without losing any.
@@ -929,9 +901,9 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		require.Len(t, rev.Attachments, 1)
 
 		// Fetch the raw doc sync data from the bucket to see if this read-only op unintentionally persisted the migrated meta.
-		syncData, err := collection.GetDocSyncData(ctx, docKey)
-		assert.NoError(t, err)
-		assert.Empty(t, syncData.Attachments)
+		syncData := GetRawSyncXattr(t, collection.dataStore, docKey)
+		require.Empty(t, syncData.Attachments)
+		base.RequireXattrNotFound(t, collection.dataStore, docKey, base.GlobalXattrName)
 
 		byeTxtData, err := base64.StdEncoding.DecodeString("Z29vZGJ5ZSBjcnVlbCB3b3JsZA==")
 		require.NoError(t, err)
@@ -967,19 +939,18 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		// It will be stamped in for 1.x clients that require it further up the stack.
 		body1, err := rev.Body()
 		require.NoError(t, err)
-		bodyAtts, foundBodyAtts := body1[BodyAttachments]
-		assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
+		require.NotContains(t, body1, BodyAttachments)
 
 		// Fetch the raw doc sync data from the bucket to make sure we actually moved attachments on write.
-		syncData, err = collection.GetDocSyncData(ctx, docKey)
-		assert.NoError(t, err)
-		assert.Len(t, syncData.Attachments, 2)
+		syncData = GetRawSyncXattr(t, collection.dataStore, docKey)
+		globalSyncAttachments := GetRawGlobalSyncAttachments(t, collection.dataStore, docKey)
+		base.RequireKeysEqual(t, []string{"bye.txt", "hello.txt"}, globalSyncAttachments)
 	})
 }
 
 // TestMigrateBodyAttachmentsMerge will set up a document with attachments in both pre-2.5 and post-2.5 metadata, making sure that both attachments are preserved.
 func TestMigrateBodyAttachmentsMerge(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 
 	const docKey = "TestAttachmentMigrate"
 
@@ -992,34 +963,24 @@ func TestMigrateBodyAttachmentsMerge(t *testing.T) {
 	var body Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev1input), &body))
 	_, _, err := collection.Put(ctx, "doc1", body)
-	assert.NoError(t, err, "Couldn't create document")
+	require.NoError(t, err, "Couldn't create document")
 
 	gotbody, err := collection.Get1xRevBody(ctx, "doc1", "", false, []string{})
-	assert.NoError(t, err, "Couldn't get document")
-	atts, ok := gotbody[BodyAttachments].(AttachmentsMeta)
-	assert.True(t, ok)
-
-	hello, ok := atts["hello.txt"].(map[string]interface{})
-	assert.True(t, ok)
-
-	helloData, ok := hello["data"].([]byte)
-	assert.True(t, ok)
-
-	assert.Equal(t, "hello world", string(helloData))
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, 11, hello["length"])
-	assert.Equal(t, 1, hello["revpos"])
-
-	bye, ok := atts["bye.txt"].(map[string]interface{})
-	assert.True(t, ok)
-
-	byeData, ok := bye["data"].([]byte)
-	assert.True(t, ok)
-
-	assert.Equal(t, "goodbye cruel world", string(byeData))
-	assert.Equal(t, "sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=", bye["digest"])
-	assert.Equal(t, 19, bye["length"])
-	assert.Equal(t, 1, bye["revpos"])
+	require.NoError(t, err)
+	require.Equal(t, AttachmentMap{
+		"hello.txt": DocAttachment{
+			Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length: 11,
+			Data:   []byte("hello world"),
+			Revpos: 1,
+		},
+		"bye.txt": DocAttachment{
+			Digest: "sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=",
+			Length: 19,
+			Data:   []byte("goodbye cruel world"),
+			Revpos: 1,
+		},
+	}, GetAttachmentsFrom1xBody(t, gotbody))
 
 	// Create 2.1 style document - metadata in sync data, _attachments in body, referencing attachments created above
 	bodyPre25 := `{
@@ -1076,50 +1037,30 @@ func TestMigrateBodyAttachmentsMerge(t *testing.T) {
   }
 }`
 
-	if base.TestUseXattrs() {
-		_, err = collection.dataStore.WriteWithXattrs(ctx, docKey, 0, 0, []byte(bodyPre25), map[string][]byte{base.SyncXattrName: []byte(syncData)}, nil, DefaultMutateInOpts())
-		assert.NoError(t, err)
-	} else {
-		newBody, err := base.InjectJSONPropertiesFromBytes([]byte(bodyPre25), base.KVPairBytes{Key: base.SyncPropertyName, Val: []byte(syncData)})
-		assert.NoError(t, err)
-		ok, err := collection.dataStore.Add(docKey, 0, newBody)
-		assert.NoError(t, err)
-		assert.True(t, ok)
-	}
+	_, err = collection.dataStore.WriteWithXattrs(ctx, docKey, 0, 0, []byte(bodyPre25), map[string][]byte{base.SyncXattrName: []byte(syncData)}, nil, DefaultMutateInOpts())
+	require.NoError(t, err)
 
 	// Fetch the raw doc sync data from the bucket to make sure we didn't store pre-2.5 attachments in syncData.
-	docSyncData, err := collection.GetDocSyncData(ctx, docKey)
-	assert.NoError(t, err)
-	assert.Len(t, docSyncData.Attachments, 1)
-	_, ok = docSyncData.Attachments["hello.txt"]
-	assert.False(t, ok)
-	_, ok = docSyncData.Attachments["bye.txt"]
-	assert.True(t, ok)
+	docSyncData := GetRawSyncXattr(t, collection.dataStore, docKey)
+	base.RequireKeysEqual(t, []string{"bye.txt"}, docSyncData.Attachments)
+	base.RequireXattrNotFound(t, collection.dataStore, docKey, base.GlobalXattrName)
 
 	rev, err := collection.GetRev(ctx, docKey, "3-a", true, nil)
 	require.NoError(t, err)
 
 	// read-only in-memory transformation should've been applied here, both attachments should be present in rev.Attachments
-	assert.Len(t, rev.Attachments, 2)
-	_, ok = rev.Attachments["hello.txt"]
-	assert.True(t, ok)
-	_, ok = rev.Attachments["bye.txt"]
-	assert.True(t, ok)
+	base.RequireKeysEqual(t, []string{"hello.txt", "bye.txt"}, rev.Attachments)
 
 	// _attachments shouldn't be present in the body at this point.
 	// It will be stamped in for 1.x clients that require it further up the stack.
 	body1, err := rev.Body()
 	require.NoError(t, err)
-	bodyAtts, foundBodyAtts := body1[BodyAttachments]
-	assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
+	require.NotContains(t, body1, BodyAttachments)
 
 	// Fetch the raw doc sync data from the bucket to see if this read-only op unintentionally persisted the migrated meta.
-	docSyncData, err = collection.GetDocSyncData(ctx, docKey)
-	assert.NoError(t, err)
-	_, ok = docSyncData.Attachments["hello.txt"]
-	assert.False(t, ok)
-	_, ok = docSyncData.Attachments["bye.txt"]
-	assert.True(t, ok)
+	docSyncData = GetRawSyncXattr(t, collection.dataStore, docKey)
+	base.RequireKeysEqual(t, []string{"bye.txt"}, docSyncData.Attachments)
+	base.RequireXattrNotFound(t, collection.dataStore, docKey, base.GlobalXattrName)
 }
 
 // TestMigrateBodyAttachmentsMergeConflicting will set up a document with the same attachment name in both pre-2.5 and post-2.5 metadata, making sure that the metadata with the most recent revpos is chosen.
@@ -1136,45 +1077,30 @@ func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
 	var body Body
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev1input), &body))
 	_, _, err := collection.Put(ctx, "doc1", body)
-	assert.NoError(t, err, "Couldn't create document")
+	require.NoError(t, err, "Couldn't create document")
 
 	gotbody, err := collection.Get1xRevBody(ctx, "doc1", "", false, []string{})
-	assert.NoError(t, err, "Couldn't get document")
-	atts, ok := gotbody[BodyAttachments].(AttachmentsMeta)
-	assert.True(t, ok)
-
-	hello, ok := atts["hello.txt"].(map[string]interface{})
-	assert.True(t, ok)
-
-	helloData, ok := hello["data"].([]byte)
-	assert.True(t, ok)
-
-	assert.Equal(t, "hello world", string(helloData))
-	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-	assert.Equal(t, 11, hello["length"])
-	assert.Equal(t, 1, hello["revpos"])
-
-	bye, ok := atts["bye.txt"].(map[string]interface{})
-	assert.True(t, ok)
-
-	byeData, ok := bye["data"].([]byte)
-	assert.True(t, ok)
-
-	assert.Equal(t, "goodbye cruel world", string(byeData))
-	assert.Equal(t, "sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=", bye["digest"])
-	assert.Equal(t, 19, bye["length"])
-	assert.Equal(t, 1, bye["revpos"])
-
-	new, ok := atts["new.txt"].(map[string]interface{})
-	assert.True(t, ok)
-
-	newData, ok := new["data"].([]byte)
-	assert.True(t, ok)
-
-	assert.Equal(t, "new data", string(newData))
-	assert.Equal(t, "sha1-AZffsEGpPp0Zn4jv1xFA8ydfxp0=", new["digest"])
-	assert.Equal(t, 8, new["length"])
-	assert.Equal(t, 1, new["revpos"])
+	require.NoError(t, err)
+	require.Equal(t, AttachmentMap{
+		"hello.txt": DocAttachment{
+			Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length: 11,
+			Data:   []byte("hello world"),
+			Revpos: 1,
+		},
+		"bye.txt": DocAttachment{
+			Digest: "sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=",
+			Length: 19,
+			Data:   []byte("goodbye cruel world"),
+			Revpos: 1,
+		},
+		"new.txt": DocAttachment{
+			Digest: "sha1-AZffsEGpPp0Zn4jv1xFA8ydfxp0=",
+			Length: 8,
+			Data:   []byte("new data"),
+			Revpos: 1,
+		},
+	}, GetAttachmentsFrom1xBody(t, gotbody))
 
 	// Create 2.1 style document - metadata in sync data, _attachments in body, referencing attachments created above
 	bodyPre25 := `{
@@ -1243,42 +1169,34 @@ func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
   }
 }`
 
-	if base.TestUseXattrs() {
-		_, err = collection.dataStore.WriteWithXattrs(ctx, docKey, 0, 0, []byte(bodyPre25), map[string][]byte{base.SyncXattrName: []byte(syncData)}, nil, DefaultMutateInOpts())
-		assert.NoError(t, err)
-	} else {
-		newBody, err := base.InjectJSONPropertiesFromBytes([]byte(bodyPre25), base.KVPairBytes{Key: base.SyncPropertyName, Val: []byte(syncData)})
-		assert.NoError(t, err)
-		ok, err := collection.dataStore.Add(docKey, 0, newBody)
-		assert.NoError(t, err)
-		assert.True(t, ok)
-	}
+	_, err = collection.dataStore.WriteWithXattrs(ctx, docKey, 0, 0, []byte(bodyPre25), map[string][]byte{base.SyncXattrName: []byte(syncData)}, nil, DefaultMutateInOpts())
+	assert.NoError(t, err)
 
 	rev, err := collection.GetRev(ctx, docKey, "3-a", true, nil)
 	require.NoError(t, err)
 
 	// read-only in-memory transformation should've been applied here, both attachments should be present in rev.Attachments
+	require.Equal(t, AttachmentsMeta{
+		"hello.txt": map[string]any{
+			"digest": "sha1-AZffsEGpPp0Zn4jv1xFA8ydfxp0=",
+			"length": json.Number("8"),
+			"revpos": json.Number("2"),
+			"stub":   true,
+		},
+		"bye.txt": map[string]any{
+			"digest": "sha1-AZffsEGpPp0Zn4jv1xFA8ydfxp0=",
+			"length": float64(8),
+			"revpos": float64(2),
+			"stub":   true,
+		},
+	}, rev.Attachments)
 	assert.Len(t, rev.Attachments, 2)
-
-	// see if we got new.txt's meta for both attachments (because of the higher revpos)
-	helloAtt, ok := rev.Attachments["hello.txt"]
-	assert.True(t, ok)
-	helloAttMeta, ok := helloAtt.(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, "sha1-AZffsEGpPp0Zn4jv1xFA8ydfxp0=", helloAttMeta["digest"])
-
-	byeAtt, ok := rev.Attachments["bye.txt"]
-	assert.True(t, ok)
-	byeAttMeta, ok := byeAtt.(map[string]interface{})
-	assert.True(t, ok)
-	assert.Equal(t, "sha1-AZffsEGpPp0Zn4jv1xFA8ydfxp0=", byeAttMeta["digest"])
 
 	// _attachments shouldn't be present in the body at this point.
 	// It will be stamped in for 1.x clients that require it further up the stack.
 	body1, err := rev.Body()
 	require.NoError(t, err)
-	bodyAtts, foundBodyAtts := body1[BodyAttachments]
-	assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
+	require.NotContains(t, body1, BodyAttachments)
 }
 
 func TestAllowedAttachments(t *testing.T) {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -899,7 +899,7 @@ func RetrieveDocRevSeqNo(t *testing.T, docxattr []byte) uint64 {
 }
 
 // MoveAttachmentXattrFromGlobalToSync is a test only function that will move any defined attachment metadata in _globalSync.attachments_meta to _sync.attachments. This turns a document written with Sync Gateway 4.0 style attachments to a document with Sync Gateway <4.0 style attachments.
-func MoveAttachmentXattrFromGlobalToSync(t *testing.T, ctx context.Context, docID string, cas uint64, value, syncXattr []byte, attachments AttachmentsMeta, macroExpand bool, dataStore base.DataStore) {
+func MoveAttachmentXattrFromGlobalToSync(t *testing.T, dataStore base.DataStore, docID string, value []byte, macroExpand bool) {
 	docSync := GetRawSyncXattr(t, dataStore, docID)
 	docSync.Attachments = GetRawGlobalSync(t, dataStore, docID).GlobalAttachments
 
@@ -916,8 +916,9 @@ func MoveAttachmentXattrFromGlobalToSync(t *testing.T, ctx context.Context, docI
 	newSync, err := base.JSONMarshal(docSync)
 	require.NoError(t, err)
 
-	_, cas, err = dataStore.GetRaw(docID)
+	_, cas, err := dataStore.GetRaw(docID)
 	require.NoError(t, err)
+	ctx := base.TestCtx(t)
 	_, err = dataStore.WriteWithXattrs(ctx, docID, 0, cas, value, map[string][]byte{base.SyncXattrName: newSync}, []string{base.GlobalXattrName}, opts)
 	require.NoError(t, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/couchbase/cbgt v1.4.10-0.20250613153003-c142c64552b2
 	github.com/couchbase/clog v0.1.0
 	github.com/couchbase/go-blip v0.0.0-20250325132327-d73efab2df06
-	github.com/couchbase/gocb/v2 v2.10.0
-	github.com/couchbase/gocbcore/v10 v10.7.0
+	github.com/couchbase/gocb/v2 v2.10.1
+	github.com/couchbase/gocbcore/v10 v10.7.1
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20250522135601-8c9a5acda2c2

--- a/go.sum
+++ b/go.sum
@@ -42,10 +42,10 @@ github.com/couchbase/go-blip v0.0.0-20250325132327-d73efab2df06 h1:npTOLlXHxAARy
 github.com/couchbase/go-blip v0.0.0-20250325132327-d73efab2df06/go.mod h1:+K082iN0fPzrWgNU/58/sMpydLVTTSdnuJ1srwlWTuk=
 github.com/couchbase/go-couchbase v0.1.1 h1:ClFXELcKj/ojyoTYbsY34QUrrYCBi/1G749sXSCkdhk=
 github.com/couchbase/go-couchbase v0.1.1/go.mod h1:+/bddYDxXsf9qt0xpDUtRR47A2GjaXmGGAqQ/k3GJ8A=
-github.com/couchbase/gocb/v2 v2.10.0 h1:NNxZ4okToU1Ylqp6F8tE41CEJQPhb2WjufryAkeubOk=
-github.com/couchbase/gocb/v2 v2.10.0/go.mod h1:OSbMfQkP7ltbKiDZhsT2mGDhkQNmvGXxptKcxAUJQ2Y=
-github.com/couchbase/gocbcore/v10 v10.7.0 h1:lAEi0PNeEGKOu8pWrPUdtLOT2oGr1J/UTdGHVPC3r/0=
-github.com/couchbase/gocbcore/v10 v10.7.0/go.mod h1:Q8JWVenMCEOuRgrDQKApHbzzPif38HzefGgRVe9apAI=
+github.com/couchbase/gocb/v2 v2.10.1 h1:5r1jngGxw3dTZdtq6Xmjq3pdU6hOwRvynvbVIp58T64=
+github.com/couchbase/gocb/v2 v2.10.1/go.mod h1:GGEJuYjrfnPHCQLcxTcIco+Puy63PS2p8QQd8FRw66I=
+github.com/couchbase/gocbcore/v10 v10.7.1 h1:6jsNDtqyfoQ8Xg6kv99rzccc3CrHbp7FjeY+ahWXTF4=
+github.com/couchbase/gocbcore/v10 v10.7.1/go.mod h1:Q8JWVenMCEOuRgrDQKApHbzzPif38HzefGgRVe9apAI=
 github.com/couchbase/gocbcoreps v0.1.3 h1:fILaKGCjxFIeCgAUG8FGmRDSpdrRggohOMKEgO9CUpg=
 github.com/couchbase/gocbcoreps v0.1.3/go.mod h1:hBFpDNPnRno6HH5cRXExhqXYRmTsFJlFHQx7vztcXPk=
 github.com/couchbase/gomemcached v0.2.1 h1:lDONROGbklo8pOt4Sr4eV436PVEaKDr3o9gUlhv9I2U=

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2921,7 +2921,7 @@ func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
 	require.Empty(t, db.GetRawSyncXattr(t, ds, docID).Attachments)
 	revpos := 1
 	if !base.IsEnterpriseEdition() {
-		revpos = 2 // this is not intentional, and maybe should be fixed. However, neither CBL nor SG since 3.0 use revpos, so a fix is low priority
+		revpos = 2 // CBG-4766 this is not intentional, and maybe should be fixed. However, neither CBL nor SG since 3.0 use revpos, so a fix is low priority
 	}
 	require.Equal(t, db.AttachmentMap{
 		"camera.txt": {

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2919,11 +2919,15 @@ func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
 
 	// assert that the attachments moved to global xattr after doc update
 	require.Empty(t, db.GetRawSyncXattr(t, ds, docID).Attachments)
+	revpos := 1
+	if !base.IsEnterpriseEdition() {
+		revpos = 2 // this is not intentional, and maybe should be fixed. However, neither CBL nor SG since 3.0 use revpos, so a fix is low priority
+	}
 	require.Equal(t, db.AttachmentMap{
 		"camera.txt": {
 			Digest:  "sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI=",
 			Length:  20,
-			Revpos:  1,
+			Revpos:  revpos,
 			Version: 2,
 			Stub:    true,
 		},

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -402,6 +402,15 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	// body should only have 3 top-level entries _id, _rev, _attachments
 	base.RequireKeysEqual(t, []string{"_id", "_rev", "_attachments"}, body)
+	require.Equal(t, db.AttachmentMap{
+		"attach1": {
+			ContentType: "text/plain",
+			Digest:      "sha1-nq0xWBV2IEkkpY3ng+PEtFnCcVY=",
+			Length:      30,
+			Revpos:      1,
+			Stub:        true,
+		},
+	}, db.GetAttachmentsFromInlineBody(t, response.BodyBytes()))
 }
 
 // Test for regression of issue #447

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -1057,7 +1057,7 @@ func TestAttachmentContentType(t *testing.T) {
 
 	// Ran against allow insecure
 	rt.GetDatabase().ServeInsecureAttachmentTypes = true
-	for index := range tests {
+	for index, _ := range tests {
 		response := rt.SendRequest("GET", fmt.Sprintf("/{{.keyspace}}/doc_allow_insecure_%d/login.aspx", index), "")
 		contentDisposition := response.Header().Get("Content-Disposition")
 

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2883,7 +2883,7 @@ func TestLegacyAttachmentMigrationToGlobalXattrOnImport(t *testing.T) {
 //   - Update this doc through sync gateway
 //   - Assert that the attachment metadata in moved from sync data to global xattr on update
 func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{AutoImport: base.Ptr(false)})
 	defer rt.Close()
 	ds := rt.GetSingleDataStore()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
@@ -2919,15 +2919,11 @@ func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
 
 	// assert that the attachments moved to global xattr after doc update
 	require.Empty(t, db.GetRawSyncXattr(t, ds, docID).Attachments)
-	revpos := 1
-	if !base.IsEnterpriseEdition() {
-		revpos = 2 // CBG-4766 this is not intentional, and maybe should be fixed. However, neither CBL nor SG since 3.0 use revpos, so a fix is low priority
-	}
 	require.Equal(t, db.AttachmentMap{
 		"camera.txt": {
 			Digest:  "sha1-VoSNiNQGHE1HirIS5HMxj6CrlHI=",
 			Length:  20,
-			Revpos:  revpos,
+			Revpos:  2,
 			Version: 2,
 			Stub:    true,
 		},

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -234,10 +234,24 @@ func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *d
 		_, doc, err := collection.Put(ctx, key, docBody)
 		require.NoError(t, err)
 		require.Equal(t, db.AttachmentsMeta{
-			"myatt": map[string]any{},
+			"myatt": map[string]any{
+				"content_type": "text/plain",
+				"digest":       "sha1-Lve95gjOVATpfV8EL5X4nxwjKHE=",
+				"length":       12,
+				"revpos":       1,
+				"stub":         true,
+				"ver":          2,
+			},
 		}, doc.Attachments)
 		require.Equal(t, db.AttachmentMap{
-			"myatt": {},
+			"myatt": {
+				ContentType: "text/plain",
+				Digest:      "sha1-Lve95gjOVATpfV8EL5X4nxwjKHE=",
+				Length:      12,
+				Revpos:      1,
+				Stub:        true,
+				Version:     2,
+			},
 		}, db.GetRawGlobalSyncAttachments(t, collection.GetCollectionDatastore(), key))
 		require.Empty(t, db.GetRawSyncXattr(t, collection.GetCollectionDatastore(), key).Attachments)
 	}

--- a/rest/attachmentmigrationtest/attachment_migration_api_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_api_test.go
@@ -233,23 +233,21 @@ func addDocsForMigrationProcess(t *testing.T, ctx context.Context, collection *d
 		key := fmt.Sprintf("%s_%d", t.Name(), i)
 		_, doc, err := collection.Put(ctx, key, docBody)
 		require.NoError(t, err)
-		assert.NotNil(t, doc.SyncData.Attachments)
+		require.Equal(t, db.AttachmentsMeta{
+			"myatt": map[string]any{},
+		}, doc.Attachments)
+		require.Equal(t, db.AttachmentMap{
+			"myatt": {},
+		}, db.GetRawGlobalSyncAttachments(t, collection.GetCollectionDatastore(), key))
+		require.Empty(t, db.GetRawSyncXattr(t, collection.GetCollectionDatastore(), key).Attachments)
 	}
 
 	// Move some subset of the documents attachment metadata from global sync to sync data
 	for j := 0; j < 5; j++ {
 		key := fmt.Sprintf("%s_%d", t.Name(), j)
-		value, xattrs, cas, err := collection.GetCollectionDatastore().GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
-		require.NoError(t, err)
-		syncXattr, ok := xattrs[base.SyncXattrName]
-		assert.True(t, ok)
-		globalXattr, ok := xattrs[base.GlobalXattrName]
-		assert.True(t, ok)
-
-		var attachs db.GlobalSyncData
-		err = base.JSONUnmarshal(globalXattr, &attachs)
+		value, _, err := collection.GetCollectionDatastore().GetRaw(key)
 		require.NoError(t, err)
 
-		db.MoveAttachmentXattrFromGlobalToSync(t, ctx, key, cas, value, syncXattr, attachs.GlobalAttachments, true, collection.GetCollectionDatastore())
+		db.MoveAttachmentXattrFromGlobalToSync(t, collection.GetCollectionDatastore(), key, value, true)
 	}
 }

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -494,14 +494,16 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 
 	// attachment assertions
 	attachments, err := retrievedDoc.GetAttachments()
-	assert.True(t, err == nil)
-	assert.Len(t, attachments, 1)
-	retrievedAttachment := attachments[input.attachmentName]
-	require.NotNil(t, retrievedAttachment)
-	assert.Equal(t, input.attachmentBody, string(retrievedAttachment.Data))
-	assert.Equal(t, len(attachmentBody), retrievedAttachment.Length)
-	assert.Equal(t, retrievedAttachment.Digest, input.attachmentDigest)
-
+	require.NoError(t, err)
+	require.Equal(t, db.AttachmentMap{
+		input.attachmentName: {
+			ContentType: base.ContentTypeJSON,
+			Digest:      input.attachmentDigest,
+			Length:      len(attachmentBody),
+			Revpos:      1,
+			Stub:        true,
+		},
+	}, attachments)
 }
 
 // TestBlipAttachNameChange tests CBL handling - attachments with changed names are sent as stubs, and not new attachments

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -12,7 +12,6 @@ package rest
 
 import (
 	"encoding/base64"
-// Removed the fmt import as it is not used in production code.
 	"net/http"
 	"testing"
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -62,7 +62,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 
 		rt.WaitForVersion(docID, version)
 
-		// revpos isn't checked, so it isn't a problem that these are different, but it is probably not intentional
+		// CBG-4766 this is not intentional, and maybe should be fixed. However, neither CBL nor SG since 3.0 use revpos, so a fix is low priority
 		revpos := 2
 		if btc.UseHLV() {
 			revpos = 1

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -12,7 +12,7 @@ package rest
 
 import (
 	"encoding/base64"
-	"fmt"
+// Removed the fmt import as it is not used in production code.
 	"net/http"
 	"testing"
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -12,6 +12,7 @@ package rest
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -62,13 +63,9 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 
 		rt.WaitForVersion(docID, version)
 
-		collection, ctx := rt.GetSingleTestDatabaseCollection()
-		syncData, err := collection.GetDocSyncData(ctx, docID)
-		require.NoError(t, err)
-
-		assert.Len(t, syncData.Attachments, 1)
-		_, found := syncData.Attachments["myAttachment"]
-		assert.True(t, found)
+		syncData := db.GetRawSyncXattr(t, rt.GetSingleDataStore(), docID)
+		require.Empty(t, syncData.Attachments)
+		base.RequireKeysEqual(t, []string{"myAttachment"}, db.GetRawGlobalSyncAttachments(t, rt.GetSingleDataStore(), docID))
 
 		// Turn deltas on
 		btc.ClientDeltas = true
@@ -84,12 +81,9 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 
 		rt.WaitForVersion(docID, version)
 
-		syncData, err = collection.GetDocSyncData(ctx, docID)
-		require.NoError(t, err)
-
-		assert.Len(t, syncData.Attachments, 1)
-		_, found = syncData.Attachments["myAttachment"]
-		assert.True(t, found)
+		syncData = db.GetRawSyncXattr(t, rt.GetSingleDataStore(), docID)
+		require.Empty(t, syncData.Attachments)
+		base.RequireKeysEqual(t, []string{"myAttachment"}, db.GetRawGlobalSyncAttachments(t, rt.GetSingleDataStore(), docID))
 	})
 }
 
@@ -122,8 +116,6 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, ClientDeltas: true}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
-
-		collection, ctx := rt.GetSingleTestDatabaseCollection()
 
 		btcRunner.StartPush(btc.id)
 
@@ -176,11 +168,9 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 			rt.WaitForVersion(tc.docID, version)
 
 			if tc.hasAttachment {
-				syncData, err := collection.GetDocSyncData(ctx, tc.docID)
-				require.NoError(t, err)
-				assert.Len(t, syncData.Attachments, 1)
-				_, found := syncData.Attachments["myAttachment"]
-				assert.True(t, found)
+				syncData := db.GetRawSyncXattr(t, rt.GetSingleDataStore(), tc.docID)
+				require.Empty(t, syncData.Attachments)
+				base.RequireKeysEqual(t, []string{"myAttachment"}, db.GetRawGlobalSyncAttachments(t, rt.GetSingleDataStore(), tc.docID))
 			}
 		}
 	})
@@ -241,22 +231,20 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 		assert.Len(t, greetings, 1)
 		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[0])
 
-		attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
-		require.True(t, ok)
-		assert.Len(t, attachments, 2)
-		hello, ok := attachments["hello.txt"].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-		assert.Equal(t, float64(11), hello["length"])
-		assert.Equal(t, float64(1), hello["revpos"])
-		assert.Equal(t, true, hello["stub"])
-
-		world, ok := attachments["world.txt"].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, "sha1-qiF39gVoGPFzpRQkNYcY9u3wx9Y=", world["digest"])
-		assert.Equal(t, float64(11), world["length"])
-		assert.Equal(t, float64(2), world["revpos"])
-		assert.Equal(t, true, world["stub"])
+		require.Equal(t, db.AttachmentMap{
+			"hello.txt": {
+				Revpos: 1,
+				Length: 11,
+				Stub:   true,
+				Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			},
+			"world.txt": {
+				Revpos: 2,
+				Length: 11,
+				Stub:   true,
+				Digest: "sha1-qiF39gVoGPFzpRQkNYcY9u3wx9Y=",
+			},
+		}, db.GetAttachmentsFrom1xBody(t, respBody))
 	})
 }
 
@@ -298,17 +286,14 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		version2 := rt.UpdateDocDirectly(doc1ID, version, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`))
 
 		data = btcRunner.WaitForVersion(client.id, doc1ID, version2)
-		var dataMap map[string]interface{}
-		assert.NoError(t, base.JSONUnmarshal(data, &dataMap))
-		atts, ok := dataMap[db.BodyAttachments].(map[string]interface{})
-		require.True(t, ok)
-		assert.Len(t, atts, 1)
-		hello, ok := atts["hello.txt"].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-		assert.Equal(t, float64(11), hello["length"])
-		assert.Equal(t, float64(2), hello["revpos"])
-		assert.Equal(t, true, hello["stub"])
+		require.Equal(t, db.AttachmentMap{
+			"hello.txt": {
+				Revpos: 2,
+				Length: 11,
+				Stub:   true,
+				Digest: "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			},
+		}, db.GetAttachmentsFromInlineBody(t, data))
 
 		// message #3 is the getAttachment message that is sent in-between rev processing
 		msg := client.pullReplication.WaitForMessage(3)
@@ -332,28 +317,28 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 			// Check the request body was NOT the delta
 			msgBody, err := msg.Body()
 			assert.NoError(t, err)
-			assert.NotEqual(t, `{"_attachments":[{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}]}`, string(msgBody))
-			assert.Contains(t, string(msgBody), `"stub":true`)
-			assert.Contains(t, string(msgBody), `"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="`)
-			assert.Contains(t, string(msgBody), `"revpos":2`)
-			assert.Contains(t, string(msgBody), `"length":11`)
-			assert.Contains(t, string(msgBody), `"greetings":[{"hello":"world!"},{"hi":"alice"}]`)
+			fmt.Printf("msgBody: %s\n", string(msgBody))
+			assert.JSONEq(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}, "greetings": [{"hello": "world!"}, {"hi": "alice"}]}`, string(msgBody))
 		}
 
 		respBody := rt.GetDocVersion(doc1ID, version2)
 		assert.Equal(t, doc1ID, respBody[db.BodyId])
-		greetings := respBody["greetings"].([]interface{})
-		assert.Len(t, greetings, 2)
-		assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
-		assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
-		atts = respBody[db.BodyAttachments].(map[string]interface{})
-		assert.Len(t, atts, 1)
-		assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
-		assert.Equal(t, float64(11), hello["length"])
-		assert.Equal(t, float64(2), hello["revpos"])
-		assert.Equal(t, true, hello["stub"])
-
-		// assert.Equal(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}},"_id":"doc1","_rev":"2-10000d5ec533b29b117e60274b1e3653","greetings":[{"hello":"world!"},{"hi":"alice"}]}`, resp.Body.String())
+		require.Equal(t, db.Body{
+			"_id":  doc1ID,
+			"_rev": "2-10000d5ec533b29b117e60274b1e3653",
+			"greetings": []any{
+				map[string]any{"hello": "world!"},
+				map[string]any{"hi": "alice"},
+			},
+			"_attachments": map[string]any{
+				"hello.txt": map[string]any{
+					"revpos": float64(2),
+					"length": float64(11),
+					"stub":   true,
+					"digest": "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+				},
+			},
+		}, respBody)
 	})
 }
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -317,7 +317,6 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 			// Check the request body was NOT the delta
 			msgBody, err := msg.Body()
 			assert.NoError(t, err)
-			fmt.Printf("msgBody: %s\n", string(msgBody))
 			assert.JSONEq(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}}, "greetings": [{"hello": "world!"}, {"hi": "alice"}]}`, string(msgBody))
 		}
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2722,18 +2722,10 @@ func TestMigrationOfAttachmentsOnImport(t *testing.T) {
 	rt.PutDoc(key, body)
 
 	// grab defined attachment metadata to move to sync data
-	value, xattrs, cas, err := dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
-	require.NoError(t, err)
-	syncXattr, ok := xattrs[base.SyncXattrName]
-	require.True(t, ok)
-	globalXattr, ok := xattrs[base.GlobalXattrName]
-	require.True(t, ok)
-
-	var attachs db.GlobalSyncData
-	err = base.JSONUnmarshal(globalXattr, &attachs)
+	value, _, _, err := dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
 	require.NoError(t, err)
 
-	db.MoveAttachmentXattrFromGlobalToSync(t, ctx, key, cas, value, syncXattr, attachs.GlobalAttachments, true, dataStore)
+	db.MoveAttachmentXattrFromGlobalToSync(t, dataStore, key, value, true)
 
 	// retry loop to wait for import event to arrive over dcp, as doc won't be 'imported' we can't wait for import stat
 	var retryXattrs map[string][]byte
@@ -2745,13 +2737,13 @@ func TestMigrationOfAttachmentsOnImport(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	syncXattr, ok = retryXattrs[base.SyncXattrName]
+	syncXattr, ok := retryXattrs[base.SyncXattrName]
 	require.True(t, ok)
-	globalXattr, ok = retryXattrs[base.GlobalXattrName]
+	globalXattr, ok := retryXattrs[base.GlobalXattrName]
 	require.True(t, ok)
 
 	// empty global sync,
-	attachs = db.GlobalSyncData{}
+	attachs := db.GlobalSyncData{}
 	err = base.JSONUnmarshal(globalXattr, &attachs)
 	require.NoError(t, err)
 	var syncData db.SyncData
@@ -2759,10 +2751,16 @@ func TestMigrationOfAttachmentsOnImport(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert that the attachment metadata has been moved
-	assert.NotNil(t, attachs.GlobalAttachments)
-	assert.Nil(t, syncData.Attachments)
-	att := attachs.GlobalAttachments["hello.txt"].(map[string]interface{})
-	assert.Equal(t, float64(11), att["length"])
+	require.Empty(t, db.GetRawSyncXattr(t, dataStore, key).Attachments)
+	require.Equal(t, db.AttachmentMap{
+		"hello.txt": {
+			Digest:  "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length:  11,
+			Revpos:  1,
+			Stub:    true,
+			Version: 2,
+		},
+	}, db.GetRawGlobalSyncAttachments(t, dataStore, key))
 
 	// assert that no import took place
 	base.RequireWaitForStat(t, func() int64 {
@@ -2774,7 +2772,7 @@ func TestMigrationOfAttachmentsOnImport(t *testing.T) {
 	body = `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	rt.PutDoc(key, body)
 
-	_, xattrs, cas, err = dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
+	_, xattrs, _, err := dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
 	require.NoError(t, err)
 
 	syncXattr, ok = xattrs[base.SyncXattrName]
@@ -2788,7 +2786,7 @@ func TestMigrationOfAttachmentsOnImport(t *testing.T) {
 
 	// change doc body to trigger import on feed
 	value = []byte(`{"test": "doc"}`)
-	db.MoveAttachmentXattrFromGlobalToSync(t, ctx, key, cas, value, syncXattr, attachs.GlobalAttachments, false, dataStore)
+	db.MoveAttachmentXattrFromGlobalToSync(t, dataStore, key, value, false)
 
 	// Wait for import
 	base.RequireWaitForStat(t, func() int64 {
@@ -2796,24 +2794,16 @@ func TestMigrationOfAttachmentsOnImport(t *testing.T) {
 	}, 1)
 
 	// grab the sync and global xattr from doc2
-	xattrs, _, err = dataStore.GetXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
-	require.NoError(t, err)
-	syncXattr, ok = xattrs[base.SyncXattrName]
-	require.True(t, ok)
-	globalXattr, ok = xattrs[base.GlobalXattrName]
-	require.True(t, ok)
-
-	err = base.JSONUnmarshal(globalXattr, &attachs)
-	require.NoError(t, err)
-	syncData = db.SyncData{}
-	err = base.JSONUnmarshal(syncXattr, &syncData)
-	require.NoError(t, err)
-
-	// assert that the attachment metadata has been moved
-	assert.NotNil(t, attachs.GlobalAttachments)
-	assert.Nil(t, syncData.Attachments)
-	att = attachs.GlobalAttachments["hello.txt"].(map[string]interface{})
-	assert.Equal(t, float64(11), att["length"])
+	require.Empty(t, db.GetRawSyncXattr(t, dataStore, key).Attachments)
+	require.Equal(t, db.AttachmentMap{
+		"hello.txt": {
+			Digest:  "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length:  11,
+			Revpos:  1,
+			Stub:    true,
+			Version: 2,
+		},
+	}, db.GetRawGlobalSyncAttachments(t, dataStore, key))
 }
 
 // TestMigrationOfAttachmentsOnDemandImport:
@@ -2834,96 +2824,51 @@ func TestMigrationOfAttachmentsOnDemandImport(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
-	ctx := base.TestCtx(t)
 
 	key := "doc1"
 	body := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	rt.PutDoc(key, body)
 
-	_, xattrs, cas, err := dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
-	require.NoError(t, err)
-	syncXattr, ok := xattrs[base.SyncXattrName]
-	require.True(t, ok)
-	globalXattr, ok := xattrs[base.GlobalXattrName]
-	require.True(t, ok)
-
-	// grab defined attachment metadata to move to sync data
-	var attachs db.GlobalSyncData
-	err = base.JSONUnmarshal(globalXattr, &attachs)
-	require.NoError(t, err)
-
 	value := []byte(`{"update": "doc"}`)
-	db.MoveAttachmentXattrFromGlobalToSync(t, ctx, key, cas, value, syncXattr, attachs.GlobalAttachments, false, dataStore)
+	db.MoveAttachmentXattrFromGlobalToSync(t, dataStore, key, value, false)
 
 	// on demand import for get
 	_, _ = rt.GetDoc(key)
 
-	xattrs, _, err = dataStore.GetXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
-	require.NoError(t, err)
-
-	syncXattr, ok = xattrs[base.SyncXattrName]
-	require.True(t, ok)
-	globalXattr, ok = xattrs[base.GlobalXattrName]
-	require.True(t, ok)
-
-	// empty global sync,
-	attachs = db.GlobalSyncData{}
-
-	err = base.JSONUnmarshal(globalXattr, &attachs)
-	require.NoError(t, err)
-	var syncData db.SyncData
-	err = base.JSONUnmarshal(syncXattr, &syncData)
-	require.NoError(t, err)
-
 	// assert that the attachment metadata has been moved
-	assert.NotNil(t, attachs.GlobalAttachments)
-	assert.Nil(t, syncData.Attachments)
-	att := attachs.GlobalAttachments["hello.txt"].(map[string]interface{})
-	assert.Equal(t, float64(11), att["length"])
+	require.Empty(t, db.GetRawSyncXattr(t, dataStore, key).Attachments)
+	require.Equal(t, db.AttachmentMap{
+		"hello.txt": {
+			Digest:  "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length:  11,
+			Revpos:  1,
+			Stub:    true,
+			Version: 2,
+		},
+	}, db.GetRawGlobalSyncAttachments(t, dataStore, key))
 
 	key = "doc2"
 	body = `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	rt.PutDoc(key, body)
 
-	_, xattrs, cas, err = dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
-	require.NoError(t, err)
-	syncXattr, ok = xattrs[base.SyncXattrName]
-	require.True(t, ok)
-	globalXattr, ok = xattrs[base.GlobalXattrName]
-	require.True(t, ok)
-
-	// grab defined attachment metadata to move to sync data
-	attachs = db.GlobalSyncData{}
-	err = base.JSONUnmarshal(globalXattr, &attachs)
-	require.NoError(t, err)
 	value = []byte(`{"update": "doc"}`)
-	db.MoveAttachmentXattrFromGlobalToSync(t, ctx, key, cas, value, syncXattr, attachs.GlobalAttachments, false, dataStore)
+	db.MoveAttachmentXattrFromGlobalToSync(t, dataStore, key, value, false)
 
 	// trigger on demand import for write
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc2", `{}`)
 	rest.RequireStatus(t, resp, http.StatusConflict)
 
-	// assert that the attachments metadata is migrated
-	xattrs, _, err = dataStore.GetXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
-	require.NoError(t, err)
-	syncXattr, ok = xattrs[base.SyncXattrName]
-	require.True(t, ok)
-	globalXattr, ok = xattrs[base.GlobalXattrName]
-	require.True(t, ok)
-
-	// empty global sync,
-	attachs = db.GlobalSyncData{}
-	err = base.JSONUnmarshal(globalXattr, &attachs)
-	require.NoError(t, err)
-	syncData = db.SyncData{}
-	err = base.JSONUnmarshal(syncXattr, &syncData)
-	require.NoError(t, err)
-
 	// assert that the attachment metadata has been moved
-	assert.NotNil(t, attachs.GlobalAttachments)
-	assert.Nil(t, syncData.Attachments)
-	att = attachs.GlobalAttachments["hello.txt"].(map[string]interface{})
-	assert.Equal(t, float64(11), att["length"])
+	require.Empty(t, db.GetRawSyncXattr(t, dataStore, key).Attachments)
+	require.Equal(t, db.AttachmentMap{
+		"hello.txt": {
+			Digest:  "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=",
+			Length:  11,
+			Revpos:  1,
+			Stub:    true,
+			Version: 2,
+		},
+	}, db.GetRawGlobalSyncAttachments(t, dataStore, key))
 }
 
 func getMou(t *testing.T, mouBytes []byte) db.MetadataOnlyUpdate {

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -2772,18 +2772,6 @@ func TestMigrationOfAttachmentsOnImport(t *testing.T) {
 	body = `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	rt.PutDoc(key, body)
 
-	_, xattrs, _, err := dataStore.GetWithXattrs(ctx, key, []string{base.SyncXattrName, base.GlobalXattrName})
-	require.NoError(t, err)
-
-	syncXattr, ok = xattrs[base.SyncXattrName]
-	require.True(t, ok)
-	globalXattr, ok = xattrs[base.GlobalXattrName]
-	require.True(t, ok)
-	// grab defined attachment metadata to move to sync data
-	attachs = db.GlobalSyncData{}
-	err = base.JSONUnmarshal(globalXattr, &attachs)
-	require.NoError(t, err)
-
 	// change doc body to trigger import on feed
 	value = []byte(`{"test": "doc"}`)
 	db.MoveAttachmentXattrFromGlobalToSync(t, dataStore, key, value, false)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1093,7 +1093,13 @@ func (rt *RestTester) SetAdminChannels(username string, keyspace string, channel
 		return err
 	}
 
-	currentConfig.SetExplicitChannels(*scopeName, *collectionName, channels...)
+	if scopeName == nil || collectionName == nil {
+		if channels != nil {
+			currentConfig.ExplicitChannels = base.SetFromArray(channels)
+		}
+	} else {
+		currentConfig.SetExplicitChannels(*scopeName, *collectionName, channels...)
+	}
 	// Remove read only properties returned from the user api
 	for _, scope := range currentConfig.CollectionAccess {
 		if scope != nil {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1900,7 +1900,7 @@ func (bt *BlipTester) SendRevWithAttachment(input SendRevWithAttachmentInput) (s
 	}
 
 	doc.SetAttachments(db.AttachmentMap{
-		input.attachmentName: &myAttachment,
+		input.attachmentName: myAttachment,
 	})
 
 	docBody, err := base.JSONMarshal(doc)
@@ -2291,7 +2291,7 @@ func (d RestDocument) GetAttachments() (db.AttachmentMap, error) {
 				return db.AttachmentMap{}, err
 			}
 
-			attachmentMap[attachmentName] = &docAttachment
+			attachmentMap[attachmentName] = docAttachment
 		}
 
 		// Avoid the unnecessary re-Marshal + re-Unmarshal

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -70,15 +70,15 @@ func TestAttachmentRoundTrip(t *testing.T) {
 
 	doc := RestDocument{}
 	attachmentMap := db.AttachmentMap{
-		"foo": &db.DocAttachment{
+		"foo": db.DocAttachment{
 			ContentType: "application/octet-stream",
 			Digest:      "WHATEVER",
 		},
-		"bar": &db.DocAttachment{
+		"bar": db.DocAttachment{
 			ContentType: "text/plain",
 			Digest:      "something",
 		},
-		"baz": &db.DocAttachment{
+		"baz": db.DocAttachment{
 			Data: []byte(""),
 		},
 	}

--- a/topologytest/main_test.go
+++ b/topologytest/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 		base.SkipTestMain(m, "Tests are disabled for Couchbase Server by default, to enable set %s=true environment variable", base.TbpEnvTopologyTests)
 		return
 	}
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
 	// Do not create indexes for this test, so they are built by server_context.go
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }


### PR DESCRIPTION
CBG-4280 Improve test assertions for attachments

This is improving the assertions for refactoring,

The plan of refactoring is to consolidate `Document.GlobalSyncData.Attachments` and `Document.DocAttachments` and rename `Document.SyncData.Attachments` -> `Document.SyncData.AttachmentsPre4dot0`. When referring to a document in memory, `Document.Attachments` should be the canonical way to do it, since `Document.GlobalSyncData` is an embedded struct.

The goal of attachment handling in 4.0 is to be able to read attachments in different formats:

- inline body (pre xattrs)
- `_sync.attachments`
- `_globalSync.attachments_meta`

When the document is written to the collection then only place attachment data should be is `globalSync.attachments_meta`.

- `/ks/doc` or `/_bulk_get` -> `_attachments` as a key inline to the body. Sometimes this appears to have the full contents of the attachment.
- blip message -> `_attachments` as a key inline to the body, with stub always.

These test changes should not be changing the code, just adding full assertions for the types. The reviewer should validate this.

I made use of `DocAttachment` data structure and changed `AttachmentMap` to use the concrete `DocAttachment` rather than a pointer so I could do `require.Equal(t, AttachmentMap{}, m)`. I can't see when this would cause problems or result in an extra copies because right now this is only used in test code. Aspirationally a future ticket could imagine using `DocAttachment` or similar structure to be `globalSync.attachments_meta` rather than `map[string]any`.

The one piece I'm worried about is making `Data` json marshalable and whether I've changed production code. That's why I verify the full contents of the body. I've considered whether to allow this be unmarshable but not marshable, but that seemed to blow up the scope of this PR.

# Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3223/
