### PR TITLE
CBG-4826 increase wait time for slow computers

### DIFF
--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // totalWaitTime is the time to wait for a document on a peer. This time is low for rosmar and high for Couchbase Server.
-var totalWaitTime = 3 * time.Second
+var totalWaitTime = 8 * time.Second
 
 // pollInterval is the time to poll to see if a document is updated on a peer
 var pollInterval = 1 * time.Millisecond


### PR DESCRIPTION
CBG-4826 increase wait time for slow computers

Slow mobile jenkins hits this timeout and things do not always converge. The timeout is low to make tests fail faster interactively, we could also consider increasing the timeout by checking `CI` environment variable and keep interactive time lower.
