### PR TITLE
Store supported subprotocols on BlipTestClientRunner

### DIFF
--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2251,12 +2251,11 @@ func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
 	const (
 		doc1ID = "doc1"
 	)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPull(btc.id)
@@ -2303,12 +2302,11 @@ func TestUpdateExistingAttachment(t *testing.T) {
 		doc2ID = "doc2"
 	)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPull(btc.id)
@@ -2358,12 +2356,11 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 	const doc1ID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPull(btc.id)
@@ -2396,12 +2393,11 @@ func TestAttachmentWithErroneousRevPos(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 		// Create rev 1 with the hello.txt attachment
 		const docID = "doc"
@@ -2576,12 +2572,11 @@ func TestCBLRevposHandling(t *testing.T) {
 		doc2ID = "doc2"
 	)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		startingBody := db.Body{"foo": "bar"}
@@ -2869,14 +2864,13 @@ func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
 func TestBlipPushRevWithAttachment(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
-		// Setup
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTesterPersistentConfig(t)
 		defer rt.Close()
 		const username = "bernard"
 		rt.CreateUser(username, nil)
 
-		opts := &BlipTesterClientOpts{Username: username, SupportedBLIPProtocols: SupportedBLIPProtocols}
+		opts := &BlipTesterClientOpts{Username: username}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
 

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1221,7 +1221,7 @@ func TestAuditDocumentCreateUpdateEvents(t *testing.T) {
 func TestAuditChangesFeedStart(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // CBG-4166
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 
 		rt := createAuditLoggingRestTester(t)
 		defer rt.Close()
@@ -1238,8 +1238,7 @@ func TestAuditChangesFeedStart(t *testing.T) {
 
 		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		const (
@@ -1573,7 +1572,7 @@ func createAuditLoggingRestTester(t *testing.T) *RestTester {
 
 func TestAuditBlipCRUD(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 
 		rt := createAuditLoggingRestTester(t)
 		defer rt.Close()
@@ -1593,8 +1592,7 @@ func TestAuditBlipCRUD(t *testing.T) {
 
 		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		testCases := []struct {

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -45,17 +45,13 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 	const docID = "doc1"
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.RunSubprotocolV2(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{}
-		opts.SupportedBLIPProtocols = []string{db.CBMobileReplicationV2.SubprotocolString()}
-
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPull(btc.id)
@@ -119,12 +115,11 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 	const docID = "doc1"
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPull(btc.id)
@@ -187,15 +182,12 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 	)
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.RunSubprotocolV2(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			SupportedBLIPProtocols: []string{db.CBMobileReplicationV2.SubprotocolString()},
-		})
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPull(btc.id)
@@ -245,15 +237,12 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 	)
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Doesn't require HLV - attachment v2 protocol test
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.RunSubprotocolV2(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			SupportedBLIPProtocols: []string{db.CBMobileReplicationV2.SubprotocolString()},
-		})
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPush(btc.id)
@@ -284,13 +273,12 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		docID := t.Name()
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, SourceID: "abc"}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPush(btc.id)
@@ -348,12 +336,11 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // There is no such thing as branching ancestors in version vectors
 
 	const docID = "doc1"
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, SourceID: "abc"}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 		btcRunner.StartPull(btc.id)
 
@@ -509,13 +496,12 @@ func TestBlipAttachNameChange(t *testing.T) {
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
 		docID := "doc"
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client1.Close()
 
 		btcRunner.StartPull(client1.id)
@@ -560,12 +546,11 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires legacy attachment upgrade to HLV (CBG-3806)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client1.Close()
 		// Create document in the bucket with a legacy attachment
 		docID := "doc"
@@ -609,12 +594,11 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // Requires legacy attachment upgrade to HLV (CBG-3806)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client1 := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client1.Close()
 
 		// Create document in the bucket with a legacy attachment.  Properties here align with rawDocWithAttachmentAndSyncMeta
@@ -686,12 +670,11 @@ func TestPushDocWithNonRootAttachmentProperty(t *testing.T) {
 	doc3ID := t.Name() + "doc3"
 	doc4ID := t.Name() + "doc4"
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		btcRunner.StartPush(btc.id)

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -30,12 +30,11 @@ func TestBlipGetCollections(t *testing.T) {
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTesterMultipleCollections(t, rtConfig, 1)
 		defer rt.Close()
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
 			SkipCollectionsInitialization: true,
-			SupportedBLIPProtocols:        SupportedBLIPProtocols,
 		})
 		defer btc.Close()
 
@@ -153,12 +152,11 @@ func TestBlipReplicationNoDefaultCollection(t *testing.T) {
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 		checkpointID1 := "checkpoint1"
 		checkpoint1Body := db.Body{"seq": "123"}
@@ -185,12 +183,11 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		checkpointID1 := "checkpoint1"
@@ -249,12 +246,11 @@ func TestCollectionsReplication(t *testing.T) {
 	const docID = "doc1"
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		version := btc.rt.PutDocDirectly(docID, db.Body{})
@@ -272,12 +268,11 @@ func TestBlipReplicationMultipleCollections(t *testing.T) {
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		docName := "doc1"
@@ -311,12 +306,11 @@ func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTesterMultipleCollections(t, rtConfig, 2)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		body := `{"foo":"bar"}`

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1997,7 +1997,7 @@ func TestSendReplacementRevision(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 
 	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // requires cv in PUT rest response
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				rt := NewRestTester(t,
@@ -2029,10 +2029,9 @@ func TestSendReplacementRevision(t *testing.T) {
 				}
 
 				opts := &BlipTesterClientOpts{
-					Username:               alice,
-					SupportedBLIPProtocols: SupportedBLIPProtocols,
-					sendReplacementRevs:    test.clientSendReplacementRevs,
-					changesEntryCallback:   changesEntryCallbackFn,
+					Username:             alice,
+					sendReplacementRevs:  test.clientSendReplacementRevs,
+					changesEntryCallback: changesEntryCallbackFn,
 				}
 				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 				defer btc.Close()
@@ -2099,12 +2098,11 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 		client.ClientDeltas = true
 
@@ -2140,13 +2138,12 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.SkipSubtest[RevtreeSubtestName] = true // V4 replication only test
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 		collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 
 		btcRunner.StartPull(client.id)
@@ -2192,12 +2189,11 @@ func TestBlipClientSendDelete(t *testing.T) {
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 
 		btcRunner.StartPush(client.id)
@@ -2221,12 +2217,11 @@ func TestActiveOnlyContinuous(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc1"
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		version := rt.PutDocDirectly(docID, db.Body{"test": true})
@@ -2252,12 +2247,11 @@ func TestBlipNorev(t *testing.T) {
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
 		norevMsg := db.NewNoRevMessage()
@@ -2304,17 +2298,16 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 		defer rt.Close()
 
 		const user = "user"
 		rt.CreateUser(user, []string{"A", "B"})
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               user,
-			ClientDeltas:           false,
-			SendRevocations:        true,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username:        user,
+			ClientDeltas:    false,
+			SendRevocations: true,
 		})
 		defer btc.Close()
 
@@ -2386,17 +2379,16 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 		defer rt.Close()
 
 		const user = "user"
 		rt.CreateUser(user, []string{"A", "B"})
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               user,
-			ClientDeltas:           false,
-			SendRevocations:        true,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username:        user,
+			ClientDeltas:    false,
+			SendRevocations: true,
 		})
 		defer btc.Close()
 
@@ -2669,7 +2661,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		// Setup
 		rt := NewRestTester(t,
 			&RestTesterConfig{
@@ -2677,8 +2669,7 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 			})
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 
 		// Track last sequence for next changes feed
@@ -2858,7 +2849,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 		},
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		for _, test := range testCases {
 			t.Run(fmt.Sprintf("%s", test.error), func(t *testing.T) {
 				docName := fmt.Sprintf("%s", test.error)
@@ -2872,8 +2863,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 				leakyDataStore, ok := base.AsLeakyDataStore(rt.Bucket().DefaultDataStore())
 				require.True(t, ok)
 
-				opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 				defer btc.Close()
 
 				// Change noRev handler so it's known when a noRev is received
@@ -2930,12 +2920,11 @@ func TestUnsubChanges(t *testing.T) {
 		doc2ID = "doc2ID"
 	)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 		// Confirm no error message or panic is returned in response
 		btcRunner.UnsubPullChanges(btc.id)
@@ -2985,7 +2974,7 @@ func TestRequestPlusPull(t *testing.T) {
 			}`,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 		database := rt.GetDatabase()
@@ -2993,8 +2982,7 @@ func TestRequestPlusPull(t *testing.T) {
 		const bernard = "bernard"
 		rt.CreateUser(bernard, nil)
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               bernard,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username: bernard,
 		})
 		defer client.Close()
 
@@ -3049,7 +3037,7 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 		database := rt.GetDatabase()
@@ -3057,8 +3045,7 @@ func TestRequestPlusPullDbConfig(t *testing.T) {
 		const bernard = "bernard"
 		rt.CreateUser(bernard, nil)
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               bernard,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username: bernard,
 		})
 		defer client.Close()
 
@@ -3113,14 +3100,13 @@ func TestBlipRefreshUser(t *testing.T) {
 	const docID = "doc1"
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
 		const username = "bernard"
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               username,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username: username,
 		})
 		defer btc.Close()
 
@@ -3163,7 +3149,7 @@ func TestImportInvalidSyncGetsNoRev(t *testing.T) {
 	docID := "doc" + t.Name()
 	docID2 := "doc2" + t.Name()
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &RestTesterConfig{
 			AutoImport: base.Ptr(false),
 			SyncFn:     channels.DocChannelsSyncFunction,
@@ -3175,8 +3161,7 @@ func TestImportInvalidSyncGetsNoRev(t *testing.T) {
 		collection, ctx := rt.GetSingleTestDatabaseCollection()
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
-			Username:               bob,
+			Username: bob,
 		})
 		defer btc.Close()
 		version := rt.PutDocDirectly(docID, JsonToMap(t, `{"some":"data", "channels":["ABC"]}`))
@@ -3222,7 +3207,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyCache, base.KeyChanges, base.KeySGTest)
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // CBG-4166
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		syncFn := `function(doc) {
 						if (doc.invalid) {
 							throw("invalid document")
@@ -3314,8 +3299,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 				rt.GetDatabase().FlushRevisionCacheForTest()
 
 				btc2 := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-					Username:               username,
-					SupportedBLIPProtocols: SupportedBLIPProtocols,
+					Username: username,
 				})
 				defer btc2.Close()
 
@@ -3334,7 +3318,7 @@ func TestBlipDatabaseClose(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTesterPersistentConfig(t)
 		defer rt.Close()
 		const alice = "alice"
@@ -3352,7 +3336,7 @@ func TestBlipDatabaseClose(t *testing.T) {
 
 		// put a doc, and make sure blip connection is established
 		markerDoc := "markerDoc"
-		markerDocVersion := rt.CreateTestDoc(markerDoc)
+		markerDocVersion := rt.PutDocDirectly(markerDoc, db.Body{"mark": "doc"})
 		rt.WaitForPendingChanges()
 		btcRunner.StartPull(btc.id)
 
@@ -3390,14 +3374,13 @@ func TestPutRevBlip(t *testing.T) {
 func TestBlipMergeVersions(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.SkipSubtest[RevtreeSubtestName] = true // requires hlv
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTesterPersistentConfig(t)
 		defer rt.Close()
 		const alice = "alice"
 		rt.CreateUser(alice, []string{"*"})
 		opts := &BlipTesterClientOpts{
-			Username:               alice,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username: alice,
 		}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()
@@ -3474,7 +3457,7 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		var shouldChannelQueryError atomic.Bool
 		rt := NewRestTester(t, &RestTesterConfig{
 			LeakyBucketConfig: &base.LeakyBucketConfig{
@@ -3520,7 +3503,7 @@ func TestBlipPushRevOnResurrection(t *testing.T) {
 
 			btcRunner.SkipSubtest[VersionVectorSubtestName] = true // CBG-4786 skipped pending work in this ticket
 
-			btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+			btcRunner.Run(func(t *testing.T) {
 				rt := NewRestTester(t, &RestTesterConfig{
 					PersistentConfig: true,
 				})
@@ -3540,7 +3523,7 @@ func TestBlipPushRevOnResurrection(t *testing.T) {
 
 				const alice = "alice"
 				rt.CreateUser(alice, nil)
-				opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols, Username: "alice"}
+				opts := &BlipTesterClientOpts{Username: "alice"}
 				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 				defer btc.Close()
 
@@ -3559,7 +3542,7 @@ func TestBlipPullConflict(t *testing.T) {
 
 	btcRunner.SkipSubtest[RevtreeSubtestName] = true
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTesterPersistentConfig(t)
 		defer rt.Close()
 
@@ -3573,8 +3556,7 @@ func TestBlipPullConflict(t *testing.T) {
 		sgVersion := rt.PutDocDirectly(docID, db.Body{"actor": "sg"})
 
 		opts := &BlipTesterClientOpts{
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
-			Username:               alice,
+			Username: alice,
 		}
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer btc.Close()

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3601,12 +3601,11 @@ func TestTombstoneCount(t *testing.T) {
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 
 		btcRunner.StartPush(client.id)

--- a/rest/blip_api_no_race_test.go
+++ b/rest/blip_api_no_race_test.go
@@ -47,12 +47,11 @@ func TestBlipPusherUpdateDatabase(t *testing.T) {
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t, &rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 
 		var lastPushRevErr atomic.Value

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -38,14 +38,13 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 	docID := t.Name() + "_doc1"
 	docID2 := t.Name() + "_doc2"
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t,
 			&rtConfig)
 		defer rt.Close()
 		ctx := base.TestCtx(t)
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 
 		btcRunner.StartPull(client.id)
@@ -104,13 +103,12 @@ func TestBlipClientPushAndPullReplication(t *testing.T) {
 	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc1"
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t,
 			&rtConfig)
 		defer rt.Close()
 
-		opts := &BlipTesterClientOpts{SupportedBLIPProtocols: SupportedBLIPProtocols}
-		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 
 		btcRunner.StartPull(client.id)

--- a/rest/blip_channel_filter_test.go
+++ b/rest/blip_channel_filter_test.go
@@ -22,7 +22,7 @@ import (
 func TestChannelFilterRemovalFromChannel(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache, base.KeyCRUD, base.KeyHTTP)
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T, _ []string) {
+	btcRunner.Run(func(t *testing.T) {
 		for _, sendDocWithChannelRemoval := range []bool{true, false} {
 			t.Run(fmt.Sprintf("sendDocWithChannelRemoval=%v", sendDocWithChannelRemoval), func(t *testing.T) {
 				rt := NewRestTester(t, &RestTesterConfig{

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2205,15 +2205,14 @@ func TestRevocationMessage(t *testing.T) {
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		revocationTester, rt := InitScenario(t, nil)
 		defer rt.Close()
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "user",
-			ClientDeltas:           false,
-			SendRevocations:        true,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username:        "user",
+			ClientDeltas:    false,
+			SendRevocations: true,
 		})
 		defer btc.Close()
 
@@ -2314,15 +2313,14 @@ func TestRevocationNoRev(t *testing.T) {
 	const docID = "doc"
 	const waitMarkerID = "docmarker"
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		revocationTester, rt := InitScenario(t, nil)
 		defer rt.Close()
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "user",
-			ClientDeltas:           false,
-			SendRevocations:        true,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username:        "user",
+			ClientDeltas:    false,
+			SendRevocations: true,
 		})
 		defer btc.Close()
 
@@ -2376,7 +2374,7 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	const docID = "doc"
 	const waitMarkerID = "docmarker"
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		var throw atomic.Bool
 		// Two callbacks to cover usage with CBS/Xattrs and without
 		revocationTester, rt := InitScenario(
@@ -2400,10 +2398,9 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 		defer rt.Close()
 
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "user",
-			ClientDeltas:           false,
-			SendRevocations:        true,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username:        "user",
+			ClientDeltas:    false,
+			SendRevocations: true,
 		})
 		defer btc.Close()
 
@@ -2446,7 +2443,7 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
-	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
+	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t,
 			&RestTesterConfig{
 				GuestEnabled: false,
@@ -2470,9 +2467,8 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 
 		// 4. Try to sync
 		bt := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{
-			Username:               "bilbo",
-			SendRevocations:        true,
-			SupportedBLIPProtocols: SupportedBLIPProtocols,
+			Username:        "bilbo",
+			SendRevocations: true,
 		})
 		defer bt.Close()
 

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -62,10 +62,9 @@ type BlipTesterClientOpts struct {
 	ClientDeltas                  bool // Support deltas on the client side
 	Username                      string
 	SendRevocations               bool
-	SupportedBLIPProtocols        []string
 	SkipCollectionsInitialization bool
 
-	AllowCreationWithoutBlipTesterClientRunner bool // Allow the client to be created outside of a BlipTesterClientRunner.Run() subtest
+	AllowCreationWithoutBlipTesterClientRunner bool // Allow the client to be created outside of a BlipTesterClientRunner.Run subtest
 	// a deltaSrc rev ID for which to reject a delta
 	rejectDeltasForSrcRev string
 
@@ -94,10 +93,11 @@ const defaultBlipTesterClientRevsLimit = 20
 type BlipTesterClient struct {
 	BlipTesterClientOpts
 
-	id              uint32 // unique ID for the client
-	rt              *RestTester
-	pullReplication *BlipTesterReplicator // SG -> CBL replications
-	pushReplication *BlipTesterReplicator // CBL -> SG replications
+	supportedSubprotocols []string // subprotocols supported by this client, e.g. db.CBMobileReplicationV2
+	id                    uint32   // unique ID for the client
+	rt                    *RestTester
+	pullReplication       *BlipTesterReplicator // SG -> CBL replications
+	pushReplication       *BlipTesterReplicator // CBL -> SG replications
 
 	collectionClients        []*BlipTesterCollectionClient
 	nonCollectionAwareClient *BlipTesterCollectionClient
@@ -460,6 +460,7 @@ type BlipTestClientRunner struct {
 	t                           *testing.T
 	initialisedInsideRunnerCode bool            // flag to check that the BlipTesterClient is being initialised in the correct area (inside the Run() method)
 	SkipSubtest                 map[string]bool // map of sub tests on the blip tester runner to skip
+	supportedSubprotocols       []string        // subprotocols supported by all clients created by this runner
 }
 
 // BlipTesterReplicator is a BlipTester which stores a map of messages keyed by Serial Number
@@ -480,6 +481,11 @@ func NewBlipTesterClientRunner(t *testing.T) *BlipTestClientRunner {
 		clients:     make(map[uint32]*BlipTesterClient),
 		SkipSubtest: make(map[string]bool),
 	}
+}
+
+// SetSubprotocols forces all BlipTesterClient to run with specific subprotocols. Use BlipTestClientRunner.Run to run tests.
+func (btcRunner *BlipTestClientRunner) SetSubprotocols(subprotocols []string) {
+	btcRunner.supportedSubprotocols = subprotocols
 }
 
 // Close shuts down all the clients and clears all messages stored.
@@ -963,7 +969,7 @@ func (btcc *BlipTesterCollectionClient) updateLastReplicatedRev(docID string, ve
 func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient, skipCollectionsInitialization bool) *BlipTesterReplicator {
 	bt := NewBlipTesterFromSpecWithRT(btc.rt, &BlipTesterSpec{
 		connectingUsername:            btc.Username,
-		blipProtocols:                 btc.SupportedBLIPProtocols,
+		blipProtocols:                 btc.supportedSubprotocols,
 		skipCollectionsInitialization: skipCollectionsInitialization,
 		origin:                        btc.origin,
 	})
@@ -1011,10 +1017,11 @@ func (btcRunner *BlipTestClientRunner) NewBlipTesterClientOptsWithRT(rt *RestTes
 		opts.ConflictResolver = ConflictResolverLastWriteWins
 	}
 	client = &BlipTesterClient{
-		BlipTesterClientOpts: *opts,
-		rt:                   rt,
-		id:                   id.ID(),
-		hlc:                  rosmar.NewHybridLogicalClock(0),
+		BlipTesterClientOpts:  *opts,
+		rt:                    rt,
+		id:                    id.ID(),
+		hlc:                   rosmar.NewHybridLogicalClock(0),
+		supportedSubprotocols: btcRunner.supportedSubprotocols,
 	}
 	btcRunner.clients[client.id] = client
 	client.createBlipTesterReplications()
@@ -1048,21 +1055,46 @@ func (btcRunner *BlipTestClientRunner) TB() testing.TB {
 	return btcRunner.t
 }
 
-func (btcRunner *BlipTestClientRunner) Run(test func(t *testing.T, SupportedBLIPProtocols []string)) {
+// Run runs the tests in two modes: one with revtree subprotocol enabled and one with version vector subprotocol enabled.
+func (btcRunner *BlipTestClientRunner) Run(test func(t *testing.T)) {
+	if btcRunner.initialisedInsideRunnerCode {
+		require.FailNow(btcRunner.TB(), "must not initialise BlipTesterClient inside Run() method")
+	}
 	btcRunner.initialisedInsideRunnerCode = true
 	// reset to protect against someone creating a new client after Run() is run
-	defer func() { btcRunner.initialisedInsideRunnerCode = false }()
+	defer func() {
+		btcRunner.initialisedInsideRunnerCode = false
+		btcRunner.clients = make(map[uint32]*BlipTesterClient) // reset clients map
+	}()
 	if !btcRunner.SkipSubtest[RevtreeSubtestName] {
 		btcRunner.t.Run(RevtreeSubtestName, func(t *testing.T) {
-			test(t, []string{db.CBMobileReplicationV3.SubprotocolString()})
+			btcRunner.supportedSubprotocols = []string{db.CBMobileReplicationV3.SubprotocolString()}
+			test(t)
 		})
 	}
+	btcRunner.clients = make(map[uint32]*BlipTesterClient) // reset clients map to avoid confusion in the next subtest
+
 	if !btcRunner.SkipSubtest[VersionVectorSubtestName] {
 		btcRunner.t.Run(VersionVectorSubtestName, func(t *testing.T) {
 			// bump sub protocol version here
-			test(t, []string{db.CBMobileReplicationV4.SubprotocolString()})
+			btcRunner.supportedSubprotocols = []string{db.CBMobileReplicationV4.SubprotocolString()}
+			test(t)
 		})
 	}
+}
+
+// RunSubprotocolV2 runs the test with the subprotocol v2 enabled. This is used for testing the revtree subprotocol. Prefer BlipTestClientRunner.Run() for general tests.
+func (btcRunner *BlipTestClientRunner) RunSubprotocolV2(test func(t *testing.T)) {
+	if btcRunner.initialisedInsideRunnerCode {
+		require.FailNow(btcRunner.TB(), "must not initialise BlipTesterClient inside Run() method")
+	}
+	btcRunner.initialisedInsideRunnerCode = true
+	// reset to protect against someone creating a new client after Run() is run
+	defer func() { btcRunner.initialisedInsideRunnerCode = false }()
+	btcRunner.t.Run(RevtreeSubtestName, func(t *testing.T) {
+		btcRunner.supportedSubprotocols = []string{db.CBMobileReplicationV2.SubprotocolString()}
+		test(t)
+	})
 }
 
 // tearDownBlipClientReplications closes the push and pull replications for the client.
@@ -1674,7 +1706,7 @@ func (btcc *BlipTesterCollectionClient) GetVersion(docID string, docVersion DocV
 }
 
 func (btc *BlipTesterClient) UseHLV() bool {
-	for _, protocol := range btc.SupportedBLIPProtocols {
+	for _, protocol := range btc.supportedSubprotocols {
 		subProtocol, err := db.ParseSubprotocolString(protocol)
 		require.NoError(btc.rt.TB(), err)
 		if subProtocol >= db.CBMobileReplicationV4 {
@@ -1685,7 +1717,7 @@ func (btc *BlipTesterClient) UseHLV() bool {
 }
 
 func (btc *BlipTesterClient) AssertOnBlipHistory(t *testing.T, msg *blip.Message, docVersion DocVersion) {
-	subProtocol, err := db.ParseSubprotocolString(btc.SupportedBLIPProtocols[0])
+	subProtocol, err := db.ParseSubprotocolString(btc.supportedSubprotocols[0])
 	require.NoError(t, err)
 	if subProtocol >= db.CBMobileReplicationV4 { // history could be empty a lot of the time in HLV messages as updates from the same source won't populate previous versions
 		if msg.Properties[db.RevMessageHistory] != "" {
@@ -1887,7 +1919,7 @@ func (btcRunner *BlipTestClientRunner) WaitForVersion(clientID uint32, docID str
 	return btcRunner.SingleCollection(clientID).WaitForVersion(docID, docVersion)
 }
 
-// WaitForBlipRevMessage blocks until any blip message with a given docID has been stored by the client, and returns the message when found. If document is not not found after 10 seconds, test will fail.
+// WaitForDoc until any blip message with a given docID has been stored by the client, and returns the message when found. If document is not not found after 10 seconds, test will fail.
 func (btcRunner *BlipTestClientRunner) WaitForDoc(clientID uint32, docID string) []byte {
 	return btcRunner.SingleCollection(clientID).WaitForDoc(docID)
 }
@@ -2077,7 +2109,7 @@ func (btcc *BlipTesterCollectionClient) getAllRevisions(docID string) []DocVersi
 }
 
 func (btc *BlipTesterClient) AssertDeltaSrcProperty(t *testing.T, msg *blip.Message, docVersion DocVersion) {
-	subProtocol, err := db.ParseSubprotocolString(btc.SupportedBLIPProtocols[0])
+	subProtocol, err := db.ParseSubprotocolString(btc.supportedSubprotocols[0])
 	require.NoError(t, err)
 	rev := docVersion.GetRev(subProtocol >= db.CBMobileReplicationV4)
 	assert.Equal(t, rev, msg.Properties[db.RevMessageDeltaSrc])

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1090,7 +1090,10 @@ func (btcRunner *BlipTestClientRunner) RunSubprotocolV2(test func(t *testing.T))
 	}
 	btcRunner.initialisedInsideRunnerCode = true
 	// reset to protect against someone creating a new client after Run() is run
-	defer func() { btcRunner.initialisedInsideRunnerCode = false }()
+	defer func() {
+		btcRunner.initialisedInsideRunnerCode = false
+		btcRunner.clients = make(map[uint32]*BlipTesterClient) // reset clients map
+	}()
 	btcRunner.t.Run(RevtreeSubtestName, func(t *testing.T) {
 		btcRunner.supportedSubprotocols = []string{db.CBMobileReplicationV2.SubprotocolString()}
 		test(t)

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -226,9 +226,9 @@ func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, config PeerReplicat
 	}
 	const username = "user"
 	sg.rt.CreateUser(username, []string{"*"})
+	replication.btcRunner.SetSubprotocols([]string{db.CBMobileReplicationV4.SubprotocolString()})
 	replication.btc = replication.btcRunner.NewBlipTesterClientOptsWithRT(sg.rt, &rest.BlipTesterClientOpts{
-		Username:               username,
-		SupportedBLIPProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()},
+		Username: username,
 		AllowCreationWithoutBlipTesterClientRunner: true,
 		SourceID: p.SourceID(),
 	},


### PR DESCRIPTION
This simplifies the call stack, means you can't accidentally forget to run with different protocols. There were several tests that do run twice, but not with V4 protocol. This is fixed in this PR.

Tests that only ran in V3:
    - `TestBlipDatabaseClose`
    - `TestChannelFilterRemovalFromChannel`
    - `TestChangesFeedExitDisconnect`
    
Clarifies use of `db.CBMobileReplicationV2.SubprotocolString()` for old protocol tests by explicitly calling `btcRunner.RunSubprotocolV2` instead of skipping one of the tests with versionVector but forcing a different subprotocol.

The real fix I want to put in here is to clear `btcRunner.clients = make(map[uint32]*BlipTesterClient) // reset clients map` between tests, and I'd be happy to drop the other code.

It is kind of crappy to have `supportedSubprotcols` be a global for `btcRunner`, but I think this prevents some accidental misuse. I'm open to a better idea. I also have to do something a bit odd in topologytests where we aren't using `btcRunner.Run` but I do want to force a subprotocol. Right now that is only version 4, but there's a planned enhancement to run v3.

As a future enhancement, I'd be tempted to drop forcing V3 if no protocol is specified here https://github.com/couchbase/sync_gateway/blob/946c5fe652bc5fad3b41ee5aa8f91570662c991e/rest/utilities_testing.go#L1464 to force code that doesn't use btcRunner to test both protocols, or explicitly test only one. That is not all urgent, but might be worth post code complete testing to cover more test cases we might have missed.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
f

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/42/ (independent flake in code not part of this change)