### PR TITLE
CBG-4729: Add metrics to count tombstones per database

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -1939,6 +1939,7 @@ func (d *DbStats) unregisterDatabaseStats() {
 	prometheus.Unregister(d.DatabaseStats.NumPublicAllDocsRequests)
 	prometheus.Unregister(d.DatabaseStats.NumDocsPreFilterPublicAllDocs)
 	prometheus.Unregister(d.DatabaseStats.NumDocsPostFilterPublicAllDocs)
+	prometheus.Unregister(d.DatabaseStats.TombstoneCount)
 }
 
 func (d *DbStats) CollectionStat(scopeName, collectionName string) (*CollectionStats, error) {

--- a/base/stats.go
+++ b/base/stats.go
@@ -707,6 +707,8 @@ type DatabaseStats struct {
 	NumDocsPostFilterPublicAllDocs *SgwIntStat `json:"num_docs_post_filter_public_all_docs"`
 	// NumDocsPreFilterPublicAllDocs is the total number of documents returned before filtering for /_all_docs on the public interface.
 	NumDocsPreFilterPublicAllDocs *SgwIntStat `json:"num_docs_pre_filter_public_all_docs"`
+	// TombstoneCount is the total nummber of tombstones received by Sync Gateway
+	TombstoneCount *SgwIntStat `json:"tombstone_count"`
 }
 
 // This wrapper ensures that an expvar.Map type can be marshalled into JSON. The expvar.Map has no method to go direct to
@@ -1312,15 +1314,12 @@ func (s *SgwStats) ClearDBStats(name string) {
 	s.DbStats[name].unregisterQueryStats()
 
 	delete(s.DbStats, name)
-
 }
 
 // Removes the per-database stats for this database by removing the database from the map
 func RemovePerDbStats(dbName string) {
-
 	// Clear out the stats for this db since they will no longer be updated.
 	SyncGatewayStats.ClearDBStats(dbName)
-
 }
 
 func (d *DbStats) initCacheStats() error {
@@ -1878,6 +1877,10 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.TombstoneCount, err = NewIntStat(SubsystemDatabaseKey, "tombstone_count", StatUnitNoUnits, TombstoneCount, StatAddedVersion4dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityInternal, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.ImportFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
 
 	resUtil.CacheFeedMapStats = &ExpVarMapWrapper{new(expvar.Map).Init()}
@@ -2034,7 +2037,6 @@ func (d *DbStats) initSecurityStats() error {
 }
 
 func (d *DbStats) unregisterReplicationStats(replicationID string) {
-
 	if d.DbReplicatorStats[replicationID] == nil {
 		return
 	}
@@ -2333,7 +2335,6 @@ func (dbr *DbReplicatorStats) Reset() {
 	dbr.ExpectedSequenceLenPostCleanup.Set(0)
 	dbr.ProcessedSequenceLen.Set(0)
 	dbr.ProcessedSequenceLenPostCleanup.Set(0)
-
 }
 
 func (d *DbStats) Security() *SecurityStats {

--- a/base/stats.go
+++ b/base/stats.go
@@ -1876,7 +1876,7 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.TombstoneCount, err = NewIntStat(SubsystemDatabaseKey, "tombstone_count", StatUnitNoUnits, TombstoneCount, StatAddedVersion4dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityInternal, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.TombstoneCount, err = NewIntStat(SubsystemDatabaseKey, "tombstone_count", StatUnitNoUnits, TombstoneCountDesc, StatAddedVersion4dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -707,7 +707,7 @@ type DatabaseStats struct {
 	NumDocsPostFilterPublicAllDocs *SgwIntStat `json:"num_docs_post_filter_public_all_docs"`
 	// NumDocsPreFilterPublicAllDocs is the total number of documents returned before filtering for /_all_docs on the public interface.
 	NumDocsPreFilterPublicAllDocs *SgwIntStat `json:"num_docs_pre_filter_public_all_docs"`
-	// TombstoneCount is the total nummber of tombstones received by Sync Gateway
+	// TombstoneCount is the total number of tombstones received by Sync Gateway
 	TombstoneCount *SgwIntStat `json:"tombstone_count"`
 }
 
@@ -1312,7 +1312,6 @@ func (s *SgwStats) ClearDBStats(name string) {
 	}
 
 	s.DbStats[name].unregisterQueryStats()
-
 	delete(s.DbStats, name)
 }
 

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -344,7 +344,7 @@ const (
 
 	NumDocsPostFilterPublicAllDocsDesc = "The total number of documents returned on all public /_all_docs requests after filtering"
 
-	TombstoneCount = "The total number of tombstones processed by database"
+	TombstoneCountDesc = "The total number of tombstones processed by database"
 )
 
 // Delta Sync stats descriptions

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -343,6 +343,8 @@ const (
 	NumDocsPreFilterPublicAllDocsDesc = "The total number of documents returned on all public /_all_docs requests before filtering"
 
 	NumDocsPostFilterPublicAllDocsDesc = "The total number of documents returned on all public /_all_docs requests after filtering"
+
+	TombstoneCount = "The total number of tombstones processed by database"
 )
 
 // Delta Sync stats descriptions

--- a/db/crud.go
+++ b/db/crud.go
@@ -2624,6 +2624,9 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 	if inConflict {
 		db.dbStats().Database().ConflictWriteCount.Add(1)
 	}
+	if doc.IsDeleted() {
+		db.dbStats().Database().TombstoneCount.Add(1)
+	}
 
 	if doc.History[newRevID] != nil {
 		// Store the new revision in the cache

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3611,3 +3611,36 @@ func TestBlipPullConflict(t *testing.T) {
 		require.True(t, bucketDoc.HLV.Equal(postConflictHLV), "Expected bucket doc HLV to match post-conflict HLV, got %#v, expected %#v", bucketDoc.HLV, postConflictHLV)
 	})
 }
+
+func TestTombstoneCount(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	rtConfig := RestTesterConfig{
+		GuestEnabled: true,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+
+		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		btcRunner.StartPush(client.id)
+
+		const docID1 = "doc1"
+		docVersion := btcRunner.AddRev(client.id, docID1, EmptyDocVersion(), []byte(`{"key": "val"}`))
+		rt.WaitForVersion(docID1, docVersion)
+
+		deleteVersion := btcRunner.DeleteDoc(client.id, docID1, &docVersion)
+		rt.WaitForTombstone(docID1, deleteVersion)
+		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DatabaseStats.TombstoneCount.Value())
+
+		const docID2 = "doc2"
+		version := rt.CreateTestDoc(docID2)
+		rt.DeleteDoc(docID2, version)
+		assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DatabaseStats.TombstoneCount.Value())
+	})
+
+}


### PR DESCRIPTION
CBG-4729

- Added metrics to count the number of tombstones received per database
- Added Test Case to validate the working of tombstone metric when tombstone is received from REST API or BLIP

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/41/
