### PR TITLE
CBG-4778: LWW conflict resolution for ISGR

### DIFF
--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -70,8 +70,10 @@ type ActiveReplicatorConfig struct {
 	ActiveDB *Database
 	// WebsocketPingInterval is the time between websocket heartbeats sent by the active replicator.
 	WebsocketPingInterval time.Duration
-	// Conflict resolver
+	// Conflict resolver for rev tree conflicts.  If nil, the default conflict resolver will be used.
 	ConflictResolverFunc ConflictResolverFunc
+	// ConflictResolverFuncForHLV for hlv clients to resolve conflicts. If nil, the default conflict resolver will be used.
+	ConflictResolverFuncForHLV ConflictResolverFunc
 	// Conflict resolution type.  Required for Equals comparison only
 	ConflictResolutionType ConflictResolverType
 	// Conflict resolver source, for custom conflict resolver.  Required for Equals comparison only

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1350,7 +1350,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
 	if bh.useHLV() && changeIsVector {
-		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc, legacyRevList, isBlipRevTreeProperty)
+		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc, legacyRevList, isBlipRevTreeProperty, bh.conflictResolver)
 	} else if bh.conflictResolver != nil {
 		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	} else {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1348,11 +1348,11 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 
 	// If the doc is a tombstone we want to allow conflicts when running SGR2
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
-	forceAllowConflictingTombstone := newDoc.Deleted && (bh.conflictResolver != nil || bh.clientType == BLIPClientTypeSGR2)
+	forceAllowConflictingTombstone := newDoc.Deleted && (!bh.conflictResolver.IsEmpty() || bh.clientType == BLIPClientTypeSGR2)
 	if bh.useHLV() && changeIsVector {
 		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc, legacyRevList, isBlipRevTreeProperty, bh.conflictResolver)
-	} else if bh.conflictResolver != nil {
-		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
+	} else if bh.conflictResolver.revTreeConflictResolver != nil {
+		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver.revTreeConflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	} else {
 		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -112,7 +112,7 @@ type BlipSyncContext struct {
 	userName                    string            // Avoid contention on db.user during userChangeWaiter user lookup
 	replicationStats            *BlipSyncStats    // Replication stats
 	purgeOnRemoval              bool              // Purges the document when we pull a _removed:true revision.
-	conflictResolver            *ConflictResolver // Conflict resolver for active replications
+	conflictResolver            ConflictResolvers // Conflict resolver(s) for active replications, we possibly have two if running in version 4 replication mode for use when legacy revs are present
 	changesPendingResponseCount int64             // Number of changes messages pending changesResponse
 	// TODO: For review, whether sendRevAllConflicts needs to be per sendChanges invocation
 	sendRevNoConflicts bool                      // Whether to set noconflicts=true when sending revisions

--- a/db/crud.go
+++ b/db/crud.go
@@ -1380,7 +1380,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 						base.InfofCtx(ctx, base.KeyCRUD, "Failed to resolve HLV conflict for doc %s, error: %v", base.UD(doc.ID), err)
 						return nil, nil, false, nil, err
 					}
-					conflictResolved = true  // mark that we resolved the conflict so we don't overwrite the HLV MV below
+					conflictResolved = true // mark that we resolved the conflict so we don't overwrite the HLV MV below
 					// overwrite the existing HLV with the new one
 					doc.HLV = newHLV
 				}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1800,7 +1800,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 		PreviousVersions: pv,
 	}
 
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, nil)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{})
 	assertHTTPError(t, err, 409)
 	require.Nil(t, doc)
 	require.Nil(t, cv)
@@ -1810,7 +1810,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	// TODO: because currentRev isn't being updated, storeOldBodyInRevTreeAndUpdateCurrent isn't
 	//  updating the document body.   Need to review whether it makes sense to keep using
 	// storeOldBodyInRevTreeAndUpdateCurrent, or if this needs a larger overhaul to support VV
-	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, nil)
+	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{})
 	require.NoError(t, err)
 	assert.Equal(t, "test", cv.SourceID)
 	assert.Equal(t, incomingVersion, cv.Value)
@@ -1832,7 +1832,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 
 	// Attempt to push the same client update, validate server rejects as an already known version and cancels the update.
 	// This case doesn't return error, verify that SyncData hasn't been changed.
-	_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, nil)
+	_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{})
 	require.NoError(t, err)
 	syncData2, err := collection.GetDocSyncData(ctx, "doc1")
 	require.NoError(t, err)
@@ -1878,7 +1878,7 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	}
 
 	// assert that a conflict is correctly identified and the doc and cv are nil
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, nil)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{})
 	assertHTTPError(t, err, 409)
 	require.Nil(t, doc)
 	require.Nil(t, cv)
@@ -1918,7 +1918,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 		PreviousVersions: pv,
 	}
 	// call PutExistingCurrentVersion with empty existing doc
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{}, nil, false, nil)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{}, nil, false, ConflictResolvers{})
 	require.NoError(t, err)
 	assert.NotNil(t, doc)
 	// assert on returned CV value

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1800,7 +1800,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 		PreviousVersions: pv,
 	}
 
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, nil)
 	assertHTTPError(t, err, 409)
 	require.Nil(t, doc)
 	require.Nil(t, cv)
@@ -1810,7 +1810,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	// TODO: because currentRev isn't being updated, storeOldBodyInRevTreeAndUpdateCurrent isn't
 	//  updating the document body.   Need to review whether it makes sense to keep using
 	// storeOldBodyInRevTreeAndUpdateCurrent, or if this needs a larger overhaul to support VV
-	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false)
+	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "test", cv.SourceID)
 	assert.Equal(t, incomingVersion, cv.Value)
@@ -1832,7 +1832,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 
 	// Attempt to push the same client update, validate server rejects as an already known version and cancels the update.
 	// This case doesn't return error, verify that SyncData hasn't been changed.
-	_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false)
+	_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, nil)
 	require.NoError(t, err)
 	syncData2, err := collection.GetDocSyncData(ctx, "doc1")
 	require.NoError(t, err)
@@ -1878,7 +1878,7 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	}
 
 	// assert that a conflict is correctly identified and the doc and cv are nil
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, nil)
 	assertHTTPError(t, err, 409)
 	require.Nil(t, doc)
 	require.Nil(t, cv)
@@ -1918,7 +1918,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 		PreviousVersions: pv,
 	}
 	// call PutExistingCurrentVersion with empty existing doc
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{}, nil, false)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{}, nil, false, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, doc)
 	// assert on returned CV value

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -821,3 +821,126 @@ func (hlv *HybridLogicalVector) MergeWithIncomingHLV(newCV Version, incomingHLV 
 	hlv.UpdateHistory(incomingHLV)
 	return nil
 }
