### PR TITLE
CBG-4452 remove failing test that is not useful

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -899,12 +899,6 @@ func (btcc *BlipTesterCollectionClient) updateLastReplicatedRev(docID string, ve
 	rev.message = msg
 }
 
-func (c *BlipTesterCollectionClient) lastSeq() clientSeq {
-	c.seqLock.RLock()
-	defer c.seqLock.RUnlock()
-	return c._seqLast
-}
-
 func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, skipCollectionsInitialization bool) *BlipTesterReplicator {
 	bt, err := NewBlipTesterFromSpecWithRT(tb, &BlipTesterSpec{
 		connectingPassword:            RestTesterDefaultUserPassword,


### PR DESCRIPTION
This test was removed in 3.3 in https://github.com/couchbase/sync_gateway/pull/7382 but when anemone was merged to main, I picked the version of changes on anemone since this code was modified on anemone separately from main.
