### PR TITLE
CBG-4826 do not managle history if only mv present

### DIFF
--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -479,6 +479,9 @@ func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, 
 //  1. cv only:    		cv
 //  2. cv and pv:  		cv;pv
 //  3. cv, pv, and mv: 	cv,mv;pv
+//  4. cv, mv only:
+//     a. cv,mv;
+//     b. cv,mv
 //
 // Function will return list of revIDs if legacy rev ID was found in the HLV history section (PV)
 // TODO: CBG-3662 - Optimise once we've settled on and tested the format with CBL

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -478,7 +478,7 @@ func appendRevocationMacroExpansions(currentSpec []sgbucket.MacroExpansionSpec, 
 // blip string may be the following formats
 //  1. cv only:    		cv
 //  2. cv and pv:  		cv;pv
-//  3. cv, pv, and mv: 	cv;mv;pv
+//  3. cv, pv, and mv: 	cv,mv;pv
 //
 // Function will return list of revIDs if legacy rev ID was found in the HLV history section (PV)
 // TODO: CBG-3662 - Optimise once we've settled on and tested the format with CBL

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -636,6 +636,20 @@ func getHLVTestCases(t testing.TB) []extractHLVFromBlipMsgBMarkCases {
 			},
 		},
 		{
+			name:      "cv,mv,mv;",
+			hlvString: "25@def, 22@def, 21@eff;",
+			expectedHLV: HybridLogicalVector{
+				CurrentVersionCAS: 0,
+				Version:           stringHexToUint(t, "25"),
+				SourceID:          "def",
+				MergeVersions: map[string]uint64{
+					"def": stringHexToUint(t, "22"),
+					"eff": stringHexToUint(t, "21"),
+				},
+			},
+		},
+
+		{
 			name:      "cv, mv and pv, leading spaces",                                                                                                                                                           // with spaces
 			hlvString: "25@def, 22@def, 21@eff, 500@x, 501@xx, 4000@xxx, 700@y, 701@yy, 702@yyy; 20@abc, 18@hij, 3@x2, 4@xx2, 5@xxx2, 6@xxxx, 7@xxxxx, 3@y2, 4@yy2, 5@yyy2, 6@yyyy, 7@yyyyy, 2@xy, 3@xyy, 4@xxy", // 15 pv 8 mv
 			expectedHLV: HybridLogicalVector{

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1249,7 +1249,13 @@ func (e proposeChangeBatchEntry) MarshalJSON() ([]byte, error) {
 	if e.useHLV() {
 		// Until CBG-4461 is implemented the second value in the array is the full HLV.
 		if e.historyStr() != "" {
-			rev += ";" + e.historyStr()
+			// if mv present, this will already contain a ;
+			// else add one
+			if strings.Contains(e.historyStr(), ";") {
+				rev += "," + e.historyStr()
+			} else {
+				rev += ";" + e.historyStr()
+			}
 		}
 	}
 	fmt.Fprintf(output, `["%s","%s"`, e.docID, rev)

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -591,7 +591,7 @@ func (btr *BlipTesterReplicator) handleChanges(ctx context.Context, btc *BlipTes
 						knownRevs[i] = []interface{}{} // sending empty array means we've not seen the doc before, but still want it
 						continue
 					} else if localHLV.DominatesSource(changesVersion) {
-						base.DebugfCtx(ctx, base.KeySGTest, "Skipping changes for incoming doc %q with rev %#v as we already have a newer version %#v", docID, changesVersion.Value, changesVersion.SourceID, localHLV)
+						base.DebugfCtx(ctx, base.KeySGTest, "Skipping changes for incoming doc %q with rev %s as we already have a newer version %#v", docID, changesVersion, localHLV)
 						knownRevs[i] = nil // Send back null to signal we don't need this change
 					} else {
 						require.NotEmpty(btr.TB(), localHLV.GetCurrentVersionString())
@@ -1247,14 +1247,16 @@ func (e proposeChangeBatchEntry) MarshalJSON() ([]byte, error) {
 	output := &bytes.Buffer{}
 	rev := e.Rev()
 	if e.useHLV() {
-		// Until CBG-4461 is implemented the second value in the array is the full HLV.
-		if e.historyStr() != "" {
+		history := e.historyStr()
+		// In Couchbase Lite 4.0.0, the full history is sent. CBL-4461 is a future optimization for Couchbase Lite to
+		// send only CV. When this is implemented by CBL, modifying the default blip testing behavior is OK.
+		if history != "" {
 			// if mv present, this will already contain a ;
 			// else add one
-			if strings.Contains(e.historyStr(), ";") {
-				rev += "," + e.historyStr()
+			if strings.Contains(history, ";") {
+				rev += "," + history
 			} else {
-				rev += ";" + e.historyStr()
+				rev += ";" + history
 			}
 		}
 	}

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -591,7 +591,7 @@ func (btr *BlipTesterReplicator) handleChanges(ctx context.Context, btc *BlipTes
 						knownRevs[i] = []interface{}{} // sending empty array means we've not seen the doc before, but still want it
 						continue
 					} else if localHLV.DominatesSource(changesVersion) {
-						base.DebugfCtx(ctx, base.KeySGTest, "Skipping changes for incoming doc %q with rev %d@%s as we already have a newer version %#+v", docID, changesVersion.Value, changesVersion.SourceID, localHLV)
+						base.DebugfCtx(ctx, base.KeySGTest, "Skipping changes for incoming doc %q with rev %#v as we already have a newer version %#v", docID, changesVersion.Value, changesVersion.SourceID, localHLV)
 						knownRevs[i] = nil // Send back null to signal we don't need this change
 					} else {
 						require.NotEmpty(btr.TB(), localHLV.GetCurrentVersionString())

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -335,7 +335,8 @@ func TestRequest(t *testing.T) {
 }
 
 func TestUtilitiesProposeChangesBatch(t *testing.T) {
-	// remove test when CBG-4461, this tests existing CBL behavior but not necessarily desired behavior
+	// Currently proposeChanges sends the full history to match the Couchbase Lite 4.0.0 implementation. When CBL
+	// implements CBL-4433 and only sends CV, it would be OK to remove this test.
 	testCases := []struct {
 		name  string
 		entry proposeChangeBatchEntry

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -333,3 +333,68 @@ func TestRequest(t *testing.T) {
 		_ = Request(http.MethodGet, "%", "")
 	})
 }
+
+func TestUtilitiesProposeChangesBatch(t *testing.T) {
+	// remove test when CBG-4461, this tests existing CBL behavior but not necessarily desired behavior
+	testCases := []struct {
+		name  string
+		entry proposeChangeBatchEntry
+		// expected can be one of multiple valid values, since the order of the HLV versions is not guaranteed
+		expected []string
+	}{
+		{
+			name: "cv,mv",
+			entry: proposeChangeBatchEntry{
+				docID: "doc1",
+				version: DocVersion{
+					CV: db.Version{SourceID: "cbl1", Value: 2},
+				},
+				hlvHistory: db.HybridLogicalVector{
+					Version:  2,
+					SourceID: "cbl1",
+					MergeVersions: db.HLVVersions{
+						"rosmar1": 1,
+						"rosmar2": 2,
+					},
+				},
+				latestServerVersion: DocVersion{
+					CV: db.Version{SourceID: "rosmar1", Value: 1},
+				},
+			},
+			expected: []string{
+				`["doc1","2@cbl1,2@rosmar2,1@rosmar1;","1@rosmar1"]`,
+				`["doc1","2@cbl1,1@rosmar1,2@rosmar2;","1@rosmar1"]`,
+			},
+		},
+		{
+			name: "cv,pv",
+			entry: proposeChangeBatchEntry{
+				docID: "doc1",
+				version: DocVersion{
+					CV: db.Version{SourceID: "cbl1", Value: 4},
+				},
+				hlvHistory: db.HybridLogicalVector{
+					Version:  4,
+					SourceID: "cbl1",
+					PreviousVersions: db.HLVVersions{
+						"rosmar1": 3,
+						"rosmar2": 2,
+					},
+				},
+				latestServerVersion: DocVersion{
+					CV: db.Version{SourceID: "rosmar1", Value: 1},
+				},
+			},
+			expected: []string{
+				`["doc1","4@cbl1;2@rosmar2,3@rosmar1","1@rosmar1"]`,
+				`["doc1","4@cbl1;3@rosmar1,2@rosmar2","1@rosmar1"]`,
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			output := string(base.MustJSONMarshal(t, test.entry))
+			require.Contains(t, test.expected, output)
+		})
+	}
+}


### PR DESCRIPTION
Fixes an issue in topologytests:

```
2025-08-27T18:09:39.310Z [INF] CRUD: c:[2782b301] db:sg1 col:sg_test_0 CheckProposedVersion for doc <ud>doc_MultiActorConflictResurrect_2x_CBL<->SG<->CBS_XDCR_only_1.3</ud> unable to extract proposedHLV from rev message, will be treated as conflict: invalid hlv in changes message received, more than one semi-colon: "6@cbl1;4@rosmar2,3@rosmar1;"
2025-08-27T18:09:39.310Z [DBG] TEST+: c:cbl1 proposeChanges response: [409]
```

The fix is in `proposeChangesBatchEntry.MarshalJSON` but I wrote a test to indicate valid HLV format:

`cv,mv,mv;` is equivalent to `cv,mv,mv`

https://github.com/couchbase/sync_gateway/pull/7722 helps debug this.

NOTE: this doesn't fix all the test failures, but fixes one subset of them.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/60/
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/TopologyTests/38/