### PR TITLE
CBG-4753: Add `version_type` preference for `/_changes` to allow CV-aware consumers

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -534,7 +534,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
 		ID:           "doc-1",
-		Changes:      []ChangeRev{{"rev": "1-a"}},
+		Changes:      []ChangeByVersionType{{"rev": "1-a"}},
 		collectionID: collectionID}, changes[0])
 
 	lastSeq := changes[len(changes)-1].Seq
@@ -568,7 +568,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 	assert.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 3, LowSeq: 3},
 		ID:           "doc-3",
-		Changes:      []ChangeRev{{"rev": "1-a"}},
+		Changes:      []ChangeByVersionType{{"rev": "1-a"}},
 		collectionID: collectionID,
 	}, changes[0])
 
@@ -722,7 +722,7 @@ func TestLowSequenceHandling(t *testing.T) {
 	require.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
 		ID:           "doc-1",
-		Changes:      []ChangeRev{{"rev": "1-a"}},
+		Changes:      []ChangeByVersionType{{"rev": "1-a"}},
 		collectionID: collectionID}, changes[0])
 
 	// Test backfill clear - sequence numbers go back to standard handling

--- a/db/changes.go
+++ b/db/changes.go
@@ -181,7 +181,6 @@ func (db *DatabaseCollectionWithUser) AddDocToChangeEntryUsingRevCache(ctx conte
 	if err != nil {
 		return err
 	}
-	// TODO: Stamp CV?
 	entry.Doc, err = rev.As1xBytes(ctx, db, nil, nil, false)
 	return err
 }

--- a/db/changes.go
+++ b/db/changes.go
@@ -1366,9 +1366,9 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 
 	switch options.VersionType {
 	case ChangesVersionTypeCV:
-		row.Changes = []ChangeByVersionType{{options.VersionType: populatedDoc.HLV.GetCurrentVersionString()}}
+		row.Changes = []ChangeByVersionType{{ChangesVersionTypeCV: populatedDoc.HLV.GetCurrentVersionString()}}
 	case "", ChangesVersionTypeRevTreeID:
-		row.Changes = []ChangeByVersionType{{options.VersionType: populatedDoc.CurrentRev}}
+		row.Changes = []ChangeByVersionType{{ChangesVersionTypeRevTreeID: populatedDoc.CurrentRev}}
 	default:
 		base.AssertfCtx(ctx, "createChangeEntry called with an unsupported VersionType: %s", options.VersionType)
 	}

--- a/db/changes.go
+++ b/db/changes.go
@@ -1364,14 +1364,13 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 		return nil
 	}
 
-	row.Changes = []ChangeByVersionType{{ChangesVersionTypeRevTreeID: populatedDoc.CurrentRev}}
 	switch options.VersionType {
 	case ChangesVersionTypeCV:
-		row.Changes[0] = ChangeByVersionType{options.VersionType: populatedDoc.HLV.GetCurrentVersionString()}
-	case ChangesVersionTypeRevTreeID:
-		fallthrough
+		row.Changes = []ChangeByVersionType{{options.VersionType: populatedDoc.HLV.GetCurrentVersionString()}}
+	case "", ChangesVersionTypeRevTreeID:
+		row.Changes = []ChangeByVersionType{{options.VersionType: populatedDoc.CurrentRev}}
 	default:
-		// already initialized with a 'rev' change entry above
+		base.AssertfCtx(ctx, "createChangeEntry called with an unsupported VersionType: %s", options.VersionType)
 	}
 
 	row.Deleted = populatedDoc.Deleted

--- a/db/changes.go
+++ b/db/changes.go
@@ -51,6 +51,8 @@ const (
 	ChangesVersionTypeCV        ChangesVersionType = "cv"  // Use current version in changes feed entries
 )
 
