### PR TITLE
Improve topologytest logging

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -48,7 +48,7 @@ func newRosmarTracker(numBuckets int) *rosmarTracker {
 }
 
 // getNextBucketIdx returns the next available bucket index in a rosmarTracker. This will return the lowest available
-// number starting at 0. If all buckets are in use, it will return an error.
+// number starting at 1. If all buckets are in use, it will return an error.
 func (r *rosmarTracker) GetNextBucketIdx() (int, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -56,7 +56,7 @@ func (r *rosmarTracker) GetNextBucketIdx() (int, error) {
 	for i, active := range r.activeBuckets {
 		if !active {
 			r.activeBuckets[i] = true
-			return i, nil
+			return i + 1, nil
 		}
 	}
 	return 0, fmt.Errorf("no rosmar buckets available, all have been used")
@@ -66,7 +66,7 @@ func (r *rosmarTracker) GetNextBucketIdx() (int, error) {
 func (r *rosmarTracker) ReleaseBucketIdx(idx int) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	r.activeBuckets[idx] = false
+	r.activeBuckets[idx-1] = false
 }
 
 // TestBucketPool is used to manage a pool of pre-prepared buckets for testing purposes.

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -143,6 +143,10 @@ func (v Version) String() string {
 	return strconv.FormatUint(v.Value, 16) + "@" + v.SourceID
 }
 
+func (v Version) GoString() string {
+	return fmt.Sprintf("Version{SourceID:%s, Value:%d}", v.SourceID, v.Value)
+}
+
 // IsEmpty returns true if the version is empty/zero value.
 func (v Version) IsEmpty() bool {
 	return v.SourceID == "" && v.Value == 0
@@ -179,7 +183,7 @@ func NewHybridLogicalVector() *HybridLogicalVector {
 	}
 }
 
-func (hlv *HybridLogicalVector) Equals(other *HybridLogicalVector) bool {
+func (hlv *HybridLogicalVector) Equal(other *HybridLogicalVector) bool {
 	if hlv.SourceID != other.SourceID {
 		return false
 	}
@@ -663,6 +667,6 @@ func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
 	return nil
 }
 
-func (hlv *HybridLogicalVector) GoString() string {
-	return fmt.Sprintf("HybridLogicalVector{CurrentVersionCAS:%d, SourceID:%s, Version:%d, PreviousVersions:%+v, MergeVersions:%+v}", hlv.CurrentVersionCAS, hlv.SourceID, hlv.Version, hlv.PreviousVersions, hlv.MergeVersions)
+func (hlv HybridLogicalVector) GoString() string {
+	return fmt.Sprintf("HybridLogicalVector{CurrentVersionCAS:%d, SourceID:%s, Version:%d, PreviousVersions:%#+v, MergeVersions:%#+v}", hlv.CurrentVersionCAS, hlv.SourceID, hlv.Version, hlv.PreviousVersions, hlv.MergeVersions)
 }

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1408,7 +1408,7 @@ func TestAddVersion(t *testing.T) {
 
 			expectedHLV, _, err := ExtractHLVFromBlipMessage(tc.expectedHLV)
 			require.NoError(t, err)
-			require.True(t, hlv.Equals(expectedHLV), "expected %#v does not match actual %#v", expectedHLV, hlv)
+			require.True(t, hlv.Equal(expectedHLV), "expected %#v does not match actual %#v", expectedHLV, hlv)
 
 		})
 	}

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -28,8 +28,12 @@ type DocVersion struct {
 	CV        Version
 }
 
-func (v *DocVersion) String() string {
-	return fmt.Sprintf("RevTreeID: %s", v.RevTreeID)
+func (v DocVersion) String() string {
+	return fmt.Sprintf("RevTreeID:%s,CV:%#v", v.RevTreeID, v.CV)
+}
+
+func (v DocVersion) GoString() string {
+	return fmt.Sprintf("DocVersion{RevTreeID:%s,CV:%#v}", v.RevTreeID, v.CV)
 }
 
 func (v DocVersion) Equal(o DocVersion) bool {

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -899,15 +899,6 @@ func (btcc *BlipTesterCollectionClient) updateLastReplicatedRev(docID string, ve
 	rev.message = msg
 }
 
-func (btcc *BlipTesterCollectionClient) getLastReplicatedRev(docID string) (version DocVersion, ok bool) {
-	btcc.seqLock.RLock()
-	defer btcc.seqLock.RUnlock()
-	doc, ok := btcc._getClientDoc(docID)
-	require.True(btcc.TB(), ok, "docID %q not found in _seqFromDocID", docID)
-	latestServerVersion := doc._latestServerVersion
-	return latestServerVersion, latestServerVersion.RevTreeID != "" || latestServerVersion.CV.Value != 0
-}
-
 func (c *BlipTesterCollectionClient) lastSeq() clientSeq {
 	c.seqLock.RLock()
 	defer c.seqLock.RUnlock()
@@ -1164,6 +1155,24 @@ func (e proposeChangeBatchEntry) Rev() string {
 	return e.version.RevTreeID
 }
 
+func (e proposeChangeBatchEntry) MarshalJSON() ([]byte, error) {
+	output := &bytes.Buffer{}
+	fmt.Fprintf(output, `["%s","%s"`, e.docID, e.Rev())
+	if e.latestServerVersion.RevTreeID != "" || e.latestServerVersion.CV.Value != 0 {
+		if e.useHLV() {
+			fmt.Fprintf(output, `,"%s"`, e.latestServerVersion.CV.String())
+		} else {
+			fmt.Fprintf(output, `,"%s"`, e.latestServerVersion.RevTreeID)
+		}
+	}
+	fmt.Fprintf(output, "]")
+	return output.Bytes(), nil
+}
+
+func (e proposeChangeBatchEntry) GoString() string {
+	return fmt.Sprintf("proposeChangeBatchEntry{docID: %q, version:%v,revTreeIDHistory:%v,hlvHistory:%v,seq:%d,latestServerVersion:%v,isDelete: %t}", e.docID, e.version, e.revTreeIDHistory, e.hlvHistory, e.seq, e.latestServerVersion, e.isDelete)
+}
+
 // StartPull will begin a push replication with the given options between the client and server
 func (btcc *BlipTesterCollectionClient) StartPushWithOpts(opts BlipTesterPushOptions) {
 	require.True(btcc.TB(), btcc.pushRunning.CASRetry(false, true), "push replication already running")
@@ -1199,28 +1208,11 @@ func (btcc *BlipTesterCollectionClient) sendProposeChanges(ctx context.Context, 
 	proposeChangesRequest := blip.NewRequest()
 	proposeChangesRequest.SetProfile(db.MessageProposeChanges)
 
-	proposeChangesRequestBody := bytes.NewBufferString(`[`)
-	for i, change := range changesBatch {
-		if i > 0 {
-			proposeChangesRequestBody.WriteString(",")
-		}
-		proposeChangesRequestBody.WriteString(fmt.Sprintf(`["%s","%s"`, change.docID, change.Rev()))
-		// write last known server version to support no-conflict mode
-		if serverVersion, ok := btcc.getLastReplicatedRev(change.docID); ok {
-			base.DebugfCtx(ctx, base.KeySGTest, "specifying last known server version for doc %s = %v", change.docID, serverVersion)
-			if btcc.UseHLV() {
-				proposeChangesRequestBody.WriteString(fmt.Sprintf(`,"%s"`, serverVersion.CV.String()))
-			} else {
-				proposeChangesRequestBody.WriteString(fmt.Sprintf(`,"%s"`, serverVersion.RevTreeID))
-			}
-		}
-		proposeChangesRequestBody.WriteString(`]`)
-	}
-	proposeChangesRequestBody.WriteString(`]`)
-	proposeChangesRequestBodyBytes := proposeChangesRequestBody.Bytes()
-	proposeChangesRequest.SetBody(proposeChangesRequestBodyBytes)
+	proposeChangesRequestBody, err := base.JSONMarshal(changesBatch)
+	require.NoError(btcc.TB(), err, "error marshalling proposeChanges request body: %v", err)
+	proposeChangesRequest.SetBody(proposeChangesRequestBody)
 
-	base.DebugfCtx(ctx, base.KeySGTest, "proposeChanges request: %s", string(proposeChangesRequestBodyBytes))
+	base.DebugfCtx(ctx, base.KeySGTest, "proposeChanges request body: %s, changes:%#+v", string(proposeChangesRequestBody), changesBatch)
 
 	btcc.addCollectionProperty(proposeChangesRequest)
 
@@ -1265,7 +1257,7 @@ func (btcc *BlipTesterCollectionClient) sendRev(ctx context.Context, change prop
 
 	btcc.addCollectionProperty(revRequest)
 	btcc.sendPushMsg(revRequest)
-	base.DebugfCtx(ctx, base.KeySGTest, "sent doc %s / %v", change.docID, change.version)
+	base.DebugfCtx(ctx, base.KeySGTest, "sent doc %s / %#v", change.docID, change.version)
 	// block until remote has actually processed the rev and sent a response
 	revResp := revRequest.Response()
 	errorCode := revResp.Properties["Error-Code"]
@@ -1275,7 +1267,7 @@ func (btcc *BlipTesterCollectionClient) sendRev(ctx context.Context, change prop
 		return
 	}
 	require.NotContains(btcc.TB(), revResp.Properties, "Error-Domain", "unexpected error response from rev %#v", revResp)
-	base.DebugfCtx(ctx, base.KeySGTest, "peer acked rev %s / %v", change.docID, change.version)
+	base.DebugfCtx(ctx, base.KeySGTest, "peer acked rev %s / %#v", change.docID, change.version)
 	btcc.updateLastReplicatedRev(change.docID, change.version, revRequest)
 }
 
@@ -1646,7 +1638,7 @@ func (btcc *BlipTesterCollectionClient) WaitForVersion(docID string, docVersion 
 		var found bool
 		var lastKnownVersion *DocVersion
 		data, lastKnownVersion, found = btcc.GetVersion(docID, docVersion)
-		assert.True(c, found, "Could not find docID:%+v Version %+v, last known version: %s", docID, docVersion, lastKnownVersion)
+		assert.True(c, found, "Could not find docID:%+v Version %+v, last known version: %#v", docID, docVersion, lastKnownVersion)
 	}, 10*time.Second, 5*time.Millisecond, "BlipTesterClient timed out waiting for doc %+v Version %+v", docID, docVersion)
 	return data
 }

--- a/topologytest/main_test.go
+++ b/topologytest/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 		base.SkipTestMain(m, "Tests are disabled for Couchbase Server by default, to enable set %s=true environment variable", base.TbpEnvTopologyTests)
 		return
 	}
-	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192}
+	tbpOptions := base.TestBucketPoolOptions{MemWatermarkThresholdMB: 8192, NumCollectionsPerBucket: 1}
 	// Do not create indexes for this test, so they are built by server_context.go
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -21,8 +21,6 @@ func TestMultiActorConflictCreate(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
-			replications.Stop()
-
 			docID := getDocID(t)
 			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
 			replications.Start()
@@ -47,7 +45,6 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
-			replications.Stop()
 
 			docID := getDocID(t)
 			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
@@ -79,8 +76,6 @@ func TestMultiActorConflictDelete(t *testing.T) {
 		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
-			replications.Stop()
-
 			docID := getDocID(t)
 			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)
 
@@ -115,7 +110,6 @@ func TestMultiActorConflictResurrect(t *testing.T) {
 		}
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
-			replications.Stop()
 
 			docID := getDocID(t)
 			docVersion := createConflictingDocs(t, collectionName, peers, docID, topology.description)

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -23,7 +23,7 @@ func TestMultiActorUpdate(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
-
+			replications.Start()
 			for createPeerName, createPeer := range peers.ActivePeers() {
 				for updatePeerName, updatePeer := range peers {
 					docID := getDocID(t) + "_create=" + createPeerName + ",update=" + updatePeerName
@@ -51,7 +51,7 @@ func TestMultiActorDelete(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
-
+			replications.Start()
 			for createPeerName, createPeer := range peers.ActivePeers() {
 				for deletePeerName, deletePeer := range peers {
 					docID := getDocID(t) + "_create=" + createPeerName + ",update=" + deletePeerName
@@ -79,7 +79,7 @@ func TestMultiActorResurrect(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
-
+			replications.Start()
 			for createPeerName, createPeer := range peers.ActivePeers() {
 				for deletePeerName, deletePeer := range peers {
 					for resurrectPeerName, resurrectPeer := range peers {

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -330,11 +330,6 @@ func setupTests(t *testing.T, topology Topology) (base.ScopeAndCollectionName, P
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyVV, base.KeyCRUD, base.KeySync)
 	peers := createPeers(t, topology.peers)
 	replications := createPeerReplications(t, peers, topology.replications)
-
-	for _, replication := range replications {
-		// temporarily start the replication before writing the document, limitation of CouchbaseLiteMockPeer as active peer since WriteDocument is calls PushRev
-		replication.Start()
-	}
 	return getSingleDsName(), peers, replications
 }
 

--- a/topologytest/single_actor_test.go
+++ b/topologytest/single_actor_test.go
@@ -21,6 +21,7 @@ func TestSingleActorCreate(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
+			replications.Start()
 			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
@@ -44,6 +45,7 @@ func TestSingleActorUpdate(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
+			replications.Start()
 			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
@@ -74,6 +76,7 @@ func TestSingleActorDelete(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
+			replications.Start()
 			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)
@@ -104,6 +107,7 @@ func TestSingleActorResurrect(t *testing.T) {
 	for _, topology := range append(simpleTopologies, Topologies...) {
 		t.Run(topology.description, func(t *testing.T) {
 			collectionName, peers, replications := setupTests(t, topology)
+			replications.Start()
 			for activePeerID, activePeer := range peers.ActivePeers() {
 				t.Run(fmt.Sprintf("actor=%s", activePeerID), func(t *testing.T) {
 					updatePeersT(t, peers)

--- a/topologytest/version_test.go
+++ b/topologytest/version_test.go
@@ -41,18 +41,18 @@ func (v DocMetadata) CV(t require.TestingT) db.Version {
 
 func (v DocMetadata) IsHLVEqual(other DocMetadata) bool {
 	if v.ImplicitHLV != nil {
-		return other.hlvEquals(v.ImplicitHLV)
+		return other.hlvEqual(v.ImplicitHLV)
 	} else if v.HLV != nil {
-		return other.hlvEquals(v.HLV)
+		return other.hlvEqual(v.HLV)
 	}
 	return other.ImplicitHLV == nil && other.HLV == nil
 }
 
-func (v DocMetadata) hlvEquals(hlv *db.HybridLogicalVector) bool {
+func (v DocMetadata) hlvEqual(hlv *db.HybridLogicalVector) bool {
 	if v.ImplicitHLV != nil {
-		return v.ImplicitHLV.Equals(hlv)
+		return v.ImplicitHLV.Equal(hlv)
 	} else if v.HLV != nil {
-		return v.HLV.Equals(hlv)
+		return v.HLV.Equal(hlv)
 	}
 	return hlv == nil
 }


### PR DESCRIPTION
Most of the issues come down to comparing version numbers which are more easily compared as decimal. If `uint64` is written with `%#v`, it will write the number as hexadecimal.

- Set `GoString` on db.Version and DocVersion to write CV as decimal
- Switch name from `Equals` to `Equal` to match conventions
- improve logging around propose changes. The versions are typically little endian hexadecimal, but typically the actual version numbers are more important. Move the building of the message directly to `MarshalJSON` to avoid splitting information in multiple places
- Only create a single collection to speed up test time
- Start rosmar buckets at rosmar1, rosmar2 to line up with sg1,sg2 and cbs1,cbs2 in tests
- Don't start replications in `setupTests` to avoid having to stop the replications before the tests run in multi actor conflict

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3240/
