### PR TITLE
Print doc state on all peers on failure

### DIFF
--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -70,6 +70,17 @@ func (p *CouchbaseLiteMockPeer) GetDocument(dsName sgbucket.DataStoreName, docID
 	return *meta, body
 }
 
+// GetDocumentIfExists returns the latest version of a document.
+func (p *CouchbaseLiteMockPeer) GetDocumentIfExists(dsName sgbucket.DataStoreName, docID string) (m DocMetadata, body *db.Body, exists bool) {
+	bodyBytes, meta := p.getLatestDocVersion(dsName, docID)
+	if meta == nil {
+		return DocMetadata{}, nil, false
+	}
+	require.NotNil(p.TB(), meta, "docID:%s not found on %s", docID, p)
+	require.NoError(p.TB(), base.JSONUnmarshal(bodyBytes, &body))
+	return *meta, body, true
+}
+
 // getSingleSGBlipClient returns the single blip client for the peer. If there are multiple clients, or no clients it will fail the test. This is temporary to stub support for multiple Sync Gateway peers, see CBG-4433.
 func (p *CouchbaseLiteMockPeer) getSingleSGBlipClient() *PeerBlipTesterClient {
 	// couchbase lite peer can't exist separately from sync gateway peer, CBG-4433
@@ -127,7 +138,7 @@ func (p *CouchbaseLiteMockPeer) DeleteDocument(dsName sgbucket.DataStoreName, do
 }
 
 // WaitForDocVersion waits for a document to reach a specific version. The test will fail if the document does not reach the expected version in 20s.
-func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, replications Replications) db.Body {
+func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) db.Body {
 	var data []byte
 	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
 		var actual *DocMetadata
@@ -135,7 +146,23 @@ func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName,
 		if !assert.NotNil(c, actual, "Could not find docID:%+v on %p\nVersion %#v", docID, p, expected) {
 			return
 		}
-		assertHLVEqual(c, docID, p.name, *actual, data, expected, replications)
+		assertHLVEqual(c, dsName, docID, p.name, *actual, data, expected, topology)
+	}, totalWaitTime, pollInterval)
+	var body db.Body
+	require.NoError(p.TB(), base.JSONUnmarshal(data, &body))
+	return body
+}
+
+// WaitForCV waits for a document to reach a specific CV. Returns the state of the document at that version. The test will fail if the document does not reach the expected version in 20s.
+func (p *CouchbaseLiteMockPeer) WaitForCV(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) db.Body {
+	var data []byte
+	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
+		var actual *DocMetadata
+		data, actual = p.getLatestDocVersion(dsName, docID)
+		if !assert.NotNil(c, actual, "Could not find docID:%+v on %p\nVersion %#v", docID, p, expected) {
+			return
+		}
+		assertCVEqual(c, dsName, docID, p.name, *actual, data, expected, topology)
 	}, totalWaitTime, pollInterval)
 	var body db.Body
 	require.NoError(p.TB(), base.JSONUnmarshal(data, &body))
@@ -143,14 +170,14 @@ func (p *CouchbaseLiteMockPeer) WaitForDocVersion(dsName sgbucket.DataStoreName,
 }
 
 // WaitForTombstoneVersion waits for a document to reach a specific version, this must be a tombstone. The test will fail if the document does not reach the expected version in 20s.
-func (p *CouchbaseLiteMockPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, replications Replications) {
+func (p *CouchbaseLiteMockPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) {
 	client := p.getSingleSGBlipClient().CollectionClient(dsName)
 	expectedVersion := db.DocVersion{CV: expected.CV(p.TB())}
 	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
 		isTombstone, err := client.IsVersionTombstone(docID, expectedVersion)
 		require.NoError(c, err)
-		assert.True(c, isTombstone, "expected docID %s on peer %s to be deleted. Replications:\n%s", docID, p, replications.Stats())
-	}, totalWaitTime, pollInterval)
+		assert.True(c, isTombstone, "expected docID %s on peer %s to be deleted.", docID, p)
+	}, totalWaitTime, pollInterval, topology.GetDocState(p.TB(), dsName, docID))
 }
 
 // Close will shut down the peer and close any active replications on the peer.

