### PR TITLE
Use WaitUntilReady retry strategy for test pool

### DIFF
--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -39,7 +39,11 @@ type tbpCluster struct {
 
 // newTestCluster returns a cluster based on the driver used by the defaultBucketSpec.
 func newTestCluster(ctx context.Context, clusterSpec CouchbaseClusterSpec) (*tbpCluster, error) {
-	agent, err := NewClusterAgent(ctx, clusterSpec, TestClusterReadyTimeout)
+	agent, err := NewClusterAgent(ctx, clusterSpec,
+		CouchbaseClusterWaitUntilReadyOptions{
+			Timeout:       TestClusterReadyTimeout,
+			RetryStrategy: gocbcore.NewBestEffortRetryStrategy(nil),
+		})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create cluster agent: %w", err)
 	}

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocbcore/v10"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
@@ -88,7 +89,10 @@ func TestX509UnknownAuthorityWrap(t *testing.T) {
 			CACertpath:    sc.Bootstrap.CACertPath,
 			TLSSkipVerify: base.ValDefault(sc.Bootstrap.ServerTLSSkipVerify, false),
 		},
-		base.TestClusterReadyTimeout,
+		base.CouchbaseClusterWaitUntilReadyOptions{
+			Timeout:       base.TestClusterReadyTimeout,
+			RetryStrategy: gocbcore.NewBestEffortRetryStrategy(nil),
+		},
 	)
 	assert.Error(t, err)
 


### PR DESCRIPTION
Followup to https://github.com/couchbase/sync_gateway/pull/7642. I don't know why this only hits MasterIntegration and not Sync Gateway Integration Tests but I could reproduce locally.
