### PR TITLE
CBG-3778 remove rt.*Directly functions

### DIFF
--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -1144,7 +1144,7 @@ func TestAllDocsCV(t *testing.T) {
 	defer rt.Close()
 
 	const docID = "foo"
-	docVersion := rt.PutDocDirectly(docID, db.Body{"foo": "bar"})
+	docVersion := rt.PutDoc(docID, `{"foo": "bar"}`)
 
 	testCases := []struct {
 		name   string

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2870,7 +2870,7 @@ func TestPvDeltaReadAndWrite(t *testing.T) {
 	version1, _ := rt.GetDoc(docID)
 
 	// update the above doc, this should push CV to PV and adds a new CV
-	version2 := rt.UpdateDocDirectly(docID, version1, db.Body{"new": "update!"})
+	version2 := rt.UpdateDoc(docID, version1, `{"new": "update!"}`)
 	newDoc, _, err := collection.GetDocWithXattrs(ctx, existingHLVKey, db.DocUnmarshalAll)
 	require.NoError(t, err)
 	casV2 := newDoc.Cas

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2314,8 +2314,8 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		btcRunner.StartPull(btc.id)
 		btcRunner.StartPush(btc.id)
 
-		doc1Version := rt.PutDocDirectly(doc1ID, db.Body{})
-		doc2Version := rt.PutDocDirectly(doc2ID, db.Body{})
+		doc1Version := rt.PutDoc(doc1ID, "{}")
+		doc2Version := rt.PutDoc(doc2ID, "{}")
 
 		btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 		btcRunner.WaitForVersion(btc.id, doc2ID, doc2Version)
@@ -2370,7 +2370,7 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 		btcRunner.StartPush(btc.id)
 
 		// Add doc1
-		doc1Version := rt.PutDocDirectly(doc1ID, db.Body{})
+		doc1Version := rt.PutDoc(doc1ID, "{}")
 
 		btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 
@@ -2648,9 +2648,9 @@ func TestCBLRevposHandling(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
 		defer btc.Close()
 
-		startingBody := db.Body{"foo": "bar"}
-		doc1Version1 := rt.PutDocDirectly(doc1ID, startingBody)
-		doc2Version1 := rt.PutDocDirectly(doc2ID, startingBody)
+		startingBody := `{"foo": "bar"}`
+		doc1Version1 := rt.PutDoc(doc1ID, startingBody)
+		doc2Version1 := rt.PutDoc(doc2ID, startingBody)
 
 		rt.WaitForPendingChanges()
 		btcRunner.StartOneshotPull(btc.id)

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -257,7 +257,7 @@ func TestCollectionsReplication(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 
-		version := btc.rt.PutDocDirectly(docID, db.Body{})
+		version := btc.rt.PutDoc(docID, "{}")
 
 		btc.rt.WaitForPendingChanges()
 		btcRunner.StartOneshotPull(btc.id)
@@ -283,8 +283,8 @@ func TestBlipReplicationMultipleCollections(t *testing.T) {
 		docName := "doc1"
 		body := `{"foo":"bar"}`
 		versions := make([]DocVersion, 0, len(btc.rt.GetKeyspaces()))
-		for _, collection := range btc.rt.GetDbCollections() {
-			docVersion := rt.PutDocDirectlyInCollection(collection, docName, db.Body{"foo": "bar"})
+		for _, ks := range btc.rt.GetKeyspaces() {
+			docVersion := rt.PutDocWithKeyspace(ks, docName, `{"foo": "bar"}`)
 			versions = append(versions, docVersion)
 		}
 		btc.rt.WaitForPendingChanges()
@@ -323,7 +323,7 @@ func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
 		collectionDocIDs := make(map[string][]string)
 		collectionVersions := make(map[string][]DocVersion)
 		require.Len(t, btc.rt.GetKeyspaces(), 2)
-		for i, collection := range btc.rt.GetDbCollections() {
+		for i, ks := range btc.rt.GetKeyspaces() {
 			// intentionally create collections with different size replications to ensure one collection finishing won't cancel another one
 			docCount := 10
 			if i == 0 {
@@ -332,7 +332,7 @@ func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
 			blipName := btc.rt.getCollectionsForBLIP()[i]
 			for j := 0; j < docCount; j++ {
 				docName := fmt.Sprintf("doc%d", j)
-				version := rt.PutDocDirectlyInCollection(collection, docName, db.Body{"foo": "bar"})
+				version := rt.PutDocWithKeyspace(ks, docName, `{"foo": "bar"}`)
 
 				collectionVersions[blipName] = append(collectionVersions[blipName], version)
 				collectionDocIDs[blipName] = append(collectionDocIDs[blipName], docName)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1269,7 +1269,7 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 	// Get non-deleted rev
 	response := bt.restTester.SendAdminRequest("GET", "/{{.keyspace}}/largeNumberRev?rev=1-abc", "")
 	RequireStatus(t, response, 200) // Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
-	responseString := string(response.Body.Bytes())
+	responseString := response.BodyString()
 	if !strings.Contains(responseString, `9223372036854775807`) {
 		t.Errorf("Response does not contain the expected number format.  Response: %s", responseString)
 	}
@@ -2027,7 +2027,7 @@ func TestSendReplacementRevision(t *testing.T) {
 				defer rt.Close()
 
 				docID := test.name
-				version1 := rt.PutDocDirectly(docID, JsonToMap(t, fmt.Sprintf(`{"foo":"bar","channels":["%s"]}`, rev1Channel)))
+				version1 := rt.PutDoc(docID, fmt.Sprintf(`{"foo":"bar","channels":["%s"]}`, rev1Channel))
 				updatedVersion := make(chan DocVersion)
 				collection, ctx := rt.GetSingleTestDatabaseCollection()
 
@@ -2130,13 +2130,13 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 
 		const docID = "doc1"
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-		version1 := rt.PutDocDirectly(docID, db.Body{"hello": "world!"})
+		version1 := rt.PutDoc(docID, `{"hello": "world!"}`)
 
 		data := btcRunner.WaitForVersion(client.id, docID, version1)
 		assert.Equal(t, `{"hello":"world!"}`, string(data))
 
 		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-		version2 := rt.UpdateDocDirectly(docID, version1, db.Body{"hello": "alice"})
+		version2 := rt.UpdateDoc(docID, version1, `{"hello": "alice"}`)
 
 		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"hello":"alice"}`, string(data))
@@ -2192,7 +2192,7 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 		_ = btcRunner.WaitForVersion(client.id, docID, version1)
 
 		// update the above doc
-		version2 := rt.UpdateDocDirectly(docID, version1, db.Body{"hello": "world!"})
+		version2 := rt.UpdateDoc(docID, version1, `{"hello": "world!"}`)
 
 		data := btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"hello":"world!"}`, string(data))
@@ -2247,7 +2247,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 
-		version := rt.PutDocDirectly(docID, db.Body{"test": true})
+		version := rt.PutDoc(docID, `{"test": true}`)
 
 		// start an initial pull
 		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: true, Since: "0", ActiveOnly: true})
@@ -2255,7 +2255,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 		assert.Equal(t, `{"test":true}`, string(rev))
 
 		// delete the doc and make sure the client still gets the tombstone replicated
-		deletedVersion := rt.DeleteDocDirectly(docID, version)
+		deletedVersion := rt.DeleteDoc(docID, version)
 
 		rev = btcRunner.WaitForVersion(btc.id, docID, deletedVersion)
 		assert.Equal(t, `{}`, string(rev))
@@ -2338,7 +2338,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		defer btc.Close()
 
 		const docID = "doc"
-		version := rt.PutDocDirectly(docID, db.Body{"channels": []string{"A", "B"}})
+		version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
 		changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
@@ -2347,7 +2347,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
-		version = rt.UpdateDocDirectly(docID, version, db.Body{"channels": []string{"B"}})
+		version = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
 
 		changes = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
@@ -2356,9 +2356,9 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
-		version = rt.UpdateDocDirectly(docID, version, db.Body{"channels": []string{}})
+		version = rt.UpdateDoc(docID, version, `{"channels": []}`)
 		const docMarker = "docmarker"
-		docMarkerVersion := rt.PutDocDirectly(docMarker, db.Body{"channels": []string{"!"}})
+		docMarkerVersion := rt.PutDoc(docMarker, `{"channels": ["!"]}`)
 
 		changes = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
@@ -2423,7 +2423,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		const (
 			docID = "doc"
 		)
-		version := rt.PutDocDirectly(docID, db.Body{"channels": []string{"A", "B"}})
+		version := rt.PutDoc(docID, `{"channels": ["A", "B"]}`)
 
 		changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
@@ -2432,7 +2432,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
 
-		version = rt.UpdateDocDirectly(docID, version, db.Body{"channels": []string{"C"}})
+		version = rt.UpdateDoc(docID, version, `{"channels": ["C"]}`)
 		rt.WaitForPendingChanges()
 
 		// At this point changes should send revocation, as document isn't in any of the user's channels
@@ -2445,7 +2445,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 		_ = rt.UpdateDoc(docID, version, `{"channels": ["B"]}`)
 		markerID := "docmarker"
-		markerVersion := rt.PutDocDirectly(markerID, db.Body{"channels": []string{"A"}})
+		markerVersion := rt.PutDoc(markerID, `{"channels": ["A"]}`)
 		rt.WaitForPendingChanges()
 
 		// Revocation should not be sent over blip, as document is now in user's channels - only marker document should be received
@@ -2789,7 +2789,7 @@ func TestProcessRevIncrementsStat(t *testing.T) {
 	defer func() { require.NoError(t, ar.Stop()) }()
 
 	activeRT.WaitForPendingChanges()
-	activeRT.WaitForVersion(docID, version)
+	activeRT.WaitForRevTreeVersion(docID, version)
 
 	base.RequireWaitForStat(t, pullStats.HandleRevCount.Value, 1)
 	assert.NotEqualValues(t, 0, pullStats.HandleRevBytes.Value())
@@ -2901,7 +2901,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 					recievedNoRevs <- msg
 				}
 
-				version := rt.PutDocDirectly(docName, db.Body{"foo": "bar"})
+				version := rt.PutDoc(docName, `{"foo": "bar"}`)
 
 				// Make the LeakyBucket return an error
 				leakyDataStore.SetGetRawCallback(func(key string) error {
@@ -2961,7 +2961,7 @@ func TestUnsubChanges(t *testing.T) {
 		// Sub changes
 		btcRunner.StartPull(btc.id)
 
-		doc1Version := rt.PutDocDirectly(doc1ID, db.Body{"key": "val1"})
+		doc1Version := rt.PutDoc(doc1ID, `{"key": "val1"}`)
 		_ = btcRunner.WaitForVersion(btc.id, doc1ID, doc1Version)
 
 		activeReplStat := rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplActiveContinuous
@@ -2972,7 +2972,7 @@ func TestUnsubChanges(t *testing.T) {
 		base.RequireWaitForStat(t, activeReplStat.Value, 0)
 
 		// Confirm no more changes are being sent
-		doc2Version := rt.PutDocDirectly(doc2ID, db.Body{"key": "val1"})
+		doc2Version := rt.PutDoc(doc2ID, `{"key": "val1"}`)
 		err := rt.WaitForConditionWithOptions(func() bool {
 			_, found := btcRunner.GetVersion(btc.id, "doc2", doc2Version)
 			return found
@@ -3145,7 +3145,7 @@ func TestBlipRefreshUser(t *testing.T) {
 		// add chan1 explicitly
 		rt.CreateUser(username, []string{"chan1"})
 
-		version := rt.PutDocDirectly(docID, db.Body{"channels": []string{"chan1"}})
+		version := rt.PutDoc(docID, `{"channels": []string{"chan1"}}`)
 
 		// Start a regular one-shot pull
 		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Continuous: true, Since: "0"})
@@ -3199,8 +3199,8 @@ func TestImportInvalidSyncGetsNoRev(t *testing.T) {
 			Channels:               []string{"ABC"},
 		})
 		defer btc.Close()
-		version := rt.PutDocDirectly(docID, JsonToMap(t, `{"some":"data", "channels":["ABC"]}`))
-		version2 := rt.PutDocDirectly(docID2, JsonToMap(t, `{"some":"data", "channels":["ABC"]}`))
+		version := rt.PutDoc(docID, `{"some":"data", "channels":["ABC"]}`)
+		version2 := rt.PutDoc(docID2, `{"some":"data", "channels":["ABC"]}`)
 		rt.WaitForPendingChanges()
 
 		// get changes resident in channel cache

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -246,7 +246,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 		// Create doc1 rev 1-77d9041e49931ceef58a1eef5fd032e8 on SG with an attachment
 		bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
 		// put doc directly needs to be here
-		version1 := rt.PutDocDirectly(docID, JsonToMap(t, bodyText))
+		version1 := rt.PutDoc(docID, bodyText)
 		data := btcRunner.WaitForVersion(btc.id, docID, version1)
 		bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
 		require.JSONEq(t, bodyTextExpected, string(data))
@@ -309,13 +309,13 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-		version := rt.PutDocDirectly(doc1ID, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`))
+		version := rt.PutDoc(doc1ID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
 		data := btcRunner.WaitForVersion(client.id, doc1ID, version)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
 		// create doc1 rev 2-10000d5ec533b29b117e60274b1e3653 on SG with the first attachment
-		version2 := rt.UpdateDocDirectly(doc1ID, version, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`))
+		version2 := rt.UpdateDoc(doc1ID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
 
 		data = btcRunner.WaitForVersion(client.id, doc1ID, version2)
 		require.Equal(t, db.AttachmentMap{
@@ -408,13 +408,13 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-		version := rt.PutDocDirectly(docID, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`))
+		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
 		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-		version2 := rt.UpdateDocDirectly(docID, version, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 1234567890123}]}`))
+		version2 := rt.UpdateDoc(docID, version, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 1234567890123}]}`)
 
 		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":1234567890123}]}`, string(data))
@@ -476,7 +476,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 
 		docID := "doc1"
 		// create doc1 rev 1
-		docVersion1 := rt.PutDocDirectly(docID, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`))
+		docVersion1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
 		deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 
@@ -497,7 +497,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
 		// create doc1 rev 2
-		docVersion2 := rt.UpdateDocDirectly(docID, docVersion1, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 1234567890123}]}`))
+		docVersion2 := rt.UpdateDoc(docID, docVersion1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 1234567890123}]}`)
 
 		data = btcRunner.WaitForVersion(client.id, docID, docVersion2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":1234567890123}]}`, string(data))
@@ -562,14 +562,14 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-1513b53e2738671e634d9dd111f48de0
-		version := rt.PutDocDirectly(docID, JsonToMap(t, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`))
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Contains(t, string(data), `"channels":["public"]`)
 		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
 		// create doc1 rev 2-ff91e11bc1fd12bbb4815a06571859a9
-		version = rt.UpdateDocDirectly(docID, version, JsonToMap(t, `{"channels": ["private"], "greetings": [{"hello": "world!"}, {"hi": "bob"}]}`))
+		version = rt.UpdateDoc(docID, version, `{"channels": ["private"], "greetings": [{"hello": "world!"}, {"hi": "bob"}]}`)
 
 		data = btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"_removed":true}`, string(data))
@@ -637,13 +637,13 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 
 		const docID = "doc1"
 		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
-		version := rt.PutDocDirectly(docID, JsonToMap(t, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`))
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Contains(t, string(data), `"channels":["public"]`)
 		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
 		// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
-		version = rt.DeleteDocDirectly(docID, version)
+		version = rt.DeleteDoc(docID, version)
 
 		data = btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{}`, string(data))
@@ -739,7 +739,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		btcRunner.StartPull(client1.id)
 
 		// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
-		version := rt.PutDocDirectly(docID, JsonToMap(t, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`))
+		version := rt.PutDoc(docID, `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)
 
 		data := btcRunner.WaitForVersion(client1.id, docID, version)
 		assert.Contains(t, string(data), `"channels":["public"]`)
@@ -752,7 +752,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		assert.Contains(t, string(data), `"greetings":[{"hello":"world!"}]`)
 
 		// tombstone doc1 at rev 2-2db70833630b396ef98a3ec75b3e90fc
-		version = rt.DeleteDocDirectly(docID, version)
+		version = rt.DeleteDoc(docID, version)
 
 		data = btcRunner.WaitForVersion(client1.id, docID, version)
 		assert.Equal(t, `{}`, string(data))
@@ -858,7 +858,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-		version1 := rt.PutDocDirectly(docID, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`))
+		version1 := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
 		data := btcRunner.WaitForVersion(client.id, docID, version1)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
@@ -873,7 +873,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
 		// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-		version2 := rt.UpdateDocDirectly(docID, version1, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`))
+		version2 := rt.UpdateDoc(docID, version1, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`)
 
 		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
@@ -966,7 +966,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-		version := rt.PutDocDirectly(docID, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`))
+		version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 
 		data := btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
@@ -1011,7 +1011,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{"howdy": "bob"}, greetings[2])
 
 		// tombstone doc1 (gets rev 3-f3be6c85e0362153005dae6f08fc68bb)
-		deletedVersion := rt.DeleteDocDirectly(docID, newRev)
+		deletedVersion := rt.DeleteDoc(docID, newRev)
 
 		data = btcRunner.WaitForVersion(client.id, docID, deletedVersion)
 		assert.Equal(t, `{}`, string(data))
@@ -1100,7 +1100,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		var body db.Body
 		require.NoError(t, base.JSONUnmarshal([]byte(rawBody), &body))
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
-		version1 := rt.PutDocDirectly(docID, body)
+		version1 := rt.PutDoc(docID, rawBody)
 
 		data := btcRunner.WaitForVersion(client.id, docID, version1)
 		assert.Equal(t, rawBody, string(data))

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +50,7 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 		btcRunner.StartPull(client.id)
 
 		// create doc1 on SG and wait to replicate to client
-		versionDoc1 := rt.PutDocDirectly(docID, JsonToMap(t, `{"test": "value"}`))
+		versionDoc1 := rt.PutDoc(docID, `{"test": "value"}`)
 		btcRunner.WaitForVersion(client.id, docID, versionDoc1)
 
 		// alter sync data of this doc to artificially create skipped sequences
@@ -77,11 +76,11 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 		}, time.Second*10, time.Millisecond*100)
 
 		// assert new change added still replicates to client
-		versionDoc2 := rt.PutDocDirectly(docID2, JsonToMap(t, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`))
+		versionDoc2 := rt.PutDoc(docID2, `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
 		btcRunner.WaitForVersion(client.id, docID2, versionDoc2)
 
 		// update doc1 that will trigger unused seq release to clear skipped and assert that update is received
-		versionDoc1 = rt.UpdateDocDirectly(docID, versionDoc1, JsonToMap(t, `{"test": "new value"}`))
+		versionDoc1 = rt.UpdateDoc(docID, versionDoc1, `{"test": "new value"}`)
 		btcRunner.WaitForVersion(client.id, docID, versionDoc1)
 
 		// assert skipped is cleared and skipped sequence broadcast is not sent
@@ -117,12 +116,12 @@ func TestBlipClientPushAndPullReplication(t *testing.T) {
 		btcRunner.StartPush(client.id)
 
 		// create doc1 on SG
-		docBody := db.Body{"greetings": []map[string]interface{}{{"hello": "world!"}, {"hi": "alice"}}}
-		version := rt.PutDocDirectly(docID, docBody)
+		docBody := `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`
+		version := rt.PutDoc(docID, docBody)
 
 		// wait for doc on client
 		data := btcRunner.WaitForVersion(client.id, docID, version)
-		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
+		assert.Equal(t, docBody, string(data))
 
 		// update doc1 on client
 		newRev := btcRunner.AddRev(client.id, docID, &version, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -259,7 +259,7 @@ func TestProcessLegacyRev(t *testing.T) {
 	collection, _ := rt.GetSingleTestDatabaseCollection()
 
 	// add doc to SGW
-	docVersion := rt.PutDocDirectly("doc1", db.Body{"test": "doc"})
+	docVersion := rt.PutDoc("doc1", `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
 	// Send another rev of same doc
@@ -329,7 +329,7 @@ func TestProcessRevWithLegacyHistory(t *testing.T) {
 	)
 
 	// 1. CBL sends rev=1010@CBL1, history=1-abc when SGW has current rev 1-abc (document underwent an update before being pushed to SGW)
-	docVersion := rt.PutDocDirectly(docID, db.Body{"test": "doc"})
+	docVersion := rt.PutDoc(docID, `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
 	// remove hlv here to simulate a legacy rev
@@ -349,7 +349,7 @@ func TestProcessRevWithLegacyHistory(t *testing.T) {
 	assert.NotNil(t, bucketDoc.History[rev1ID])
 
 	// 2. CBL sends rev=1010@CBL1, history=1000@CBL2,1-abc when SGW has current rev 1-abc (document underwent multiple p2p updates before being pushed to SGW)
-	docVersion = rt.PutDocDirectly(docID2, db.Body{"test": "doc"})
+	docVersion = rt.PutDoc(docID2, `{"test": "doc"}`)
 	rev1ID = docVersion.RevTreeID
 
 	// remove hlv here to simulate a legacy rev
@@ -370,7 +370,7 @@ func TestProcessRevWithLegacyHistory(t *testing.T) {
 	assert.NotNil(t, bucketDoc.History[rev1ID])
 
 	// 3. CBL sends rev=1010@CBL1, history=1000@CBL2,2-abc,1-abc when SGW has current rev 1-abc (document underwent multiple legacy and p2p updates before being pushed to SGW)
-	docVersion = rt.PutDocDirectly(docID3, db.Body{"test": "doc"})
+	docVersion = rt.PutDoc(docID3, `{"test": "doc"}`)
 	rev1ID = docVersion.RevTreeID
 
 	// remove hlv here to simulate a legacy rev
@@ -405,9 +405,9 @@ func TestProcessRevWithLegacyHistory(t *testing.T) {
 
 	// 5. CBL sends rev=1010@CBL1, history=2-abc and SGW has 1000@CBL2, 2-abc
 	// although HLV's are in conflict, this should pass conflict check as local current rev is parent of incoming rev
-	docVersion = rt.PutDocDirectly(docID5, db.Body{"test": "doc"})
+	docVersion = rt.PutDoc(docID5, `{"test": "doc"}`)
 
-	docVersion = rt.UpdateDocDirectly(docID5, docVersion, db.Body{"some": "update"})
+	docVersion = rt.UpdateDoc(docID5, docVersion, `{"some": "update"}`)
 	version := docVersion.CV.Value
 	rev2ID := docVersion.RevTreeID
 	pushedRev := db.Version{
@@ -433,7 +433,7 @@ func TestProcessRevWithLegacyHistory(t *testing.T) {
 	// - a pre 4.0 client pulling this doc on one shot replication
 	// - then this doc being updated a couple of times on client before client gets upgraded to 4.0
 	// - after the upgrade client updates it again and pushes to SGW
-	docVersion = rt.PutDocDirectly(docID6, db.Body{"test": "doc"})
+	docVersion = rt.PutDoc(docID6, `{"test": "doc"}`)
 	rev1ID = docVersion.RevTreeID
 
 	pushedRev = db.Version{
@@ -480,13 +480,13 @@ func TestProcessRevWithLegacyHistoryConflict(t *testing.T) {
 	)
 
 	// 1. conflicting changes with legacy rev on both sides of communication (no upgrade of doc at all)
-	docVersion := rt.PutDocDirectly(docID, db.Body{"test": "doc"})
+	docVersion := rt.PutDoc(docID, `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly(docID, docVersion, db.Body{"some": "update"})
+	docVersion = rt.UpdateDoc(docID, docVersion, `{"some": "update"}`)
 	rev2ID := docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly(docID, docVersion, db.Body{"some": "update2"})
+	docVersion = rt.UpdateDoc(docID, docVersion, `{"some": "update2"}`)
 
 	// remove hlv here to simulate a legacy rev
 	require.NoError(t, ds.RemoveXattrs(base.TestCtx(t), docID, []string{base.VvXattrName}, docVersion.CV.Value))
@@ -498,13 +498,13 @@ func TestProcessRevWithLegacyHistoryConflict(t *testing.T) {
 	require.ErrorContains(t, err, "Document revision conflict")
 
 	// 2. same as above but not having the rev be legacy on SGW side (don't remove the hlv)
-	docVersion = rt.PutDocDirectly(docID2, db.Body{"test": "doc"})
+	docVersion = rt.PutDoc(docID2, `{"test": "doc"}`)
 	rev1ID = docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly(docID2, docVersion, db.Body{"some": "update"})
+	docVersion = rt.UpdateDoc(docID2, docVersion, `{"some": "update"}`)
 	rev2ID = docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly(docID2, docVersion, db.Body{"some": "update2"})
+	docVersion = rt.UpdateDoc(docID2, docVersion, `{"some": "update2"}`)
 
 	history = []string{rev2ID, rev1ID}
 	sent, _, _, err = bt.SendRevWithHistory(docID2, "3-abc", history, []byte(`{"key": "val"}`), blip.Properties{})
@@ -512,10 +512,10 @@ func TestProcessRevWithLegacyHistoryConflict(t *testing.T) {
 	require.ErrorContains(t, err, "Document revision conflict")
 
 	// 3. CBL sends rev=1010@CBL1, history=1000@CBL2,1-abc when SGW has current rev 2-abc (document underwent multiple p2p updates before being pushed to SGW)
-	docVersion = rt.PutDocDirectly(docID3, db.Body{"test": "doc"})
+	docVersion = rt.PutDoc(docID3, `{"test": "doc"}`)
 	rev1ID = docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly(docID3, docVersion, db.Body{"some": "update"})
+	docVersion = rt.UpdateDoc(docID3, docVersion, `{"some": "update"}`)
 
 	// remove hlv here to simulate a legacy rev
 	require.NoError(t, ds.RemoveXattrs(base.TestCtx(t), docID3, []string{base.VvXattrName}, docVersion.CV.Value))
@@ -545,10 +545,10 @@ func TestChangesResponseLegacyRev(t *testing.T) {
 	defer bt.Close()
 	rt := bt.restTester
 
-	docVersion := rt.PutDocDirectly("doc1", db.Body{"test": "doc"})
+	docVersion := rt.PutDoc("doc1", `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
-	docVersion2 := rt.UpdateDocDirectly("doc1", docVersion, db.Body{"test": "update"})
+	docVersion2 := rt.UpdateDoc("doc1", docVersion, `{"test": "update"}`)
 	// wait for pending change to avoid flakes where changes feed didn't pick up this change
 	rt.WaitForPendingChanges()
 	receivedChangesRequestWg := sync.WaitGroup{}
@@ -646,7 +646,7 @@ func TestChangesResponseWithHLVInHistory(t *testing.T) {
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 
-	docVersion := rt.PutDocDirectly("doc1", db.Body{"test": "doc"})
+	docVersion := rt.PutDoc("doc1", `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
 	newDoc, _, err := collection.GetDocWithXattrs(ctx, "doc1", db.DocUnmarshalAll)
@@ -753,7 +753,7 @@ func TestCBLHasPreUpgradeMutationThatHasNotBeenReplicated(t *testing.T) {
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 	ds := rt.GetSingleDataStore()
 
-	docVersion := rt.PutDocDirectly("doc1", db.Body{"test": "doc"})
+	docVersion := rt.PutDoc("doc1", `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
 	// remove hlv here to simulate a legacy rev
@@ -790,10 +790,10 @@ func TestCBLHasOfPreUpgradeMutationThatSGWAlreadyKnows(t *testing.T) {
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 	ds := rt.GetSingleDataStore()
 
-	docVersion := rt.PutDocDirectly("doc1", db.Body{"test": "doc"})
+	docVersion := rt.PutDoc("doc1", `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly("doc1", docVersion, db.Body{"test": "update"})
+	docVersion = rt.UpdateDoc("doc1", docVersion, `{"test": "update"}`)
 	rev2ID := docVersion.RevTreeID
 
 	// remove hlv here to simulate a legacy rev
@@ -829,10 +829,10 @@ func TestPushOfPostUpgradeMutationThatHasCommonAncestorToSGWVersion(t *testing.T
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 	ds := rt.GetSingleDataStore()
 
-	docVersion := rt.PutDocDirectly("doc1", db.Body{"test": "doc"})
+	docVersion := rt.PutDoc("doc1", `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly("doc1", docVersion, db.Body{"test": "update"})
+	docVersion = rt.UpdateDoc("doc1", docVersion, `{"test": "update"}`)
 	rev2ID := docVersion.RevTreeID
 
 	// remove hlv here to simulate a legacy rev
@@ -868,13 +868,13 @@ func TestPushDocConflictBetweenPreUpgradeCBLMutationAndPreUpgradeSGWMutation(t *
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 	ds := rt.GetSingleDataStore()
 
-	docVersion := rt.PutDocDirectly("doc1", db.Body{"test": "doc"})
+	docVersion := rt.PutDoc("doc1", `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly("doc1", docVersion, db.Body{"test": "update"})
+	docVersion = rt.UpdateDoc("doc1", docVersion, `{"test": "update"}`)
 	rev2ID := docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly("doc1", docVersion, db.Body{"test": "update1"})
+	docVersion = rt.UpdateDoc("doc1", docVersion, `{"test": "update1"}`)
 	rev3ID := docVersion.RevTreeID
 
 	// remove hlv here to simulate a legacy rev
@@ -910,13 +910,13 @@ func TestPushDocConflictBetweenPreUpgradeCBLMutationAndPostUpgradeSGWMutation(t 
 	rt := bt.restTester
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 
-	docVersion := rt.PutDocDirectly("doc1", db.Body{"test": "doc"})
+	docVersion := rt.PutDoc("doc1", `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly("doc1", docVersion, db.Body{"test": "update"})
+	docVersion = rt.UpdateDoc("doc1", docVersion, `{"test": "update"}`)
 	rev2ID := docVersion.RevTreeID
 
-	docVersion = rt.UpdateDocDirectly("doc1", docVersion, db.Body{"test": "update1"})
+	docVersion = rt.UpdateDoc("doc1", docVersion, `{"test": "update1"}`)
 	rev3ID := docVersion.RevTreeID
 
 	// send rev 3-def
@@ -954,7 +954,7 @@ func TestConflictBetweenPostUpgradeCBLMutationAndPostUpgradeSGWMutation(t *testi
 		docID2 = "doc2"
 	)
 
-	docVersion := rt.PutDocDirectly(docID, db.Body{"test": "doc"})
+	docVersion := rt.PutDoc(docID, `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
 	history := []string{rev1ID}
@@ -970,7 +970,7 @@ func TestConflictBetweenPostUpgradeCBLMutationAndPostUpgradeSGWMutation(t *testi
 	assert.Equal(t, docVersion.CV.Value, bucketDoc.HLV.PreviousVersions[docVersion.CV.SourceID])
 
 	// conflict rev
-	docVersion = rt.PutDocDirectly(docID2, db.Body{"some": "doc"})
+	docVersion = rt.PutDoc(docID2, `{"some": "doc"}`)
 	rev1ID = docVersion.RevTreeID
 
 	history = []string{"1-abc"}
@@ -998,7 +998,7 @@ func TestLegacyRevNotInConflict(t *testing.T) {
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 	const docID = "doc1"
 
-	docVersion := rt.PutDocDirectly(docID, db.Body{"test": "doc"})
+	docVersion := rt.PutDoc(docID, `{"test": "doc"}`)
 	rev1ID := docVersion.RevTreeID
 
 	// have two history entries, 1 rev from a different CBL and 1 legacy rev, should generate conflict

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -75,7 +75,13 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	resp = BootstrapAdminRequest(t, sc, http.MethodGet, "/db1/doc1", ``)
 	resp.RequireStatus(http.StatusNotFound)
 	resp = BootstrapAdminRequest(t, sc, http.MethodPut, "/db1/doc1", `{"foo":"bar"}`)
-	resp.RequireResponse(http.StatusCreated, `{"id":"doc1","ok":true,"rev":"1-cd809becc169215072fd567eebd8b8de"}`)
+	resp.RequireStatus(http.StatusCreated)
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal([]byte(resp.Body), &body))
+	// check for CV existence, but delete it since the value wil differ each time
+	require.Contains(t, body, "cv")
+	delete(body, "cv")
+	require.Equal(t, db.Body{"id": "doc1", "ok": true, "rev": "1-cd809becc169215072fd567eebd8b8de"}, body)
 	resp = BootstrapAdminRequest(t, sc, http.MethodGet, "/db1/doc1", ``)
 	resp.RequireStatus(http.StatusOK)
 	assert.Contains(t, resp.Body, `"foo":"bar"`)

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1809,7 +1809,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 			"type":     "pruned",
 			"channels": []string{"gamma"},
 		}
-		docVersion := rt.UpdateDocDirectly("doc_pruned", db.DocVersion{RevTreeID: revid}, body)
+		docVersion := rt.UpdateDoc("doc_pruned", db.DocVersion{RevTreeID: revid}, string(base.MustJSONMarshal(t, body)))
 		revid = docVersion.RevTreeID
 		cvs = append(cvs, docVersion.CV.String())
 	}

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -395,6 +395,7 @@ func (h *handler) handlePutAttachment() error {
 	}
 	h.setEtag(newRev)
 
+	// CBG-4751: add tests for CV
 	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`","cv":"`+doc.HLV.GetCurrentVersionString()+`"}`))
 	return nil
 }
@@ -532,7 +533,7 @@ func (h *handler) handlePutDoc() error {
 			return err
 		}
 	}
-	// FIXME: TestConcurrentNewEditsFalse does not always have a doc populated
+	// doc is nil if document already exists, and CV is empty. Consider fixing in CBG-4751 to return current HLV. CBG-4751 will add tests.
 	if doc == nil {
 		h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
 	} else {
@@ -677,6 +678,7 @@ func (h *handler) handleDeleteDoc() error {
 	}
 	newRev, doc, err := h.collection.DeleteDoc(h.ctx(), docid, revid)
 	if err == nil {
+		// CBG-4751: should add tests for CV
 		h.writeRawJSONStatus(http.StatusOK, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`","cv":"`+doc.HLV.GetCurrentVersionString()+`"}`))
 	}
 	return err

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -180,7 +180,8 @@ func TestGetDocWithCV(t *testing.T) {
 	defer rt.Close()
 
 	docID := "doc1"
-	docVersion := rt.PutDocDirectly(docID, db.Body{"foo": "bar"})
+	docVersion := rt.PutDoc(docID, `{"foo": "bar"}`)
+	require.NotEmpty(t, docVersion.CV)
 	testCases := []struct {
 		name      string
 		url       string
@@ -231,8 +232,8 @@ func TestBulkGetWithCV(t *testing.T) {
 
 	doc1ID := "doc1"
 	doc2ID := "doc2"
-	doc1Version := rt.PutDocDirectly(doc1ID, db.Body{"foo": "bar"})
-	doc2Version := rt.PutDocDirectly(doc2ID, db.Body{"foo": "baz"})
+	doc1Version := rt.PutDoc(doc1ID, `{"foo": "bar"}`)
+	doc2Version := rt.PutDoc(doc2ID, `{"foo": "baz"}`)
 	testCases := []struct {
 		name   string
 		url    string

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -208,12 +208,12 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 
 	// 1. Create revision with history
 	docID := t.Name()
-	version := rt.PutDocDirectly(docID, rest.JsonToMap(t, `{"val":-1}`))
+	version := rt.PutDoc(docID, `{"val":-1}`)
 	cv := version.CV.String()
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
 	for i := 0; i < 10; i++ {
-		version = rt.UpdateDocDirectly(docID, version, rest.JsonToMap(t, fmt.Sprintf(`{"val":%d}`, i)))
+		version = rt.UpdateDoc(docID, version, fmt.Sprintf(`{"val":%d}`, i))
 		// Purge old revision JSON to simulate expiry, and to verify import doesn't attempt multiple retrievals
 		// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 		cvHash := base.Crc32cHashString([]byte(cv))

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -3751,7 +3751,6 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 //   - Deletes the document in rt2, and waits for the tombstone to get to rt1.
 func TestActiveReplicatorPullTombstone(t *testing.T) {
-	t.Skip("TEMP")
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2224,7 +2224,7 @@ func TestRevocationMessage(t *testing.T) {
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
-		version := rt.PutDocDirectly("doc", db.Body{"channels": "A"})
+		version := rt.PutDoc("doc", `{"channels": "A"}`)
 
 		// Start pull
 		rt.WaitForPendingChanges()
@@ -2237,10 +2237,10 @@ func TestRevocationMessage(t *testing.T) {
 		revocationTester.removeRole("user", "foo")
 
 		const doc1ID = "doc1"
-		version = rt.PutDocDirectly(doc1ID, db.Body{"channels": "!"})
+		version = rt.PutDoc(doc1ID, `{"channels": "!"}`)
 
 		revocationTester.fillToSeq(10)
-		version = rt.UpdateDocDirectly(doc1ID, version, db.Body{})
+		version = rt.UpdateDoc(doc1ID, version, `{}`)
 
 		// Start a pull since 5 to receive revocation and removal
 		rt.WaitForPendingChanges()
@@ -2335,7 +2335,7 @@ func TestRevocationNoRev(t *testing.T) {
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
 
-		version := rt.PutDocDirectly(docID, db.Body{"channels": "A"})
+		version := rt.PutDoc(docID, `{"channels": "A"}`)
 		rt.WaitForPendingChanges()
 		firstOneShotSinceSeq := rt.GetDocumentSequence("doc")
 
@@ -2348,9 +2348,9 @@ func TestRevocationNoRev(t *testing.T) {
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
 
-		_ = rt.UpdateDocDirectly(docID, version, db.Body{"channels": "A", "val": "mutate"})
+		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
-		waitMarkerVersion := rt.PutDocDirectly(waitMarkerID, db.Body{"channels": "!"})
+		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
 		rt.WaitForPendingChanges()
 
 		lastSeqStr := strconv.FormatUint(firstOneShotSinceSeq, 10)
@@ -2416,7 +2416,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 		// Skip to seq 4 and then create doc in channel A
 		revocationTester.fillToSeq(4)
-		version := rt.PutDocDirectly(docID, db.Body{"channels": "A"})
+		version := rt.PutDoc(docID, `{"channels": "A"}`)
 
 		// OneShot pull to grab doc
 		rt.WaitForPendingChanges()
@@ -2430,9 +2430,9 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")
 
-		_ = rt.UpdateDocDirectly(docID, version, db.Body{"channels": "A", "val": "mutate"})
+		_ = rt.UpdateDoc(docID, version, `{"channels": "A", "val": "mutate"}`)
 
-		waitMarkerVersion := rt.PutDocDirectly(waitMarkerID, db.Body{"channels": "!"})
+		waitMarkerVersion := rt.PutDoc(waitMarkerID, `{"channels": "!"}`)
 		rt.WaitForPendingChanges()
 
 		rt.WaitForPendingChanges()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2420,11 +2420,15 @@ func DocVersionFromPutResponse(t testing.TB, response *TestResponse) DocVersion 
 	var r struct {
 		DocID *string `json:"id"`
 		RevID *string `json:"rev"`
+		CV    *string `json:"cv"`
 	}
 	require.NoError(t, json.Unmarshal(response.BodyBytes(), &r))
 	require.NotNil(t, r.RevID, "expecting non-nil rev ID from response: %s", string(response.BodyBytes()))
 	require.NotEqual(t, "", *r.RevID, "expecting non-empty rev ID from response: %s", string(response.BodyBytes()))
-	return DocVersion{RevTreeID: *r.RevID}
+	require.NotNil(t, r.CV, "expecting non-nil conflict vector from response: %s", string(response.BodyBytes()))
+	cv, err := db.ParseVersion(*r.CV)
+	require.NoError(t, err, "invalid CV from response: %s", string(response.BodyBytes()))
+	return DocVersion{RevTreeID: *r.RevID, CV: cv}
 }
 
 func MarshalConfig(t *testing.T, config db.ReplicationConfig) string {


### PR DESCRIPTION
CBG-3778 remove rt.*Directly functions

- change the REST functions to add CV property. Add ticket to write tests.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3247/ (known flakes)
