### PR TITLE
CBG-4273: More Frequent log rotation

### DIFF
--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -44,7 +44,7 @@ const (
 	consoleLoggerCollateFlushTimeout = 1 * time.Millisecond
 	fileLoggerCollateFlushTimeout    = 10 * time.Millisecond
 
-	rotatedLogDeletionInterval = time.Hour // not configurable
+	rotatedLogDeletionInterval = time.Minute // not configurable
 
 	logFilePermission = 0644 // rw-r--r--
 )


### PR DESCRIPTION
CBG-4273

Describe your PR here...
- Changing the frequency of log rotation from 1 hour to 1 minute
- This is to prevent log files consuming a lot of space on the disk

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/44/
  - flaky test