+
+// DefaultLWWConflictResolutionType will resolve a conflict based of its CV value, returning the document with the
+// highest CV value for a LWW conflict resolution.
+func DefaultLWWConflictResolutionType(ctx context.Context, conflict Conflict) (Body, error) {
+	if conflict.LocalHLV == nil || conflict.RemoteHLV == nil {
+		return nil, errors.New("local or incoming document is nil for resolveConflict")
+	}
+	// resolve conflict in favor of remote document, remote wins case
+	if conflict.RemoteHLV.Version > conflict.LocalHLV.Version {
+		// remote document wins
+		return conflict.RemoteDocument, nil
+	}
+	return conflict.LocalDocument, nil
+}
+
+// localWinsConflictResolutionForHLV will alter the HLV for a local wins conflict resolution. Preserving local MV
+// unless incoming MV has a src common with local MV and has a higher version, in which case local MV is invalidated and moved to PV.
+// In the eventuality that local CV is <= to incoming CV, a new CV will be created with this db's sourceID
+func localWinsConflictResolutionForHLV(ctx context.Context, localHLV, incomingHLV *HybridLogicalVector, docID, sourceID string) (*HybridLogicalVector, error) {
+	if localHLV == nil || incomingHLV == nil {
+		return nil, errors.New("local or incoming hlv is nil for resolveConflict")
+	}
+
+	newHLV := localHLV.Copy()
+
+	defer func() {
+		base.DebugfCtx(ctx, base.KeyVV, "resolved conflict for doc %s in favour of local wins, resulting HLV: %v", base.UD(docID), newHLV)
+	}()
+
+	if localHLV.Version > incomingHLV.Version {
+		// no need to generate new CV value
+		newHLV.addNewerVersionTmp(incomingHLV)
+		return newHLV, nil
+	}
+
+	// here local CV version is <= to incoming CV version, thus we need to create a new CV with this db's sourceID then
+	// move any mv to pv
+	base.DebugfCtx(ctx, base.KeyVV, "new cv needed for doc %s in local wins conflict resolution, local hlv: %v, incoming hlv: %v", base.UD(docID), localHLV, incomingHLV)
+	newHLV.SourceID = sourceID
+	newHLV.Version = expandMacroCASValueUint64 // set new version to the macro expansion value
+	newHLV.CurrentVersionCAS = expandMacroCASValueUint64
+
+	newHLV.addNewerVersionsToPV(newHLV.MergeVersions) // add any newer merge version to pv
+	newHLV.MergeVersions = make(HLVVersions)
+	// now add local and incoming docs CV's to the new local HLV merge versions
+	newHLV.MergeVersions[localHLV.SourceID] = localHLV.Version       // add local cv to mv
+	newHLV.MergeVersions[incomingHLV.SourceID] = incomingHLV.Version // add incoming cv to mv
+
+	// now add any newer versions in pv from incoming doc to local docs pv
+	newHLV.addNewerVersionsToPV(incomingHLV.PreviousVersions)
+
+	return newHLV, nil
+}
+
+// remoteWinsConflictResolutionForHLV will alter the HLV for a remote wins conflict resolution. Preserving incoming MV
+// unless local MV has a src common with incoming MV and has a higher version, in which case incoming MV is invalidated and moved to PV.
+func remoteWinsConflictResolutionForHLV(ctx context.Context, docID string, localHLV, incomingHLV *HybridLogicalVector) (*HybridLogicalVector, error) {
+	if localHLV == nil || incomingHLV == nil {
+		return nil, errors.New("local or incoming hlv is nil for resolveConflict")
+	}
+
+	newHLV := incomingHLV.Copy()
+
+	newHLV.addNewerVersionTmp(localHLV)
+
+	base.DebugfCtx(ctx, base.KeyVV, "resolved conflict for doc %s in favour of remote wins, resulting HLV: %v", base.UD(docID), newHLV)
+	return newHLV, nil
+}
+
+// addNewerVersionTmp Its temporary function until AddNewerVersions work is done. It adds any newer versions to the winning
+// HLV from the non-winning HLV. It does the following steps:
+// 	- Moving the non-winning CV to pv
+// 	- Preserves winning MV unless non-winning MV has a sourceID in common with winning MV and has a higher version in which
+// 	case MV is invalidated and moved to PV
+// 	- Adds any newer PV entries from non-winning HLV to winning HLV PV a
+//	- Adds any non-winning MV entries to winning HLV PV
+func (hlv *HybridLogicalVector) addNewerVersionTmp(nonWinningVector *HybridLogicalVector) {
+
+	// add non winning vector cv to pv if version is newer
+	versionForNonWinningCv := hlv.PreviousVersions[nonWinningVector.SourceID]
+	if versionForNonWinningCv == 0 || versionForNonWinningCv < nonWinningVector.Version {
+		hlv.SetPreviousVersion(nonWinningVector.SourceID, nonWinningVector.Version)
+	}
+
+	// if incoming hlv in this function has greater value for any common sourceID for merge versions, local merge
+	// version no longer valid and we should move to PV
+	for mergeSource, mergeValue := range nonWinningVector.MergeVersions {
+		if winningHLVMergeVal, ok := hlv.MergeVersions[mergeSource]; ok {
+			if winningHLVMergeVal < mergeValue {
+				hlv.addNewerVersionsToPV(hlv.MergeVersions)
+				hlv.MergeVersions = nil // clear merge versions
+			}
+		}
+	}
+
+	// add any newer PV entries from nonWinningVector to local HLV
+	hlv.addNewerVersionsToPV(nonWinningVector.PreviousVersions)
+
+	// add any incoming hlv merge versions to local HLV pv
+	hlv.addNewerVersionsToPV(nonWinningVector.MergeVersions)
+
+	// ensure no duplicates of cv or mv in pv
+	delete(hlv.PreviousVersions, hlv.SourceID)
+	for source := range hlv.MergeVersions {
+		delete(hlv.PreviousVersions, source)
+	}
+}
+
+// addNewerVersionsToPV is helper function to add any newer versions from incoming map to the local HLV PV. If a src
+// exists in local map and incoming map, the higher version is retained, if src only exists in incoming map, its added to local PV.
+func (hlv *HybridLogicalVector) addNewerVersionsToPV(inComingMap HLVVersions) {
+	// add any newer PV entries from incomingVector to local HLV
+	for sourceID, incomingValue := range inComingMap {
+		if hlv.PreviousVersions[sourceID] == 0 {
+			hlv.SetPreviousVersion(sourceID, incomingValue)
+		} else {
+			// if we get here then there is entry for this source in PV so we must check if its newer or not
+			if hlv.PreviousVersions[sourceID] < incomingValue {
+				hlv.SetPreviousVersion(sourceID, incomingValue)
+			}
+		}
+	}
+}

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -892,11 +892,11 @@ func remoteWinsConflictResolutionForHLV(ctx context.Context, docID string, local
 
 // addNewerVersionTmp Its temporary function until AddNewerVersions work is done. It adds any newer versions to the winning
 // HLV from the non-winning HLV. It does the following steps:
-// 	- Moving the non-winning CV to pv
-// 	- Preserves winning MV unless non-winning MV has a sourceID in common with winning MV and has a higher version in which
-// 	case MV is invalidated and moved to PV
-// 	- Adds any newer PV entries from non-winning HLV to winning HLV PV a
-//	- Adds any non-winning MV entries to winning HLV PV
+//   - Moving the non-winning CV to pv
+//   - Preserves winning MV unless non-winning MV has a sourceID in common with winning MV and has a higher version in which
+//     case MV is invalidated and moved to PV
+//   - Adds any newer PV entries from non-winning HLV to winning HLV PV a
+//   - Adds any non-winning MV entries to winning HLV PV
 func (hlv *HybridLogicalVector) addNewerVersionTmp(nonWinningVector *HybridLogicalVector) {
 
 	// add non winning vector cv to pv if version is newer

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -9,7 +9,6 @@
 package db
 
 import (
-	"math"
 	"math/rand/v2"
 	"strconv"
 	"strings"
@@ -1355,7 +1354,7 @@ func TestIsInConflict(t *testing.T) {
 	}
 }
 
-func TestHLVUpddateFromIncomingRemoteWins(t *testing.T) {
+func TestHLVUpdateFromIncomingRemoteWins(t *testing.T) {
 	testCases := []struct {
 		name        string
 		existingHLV string
@@ -1556,61 +1555,6 @@ func TestHLVUpdateFromIncomingNewCV(t *testing.T) {
 	}
 }
 
-func TestAddNewerVersionsTMP(t *testing.T) {
-	testCases := []struct {
-		name          string
-		newHLV        string
-		nonWinningHLV string
-		expectedHLV   string
-	}{
-		{
-			name:          "MV has entry higher than non winning HLV",
-			newHLV:        "10@abc,8@def,9@efg;1@foo",
-			nonWinningHLV: "10@abc,8@def,2@efg;1@foo,2@bar",
-			expectedHLV:   "10@abc,8@def,9@efg;1@foo,2@bar",
-		},
-		{
-			name:          "winning MV has entry lower than incoming HLV",
-			newHLV:        "20@abc,2@def,3@efg;1@foo",
-			nonWinningHLV: "20@abc,10@def,9@efg;2@foo,4@bar",
-			expectedHLV:   "20@abc;10@def,9@efg,2@foo,4@bar",
-		},
-		{
-			name:          "No common elems in MV",
-			newHLV:        "20@abc,10@def,11@efg;5@foo",
-			nonWinningHLV: "20@abc,9@xyz,8@lmn;2@foo,4@bar",
-			expectedHLV:   "20@abc,10@def,11@efg;9@xyz,8@lmn,5@foo,4@bar",
-		},
-		{
-			name:          "newHLV had MV and non winning HLV does not",
-			newHLV:        "20@abc,10@def,11@efg;5@foo",
-			nonWinningHLV: "20@abc;9@xyz,8@lmn,2@foo,4@bar",
-			expectedHLV:   "20@abc,10@def,11@efg;9@xyz,8@lmn,5@foo,4@bar",
-		},
-		{
-			name:          "non winning HLV has MV and newHLV does not",
-			newHLV:        "20@abc;9@xyz,8@lmn,2@foo,4@bar",
-			nonWinningHLV: "20@abc,10@def,11@efg;5@foo",
-			expectedHLV:   "20@abc;10@def,11@efg,9@xyz,8@lmn,5@foo,4@bar",
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			localHLV, _, err := extractHLVFromBlipString(tc.newHLV)
-			require.NoError(t, err)
-			incomingHLV, _, err := extractHLVFromBlipString(tc.nonWinningHLV)
-			require.NoError(t, err)
-
-			localHLV.addNewerVersionTmp(incomingHLV)
-
-			expectedHLV, _, err := extractHLVFromBlipString(tc.expectedHLV)
-			require.NoError(t, err)
-
-			require.Equal(t, expectedHLV, localHLV)
-		})
-	}
-}
-
 func TestLocalWinsConflictResolutionForHLV(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -1622,43 +1566,67 @@ func TestLocalWinsConflictResolutionForHLV(t *testing.T) {
 			name:        "local doc has MV remote does not",
 			localHLV:    "20@abc,10@def,11@efg;5@foo",
 			remoteHLV:   "10@xyz;8@foo,9@bar",
-			expectedHLV: "20@abc,10@def,11@efg;10@xyz,8@foo,9@bar",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@xyz,20@abc;10@def,11@efg,8@foo,9@bar",
 		},
 		{
 			name:        "local doc has no MV and remote does",
 			localHLV:    "20@abc;5@foo",
 			remoteHLV:   "11@xyz,10@def,11@efg;7@foo",
-			expectedHLV: "20@abc;10@def,11@xyz,11@efg,7@foo",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,11@xyz,20@abc;10@def,11@efg,7@foo",
+		},
+		{
+			name:        "local HLV had CV in common with remote HLV PV",
+			localHLV:    "20@abc;5@foo",
+			remoteHLV:   "11@xyz;7@foo,10@abc",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,11@xyz,20@abc;7@foo",
+		},
+		{
+			name:        "remote HLV had CV in common with local HLV PV",
+			localHLV:    "20@abc;5@foo,10@xyz",
+			remoteHLV:   "11@xyz;7@foo",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,20@abc,11@xyz;7@foo",
 		},
 		{
 			name:        "local hlv has MV entry less than remote hlv",
 			localHLV:    "10@abc,1@def,3@efg;1@foo",
 			remoteHLV:   "2@xyz,8@def,9@efg;1@foo",
-			expectedHLV: "10@abc;8@def,9@efg,1@foo,2@xyz",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,2@xyz,10@abc;8@def,9@efg,1@foo",
+		},
+		{
+			name:        "local hlv has PV entry less than remote hlv PV entry",
+			localHLV:    "10@abc;1@foo,3@def",
+			remoteHLV:   "2@xyz;8@def,9@efg,4@foo",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,2@xyz,10@abc;4@foo,8@def,9@efg",
 		},
 		{
 			name:        "local hlv has MV entry greater than remote hlv",
 			localHLV:    "10@abc,10@def,11@efg;1@foo",
 			remoteHLV:   "2@xyz,8@def,9@efg;1@bar",
-			expectedHLV: "10@abc,10@def,11@efg;1@bar,1@foo,2@xyz",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,2@xyz;11@efg,1@foo,1@bar,10@def",
+		},
+		{
+			name:        "local hlv has PV entry greater than remote hlv PV entry",
+			localHLV:    "10@abc;10@foo,11@def",
+			remoteHLV:   "2@xyz;8@def,9@efg",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,2@xyz;11@def,9@efg,10@foo",
 		},
 		{
 			name:        "both local and remote have mv and no common sources",
 			localHLV:    "10@abc,10@def,11@efg;1@foo",
 			remoteHLV:   "2@xyz,8@lmn,9@pqr;1@bar",
-			expectedHLV: "10@abc,10@def,11@efg;2@xyz,8@lmn,9@pqr,1@bar,1@foo",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,2@xyz;10@def,11@efg,8@lmn,9@pqr,1@bar,1@foo",
 		},
 		{
-			name:        "local hlv has cv less than remote hlv",
+			name:        "both lcoal and remote have no common sources in PV",
 			localHLV:    "10@abc;1@foo",
 			remoteHLV:   "20@xyz;2@bar",
 			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,20@xyz;1@foo,2@bar",
 		},
 		{
-			name:        "local hlv has cv greater than remote hlv",
-			localHLV:    "20@abc;1@foo",
-			remoteHLV:   "10@xyz;2@bar",
-			expectedHLV: "20@abc;1@foo,10@xyz,2@bar",
+			name:        "local hlv has cv less than remote hlv",
+			localHLV:    "10@abc;1@foo",
+			remoteHLV:   "20@xyz;2@foo",
+			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,20@xyz;2@foo",
 		},
 	}
 	for _, tc := range testCases {
@@ -1673,74 +1641,8 @@ func TestLocalWinsConflictResolutionForHLV(t *testing.T) {
 
 			expectedHLV, _, err := extractHLVFromBlipString(tc.expectedHLV)
 			require.NoError(t, err)
-			if expectedHLV.Version == math.MaxUint64 {
-				expectedHLV.CurrentVersionCAS = math.MaxUint64
-			}
 
 			require.Equal(t, expectedHLV, localWinsHLV)
 		})
 	}
-}
-
-func TestRemoteWinsConflictResolutionForHLV(t *testing.T) {
-	testCases := []struct {
-		name        string
-		localHLV    string
-		remoteHLV   string
-		expectedHLV string
-	}{
-		{
-			name:        "remote hlv has mv and local does not",
-			localHLV:    "10@abc;1@foo",
-			remoteHLV:   "20@xyz,10@def,11@efg;5@bar",
-			expectedHLV: "20@xyz,10@def,11@efg;1@foo,5@bar,10@abc",
-		},
-		{
-			name:        "remote hlv has no mv and local does",
-			localHLV:    "20@abc,10@def,11@efg;5@foo",
-			remoteHLV:   "10@xyz;8@bar,9@baz",
-			expectedHLV: "10@xyz;10@def,11@efg,8@bar,9@baz,5@foo,20@abc",
-		},
-		{
-			name:        "remote hlv has mv entry less than local hlv",
-			localHLV:    "10@abc,8@def,9@efg;1@foo",
-			remoteHLV:   "2@xyz,1@def,3@efg;1@bar",
-			expectedHLV: "2@xyz;8@def,9@efg,1@foo,1@bar,10@abc",
-		},
-		{
-			name:        "remote hlv has mv entry greater than local hlv",
-			localHLV:    "10@abc,4@def,5@efg;1@foo",
-			remoteHLV:   "2@xyz,8@def,9@efg;1@bar,2@foo",
-			expectedHLV: "2@xyz,8@def,9@efg;10@abc,1@bar,2@foo",
-		},
-		{
-			name:        "remote hlv has mv and no common sources with local",
-			localHLV:    "10@abc,10@def,11@efg;1@foo",
-			remoteHLV:   "2@xyz,8@lmn,9@pqr;1@bar",
-			expectedHLV: "2@xyz,8@lmn,9@pqr;10@abc,10@def,11@efg,1@bar,1@foo",
-		},
-		{
-			name:        "remote and local have no mv",
-			localHLV:    "10@abc;1@foo",
-			remoteHLV:   "20@xyz;2@bar",
-			expectedHLV: "20@xyz;1@foo,2@bar,10@abc",
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			localHLV, _, err := extractHLVFromBlipString(tc.localHLV)
-			require.NoError(t, err)
-			remoteHLV, _, err := extractHLVFromBlipString(tc.remoteHLV)
-			require.NoError(t, err)
-
-			remoteWinsHLV, err := remoteWinsConflictResolutionForHLV(t.Context(), "testDoc", localHLV, remoteHLV)
-			require.NoError(t, err)
-
-			expectedHLV, _, err := extractHLVFromBlipString(tc.expectedHLV)
-			require.NoError(t, err)
-
-			require.Equal(t, expectedHLV, remoteWinsHLV)
-		})
-	}
-
 }

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1559,8 +1559,8 @@ func TestHLVUpdateFromIncomingNewCV(t *testing.T) {
 func TestAddNewerVersionsTMP(t *testing.T) {
 	testCases := []struct {
 		name          string
-		newHLV        string // new hlv init in step 1 of local/remote wins
-		nonWinningHLV string // is local/remote hlv
+		newHLV        string
+		nonWinningHLV string
 		expectedHLV   string
 	}{
 		{

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -166,7 +166,7 @@ func TestOnDemandImportMou(t *testing.T) {
 				case "PutExistingCurrentVersion":
 					hlv := NewHybridLogicalVector()
 					var legacyRevList []string
-					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList, false)
+					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList, false, nil)
 					assertHTTPError(t, err, 409)
 				default:
 					require.FailNow(t, fmt.Sprintf("unexpected funcName: %s", funcName))

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -166,7 +166,7 @@ func TestOnDemandImportMou(t *testing.T) {
 				case "PutExistingCurrentVersion":
 					hlv := NewHybridLogicalVector()
 					var legacyRevList []string
-					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList, false, nil)
+					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList, false, ConflictResolvers{})
 					assertHTTPError(t, err, 409)
 				default:
 					require.FailNow(t, fmt.Sprintf("unexpected funcName: %s", funcName))

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -615,23 +615,25 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 	// but both are legacy pre upgrades docs without HLV.
 	if rc.Direction == ActiveReplicatorTypePull || rc.Direction == ActiveReplicatorTypePushAndPull {
 		if config.ConflictResolutionType == "" {
-			rc.ConflictResolverFunc, err = NewConflictResolverFunc(m.loggingCtx, ConflictResolverDefault, "", m.dbContext.Options.JavascriptTimeout)
-			if err != nil {
-				return nil, err
+			var newConflictResErr error
+			rc.ConflictResolverFunc, newConflictResErr = NewConflictResolverFunc(m.loggingCtx, ConflictResolverDefault, "", m.dbContext.Options.JavascriptTimeout)
+			if newConflictResErr != nil {
+				return nil, newConflictResErr
 			}
-			rc.ConflictResolverFuncForHLV, err = NewConflictResolverFuncForHLV(m.loggingCtx, ConflictResolverDefault, "", m.dbContext.Options.JavascriptTimeout)
-			if err != nil {
-				return nil, err
+			rc.ConflictResolverFuncForHLV, newConflictResErr = NewConflictResolverFuncForHLV(m.loggingCtx, ConflictResolverDefault, "", m.dbContext.Options.JavascriptTimeout)
+			if newConflictResErr != nil {
+				return nil, newConflictResErr
 			}
 		} else {
-			rc.ConflictResolverFunc, err = NewConflictResolverFunc(m.loggingCtx, config.ConflictResolutionType, config.ConflictResolutionFn, m.dbContext.Options.JavascriptTimeout)
-			if err != nil {
-				return nil, err
+			var newConflictResErr error
+			rc.ConflictResolverFunc, newConflictResErr = NewConflictResolverFunc(m.loggingCtx, config.ConflictResolutionType, config.ConflictResolutionFn, m.dbContext.Options.JavascriptTimeout)
+			if newConflictResErr != nil {
+				return nil, newConflictResErr
 			}
 			rc.ConflictResolverFuncSrc = config.ConflictResolutionFn
-			rc.ConflictResolverFuncForHLV, err = NewConflictResolverFuncForHLV(m.loggingCtx, config.ConflictResolutionType, config.ConflictResolutionFn, m.dbContext.Options.JavascriptTimeout)
-			if err != nil {
-				return nil, err
+			rc.ConflictResolverFuncForHLV, newConflictResErr = NewConflictResolverFuncForHLV(m.loggingCtx, config.ConflictResolutionType, config.ConflictResolutionFn, m.dbContext.Options.JavascriptTimeout)
+			if newConflictResErr != nil {
+				return nil, newConflictResErr
 			}
 		}
 		rc.ConflictResolutionType = config.ConflictResolutionType

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -616,14 +616,23 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 	if rc.Direction == ActiveReplicatorTypePull || rc.Direction == ActiveReplicatorTypePushAndPull {
 		if config.ConflictResolutionType == "" {
 			rc.ConflictResolverFunc, err = NewConflictResolverFunc(m.loggingCtx, ConflictResolverDefault, "", m.dbContext.Options.JavascriptTimeout)
+			if err != nil {
+				return nil, err
+			}
 			rc.ConflictResolverFuncForHLV, err = NewConflictResolverFuncForHLV(m.loggingCtx, ConflictResolverDefault, "", m.dbContext.Options.JavascriptTimeout)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			rc.ConflictResolverFunc, err = NewConflictResolverFunc(m.loggingCtx, config.ConflictResolutionType, config.ConflictResolutionFn, m.dbContext.Options.JavascriptTimeout)
+			if err != nil {
+				return nil, err
+			}
 			rc.ConflictResolverFuncSrc = config.ConflictResolutionFn
 			rc.ConflictResolverFuncForHLV, err = NewConflictResolverFuncForHLV(m.loggingCtx, config.ConflictResolutionType, config.ConflictResolutionFn, m.dbContext.Options.JavascriptTimeout)
-		}
-		if err != nil {
-			return nil, err
+			if err != nil {
+				return nil, err
+			}
 		}
 		rc.ConflictResolutionType = config.ConflictResolutionType
 	}

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -52,7 +52,7 @@ const (
 // Conflict is the input to all conflict resolvers.  LocalDocument and RemoteDocument
 // are expected to be document bodies with metadata injected into the body following
 // the same approach used for doc and oldDoc in the Sync Function. LocalHLV and RemoteHLV
-// will be the documents HLVs, these are needed for HLV ready conflict resolution.
+// will be the documents HLVs.
 type Conflict struct {
 	LocalDocument  Body `json:"LocalDocument"`
 	RemoteDocument Body `json:"RemoteDocument"`
@@ -167,9 +167,9 @@ func (c *ConflictResolver) ResolveForHLV(ctx context.Context, conflict Conflict)
 		return winner, ConflictResolutionRemote, nil
 	}
 
-	base.InfofCtx(ctx, base.KeyReplicate, "Conflict resolver returned non-empty revID (%s) not matching local (%s) or remote (%s), treating result as merge.", winningRev, localRev, remoteRev)
+	base.WarnfCtx(ctx, "Conflict resolver returned non-empty cv (%s) not matching local (%s) or remote (%s).", winningRev, localRev, remoteRev)
 	c.stats.ConflictResultMergeCount.Add(1)
-	return winner, ConflictResolutionMerge, err
+	return winner, "", errors.New("conflict resolver returned non-empty cv not matching local or remote")
 }
 
 // DefaultConflictResolver uses the same logic as revTree.WinningRevision,

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -100,6 +100,17 @@ type ConflictResolver struct {
 	stats *ConflictResolverStats
 }
 
+// ConflictResolvers is a container for both revTree and HLV conflict resolvers
+type ConflictResolvers struct {
+	revTreeConflictResolver *ConflictResolver
+	hlvConflictResolver     *ConflictResolver
+	stats                   *ConflictResolverStats
+}
+
+func (c *ConflictResolvers) IsEmpty() bool {
+	return c == nil || (c.revTreeConflictResolver == nil && c.hlvConflictResolver == nil)
+}
+
 func NewConflictResolver(crf ConflictResolverFunc, statsContainer *base.DbReplicatorStats) *ConflictResolver {
 	resolver := &ConflictResolver{
 		crf:   crf,

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -104,7 +104,6 @@ type ConflictResolver struct {
 type ConflictResolvers struct {
 	revTreeConflictResolver *ConflictResolver
 	hlvConflictResolver     *ConflictResolver
-	stats                   *ConflictResolverStats
 }
 
 func (c *ConflictResolvers) IsEmpty() bool {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -884,7 +884,7 @@ func (c *DatabaseCollectionWithUser) UpsertTestDocWithVersion(ctx context.Contex
 		}
 	}
 
-	doc, _, _, err := c.PutExistingCurrentVersion(ctx, newDoc, newDocHLV, currentBucketDoc, nil, false)
+	doc, _, _, err := c.PutExistingCurrentVersion(ctx, newDoc, newDocHLV, currentBucketDoc, nil, false, nil)
 	require.NoError(t, err)
 	return doc
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -884,7 +884,7 @@ func (c *DatabaseCollectionWithUser) UpsertTestDocWithVersion(ctx context.Contex
 		}
 	}
 
-	doc, _, _, err := c.PutExistingCurrentVersion(ctx, newDoc, newDocHLV, currentBucketDoc, nil, false, nil)
+	doc, _, _, err := c.PutExistingCurrentVersion(ctx, newDoc, newDocHLV, currentBucketDoc, nil, false, ConflictResolvers{})
 	require.NoError(t, err)
 	return doc
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2723,7 +2723,6 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 func TestProcessRevIncrementsStat(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-	t.Skip("CBG-4791 - rev tree generated on active is different from passive, this will be mitigated by CBG-4791")
 
 	activeRT, remoteRT, remoteURLString, teardown := SetupSGRPeers(t)
 	defer teardown()

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -148,6 +148,7 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 				require.Len(t, rt1Doc.HLV.MergeVersions, 2)
 				assert.Equal(t, rt1Version.CV.Value, rt1Doc.HLV.MergeVersions[rt1Version.CV.SourceID])
 				assert.Equal(t, nonWinningRevPreConflict.CV.Value, rt1Doc.HLV.MergeVersions[nonWinningRevPreConflict.CV.SourceID])
+				require.Len(t, rt1Doc.HLV.PreviousVersions, 0)
 			}
 			// grab local doc body and assert it is as expected
 			actualBody, err := rt1Doc.BodyBytes(rt1ctx)
@@ -233,7 +234,6 @@ func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 		localWinsCaseDoc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
 		require.NoError(t, err)
 		expectedWinner = rt1Version
-		//expectedWinner.CV.Value = localWinsCaseDoc.Cas
 		expectedConflictResBody, err = localWinsCaseDoc.BodyBytes(rt2ctx)
 		require.NoError(t, err)
 		nonWinningRevPreConflict = version
@@ -272,6 +272,7 @@ func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 		require.Len(t, rt1Doc.HLV.MergeVersions, 2)
 		assert.Equal(t, rt1Version.CV.Value, rt1Doc.HLV.MergeVersions[rt1Version.CV.SourceID])
 		assert.Equal(t, nonWinningRevPreConflict.CV.Value, rt1Doc.HLV.MergeVersions[nonWinningRevPreConflict.CV.SourceID])
+		require.Len(t, rt1Doc.HLV.PreviousVersions, 0)
 	}
 	// grab local doc body and assert it is as expected
 	actualBody, err := rt1Doc.BodyBytes(rt1ctx)
@@ -494,7 +495,7 @@ func TestActiveReplicatorLocalWinsCases(t *testing.T) {
 				MergeVersions:    make(db.HLVVersions),
 				PreviousVersions: testCase.expectedPV,
 			}
-			// add current CV's opt expected MV
+			// add current CV's to expected MV
 			expectedHLV.MergeVersions[rt1.GetDatabase().EncodedSourceID] = localCas
 			expectedHLV.MergeVersions[rt2.GetDatabase().EncodedSourceID] = remoteCas
 
@@ -527,6 +528,7 @@ func TestActiveReplicatorLocalWinsCases(t *testing.T) {
 				assert.Equal(t, val, rt1Doc.HLV.PreviousVersions[key], "Expected key or value is missing in previous versions")
 			}
 			// assert on mv
+			require.Len(t, rt1Doc.HLV.MergeVersions, len(expectedHLV.MergeVersions))
 			for key, val := range expectedHLV.MergeVersions {
 				assert.Equal(t, val, rt1Doc.HLV.MergeVersions[key], "Expected key or value is missing in merge versions")
 			}

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -69,11 +69,11 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
-				ChangesBatchSize:     200,
-				ReplicationStatsMap:  dbReplicatorStats(t),
-				ConflictResolverFunc: resolverFunc,
-				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:           false,
+				ChangesBatchSize:           200,
+				ReplicationStatsMap:        dbReplicatorStats(t),
+				ConflictResolverFuncForHLV: resolverFunc,
+				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:                 false,
 			})
 			require.NoError(t, err)
 			defer func() { assert.NoError(t, ar.Stop()) }()
@@ -190,11 +190,11 @@ func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		ChangesBatchSize:     200,
-		ReplicationStatsMap:  dbReplicatorStats(t),
-		ConflictResolverFunc: resolverFunc,
-		CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
-		Continuous:           false,
+		ChangesBatchSize:           200,
+		ReplicationStatsMap:        dbReplicatorStats(t),
+		ConflictResolverFuncForHLV: resolverFunc,
+		CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+		Continuous:                 false,
 	})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, ar.Stop()) }()
@@ -426,11 +426,11 @@ func TestActiveReplicatorLocalWinsCases(t *testing.T) {
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
-				ChangesBatchSize:     200,
-				ReplicationStatsMap:  dbReplicatorStats(t),
-				ConflictResolverFunc: resolverFunc,
-				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:           false,
+				ChangesBatchSize:           200,
+				ReplicationStatsMap:        dbReplicatorStats(t),
+				ConflictResolverFuncForHLV: resolverFunc,
+				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:                 false,
 			})
 			require.NoError(t, err)
 			defer func() { assert.NoError(t, ar.Stop()) }()
@@ -706,11 +706,11 @@ func TestActiveReplicatorRemoteWinsCases(t *testing.T) {
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
-				ChangesBatchSize:     200,
-				ReplicationStatsMap:  dbReplicatorStats(t),
-				ConflictResolverFunc: resolverFunc,
-				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:           false,
+				ChangesBatchSize:           200,
+				ReplicationStatsMap:        dbReplicatorStats(t),
+				ConflictResolverFuncForHLV: resolverFunc,
+				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:                 false,
 			})
 			require.NoError(t, err)
 			defer func() { assert.NoError(t, ar.Stop()) }()
