### PR TITLE
CBG-4846: legacy rev api should not write _vv xattr at all

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1016,6 +1016,9 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 		}
 		// update the cvCAS on the SGWrite event too
 		d.HLV.CurrentVersionCAS = expandMacroCASValueUint64
+	case NoHLVUpdateForTest:
+		// no hlv update event for testing purposes only (used to simulate pre upgraded write)
+		return d, nil
 	}
 	d.SyncData.SetCV(d.HLV)
 	return d, nil
@@ -2652,6 +2655,10 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				if currentXattrs[base.GlobalXattrName] != nil && !isNewDocCreation {
 					updatedDoc.XattrsToDelete = append(updatedDoc.XattrsToDelete, base.GlobalXattrName)
 				}
+			}
+			if docUpdateEvent == NoHLVUpdateForTest {
+				// If this is a test update where we don't want to update the HLV
+				delete(updatedDoc.Xattrs, base.VvXattrName)
 			}
 
 			// Warn when sync data is larger than a configured threshold

--- a/db/crud.go
+++ b/db/crud.go
@@ -2657,7 +2657,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				}
 			}
 			if docUpdateEvent == NoHLVUpdateForTest {
-				// If this is a test update where we don't want to update the HLV
+				// If this is a test update where we don't want to update the HLV, we should remote VV xattr here
+				// this will simulate a pre upgraded document being cerated in the bucket
 				delete(updatedDoc.Xattrs, base.VvXattrName)
 			}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -2657,8 +2657,8 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 				}
 			}
 			if docUpdateEvent == NoHLVUpdateForTest {
-				// If this is a test update where we don't want to update the HLV, we should remote VV xattr here
-				// this will simulate a pre upgraded document being cerated in the bucket
+				// This is a test seam to allow CRUD operations to push non HLV aware documents
+				// this will simulate a pre upgraded documents
 				delete(updatedDoc.Xattrs, base.VvXattrName)
 			}
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1012,7 +1012,7 @@ func TestCreateLegacyRevDoc(t *testing.T) {
 	ds := dbc.GetCollectionDatastore()
 	_, _, err := ds.GetXattrs(ctx, "legacydoc", []string{base.VvXattrName})
 	require.Error(t, err) // should error as xattr not found
-	require.True(t, base.IsXattrNotFoundError(err))
+	base.RequireXattrNotFoundError(t, err)
 }
 
 // TestBulkDocsNoEdits verifies that POSTing /_bulk_docs with new_edits=false stores

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1000,6 +1000,21 @@ func TestBulkDocsLegacyRevNoop(t *testing.T) {
 	}, docs)
 }
 
+func TestCreateLegacyRevDoc(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	// create legacy rev (without CV)
+	dbc, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+	_, _ = dbc.CreateDocNoHLV(t, ctx, "legacydoc", db.Body{"foo": "bar"})
+
+	// fetch doc and assert that no _vv is present
+	ds := dbc.GetCollectionDatastore()
+	_, _, err := ds.GetXattrs(ctx, "legacydoc", []string{base.VvXattrName})
+	require.Error(t, err) // should error as xattr not found
+	require.True(t, base.IsXattrNotFoundError(err))
+}
+
 // TestBulkDocsNoEdits verifies that POSTing /_bulk_docs with new_edits=false stores
 // the provided revisions verbatim, and subsequent posts append the given history without generating new rev IDs.
 func TestBulkDocsNoEdits(t *testing.T) {


### PR DESCRIPTION
CBG-4846

- Legacy rev API was writing empty source version to the _vv xattr:
<img width="619" height="611" alt="Screenshot 2025-09-03 at 14 26 54" src="https://github.com/user-attachments/assets/cf65156a-5f38-4ba6-91ce-f9c8ceb4589b" />

- This will lead to issues in `PutExistingCurrentVersion` where the HLV will not be nil and thus will run conflict check on empty hlv
- API now removes the _vv xattr from updated xattrs when `NoHLVUpdateForTest` is set:
```
{
  "meta": {
    "id": "legacydoc",
    "rev": "1-1861c9bf074e00000000000000000000",
    "expiration": 0,
    "flags": 0,
    "type": "json"
  },
  "xattrs": {
    "_sync": {
      "cas": "0x00004e07bfc96118",
      "channel_set": [
        {
          "name": "sg_test_0",
          "start": 1
        }
      ],
      "channel_set_history": null,
      "channels": {
        "sg_test_0": null
      },
      "cluster_uuid": "809b85c17bc87b5471ea112973f9f5b1",
      "history": {
        "channels": [
          [
            "sg_test_0"
          ]
        ],
        "parents": [
          -1
        ],
        "revs": [
          "1-cd809becc169215072fd567eebd8b8de"
        ]
      },
      "recent_sequences": [
        1
      ],
      "rev": "1-cd809becc169215072fd567eebd8b8de",
      "sequence": 1,
      "time_saved": "2025-09-03T14:45:51.93844+01:00",
      "value_crc32c": "0x5451e331"
    }
  }
}
```

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/64/