+// ParseChangesVersionType parses a string into a ChangesVersionType.
+// If "" is passed, it defaults to ChangesVersionTypeRevTreeID as a default fallback.
 func ParseChangesVersionType(s string) (ChangesVersionType, error) {
 	switch ChangesVersionType(s) {
 	case "", ChangesVersionTypeRevTreeID:

--- a/db/changes.go
+++ b/db/changes.go
@@ -1370,7 +1370,7 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 	case "", ChangesVersionTypeRevTreeID:
 		row.Changes = []ChangeByVersionType{{ChangesVersionTypeRevTreeID: populatedDoc.CurrentRev}}
 	default:
-		base.AssertfCtx(ctx, "createChangeEntry called with an unsupported VersionType: %s", options.VersionType)
+		base.AssertfCtx(ctx, "createChangeEntry called with an unsupported VersionType: %q", options.VersionType)
 	}
 
 	row.Deleted = populatedDoc.Deleted
@@ -1424,7 +1424,7 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 
 func (options ChangesOptions) String() string {
 	return fmt.Sprintf(
-		`{Since: %s, Limit: %d, Conflicts: %t, IncludeDocs: %t, Wait: %t, Continuous: %t, HeartbeatMs: %d, TimeoutMs: %d, ActiveOnly: %t, Revocations: %t, RequestPlusSeq: %d, VersionType: %s}`,
+		`{Since: %s, Limit: %d, Conflicts: %t, IncludeDocs: %t, Wait: %t, Continuous: %t, HeartbeatMs: %d, TimeoutMs: %d, ActiveOnly: %t, Revocations: %t, RequestPlusSeq: %d, VersionType: %q}`,
 		options.Since,
 		options.Limit,
 		options.Conflicts,

--- a/db/changes.go
+++ b/db/changes.go
@@ -204,17 +204,13 @@ func (db *DatabaseCollectionWithUser) AddDocInstanceToChangeEntry(ctx context.Co
 	}
 	if options.IncludeDocs {
 		var err error
-		// TODO: CBG-4776 - fetch by CV
-		if !isLegacyRev(revID) {
-			base.AssertfCtx(ctx, "AddDocInstanceToChangeEntry: got IncludeDocs and a CV - can't fetch doc body yet")
-			return nil
-		}
-
-		entry.Doc, _, err = db.get1xRevFromDoc(ctx, doc, revID, false)
-		db.dbStats().Database().NumDocReadsRest.Add(1)
+		// TODO: CBG-4776 - fetch by CV with sane APIs
+		err = db.AddDocToChangeEntryUsingRevCache(ctx, entry, revID)
 		if err != nil {
-			base.WarnfCtx(ctx, "Changes feed: error getting doc %q/%q: %v", base.UD(doc.ID), revID, err)
+			base.WarnfCtx(ctx, "Changes feed: error getting revision body for %q (%s): %v", base.UD(entry.ID), revID, err)
+			return err
 		}
+		db.dbStats().Database().NumDocReadsRest.Add(1)
 	}
 
 	return nil

--- a/db/changes.go
+++ b/db/changes.go
@@ -1415,8 +1415,7 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 	row.Removed = base.SetFromArray(removedChannels)
 	if options.IncludeDocs || options.Conflicts {
 		if err := db.AddDocInstanceToChangeEntry(ctx, row, populatedDoc, options); err != nil {
-			base.WarnfCtx(ctx, "Unable to add doc instance to change entry for %s: %v", base.UD(docid), err)
-			return nil
+			base.WarnfCtx(ctx, "Unable to add doc instance to change entry for %s: %v - will return metadata only", base.UD(docid), err)
 		}
 	}
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -162,7 +162,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	require.Len(t, changes, 1)
 	assert.Equal(t, "doc2", changes[0].ID)
-	assert.Equal(t, []ChangeRev{{"rev": revid}}, changes[0].Changes)
+	assert.Equal(t, []ChangeByVersionType{{"rev": revid}}, changes[0].Changes)
 
 	// validate from zero
 	changes = getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
@@ -234,7 +234,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	require.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 1},
 		ID:           "alpha",
-		Changes:      []ChangeRev{{"rev": revid}},
+		Changes:      []ChangeByVersionType{{"rev": revid}},
 		collectionID: collectionID}, changes[0])
 
 	lastSeq := getLastSeq(changes)
@@ -279,7 +279,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 		ID:           "alpha",
 		Removed:      base.SetOf("A"),
 		allRemoved:   true,
-		Changes:      []ChangeRev{{"rev": "2-e99405a23fa102238fa8c3fd499b15bc"}},
+		Changes:      []ChangeByVersionType{{"rev": "2-e99405a23fa102238fa8c3fd499b15bc"}},
 		collectionID: collectionID}, changes[0])
 
 	printChanges(changes)
