### PR TITLE
CBG-4836: legacy rev documents not handled in createChangesEntry

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -1358,9 +1358,16 @@ func createChangesEntry(ctx context.Context, docid string, db *DatabaseCollectio
 		return nil
 	}
 
-	switch options.VersionType {
+	versionRequested := options.VersionType
+	cvString := populatedDoc.HLV.GetCurrentVersionString()
+	if cvString == "" {
+		// Document has no HLV - force to rev-tree ID
+		versionRequested = ChangesVersionTypeRevTreeID
+	}
+
+	switch versionRequested {
 	case ChangesVersionTypeCV:
-		row.Changes = []ChangeByVersionType{{ChangesVersionTypeCV: populatedDoc.HLV.GetCurrentVersionString()}}
+		row.Changes = []ChangeByVersionType{{ChangesVersionTypeCV: cvString}}
 	case "", ChangesVersionTypeRevTreeID:
 		row.Changes = []ChangeByVersionType{{ChangesVersionTypeRevTreeID: populatedDoc.GetRevTreeID()}}
 	default:


### PR DESCRIPTION
CBG-4836

- Fixes returning revID when CV change type is requested if CV is missing on the doc (legacy doc) 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/56/
