### PR TITLE
blip tester: pass full history to proposeChanges

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -3318,7 +3318,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 		// previousVersion didn't match, but proposed version and server CV have matching source, and proposed version is newer
 		return ProposedRev_OK, ""
 	} else {
-		// Temporary (CBG-4466): check the full HLV that's being sent by CBL with proposeChanges messages.
+		// Temporary (CBG-4461): check the full HLV that's being sent by CBL with proposeChanges messages.
 		// If the current server cv is dominated by the incoming HLV (i.e. the incoming HLV has an entry for the same source
 		// with a version that's greater than or equal to the server's cv), then we can accept the proposed version.
 		proposedHLV, _, err := ExtractHLVFromBlipMessage(proposedHLVString)

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1281,7 +1281,7 @@ func (btcc *BlipTesterCollectionClient) sendRev(ctx context.Context, change prop
 		return
 	}
 	if errorCode == strconv.Itoa(http.StatusConflict) {
-		// If there is a conflict created between the proceeding proposeChanges and this rev message.
+		// If there is a conflict created between the preceding proposeChanges and this rev message.
 		// this is not an error.
 		return
 	}


### PR DESCRIPTION
There are not yet tests which require this code, that will come shortly.

- Fix jira ticket number about proposeChanges
- Pass full hlv history to proposeChanges
- Accept 409 pushing a rev, which will happen if `proposeChanges` was OK and then a conflict appears wheen

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3237/
