### PR TITLE
CBG-4776: Fetch by CV REST API

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -295,13 +295,13 @@ func (c *DatabaseCollection) OnDemandImportForGet(ctx context.Context, docid str
 	return docOut, nil
 }
 
-// GetRev returns the revision for the given docID and revID, or the current active revision if revID is empty.
-func (db *DatabaseCollectionWithUser) GetRev(ctx context.Context, docID, revID string, history bool, attachmentsSince []string) (DocumentRevision, error) {
+// GetRev returns the revision for the given docID and revOrCV, or the current active revision if revOrCV is empty.
+func (db *DatabaseCollectionWithUser) GetRev(ctx context.Context, docID, revOrCV string, history bool, attachmentsSince []string) (DocumentRevision, error) {
 	maxHistory := 0
 	if history {
 		maxHistory = math.MaxInt32
 	}
-	return db.getRev(ctx, docID, revID, maxHistory, nil)
+	return db.getRev(ctx, docID, revOrCV, maxHistory, nil)
 }
 
 // Returns the body of the current revision of a document
@@ -2765,6 +2765,7 @@ func (db *DatabaseCollectionWithUser) postWriteUpdateHLV(ctx context.Context, do
 		doc.HLV.CurrentVersionCAS = casOut
 	}
 	// backup new revision to the bucket now we have a doc assigned a CV (post macro expansion) for delta generation purposes
+	// we don't need to store revision body backups without delta sync in 4.0, since all clients know how to use the sendReplacementRevs feature
 	backupRev := db.deltaSyncEnabled() && db.deltaSyncRevMaxAgeSeconds() != 0
 	if db.UseXattrs() && backupRev {
 		var newBodyWithAtts = doc._rawBody

--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -342,7 +342,7 @@ rev:
   schema:
     type: string
   example: 2-5145e1086bb8d1d71a531e9f6b543c58
-  description: The document revision to target. If this is a CV value, ensure the query parameter is URL encoded (`+`->`%2B`, `@`->`%40`, etc.)
+  description: The document revision to target. This can be a RevTree ID or a CV (Current Version) ID. If this is a CV value, ensure the query parameter is URL encoded (`+`->`%2B`, `@`->`%40`, etc.)
 revs_from:
   name: revs_from
   in: query

--- a/docs/api/paths/public/keyspace-docid.yaml
+++ b/docs/api/paths/public/keyspace-docid.yaml
@@ -27,7 +27,7 @@ get:
         Etag:
           schema:
             type: string
-          description: The document revision ID if only returning 1 revision.
+          description: An optimistic concurrency control (OCC) value used to prevent conflicts in a subsequent update. This value can be a RevTree ID or a CV (Current Version) ID, depending on the version type requested.
       content:
         application/json:
           schema:

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2135,6 +2135,9 @@ func TestAttachmentsMissing(t *testing.T) {
 
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
+	// strip CV from version - we don't store revision backups for old CVs like we do for RevIDs
+	version2.CV = db.Version{}
+
 	body := rt.GetDocVersion(docID, version2)
 	require.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", body["_attachments"].(map[string]interface{})["hello.txt"].(map[string]interface{})["digest"])
 }
@@ -2157,6 +2160,9 @@ func TestAttachmentsMissingNoBody(t *testing.T) {
 	_ = rt.PutNewEditsFalse(docID, NewDocVersionFromFakeRev("2-b"), &version1, `{}`)
 
 	rt.GetDatabase().FlushRevisionCacheForTest()
+
+	// strip CV from version - we don't store revision backups for old CVs like we do for RevIDs
+	version2.CV = db.Version{}
 
 	body := rt.GetDocVersion(docID, version2)
 	require.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", body["_attachments"].(map[string]interface{})["hello.txt"].(map[string]interface{})["digest"])

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -82,7 +82,7 @@ func (rt *RestTester) GetDocVersion(docID string, version DocVersion) db.Body {
 	if !version.CV.IsEmpty() {
 		occValue = version.CV.String()
 	}
-	rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID+"?rev="+occValue, "")
+	rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID+"?rev="+url.QueryEscape(occValue), "")
 	RequireStatus(rt.TB(), rawResponse, http.StatusOK)
 	var body db.Body
 	require.NoError(rt.TB(), base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))


### PR DESCRIPTION
CBG-4776

This was already implemented, so this is a tiny clean-up exercise and ensuring there's general test coverage of CV in GETs via `RestTester.GetDocVersion`

The few test changes that had to be made were small corner-cases that only work in RevTree fetches - we don't take old revision backups in exactly the same way for CV so the test assumptions didn't hold up when using CV instead of RevTreeID.

## Dependencies
- [x] #7693 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