@@ -352,7 +352,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	require.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 1},
 		ID:           "alpha",
-		Changes:      []ChangeRev{{"rev": revid}},
+		Changes:      []ChangeByVersionType{{"rev": revid}},
 		collectionID: collectionID}, changes[0])
 
 	lastSeq := getLastSeq(changes)
@@ -392,7 +392,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	require.Equal(t, &ChangeEntry{
 		Seq:          SequenceID{Seq: 3},
 		ID:           "alpha",
-		Changes:      []ChangeRev{{"rev": "3-e99405a23fa102238fa8c3fd499b15bc"}},
+		Changes:      []ChangeByVersionType{{"rev": "3-e99405a23fa102238fa8c3fd499b15bc"}},
 		collectionID: collectionID}, changes[0])
 
 	printChanges(changes)

--- a/db/crud.go
+++ b/db/crud.go
@@ -361,20 +361,36 @@ func (db *DatabaseCollectionWithUser) Get1xRevBodyWithHistory(ctx context.Contex
 //   - attachmentsSince is nil to return no attachment bodies, otherwise a (possibly empty) list of
 //     revisions for which the client already has attachments and doesn't need bodies. Any attachment
 //     that hasn't changed since one of those revisions will be returned as a stub.
-func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revid string, maxHistory int, historyFrom []string) (revision DocumentRevision, err error) {
-	if revid != "" {
+func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revOrCV string, maxHistory int, historyFrom []string) (DocumentRevision, error) {
+	var (
+		revID *string
+		cv    *Version
+	)
+
+	var (
+		revision DocumentRevision
+		getErr   error
+	)
+	if revOrCV != "" {
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
-		revision, err = db.revisionCache.GetWithRev(ctx, docid, revid, RevCacheOmitDelta)
+		if currentVersion, parseErr := ParseVersion(revOrCV); parseErr != nil {
+			// try as a rev ID
+			revID = &revOrCV
+			revision, getErr = db.revisionCache.GetWithRev(ctx, docid, *revID, RevCacheOmitDelta)
+		} else {
+			cv = &currentVersion
+			revision, getErr = db.revisionCache.GetWithCV(ctx, docid, cv, RevCacheOmitDelta)
+		}
 	} else {
-		// No rev ID given, so load active revision
-		revision, err = db.revisionCache.GetActive(ctx, docid)
+		// No rev given, so load active revision
+		revision, getErr = db.revisionCache.GetActive(ctx, docid)
 	}
-	if err != nil {
-		return DocumentRevision{}, err
+	if getErr != nil {
+		return DocumentRevision{}, getErr
 	}
 
-	return db.documentRevisionForRequest(ctx, docid, revision, &revid, nil, maxHistory, historyFrom)
+	return db.documentRevisionForRequest(ctx, docid, revision, revID, cv, maxHistory, historyFrom)
 }
 
 // documentRevisionForRequest processes the given DocumentRevision and returns a version of it for a given client request, depending on access, deleted, etc.

--- a/db/crud.go
+++ b/db/crud.go
@@ -354,7 +354,7 @@ func (db *DatabaseCollectionWithUser) Get1xRevBodyWithHistory(ctx context.Contex
 
 // Underlying revision retrieval used by Get1xRevBody, Get1xRevBodyWithHistory, GetRevCopy.
 // Returns the revision of a document using the revision cache.
-//   - revid may be "", meaning the current revision.
+//   - revOrCV may be "", meaning the current revision. It can be a RevTree ID or a HLV CV.
 //   - maxHistory is >0 if the caller wants a revision history; it's the max length of the history.
 //   - historyFrom is an optional list of revIDs the client already has. If any of these are found
 //     in the revision's history, it will be trimmed after that revID.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1718,7 +1718,7 @@ func TestConflicts(t *testing.T) {
 	assert.Equal(t, &ChangeEntry{
 		Seq:            SequenceID{Seq: 3},
 		ID:             "doc",
-		Changes:        []ChangeRev{{"rev": "2-b"}, {"rev": "2-a"}},
+		Changes:        []ChangeByVersionType{{"rev": "2-b"}, {"rev": "2-a"}},
 		branched:       true,
 		collectionID:   collectionID,
 		CurrentVersion: &Version{SourceID: source, Value: version},
@@ -1753,7 +1753,7 @@ func TestConflicts(t *testing.T) {
 	assert.Equal(t, &ChangeEntry{
 		Seq:            SequenceID{Seq: 4},
 		ID:             "doc",
-		Changes:        []ChangeRev{{"rev": "2-a"}, {"rev": rev3}},
+		Changes:        []ChangeByVersionType{{"rev": "2-a"}, {"rev": rev3}},
 		branched:       true,
 		collectionID:   collectionID,
 		CurrentVersion: &Version{SourceID: bucketUUID, Value: doc.Cas},

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -241,7 +241,9 @@ func (rev *DocumentRevision) Inject1xBodyProperties(ctx context.Context, db *Dat
 		{Key: BodyRev, Val: rev.RevID},
 	}
 
-	// TODO: Stamp CV if available?
+	if rev.CV != nil {
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyCV, Val: rev.CV.String()})
+	}
 
 	if requestedHistory != nil {
 		kvPairs = append(kvPairs, base.KVPair{Key: BodyRevisions, Val: requestedHistory})

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -241,6 +241,8 @@ func (rev *DocumentRevision) Inject1xBodyProperties(ctx context.Context, db *Dat
 		{Key: BodyRev, Val: rev.RevID},
 	}
 
+	// TODO: Stamp CV if available?
+
 	if requestedHistory != nil {
 		kvPairs = append(kvPairs, base.KVPair{Key: BodyRevisions, Val: requestedHistory})
 	}

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -120,11 +120,11 @@ func parseIntegerSequenceID(str string) (SequenceID, error) {
 			return SequenceID{}, err
 		}
 	} else {
-		return SequenceID{}, base.HTTPErrorf(400, "Invalid sequence")
+		return SequenceID{}, base.HTTPErrorf(400, "Invalid sequence: %q", str)
 	}
 
 	if err != nil {
-		return SequenceID{}, base.HTTPErrorf(400, "Invalid sequence")
+		return SequenceID{}, base.HTTPErrorf(400, "Invalid sequence: %q", str)
 	}
 	return s, nil
 }

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -545,7 +545,7 @@ Changes-feed:
             description: The document ID the change happened on.
             type: string
           changes:
-            description: List of document leafs with each leaf containing only a `rev` field.
+            description: List of document leafs with each leaf containing only a `rev` or `cv` field.
             type: array
             items:
               oneOf:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -549,15 +549,18 @@ Changes-feed:
             type: array
             items:
               type: object
+              minProperties: 1
+              maxProperties: 1
               properties:
                 rev:
-                  description: The new Revision ID that was caused by that change. This is omitted when the `version_type` parameter is `cv`.
+                  description: |
+                    The new Revision ID associated with the change.
+                    This is usually omitted in favour of the `cv` property when the `version_type` preference is set to `cv`,
+                    however data written prior to Sync Gateway 4.0 can still emit `rev` only change entries if we do not have a `cv` available for that document revision.
                   type: string
-                  optional: true
                 cv:
-                  description: The new Current Version that was caused by that change. This is present only when the `version_type` parameter is `cv`.
+                  description: The new Current Version associated with the change. This value requires the `version_type` preference set to `cv`.
                   type: string
-                  optional: true
             uniqueItems: true
       uniqueItems: true
     last_seq:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -548,19 +548,19 @@ Changes-feed:
             description: List of document leafs with each leaf containing only a `rev` field.
             type: array
             items:
-              type: object
-              minProperties: 1
-              maxProperties: 1
-              properties:
-                rev:
-                  description: |
-                    The new Revision ID associated with the change.
-                    This is usually omitted in favour of the `cv` property when the `version_type` preference is set to `cv`,
-                    however data written prior to Sync Gateway 4.0 can still emit `rev` only change entries if we do not have a `cv` available for that document revision.
-                  type: string
-                cv:
-                  description: The new Current Version associated with the change. This value requires the `version_type` preference set to `cv`.
-                  type: string
+              oneOf:
+                - type: object
+                  properties:
+                    rev:
+                      description: The Revision Tree ID associated with the change. This may be returned even when the `version_type` preference is set to `cv` if this document was an old revision written prior to upgrading to SG 4.0+
+                      type: string
+                  title: Revision Tree ID
+                - type: object
+                  properties:
+                    cv:
+                      description: The HLV Current Version associated with the change. This value requires the `version_type` preference set to `cv` and this document revision being written through SG 4.0+
+                      type: string
+                  title: HLV Current Version
             uniqueItems: true
       uniqueItems: true
     last_seq:

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -551,8 +551,13 @@ Changes-feed:
               type: object
               properties:
                 rev:
-                  description: The new revision that was caused by that change.
+                  description: The new Revision ID that was caused by that change. This is omitted when the `version_type` parameter is `cv`.
                   type: string
+                  optional: true
+                cv:
+                  description: The new Current Version that was caused by that change. This is present only when the `version_type` parameter is `cv`.
+                  type: string
+                  optional: true
             uniqueItems: true
       uniqueItems: true
     last_seq:

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -102,6 +102,15 @@ get:
       schema:
         type: boolean
         default: false
+    - name: version_type
+      in: query
+      description: The type of document versioning to use for the changes feed.
+      schema:
+        type: string
+        default: rev
+        enum:
+          - rev
+          - cv
   responses:
     '200':
       $ref: ../../components/responses.yaml#/changes-feed
@@ -166,6 +175,13 @@ post:
               description: 'When true, ensures all valid documents written prior to the request being issued are included in the response.  This is only applicable for non-continuous feeds.'
               type: boolean
               default: false
+            version_type:
+              description: The type of document versioning to use for the changes feed.
+              type: string
+              default: rev
+              enum:
+                - rev
+                - cv
   responses:
     '200':
       $ref: ../../components/responses.yaml#/changes-feed

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -104,7 +104,7 @@ get:
         default: false
     - name: version_type
       in: query
-      description: The type of document versioning to use for the changes feed.
+      description: The preferred type of document versioning to use for the changes feed.
       schema:
         type: string
         default: rev
@@ -176,7 +176,7 @@ post:
               type: boolean
               default: false
             version_type:
-              description: The type of document versioning to use for the changes feed.
+              description: The preferred type of document versioning to use for the changes feed.
               type: string
               default: rev
               enum:

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -111,6 +111,9 @@ get:
         enum:
           - rev
           - cv
+        x-enumDescriptions:
+          rev: 'Revision Tree IDs. For example: 1-293a80ce8f4874724732f27d35b3959a13cd96e0'
+          cv: 'HLV Current Version. For example: 1854e4e557cc0000@zTWkmBiYZgNQo7BHVZrB/Q'
   responses:
     '200':
       $ref: ../../components/responses.yaml#/changes-feed
@@ -182,6 +185,9 @@ post:
               enum:
                 - rev
                 - cv
+              x-enumDescriptions:
+                rev: 'Revision Tree IDs. For example: 1-293a80ce8f4874724732f27d35b3959a13cd96e0'
+                cv: 'HLV Current Version. For example: 1854e4e557cc0000@zTWkmBiYZgNQo7BHVZrB/Q'
   responses:
     '200':
       $ref: ../../components/responses.yaml#/changes-feed

--- a/docs/api/paths/public/keyspace-_changes.yaml
+++ b/docs/api/paths/public/keyspace-_changes.yaml
@@ -81,7 +81,7 @@ get:
         minimum: 0
     - name: feed
       in: query
-      description: 'The type of changes feed to use. '
+      description: 'The type of changes feed to use.'
       schema:
         type: string
         default: normal
@@ -90,6 +90,18 @@ get:
           - longpoll
           - continuous
           - websocket
+    - name: version_type
+      in: query
+      description: 'The preferred type of document versioning to use for the changes feed.'
+      schema:
+        type: string
+        default: rev
+        enum:
+          - rev
+          - cv
+        x-enumDescriptions:
+          rev: 'Revision Tree IDs. For example: 1-293a80ce8f4874724732f27d35b3959a13cd96e0'
+          cv: 'HLV Current Version. For example: 1854e4e557cc0000@zTWkmBiYZgNQo7BHVZrB/Q'
   responses:
     '200':
       $ref: ../../components/responses.yaml#/changes-feed

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2342,7 +2342,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0])
 
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
@@ -2351,7 +2351,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		changes = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0])
 
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
@@ -2362,11 +2362,11 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		changes = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0])
 		assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
 		assert.False(t, changes.Results[0].Revoked)
 		assert.Equal(t, "docmarker", changes.Results[1].ID)