--- a/topologytest/couchbase_server_peer_test.go
+++ b/topologytest/couchbase_server_peer_test.go
@@ -200,7 +200,7 @@ func (p *CouchbaseServerPeer) WaitForCV(dsName sgbucket.DataStoreName, docID str
 // WaitForTombstoneVersion waits for a document to reach a specific version, this must be a tombstone. The test will fail if the document does not reach the expected version in 20s.
 func (p *CouchbaseServerPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) {
 	docBytes := p.waitForDocVersion(dsName, docID, expected, topology)
-	require.Empty(p.TB(), docBytes, "expected tombstone for docID %s, got %s.%s", docID, docBytes, topology)
+	require.Empty(p.TB(), docBytes, "expected tombstone for docID %s, got %s. %s", docID, docBytes, topology.GetDocState(p.TB(), dsName, docID))
 }
 
 // waitForDocVersion waits for a document to reach a specific version and returns the body in bytes. The bytes will be nil if the document is a tombstone. The test will fail if the document does not reach the expected version in 20s.

--- a/topologytest/hlv_test.go
+++ b/topologytest/hlv_test.go
@@ -50,53 +50,43 @@ func stripInternalProperties(body db.Body) {
 }
 
 // waitForVersionAndBody waits for a document to reach a specific version on all peers.
-func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, replications Replications, docID string, expectedVersion BodyAndVersion) {
+func waitForVersionAndBody(t *testing.T, dsName base.ScopeAndCollectionName, docID string, expectedVersion BodyAndVersion, topology Topology) {
 	t.Logf("waiting for doc version on all peers, written from %s: %#v", expectedVersion.updatePeer, expectedVersion)
-	for _, peer := range peers.SortedPeers() {
+	for _, peer := range topology.SortedPeers() {
 		t.Logf("waiting for doc version on peer %s, written from %s: %#v", peer, expectedVersion.updatePeer, expectedVersion)
-		body := peer.WaitForDocVersion(dsName, docID, expectedVersion.docMeta, replications)
+		body := peer.WaitForDocVersion(dsName, docID, expectedVersion.docMeta, topology)
 		requireBodyEqual(t, expectedVersion.body, body)
 	}
 }
 
-func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, replications Replications, docID string, expectedVersion BodyAndVersion) {
-	t.Logf("waiting for tombstone version on all peers, written from %s: %#v", expectedVersion.updatePeer, expectedVersion)
-	for _, peer := range peers.SortedPeers() {
-		t.Logf("waiting for tombstone version on peer %s, written from %s: %#v", peer, expectedVersion.updatePeer, expectedVersion)
-		peer.WaitForTombstoneVersion(dsName, docID, expectedVersion.docMeta, replications)
+// waitForCVAndBody waits for a document to reach a specific cv on all peers.
+func waitForCVAndBody(t *testing.T, dsName base.ScopeAndCollectionName, docID string, expectedVersion BodyAndVersion, topology Topology) {
+	t.Logf("waiting for doc version on all peers, written from %s: %#v", expectedVersion.updatePeer, expectedVersion)
+	for _, peer := range topology.SortedPeers() {
+		t.Logf("waiting for doc version on peer %s, written from %s: %#v", peer, expectedVersion.updatePeer, expectedVersion)
+		body := peer.WaitForCV(dsName, docID, expectedVersion.docMeta, topology)
+		requireBodyEqual(t, expectedVersion.body, body)
 	}
 }
-
-// removeSyncGatewayBackingPeers will check if there is sync gateway in topology, if so will track the backing CBS
-// so we can skip creating docs on these peers (avoiding conflicts between docs created on the SGW and cbs)
-func removeSyncGatewayBackingPeers(peers map[string]Peer) map[string]bool {
-	peersToRemove := make(map[string]bool)
-	if peers["sg1"] != nil {
-		// remove the backing store from doc update cycle to avoid conflicts on creating the document in bucket
-		peersToRemove["cbs1"] = true
+func waitForTombstoneVersion(t *testing.T, dsName base.ScopeAndCollectionName, docID string, expectedVersion BodyAndVersion, topology Topology) {
+	t.Logf("waiting for tombstone version on all peers, written from %s: %#v", expectedVersion.updatePeer, expectedVersion)
+	for _, peer := range topology.SortedPeers() {
+		t.Logf("waiting for tombstone version on peer %s, written from %s: %#v", peer, expectedVersion.updatePeer, expectedVersion)
+		peer.WaitForTombstoneVersion(dsName, docID, expectedVersion.docMeta, topology)
 	}
-	if peers["sg2"] != nil {
-		// remove the backing store from doc update cycle to avoid conflicts on creating the document in bucket
-		peersToRemove["cbs2"] = true
-	}
-	return peersToRemove
 }
 
 // createConflictingDocs will create a doc on each peer of the same doc ID to create conflicting documents, then
 // returns the last peer to have a doc created on it
-func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID, topologyDescription string) (lastWrite BodyAndVersion) {
-	backingPeers := removeSyncGatewayBackingPeers(peers)
-	documentVersion := make([]BodyAndVersion, 0, len(peers))
-	for peerName, peer := range peers {
-		if backingPeers[peerName] {
-			continue
-		}
+func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, docID string, topology Topology) (lastWrite BodyAndVersion) {
+	var documentVersion []BodyAndVersion
+	for peerName, peer := range topology.peers.NonImportSortedPeers() {
 		if peer.Type() == PeerTypeCouchbaseLite {
 			// FIXME: Skipping Couchbase Lite tests for multi actor conflicts, CBG-4434
 			continue
 		}
-		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, peerName, topologyDescription))
-		docVersion := peer.CreateDocument(dsName, docID, docBody)
+		docBody := fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "create"}`, peerName, topology.specDescription)
+		docVersion := peer.CreateDocument(dsName, docID, []byte(docBody))
 		t.Logf("%s - createVersion: %#v", peerName, docVersion.docMeta)
 		documentVersion = append(documentVersion, docVersion)
 	}
@@ -108,15 +98,11 @@ func createConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 
 // updateConflictingDocs will update a doc on each peer of the same doc ID to create conflicting document mutations, then
 // returns the last peer to have a doc updated on it.
-func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID, topologyDescription string) (lastWrite BodyAndVersion) {
-	backingPeers := removeSyncGatewayBackingPeers(peers)
+func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, docID string, topology Topology) (lastWrite BodyAndVersion) {
 	var documentVersion []BodyAndVersion
-	for peerName, peer := range peers {
-		if backingPeers[peerName] {
-			continue
-		}
-		docBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "update"}`, peerName, topologyDescription))
-		docVersion := peer.WriteDocument(dsName, docID, docBody)
+	for peerName, peer := range topology.peers.NonImportSortedPeers() {
+		docBody := fmt.Sprintf(`{"activePeer": "%s", "topology": "%s", "action": "update"}`, peerName, topology.specDescription)
+		docVersion := peer.WriteDocument(dsName, docID, []byte(docBody))
 		t.Logf("updateVersion: %#v", docVersion.docMeta)
 		documentVersion = append(documentVersion, docVersion)
 	}
@@ -128,13 +114,9 @@ func updateConflictingDocs(t *testing.T, dsName base.ScopeAndCollectionName, pee
 
 // deleteConflictDocs will delete a doc on each peer of the same doc ID to create conflicting document deletions, then
 // returns the last peer to have a doc deleted on it
-func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, peers Peers, docID string) (lastWrite BodyAndVersion) {
-	backingPeers := removeSyncGatewayBackingPeers(peers)
+func deleteConflictDocs(t *testing.T, dsName base.ScopeAndCollectionName, docID string, topology Topology) (lastWrite BodyAndVersion) {
 	var documentVersion []BodyAndVersion
-	for peerName, peer := range peers {
-		if backingPeers[peerName] {
-			continue
-		}
+	for peerName, peer := range topology.peers.NonImportSortedPeers() {
 		deleteVersion := peer.DeleteDocument(dsName, docID)
 		t.Logf("deleteVersion: %#v", deleteVersion)
 		documentVersion = append(documentVersion, BodyAndVersion{docMeta: deleteVersion, updatePeer: peerName})

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -20,21 +20,23 @@ import (
 // 4. update each document on a single peer, documents exist in pairwise create peer and update peer
 // 5. wait for the hlv for updated documents to synchronized
 func TestMultiActorUpdate(t *testing.T) {
-	for _, topology := range append(simpleTopologies, Topologies...) {
-		t.Run(topology.description, func(t *testing.T) {
-			collectionName, peers, replications := setupTests(t, topology)
-			replications.Start()
-			for createPeerName, createPeer := range peers.ActivePeers() {
-				for updatePeerName, updatePeer := range peers {
-					docID := getDocID(t) + "_create=" + createPeerName + ",update=" + updatePeerName
-					body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "updatePeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, updatePeer, topology.description))
-					createVersion := createPeer.CreateDocument(collectionName, docID, body1)
-					waitForVersionAndBody(t, collectionName, peers, replications, docID, createVersion)
+	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
+		t.Run(topologySpec.description, func(t *testing.T) {
+			collectionName, topology := setupTests(t, topologySpec)
+			topology.StartReplications()
+			for createPeerName, createPeer := range topology.peers.ActivePeers() {
+				for updatePeerName, updatePeer := range topology.SortedPeers() {
+					topology.Run(t, "create="+createPeerName+",update="+updatePeerName, func(t *testing.T) {
+						docID := getDocID(t) + "_create=" + createPeerName + ",update=" + updatePeerName
+						body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "updatePeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, updatePeer, topology.specDescription))
+						createVersion := createPeer.CreateDocument(collectionName, docID, body1)
+						waitForVersionAndBody(t, collectionName, docID, createVersion, topology)
 
-					newBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "updatePeer": "%s", "topology": "%s", "action": "update"}`, updatePeerName, createPeerName, updatePeerName, topology.description))
-					updateVersion := updatePeer.WriteDocument(collectionName, docID, newBody)
+						newBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "updatePeer": "%s", "topology": "%s", "action": "update"}`, updatePeerName, createPeerName, updatePeerName, topology.specDescription))
+						updateVersion := updatePeer.WriteDocument(collectionName, docID, newBody)
 
-					waitForVersionAndBody(t, collectionName, peers, replications, docID, updateVersion)
+						waitForVersionAndBody(t, collectionName, docID, updateVersion, topology)
+					})
 				}
 			}
 		})
@@ -48,19 +50,21 @@ func TestMultiActorUpdate(t *testing.T) {
 // 4. delete each document on a single peer, documents exist in pairwise create peer and update peer
 // 5. wait for the hlv for updated documents to synchronized
 func TestMultiActorDelete(t *testing.T) {
-	for _, topology := range append(simpleTopologies, Topologies...) {
-		t.Run(topology.description, func(t *testing.T) {
-			collectionName, peers, replications := setupTests(t, topology)
-			replications.Start()
-			for createPeerName, createPeer := range peers.ActivePeers() {
-				for deletePeerName, deletePeer := range peers {
-					docID := getDocID(t) + "_create=" + createPeerName + ",update=" + deletePeerName
-					body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, deletePeer, topology.description))
-					createVersion := createPeer.CreateDocument(collectionName, docID, body1)
-					waitForVersionAndBody(t, collectionName, peers, replications, docID, createVersion)
+	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
+		t.Run(topologySpec.description, func(t *testing.T) {
+			collectionName, topology := setupTests(t, topologySpec)
+			topology.StartReplications()
+			for createPeerName, createPeer := range topology.ActivePeers() {
+				for deletePeerName, deletePeer := range topology.SortedPeers() {
+					topology.Run(t, "create="+createPeerName+",delete="+deletePeerName, func(t *testing.T) {
+						docID := getDocID(t) + "_create=" + createPeerName + ",update=" + deletePeerName
+						body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, deletePeer, topology.specDescription))
+						createVersion := createPeer.CreateDocument(collectionName, docID, body1)
+						waitForVersionAndBody(t, collectionName, docID, createVersion, topology)
 
-					deleteVersion := deletePeer.DeleteDocument(collectionName, docID)
-					waitForTombstoneVersion(t, collectionName, peers, replications, docID, BodyAndVersion{docMeta: deleteVersion, updatePeer: deletePeerName})
+						deleteVersion := deletePeer.DeleteDocument(collectionName, docID)
+						waitForTombstoneVersion(t, collectionName, docID, BodyAndVersion{docMeta: deleteVersion, updatePeer: deletePeerName}, topology)
+					})
 				}
 			}
 		})
@@ -76,24 +80,31 @@ func TestMultiActorDelete(t *testing.T) {
 // 6. resurrect each document on a single peer
 // 7. wait for the hlv for updated documents to be synchronized
 func TestMultiActorResurrect(t *testing.T) {
-	for _, topology := range append(simpleTopologies, Topologies...) {
-		t.Run(topology.description, func(t *testing.T) {
-			collectionName, peers, replications := setupTests(t, topology)
-			replications.Start()
-			for createPeerName, createPeer := range peers.ActivePeers() {
-				for deletePeerName, deletePeer := range peers {
-					for resurrectPeerName, resurrectPeer := range peers {
-						docID := getDocID(t) + "_create=" + createPeerName + ",delete=" + deletePeerName + ",resurrect=" + resurrectPeerName
-						body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "resurrectPeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, deletePeer, resurrectPeer, topology.description))
-						createVersion := createPeer.CreateDocument(collectionName, docID, body1)
-						waitForVersionAndBody(t, collectionName, peers, replications, docID, createVersion)
+	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
+		t.Run(topologySpec.description, func(t *testing.T) {
+			collectionName, topology := setupTests(t, topologySpec)
+			topology.StartReplications()
+			for createPeerName, createPeer := range topology.ActivePeers() {
+				for deletePeerName, deletePeer := range topology.SortedPeers() {
+					for resurrectPeerName, resurrectPeer := range topology.SortedPeers() {
+						topology.Run(t, fmt.Sprintf("create=%s,delete=%s,resurrect=%s", createPeerName, deletePeerName, resurrectPeerName), func(t *testing.T) {
+							docID := getDocID(t) + "_create=" + createPeerName + ",delete=" + deletePeerName + ",resurrect=" + resurrectPeerName
+							body1 := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "resurrectPeer": "%s", "topology": "%s", "action": "create"}`, createPeerName, createPeerName, deletePeer, resurrectPeer, topologySpec.description))
+							createVersion := createPeer.CreateDocument(collectionName, docID, body1)
+							waitForVersionAndBody(t, collectionName, docID, createVersion, topology)
 
-						deleteVersion := deletePeer.DeleteDocument(collectionName, docID)
-						waitForTombstoneVersion(t, collectionName, peers, replications, docID, BodyAndVersion{docMeta: deleteVersion, updatePeer: deletePeerName})
+							deleteVersion := deletePeer.DeleteDocument(collectionName, docID)
+							waitForTombstoneVersion(t, collectionName, docID, BodyAndVersion{docMeta: deleteVersion, updatePeer: deletePeerName}, topology)
 
-						resBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "resurrectPeer": "%s", "topology": "%s", "action": "resurrect"}`, resurrectPeerName, createPeerName, deletePeer, resurrectPeer, topology.description))
-						resurrectVersion := resurrectPeer.WriteDocument(collectionName, docID, resBody)
-						waitForVersionAndBody(t, collectionName, peers, replications, docID, resurrectVersion)
+							resBody := []byte(fmt.Sprintf(`{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "resurrectPeer": "%s", "topology": "%s", "action": "resurrect"}`, resurrectPeerName, createPeerName, deletePeer, resurrectPeer, topology.specDescription))
+							resurrectVersion := resurrectPeer.WriteDocument(collectionName, docID, resBody)
+							// in the case of a Couchbase Server resurrection, the hlv is lost since all system xattrs are lost on a resurrection
+							if resurrectPeer.Type() == PeerTypeCouchbaseServer {
+								waitForCVAndBody(t, collectionName, docID, resurrectVersion, topology)
+							} else {
+								waitForVersionAndBody(t, collectionName, docID, resurrectVersion, topology)
+							}
+						})
 					}
 				}
 			}

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -15,6 +15,7 @@ import (
 	"iter"
 	"maps"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/xdcr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,6 +43,10 @@ func init() {
 type Peer interface {
 	// GetDocument returns the latest version of a document. The test will fail the document does not exist.
 	GetDocument(dsName sgbucket.DataStoreName, docID string) (DocMetadata, db.Body)
+
+	// GetDocument returns the latest version of a document if it exists.
+	GetDocumentIfExists(dsName sgbucket.DataStoreName, docID string) (DocMetadata, *db.Body, bool)
+
 	// CreateDocument creates a document on the peer. The test will fail if the document already exists.
 	CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion
 	// WriteDocument upserts a document to the peer. The test will fail if the write does not succeed. Reasons for failure might be sync function rejections for Sync Gateway rejections.
@@ -49,10 +55,13 @@ type Peer interface {
 	DeleteDocument(dsName sgbucket.DataStoreName, docID string) DocMetadata
 
 	// WaitForDocVersion waits for a document to reach a specific version. Returns the state of the document at that version. The test will fail if the document does not reach the expected version in 20s.
-	WaitForDocVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, replications Replications) db.Body
+	WaitForDocVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) db.Body
+
+	// WaitForCV waits for a document to reach a specific CV. Returns the state of the document at that version. The test will fail if the document does not reach the expected version in 20s.
+	WaitForCV(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) db.Body
 
 	// WaitForTombstoneVersion waits for a document to reach a specific version. This document must be a tombstone. The test will fail if the document does not reach the expected version in 20s.
-	WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, replications Replications)
+	WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology)
 
 	// CreateReplication creates a replication instance
 	CreateReplication(Peer, PeerReplicationConfig) PeerReplication
@@ -117,7 +126,44 @@ func (p Peers) SortedPeers() iter.Seq2[string, Peer] {
 	}
 }
 
-// UniqueTopologyPeers returns a list of unique peers in the topology. If there is an identical symmetric peer, do not return it.
+// NonImportSortedPeers returns a sorted iterator peers that will not cause import operations. For example:
+//   - cbs1 <-> sg1 <-> cbl1 would return sg1 and cbl1, but not cbs1
+//   - cbs1 <-> cbs2 would return cbs1 and cbs2
+//   - cbs1 <-> sg1 <-> cbl1 and cbs1 <-> cbs2 would return sg1, cbl1, cbs2, but not cbs1
+func (p Peers) NonImportSortedPeers() iter.Seq2[string, Peer] {
+	peerNames := slices.Collect(maps.Keys(p))
+	slices.Sort(peerNames)
+	backingBuckets := make(map[string][]string, len(peerNames))
+	for peerName, peer := range p {
+		if peer.GetBackingBucket() == nil {
+			continue // Couchbase Lite peers do not have a backing bucket
+		}
+		bucketPeers, ok := backingBuckets[peer.GetBackingBucket().GetName()]
+		if !ok {
+			bucketPeers = make([]string, 0)
+		}
+		bucketPeers = append(bucketPeers, peerName)
+		backingBuckets[peer.GetBackingBucket().GetName()] = bucketPeers
+	}
+	return func(yield func(k string, v Peer) bool) {
+		for _, peerName := range peerNames {
+			fmt.Printf("TopologyTest: yielding peer %s\n", peerName)
+			peer := p[peerName]
+			if peer.Type() == PeerTypeCouchbaseServer {
+				// If the peer is a Couchbase Server peer, we do not want to yield it if it is the only peer with that backing bucket.
+				if len(backingBuckets[peer.GetBackingBucket().GetName()]) > 1 {
+					fmt.Printf("TopologyTest: skipping peer %s\n", peerName)
+					continue
+				}
+			}
+			if !yield(peerName, p[peerName]) {
+				return
+			}
+		}
+	}
+}
+
+// ActivePeers returns a list of unique peers in the topology. If there is an identical symmetric peer, do not return it.
 func (p Peers) ActivePeers() iter.Seq2[string, Peer] {
 	keys := slices.Collect(maps.Keys(p))
 	slices.Sort(keys)
@@ -161,6 +207,62 @@ func (r Replications) Stats() string {
 		stats += fmt.Sprintf("%s: %s\n", replication, replication.Stats())
 	}
 	return stats
+}
+
+// Topology describes an instantiated set of peers and replications.
+type Topology struct {
+	peers           Peers
+	replications    Replications
+	specDescription string // description of the topology specification used to create this topology
+}
+
+// GetDocState returns the current state of a document across all peers.
+func (to Topology) GetDocState(t assert.TestingT, dsName sgbucket.DataStoreName, docID string) string {
+	globalState := &strings.Builder{}
+	for peerName, peer := range to.peers.SortedPeers() {
+		docMeta, body, ok := peer.GetDocumentIfExists(dsName, docID)
+		if !ok {
+			fmt.Fprintf(globalState, "====\npeer(%s)\n----\nDocument %s does not exist\n", peerName, docID)
+			continue
+		}
+		fmt.Fprintf(globalState, "====\npeer(%s)\n----\n%#v\nbody:%v\n", peerName, docMeta, body)
+	}
+	for _, replication := range to.replications {
+		fmt.Fprintf(globalState, "====\nreplication(%s)\n----\n%s\n", replication, replication.Stats())
+	}
+	return globalState.String()
+}
+
+// ActivePeers returns a list of unique peers in the topology. If there is an identical symmetric peer, do not return it.
+func (to Topology) ActivePeers() iter.Seq2[string, Peer] {
+	return to.peers.ActivePeers()
+}
+
+// SortedPeers returns a sorted list of peers by name, for deterministic output.
+func (to Topology) SortedPeers() iter.Seq2[string, Peer] {
+	return to.peers.SortedPeers()
+}
+
+// Run is equivalent to testing.T.Run() but updates the underlying TB to the new testing.T
+// so that checks are made against the right instance (otherwise the outer test complains
+// "subtest may have called FailNow on a parent test")
+func (to *Topology) Run(t *testing.T, name string, test func(*testing.T)) {
+	t.Run(name, func(t *testing.T) {
+		for _, peer := range to.peers {
+			oldTB := peer.TB().(*testing.T)
+			t.Cleanup(func() { peer.UpdateTB(oldTB) })
+			peer.UpdateTB(t)
+		}
+		test(t)
+	})
+}
+
+func (to Topology) StartReplications() {
+	to.replications.Start()
+}
+
+func (to Topology) StopReplications() {
+	to.replications.Stop()
 }
 
 // PeerReplicationDirection represents the direction of a replication from the active peer.
@@ -317,20 +419,12 @@ func createPeers(t *testing.T, peersOptions map[string]PeerOptions) Peers {
 	return peers
 }
 
-func updatePeersT(t *testing.T, peers map[string]Peer) {
-	for _, peer := range peers {
-		oldTB := peer.TB().(*testing.T)
-		t.Cleanup(func() { peer.UpdateTB(oldTB) })
-		peer.UpdateTB(t)
-	}
-}
-
 // setupTests returns a map of peers and a list of replications. The peers will be closed and the buckets will be destroyed by t.Cleanup.
-func setupTests(t *testing.T, topology Topology) (base.ScopeAndCollectionName, Peers, Replications) {
+func setupTests(t *testing.T, topology TopologySpecification) (base.ScopeAndCollectionName, Topology) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport, base.KeyVV, base.KeyCRUD, base.KeySync)
 	peers := createPeers(t, topology.peers)
 	replications := createPeerReplications(t, peers, topology.replications)
-	return getSingleDsName(), peers, replications
+	return getSingleDsName(), Topology{peers: peers, replications: replications}
 }
 
 func TestPeerImplementation(t *testing.T) {
@@ -385,6 +479,10 @@ func TestPeerImplementation(t *testing.T) {
 				defer pushReplication.Stop()
 				replications = append(replications, pushReplication)
 			}
+			topology := Topology{
+				peers:        peers,
+				replications: replications,
+			}
 
 			docID := t.Name()
 			collectionName := getSingleDsName()
@@ -399,7 +497,7 @@ func TestPeerImplementation(t *testing.T) {
 				require.Empty(t, createVersion.docMeta.RevTreeID)
 			}
 
-			peer.WaitForDocVersion(collectionName, docID, createVersion.docMeta, replications)
+			peer.WaitForDocVersion(collectionName, docID, createVersion.docMeta, topology)
 			// Check Get after creation
 			roundtripGetVersion, roundtripGetbody := peer.GetDocument(collectionName, docID)
 			require.Equal(t, createVersion.docMeta, roundtripGetVersion)
@@ -416,7 +514,7 @@ func TestPeerImplementation(t *testing.T) {
 			} else {
 				require.Empty(t, updateVersion.docMeta.RevTreeID)
 			}
-			peer.WaitForDocVersion(collectionName, docID, updateVersion.docMeta, replications)
+			peer.WaitForDocVersion(collectionName, docID, updateVersion.docMeta, topology)
 
 			// Check Get after update
 			roundtripGetVersion, roundtripGetbody = peer.GetDocument(collectionName, docID)
@@ -435,7 +533,7 @@ func TestPeerImplementation(t *testing.T) {
 			} else {
 				require.Empty(t, deleteVersion.RevTreeID)
 			}
-			peer.WaitForTombstoneVersion(collectionName, docID, deleteVersion, replications)
+			peer.WaitForTombstoneVersion(collectionName, docID, deleteVersion, topology)
 
 			// Resurrection
 			resurrectionBody := []byte(`{"op": "resurrection"}`)
@@ -454,7 +552,7 @@ func TestPeerImplementation(t *testing.T) {
 			} else {
 				require.Empty(t, resurrectionVersion.docMeta.RevTreeID)
 			}
-			peer.WaitForDocVersion(collectionName, docID, resurrectionVersion.docMeta, replications)
+			peer.WaitForDocVersion(collectionName, docID, resurrectionVersion.docMeta, topology)
 
 			ctx := peer.Context()
 			if peer.Type() != PeerTypeCouchbaseLite {

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -147,12 +147,10 @@ func (p Peers) NonImportSortedPeers() iter.Seq2[string, Peer] {
 	}
 	return func(yield func(k string, v Peer) bool) {
 		for _, peerName := range peerNames {
-			fmt.Printf("TopologyTest: yielding peer %s\n", peerName)
 			peer := p[peerName]
 			if peer.Type() == PeerTypeCouchbaseServer {
 				// If the peer is a Couchbase Server peer, we do not want to yield it if it is the only peer with that backing bucket.
 				if len(backingBuckets[peer.GetBackingBucket().GetName()]) > 1 {
-					fmt.Printf("TopologyTest: skipping peer %s\n", peerName)
 					continue
 				}
 			}

--- a/topologytest/sync_gateway_peer_test.go
+++ b/topologytest/sync_gateway_peer_test.go
@@ -66,6 +66,17 @@ func (p *SyncGatewayPeer) GetDocument(dsName sgbucket.DataStoreName, docID strin
 	return DocMetadataFromDocument(doc), doc.Body(ctx)
 }
 
+// GetDocumentIfExists returns the latest version of a document if it exists.
+func (p *SyncGatewayPeer) GetDocumentIfExists(dsName sgbucket.DataStoreName, docID string) (meta DocMetadata, body *db.Body, exists bool) {
+	collection, ctx := p.getCollection(dsName)
+	doc, err := collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+	if base.IsDocNotFoundError(err) {
+		return DocMetadata{}, nil, false
+	}
+	require.NoError(p.TB(), err)
+	return DocMetadataFromDocument(doc), base.Ptr(doc.Body(ctx)), true
+}
+
 // CreateDocument creates a document on the peer. The test will fail if the document already exists.
 func (p *SyncGatewayPeer) CreateDocument(dsName sgbucket.DataStoreName, docID string, body []byte) BodyAndVersion {
 	docMetadata := p.writeDocument(dsName, docID, body)
@@ -134,7 +145,7 @@ func (p *SyncGatewayPeer) DeleteDocument(dsName sgbucket.DataStoreName, docID st
 }
 
 // WaitForDocVersion waits for a document to reach a specific version. The test will fail if the document does not reach the expected version in 20s.
-func (p *SyncGatewayPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, replications Replications) db.Body {
+func (p *SyncGatewayPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) db.Body {
 	collection, ctx := p.getCollection(dsName)
 	var doc *db.Document
 	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
@@ -148,15 +159,34 @@ func (p *SyncGatewayPeer) WaitForDocVersion(dsName sgbucket.DataStoreName, docID
 		// Only assert on CV since RevTreeID might not be present if this was a Couchbase Server write
 		bodyBytes, err := doc.BodyBytes(ctx)
 		assert.NoError(c, err)
-		assertHLVEqual(c, docID, p.name, version, bodyBytes, expected, replications)
+		assertHLVEqual(c, dsName, docID, p.name, version, bodyBytes, expected, topology)
+	}, totalWaitTime, pollInterval)
+	return doc.Body(ctx)
+}
+
+// WaitForCV waits for a document to reach a specific CV. The test will fail if the document does not reach the expected version in 20s.
+func (p *SyncGatewayPeer) WaitForCV(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) db.Body {
+	collection, ctx := p.getCollection(dsName)
+	var doc *db.Document
+	require.EventuallyWithT(p.TB(), func(c *assert.CollectT) {
+		var err error
+		doc, err = collection.GetDocument(ctx, docID, db.DocUnmarshalAll)
+		assert.NoError(c, err)
+		if doc == nil {
+			return
+		}
+		version := DocMetadataFromDocument(doc)
+		bodyBytes, err := doc.BodyBytes(ctx)
+		assert.NoError(c, err)
+		assertCVEqual(c, dsName, docID, p.name, version, bodyBytes, expected, topology)
 	}, totalWaitTime, pollInterval)
 	return doc.Body(ctx)
 }
 
 // WaitForTombstoneVersion waits for a document to reach a specific version, this must be a tombstone. The test will fail if the document does not reach the expected version in 20s.
-func (p *SyncGatewayPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, replications Replications) {
-	docBytes := p.WaitForDocVersion(dsName, docID, expected, replications)
-	require.Empty(p.TB(), docBytes, "expected tombstone for docID %s, got %s. Replications:\n%s", docID, docBytes, replications.Stats())
+func (p *SyncGatewayPeer) WaitForTombstoneVersion(dsName sgbucket.DataStoreName, docID string, expected DocMetadata, topology Topology) {
+	docBytes := p.WaitForDocVersion(dsName, docID, expected, topology)
+	require.Empty(p.TB(), docBytes, "expected tombstone for docID %s, got %s. Replications:\n%s", docID, docBytes, topology.GetDocState(p.TB(), dsName, docID))
 }
 
 // Close will shut down the peer and close any active replications on the peer.

--- a/topologytest/topologies_test.go
+++ b/topologytest/topologies_test.go
@@ -8,15 +8,15 @@
 
 package topologytest
 
-// Topology defines a topology for a set of peers and replications. This can include Couchbase Server, Sync Gateway, and Couchbase Lite peers, with push or pull replications between them.
-type Topology struct {
+// TopologySpecification defines a topology for a set of peers and replications. This can include Couchbase Server, Sync Gateway, and Couchbase Lite peers, with push or pull replications between them.
+type TopologySpecification struct {
 	description  string
 	peers        map[string]PeerOptions
 	replications []PeerReplicationDefinition
 }
 
 // Topologies represents user configurations of replications.
-var Topologies = []Topology{
+var TopologySpecifications = []TopologySpecification{
 	{
 		/*
 			+ - - - - - - +
@@ -273,9 +273,9 @@ var Topologies = []Topology{
 	*/
 }
 
-// simpleTopologies represents simplified topologies to make testing the integration test code easier.
+// simpleTopologySpecifications represents simplified topologies to make testing the integration test code easier.
 // nolint: unused
-var simpleTopologies = []Topology{
+var simpleTopologySpecifications = []TopologySpecification{
 	{
 
 		/*


### PR DESCRIPTION
Create `Topology.GetDocState` to print the state of the document and replications on failure to make it easier to debug, rather than add all the information adhoc.

- This required passing `Peers` and `Replications` into all the assertions, so I just bundled them into a `Topology` struct.
- Create `GetDocumentIfExists` for `GetDocState` only, since the document might not exist and I don't want this to fail the test assertions.

Enhancement-ish, will be required when I push https://github.com/couchbase/sync_gateway/pull/7657. We can't wait for full HLV on resurrection because a resurrection will drop system xattrs. See the following example:

1. cbl writes `1@cbl1`
2. start replications
3. `cv:1@cbl1` everywhere
4. stop replications
5. sg delete, creates `cv:2@cbs1, pv:1@cbl1`
6. start replications
7. `cv:2@cbs1 pv:1@cbl1` exists everywhere
8. stop replications
9. cbs resurrect `cv:3@cbs1` (NOTE: pv cleared due CBS resurrection dropping system xattrs)
10. start replications
   a. cbl ends up with `cv:3@cbs1, pv:1@cbl1`
   b. sg/cbs end up with `cv:3@cbs1`
