### PR TITLE
Simplify bucket names and sourceID for rosmar

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -36,16 +36,13 @@ var GTestBucketPool *TestBucketPool
 // tracker is to be able to name in low sequential orders like Couchbase Server bucket pool: rosmar0, rosmar1, etc.
 type rosmarTracker struct {
 	lock          sync.Mutex
-	activeBuckets map[int]bool
+	activeBuckets []bool
 }
 
 // newRosmarTracker initializes a new rosmarTracker with the specified number of buckets.
 func newRosmarTracker(numBuckets int) *rosmarTracker {
 	r := &rosmarTracker{
-		activeBuckets: make(map[int]bool, numBuckets),
-	}
-	for i := range numBuckets {
-		r.activeBuckets[i] = false
+		activeBuckets: make([]bool, numBuckets),
 	}
 	return r
 }
@@ -56,8 +53,8 @@ func (r *rosmarTracker) GetNextBucketIdx() (int, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	// iterate over len of activeBuckets to find the first lexicographically in a map
-	for i := range len(r.activeBuckets) {
-		if !r.activeBuckets[i] {
+	for i, active := range r.activeBuckets {
+		if !active {
 			r.activeBuckets[i] = true
 			return i, nil
 		}

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -9,9 +9,7 @@
 package db
 
 import (
-	"crypto/md5"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"maps"
 	"sort"
@@ -595,18 +593,6 @@ func EncodeSource(source string) string {
 // EncodeValueStr converts a simplified number ("1") to a hex-encoded string
 func EncodeValueStr(value string) (string, error) {
 	return base.StringDecimalToLittleEndianHex(strings.TrimSpace(value))
-}
-
-// CreateEncodedSourceID will hash the bucket UUID and cluster UUID using md5 hash function then will base64 encode it
-// This function is in sync with xdcr implementation of UUIDstoDocumentSource https://github.com/couchbase/goxdcr/blob/dfba7a5b4251d93db46e2b0b4b55ea014218931b/hlv/hlv.go#L51
-func CreateEncodedSourceID(bucketUUID, clusterUUID string) (string, error) {
-	md5Hash := md5.Sum([]byte(bucketUUID + clusterUUID))
-	hexStr := hex.EncodeToString(md5Hash[:])
-	source, err := base.HexToBase64(hexStr)
-	if err != nil {
-		return "", err
-	}
-	return string(source), nil
 }
 
 func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -237,7 +237,7 @@ func NewPeer(t *testing.T, name string, buckets map[PeerBucketID]*base.TestBucke
 	case PeerTypeCouchbaseServer:
 		bucket, ok := buckets[opts.BucketID]
 		require.True(t, ok, "bucket not found for bucket ID %d", opts.BucketID)
-		sourceID, err := xdcr.GetSourceID(base.TestCtx(t), bucket)
+		sourceID, err := base.GetSourceID(base.TestCtx(t), bucket)
 		require.NoError(t, err)
 		p := &CouchbaseServerPeer{
 			name:               name,

--- a/xdcr/replication.go
+++ b/xdcr/replication.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/rosmar"
 )
 
@@ -78,17 +77,4 @@ func NewXDCR(ctx context.Context, fromBucket, toBucket base.Bucket, opts XDCROpt
 		return nil, fmt.Errorf("toBucket must be a *base.GocbV2Bucket since fromBucket was a gocbBucket, got %T", toBucket)
 	}
 	return newCouchbaseServerManager(ctx, gocbFromBucket, gocbToBucket, opts)
-}
-
-// GetSourceID returns the source ID for a bucket.
-func GetSourceID(ctx context.Context, bucket base.Bucket) (string, error) {
-	serverUUID, err := db.GetServerUUID(ctx, bucket)
-	if err != nil {
-		return "", err
-	}
-	bucketUUID, err := bucket.UUID()
-	if err != nil {
-		return "", err
-	}
-	return db.CreateEncodedSourceID(bucketUUID, serverUUID)
 }

--- a/xdcr/rosmar_xdcr.go
+++ b/xdcr/rosmar_xdcr.go
@@ -67,7 +67,7 @@ func newRosmarManager(ctx context.Context, fromBucket, toBucket *rosmar.Bucket, 
 	if opts.Mobile != MobileOn {
 		return nil, errors.New("Only sgbucket.XDCRMobileOn is supported in rosmar")
 	}
-	fromBucketSourceID, err := GetSourceID(ctx, fromBucket)
+	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
 	if err != nil {
 		return nil, fmt.Errorf("Could not get source ID for %s: %w", fromBucket.GetName(), err)
 	}

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -70,7 +70,7 @@ func TestMobileXDCRNoSyncDataCopied(t *testing.T) {
 		fromDs = fromBucket.DefaultDataStore()
 		toDs = toBucket.DefaultDataStore()
 	}
-	fromBucketSourceID, err := GetSourceID(ctx, fromBucket)
+	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
 	require.NoError(t, err)
 	docCas := make(map[string]uint64)
 	for _, doc := range []string{syncDoc, attachmentDoc, normalDoc} {
@@ -155,7 +155,7 @@ func getTwoBucketDataStores(t *testing.T) (base.Bucket, sgbucket.DataStore, base
 func TestReplicateVV(t *testing.T) {
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
-	fromBucketSourceID, err := GetSourceID(ctx, fromBucket)
+	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
 	require.NoError(t, err)
 
 	hlvAgent := db.NewHLVAgent(t, fromDs, "fakeHLVSourceID", base.VvXattrName)
@@ -276,7 +276,7 @@ func TestReplicateVV(t *testing.T) {
 func TestVVWriteTwice(t *testing.T) {
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
-	fromBucketSourceID, err := GetSourceID(ctx, fromBucket)
+	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
 	require.NoError(t, err)
 
 	docID := "doc1"
@@ -311,7 +311,7 @@ func TestVVObeyMou(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeySGTest)
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
-	fromBucketSourceID, err := GetSourceID(ctx, fromBucket)
+	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
 	require.NoError(t, err)
 
 	docID := "doc1"
@@ -390,7 +390,7 @@ func TestVVMouImport(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeySGTest)
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
-	fromBucketSourceID, err := GetSourceID(ctx, fromBucket)
+	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
 	require.NoError(t, err)
 
 	docID := "doc1"
@@ -500,7 +500,7 @@ func TestVVMouImport(t *testing.T) {
 func TestLWWAfterInitialReplication(t *testing.T) {
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
-	fromBucketSourceID, err := GetSourceID(ctx, fromBucket)
+	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
 	require.NoError(t, err)
 
 	docID := "doc1"
@@ -631,9 +631,9 @@ func TestVVMultiActor(t *testing.T) {
 	}
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
-	fromBucketSourceID, err := GetSourceID(ctx, fromBucket)
+	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
 	require.NoError(t, err)
-	toBucketSourceID, err := GetSourceID(ctx, toBucket)
+	toBucketSourceID, err := base.GetSourceID(ctx, toBucket)
 	require.NoError(t, err)
 
 	// Create document on source


### PR DESCRIPTION
Ease debugging of topologytest by allow buckets to be named rosmar0, rosmar1. Use a matching sourceID for the bucket name.

- Probably overengineered rosmarTracker to always have rosmar buckets be named rosmar0, rosmar1, rosmar2, rosmar3 rather than strictly counting up from the start of a test process
- Changed SourceID for rosmar buckets to match the bucket name since it is guaranteed to be unique for in memory buckets and makes it easier correlate source IDs when debugging topologytests.
- Move all the sourceID related functions from db, xdcr -> base. There is no functional change.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
