### PR TITLE
Increase WaitUntilReady for tests

### DIFF
--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -194,7 +194,7 @@ func MgmtRequest(client *http.Client, mgmtEp, method, uri, contentType, username
 }
 
 // NewClusterAgent creates a new gocbcore agent for a couchbase cluster.
-func NewClusterAgent(ctx context.Context, spec CouchbaseClusterSpec) (*gocbcore.Agent, error) {
+func NewClusterAgent(ctx context.Context, spec CouchbaseClusterSpec, waitUntilReadyTimeout time.Duration) (*gocbcore.Agent, error) {
 	authenticator, err := GoCBCoreAuthConfig(spec.Username, spec.Password, spec.X509Certpath, spec.X509Keypath)
 	if err != nil {
 		return nil, err
@@ -240,7 +240,7 @@ func NewClusterAgent(ctx context.Context, spec CouchbaseClusterSpec) (*gocbcore.
 
 	agentReadyErr := make(chan error)
 	_, err = agent.WaitUntilReady(
-		time.Now().Add(5*time.Second),
+		time.Now().Add(waitUntilReadyTimeout),
 		gocbcore.WaitUntilReadyOptions{
 			ServiceTypes: []gocbcore.ServiceType{gocbcore.MgmtService},
 		},

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -23,6 +23,8 @@ import (
 	"github.com/couchbase/gocbcore/v10"
 )
 
+const TestClusterReadyTimeout = 90 * time.Second
+
 // tbpCluster represents a gocb v2 cluster
 type tbpCluster struct {
 	// version is the Couchbase Server version
@@ -37,7 +39,7 @@ type tbpCluster struct {
 
 // newTestCluster returns a cluster based on the driver used by the defaultBucketSpec.
 func newTestCluster(ctx context.Context, clusterSpec CouchbaseClusterSpec) (*tbpCluster, error) {
-	agent, err := NewClusterAgent(ctx, clusterSpec)
+	agent, err := NewClusterAgent(ctx, clusterSpec, TestClusterReadyTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create cluster agent: %w", err)
 	}
@@ -92,10 +94,9 @@ func getGocbClusterForTest(ctx context.Context, clusterSpec CouchbaseClusterSpec
 	if err != nil {
 		return nil, "", fmt.Errorf("couldn't connect to cluster %q: %w", connStr, err)
 	}
-	const clusterReadyTimeout = 90 * time.Second
-	err = cluster.WaitUntilReady(clusterReadyTimeout, nil)
+	err = cluster.WaitUntilReady(TestClusterReadyTimeout, nil)
 	if err != nil {
-		FatalfCtx(ctx, "Cluster not ready after %ds: %v", int(clusterReadyTimeout.Seconds()), err)
+		FatalfCtx(ctx, "Cluster not ready after %ds: %v", int(TestClusterReadyTimeout.Seconds()), err)
 	}
 	return cluster, connStr, nil
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1841,6 +1841,8 @@ func (sc *ServerContext) updateCalculatedStats(ctx context.Context) {
 // Uses retry loop
 func (sc *ServerContext) initializeGoCBAgent(ctx context.Context) (*gocbcore.Agent, error) {
 	err, agent := base.RetryLoop(ctx, "Initialize Cluster Agent", func() (shouldRetry bool, err error, agent *gocbcore.Agent) {
+		// this timeout is pretty short since we are doing external retries
+		waitUntilReadyTimeout := 5 * time.Second
 		agent, err = base.NewClusterAgent(
 			ctx,
 			base.CouchbaseClusterSpec{
@@ -1851,7 +1853,7 @@ func (sc *ServerContext) initializeGoCBAgent(ctx context.Context) (*gocbcore.Age
 				X509Keypath:   sc.Config.Bootstrap.X509KeyPath,
 				CACertpath:    sc.Config.Bootstrap.CACertPath,
 				TLSSkipVerify: base.ValDefault(sc.Config.Bootstrap.ServerTLSSkipVerify, false),
-			})
+			}, waitUntilReadyTimeout)
 		if err != nil {
 			// since we're starting up - let's be verbose (on console) about these retries happening ... otherwise it looks like nothing is happening ...
 			base.ConsolefCtx(ctx, base.LevelInfo, base.KeyConfig, "Couldn't initialize cluster agent: %v - will retry...", err)

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -88,6 +88,7 @@ func TestX509UnknownAuthorityWrap(t *testing.T) {
 			CACertpath:    sc.Bootstrap.CACertPath,
 			TLSSkipVerify: base.ValDefault(sc.Bootstrap.ServerTLSSkipVerify, false),
 		},
+		base.TestClusterReadyTimeout,
 	)
 	assert.Error(t, err)
 


### PR DESCRIPTION
Increase WaitUntilReady for the cluster agent to 90 seconds. This restores the previous value before https://github.com/couchbase/sync_gateway/commit/5108469f708de4bf7b1c1f7e63e1887409c1a176 happened and I refactored the `WaitUntilReady` value to match the same value as when `ServerContext` gets initialized.

I kept the production line of code the same with a 5 second timeout, although that does an external retry loop for 2 minutes, so that also retries for more than 90s.

5s results in errors from the first tests that run in jenkins:

```
2025-07-21T14:56:25.500Z [WRN] gocb: CCCPPOLL: Failed to retrieve CCCP config. document not found | {"status_code":1,"error_name":"KEY_ENOENT","error_description":"Not Found","opaque":7,"last_dispatched_to":"127.0.0.1:11210","last_dispatched_from":"127.0.0.1:46556","last_connection_id":"67b88bcb98bcabdb/a0a1c2e0162f6c70"} -- base.GoCBCoreLoggerRemapped.Log() at logger_external.go:129
2025-07-21T14:56:25.500Z [WRN] gocb: CCCPPOLL: Failed to retrieve config from any node. -- base.GoCBCoreLoggerRemapped.Log() at logger_external.go:129
2025/07/21 14:56:25 2025-07-21T14:56:25.543Z TEST: Couldn't create test cluster: couldn't create cluster agent: document not found | {"status_code":1,"error_name":"KEY_ENOENT","error_description":"Not Found","opaque":7,"last_dispatched_to":"127.0.0.1:11210","last_dispatched_from":"127.0.0.1:46556","last_connection_id":"67b88bcb98bcabdb/a0a1c2e0162f6c70"}
FAIL	github.com/couchbase/sync_gateway/auth	0.083s
```
