### PR TITLE
Add debug logging

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1391,7 +1391,7 @@ func (btcc *BlipTesterCollectionClient) sendRevisions(ctx context.Context, chang
 	require.NoError(btcc.TB(), err)
 	var response []int
 	err = base.JSONUnmarshal(rspBody, &response)
-	require.NoError(btcc.TB(), err)
+	require.NoError(btcc.TB(), err, "error unmarshalling proposeChanges response body: %v from %s", err, string(rspBody))
 	for i, change := range changesBatch {
 		var status int
 		if i >= len(response) {


### PR DESCRIPTION
I found another intermittent failure, but I'm not sure what the body is:

```
16:15:30         utilities_testing_blip_client.go:1394: 
16:15:30             	Error Trace:	/home/ubuntu/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1394
16:15:30             	            				/home/ubuntu/workspace/sgw-unix-build/4.0.0/enterprise/sync_gateway/rest/utilities_testing_blip_client.go:1301
16:15:30             	            				/home/ubuntu/cbdeps/go1.24.4/src/runtime/asm_arm64.s:1223
16:15:30             	Error:      	Received unexpected error:
16:15:30             	            	[]int: decode slice: expect [ or n, but found , error found in #0 byte of ...||..., bigger context ...||...
16:15:30             	Test:       	TestMultiActorConflictDelete/CBL<->SG<->CBS_1.1
16:15:30     --- FAIL: TestMultiActorConflictDelete/CBL<->SG<->CBS1_CBS1<->CBS2_1.2 (0.39s)
```