@@ -926,11 +926,11 @@ func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
-				ChangesBatchSize:     200,
-				ReplicationStatsMap:  dbReplicatorStats(t),
-				ConflictResolverFunc: resolverFunc,
-				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:           false,
+				ChangesBatchSize:           200,
+				ReplicationStatsMap:        dbReplicatorStats(t),
+				ConflictResolverFuncForHLV: resolverFunc,
+				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:                 false,
 			})
 			require.NoError(t, err)
 			defer func() { assert.NoError(t, ar.Stop()) }()
@@ -1101,11 +1101,11 @@ func TestActiveReplicatorAttachmentHandling(t *testing.T) {
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
-				ChangesBatchSize:     200,
-				ReplicationStatsMap:  dbReplicatorStats(t),
-				ConflictResolverFunc: resolverFunc,
-				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:           false,
+				ChangesBatchSize:           200,
+				ReplicationStatsMap:        dbReplicatorStats(t),
+				ConflictResolverFuncForHLV: resolverFunc,
+				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:                 false,
 			})
 			require.NoError(t, err)
 			defer func() { assert.NoError(t, ar.Stop()) }()
@@ -1216,11 +1216,11 @@ func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
-				ChangesBatchSize:     200,
-				ReplicationStatsMap:  dbReplicatorStats(t),
-				ConflictResolverFunc: resolverFunc,
-				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:           false,
+				ChangesBatchSize:           200,
+				ReplicationStatsMap:        dbReplicatorStats(t),
+				ConflictResolverFuncForHLV: resolverFunc,
+				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:                 false,
 			})
 			require.NoError(t, err)
 			defer func() { assert.NoError(t, ar.Stop()) }()

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -1,0 +1,1167 @@
+//  Copyright 2025-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
+package replicatortest
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActiveReplicatorHLVConflictRemoteAmndLocalWins(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyVV, base.KeyCRUD, base.KeySync, base.KeyReplicate, base.KeyChanges)
+	base.RequireNumTestBuckets(t, 2)
+	testCases := []struct {
+		name            string
+		conflictResType db.ConflictResolverType
+	}{
+		{
+			name:            "HLV Conflict Remote Wins",
+			conflictResType: db.ConflictResolverRemoteWins,
+		},
+		{
+			name:            "HLV Conflict Local Wins",
+			conflictResType: db.ConflictResolverLocalWins,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Passive
+			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt2.Close()
+			username := "alice"
+			rt2.CreateUser(username, []string{username})
+
+			// Active
+			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt1.Close()
+			ctx1 := rt1.Context()
+
+			docID := "doc1_"
+			version := rt2.PutDocDirectly(docID, rest.JsonToMap(t, `{"source":"rt2","channels":["alice"]}`))
+			rt2.WaitForPendingChanges()
+
+			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+			require.NoError(t, err)
+
+			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePull,
+				RemoteDBURL: userDBURL(rt2, username),
+				ActiveDB: &db.Database{
+					DatabaseContext: rt1.GetDatabase(),
+				},
+				ChangesBatchSize:     200,
+				ReplicationStatsMap:  dbReplicatorStats(t),
+				ConflictResolverFunc: resolverFunc,
+				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:           false,
+			})
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, ar.Stop()) }()
+
+			// Start the replicator
+			require.NoError(t, ar.Start(ctx1))
+
+			// wait for the document originally written to rt1 to arrive at rt2
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+			rt1Version, _ := rt1.GetDoc(docID)
+			rest.RequireDocVersionEqual(t, version, rt1Version)
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			var expectedConflictResBody []byte
+
+			for i := 0; i < 10; i++ {
+				version = rt2.UpdateDocDirectly(docID, version, rest.JsonToMap(t, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i)))
+			}
+			rt2.WaitForPendingChanges()
+			for i := 0; i < 10; i++ {
+				rt1Version = rt1.UpdateDocDirectly(docID, rt1Version, rest.JsonToMap(t, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i)))
+			}
+			rt1.WaitForPendingChanges()
+
+			rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
+			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
+
+			var nonWinningRevPreConflict rest.DocVersion
+			if testCase.conflictResType == db.ConflictResolverRemoteWins {
+				docToPull, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+				expectedConflictResBody, err = docToPull.BodyBytes(rt2ctx)
+				require.NoError(t, err)
+
+				nonWinningRevPreConflict = rt1Version
+			} else {
+				localDoc, err := rt1collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+				expectedConflictResBody, err = localDoc.BodyBytes(rt2ctx)
+				require.NoError(t, err)
+
+				nonWinningRevPreConflict = version
+			}
+
+			// start again for new revisions
+			require.NoError(t, ar.Start(ctx1))
+
+			changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+			replicatedVersion, _ := rt1.GetDoc(docID)
+			// CBG-4791 - switch to RequireDocVersionEqual
+			if testCase.conflictResType == db.ConflictResolverRemoteWins {
+				rest.RequireDocumentCV(t, version, replicatedVersion)
+			} else {
+				rest.RequireDocumentCV(t, rt1Version, replicatedVersion)
+			}
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			// assert HLV and body is as expected
+			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			if testCase.conflictResType == db.ConflictResolverRemoteWins {
+				rest.RequireDocumentCV(t, version, rt1Doc.ExtractDocVersion())
+			} else {
+				rest.RequireDocumentCV(t, rt1Version, rt1Doc.ExtractDocVersion())
+			}
+			// PV should have the source version pair from the updates on rt1
+			require.Len(t, rt1Doc.HLV.PreviousVersions, 1)
+			assert.Equal(t, nonWinningRevPreConflict.CV.Value, rt1Doc.HLV.PreviousVersions[nonWinningRevPreConflict.CV.SourceID])
+			// grab local doc body and assert it is as expected
+			actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+			require.NoError(t, err)
+			assert.Equal(t, expectedConflictResBody, actualBody)
+		})
+	}
+}
+
+func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyVV, base.KeyCRUD, base.KeySync, base.KeyReplicate, base.KeyChanges)
+	base.RequireNumTestBuckets(t, 2)
+	// Passive
+	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
+	})
+	defer rt2.Close()
+	username := "alice"
+	rt2.CreateUser(username, []string{username})
+
+	// Active
+	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+		SyncFn: channels.DocChannelsSyncFunction,
+	})
+	defer rt1.Close()
+	ctx1 := rt1.Context()
+
+	docID := "doc1_"
+	version := rt2.PutDocDirectly(docID, rest.JsonToMap(t, `{"source":"rt2","channels":["alice"]}`))
+	rt2.WaitForPendingChanges()
+
+	resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
+	require.NoError(t, err)
+
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: userDBURL(rt2, username),
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize:     200,
+		ReplicationStatsMap:  dbReplicatorStats(t),
+		ConflictResolverFunc: resolverFunc,
+		CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
+		Continuous:           false,
+	})
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, ar.Stop()) }()
+
+	// Start the replicator
+	require.NoError(t, ar.Start(ctx1))
+
+	// wait for the document originally written to rt1 to arrive at rt2
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+	changesResults.RequireDocIDs(t, []string{docID})
+	rt1Version, _ := rt1.GetDoc(docID)
+	rest.RequireDocVersionEqual(t, version, rt1Version)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+	}, time.Second*20, time.Millisecond*100)
+
+	var expectedConflictResBody []byte
+	var expectedWinner rest.DocVersion
+	var nonWinningRevPreConflict rest.DocVersion
+
+	for i := 0; i < 10; i++ {
+		version = rt2.UpdateDocDirectly(docID, version, rest.JsonToMap(t, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i)))
+	}
+	rt2.WaitForPendingChanges()
+	for i := 0; i < 10; i++ {
+		rt1Version = rt1.UpdateDocDirectly(docID, rt1Version, rest.JsonToMap(t, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i)))
+	}
+	rt1.WaitForPendingChanges()
+
+	rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
+	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
+
+	// pull out expected winner and expected conflict response body
+	if rt1Version.CV.Value > version.CV.Value {
+		docToPull, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		expectedWinner = rt1Version
+		expectedConflictResBody, err = docToPull.BodyBytes(rt2ctx)
+		require.NoError(t, err)
+		nonWinningRevPreConflict = version
+	} else {
+		localDoc, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		expectedWinner = version
+		expectedConflictResBody, err = localDoc.BodyBytes(rt2ctx)
+		require.NoError(t, err)
+		nonWinningRevPreConflict = rt1Version
+	}
+
+	// start again for new revisions
+	require.NoError(t, ar.Start(ctx1))
+
+	changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+	changesResults.RequireDocIDs(t, []string{docID})
+	replicatedVersion, _ := rt1.GetDoc(docID)
+	// CBG-4791 - switch to RequireDocVersionEqual
+	rest.RequireDocumentCV(t, expectedWinner, replicatedVersion)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+	}, time.Second*20, time.Millisecond*100)
+
+	rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+	rest.RequireDocumentCV(t, expectedWinner, rt1Doc.ExtractDocVersion())
+	// PV should have the source version pair from the updates on rt1
+	require.Len(t, rt1Doc.HLV.PreviousVersions, 1)
+	assert.Equal(t, nonWinningRevPreConflict.CV.Value, rt1Doc.HLV.PreviousVersions[nonWinningRevPreConflict.CV.SourceID])
+	// grab local doc body and assert it is as expected
+	actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+	require.NoError(t, err)
+	fmt.Println(string(actualBody), "expected:", string(expectedConflictResBody))
+	assert.Equal(t, expectedConflictResBody, actualBody)
+}
+
+func TestActiveReplicatorLocalWinsWithMV(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyVV, base.KeyCRUD, base.KeySync, base.KeyReplicate, base.KeyChanges, base.KeyImport)
+	base.RequireNumTestBuckets(t, 2)
+
+	const (
+		mergeVersion1 = "xyz"
+		mergeVersion2 = "abc"
+	)
+
+	testCases := []struct {
+		name              string
+		olderVersionLocal bool
+		mvForRemote       db.HLVVersions
+		mvForLocal        db.HLVVersions
+		expectedMV        db.HLVVersions
+		expectedFlushToPV db.HLVVersions
+	}{
+		{
+			name: "MV on remote doc and no MV on local doc",
+			mvForRemote: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			expectedFlushToPV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+		{
+			name: "MV on remote doc with higher value than MV on local doc",
+			mvForRemote: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			mvForLocal: db.HLVVersions{
+				mergeVersion1: 100,
+				mergeVersion2: 50,
+			},
+			expectedFlushToPV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+		{
+			name: "MV on remote doc with lower value than MV on local doc",
+			mvForRemote: db.HLVVersions{
+				mergeVersion1: 100,
+				mergeVersion2: 50,
+			},
+			mvForLocal: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			expectedMV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+		{
+			name: "MV on local doc and no MV on remote doc",
+			mvForLocal: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			expectedMV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+		{
+			name: "CV on remote is newer than local CV",
+			mvForLocal: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			expectedMV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Passive
+			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt2.Close()
+			username := "alice"
+			rt2.CreateUser(username, []string{username})
+
+			// Active
+			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt1.Close()
+			ctx1 := rt1.Context()
+			ctx2 := rt2.Context()
+
+			docID := "doc1_"
+			version := rt2.PutDocDirectly(docID, rest.JsonToMap(t, `{"source":"rt2","channels":["alice"]}`))
+			rt2.WaitForPendingChanges()
+
+			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverLocalWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
+			require.NoError(t, err)
+
+			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePull,
+				RemoteDBURL: userDBURL(rt2, username),
+				ActiveDB: &db.Database{
+					DatabaseContext: rt1.GetDatabase(),
+				},
+				ChangesBatchSize:     200,
+				ReplicationStatsMap:  dbReplicatorStats(t),
+				ConflictResolverFunc: resolverFunc,
+				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:           false,
+			})
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, ar.Stop()) }()
+
+			// Start the replicator
+			require.NoError(t, ar.Start(ctx1))
+
+			// wait for the document originally written to rt1 to arrive at rt2
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+			rt1Version, _ := rt1.GetDoc(docID)
+			rest.RequireDocVersionEqual(t, version, rt1Version)
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			// alter remote doc HLV to have MV
+			newHLVForRemote := &db.HybridLogicalVector{
+				Version:       math.MaxUint64, // will macro expand
+				SourceID:      version.CV.SourceID,
+				MergeVersions: testCase.mvForRemote,
+				PreviousVersions: map[string]uint64{
+					"foo": 100,
+				},
+			}
+
+			// create local hlv for conflict (simulating an update locally)
+			newHLVForLocal := &db.HybridLogicalVector{
+				SourceID: rt1.GetDatabase().EncodedSourceID,
+				Version:  math.MaxUint64, // will macro expand
+				PreviousVersions: map[string]uint64{
+					rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
+				},
+				MergeVersions: testCase.mvForLocal,
+			}
+			if testCase.olderVersionLocal {
+				// alter cv version to be low number to simulate older version than remote
+				newHLVForLocal.Version = 50
+			}
+
+			docBody := map[string]interface{}{
+				"source":   "rt2",
+				"channels": []string{"alice"},
+				"some":     "data",
+			}
+			remoteCas := db.AlterHLVForTest(t, ctx1, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
+			_, _ = rt2.GetDoc(docID) // ensure doc is imported
+			base.RequireWaitForStat(t, func() int64 {
+				return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+			}, 1)
+
+			docBody = map[string]interface{}{
+				"source":   "rt1",
+				"channels": []string{"alice"},
+			}
+			localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
+			_, _ = rt1.GetDoc(docID) // ensure doc is imported
+			base.RequireWaitForStat(t, func() int64 {
+				return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+			}, 1)
+
+			expectedHLV := &db.HybridLogicalVector{
+				SourceID:      rt1.GetDatabase().EncodedSourceID,
+				Version:       localCas,
+				MergeVersions: testCase.expectedMV,
+				PreviousVersions: map[string]uint64{
+					"foo":                             100,
+					rt2.GetDatabase().EncodedSourceID: remoteCas,
+				},
+			}
+
+			// add expected flush to PV if needed
+			if len(testCase.expectedFlushToPV) != 0 {
+				for key, value := range testCase.expectedFlushToPV {
+					expectedHLV.PreviousVersions[key] = value
+				}
+			}
+
+			rt1.WaitForPendingChanges()
+			rt2.WaitForPendingChanges()
+
+			// start again for new revisions
+			require.NoError(t, ar.Start(ctx1))
+
+			changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+
+			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			cvSource, cvValue := rt1Doc.HLV.GetCurrentVersion()
+			// CBG-4791 - assert on rev tree here too
+			assert.Equal(t, expectedHLV.SourceID, cvSource)
+			if !testCase.olderVersionLocal {
+				assert.Equal(t, expectedHLV.Version, cvValue)
+			} else {
+				// new cv will have been generated as local cv was older than remote
+				assert.Equal(t, rt1Doc.Cas, cvValue)
+			}
+			if len(testCase.expectedFlushToPV) == 0 {
+				require.Len(t, rt1Doc.HLV.PreviousVersions, 2)
+			} else {
+				require.Len(t, rt1Doc.HLV.PreviousVersions, 4)
+			}
+			assert.Equal(t, expectedHLV.PreviousVersions["foo"], rt1Doc.HLV.PreviousVersions["foo"])
+			assert.Equal(t, expectedHLV.PreviousVersions[rt1.GetDatabase().EncodedSourceID], rt1Doc.HLV.PreviousVersions[rt1.GetDatabase().EncodedSourceID])
+			if len(testCase.expectedFlushToPV) == 0 {
+				require.Len(t, rt1Doc.HLV.MergeVersions, 2)
+				assert.Equal(t, expectedHLV.MergeVersions[mergeVersion1], rt1Doc.HLV.MergeVersions[mergeVersion1])
+				assert.Equal(t, expectedHLV.MergeVersions[mergeVersion2], rt1Doc.HLV.MergeVersions[mergeVersion2])
+			} else {
+				require.Len(t, rt1Doc.HLV.MergeVersions, 0)
+				for key, value := range testCase.expectedFlushToPV {
+					assert.Equal(t, value, rt1Doc.HLV.PreviousVersions[key], "Expected key %s to have value %d in previous versions", key, value)
+				}
+			}
+		})
+	}
+}
+
+func TestActiveReplicatorRemoteWinsWithMV(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyVV, base.KeyCRUD, base.KeySync, base.KeyReplicate, base.KeyChanges, base.KeyImport)
+	base.RequireNumTestBuckets(t, 2)
+
+	const (
+		mergeVersion1 = "xyz"
+		mergeVersion2 = "abc"
+	)
+
+	testCases := []struct {
+		name              string
+		mvForRemote       db.HLVVersions
+		mvForLocal        db.HLVVersions
+		expectedMV        db.HLVVersions
+		expectedFlushToPV db.HLVVersions
+	}{
+		{
+			name: "MV on remote doc and no MV on local doc",
+			mvForRemote: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			expectedMV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+		{
+			name: "MV on remote doc with higher value than MV on local doc",
+			mvForRemote: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			mvForLocal: db.HLVVersions{
+				mergeVersion1: 100,
+				mergeVersion2: 50,
+			},
+			expectedMV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+		{
+			name: "MV on remote doc with lower value than MV on local doc",
+			mvForRemote: db.HLVVersions{
+				mergeVersion1: 100,
+				mergeVersion2: 50,
+			},
+			mvForLocal: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			expectedMV: nil, // mo MV expected should be flushed to pv
+			expectedFlushToPV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+		{
+			name: "MV on local doc and no MV on remote doc",
+			mvForLocal: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+			expectedMV: nil, // no MV expected should be flushed to pv
+			expectedFlushToPV: db.HLVVersions{
+				mergeVersion1: 200,
+				mergeVersion2: 300,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Passive
+			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt2.Close()
+			username := "alice"
+			rt2.CreateUser(username, []string{username})
+
+			// Active
+			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt1.Close()
+			ctx1 := rt1.Context()
+			ctx2 := rt2.Context()
+
+			docID := "doc1_"
+			version := rt2.PutDocDirectly(docID, rest.JsonToMap(t, `{"source":"rt2","channels":["alice"]}`))
+			rt2.WaitForPendingChanges()
+
+			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverRemoteWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
+			require.NoError(t, err)
+
+			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePull,
+				RemoteDBURL: userDBURL(rt2, username),
+				ActiveDB: &db.Database{
+					DatabaseContext: rt1.GetDatabase(),
+				},
+				ChangesBatchSize:     200,
+				ReplicationStatsMap:  dbReplicatorStats(t),
+				ConflictResolverFunc: resolverFunc,
+				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:           false,
+			})
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, ar.Stop()) }()
+
+			// Start the replicator
+			require.NoError(t, ar.Start(ctx1))
+
+			// wait for the document originally written to rt1 to arrive at rt2
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+			rt1Version, _ := rt1.GetDoc(docID)
+			rest.RequireDocVersionEqual(t, version, rt1Version)
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			// alter remote doc HLV to have MV
+			newHLVForRemote := &db.HybridLogicalVector{
+				Version:       math.MaxUint64, // will macro expand
+				SourceID:      version.CV.SourceID,
+				MergeVersions: testCase.mvForRemote,
+				PreviousVersions: map[string]uint64{
+					"foo": 100,
+				},
+			}
+
+			// create local hlv for conflict (simulating an update locally)
+			newHLVForLocal := &db.HybridLogicalVector{
+				SourceID: rt1.GetDatabase().EncodedSourceID,
+				Version:  math.MaxUint64, // will macro expand
+				PreviousVersions: map[string]uint64{
+					rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
+				},
+				MergeVersions: testCase.mvForLocal,
+			}
+
+			docBody := map[string]interface{}{
+				"source":   "rt2",
+				"channels": []string{"alice"},
+				"some":     "data",
+			}
+			remoteCas := db.AlterHLVForTest(t, ctx1, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
+			_, _ = rt2.GetDoc(docID) // ensure doc is imported
+			base.RequireWaitForStat(t, func() int64 {
+				return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+			}, 1)
+
+			docBody = map[string]interface{}{
+				"source":   "rt1",
+				"channels": []string{"alice"},
+			}
+			localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
+			_, _ = rt1.GetDoc(docID) // ensure doc is imported
+			base.RequireWaitForStat(t, func() int64 {
+				return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+			}, 1)
+
+			expectedHLV := &db.HybridLogicalVector{
+				SourceID:      rt2.GetDatabase().EncodedSourceID,
+				Version:       remoteCas,
+				MergeVersions: testCase.expectedMV,
+				PreviousVersions: map[string]uint64{
+					"foo":                             100,
+					rt1.GetDatabase().EncodedSourceID: localCas,
+				},
+			}
+			// add expected flush to PV if needed
+			if len(testCase.expectedFlushToPV) != 0 {
+				for key, value := range testCase.expectedFlushToPV {
+					expectedHLV.PreviousVersions[key] = value
+				}
+			}
+
+			rt1.WaitForPendingChanges()
+			rt2.WaitForPendingChanges()
+
+			// start again for new revisions
+			require.NoError(t, ar.Start(ctx1))
+
+			changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+
+			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			cvSource, cvValue := rt1Doc.HLV.GetCurrentVersion()
+			// CBG-4791 - assert on rev tree here too
+			assert.Equal(t, expectedHLV.SourceID, cvSource)
+			assert.Equal(t, expectedHLV.Version, cvValue)
+			if len(testCase.expectedFlushToPV) == 0 {
+				require.Len(t, rt1Doc.HLV.PreviousVersions, 2)
+			} else {
+				require.Len(t, rt1Doc.HLV.PreviousVersions, 4)
+			}
+			assert.Equal(t, expectedHLV.PreviousVersions["foo"], rt1Doc.HLV.PreviousVersions["foo"])
+			assert.Equal(t, expectedHLV.PreviousVersions[rt1.GetDatabase().EncodedSourceID], rt1Doc.HLV.PreviousVersions[rt1.GetDatabase().EncodedSourceID])
+			if len(testCase.expectedFlushToPV) == 0 {
+				require.Len(t, rt1Doc.HLV.MergeVersions, 2)
+				assert.Equal(t, expectedHLV.MergeVersions[mergeVersion1], rt1Doc.HLV.MergeVersions[mergeVersion1])
+				assert.Equal(t, expectedHLV.MergeVersions[mergeVersion2], rt1Doc.HLV.MergeVersions[mergeVersion2])
+			} else {
+				require.Len(t, rt1Doc.HLV.MergeVersions, 0)
+				for key, value := range testCase.expectedFlushToPV {
+					assert.Equal(t, value, rt1Doc.HLV.PreviousVersions[key], "Expected key %s to have value %d in previous versions", key, value)
+				}
+			}
+		})
+	}
+}
+
+func TestActiveReplicatorHLVConflictNoCommonMV(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyVV, base.KeyCRUD, base.KeySync, base.KeyReplicate, base.KeyChanges, base.KeyImport)
+	base.RequireNumTestBuckets(t, 2)
+
+	testCases := []struct {
+		name                 string
+		localMV              db.HLVVersions
+		remoteMV             db.HLVVersions
+		expectedMV           db.HLVVersions
+		expectedPV           db.HLVVersions
+		conflictResolverType db.ConflictResolverType
+	}{
+		{
+			name: "No common MV remote wins",
+			localMV: db.HLVVersions{
+				"xyz": 100,
+				"abc": 200,
+			},
+			remoteMV: db.HLVVersions{
+				"def": 300,
+				"ghi": 400,
+			},
+			expectedPV: db.HLVVersions{
+				"xyz": 100,
+				"abc": 200,
+			},
+			expectedMV: db.HLVVersions{
+				"def": 300,
+				"ghi": 400,
+			},
+			conflictResolverType: db.ConflictResolverRemoteWins,
+		},
+		{
+			name: "No common MV local wins",
+			localMV: db.HLVVersions{
+				"xyz": 100,
+				"abc": 200,
+			},
+			remoteMV: db.HLVVersions{
+				"def": 300,
+				"ghi": 400,
+			},
+			expectedPV: db.HLVVersions{
+				"def": 300,
+				"ghi": 400,
+			},
+			expectedMV: db.HLVVersions{
+				"xyz": 100,
+				"abc": 200,
+			},
+			conflictResolverType: db.ConflictResolverLocalWins,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Passive
+			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt2.Close()
+			username := "alice"
+			rt2.CreateUser(username, []string{username})
+
+			// Active
+			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt1.Close()
+			ctx1 := rt1.Context()
+			ctx2 := rt2.Context()
+
+			docID := "doc1_"
+			version := rt2.PutDocDirectly(docID, rest.JsonToMap(t, `{"source":"rt2","channels":["alice"]}`))
+			rt2.WaitForPendingChanges()
+
+			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+			require.NoError(t, err)
+
+			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePull,
+				RemoteDBURL: userDBURL(rt2, username),
+				ActiveDB: &db.Database{
+					DatabaseContext: rt1.GetDatabase(),
+				},
+				ChangesBatchSize:     200,
+				ReplicationStatsMap:  dbReplicatorStats(t),
+				ConflictResolverFunc: resolverFunc,
+				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:           false,
+			})
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, ar.Stop()) }()
+
+			// Start the replicator
+			require.NoError(t, ar.Start(ctx1))
+
+			// wait for the document originally written to rt1 to arrive at rt2
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+			rt1Version, _ := rt1.GetDoc(docID)
+			rest.RequireDocVersionEqual(t, version, rt1Version)
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			// alter remote doc HLV to have MV
+			newHLVForRemote := &db.HybridLogicalVector{
+				Version:       math.MaxUint64, // will macro expand
+				SourceID:      version.CV.SourceID,
+				MergeVersions: testCase.remoteMV,
+			}
+
+			// create local hlv for conflict (simulating an update locally)
+			newHLVForLocal := &db.HybridLogicalVector{
+				SourceID: rt1.GetDatabase().EncodedSourceID,
+				Version:  math.MaxUint64, // will macro expand
+				PreviousVersions: map[string]uint64{
+					rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
+				},
+				MergeVersions: testCase.localMV,
+			}
+
+			docBody := map[string]interface{}{
+				"source":   "rt2",
+				"channels": []string{"alice"},
+				"some":     "data",
+			}
+			remoteCas := db.AlterHLVForTest(t, ctx1, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
+			_, _ = rt2.GetDoc(docID) // ensure doc is imported
+			base.RequireWaitForStat(t, func() int64 {
+				return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+			}, 1)
+
+			docBody = map[string]interface{}{
+				"source":   "rt1",
+				"channels": []string{"alice"},
+			}
+			localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
+			_, _ = rt1.GetDoc(docID) // ensure doc is imported
+			base.RequireWaitForStat(t, func() int64 {
+				return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+			}, 1)
+
+			rt1.WaitForPendingChanges()
+			rt2.WaitForPendingChanges()
+
+			// start again for new revisions
+			require.NoError(t, ar.Start(ctx1))
+
+			changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			var expectedHLV *db.HybridLogicalVector
+			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+				expectedHLV = &db.HybridLogicalVector{
+					SourceID:      rt2.GetDatabase().EncodedSourceID,
+					Version:       remoteCas,
+					MergeVersions: testCase.expectedMV,
+					PreviousVersions: map[string]uint64{
+						rt1.GetDatabase().EncodedSourceID: localCas,
+					},
+				}
+			} else {
+				expectedHLV = &db.HybridLogicalVector{
+					SourceID:      rt1.GetDatabase().EncodedSourceID,
+					Version:       localCas,
+					MergeVersions: testCase.expectedMV,
+					PreviousVersions: map[string]uint64{
+						rt2.GetDatabase().EncodedSourceID: remoteCas,
+					},
+				}
+			}
+			// add extra pv expected
+			for key, value := range testCase.expectedPV {
+				expectedHLV.PreviousVersions[key] = value
+			}
+
+			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+
+			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			cvSource, cvValue := rt1Doc.HLV.GetCurrentVersion()
+			// CBG-4791 - assert on rev tree here too
+			assert.Equal(t, expectedHLV.SourceID, cvSource)
+			assert.Equal(t, expectedHLV.Version, cvValue)
+
+			for key, value := range expectedHLV.PreviousVersions {
+				assert.Equal(t, value, rt1Doc.HLV.PreviousVersions[key], "Expected key %s to have value %d in previous versions", key, value)
+			}
+			for key, value := range expectedHLV.MergeVersions {
+				assert.Equal(t, value, rt1Doc.HLV.MergeVersions[key], "Expected key %s to have value %d in merge versions", key, value)
+			}
+		})
+	}
+}
+
+func TestActiveReplicatorAttachmentHandling(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyVV, base.KeyCRUD, base.KeySync, base.KeyReplicate, base.KeyChanges, base.KeyImport)
+	base.RequireNumTestBuckets(t, 2)
+
+	testCases := []struct {
+		name                 string
+		conflictResolverType db.ConflictResolverType
+	}{
+		{
+			name:                 "remote wins",
+			conflictResolverType: db.ConflictResolverRemoteWins,
+		},
+		{
+			name:                 "local wins",
+			conflictResolverType: db.ConflictResolverLocalWins,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Passive
+			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt2.Close()
+			username := "alice"
+			rt2.CreateUser(username, []string{username})
+
+			// Active
+			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt1.Close()
+			ctx1 := rt1.Context()
+
+			docID := "doc1_"
+			version := rt2.PutDocDirectly(docID, rest.JsonToMap(t, `{"source":"rt2","channels":["alice"]}`))
+			rt2.WaitForPendingChanges()
+
+			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+			require.NoError(t, err)
+
+			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePull,
+				RemoteDBURL: userDBURL(rt2, username),
+				ActiveDB: &db.Database{
+					DatabaseContext: rt1.GetDatabase(),
+				},
+				ChangesBatchSize:     200,
+				ReplicationStatsMap:  dbReplicatorStats(t),
+				ConflictResolverFunc: resolverFunc,
+				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:           false,
+			})
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, ar.Stop()) }()
+
+			// Start the replicator
+			require.NoError(t, ar.Start(ctx1))
+
+			// wait for the document originally written to rt1 to arrive at rt2
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+			rt1Version, _ := rt1.GetDoc(docID)
+			rest.RequireDocVersionEqual(t, version, rt1Version)
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			// update remote doc to have two attachments
+			version = rt2.UpdateDocDirectly(docID, version, rest.JsonToMap(t, `{"source":"rt2", "channels": ["alice"], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}, "world.txt": {"data":"aGVsbG8gd29ybGQ="}}}`))
+			// update local to have one different attachment
+			rt1Version = rt1.UpdateDocDirectly(docID, rt1Version, rest.JsonToMap(t, `{"source":"rt1", "channels": ["alice"], "_attachments": {"different.txt": {"data":"aGVsbG8gd29ybGQ="}}}`))
+			rt2.WaitForPendingChanges()
+			rt1.WaitForPendingChanges()
+
+			// Start the replicator
+			require.NoError(t, ar.Start(ctx1))
+
+			// wait for the document originally written to rt1 to arrive at rt2
+			changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+
+			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+
+			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+				// remote wins, so we expect the remote attachments to be present
+				// CBG-4791 - switch to RequireDocVersionEqual
+				rest.RequireDocumentCV(t, version, rt1Doc.ExtractDocVersion())
+
+				attMeta := rt1Doc.Attachments()
+				require.Len(t, attMeta, 2)
+				base.RequireKeysEqual(t, []string{"hello.txt", "world.txt"}, attMeta)
+			} else {
+				// local wins, so we expect the local attachment to be present
+
+				// CBG-4791 - switch to RequireDocVersionEqual
+				rest.RequireDocumentCV(t, rt1Version, rt1Doc.ExtractDocVersion())
+
+				attMeta := rt1Doc.Attachments()
+				require.Len(t, attMeta, 1)
+				base.RequireKeysEqual(t, []string{"different.txt"}, attMeta)
+			}
+		})
+	}
+}
+
+func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyVV, base.KeyCRUD, base.KeySync, base.KeyReplicate, base.KeyChanges, base.KeyImport)
+	base.RequireNumTestBuckets(t, 2)
+
+	testCases := []struct {
+		name                 string
+		conflictResolverType db.ConflictResolverType
+	}{
+		{
+			name:                 "remote wins",
+			conflictResolverType: db.ConflictResolverRemoteWins,
+		},
+		{
+			name:                 "local wins",
+			conflictResolverType: db.ConflictResolverLocalWins,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Passive
+			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt2.Close()
+			username := "alice"
+			rt2.CreateUser(username, []string{username})
+
+			// Active
+			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+			})
+			defer rt1.Close()
+			ctx1 := rt1.Context()
+
+			docID := "doc1_"
+			version := rt2.PutDocDirectly(docID, rest.JsonToMap(t, `{"source":"rt2","channels":["alice"]}`))
+			rt2.WaitForPendingChanges()
+
+			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+			require.NoError(t, err)
+
+			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePull,
+				RemoteDBURL: userDBURL(rt2, username),
+				ActiveDB: &db.Database{
+					DatabaseContext: rt1.GetDatabase(),
+				},
+				ChangesBatchSize:     200,
+				ReplicationStatsMap:  dbReplicatorStats(t),
+				ConflictResolverFunc: resolverFunc,
+				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:           false,
+			})
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, ar.Stop()) }()
+
+			// Start the replicator
+			require.NoError(t, ar.Start(ctx1))
+
+			// wait for the document originally written to rt1 to arrive at rt2
+			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+			rt1Version, _ := rt1.GetDoc(docID)
+			rest.RequireDocVersionEqual(t, version, rt1Version)
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			// update winning rev to be a tombstone
+			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+				// remote wins, so we update the remote doc to be a tombstone
+				version = rt2.DeleteDocDirectly(docID, version)
+			} else {
+				// need to update remote doc to have something to replicate
+				version = rt2.UpdateDocDirectly(docID, version, rest.JsonToMap(t, `{"source":"rt2","channels":["alice"]}`))
+				// local wins, so we update the local doc to be a tombstone
+				rt1Version = rt1.DeleteDocDirectly(docID, rt1Version)
+			}
+			rt2.WaitForPendingChanges()
+			rt1.WaitForPendingChanges()
+
+			// Start the replicator
+			require.NoError(t, ar.Start(ctx1))
+
+			// wait for the document originally written to rt1 to arrive at rt2
+			changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+			changesResults.RequireDocIDs(t, []string{docID})
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+			}, time.Second*20, time.Millisecond*100)
+
+			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+
+			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+				// CBG-4791 - switch to RequireDocVersionEqual
+				rest.RequireDocumentCV(t, version, rt1Doc.ExtractDocVersion())
+			} else {
+				// CBG-4791 - switch to RequireDocVersionEqual
+				rest.RequireDocumentCV(t, rt1Version, rt1Doc.ExtractDocVersion())
+			}
+			assert.True(t, rt1Doc.IsDeleted(), "Expected document to be a tombstone after remote wins conflict resolution")
+		})
+	}
+}

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -267,7 +267,6 @@ func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 	// grab local doc body and assert it is as expected
 	actualBody, err := rt1Doc.BodyBytes(rt1ctx)
 	require.NoError(t, err)
