### PR TITLE
CBG-4752: Bulk APIs for CV (read and write)

### DIFF
--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -168,6 +168,9 @@ func (rv *RevAndVersion) UnmarshalJSON(data []byte) error {
 
 // CV returns ver@src in big endian format 1@cbl for CBL format.
 func (rv RevAndVersion) CV() string {
+	if rv.CurrentSource == "" || rv.CurrentVersion == "" {
+		return ""
+	}
 	// this should match db.Version.String()
 	return strconv.FormatUint(base.HexCasToUint64(rv.CurrentVersion), 16) + "@" + rv.CurrentSource
 }

--- a/db/database.go
+++ b/db/database.go
@@ -984,8 +984,8 @@ func (c *DatabaseCollection) processForEachDocIDResults(ctx context.Context, cal
 			found = results.Next(ctx, &viewRow)
 			if found {
 				docid = viewRow.Key
-				revid = viewRow.Value.RevID.RevTreeID
-				cv = viewRow.Value.RevID.CV()
+				revid = viewRow.Value.Rev.RevTreeID
+				cv = viewRow.Value.Rev.CV()
 				seq = viewRow.Value.Sequence
 				channels = viewRow.Value.Channels
 			}
@@ -993,8 +993,8 @@ func (c *DatabaseCollection) processForEachDocIDResults(ctx context.Context, cal
 			found = results.Next(ctx, &queryRow)
 			if found {
 				docid = queryRow.Id
-				revid = queryRow.RevID.RevTreeID
-				cv = queryRow.RevID.CV()
+				revid = queryRow.Rev.RevTreeID
+				cv = queryRow.Rev.CV()
 				seq = queryRow.Sequence
 				channels = make([]string, 0)
 				// Query returns all channels, but we only want to return active channels

--- a/db/document.go
+++ b/db/document.go
@@ -131,6 +131,13 @@ func (sd *SyncData) GetRevTreeID() string {
 	return sd.RevAndVersion.RevTreeID
 }
 
+func (sd *SyncData) CV() string {
+	if sd == nil {
+		return ""
+	}
+	return sd.RevAndVersion.CV()
+}
+
 // determine set of current channels based on removal entries.
 func (sd *SyncData) getCurrentChannels() base.Set {
 	ch := base.SetOf()

--- a/db/query.go
+++ b/db/query.go
@@ -688,7 +688,7 @@ func (context *DatabaseContext) QueryAllRoles(ctx context.Context, startKey stri
 type AllDocsViewQueryRow struct {
 	Key   string
 	Value struct {
-		RevID    channels.RevAndVersion `json:"r"`
+		Rev      channels.RevAndVersion `json:"r"`
 		Sequence uint64                 `json:"s"`
 		Channels []string               `json:"c"`
 	}
@@ -696,7 +696,7 @@ type AllDocsViewQueryRow struct {
 
 type AllDocsIndexQueryRow struct {
 	Id       string
-	RevID    channels.RevAndVersion `json:"r"`
+	Rev      channels.RevAndVersion `json:"r"`
 	Sequence uint64                 `json:"s"`
 	Channels channels.ChannelMap    `json:"c"`
 }

--- a/docs/api/components/parameters.yaml
+++ b/docs/api/components/parameters.yaml
@@ -387,13 +387,6 @@ show_exp:
   schema:
     type: boolean
   description: Whether to show the expiry property (`_exp`) in the response.
-show_cv:
-  name: show_cv
-  in: query
-  required: false
-  schema:
-    type: boolean
-  description: Output the Current Version in the response as property `_cv`.
 startkey:
   name: startkey
   in: query

--- a/docs/api/paths/admin/keyspace-_all_docs.yaml
+++ b/docs/api/paths/admin/keyspace-_all_docs.yaml
@@ -29,7 +29,6 @@ get:
     - $ref: ../../components/parameters.yaml#/startkey
     - $ref: ../../components/parameters.yaml#/endkey
     - $ref: ../../components/parameters.yaml#/limit-result-rows
-    - $ref: ../../components/parameters.yaml#/show_cv
   responses:
     '200':
       $ref: ../../components/responses.yaml#/all-docs

--- a/docs/api/paths/admin/keyspace-_bulk_get.yaml
+++ b/docs/api/paths/admin/keyspace-_bulk_get.yaml
@@ -45,7 +45,6 @@ post:
       description: If this header includes `gzip` then the the HTTP response will be compressed. This takes priority over `X-Accept-Part-Encoding`. Only part compression will be done if `X-Accept-Part-Encoding=gzip` and the `User-Agent` is below 1.2 due to clients not being able to handle full compression.
       schema:
         type: string
-    - $ref: ../../components/parameters.yaml#/show_cv
   requestBody:
     content:
       application/json:

--- a/docs/api/paths/public/keyspace-_all_docs.yaml
+++ b/docs/api/paths/public/keyspace-_all_docs.yaml
@@ -24,7 +24,6 @@ get:
     - $ref: ../../components/parameters.yaml#/startkey
     - $ref: ../../components/parameters.yaml#/endkey
     - $ref: ../../components/parameters.yaml#/limit-result-rows
-    - $ref: ../../components/parameters.yaml#/show_cv
   responses:
     '200':
       $ref: ../../components/responses.yaml#/all-docs

--- a/docs/api/paths/public/keyspace-_bulk_get.yaml
+++ b/docs/api/paths/public/keyspace-_bulk_get.yaml
@@ -40,7 +40,6 @@ post:
       description: If this header includes `gzip` then the the HTTP response will be compressed. This takes priority over `X-Accept-Part-Encoding`. Only part compression will be done if `X-Accept-Part-Encoding=gzip` and the `User-Agent` is below 1.2 due to clients not being able to handle full compression.
       schema:
         type: string
-    - $ref: ../../components/parameters.yaml#/show_cv
   requestBody:
     content:
       application/json:

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -1157,15 +1157,6 @@ func TestAllDocsCV(t *testing.T) {
 			output: fmt.Sprintf(`{
 				"total_rows": 1,
 				"update_seq": 1,
-				"rows": [{"key": "%s", "id": "%s", "value": {"rev": "%s"}}]
-			}`, docID, docID, docVersion.RevTreeID),
-		},
-		{
-			name: "cvs=true",
-			url:  "/{{.keyspace}}/_all_docs?show_cv=true",
-			output: fmt.Sprintf(`{
-				"total_rows": 1,
-				"update_seq": 1,
 				"rows": [{"key": "%s", "id": "%s", "value": {"rev": "%s", "cv": "%s"}}]
 			}`, docID, docID, docVersion.RevTreeID, docVersion.CV.String()),
 		},

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -496,11 +496,20 @@ func TestForceAPIForbiddenErrors(t *testing.T) {
 		})
 	}
 }
-func TestBulkDocsChangeToAccess(t *testing.T) {
 
+// TestBulkDocsChangeToAccess verifies that access() grants from one doc in a single bulk_docs request apply to subsequent docs in the same batch.
+func TestBulkDocsChangeToAccess(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAccess)
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { requireAccess(doc.channel)}}`}
+	rtConfig := RestTesterConfig{SyncFn: `
+function(doc) {
+	if(doc.type == "setaccess") {
+		channel(doc.channel);
+		access(doc.owner, doc.channel);
+	} else {
+		requireAccess(doc.channel);
+	}
+}`}
 	rt := NewRestTesterDefaultCollection(t, &rtConfig)
 	defer rt.Close()
 
@@ -518,17 +527,18 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 	assert.NoError(t, a.Save(user))
 
 	input := `{"docs": [{"_id": "bulk1", "type" : "setaccess", "owner":"user1" , "channel":"chan1"}, {"_id": "bulk2" , "channel":"chan1"}]}`
-
 	response := rt.SendUserRequest("POST", "/db/_bulk_docs", input, "user1")
 	RequireStatus(t, response, 201)
 
 	var docs []interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Len(t, docs, 2)
-	assert.Equal(t, map[string]interface{}{"rev": "1-afbcffa8a4641a0f4dd94d3fc9593e74", "id": "bulk1"}, docs[0])
-
-	assert.Equal(t, map[string]interface{}{"rev": "1-4d79588b9fe9c38faae61f0c1b9471c0", "id": "bulk2"}, docs[1])
-
+	require.Len(t, docs, 2)
+	assert.NotContains(t, response.BodyString(), `missing channel access`)
+	assert.NotContains(t, response.BodyString(), `"status":403"`)
+	assert.Contains(t, response.BodyString(), `"id":"bulk1"`)
+	assert.Contains(t, response.BodyString(), `"rev":"1-afbcffa8a4641a0f4dd94d3fc9593e74"`)
+	assert.Contains(t, response.BodyString(), `"id":"bulk2"`)
+	assert.Contains(t, response.BodyString(), `"rev":"1-4d79588b9fe9c38faae61f0c1b9471c0"`)
 }
 
 // Test _all_docs API call under different security scenarios

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -502,14 +502,14 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAccess)
 
 	rtConfig := RestTesterConfig{SyncFn: `
-function(doc) {
-	if(doc.type == "setaccess") {
-		channel(doc.channel);
-		access(doc.owner, doc.channel);
-	} else {
-		requireAccess(doc.channel);
-	}
-}`}
+		function(doc) {
+			if(doc.type == "setaccess") {
+				channel(doc.channel);
+				access(doc.owner, doc.channel);
+			} else {
+				requireAccess(doc.channel);
+			}
+		}`}
 	rt := NewRestTesterDefaultCollection(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -402,48 +402,129 @@ func assertGatewayStatus(t *testing.T, response *TestResponse, expected int) {
 }
 
 func TestBulkDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
+	tests := []struct {
+		occKey string
+	}{
+		{occKey: db.BodyRev},
+		{occKey: db.BodyCV},
+	}
 
-	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2}, {"_id": "_local/bulk3", "n": 3}]}`
-	response := rt.SendAdminRequest("POST", "/{{.keyspace}}/_bulk_docs", input)
-	RequireStatus(t, response, 201)
+	for _, test := range tests {
+		t.Run(test.occKey, func(t *testing.T) {
+			rt := NewRestTester(t, nil)
+			defer rt.Close()
 
-	var docs []interface{}
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Len(t, docs, 3)
-	assert.Equal(t, map[string]interface{}{"rev": "1-50133ddd8e49efad34ad9ecae4cb9907", "id": "bulk1"}, docs[0])
+			const bulk1DocID = "bulk1"
+			const bulk2DocID = "bulk2"
+			const bulk3LocalDocID = "_local/bulk3"
 
-	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/bulk1", "")
-	RequireStatus(t, response, 200)
-	var respBody db.Body
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
-	assert.Equal(t, "bulk1", respBody[db.BodyId])
-	assert.Equal(t, "1-50133ddd8e49efad34ad9ecae4cb9907", respBody[db.BodyRev])
-	assert.Equal(t, float64(1), respBody["n"])
-	assert.Equal(t, map[string]interface{}{"rev": "1-035168c88bd4b80fb098a8da72f881ce", "id": "bulk2"}, docs[1])
-	assert.Equal(t, map[string]interface{}{"rev": "0-1", "id": "_local/bulk3"}, docs[2])
+			// insert all
 
-	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_local/bulk3", "")
-	RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
-	assert.Equal(t, "_local/bulk3", respBody[db.BodyId])
-	assert.Equal(t, "0-1", respBody[db.BodyRev])
-	assert.Equal(t, float64(3), respBody["n"])
+			input := fmt.Sprintf(
+				`{"docs": [{%q:%q, %q:%d}, {%q:%q, %q:%d}, {%q:%q, %q:%d}]}`,
+				db.BodyId, bulk1DocID, "n", 1,
+				db.BodyId, bulk2DocID, "n", 2,
+				db.BodyId, bulk3LocalDocID, "n", 3,
+			)
+			response := rt.SendAdminRequest(http.MethodPost, "/{{.keyspace}}/_bulk_docs", input)
+			RequireStatus(t, response, http.StatusCreated)
 
-	// update all documents
-	input = `{"docs": [{"_id": "bulk1", "_rev" : "1-50133ddd8e49efad34ad9ecae4cb9907", "n": 10}, {"_id": "bulk2", "_rev":"1-035168c88bd4b80fb098a8da72f881ce", "n": 20}, {"_id": "_local/bulk3","_rev":"0-1","n": 30}]}`
-	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_bulk_docs", input)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Len(t, docs, 3)
-	assert.Equal(t, map[string]interface{}{"rev": "2-7e384b16e63ee3218349ee568f156d6f", "id": "bulk1"}, docs[0])
+			// get persisted versions
+			bulk1Version, _ := rt.GetDoc(bulk1DocID)
+			bulk2Version, _ := rt.GetDoc(bulk2DocID)
+			bulk3Version, _ := rt.GetDoc(bulk3LocalDocID)
 
-	response = rt.SendAdminRequest("GET", "/{{.keyspace}}/_local/bulk3", "")
-	RequireStatus(t, response, 200)
-	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
-	assert.Equal(t, "_local/bulk3", respBody[db.BodyId])
-	assert.Equal(t, "0-2", respBody[db.BodyRev])
-	assert.Equal(t, float64(30), respBody["n"])
+			var docs []interface{}
+			require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
+			require.Len(t, docs, 3)
+			assert.Equal(t, map[string]interface{}{"rev": bulk1Version.RevTreeID, "cv": bulk1Version.CV.String(), "id": bulk1DocID}, docs[0])
+			assert.Equal(t, map[string]interface{}{"rev": bulk2Version.RevTreeID, "cv": bulk2Version.CV.String(), "id": bulk2DocID}, docs[1])
+			assert.Equal(t, map[string]interface{}{"rev": bulk3Version.RevTreeID, "id": bulk3LocalDocID}, docs[2])
+
+			// check stored docs
+			response = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s", bulk1DocID), "")
+			RequireStatus(t, response, http.StatusOK)
+			assert.JSONEq(t, fmt.Sprintf(`{%q:%q, %q:%q, %q:%q, %q:%d}`,
+				db.BodyId, bulk1DocID,
+				db.BodyRev, bulk1Version.RevTreeID,
+				db.BodyCV, bulk1Version.CV,
+				"n", 1,
+			), response.BodyString())
+			response = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s", bulk2DocID), "")
+			RequireStatus(t, response, http.StatusOK)
+			assert.JSONEq(t, fmt.Sprintf(`{%q:%q, %q:%q, %q:%q, %q:%d}`,
+				db.BodyId, bulk2DocID,
+				db.BodyRev, bulk2Version.RevTreeID,
+				db.BodyCV, bulk2Version.CV,
+				"n", 2,
+			), response.BodyString())
+			response = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s", bulk3LocalDocID), "")
+			RequireStatus(t, response, http.StatusOK)
+			assert.JSONEq(t, fmt.Sprintf(`{%q:%q, %q:%q, %q:%d}`,
+				db.BodyId, bulk3LocalDocID,
+				db.BodyRev, bulk3Version.RevTreeID,
+				"n", 3,
+			), response.BodyString())
+
+			// Update all documents
+			switch test.occKey {
+			case db.BodyCV:
+				input = fmt.Sprintf(
+					`{"docs": [{%q:%q, %q:%q, %q:%d}, {%q:%q, %q:%q, %q:%d}, {%q:%q, %q:%q, %q:%d}]}`,
+					db.BodyId, bulk1DocID, db.BodyCV, bulk1Version.CV, "n", 10,
+					db.BodyId, bulk2DocID, db.BodyCV, bulk2Version.CV, "n", 20,
+					db.BodyId, bulk3LocalDocID, db.BodyRev, bulk3Version.RevTreeID, "n", 30, //  local docs don't have a CV so we can only use the returned rev as the OCC value for update
+				)
+			case db.BodyRev:
+				input = fmt.Sprintf(
+					`{"docs": [{%q:%q, %q:%q, %q:%d}, {%q:%q, %q:%q, %q:%d}, {%q:%q, %q:%q, %q:%d}]}`,
+					db.BodyId, bulk1DocID, db.BodyRev, bulk1Version.RevTreeID, "n", 10,
+					db.BodyId, bulk2DocID, db.BodyRev, bulk2Version.RevTreeID, "n", 20,
+					db.BodyId, bulk3LocalDocID, db.BodyRev, bulk3Version.RevTreeID, "n", 30,
+				)
+			default:
+				t.Fatalf("Unexpected occKey: %q", test.occKey)
+			}
+			response = rt.SendAdminRequest(http.MethodPost, "/{{.keyspace}}/_bulk_docs", input)
+			RequireStatus(t, response, http.StatusCreated)
+
+			// refresh versions
+			bulk1Version, _ = rt.GetDoc(bulk1DocID)
+			bulk2Version, _ = rt.GetDoc(bulk2DocID)
+			bulk3Version, _ = rt.GetDoc(bulk3LocalDocID)
+
+			require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
+			require.Len(t, docs, 3)
+			assert.Equal(t, map[string]interface{}{"rev": bulk1Version.RevTreeID, "cv": bulk1Version.CV.String(), "id": bulk1DocID}, docs[0])
+			assert.Equal(t, map[string]interface{}{"rev": bulk2Version.RevTreeID, "cv": bulk2Version.CV.String(), "id": bulk2DocID}, docs[1])
+			assert.Equal(t, map[string]interface{}{"rev": bulk3Version.RevTreeID, "id": bulk3LocalDocID}, docs[2])
+
+			// check for stored updates
+			response = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s", bulk1DocID), "")
+			RequireStatus(t, response, http.StatusOK)
+			assert.JSONEq(t, fmt.Sprintf(`{%q:%q, %q:%q, %q:%q, %q:%d}`,
+				db.BodyId, bulk1DocID,
+				db.BodyRev, bulk1Version.RevTreeID,
+				db.BodyCV, bulk1Version.CV,
+				"n", 10,
+			), response.BodyString())
+			response = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s", bulk2DocID), "")
+			RequireStatus(t, response, http.StatusOK)
+			assert.JSONEq(t, fmt.Sprintf(`{%q:%q, %q:%q, %q:%q, %q:%d}`,
+				db.BodyId, bulk2DocID,
+				db.BodyRev, bulk2Version.RevTreeID,
+				db.BodyCV, bulk2Version.CV,
+				"n", 20,
+			), response.BodyString())
+			response = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s", bulk3LocalDocID), "")
+			RequireStatus(t, response, http.StatusOK)
+			assert.JSONEq(t, fmt.Sprintf(`{%q:%q, %q:%q, %q:%d}`,
+				db.BodyId, bulk3LocalDocID,
+				db.BodyRev, bulk3Version.RevTreeID,
+				"n", 30,
+			), response.BodyString())
+		})
+	}
 }
 
 func TestBulkDocsIDGeneration(t *testing.T) {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -536,7 +536,6 @@ func TestBulkDocsIDGeneration(t *testing.T) {
 	RequireStatus(t, response, 201)
 	var docs []map[string]string
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	log.Printf("response: %s", response.Body.Bytes())
 	RequireStatus(t, response, 201)
 	assert.Len(t, docs, 2)
 	assert.Equal(t, "1-50133ddd8e49efad34ad9ecae4cb9907", docs[0]["rev"])
@@ -990,7 +989,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
 	RequireStatus(t, response, 201)
 	var docs []interface{}
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Len(t, docs, 2)
+	require.Len(t, docs, 2)
 	assert.Equal(t, map[string]interface{}{"rev": "12-abc", "id": "bdne1"}, docs[0])
 
 	assert.Equal(t, map[string]interface{}{"rev": "34-def", "id": "bdne2"}, docs[1])
@@ -1003,7 +1002,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/{{.keyspace}}/_bulk_docs", input)
 	RequireStatus(t, response, 201)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
-	assert.Len(t, docs, 1)
+	require.Len(t, docs, 1)
 	assert.Equal(t, map[string]interface{}{"rev": "14-jkl", "id": "bdne1"}, docs[0])
 
 }

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -397,7 +397,6 @@ func (h *handler) handleBulkGet() error {
 
 	includeAttachments := h.getBoolQuery("attachments")
 	showExp := h.getBoolQuery("show_exp")
-	showCV := h.getBoolQuery("show_cv")
 
 	showRevs := h.getBoolQuery("revs")
 	globalRevsLimit := int(h.getIntQuery("revs_limit", math.MaxInt32))
@@ -479,7 +478,7 @@ func (h *handler) handleBulkGet() error {
 					HistoryFrom:      revsFrom,
 					AttachmentsSince: attsSince,
 					ShowExp:          showExp,
-					ShowCV:           showCV,
+					ShowCV:           true,
 				})
 			}
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -73,7 +73,6 @@ func (h *handler) handleAllDocs() error {
 	includeChannels := h.getBoolQuery("channels")
 	includeAccess := h.getBoolQuery("access") && h.user == nil
 	includeRevs := h.getBoolQuery("revs")
-	includeCVs := h.getBoolQuery("show_cv")
 	includeSeqs := h.getBoolQuery("update_seq")
 
 	// Get the doc IDs if this is a POST request:
@@ -190,14 +189,12 @@ func (h *handler) handleAllDocs() error {
 		row.Value = &value
 		row.ID = doc.DocID
 		value.Rev = doc.RevID
+		row.Value.CV = doc.CV
 		if includeSeqs {
 			row.UpdateSeq = doc.Sequence
 		}
 		if includeChannels {
 			row.Value.Channels = channels
-		}
-		if includeCVs {
-			row.Value.CV = doc.CV
 		}
 		return row
 	}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -579,7 +579,7 @@ func (h *handler) handleBulkDocs() error {
 			if docid != "" {
 				_, newDoc, docErr = h.collection.Put(h.ctx(), docid, doc)
 			} else {
-				_, _, newDoc, docErr = h.collection.Post(h.ctx(), doc)
+				docid, _, newDoc, docErr = h.collection.Post(h.ctx(), doc)
 			}
 		} else {
 			revisions := db.ParseRevisions(h.ctx(), doc)
@@ -601,8 +601,8 @@ func (h *handler) handleBulkDocs() error {
 			status["reason"] = msg
 			base.InfofCtx(h.ctx(), base.KeyAll, "\tBulkDocs: Doc %q --> %d %s (%v)", base.UD(docid), code, msg, docErr)
 		} else {
-			status["rev"] = newDoc.CurrentRev
-			status["cv"] = newDoc.HLV.GetCurrentVersionString()
+			status["rev"] = newDoc.GetRevTreeID()
+			status["cv"] = newDoc.RevAndVersion.CV()
 		}
 		result = append(result, status)
 	}


### PR DESCRIPTION
CBG-4752

Read and write support for CVs in bulk APIs:
- `_all_docs`
  - Removed `show_cv` option. Always return CV like we do for other APIs.
- `_bulk_get`
  - Removed `show_cv` option.
  - Renamed/cleanup (make it obvious that RevTree IDs or CVs are accepted with new variable name `revOrCV`)
- `_bulk_docs`
  - Renamed/cleanup
  - Use returned RevTree ID and CV for response
- Test fixes
  - Mostly removing the full/hardcoded bulk API responses since CV is now present

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/55/
