### PR TITLE
CBG-4288: some assertion cleanups for active replicator tests

### DIFF
--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -32,11 +32,19 @@ func (v *DocVersion) String() string {
 	return fmt.Sprintf("RevTreeID: %s", v.RevTreeID)
 }
 
-func (v DocVersion) Equal(o DocVersion) bool {
-	if v.RevTreeID != o.RevTreeID {
-		return false
+// RevOrCVEqual compares two DocVersions for equality. It checks RevID if defined or CV is defined.
+func (v DocVersion) RevOrCVEqual(o DocVersion) bool {
+	if v.RevTreeID != "" && o.RevTreeID != "" {
+		if v.RevTreeID == o.RevTreeID {
+			return true
+		}
 	}
-	return true
+	if !v.CV.IsEmpty() && !o.CV.IsEmpty() {
+		if v.CV.String() == o.CV.String() {
+			return true
+		}
+	}
+	return false
 }
 
 func (v DocVersion) GetRev(useHLV bool) string {

--- a/rest/replicatortest/replicator_test_helper.go
+++ b/rest/replicatortest/replicator_test_helper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Helper functions for SGR testing
@@ -68,9 +69,12 @@ func addActiveRT(t *testing.T, dbName string, testBucket *base.TestBucket) (acti
 	return activeRT
 }
 
-// requireDocumentVersion asserts that the given ChangeRev has the expected version for a given entry returned by _changes feed
-func requireDocumentVersion(t testing.TB, expected rest.DocVersion, doc *db.Document) {
-	rest.RequireDocVersionEqual(t, expected, rest.DocVersion{RevTreeID: doc.SyncData.CurrentRev})
+// requireDocumentVersion asserts that the given document has the expected version
+func requireDocumentVersion(t testing.TB, expected rest.DocVersion, doc *db.Document, checkCV bool) {
+	if checkCV {
+		require.Equal(t, expected.CV, *doc.SyncData.HLV.ExtractCurrentVersionFromHLV())
+	}
+	require.Equal(t, expected.RevTreeID, doc.SyncData.CurrentRev)
 }
 
 // createOrUpdateDoc creates a new document the specified document id, and body value in a channel named "alice".


### PR DESCRIPTION
CBG-4288

- Changed equal function top check rev ID of defined then CV of defined. 
- I have added some assertions to CV on `requireDocumentVersion` 
- Overall in two minds if this PR is even necessary, I will probably add better assertion functions for testing ISGR when we actually have some parts implemented. For example, until we have the new rev tree property implemented I can't realistically assert on both CV and revID on remote compared to local. Given we will only be sending HLV in messages. Same for < 4 protocol, we can't assert on what a CV will be at remote if the only property being sent is revID properties. So its not totally correct we can assert on both at the same time always. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/000/