-	fmt.Println(string(actualBody), "expected:", string(expectedConflictResBody))
 	assert.Equal(t, expectedConflictResBody, actualBody)
 }
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -6171,6 +6171,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 // whilst applying default conflict resolution policy through pushAndPull replication.
 func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 
+	// CBG-4799: tests wil be refactored to allow for easier switch between rev tree and version vector
 	base.LongRunningTest(t)
 	base.RequireNumTestBuckets(t, 2)
 	if !base.TestUseXattrs() {
@@ -6261,23 +6262,25 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			defer func() { require.NoError(t, ar.Stop(), "Error stopping replication") }()
 
 			// Wait for the original document revision written to activeRT to arrive at passiveRT.
-			passiveRT.WaitForVersion(docID, activeRTVersionCreated)
+			passiveRT.WaitForVersionRevIDOnly(docID, activeRTVersionCreated) // < v4 replication only sends revID
 
 			// Stop replication.
 			require.NoError(t, ar.Stop(), "Error stopping replication")
 
 			// Update the document on activeRT to build a revision history.
+			activeRTVersionCreated.CV = db.Version{} // need to clear cv to update with revID not CV
 			activeRTVersionUpdated := updateDoc(activeRT, docID, activeRTVersionCreated, "bar")
 
 			// Tombstone the document on activeRT to mark the tip of the revision history for deletion.
 			tombstoneVersion := activeRT.DeleteDoc(docID, activeRTVersionUpdated)
 
-			activeRT.WaitForTombstone(docID, tombstoneVersion)
+			activeRT.WaitForTombstoneRevIDOnly(docID, tombstoneVersion) // < v4 replication only sends revID
 
 			// Update the document on passiveRT with the specified body values.
 			passiveRTVersion := activeRTVersionCreated
 			for _, bodyValue := range test.remoteBodyValues {
 				passiveRTVersion = updateDoc(passiveRT, docID, passiveRTVersion, bodyValue)
+				passiveRTVersion.CV = db.Version{} // need to clear cv to update with revID not CV
 			}
 
 			// Start replication.
@@ -6286,8 +6289,8 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			// the winning revision to be written to both activeRT and passiveRT buckets. Check whether the
 			// winning revision is a tombstone; tombstone revision wins over non-tombstone revision.
 			expectedVersion := rest.NewDocVersionFromFakeRev(test.expectedRevID)
-			activeRT.WaitForTombstone(docID, expectedVersion)
-			passiveRT.WaitForTombstone(docID, expectedVersion)
+			activeRT.WaitForTombstoneRevIDOnly(docID, expectedVersion)
+			passiveRT.WaitForTombstoneRevIDOnly(docID, expectedVersion)
 		})
 	}
 }
