### PR TITLE
CBG-4767 2: Make `AuditIDDocumentRead` tolerant to invalid `SyncData` in `_raw` endpoint

### DIFF
--- a/base/logger_audit.go
+++ b/base/logger_audit.go
@@ -115,6 +115,12 @@ func (f AuditFields) merge(ctx context.Context, overwrites AuditFields) AuditFie
 	return f
 }
 
+// AuditEventIsEnabled checks if the given audit event ID is enabled for the current context.
+// This may be used to avoid the cost of some data processing/gathering ahead of an audit event.
+func AuditEventIsEnabled(ctx context.Context, id AuditID) bool {
+	return auditLogger.Load().shouldLog(id, ctx)
+}
+
 // Audit creates and logs an audit event for the given ID and a set of additional data associated with the request.
 func Audit(ctx context.Context, id AuditID, additionalData AuditFields) {
 	var fields AuditFields

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1479,7 +1479,9 @@ func (h *handler) handleGetRawDoc() error {
 				Rev channels.RevAndVersion `json:"rev"`
 			}
 			if err := json.Unmarshal(syncData, &sdRev); err != nil {
-				base.WarnfCtx(h.ctx(), "couldn't unmarshal doc %q SyncData xattr value %q: %s", base.UD(docID), syncData, err)
+				// syncData is not normally generally redactedl, but in this case we know it's malformed in some way and want the raw data in the log message.
+				// This data may contain channel names, etc. which _are_ classed as UserData, so tag the whole thing.
+				base.WarnfCtx(h.ctx(), "couldn't unmarshal doc %q SyncData xattr value %q: %s", base.UD(docID), base.UD(syncData), err)
 			} else {
 				docCurrentRev = sdRev.Rev.RevTreeID
 			}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1479,7 +1479,7 @@ func (h *handler) handleGetRawDoc() error {
 				Rev channels.RevAndVersion `json:"rev"`
 			}
 			if err := json.Unmarshal(syncData, &sdRev); err != nil {
-				// syncData is not normally generally redactedl, but in this case we know it's malformed in some way and want the raw data in the log message.
+				// syncData is not normally generally redacted, but in this case we know it's malformed in some way and want the raw data in the log message.
 				// This data may contain channel names, etc. which _are_ classed as UserData, so tag the whole thing.
 				base.WarnfCtx(h.ctx(), "couldn't unmarshal doc %q SyncData xattr value %q: %s", base.UD(docID), base.UD(syncData), err)
 			} else {


### PR DESCRIPTION
CBG-4767 part 2

Fixes a potential flake of unknown cause in `TestGetRawDocumentError`

1. Makes the error non-fatal and uses the fallback `"unknown"` rev ID value in the audit event in the case of malformed sync data. This is really a bug fix, since this could happen in the real-world and we don't want to stop getting data back out of this API endpoint.
2. Avoids unmarshalling completely if this audit event is not enabled - it's wasted effort otherwise. This isn't really a fix like above, but just avoids this codepath in tests and production cases where it's not needed.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3234/
