### PR TITLE
CBG-4787 allow updating document that have been tombstoned

### DIFF
--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -138,7 +138,7 @@ func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string
 			return false
 		}
 
-		if syncData == nil || syncData.AttachmentsPre4dot0 == nil {
+		if syncData.IsEmpty() || syncData.AttachmentsPre4dot0 == nil {
 			// no attachments to migrate
 			return true
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -1664,7 +1664,7 @@ func (c *DatabaseCollection) releaseSequences(ctx context.Context, sequences []u
 func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, doc *Document, regenerateSequences bool, unusedSequences []uint64) (updatedDoc *Document, shouldUpdate bool, updatedExpiry *uint32, highSeq uint64, updatedUnusedSequences []uint64, err error) {
 	docid := doc.ID
 	forceUpdate := false
-	if !doc.HasValidSyncData() {
+	if doc.SyncData.IsEmpty() {
 		// This is a document not known to the sync gateway. Ignore it:
 		return nil, false, nil, doc.Sequence, unusedSequences, base.ErrUpdateCancel
 	}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -203,7 +203,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 	}
 
 	var isSGWrite bool
-	if syncData != nil {
+	if !syncData.IsEmpty() {
 		var crc32Match bool
 		isSGWrite, crc32Match, _ = syncData.IsSGWrite(event.Cas, rawBody, rawXattrs[collection.userXattrKey()])
 		if crc32Match {
@@ -243,7 +243,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 				base.DebugfCtx(ctx, base.KeyImport, "Did not import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", base.UD(docID), err)
 			}
 		}
-	} else if syncData != nil && syncData.AttachmentsPre4dot0 != nil {
+	} else if syncData.AttachmentsPre4dot0 != nil {
 		base.DebugfCtx(ctx, base.KeyImport, "Attachment metadata found in sync data for doc with id %s, migrating attachment metadata", base.UD(docID))
 		// we have attachments to migrate
 		err := collection.MigrateAttachmentMetadata(ctx, docID, event.Cas, syncData)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3494,43 +3494,35 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 }
 
 func TestBlipPushRevOnResurrection(t *testing.T) {
-	for _, allowConflicts := range []bool{true, false} {
-		t.Run(fmt.Sprintf("allowConflicts=%t", allowConflicts), func(t *testing.T) {
-			btcRunner := NewBlipTesterClientRunner(t)
-
-			btcRunner.SkipSubtest[VersionVectorSubtestName] = true // CBG-4786 CBG-4787 skipped pending work in this ticket
-
-			btcRunner.Run(func(t *testing.T) {
-				rt := NewRestTester(t, &RestTesterConfig{
-					PersistentConfig: true,
-				})
-				defer rt.Close()
-
-				dbConfig := rt.NewDbConfig()
-				dbConfig.AllowConflicts = base.Ptr(allowConflicts)
-				dbConfig.AutoImport = base.Ptr(false)
-				RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-				startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
-				docID := "doc1"
-				rt.CreateTestDoc(docID)
-
-				rt.PurgeDoc(docID)
-
-				RequireStatus(t, rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, ""), http.StatusNotFound)
-
-				const alice = "alice"
-				rt.CreateUser(alice, nil)
-				opts := &BlipTesterClientOpts{Username: "alice"}
-				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
-				defer btc.Close()
-
-				btcRunner.StartPush(btc.id)
-				docVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"resurrect":true}`))
-				rt.WaitForVersion(docID, docVersion)
-				require.Equal(t, startWarnCount, base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value())
-			})
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{
+			PersistentConfig: true,
 		})
-	}
+		defer rt.Close()
+
+		dbConfig := rt.NewDbConfig()
+		dbConfig.AutoImport = base.Ptr(false)
+		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+		startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
+		docID := "doc1"
+		rt.CreateTestDoc(docID)
+
+		rt.PurgeDoc(docID)
+
+		RequireStatus(t, rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID, ""), http.StatusNotFound)
+
+		const alice = "alice"
+		rt.CreateUser(alice, nil)
+		opts := &BlipTesterClientOpts{Username: "alice"}
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer btc.Close()
+
+		btcRunner.StartPush(btc.id)
+		docVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"resurrect":true}`))
+		rt.WaitForVersion(docID, docVersion)
+		require.Equal(t, startWarnCount, base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value())
+	})
 }
 
 func TestBlipPullConflict(t *testing.T) {


### PR DESCRIPTION
CBG-4787 allow updating document that have been tombstoned

1. Calling `Purge` on a document leaves behind a _vv that refers to a _past_ mutation of a document. If that revision would conflict with CBL, CBL would never be able to pull that tombstone as in the test `TestBlipPushRevOnResurrection`. The fix for this is in `HasConflict` which is to disable conflict checking while there is a _vv but no _hlv, to match rev tree id resurrection.
2. The fix for import code running and canceling when trying to import a deletion is in https://github.com/couchbase/sync_gateway/blob/cde6f6789baf97833e56961ca761fdfff6bc8457/db/import_listener.go#L201 because it checks `syncData == nil` which was true in 3.3 and not in 4.0. I propose an alternate way of resolving this in https://github.com/couchbase/sync_gateway/pull/7710.

- Create SyncData.IsEmpty() to allow checking for no _sync when _vv exists
- Change calls for SyncData == nil to use SyncData.IsEmpty()
- Remove a bit of dead code

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/49/

A different case could be be broken, and addressing it would be best done in a different PR:

1. doc1 is converged on CBS1 and CBS2, CBL1 with `1@abc`
2. delete doc1 on CBS1 to create `2@cbs1;1@abc`
3. delete doc1 on CBS2 to create `3@cbs2;1@abc`
4. CBL1 pull revision from CBS2 `2@cbs1;1@abc`
 5. Turn on XDCR
 6. Both CBS1 and CBS2 will have `3@cbs2;1@abc`. However, CBL1 will remain at `2@cbs1`.
 7. TODO: validate that CBL1 which isn't source ID of `abc` will be able to push a resurrection to CBS1. I'm not 100% sure this is possible, but I actually don't think this PR.