### PR TITLE
Test-only tech-debt cleanup: Make `TestCtx` use stdlib `testing.Context()` instead of a DIY version

### DIFF
--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -176,9 +176,7 @@ func NewTaskID(contextID string, taskName string) string {
 
 // TestCtx creates a context for the given test which is also cancelled once the test has completed.
 func TestCtx(t testing.TB) context.Context {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	t.Cleanup(cancelCtx)
-	return LogContextWith(ctx, &LogContext{TestName: t.Name()})
+	return LogContextWith(t.Context(), &LogContext{TestName: t.Name()})
 }
 
 // BucketCtx extends the parent context with a bucket name.


### PR DESCRIPTION
This functions very similarly to the existing DIY version we had written prior to 1.24 but uses stdlib functionality now available.

The only difference is potentially the order of cancellation. Previously it was stacked in `Cleanup()` in the order `TestCtx` was called, now the stdlib version _always_ cancels prior to running test cleanup. This is better and more predictable behavior anyway, but wasn't something we were previously capable of controlling.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3243/
