### PR TITLE
Return when sending a 422 to a rev

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -618,6 +618,7 @@ func (btr *BlipTesterReplicator) handleRev(ctx context.Context, btc *BlipTesterC
 				require.False(btr.TB(), msg.NoReply(), "expected delta rev message to be sent without noreply flag: %+v", msg)
 				response := msg.Response()
 				response.SetError("HTTP", http.StatusUnprocessableEntity, "test code intentionally rejected delta")
+				return
 			}
 
 			// unmarshal body to extract deltaSrc


### PR DESCRIPTION
Fixes some wacky pathways where the HLV gets updated twice and this rev gets added to the BlipTesterClient data store. This isn't the correct behavior. 

I think this actually doesn't usually result in a problem since the same contents are written twice, but the second time it should have a different (full) body.

I didn't find that this was a problem until I rewrote some the blip client tester code to resolve conflicts, but I wanted to pull this out into a change sooner rather than later due to unexpected behavior.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

