### PR TITLE
CBG-4797: make GetCV mirror GetRev and add request for history to it

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1153,7 +1153,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 			if parseErr != nil {
 				return base.HTTPErrorf(http.StatusUnprocessableEntity, "Unable to parse version for delta source for doc %s, error: %v", base.UD(docID), err)
 			}
-			deltaSrcRev, err = bh.collection.GetCV(bh.loggingCtx, docID, &deltaSrcVersion)
+			deltaSrcRev, err = bh.collection.GetCV(bh.loggingCtx, docID, &deltaSrcVersion, false)
 		} else {
 			deltaSrcRev, err = bh.collection.GetRev(bh.loggingCtx, docID, deltaSrcRevID, false, nil)
 		}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -687,7 +687,7 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 		if vrsErr != nil {
 			return vrsErr
 		}
-		docRev, originalErr = handleChangesResponseCollection.GetCV(bsc.loggingCtx, docID, &version)
+		docRev, originalErr = handleChangesResponseCollection.GetCV(bsc.loggingCtx, docID, &version, true)
 	}
 
 	// set if we find an alternative revision to send in the event the originally requested rev is unavailable

--- a/db/crud.go
+++ b/db/crud.go
@@ -437,7 +437,7 @@ func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Con
 	return revision, nil
 }
 
-func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *Version) (revision DocumentRevision, err error) {
+func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *Version, revTreeHistory bool) (revision DocumentRevision, err error) {
 	if cv != nil {
 		revision, err = db.revisionCache.GetWithCV(ctx, docid, cv, RevCacheOmitDelta)
 	} else {
@@ -446,8 +446,12 @@ func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, c
 	if err != nil {
 		return DocumentRevision{}, err
 	}
+	maxHistory := 0
+	if revTreeHistory {
+		maxHistory = math.MaxInt32
+	}
 
-	return db.documentRevisionForRequest(ctx, docid, revision, nil, cv, 0, nil)
+	return db.documentRevisionForRequest(ctx, docid, revision, nil, cv, maxHistory, nil)
 }
 
 // GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
@@ -1019,6 +1023,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 		// update the cvCAS on the SGWrite event too
 		d.HLV.CurrentVersionCAS = expandMacroCASValueUint64
 	}
+	fmt.Println("new hlv", d.HLV)
 	return d, nil
 }
 
@@ -2595,6 +2600,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			hlvHistory:  doc.HLV.ToHistoryForHLV(),
 			CV:          &Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version},
 		}
+
+		fmt.Println("put at rev cache", documentRevision.Deleted, documentRevision.History)
 
 		if updateRevCache {
 			if createNewRevIDSkipped {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1023,7 +1023,6 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 		// update the cvCAS on the SGWrite event too
 		d.HLV.CurrentVersionCAS = expandMacroCASValueUint64
 	}
-	fmt.Println("new hlv", d.HLV)
 	return d, nil
 }
 
@@ -2600,8 +2599,6 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			hlvHistory:  doc.HLV.ToHistoryForHLV(),
 			CV:          &Version{SourceID: doc.HLV.SourceID, Value: doc.HLV.Version},
 		}
-
-		fmt.Println("put at rev cache", documentRevision.Deleted, documentRevision.History)
 
 		if updateRevCache {
 			if createNewRevIDSkipped {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1959,7 +1959,7 @@ func TestGetCVWithDocResidentInCache(t *testing.T) {
 			vrs := doc.HLV.Version
 			src := doc.HLV.SourceID
 			sv := &Version{Value: vrs, SourceID: src}
-			revision, err := collection.GetCV(ctx, docID, sv)
+			revision, err := collection.GetCV(ctx, docID, sv, false)
 			require.NoError(t, err)
 			if testCase.access {
 				assert.Equal(t, rev, revision.RevID)
@@ -2018,7 +2018,7 @@ func TestGetByCVForDocNotResidentInCache(t *testing.T) {
 	vrs := doc.HLV.Version
 	src := doc.HLV.SourceID
 	sv := &Version{Value: vrs, SourceID: src}
-	revision, err := collection.GetCV(ctx, doc1ID, sv)
+	revision, err := collection.GetCV(ctx, doc1ID, sv, false)
 	require.NoError(t, err)
 
 	// assert the fetched doc is the first doc we added and assert that we did in fact get cache miss
@@ -2072,7 +2072,7 @@ func TestGetCVActivePathway(t *testing.T) {
 			revBody := Body{"channels": testCase.docChannels}
 			rev, doc, err := collection.Put(ctx, docID, revBody)
 			require.NoError(t, err)
-			revision, err := collection.GetCV(ctx, docID, nil)
+			revision, err := collection.GetCV(ctx, docID, nil, false)
 
 			if testCase.access == true {
 				require.NoError(t, err)


### PR DESCRIPTION
CBG-4797

- This PR mirrors what `GetRev` does for history

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGateway-Integration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGateway-Integration/3246/
