### PR TITLE
Increase topologytest high memory watermark

### DIFF
--- a/topologytest/main_test.go
+++ b/topologytest/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 		base.SkipTestMain(m, "Tests are disabled for Couchbase Server by default, to enable set %s=true environment variable", base.TbpEnvTopologyTests)
 		return
 	}
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 2048}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
 	// Do not create indexes for this test, so they are built by server_context.go
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }


### PR DESCRIPTION
Increase topologytest watermark to 8192 to match `rest` package. I do not think the watermark testing is actually very useful for this package, so I increased it quite a bit. The high watermark we currently see is about 2150, so it is just above the threshold. Some of this is probably the result of https://github.com/couchbase/sync_gateway/commit/bac77822f3b9a2f0c4cf7655baf0fc8b59505e2f which increased the bucket pool size to 4 to account for each topologytest using two buckets.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