-		RequireChangeRevVersion(t, docMarkerVersion, changes.Results[1].Changes[0])
+		RequireChangeRev(t, docMarkerVersion, changes.Results[1].Changes[0])
 		assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
 		assert.False(t, changes.Results[1].Revoked)
 
@@ -2427,7 +2427,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 		changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0])
 
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
@@ -2438,7 +2438,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		// At this point changes should send revocation, as document isn't in any of the user's channels
 		changes = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRevVersion(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0])
 
 		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Channels: "A", Continuous: false})
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2342,7 +2342,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
-		RequireChangeRev(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
@@ -2351,7 +2351,7 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		changes = rt.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRev(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
@@ -2362,11 +2362,11 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 		changes = rt.WaitForChanges(2, fmt.Sprintf("/{{.keyspace}}/_changes?since=%s&revocations=true", changes.Last_Seq), "user", true)
 		assert.Equal(t, "doc", changes.Results[0].ID)
-		RequireChangeRev(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 		assert.Equal(t, "3-1bc9dd04c8a257ba28a41eaad90d32de", changes.Results[0].Changes[0]["rev"])
 		assert.False(t, changes.Results[0].Revoked)
 		assert.Equal(t, "docmarker", changes.Results[1].ID)
-		RequireChangeRev(t, docMarkerVersion, changes.Results[1].Changes[0])
+		RequireChangeRev(t, docMarkerVersion, changes.Results[1].Changes[0], db.ChangesVersionTypeRevTreeID)
 		assert.Equal(t, "1-999bcad4aab47f0a8a24bd9d3598060c", changes.Results[1].Changes[0]["rev"])
 		assert.False(t, changes.Results[1].Revoked)
 
@@ -2427,7 +2427,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 		changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0&revocations=true", "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRev(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 
 		btcRunner.StartOneshotPull(btc.id)
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)
@@ -2438,7 +2438,7 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 		// At this point changes should send revocation, as document isn't in any of the user's channels
 		changes = rt.WaitForChanges(1, "/{{.keyspace}}/_changes?filter=sync_gateway/bychannel&channels=A&since=0&revocations=true", "user", true)
 		assert.Equal(t, docID, changes.Results[0].ID)
-		RequireChangeRev(t, version, changes.Results[0].Changes[0])
+		RequireChangeRev(t, version, changes.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 
 		btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Channels: "A", Continuous: false})
 		_ = btcRunner.WaitForVersion(btc.id, docID, version)

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -428,7 +428,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 					}
 					_ = encoder.Encode(entry)
 					lastSeq = entry.Seq
-					entry.AuditReadEvent(h.ctx(), options.VersionType)
+					entry.AuditReadEvent(h.ctx())
 				}
 
 			case <-heartbeat:

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -501,7 +501,7 @@ func (h *handler) sendContinuousChangesByHTTP(inChannels base.Set, options db.Ch
 					break
 				}
 
