### PR TITLE
CBG-4782: new rev tree property for ISGR replications

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -258,6 +258,9 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 		return nil, nil, err
 	}
 
+	// set client type to SGW on active peer
+	bsc.SetClientType(BLIPClientTypeSGR2)
+
 	// set active subprotocol after handshake
 	err = bsc.SetActiveCBMobileSubprotocol(blipContext.ActiveSubprotocol())
 	if err != nil {

--- a/db/blip.go
+++ b/db/blip.go
@@ -84,7 +84,7 @@ func defaultBlipLogger(ctx context.Context) blip.LogFn {
 }
 
 // blipRevMessageProperties returns a set of BLIP message properties for the given parameters.
-func blipRevMessageProperties(revisionHistory []string, deleted bool, seq SequenceID, replacedRevID string) blip.Properties {
+func blipRevMessageProperties(revisionHistory []string, deleted bool, seq SequenceID, replacedRevID string, revTreeProperty []string) blip.Properties {
 	properties := make(blip.Properties)
 
 	// TODO: Assert? db.SequenceID.MarshalJSON can never error
@@ -93,6 +93,10 @@ func blipRevMessageProperties(revisionHistory []string, deleted bool, seq Sequen
 
 	if len(revisionHistory) > 0 {
 		properties[RevMessageHistory] = strings.Join(revisionHistory, ",")
+	}
+
+	if len(revTreeProperty) > 0 {
+		properties[RevMessageTreeHistory] = strings.Join(revTreeProperty, ",")
 	}
 
 	if deleted {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1116,7 +1116,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	if bh.clientType == BLIPClientTypeSGR2 && len(legacyRevList) == 0 {
 		revTree, ok := rq.Properties[RevMessageTreeHistory]
 		if ok {
-			revTreeProperty = append(revTreeProperty, strings.Split(revTree, ",")...)
+			revTreeProperty = append(revTreeProperty, strings.Split(revTree, ",")...) // nolint: all
 		}
 	}
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1112,7 +1112,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		newDoc.HLV = incomingHLV
 	}
 
-	// if the client is SGW and there are no legacy revs being sent (i.e. doc is no pre upgraded doc) check the rev tree property
+	// if the client is SGW and there are no legacy revs being sent (i.e. doc is not a pre-upgraded doc) check the rev tree property
 	if bh.clientType == BLIPClientTypeSGR2 && len(legacyRevList) == 0 {
 		revTree, ok := rq.Properties[RevMessageTreeHistory]
 		if ok {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -868,4 +868,3 @@ func (bsc *BlipSyncContext) useHLV() bool {
 func (bsc *BlipSyncContext) sendRevTreeProperty() bool {
 	return bsc.activeCBMobileSubprotocol >= CBMobileReplicationV4 && bsc.clientType == BLIPClientTypeSGR2
 }
-

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -605,12 +605,17 @@ func (bsc *BlipSyncContext) setUseDeltas(clientCanUseDeltas bool) {
 func (bsc *BlipSyncContext) sendDelta(ctx context.Context, sender *blip.Sender, docID string, collectionIdx *int, deltaSrcRevID string, revDelta *RevisionDelta, seq SequenceID, resendFullRevisionFunc func() error) error {
 
 	var history []string
+	var revTreeProperty []string
 	if bsc.useHLV() {
 		history = append(history, revDelta.HlvHistory)
 	} else {
 		history = revDelta.RevisionHistory
 	}
-	properties := blipRevMessageProperties(history, revDelta.ToDeleted, seq, "")
+	if bsc.sendRevTreeProperty() {
+		revTreeProperty = append(revTreeProperty, revDelta.ToRevID)
+		revTreeProperty = append(revTreeProperty, revDelta.RevisionHistory...)
+	}
+	properties := blipRevMessageProperties(history, revDelta.ToDeleted, seq, "", revTreeProperty)
 	properties[RevMessageDeltaSrc] = deltaSrcRevID
 
 	base.DebugfCtx(ctx, base.KeySync, "Sending rev %q %s as delta. DeltaSrc:%s", base.UD(docID), revDelta.ToRevID, deltaSrcRevID)
@@ -768,14 +773,20 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 			history = append(history, docRev.hlvHistory)
 		}
 	}
+
+	var revTreeHistoryProperty []string
 	if legacyRev {
 		// append current revID and rest of rev tree after hlv history
 		revTreeHistory := toHistory(docRev.History, knownRevs, maxHistory)
 		history = append(history, docRev.RevID)
 		history = append(history, revTreeHistory...)
+	} else if bsc.sendRevTreeProperty() {
+		// if no legacy revs being sent and we are communicating with SGW client we should send revision history in the rev message
+		revTreeHistoryProperty = append(revTreeHistoryProperty, docRev.RevID) // we need current rev
+		revTreeHistoryProperty = append(revTreeHistoryProperty, toHistory(docRev.History, knownRevs, maxHistory)...)
 	}
 
-	properties := blipRevMessageProperties(history, docRev.Deleted, seq, replacedRevID)
+	properties := blipRevMessageProperties(history, docRev.Deleted, seq, replacedRevID, revTreeHistoryProperty)
 	if base.LogDebugEnabled(ctx, base.KeySync) {
 		replacedRevMsg := ""
 		if replacedRevID != "" {
@@ -851,3 +862,10 @@ func (bsc *BlipSyncContext) reportStats(updateImmediately bool) {
 func (bsc *BlipSyncContext) useHLV() bool {
 	return bsc.activeCBMobileSubprotocol >= CBMobileReplicationV4
 }
+
+// sendRevTreeProperty returns true if the rev tree property should be sent in the rev message. That is if we are
+// replicating with version vectors and the client we're communicating with is a SGW peer
+func (bsc *BlipSyncContext) sendRevTreeProperty() bool {
+	return bsc.activeCBMobileSubprotocol >= CBMobileReplicationV4 && bsc.clientType == BLIPClientTypeSGR2
+}
+

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -77,6 +77,7 @@ const (
 	RevMessageDeleted     = "deleted"
 	RevMessageSequence    = "sequence"
 	RevMessageHistory     = "history"
+	RevMessageTreeHistory = "revTree"
 	RevMessageNoConflicts = "noconflicts"
 	RevMessageDeltaSrc    = "deltaSrc"
 	RevMessageReplacedRev = "replacedRev"


### PR DESCRIPTION
CBG-4782

- PR for the transportation of the new rev tree property for ISGR replications
- Nothing is done with it yet this is done in future tickets
- Had to set client type on active peer given this wasn't set before and we need to know if its ISGR to send/receive this property

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs - #7668 not directly related but would want to rebase this or the other depending on which get merged first to ensure nothing is broken 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3244/
