### PR TITLE
CBG-4785: sendChanges support for legacy rev

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -561,12 +561,7 @@ func (bh *blipHandler) buildChangesRow(change *ChangeEntry, changeVersion Change
 	if len(changeVersion) > 1 {
 		base.AssertfCtx(bh.loggingCtx, "more changes in list than expected on change entry: %v", change.ID)
 	}
-	var rev string
-	if revID, ok := changeVersion[ChangesVersionTypeRevTreeID]; ok {
-		rev = revID
-	} else {
-		rev = changeVersion[ChangesVersionTypeCV]
-	}
+	rev := changeVersion.GetChangeEntryVersion()
 
 	if bh.activeCBMobileSubprotocol >= CBMobileReplicationV3 {
 		deletedFlags := changesDeletedFlag(0)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -662,6 +662,7 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 	var originalErr error
 	var docRev DocumentRevision
 	var localIsLegacyRev bool
+	// some of this legacy rev handing is due to change pending CBG-4784
 	if !strings.Contains(revID, "@") {
 		localIsLegacyRev = true
 	}
@@ -752,7 +753,7 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 		bsc.replicationStats.SendReplacementRevCount.Add(1)
 	}
 	var history []string
-	if !bsc.useHLV() {
+	if !bsc.useHLV() || localIsLegacyRev {
 		history = toHistory(docRev.History, knownRevs, maxHistory)
 	} else {
 		if docRev.hlvHistory != "" {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -660,7 +660,7 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 	var docRev DocumentRevision
 	var localIsLegacyRev bool
 	// some of this legacy rev handling is due to change pending CBG-4784
-	if !base.IsRevTreeID(revID) {
+	if base.IsRevTreeID(revID) {
 		localIsLegacyRev = true
 	}
 	if !bsc.useHLV() || localIsLegacyRev {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -661,7 +660,7 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 	var docRev DocumentRevision
 	var localIsLegacyRev bool
 	// some of this legacy rev handling is due to change pending CBG-4784
-	if !strings.Contains(revID, "@") {
+	if !base.IsRevTreeID(revID) {
 		localIsLegacyRev = true
 	}
 	if !bsc.useHLV() || localIsLegacyRev {

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -380,12 +380,10 @@ func (bsc *BlipSyncContext) handleChangesResponse(ctx context.Context, sender *b
 			//	element must always be a CV here which will be used for delta sync if enabled. The subsequent revID
 			//	will be used to determine what revIDs will need to be included in the revTree property for ISGR
 
-			if len(knownRevsArray) > 0 {
-				deltaSrcRevID, legacyRev, knownRevs, err = bsc.getKnownRevs(ctx, docID, knownRevsArray)
-				if err != nil {
-					base.ErrorfCtx(ctx, "Invalid response to 'changes' message. Err: %v", err)
-					return nil
-				}
+			deltaSrcRevID, legacyRev, knownRevs, err = bsc.getKnownRevs(ctx, docID, knownRevsArray)
+			if err != nil {
+				base.ErrorfCtx(ctx, "Invalid response to 'changes' message. Err: %v", err)
+				return nil
 			}
 
 			var err error
@@ -662,7 +660,7 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 	var originalErr error
 	var docRev DocumentRevision
 	var localIsLegacyRev bool
-	// some of this legacy rev handing is due to change pending CBG-4784
+	// some of this legacy rev handling is due to change pending CBG-4784
 	if !strings.Contains(revID, "@") {
 		localIsLegacyRev = true
 	}

--- a/db/changes.go
+++ b/db/changes.go
@@ -94,7 +94,6 @@ type ChangeEntry struct {
 	principalDoc   bool         // Used to indicate _user/_role docs
 	Revoked        bool         `json:"revoked,omitempty"`
 	collectionID   uint32
-	CurrentVersion *Version `json:"-"` // the current version of the change entry.  (Not marshalled, pending REST support for cv)
 }
 
 const (
@@ -560,15 +559,6 @@ func makeChangeEntry(ctx context.Context, logEntry *LogEntry, seqID SequenceID, 
 		fallthrough
 	default:
 		// already initialized with a 'rev' change entry
-	}
-
-	// populate CurrentVersion entry if log entry has sourceID and Version populated
-	// This allows current version to be nil in event of CV not being populated on log entry
-	// allowing omitempty to work as expected
-	if logEntry.SourceID != "" {
-		// TODO: CBG-4804: Remove this if we change BLIP generateBlipSyncChanges and tests to use versionType and read the value from the normal Changes array... no reason to store this info in two places.
-		// this also allows us to do a revtree ID fallback in cases where the CV is not available on an old rev, since the type is chosen inside when producing logentry and building the change row.
-		change.CurrentVersion = &Version{SourceID: logEntry.SourceID, Value: logEntry.Version}
 	}
 	if logEntry.Flags&channels.Removed != 0 {
 		change.Removed = base.SetOf(channel.Name)
@@ -1381,11 +1371,11 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 	row.Seq = SequenceID{Seq: populatedDoc.Sequence}
 	row.SetBranched((populatedDoc.Flags & channels.Branched) != 0)
 
-	if populatedDoc.HLV != nil {
-		cv := Version{}
-		cv.SourceID, cv.Value = populatedDoc.HLV.GetCurrentVersion()
-		row.CurrentVersion = &cv
-	}
+	//if populatedDoc.HLV != nil {
+	//	cv := Version{}
+	//	cv.SourceID, cv.Value = populatedDoc.HLV.GetCurrentVersion()
+	//	row.CurrentVersion = &cv
+	//}
 
 	var removedChannels []string
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -1602,3 +1602,13 @@ loop:
 
 	return feedErr, forceClose
 }
+
+// GetChangeEntryVersion will return revID version or CV version based on the ChangesVersionType populated in the map
+func (c ChangeByVersionType) GetChangeEntryVersion() (version string) {
+	if revID, ok := c[ChangesVersionTypeCV]; ok {
+		version = revID
+	} else {
+		version = c[ChangesVersionTypeRevTreeID]
+	}
+	return version
+}

--- a/db/changes.go
+++ b/db/changes.go
@@ -1371,12 +1371,6 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 	row.Seq = SequenceID{Seq: populatedDoc.Sequence}
 	row.SetBranched((populatedDoc.Flags & channels.Branched) != 0)
 
-	//if populatedDoc.HLV != nil {
-	//	cv := Version{}
-	//	cv.SourceID, cv.Value = populatedDoc.HLV.GetCurrentVersion()
-	//	row.CurrentVersion = &cv
-	//}
-
 	var removedChannels []string
 
 	userCanSeeDocChannel := false

--- a/db/changes.go
+++ b/db/changes.go
@@ -81,19 +81,19 @@ func (ce *ChangeEntry) ChangeVersionString(ctx context.Context) string {
 // A changes entry; Database.GetChanges returns an array of these.
 // Marshals into the standard CouchDB _changes format.
 type ChangeEntry struct {
-	Seq            SequenceID            `json:"seq"`
-	ID             string                `json:"id"`
-	Deleted        bool                  `json:"deleted,omitempty"`
-	Removed        base.Set              `json:"removed,omitempty"`
-	Doc            json.RawMessage       `json:"doc,omitempty"`
-	Changes        []ChangeByVersionType `json:"changes"`
-	Err            error                 `json:"err,omitempty"` // Used to notify feed consumer of errors
-	allRemoved     bool                  // Flag to track whether an entry is a removal in all channels visible to the user.
-	branched       bool
-	backfill       backfillFlag // Flag used to identify non-client entries used for backfill synchronization (di only)
-	principalDoc   bool         // Used to indicate _user/_role docs
-	Revoked        bool         `json:"revoked,omitempty"`
-	collectionID   uint32
+	Seq          SequenceID            `json:"seq"`
+	ID           string                `json:"id"`
+	Deleted      bool                  `json:"deleted,omitempty"`
+	Removed      base.Set              `json:"removed,omitempty"`
+	Doc          json.RawMessage       `json:"doc,omitempty"`
+	Changes      []ChangeByVersionType `json:"changes"`
+	Err          error                 `json:"err,omitempty"` // Used to notify feed consumer of errors
+	allRemoved   bool                  // Flag to track whether an entry is a removal in all channels visible to the user.
+	branched     bool
+	backfill     backfillFlag // Flag used to identify non-client entries used for backfill synchronization (di only)
+	principalDoc bool         // Used to indicate _user/_role docs
+	Revoked      bool         `json:"revoked,omitempty"`
+	collectionID uint32
 }
 
 const (

--- a/db/database.go
+++ b/db/database.go
@@ -54,6 +54,7 @@ const (
 	NewVersion
 	ExistingVersion
 	ExistingVersionWithUpdateToHLV
+	NoHLVUpdateForTest
 )
 
 type DocUpdateType uint32

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -988,3 +988,16 @@ func GetAttachmentsFromInlineBody(t *testing.T, responseBody []byte) AttachmentM
 func GetAttachmentsFrom1xBody(t *testing.T, body Body) AttachmentMap {
 	return GetAttachmentsFromInlineBody(t, base.MustJSONMarshal(t, body))
 }
+
+func GetChangeEntryCV(t *testing.T, entry *ChangeEntry) Version {
+	require.NotNil(t, entry.Changes)
+
+	if changeCV, ok := entry.Changes[0][ChangesVersionTypeCV]; ok {
+		changeVersion, err := ParseVersion(changeCV)
+		require.NoError(t, err)
+		return changeVersion
+	} else {
+		require.FailNow(t, "no CV found for change entry %s", entry)
+	}
+	return Version{}
+}

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -997,7 +997,7 @@ func GetChangeEntryCV(t *testing.T, entry *ChangeEntry) Version {
 		require.NoError(t, err)
 		return changeVersion
 	} else {
-		require.FailNow(t, "no CV found for change entry %s", entry)
+		require.FailNow(t, "no CV found for change entry")
 	}
 	return Version{}
 }

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -87,7 +87,8 @@ func (h *HLVAgent) UpdateWithHLV(ctx context.Context, key string, inputCas uint6
 	return cas
 }
 
-// CreateDocNoHLV is a test only function to create a document without an HLV
+// CreateDocNoHLV is a test only function to create a document without an HLV, this is useful for testing scenarios
+// where documents have not yet been updated post upgrade (pre upgraded doc so no HLV is given to it yet).
 func (db *DatabaseCollectionWithUser) CreateDocNoHLV(t *testing.T, ctx context.Context, docid string, body Body) (newRevID string, doc *Document) {
 	delete(body, BodyId)
 

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -1,3 +1,11 @@
+//  Copyright 2025-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+
 package replicatortest
 
 import (

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -1,0 +1,90 @@
+package replicatortest
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActiveReplicatorPullLegacyRev(t *testing.T) {
+	base.RequireNumTestBuckets(t, 2)
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	// Passive
+	const username = "alice"
+
+	rt2 := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: channels.DocChannelsSyncFunction,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Name: "passivedb",
+			}},
+		})
+	defer rt2.Close()
+
+	rt2.CreateUser(username, []string{username})
+
+	docID := t.Name() + "rt2doc1"
+	rt2Collection, rt2ctx := rt2.GetSingleTestDatabaseCollectionWithUser()
+	body := db.Body{"source": "rt2", "channels": []string{username}}
+	legacyRev, _ := rt2Collection.CreateDocNoHLV(t, rt2ctx, docID, body)
+
+	// Active
+	rt1 := rest.NewRestTester(t,
+		&rest.RestTesterConfig{
+			SyncFn: channels.DocChannelsSyncFunction,
+			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+				Name: "activedb",
+			}},
+		})
+	defer rt1.Close()
+	ctx1 := rt1.Context()
+
+	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: userDBURL(rt2, username),
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize:    200,
+		Continuous:          true,
+		ReplicationStatsMap: dbReplicatorStats(t),
+		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+	})
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, ar.Stop()) }()
+
+	assert.Equal(t, "", ar.GetStatus(ctx1).LastSeqPull)
+
+	// Start the replicator
+	require.NoError(t, ar.Start(ctx1))
+
+	// wait for the document originally written to rt2 to arrive at rt1
+	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+	changesResults.RequireDocIDs(t, []string{docID})
+
+	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
+	doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+	require.NoError(t, err)
+
+	expVersion := rest.DocVersion{
+		RevTreeID: legacyRev,
+		CV: db.Version{
+			SourceID: rt1.GetDatabase().EncodedSourceID,
+			Value: doc.Cas,
+		},
+	}
+	rest.RequireDocVersionEqual(t, expVersion, doc.ExtractDocVersion())
+
+	body, err = doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
+}
+

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -86,7 +86,7 @@ func TestActiveReplicatorPullLegacyRev(t *testing.T) {
 		RevTreeID: legacyRev,
 		CV: db.Version{
 			SourceID: rt1.GetDatabase().EncodedSourceID,
-			Value: doc.Cas,
+			Value:    doc.Cas,
 		},
 	}
 	rest.RequireDocVersionEqual(t, expVersion, doc.ExtractDocVersion())
@@ -95,4 +95,3 @@ func TestActiveReplicatorPullLegacyRev(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "rt2", body["source"])
 }
-


### PR DESCRIPTION
CBG-4785

- Handles sending changes for legacy rev documents by using the new version type parameter on changes options
- Built out test api for writing a doc with no HLV update
- Required some minor changes to `sendRevision` (we seemed to only be covering when remote rev was legacy an d not when local rev was legacy, this lead to failure to fetch from CV lookup revcache). I think legacy rev testing will allow me to flush out more issues like this. 
- This PR also solves CBG-4804

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/50/