@@ -6296,6 +6299,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 // whilst applying default conflict resolution policy through pushAndPull replication.
 func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 
+	// CBG-4799: tests wil be refactored to allow for easier switch between rev tree and version vector
 	base.LongRunningTest(t)
 	base.RequireNumTestBuckets(t, 2)
 	if !base.TestUseXattrs() {
@@ -6386,24 +6390,27 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			require.NoError(t, ar.Start(ctx1), "Error starting replication")
 			defer func() { require.NoError(t, ar.Stop(), "Error stopping replication") }()
 
-			rt1.WaitForVersion(docID, rt2VersionCreated)
+			rt1.WaitForVersionRevIDOnly(docID, rt2VersionCreated)
 
 			// Stop replication.
 			require.NoError(t, ar.Stop(), "Error stopping replication")
 
 			// Update the document on rt2 to build a revision history.
+			rt2VersionCreated.CV = db.Version{} // need to clear cv to update with revID not CV
 			rt2VersionUpdated := updateDoc(rt2, docID, rt2VersionCreated, "bar")
 
 			// Tombstone the document on rt2 to mark the tip of the revision history for deletion.
+			rt2VersionUpdated.CV = db.Version{} // need to clear cv to update with revID not CV
 			tombstoneVersion := rt2.DeleteDoc(docID, rt2VersionUpdated)
 
 			// Ensure that the tombstone revision is written to rt2 bucket with an empty body.
-			rt2.WaitForTombstone(docID, tombstoneVersion)
+			rt2.WaitForTombstoneRevIDOnly(docID, tombstoneVersion)
 
 			// Update the document on rt1 with the specified body values.
 			rt1Version := rt2VersionCreated
 			for _, bodyValue := range test.localBodyValues {
 				rt1Version = updateDoc(rt1, docID, rt1Version, bodyValue)
+				rt1Version.CV = db.Version{} // need to clear cv to update with revID not CV
 			}
 
 			// Start replication.
@@ -6414,8 +6421,8 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			// winning revision is a tombstone; tombstone revision wins over non-tombstone revision.
 
 			expectedVersion := rest.NewDocVersionFromFakeRev(test.expectedRevID)
-			rt1.WaitForTombstone(docID, expectedVersion)
-			rt2.WaitForTombstone(docID, expectedVersion)
+			rt1.WaitForTombstoneRevIDOnly(docID, expectedVersion)
+			rt2.WaitForTombstoneRevIDOnly(docID, expectedVersion)
 		})
 	}
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -6176,7 +6176,6 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
 	}
