### PR TITLE
Remove warning assertion, other tests can leak warnings

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3506,7 +3506,6 @@ func TestBlipPushRevOnResurrection(t *testing.T) {
 		dbConfig := rt.NewDbConfig()
 		dbConfig.AutoImport = base.Ptr(false)
 		RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-		startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value()
 		docID := "doc1"
 		rt.CreateTestDoc(docID)
 
@@ -3523,7 +3522,6 @@ func TestBlipPushRevOnResurrection(t *testing.T) {
 		btcRunner.StartPush(btc.id)
 		docVersion := btcRunner.AddRev(btc.id, docID, EmptyDocVersion(), []byte(`{"resurrect":true}`))
 		rt.WaitForVersion(docID, docVersion)
-		require.Equal(t, startWarnCount, base.SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Value())
 	})
 }
 


### PR DESCRIPTION
The warning that we are seeing is:

```
2025-08-28T14:31:15.037Z [WRN] c:SGI db:db col:sg_test_0 Unable to persist DCP metadata - will retry next snapshot. Error: cluster closed -- base.(*DCPCommon).setMetaData() at dcp_common.go:121
```

Which is from some test that leaks running an import feed after the test has been finished. I think this is from a test that uses Couchbase Server backing store.

This warning assertion was added to help https://github.com/couchbase/sync_gateway/pull/7538/files#diff-90f25c2c23e74d847a5c701d037f79c65e0325ac7a390731994ac48775182cfb but this test now tests to make sure that a resurrection can be pushed with version vectors or hlvs, and this caught a regression with vv this week.