### PR TITLE
CBG-4776 do not show empty CV if present

### DIFF
--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -171,6 +171,9 @@ func ParseVersion(versionString string) (version Version, err error) {
 
 // String returns a version/sourceID pair in CBL string format. This does not match the format serialized on CBS, which will be in 0x0 format.
 func (v Version) String() string {
+	if v.IsEmpty() {
+		return ""
+	}
 	return strconv.FormatUint(v.Value, 16) + "@" + v.SourceID
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -310,7 +310,7 @@ func (rev *DocumentRevision) Mutable1xBody(ctx context.Context, db *DatabaseColl
 		b[BodyExpiry] = rev.Expiry.Format(time.RFC3339)
 	}
 
-	if showCV && rev.CV != nil {
+	if showCV && rev.CV != nil && !rev.CV.IsEmpty() {
 		b[BodyCV] = rev.CV.String()
 	}
 

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2645,7 +2645,7 @@ func TestCBLRevposHandling(t *testing.T) {
 func CreateDocWithLegacyAttachment(t *testing.T, rt *RestTester, docID string, rawDoc []byte, attKey string, attBody []byte) DocVersion {
 	// Write attachment directly to the datastore.
 	dataStore := rt.GetSingleDataStore()
-	_, err := dataStore.Add(attKey, 0, attBody)
+	_, err := dataStore.AddRaw(attKey, 0, attBody)
 	require.NoError(t, err)
 
 	body := db.Body{}


### PR DESCRIPTION
If a document is created without an HLV, it will not have a CV present. Before this commit, GET /ks/doc would output `"_cv": "@"`.

Now `db.Version.String()` behavior matches `db.HybridLogicalVector.GetCurrentVersionString()`.

Fix a side issue of `CreateDocWithLegacyAttachment` not using a Raw document and it gets picked up by rosmar, noticed when fixing this.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/58/
