### PR TITLE
Revert "Test-only tech-debt cleanup: Make `TestCtx` use stdlib `testing.Context()` instead of a DIY version"

### DIFF
--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -176,7 +176,9 @@ func NewTaskID(contextID string, taskName string) string {
 
 // TestCtx creates a context for the given test which is also cancelled once the test has completed.
 func TestCtx(t testing.TB) context.Context {
-	return LogContextWith(t.Context(), &LogContext{TestName: t.Name()})
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	t.Cleanup(cancelCtx)
+	return LogContextWith(ctx, &LogContext{TestName: t.Name()})
 }
 
 // BucketCtx extends the parent context with a bucket name.


### PR DESCRIPTION
Reverts couchbase/sync_gateway#7669

Had unintended side-effects on topology tests which used this context in a way that observed cancellation inside `Cleanup()` code.

Wasn't caught until merge because topology tests don't run in PRs.

Will revisit after 4.0