-				change.AuditReadEvent(h.ctx(), options.VersionType)
+				change.AuditReadEvent(h.ctx())
 			}
 		} else {
 			_, err = h.response.Write([]byte("\n"))
@@ -578,7 +578,7 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 				return err
 			}
 			for _, change := range changes {
-				change.AuditReadEvent(h.ctx(), options.VersionType)
+				change.AuditReadEvent(h.ctx())
 			}
 			return err
 		})

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -466,7 +466,7 @@ func TestChangesVersionType(t *testing.T) {
 		changesRequestQueryParams string
 		changesRequestBody        string
 		expectedStatus            int
-		expectedVersionType       string
+		expectedVersionType       db.ChangesVersionType
 		expectedDocs              int
 	}{
 		{
@@ -480,7 +480,7 @@ func TestChangesVersionType(t *testing.T) {
 			changesRequestMethod:      http.MethodGet,
 			changesRequestQueryParams: "",
 			expectedStatus:            http.StatusOK,
-			expectedVersionType:       "rev",
+			expectedVersionType:       db.ChangesVersionTypeRevTreeID,
 			expectedDocs:              2,
 		},
 		{
@@ -488,7 +488,7 @@ func TestChangesVersionType(t *testing.T) {
 			changesRequestMethod:      http.MethodGet,
 			changesRequestQueryParams: "?version_type=rev",
 			expectedStatus:            http.StatusOK,
-			expectedVersionType:       "rev",
+			expectedVersionType:       db.ChangesVersionTypeRevTreeID,
 			expectedDocs:              2,
 		},
 		{
@@ -496,7 +496,7 @@ func TestChangesVersionType(t *testing.T) {
 			changesRequestMethod:      http.MethodGet,
 			changesRequestQueryParams: "?version_type=cv",
 			expectedStatus:            http.StatusOK,
-			expectedVersionType:       "cv",
+			expectedVersionType:       db.ChangesVersionTypeCV,
 			expectedDocs:              2,
 		},
 		{
@@ -504,7 +504,7 @@ func TestChangesVersionType(t *testing.T) {
 			changesRequestMethod:      http.MethodGet,
 			changesRequestQueryParams: "?version_type=rev&filter=_doc_ids&doc_ids=doc1",
 			expectedStatus:            http.StatusOK,
-			expectedVersionType:       "rev",
+			expectedVersionType:       db.ChangesVersionTypeRevTreeID,
 			expectedDocs:              1,
 		},
 		{
@@ -512,7 +512,7 @@ func TestChangesVersionType(t *testing.T) {
 			changesRequestMethod:      http.MethodGet,
 			changesRequestQueryParams: "?version_type=cv&filter=_doc_ids&doc_ids=doc1",
 			expectedStatus:            http.StatusOK,
-			expectedVersionType:       "cv",
+			expectedVersionType:       db.ChangesVersionTypeCV,
 			expectedDocs:              1,
 		},
 		{
@@ -521,7 +521,7 @@ func TestChangesVersionType(t *testing.T) {
 			changesRequestQueryParams: "",
 			changesRequestBody:        `{"version_type":"rev"}`,
 			expectedStatus:            http.StatusOK,
-			expectedVersionType:       "rev",
+			expectedVersionType:       db.ChangesVersionTypeRevTreeID,
 			expectedDocs:              2,
 		},
 		{
@@ -530,7 +530,7 @@ func TestChangesVersionType(t *testing.T) {
 			changesRequestQueryParams: "",
 			changesRequestBody:        `{"version_type":"cv"}`,
 			expectedStatus:            http.StatusOK,
-			expectedVersionType:       "cv",
+			expectedVersionType:       db.ChangesVersionTypeCV,
 			expectedDocs:              2,
 		},
 		{
@@ -539,7 +539,7 @@ func TestChangesVersionType(t *testing.T) {
 			changesRequestQueryParams: "",
 			changesRequestBody:        `{"version_type":"cv", "filter":"_doc_ids", "doc_ids":["doc1"]}`,
 			expectedStatus:            http.StatusOK,
-			expectedVersionType:       "cv",
+			expectedVersionType:       db.ChangesVersionTypeCV,
 			expectedDocs:              1,
 		},
 	}
@@ -563,7 +563,7 @@ func TestChangesVersionType(t *testing.T) {
 				for _, change := range changeEntry.Changes {
 					require.Len(t, change, 1) // ensure only one version type is present
 					// and that it was the expected one (and we have a value)
-					versionValue, ok := change[db.ChangesVersionType(test.expectedVersionType)]
+					versionValue, ok := change[test.expectedVersionType]
 					require.Truef(t, ok, "Expected version type %s, got %v", test.expectedVersionType, change)
 					require.NotEmpty(t, versionValue)
 				}

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -837,6 +837,10 @@ func assertChangeEntryMatches(t *testing.T, expectedChangeEntryString string, re
 		var resultBody db.Body
 		assert.NoError(t, expectedBody.Unmarshal(expectedChange.Doc))
 		assert.NoError(t, resultBody.Unmarshal(result.Doc))
+
+		// strip out _cv - it's not deterministic in tests like _rev is, but also tests really shouldn't be comparing full bodies! It's so brittle...
+		delete(resultBody, db.BodyCV)
+
 		db.AssertEqualBodies(t, expectedBody, resultBody)
 	} else {
 		assert.Equal(t, expectedChange.Doc, result.Doc)
@@ -1893,6 +1897,10 @@ func TestChangesIncludeDocs(t *testing.T) {
 			var resultBody db.Body
 			assert.NoError(t, expectedBody.Unmarshal(expectedChange.Doc))
 			assert.NoError(t, resultBody.Unmarshal(result.Doc))
+
+			// strip out _cv - it's not deterministic in tests like _rev is, but also tests really shouldn't be comparing full bodies! It's so brittle...
+			delete(resultBody, db.BodyCV)
+
 			db.AssertEqualBodies(t, expectedBody, resultBody)
 		} else {
 			assert.Equal(t, expectedChange.Doc, result.Doc)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -4088,7 +4088,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			rest.RequireChangeRev(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
+			rest.RequireChangeRev(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 			t.Logf("Changes response is %+v", changesResults)
 
 			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
@@ -4307,7 +4307,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			// Validate results on the local (rt1)
 			changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", localDoc.Sequence), "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			rest.RequireChangeRev(t, test.expectedVersion, changesResults.Results[0].Changes[0])
+			rest.RequireChangeRev(t, test.expectedVersion, changesResults.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 			t.Logf("Changes response is %+v", changesResults)
 
 			rawDocResponse := rt1.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, "")
@@ -4351,7 +4351,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			}
 			changesResults = rt2.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", rt2Since), "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			rest.RequireChangeRev(t, test.expectedVersion, changesResults.Results[0].Changes[0])
+			rest.RequireChangeRev(t, test.expectedVersion, changesResults.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 			t.Logf("Changes response is %+v", changesResults)
 
 			doc, err = rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
@@ -5922,7 +5922,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			// Should end up as winner under default conflict resolution.
 			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?&since=0", "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			rest.RequireChangeRev(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
+			rest.RequireChangeRev(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0], db.ChangesVersionTypeRevTreeID)
 			t.Logf("Changes response is %+v", changesResults)
 
 			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -4088,7 +4088,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			rest.RequireChangeRevVersion(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
+			rest.RequireChangeRev(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
 			t.Logf("Changes response is %+v", changesResults)
 
 			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
@@ -4307,7 +4307,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			// Validate results on the local (rt1)
 			changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", localDoc.Sequence), "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			rest.RequireChangeRevVersion(t, test.expectedVersion, changesResults.Results[0].Changes[0])
+			rest.RequireChangeRev(t, test.expectedVersion, changesResults.Results[0].Changes[0])
 			t.Logf("Changes response is %+v", changesResults)
 
 			rawDocResponse := rt1.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, "")
@@ -4351,7 +4351,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			}
 			changesResults = rt2.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", rt2Since), "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			rest.RequireChangeRevVersion(t, test.expectedVersion, changesResults.Results[0].Changes[0])
+			rest.RequireChangeRev(t, test.expectedVersion, changesResults.Results[0].Changes[0])
 			t.Logf("Changes response is %+v", changesResults)
 
 			doc, err = rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
@@ -5922,7 +5922,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			// Should end up as winner under default conflict resolution.
 			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?&since=0", "", true)
 			assert.Equal(t, docID, changesResults.Results[0].ID)
-			rest.RequireChangeRevVersion(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
+			rest.RequireChangeRev(t, test.expectedLocalVersion, changesResults.Results[0].Changes[0])
 			t.Logf("Changes response is %+v", changesResults)
 
 			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()


### PR DESCRIPTION
CBG-4753

- Adds a `version_type` option to REST API Changes feeds which has two possible options - `rev` (default) or `cv`
  - This controls whether the change entries preferentially show a revtree ID or current version value to notify clients of a new document change.
  - If old documents do not have a cv (they were written prior to 4.0, we'll still continue to send the `rev` version of the change).
  - This parameter is documented as a preference only, and notes the case where `rev` may still be produced on a feed requesting `cv`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/37/