### PR TITLE
CBG-4429: Audit with CV as doc version where possible

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -2461,7 +2461,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 		for _, att := range newAttachments {
 			auditFields := base.AuditFields{
 				base.AuditFieldDocID:        doc.ID,
-				base.AuditFieldDocVersion:   newRevID,
+				base.AuditFieldDocVersion:   newRevID, // We can't use CV in this audit event because we don't know CV until we've done the document update (which happens after the attachments are written)
 				base.AuditFieldAttachmentID: att.name,
 			}
 			if att.created {
@@ -2718,7 +2718,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 	if !isImport {
 		auditFields := base.AuditFields{
 			base.AuditFieldDocID:      docid,
-			base.AuditFieldDocVersion: newRevID,
+			base.AuditFieldDocVersion: doc.VersionString(),
 		}
 		if doc.IsDeleted() {
 			base.Audit(ctx, base.AuditIDDocumentDelete, auditFields)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2461,7 +2461,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 		for _, att := range newAttachments {
 			auditFields := base.AuditFields{
 				base.AuditFieldDocID:        doc.ID,
-				base.AuditFieldDocVersion:   newRevID, // We can't use CV in this audit event because we don't know CV until we've done the document update (which happens after the attachments are written)
+				base.AuditFieldDocVersion:   newRevID, // We can't use CV here because attachment auditing occurs before document update completion, when CV is not yet determined.
 				base.AuditFieldAttachmentID: att.name,
 			}
 			if att.created {

--- a/db/crud.go
+++ b/db/crud.go
@@ -2718,7 +2718,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 	if !isImport {
 		auditFields := base.AuditFields{
 			base.AuditFieldDocID:      docid,
-			base.AuditFieldDocVersion: doc.VersionString(),
+			base.AuditFieldDocVersion: doc.CVOrRevTreeID(),
 		}
 		if doc.IsDeleted() {
 			base.Audit(ctx, base.AuditIDDocumentDelete, auditFields)

--- a/db/database.go
+++ b/db/database.go
@@ -1813,7 +1813,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 	if err == nil {
 		base.Audit(ctx, base.AuditIDDocumentResync, base.AuditFields{
 			base.AuditFieldDocID:      docid,
-			base.AuditFieldDocVersion: updatedDoc.GetRevTreeID(),
+			base.AuditFieldDocVersion: updatedDoc.VersionString(),
 		})
 	}
 	return updatedHighSeq, unusedSequences, err

--- a/db/database.go
+++ b/db/database.go
@@ -1813,7 +1813,7 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 	if err == nil {
 		base.Audit(ctx, base.AuditIDDocumentResync, base.AuditFields{
 			base.AuditFieldDocID:      docid,
-			base.AuditFieldDocVersion: updatedDoc.VersionString(),
+			base.AuditFieldDocVersion: updatedDoc.CVOrRevTreeID(),
 		})
 	}
 	return updatedHighSeq, unusedSequences, err

--- a/db/document.go
+++ b/db/document.go
@@ -124,6 +124,7 @@ func (sd *SyncData) SetRevTreeID(revTreeID string) {
 	sd.RevAndVersion.RevTreeID = revTreeID
 }
 
+// GetRevTreeID returns the RevTreeID if available, otherwise returns an empty string.
 func (sd *SyncData) GetRevTreeID() string {
 	if sd == nil {
 		return ""
@@ -131,11 +132,23 @@ func (sd *SyncData) GetRevTreeID() string {
 	return sd.RevAndVersion.RevTreeID
 }
 
+// CV returns the CurrentVersion if available, otherwise returns an empty string.
 func (sd *SyncData) CV() string {
 	if sd == nil {
 		return ""
 	}
 	return sd.RevAndVersion.CV()
+}
+
+// VersionString returns the CurrentVersion if available, otherwise falls back to returning the RevTreeID or an empty string.
+func (sd *SyncData) VersionString() string {
+	if sd == nil {
+		return ""
+	}
+	if cv := sd.RevAndVersion.CV(); cv != "" {
+		return cv
+	}
+	return sd.RevAndVersion.RevTreeID
 }
 
 // determine set of current channels based on removal entries.
@@ -1473,4 +1486,12 @@ func (d DocVersion) Body1xKVPair() (bodyVersionKey, bodyVersionStr string) {
 		return BodyCV, cv.String()
 	}
 	return BodyRev, d.RevTreeID
+}
+
+// VersionString returns the CurrentVersion if available, otherwise falls back to returning the RevTreeID or an empty string.
+func (d DocVersion) VersionString() string {
+	if cv, ok := d.GetCV(); ok {
+		return cv.String()
+	}
+	return d.RevTreeID
 }

--- a/db/document.go
+++ b/db/document.go
@@ -140,8 +140,8 @@ func (sd *SyncData) CV() string {
 	return sd.RevAndVersion.CV()
 }
 
-// VersionString returns the CurrentVersion if available, otherwise falls back to returning the RevTreeID or an empty string.
-func (sd *SyncData) VersionString() string {
+// CVOrRevTreeID() returns the CurrentVersion if available, otherwise falls back to returning the RevTreeID or an empty string.
+func (sd *SyncData) CVOrRevTreeID() string {
 	if sd == nil {
 		return ""
 	}
@@ -1488,8 +1488,8 @@ func (d DocVersion) Body1xKVPair() (bodyVersionKey, bodyVersionStr string) {
 	return BodyRev, d.RevTreeID
 }
 
-// VersionString returns the CurrentVersion if available, otherwise falls back to returning the RevTreeID or an empty string.
-func (d DocVersion) VersionString() string {
+// CVOrRevTreeID returns the CurrentVersion if available, otherwise falls back to returning the RevTreeID or an empty string.
+func (d DocVersion) CVOrRevTreeID() string {
 	if cv, ok := d.GetCV(); ok {
 		return cv.String()
 	}

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1212,7 +1212,7 @@ func TestAuditDocumentCreateUpdateEvents(t *testing.T) {
 				testCase.auditableCode(t, docID, docVersion)
 			})
 			postAttachmentVersion, _ := rt.GetDoc(docID)
-			expectedVersion := postAttachmentVersion.VersionString()
+			expectedVersion := postAttachmentVersion.CVOrRevTreeID()
 			requireDocumentEvents(rt, base.AuditIDDocumentCreate, output, docID, expectedVersion, testCase.documentCreateCount)
 			requireDocumentEvents(rt, base.AuditIDDocumentUpdate, output, docID, expectedVersion, testCase.documentUpdateCount)
 		})

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -1436,7 +1436,7 @@ func requireDocumentMetadataReadEvents(rt *RestTester, output []byte, docID stri
 		if base.AuditID(event[base.AuditFieldID].(float64)) != base.AuditIDDocumentMetadataRead {
 			continue
 		}
-		require.Equal(rt.TB(), event[base.AuditFieldDocID], docID)
+		require.Equal(rt.TB(), docID, event[base.AuditFieldDocID])
 		countFound++
 	}
 	require.Equal(rt.TB(), count, countFound)
@@ -1451,7 +1451,7 @@ func requireDocumentReadEvents(rt *RestTester, output []byte, docID string, docV
 		if base.AuditID(event[base.AuditFieldID].(float64)) != base.AuditIDDocumentRead {
 			continue
 		}
-		require.Equal(rt.TB(), event[base.AuditFieldDocID], docID)
+		require.Equal(rt.TB(), docID, event[base.AuditFieldDocID])
 		docVersionsFound = append(docVersionsFound, event[base.AuditFieldDocVersion].(string))
 	}
 	require.Len(rt.TB(), docVersions, len(docVersionsFound), "expected exactly %d document read events, got %d", len(docVersions), len(docVersionsFound))
@@ -1467,7 +1467,7 @@ func requireAttachmentEvents(rt *RestTester, eventID base.AuditID, output []byte
 		if base.AuditID(event[base.AuditFieldID].(float64)) != eventID {
 			continue
 		}
-		require.Equal(rt.TB(), event[base.AuditFieldDocID], docID)
+		require.Equal(rt.TB(), docID, event[base.AuditFieldDocID])
 		require.Equal(rt.TB(), docVersionStr, event[base.AuditFieldDocVersion].(string))
 		require.Equal(rt.TB(), attachmentName, event[base.AuditFieldAttachmentID])
 		countFound++
@@ -1484,7 +1484,7 @@ func requireDocumentEvents(rt *RestTester, eventID base.AuditID, output []byte, 
 		if base.AuditID(event[base.AuditFieldID].(float64)) != eventID {
 			continue
 		}
-		require.Equal(rt.TB(), event[base.AuditFieldDocID], docID)
+		require.Equal(rt.TB(), docID, event[base.AuditFieldDocID])
 		require.Equal(rt.TB(), docVersion, event[base.AuditFieldDocVersion].(string))
 		countFound++
 	}
@@ -1878,7 +1878,7 @@ func TestDatabaseAuditChanges(t *testing.T) {
 				for _, event := range events {
 					eventID := base.AuditID(event[base.AuditFieldID].(float64))
 					if eventID == expectedEventID {
-						require.Equal(rt.TB(), event[base.AuditFieldDatabase], "db")
+						require.Equal(rt.TB(), "db", event[base.AuditFieldDatabase])
 						if testCase.expectedEnabledEventList != nil {
 							require.Equal(rt.TB(), testCase.expectedEnabledEventList, event[base.AuditFieldEnabledEvents])
 						}


### PR DESCRIPTION
CBG-4429

Some cases aren't possible to use CV (i.e. attachments being written before the document has been written - reliant on CAS macro expansion to determine CV) - they are kept as RevTree IDs with a comment explaining why. This is considered a known-issue that we may not fix.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/62/