-	t.Skip("CBG-4778: needs rework for version vectors")
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	defaultConflictResolverWithTombstoneTests := []struct {
@@ -6244,10 +6243,11 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 				ActiveDB: &db.Database{
 					DatabaseContext: activeRT.GetDatabase(),
 				},
-				Continuous:           true,
-				ConflictResolverFunc: defaultConflictResolver,
-				ReplicationStatsMap:  dbReplicatorStats(t),
-				CollectionsEnabled:   !activeRT.GetDatabase().OnlyDefaultCollection(),
+				Continuous:             true,
+				ConflictResolverFunc:   defaultConflictResolver,
+				ReplicationStatsMap:    dbReplicatorStats(t),
+				CollectionsEnabled:     !activeRT.GetDatabase().OnlyDefaultCollection(),
+				SupportedBLIPProtocols: []string{db.CBMobileReplicationV3.SubprotocolString()}, // only relevant for v3 and below replications
 			}
 
 			docID := "doc"
@@ -6302,7 +6302,6 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-	t.Skip("CBG-4778: needs rework for version vectors")
 
 	defaultConflictResolverWithTombstoneTests := []struct {
 		name            string   // A unique name to identify the unit test.
@@ -6370,10 +6369,11 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
-				Continuous:           true,
-				ConflictResolverFunc: defaultConflictResolver,
-				ReplicationStatsMap:  dbReplicatorStats(t),
-				CollectionsEnabled:   !rt1.GetDatabase().OnlyDefaultCollection(),
+				Continuous:             true,
+				ConflictResolverFunc:   defaultConflictResolver,
+				ReplicationStatsMap:    dbReplicatorStats(t),
+				CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+				SupportedBLIPProtocols: []string{db.CBMobileReplicationV3.SubprotocolString()}, // only relevant for v3 and below replications
 			}
 
 			// Create the first revision of the document on rt2.
