### PR TITLE
fix race condition

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -295,7 +295,7 @@ func (cd *clientDoc) _proposeChangesEntryForDoc() *proposeChangeBatchEntry {
 		}
 		revTreeIDHistory = append(revTreeIDHistory, cd._revisionsBySeq[seq].version.RevTreeID)
 	}
-	return &proposeChangeBatchEntry{docID: cd.id, version: latestRev.version, revTreeIDHistory: revTreeIDHistory, hlvHistory: latestRev.HLV, latestServerVersion: cd._latestServerVersion, seq: cd._latestSeq, isDelete: latestRev.isDelete}
+	return &proposeChangeBatchEntry{docID: cd.id, version: latestRev.version, revTreeIDHistory: revTreeIDHistory, hlvHistory: *latestRev.HLV.Copy(), latestServerVersion: cd._latestServerVersion, seq: cd._latestSeq, isDelete: latestRev.isDelete}
 }
 
 // _getLatestHLVCopy returns a copy of the HLV. If there is no document, return an empty HLV.


### PR DESCRIPTION
Fixes data race since the HLV was a shallow copy:

```
5:40:07 ==================
15:40:07 
WARNING: DATA RACE
15:40:07 Read at 0x00c00236b530 by goroutine 40313:
15:40:07   reflect.mapdelete_faststr()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/runtime/map_swiss.go:279 +0x4c
15:40:07   reflect.Value.lenNonSlice()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/reflect/value.go:1772 +0x1bc
15:40:07   reflect.Value.Len()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/reflect/value.go:1761 +0xe4
15:40:07   internal/fmtsort.Sort()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/internal/fmtsort/sort.go:56 +0xd8
15:40:07   fmt.(*pp).printValue()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:816 +0xdc0
15:40:07   fmt.(*pp).printValue()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:853 +0x1718
15:40:07   fmt.(*pp).printArg()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:759 +0x8a0
15:40:07   fmt.(*pp).doPrintf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:1074 +0x42c
15:40:07   fmt.Sprintf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:239 +0x50
15:40:07   github.com/couchbase/sync_gateway/rest.proposeChangeBatchEntry.GoString()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1235 +0x198
15:40:07   github.com/couchbase/sync_gateway/rest.(*proposeChangeBatchEntry).GoString()
15:40:07       <autogenerated>:1 +0x90
15:40:07   fmt.(*pp).handleMethods()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:650 +0x398
15:40:07   fmt.(*pp).printValue()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:770 +0xcc
15:40:07   fmt.(*pp).printValue()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:901 +0x1e74
15:40:07   fmt.(*pp).printArg()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:759 +0x8a0
15:40:07   fmt.(*pp).doPrintf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:1074 +0x42c
15:40:07   fmt.Appendf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:249 +0x5c
15:40:07   github.com/couchbase/sync_gateway/base.(*ConsoleLogger).logf.(*Logger).Printf.func1()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/log/log.go:269 +0x78
15:40:07   log.(*Logger).output()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/log/log.go:238 +0x28c
15:40:07   log.(*Logger).Printf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/log/log.go:268 +0x12c
15:40:07   github.com/couchbase/sync_gateway/base.(*ConsoleLogger).logf()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/base/logger_console.go:119 +0xb0
15:40:07   github.com/couchbase/sync_gateway/base.logTo()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/base/logging.go:236 +0x508
15:40:07   github.com/couchbase/sync_gateway/base.DebugfCtx()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/base/logging.go:173 +0x2fc
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).sendProposeChanges()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1277 +0x260
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).sendRevisions()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1342 +0x58
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).StartPushWithOpts.func1()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1260 +0x328
15:40:07 
15:40:07 Previous write at 0x00c00236b530 by goroutine 40165:
15:40:07   runtime.mapaccess2_faststr()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/internal/runtime/maps/runtime_faststr_swiss.go:162 +0x29c
15:40:07   github.com/couchbase/sync_gateway/db.(*HybridLogicalVector).AddVersion()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/db/hybrid_logical_vector.go:284 +0x560
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).upsertDoc()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1546 +0x89c
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).AddRev()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1578 +0x78
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).AddRev()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1907 +0x1c
15:40:07   github.com/couchbase/sync_gateway/rest.TestCBLRevposHandling.func1()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/attachment_test.go:2602 +0x5e0
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run.func3()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1063 +0xc0
15:40:07   testing.tRunner()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1792 +0x180
15:40:07   testing.(*T).Run.gowrap1()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x40
15:40:07 
15:40:07 Goroutine 40313 (running) created at:
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).StartPushWithOpts()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1248 +0x3c8
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).StartPush()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1171 +0x44
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).StartPush()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1878 +0x28
15:40:07   github.com/couchbase/sync_gateway/rest.TestCBLRevposHandling.func1()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/attachment_test.go:2596 +0x41c
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run.func3()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1063 +0xc0
15:40:07   testing.tRunner()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1792 +0x180
15:40:07   testing.(*T).Run.gowrap1()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x40
15:40:07 
15:40:07 Goroutine 40165 (running) created at:
15:40:07   testing.(*T).Run()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x684
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1061 +0x214
15:40:07   github.com/couchbase/sync_gateway/rest.TestCBLRevposHandling()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/attachment_test.go:2579 +0x2b0
15:40:07   testing.tRunner()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1792 +0x180
15:40:07   testing.(*T).Run.gowrap1()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x40
15:40:07 ==================
15:40:07 ==================
15:40:07 
WARNING: DATA RACE
15:40:07 Read at 0x00c0002f32c8 by goroutine 40313:
15:40:07   runtime.typedmemmove()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/runtime/mbarrier.go:152 +0x7c
15:40:07   reflect.copyVal()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/reflect/value.go:1792 +0x50
15:40:07   reflect.(*MapIter).Value()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/reflect/map_swiss.go:311 +0xf0
15:40:07   internal/fmtsort.Sort()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/internal/fmtsort/sort.go:60 +0x20c
15:40:07   fmt.(*pp).printValue()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:816 +0xdc0
15:40:07   fmt.(*pp).printValue()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:853 +0x1718
15:40:07   fmt.(*pp).printArg()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:759 +0x8a0
15:40:07   fmt.(*pp).doPrintf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:1074 +0x42c
15:40:07   fmt.Sprintf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:239 +0x50
15:40:07   github.com/couchbase/sync_gateway/rest.proposeChangeBatchEntry.GoString()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1235 +0x198
15:40:07   github.com/couchbase/sync_gateway/rest.(*proposeChangeBatchEntry).GoString()
15:40:07       <autogenerated>:1 +0x90
15:40:07   fmt.(*pp).handleMethods()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:650 +0x398
15:40:07   fmt.(*pp).printValue()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:770 +0xcc
15:40:07   fmt.(*pp).printValue()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:901 +0x1e74
15:40:07   fmt.(*pp).printArg()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:759 +0x8a0
15:40:07   fmt.(*pp).doPrintf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:1074 +0x42c
15:40:07   fmt.Appendf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/fmt/print.go:249 +0x5c
15:40:07   github.com/couchbase/sync_gateway/base.(*ConsoleLogger).logf.(*Logger).Printf.func1()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/log/log.go:269 +0x78
15:40:07   log.(*Logger).output()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/log/log.go:238 +0x28c
15:40:07   log.(*Logger).Printf()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/log/log.go:268 +0x12c
15:40:07   github.com/couchbase/sync_gateway/base.(*ConsoleLogger).logf()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/base/logger_console.go:119 +0xb0
15:40:07   github.com/couchbase/sync_gateway/base.logTo()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/base/logging.go:236 +0x508
15:40:07   github.com/couchbase/sync_gateway/base.DebugfCtx()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/base/logging.go:173 +0x2fc
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).sendProposeChanges()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1277 +0x260
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).sendRevisions()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1342 +0x58
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).StartPushWithOpts.func1()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1260 +0x328
15:40:07 
15:40:07 Previous write at 0x00c0002f32c8 by goroutine 40165:
15:40:07   github.com/couchbase/sync_gateway/db.(*HybridLogicalVector).AddVersion()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/db/hybrid_logical_vector.go:284 +0x56c
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).upsertDoc()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1546 +0x89c
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).AddRev()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1578 +0x78
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).AddRev()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1907 +0x1c
15:40:07   github.com/couchbase/sync_gateway/rest.TestCBLRevposHandling.func1()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/attachment_test.go:2602 +0x5e0
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run.func3()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1063 +0xc0
15:40:07   testing.tRunner()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1792 +0x180
15:40:07   testing.(*T).Run.gowrap1()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x40
15:40:07 
15:40:07 Goroutine 40313 (running) created at:
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).StartPushWithOpts()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1248 +0x3c8
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTesterCollectionClient).StartPush()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1171 +0x44
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).StartPush()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1878 +0x28
15:40:07   github.com/couchbase/sync_gateway/rest.TestCBLRevposHandling.func1()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/attachment_test.go:2596 +0x41c
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run.func3()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1063 +0xc0
15:40:07   testing.tRunner()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1792 +0x180
15:40:07   testing.(*T).Run.gowrap1()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x40
15:40:07 
15:40:07 Goroutine 40165 (running) created at:
15:40:07   testing.(*T).Run()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x684
15:40:07   github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1061 +0x214
15:40:07   github.com/couchbase/sync_gateway/rest.TestCBLRevposHandling()
15:40:07       /home/ec2-user/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/attachment_test.go:2579 +0x2b0
15:40:07   testing.tRunner()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1792 +0x180
15:40:07   testing.(*T).Run.gowrap1()
15:40:07       /home/ec2-user/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x40
15:40:07 ==================
15:40:07 2025-08-18T19:36:15.672Z [DBG] TEST+: t:TestCBLRevposHandling/versionVector db:db proposeChanges request body: [["doc2","185cf394e9090000@rosmar1","185cf394e9090000@rosmar1"]], changes:[]rest.proposeChangeBatchEntry{proposeChangeBatchEntry{docID: "doc2", version:RevTreeID:,CV:Version{SourceID:rosmar1, Value:1755545775658041344},revTreeIDHistory:[],hlvHistory:{0 rosmar1 1755545775658041344 map[] map[rosmar1:1755545775658041344]},seq:2,latestServerVersion:RevTreeID:,CV:Version{SourceID:rosmar1, Value:1755545775658041344},isDelete: false}}
```