### PR TITLE
CBG-4768: add missing silent handler logging level for admin port _expvar

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3205,4 +3205,9 @@ func TestSilentHandlerLoggingInTrace(t *testing.T) {
 		resp := rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_expvar", "", headers)
 		RequireStatus(t, resp, http.StatusOK)
 	})
+
+	base.AssertLogNotContains(t, "/_expvar", func() {
+		resp := rt.SendAdminRequest(http.MethodGet, "/_expvar", "")
+		RequireStatus(t, resp, http.StatusOK)
+	})
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -287,7 +287,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleStats)).Methods("GET")
 	r.Handle(kDebugURLPathPrefix,
 		makeHandlerWithOptions(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar, handlerOptions{
-			httpLogLevel: base.Ptr(base.LevelDebug), // silent handler
+			httpLogLevel: base.Ptr(silentRequestLogLevel), // silent handler
 			sgcollect:    true,
 		})).Methods("GET")
 	r.Handle("/_profile/{profilename}",


### PR DESCRIPTION
CBG-4768

- Adds silent handler logging for admin port _expvar
- This was missed as part of #7644

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3224/
