### PR TITLE
Close buckets in bucket pool

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -425,6 +425,15 @@ func (tbp *TestBucketPool) Close(ctx context.Context) {
 	}
 
 	if tbp.cluster != nil {
+		for {
+			if len(tbp.readyBucketPool) == 0 {
+				break
+			}
+			select {
+			case bucket := <-tbp.readyBucketPool:
+				bucket.Close(ctx)
+			}
+		}
 		if err := tbp.cluster.close(); err != nil {
 			tbp.Logf(ctx, "Couldn't close cluster connection: %v", err)
 		}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -390,10 +390,6 @@ func CreateProperty(size int) (result string) {
 func SetUpTestGoroutineDump(m *testing.M) (teardownFn func()) {
 	const numExpected = 1
 
-	if ok, _ := strconv.ParseBool(os.Getenv(TestEnvGoroutineDump)); !ok {
-		return func() {}
-	}
-
 	timestamp := time.Now().Unix()
 	filename := fmt.Sprintf("test-pprof-%s-%d.pb.gz", "goroutine", timestamp)
 	// create the file upfront so we know we're able to write to it before we run tests


### PR DESCRIPTION
- Fix gocbcore goroutine leaks. `SG_TEST_GOROUTINE_DUMP`. There can still be leaks because closing a bucket will asynchronously close gocbcore http.Transport and they can be waiting for data. There doesn't seem to be a way to wait for these to close.
- Do not close buckets unless we need to, to speed up test framework teardown and make tests more responsive.
- Wait for bucket creation to finish if we need to teardown buckets.
