### PR TITLE
Improve VV logging

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -978,7 +978,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 		d.HLV = &HybridLogicalVector{}
 		base.DebugfCtx(ctx, base.KeyVV, "No existing HLV for doc %s", base.UD(d.ID))
 	} else {
-		base.DebugfCtx(ctx, base.KeyVV, "Existing HLV for doc %s before modification %+v", base.UD(d.ID), d.HLV)
+		base.DebugfCtx(ctx, base.KeyVV, "Existing HLV for doc %s before modification %#v", base.UD(d.ID), d.HLV)
 	}
 	switch docUpdateEvent {
 	case ExistingVersion:
@@ -1000,9 +1000,9 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 				return nil, err
 			}
 			d.HLV.CurrentVersionCAS = d.Cas
-			base.DebugfCtx(ctx, base.KeyVV, "Adding new version to HLV due to import for doc %s, updated HLV %+v", base.UD(d.ID), d.HLV)
+			base.DebugfCtx(ctx, base.KeyVV, "Adding new version to HLV due to import for doc %s, updated HLV %#v", base.UD(d.ID), d.HLV)
 		} else {
-			base.DebugfCtx(ctx, base.KeyVV, "Not updating HLV due to _mou.cas == doc.cas for doc %s, extant HLV %+v", base.UD(d.ID), d.HLV)
+			base.DebugfCtx(ctx, base.KeyVV, "Not updating HLV due to _mou.cas == doc.cas for doc %s, extant HLV %#v", base.UD(d.ID), d.HLV)
 		}
 	case NewVersion, ExistingVersionWithUpdateToHLV:
 		// add a new entry to the version vector
@@ -3474,7 +3474,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 		// with a version that's greater than or equal to the server's cv), then we can accept the proposed version.
 		proposedHLV, _, err := extractHLVFromBlipString(proposedHLVString)
 		if err != nil {
-			base.InfofCtx(ctx, base.KeyCRUD, "CheckProposedVersion for doc %s unable to extract proposedHLV from rev message, will be treated as conflict: %v", base.UD(docid), err)
+			base.WarnfCtx(ctx, "CheckProposedVersion for doc %s unable to extract proposedHLV from rev message, will be treated as conflict: %v", base.UD(docid), err)
 		} else if proposedHLV.DominatesSource(localDocCV) {
 			base.DebugfCtx(ctx, base.KeyCRUD, "CheckProposedVersion returning OK for doc %s because incoming HLV dominates cv", base.UD(docid))
 			return ProposedRev_OK, ""

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -53,6 +53,22 @@ func (hv HLVVersions) unsorted() iter.Seq2[string, uint64] {
 	return maps.All(hv)
 }
 
+// GoString returns a string converting values to decimal.
+func (hv HLVVersions) GoString() string {
+	var sb strings.Builder
+	sb.WriteString("HLVVersions{")
+	i := 0
+	for k, v := range hv {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("%q: %d", k, v))
+		i++
+	}
+	sb.WriteString("}")
+	return sb.String()
+}
+
 // Version is representative of a single entry in a HybridLogicalVector.
 type Version struct {
 	// SourceID is an ID representing the source of the value (e.g. Couchbase Lite ID)
@@ -697,7 +713,7 @@ func (hlv *HybridLogicalVector) UnmarshalJSON(inputjson []byte) error {
 }
 
 func (hlv HybridLogicalVector) GoString() string {
-	return fmt.Sprintf("HybridLogicalVector{CurrentVersionCAS:%d, SourceID:%s, Version:%d, PreviousVersions:%#+v, MergeVersions:%#+v}", hlv.CurrentVersionCAS, hlv.SourceID, hlv.Version, hlv.PreviousVersions, hlv.MergeVersions)
+	return fmt.Sprintf("HybridLogicalVector{CurrentVersionCAS:%d, SourceID:%s, Version:%d, PreviousVersions:%#v, MergeVersions:%#v}", hlv.CurrentVersionCAS, hlv.SourceID, hlv.Version, hlv.PreviousVersions, hlv.MergeVersions)
 }
 
 // HLVConflictStatus returns whether two HLVs are in conflict or not

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -2052,7 +2052,7 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 	require.NotNil(btcc.TB(), updatedHLV, "updatedHLV should not be nil for docID %q", docID)
 	if doc._hasConflict(btcc.TB(), opts.incomingHLV) {
 		newBody, updatedHLV = btcc._resolveConflict(opts.incomingHLV, opts.body, doc._latestRev(btcc.TB()))
-		base.DebugfCtx(ctx, base.KeySGTest, "Resolved conflict for docID %q, incomingHLV:%v, existingHLV:%v, updatedHLV:%v", docID, opts.incomingHLV, doc._latestRev(btcc.TB()).HLV, updatedHLV)
+		base.DebugfCtx(ctx, base.KeySGTest, "Resolved conflict for docID %q, incomingHLV:%#v, existingHLV:%#v, updatedHLV:%#v", docID, opts.incomingHLV, doc._latestRev(btcc.TB()).HLV, updatedHLV)
 	} else {
 		base.DebugfCtx(ctx, base.KeySGTest, "No conflict")
 		if btcc.UseHLV() {


### PR DESCRIPTION
Using `%#v` instead of `%v` or `%+v` or `%#+v` will display the vv in a decimal format. I should add a ruleguard rule for this, but separately from this commit.

Switch bad rev history message to a warning, since this indicates a client has sent the wrong data and the replication is probably not going as expected. I am seeing this message in topologytests due to a bug in blip test client and I want to make this easier to debug in tests and production.
