### PR TITLE
Fix build for #7711 after #7710 refactoring

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -561,7 +561,7 @@ func (bh *blipHandler) buildChangesRow(change *ChangeEntry, changeVersion Change
 	if len(changeVersion) > 1 {
 		base.AssertfCtx(bh.loggingCtx, "more changes in list than expected on change entry: %v", change.ID)
 	}
-	rev := changeVersion.GetChangeEntryVersion()
+	rev, _ := changeVersion.GetChangeRowRev()
 
 	if bh.activeCBMobileSubprotocol >= CBMobileReplicationV3 {
 		deletedFlags := changesDeletedFlag(0)

--- a/db/changes.go
+++ b/db/changes.go
@@ -1605,10 +1605,8 @@ loop:
 
 // GetChangeEntryVersion will return revID version or CV version based on the ChangesVersionType populated in the map
 func (c ChangeByVersionType) GetChangeEntryVersion() (version string) {
-	if revID, ok := c[ChangesVersionTypeCV]; ok {
-		version = revID
-	} else {
-		version = c[ChangesVersionTypeRevTreeID]
+	if cv, ok := c[ChangesVersionTypeCV]; ok {
+		return cv
 	}
-	return version
+	return c[ChangesVersionTypeRevTreeID]
 }

--- a/db/changes.go
+++ b/db/changes.go
@@ -1603,10 +1603,10 @@ loop:
 	return feedErr, forceClose
 }
 
-// GetChangeEntryVersion will return revID version or CV version based on the ChangesVersionType populated in the map
-func (c ChangeByVersionType) GetChangeEntryVersion() (version string) {
+// GetChangeRowRev will return a rev - either a CV if available, or a RevTree ID from the ChangeByVersionType
+func (c ChangeByVersionType) GetChangeRowRev() (version string, versionType ChangesVersionType) {
 	if cv, ok := c[ChangesVersionTypeCV]; ok {
-		return cv
+		return cv, ChangesVersionTypeCV
 	}
-	return c[ChangesVersionTypeRevTreeID]
+	return c[ChangesVersionTypeRevTreeID], ChangesVersionTypeRevTreeID
 }

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -160,7 +160,7 @@ func (db *DatabaseCollectionWithUser) CreateDocNoHLV(t *testing.T, ctx context.C
 		if matchCV != "" {
 			if matchCV == doc.HLV.GetCurrentVersionString() {
 				// set matchRev to the current revision ID and allow existing codepaths to perform RevTree-based update.
-				matchRev = doc.CurrentRev
+				matchRev = doc.GetRevTreeID()
 				// bump generation based on retrieved RevTree ID
 				generation, _ = ParseRevID(ctx, matchRev)
 				generation++
@@ -177,7 +177,7 @@ func (db *DatabaseCollectionWithUser) CreateDocNoHLV(t *testing.T, ctx context.C
 		if conflictErr == nil {
 			// Make sure matchRev matches an existing leaf revision:
 			if matchRev == "" {
-				matchRev = doc.CurrentRev
+				matchRev = doc.GetRevTreeID()
 				if matchRev != "" {
 					// PUT with no parent rev given, but there is an existing current revision.
 					// This is OK as long as the current one is deleted.


### PR DESCRIPTION
- Fix build for #7711 after #7710 refactoring
- Rename variable mentioned but accepted in original #7711 PR merge
- Change function signature for future intended usage (return type as well as value)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a