@@ -6429,7 +6429,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("test is EE only (non-default conflict resolver)")
 	}
-	t.Skip("CBG-4778: Needs conflict resolution done for ISGR, also needs rev tree property done")
+	t.Skip("CBG-4830: Needs work to run in < 4 or in both 4 and >= 4 protocol")
 
 	type revisionState struct {
 		generation       int
@@ -6695,7 +6695,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 }
 func TestReplicatorConflictAttachment(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	t.Skip("CBG-4778: Needs conflict resolution done for ISGR, also needs rev tree property done")
+	t.Skip("CBG-4830: Needs work to run in < 4 or in both 4 and >= 4 protocol")
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("requires enterprise edition")
 	}

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -192,6 +192,11 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 	}, 10*time.Second, 50*time.Millisecond)
 }
 
+func (rt *RestTester) WaitForVersionRevIDOnly(docID string, version DocVersion) {
+	version.CV = db.Version{} // empty cv so WaitForVersion only asserts on revID
+	rt.WaitForVersion(docID, version)
+}
+
 // WaitForTombstone waits for a the document version to exist and be tombstoned. If the document is not found, the test will fail.
 func (rt *RestTester) WaitForTombstone(docID string, deleteVersion DocVersion) {
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
@@ -208,6 +213,11 @@ func (rt *RestTester) WaitForTombstone(docID string, deleteVersion DocVersion) {
 			assert.Equal(c, deleteVersion.CV.String(), doc.HLV.GetCurrentVersionString())
 		}
 	}, time.Second*10, time.Millisecond*100)
+}
+
+func (rt *RestTester) WaitForTombstoneRevIDOnly(docID string, deleteVersion DocVersion) {
+	deleteVersion.CV = db.Version{}
+	rt.WaitForTombstone(docID, deleteVersion)
 }
 
 func (rt *RestTester) WaitForCheckpointLastSequence(expectedName string) (string, error) {


### PR DESCRIPTION
CBG-4778

- Adds HLV conflict resolution to active replicator. We need two defined given when we build active replicator we don't know what sub-protocol we're running in but also we need reference to pre 4.0 conflict resolution for pre upgraded docs. 
- Adds lower level test around local wins and remote wins 
- Adds higher level tests for conflict resolution around local wins and remote wins cases
- Needed to have the ability to mock the HLV on a doc to look a certain way for test cases around MV so added test helper `AlterHLVForTest` 
- PR will not reconcile rev tree's at this time, later ticket for this
- PR takes into account work for [CBG-4789](https://jira.issues.couchbase.com/browse/CBG-4789) 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/53/


[CBG-4789]: https://couchbasecloud.atlassian.net/browse/CBG-4789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