### PR TITLE
CBG-4791: reconcile rev tree on v4 ISGR conflict

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1123,6 +1123,9 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		if ok {
 			legacyRevList = append(legacyRevList, strings.Split(revTree, ",")...)
 			isBlipRevTreeProperty = true
+			if len(legacyRevList) > 0 {
+				newDoc.RevID = legacyRevList[0]
+			}
 		}
 	}
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1349,7 +1349,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	// bh.conflictResolver != nil represents an active SGR2 and BLIPClientTypeSGR2 represents a passive SGR2
 	forceAllowConflictingTombstone := newDoc.Deleted && (!bh.conflictResolver.IsEmpty() || bh.clientType == BLIPClientTypeSGR2)
 	if bh.useHLV() && changeIsVector {
-		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc, legacyRevList, isBlipRevTreeProperty, bh.conflictResolver)
+		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc, legacyRevList, isBlipRevTreeProperty, bh.conflictResolver, forceAllowConflictingTombstone)
 	} else {
 		docUpdateEvent := ExistingVersionWithUpdateToHLV
 		if bh.useHLV() {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1411,9 +1411,6 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 			} else {
 				// allow conflicting tombstone, just update HLV and add any new revs from history
 				doc.HLV.UpdateWithIncomingHLV(newDocHLV)
-				if err != nil {
-					return nil, nil, false, nil, err
-				}
 				currentRevIndex, parent = doc.findWhereRevBranchesFromHistory(revTreeHistory)
 				_, addNewRevErr := doc.addNewerRevisionsToRevTreeHistory(newDoc, currentRevIndex, parent, revTreeHistory)
 				if addNewRevErr != nil {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1807,8 +1807,11 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 		Version:          incomingVersion,
 		PreviousVersions: pv,
 	}
-
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{}, false)
+	opts := PutDocOptions{
+		NewDoc:    newDoc,
+		NewDocHLV: incomingHLV,
+	}
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, opts)
 	assertHTTPError(t, err, 409)
 	require.Nil(t, doc)
 	require.Nil(t, cv)
@@ -1818,7 +1821,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	// TODO: because currentRev isn't being updated, storeOldBodyInRevTreeAndUpdateCurrent isn't
 	//  updating the document body.   Need to review whether it makes sense to keep using
 	// storeOldBodyInRevTreeAndUpdateCurrent, or if this needs a larger overhaul to support VV
-	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{}, false)
+	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, opts)
 	require.NoError(t, err)
 	assert.Equal(t, "test", cv.SourceID)
 	assert.Equal(t, incomingVersion, cv.Value)
@@ -1840,7 +1843,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 
 	// Attempt to push the same client update, validate server rejects as an already known version and cancels the update.
 	// This case doesn't return error, verify that SyncData hasn't been changed.
-	_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{}, false)
+	_, _, _, err = collection.PutExistingCurrentVersion(ctx, opts)
 	require.NoError(t, err)
 	syncData2, err := collection.GetDocSyncData(ctx, "doc1")
 	require.NoError(t, err)
@@ -1885,8 +1888,12 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 		Version:  1234,
 	}
 
+	opts := PutDocOptions{
+		NewDoc:    newDoc,
+		NewDocHLV: incomingHLV,
+	}
 	// assert that a conflict is correctly identified and the doc and cv are nil
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{}, false)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, opts)
 	assertHTTPError(t, err, 409)
 	require.Nil(t, doc)
 	require.Nil(t, cv)
@@ -1925,8 +1932,13 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 		Version:          incomingVersion,
 		PreviousVersions: pv,
 	}
+	opts := PutDocOptions{
+		NewDoc:      newDoc,
+		NewDocHLV:   incomingHLV,
+		ExistingDoc: &sgbucket.BucketDocument{},
+	}
 	// call PutExistingCurrentVersion with empty existing doc
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{}, nil, false, ConflictResolvers{}, false)
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, opts)
 	require.NoError(t, err)
 	assert.NotNil(t, doc)
 	// assert on returned CV value

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1808,7 +1808,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 		PreviousVersions: pv,
 	}
 
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{})
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{}, false)
 	assertHTTPError(t, err, 409)
 	require.Nil(t, doc)
 	require.Nil(t, cv)
@@ -1818,7 +1818,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 	// TODO: because currentRev isn't being updated, storeOldBodyInRevTreeAndUpdateCurrent isn't
 	//  updating the document body.   Need to review whether it makes sense to keep using
 	// storeOldBodyInRevTreeAndUpdateCurrent, or if this needs a larger overhaul to support VV
-	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{})
+	doc, cv, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{}, false)
 	require.NoError(t, err)
 	assert.Equal(t, "test", cv.SourceID)
 	assert.Equal(t, incomingVersion, cv.Value)
@@ -1840,7 +1840,7 @@ func TestPutExistingCurrentVersion(t *testing.T) {
 
 	// Attempt to push the same client update, validate server rejects as an already known version and cancels the update.
 	// This case doesn't return error, verify that SyncData hasn't been changed.
-	_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{})
+	_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{}, false)
 	require.NoError(t, err)
 	syncData2, err := collection.GetDocSyncData(ctx, "doc1")
 	require.NoError(t, err)
@@ -1886,7 +1886,7 @@ func TestPutExistingCurrentVersionWithConflict(t *testing.T) {
 	}
 
 	// assert that a conflict is correctly identified and the doc and cv are nil
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{})
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, nil, nil, false, ConflictResolvers{}, false)
 	assertHTTPError(t, err, 409)
 	require.Nil(t, doc)
 	require.Nil(t, cv)
@@ -1926,7 +1926,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 		PreviousVersions: pv,
 	}
 	// call PutExistingCurrentVersion with empty existing doc
-	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{}, nil, false, ConflictResolvers{})
+	doc, cv, _, err := collection.PutExistingCurrentVersion(ctx, newDoc, incomingHLV, &sgbucket.BucketDocument{}, nil, false, ConflictResolvers{}, false)
 	require.NoError(t, err)
 	assert.NotNil(t, doc)
 	// assert on returned CV value

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -761,7 +761,7 @@ func TestAlignRevTreeHistory(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := doc.alignRevTreeHistoryForHLVWrite(ctx, collection, doc, tc.incomingRevTree)
+			err := doc.alignRevTreeHistoryForHLVWrite(ctx, collection, doc, tc.incomingRevTree, false)
 			require.NoError(t, err)
 			base.RequireKeysEqual(t, tc.expectedRevTree, doc.History)
 

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -644,8 +644,8 @@ func EncodeValueStr(value string) (string, error) {
 func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
 	type BucketVector struct {
 		CurrentVersionCAS string    `json:"cvCas,omitempty"`
-		SourceID          string    `json:"src"`
-		Version           string    `json:"ver"`
+		SourceID          string    `json:"src,omitempty"`
+		Version           string    `json:"ver,omitempty"`
 		PV                *[]string `json:"pv,omitempty"`
 		MV                *[]string `json:"mv,omitempty"`
 	}
@@ -657,8 +657,10 @@ func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
 		cvCas = base.CasToString(hlv.CurrentVersionCAS)
 		bucketHLV.CurrentVersionCAS = cvCas
 	}
-	vrsCas = base.CasToString(hlv.Version)
-	bucketHLV.Version = vrsCas
+	if hlv.Version != 0 {
+		vrsCas = base.CasToString(hlv.Version)
+		bucketHLV.Version = vrsCas
+	}
 	bucketHLV.SourceID = hlv.SourceID
 
 	pvPersistedFormat := VersionsToDeltas(hlv.PreviousVersions)

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -644,8 +644,8 @@ func EncodeValueStr(value string) (string, error) {
 func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
 	type BucketVector struct {
 		CurrentVersionCAS string    `json:"cvCas,omitempty"`
-		SourceID          string    `json:"src,omitempty"`
-		Version           string    `json:"ver,omitempty"`
+		SourceID          string    `json:"src"`
+		Version           string    `json:"ver"`
 		PV                *[]string `json:"pv,omitempty"`
 		MV                *[]string `json:"mv,omitempty"`
 	}
@@ -657,10 +657,8 @@ func (hlv HybridLogicalVector) MarshalJSON() ([]byte, error) {
 		cvCas = base.CasToString(hlv.CurrentVersionCAS)
 		bucketHLV.CurrentVersionCAS = cvCas
 	}
-	if hlv.Version != 0 {
-		vrsCas = base.CasToString(hlv.Version)
-		bucketHLV.Version = vrsCas
-	}
+	vrsCas = base.CasToString(hlv.Version)
+	bucketHLV.Version = vrsCas
 	bucketHLV.SourceID = hlv.SourceID
 
 	pvPersistedFormat := VersionsToDeltas(hlv.PreviousVersions)

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -898,7 +898,6 @@ func remoteWinsConflictResolutionForHLV(ctx context.Context, docID string, local
 	if localHLV == nil || incomingHLV == nil {
 		return nil, errors.New("local or incoming hlv is nil for resolveConflict")
 	}
-	// todo: CBG-4791 - use doc history to ensure rev tree is updated correctly
 
 	newHLV := localHLV.Copy()
 

--- a/db/import.go
+++ b/db/import.go
@@ -279,7 +279,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 			rawBodyForRevID = existingDoc.Body
 		} else {
 			var bodyWithoutInternalProps Body
-			bodyWithoutInternalProps, wasStripped = stripInternalProperties(body)
+			bodyWithoutInternalProps, wasStripped = StripInternalProperties(body)
 			rawBodyForRevID, err = base.JSONMarshalCanonical(bodyWithoutInternalProps)
 			if err != nil {
 				return nil, nil, false, nil, err

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -166,7 +166,7 @@ func TestOnDemandImportMou(t *testing.T) {
 				case "PutExistingCurrentVersion":
 					hlv := NewHybridLogicalVector()
 					var legacyRevList []string
-					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList, false, ConflictResolvers{})
+					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList, false, ConflictResolvers{}, false)
 					assertHTTPError(t, err, 409)
 				default:
 					require.FailNow(t, fmt.Sprintf("unexpected funcName: %s", funcName))

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -166,7 +166,13 @@ func TestOnDemandImportMou(t *testing.T) {
 				case "PutExistingCurrentVersion":
 					hlv := NewHybridLogicalVector()
 					var legacyRevList []string
-					_, _, _, err = collection.PutExistingCurrentVersion(ctx, newDoc, hlv, rawBucketDoc, legacyRevList, false, ConflictResolvers{}, false)
+					opts := PutDocOptions{
+						NewDocHLV:      hlv,
+						NewDoc:         newDoc,
+						RevTreeHistory: legacyRevList,
+						ExistingDoc:    rawBucketDoc,
+					}
+					_, _, _, err = collection.PutExistingCurrentVersion(ctx, opts)
 					assertHTTPError(t, err, 409)
 				default:
 					require.FailNow(t, fmt.Sprintf("unexpected funcName: %s", funcName))

--- a/db/revision.go
+++ b/db/revision.go
@@ -335,7 +335,7 @@ func (body Body) FixJSONNumbers() {
 
 func CreateRevID(generation int, parentRevID string, body Body) (string, error) {
 	// This should produce the same results as TouchDB.
-	strippedBody, _ := stripInternalProperties(body)
+	strippedBody, _ := StripInternalProperties(body)
 	encoding, err := base.JSONMarshalCanonical(strippedBody)
 	if err != nil {
 		return "", err
@@ -419,8 +419,8 @@ func compareRevIDs(ctx context.Context, id1, id2 string) int {
 	return 0
 }
 
-// stripInternalProperties returns a copy of the given body with all internal underscore-prefixed keys removed, except _attachments and _deleted.
-func stripInternalProperties(b Body) (Body, bool) {
+// StripInternalProperties returns a copy of the given body with all internal underscore-prefixed keys removed, except _attachments and _deleted.
+func StripInternalProperties(b Body) (Body, bool) {
 	return stripSpecialProperties(b, true)
 }
 

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -234,9 +234,9 @@ func BenchmarkSpecialProperties(b *testing.B) {
 	}
 
 	for _, t := range tests {
-		b.Run(t.name+"-stripInternalProperties", func(bb *testing.B) {
+		b.Run(t.name+"-StripInternalProperties", func(bb *testing.B) {
 			for i := 0; i < bb.N; i++ {
-				stripInternalProperties(t.body)
+				StripInternalProperties(t.body)
 			}
 		})
 		b.Run(t.name+"-stripAllInternalProperties", func(bb *testing.B) {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -884,7 +884,12 @@ func (c *DatabaseCollectionWithUser) UpsertTestDocWithVersion(ctx context.Contex
 		}
 	}
 
-	doc, _, _, err := c.PutExistingCurrentVersion(ctx, newDoc, newDocHLV, currentBucketDoc, nil, false, ConflictResolvers{}, false)
+	opts := PutDocOptions{
+		NewDocHLV:   newDocHLV,
+		NewDoc:      newDoc,
+		ExistingDoc: currentBucketDoc,
+	}
+	doc, _, _, err := c.PutExistingCurrentVersion(ctx, opts)
 	require.NoError(t, err)
 	return doc
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -884,7 +884,7 @@ func (c *DatabaseCollectionWithUser) UpsertTestDocWithVersion(ctx context.Contex
 		}
 	}
 
-	doc, _, _, err := c.PutExistingCurrentVersion(ctx, newDoc, newDocHLV, currentBucketDoc, nil, false, ConflictResolvers{})
+	doc, _, _, err := c.PutExistingCurrentVersion(ctx, newDoc, newDocHLV, currentBucketDoc, nil, false, ConflictResolvers{}, false)
 	require.NoError(t, err)
 	return doc
 }

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -195,7 +195,7 @@ func (db *DatabaseCollectionWithUser) CreateDocNoHLV(t *testing.T, ctx context.C
 		}
 
 		// Make up a new _rev, and add it to the history:
-		bodyWithoutInternalProps, wasStripped := stripInternalProperties(body)
+		bodyWithoutInternalProps, wasStripped := StripInternalProperties(body)
 		canonicalBytesForRevID, err := base.JSONMarshalCanonical(bodyWithoutInternalProps)
 		if err != nil {
 			return nil, nil, false, nil, err

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -43,6 +43,11 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 			// Passive
 			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "passivedb",
+					},
+				},
 			})
 			defer rt2.Close()
 			username := "alice"
@@ -51,6 +56,11 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 			// Active
 			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "activedb",
+					},
+				},
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
@@ -183,6 +193,11 @@ func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 	// Passive
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
+		DatabaseConfig: &rest.DatabaseConfig{
+			DbConfig: rest.DbConfig{
+				Name: "passivedb",
+			},
+		},
 	})
 	defer rt2.Close()
 	username := "alice"
@@ -191,6 +206,11 @@ func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 	// Active
 	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
+		DatabaseConfig: &rest.DatabaseConfig{
+			DbConfig: rest.DbConfig{
+				Name: "activedb",
+			},
+		},
 	})
 	defer rt1.Close()
 	ctx1 := rt1.Context()
@@ -439,6 +459,11 @@ func TestActiveReplicatorLocalWinsCases(t *testing.T) {
 			// Passive
 			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "passivedb",
+					},
+				},
 			})
 			defer rt2.Close()
 			username := "alice"
@@ -447,6 +472,11 @@ func TestActiveReplicatorLocalWinsCases(t *testing.T) {
 			// Active
 			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "activedb",
+					},
+				},
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
@@ -738,6 +768,11 @@ func TestActiveReplicatorRemoteWinsCases(t *testing.T) {
 			// Passive
 			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "passivedb",
+					},
+				},
 			})
 			defer rt2.Close()
 			username := "alice"
@@ -746,6 +781,11 @@ func TestActiveReplicatorRemoteWinsCases(t *testing.T) {
 			// Active
 			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "activedb",
+					},
+				},
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
@@ -972,6 +1012,11 @@ func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
 			// Passive
 			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "passivedb",
+					},
+				},
 			})
 			defer rt2.Close()
 			username := "alice"
@@ -980,6 +1025,11 @@ func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
 			// Active
 			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "activedb",
+					},
+				},
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
@@ -1179,6 +1229,11 @@ func TestActiveReplicatorAttachmentHandling(t *testing.T) {
 			// Passive
 			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "passivedb",
+					},
+				},
 			})
 			defer rt2.Close()
 			username := "alice"
@@ -1187,6 +1242,11 @@ func TestActiveReplicatorAttachmentHandling(t *testing.T) {
 			// Active
 			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "activedb",
+					},
+				},
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
@@ -1325,6 +1385,11 @@ func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
 			// Passive
 			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "passivedb",
+					},
+				},
 			})
 			defer rt2.Close()
 			username := "alice"
@@ -1333,6 +1398,11 @@ func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
 			// Active
 			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
 				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "activedb",
+					},
+				},
 			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -1557,7 +1557,11 @@ func TestActiveReplicatorInvalidCustomResolver(t *testing.T) {
 		Version:  1234,
 	}
 	// add local version
-	_, _, _, err := rt1Collection.PutExistingCurrentVersion(rt1Ctx, newDoc, incomingHLV, nil, nil, false, db.ConflictResolvers{}, false)
+	opts := db.PutDocOptions{
+		NewDoc:    newDoc,
+		NewDocHLV: incomingHLV,
+	}
+	_, _, _, err := rt1Collection.PutExistingCurrentVersion(rt1Ctx, opts)
 	require.NoError(t, err)
 
 	newDoc = db.CreateTestDocument(docID, "", rest.JsonToMap(t, `{"some": "data"}`), false, 0)
@@ -1565,7 +1569,9 @@ func TestActiveReplicatorInvalidCustomResolver(t *testing.T) {
 		SourceID: "def",
 		Version:  1234,
 	}
-	_, _, _, err = rt2Collection.PutExistingCurrentVersion(rt2Ctx, newDoc, incomingHLV, nil, nil, false, db.ConflictResolvers{}, false)
+	opts.NewDocHLV = incomingHLV
+	opts.NewDoc = newDoc
+	_, _, _, err = rt2Collection.PutExistingCurrentVersion(rt2Ctx, opts)
 	require.NoError(t, err)
 
 	resolver := `function(conflict) {var mergedDoc = new Object(); 
@@ -1685,7 +1691,11 @@ func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
 				Version:  1234,
 			}
 			// add local version
-			localDoc, _, _, err := rt1Collection.PutExistingCurrentVersion(rt1Ctx, newDoc, incomingHLV, nil, nil, false, db.ConflictResolvers{}, false)
+			opts := db.PutDocOptions{
+				NewDoc:    newDoc,
+				NewDocHLV: incomingHLV,
+			}
+			localDoc, _, _, err := rt1Collection.PutExistingCurrentVersion(rt1Ctx, opts)
 			require.NoError(t, err)
 
 			newDoc = db.CreateTestDocument(docID, "", rest.JsonToMap(t, testCase.remoteBody), false, 0)
@@ -1693,7 +1703,11 @@ func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
 				SourceID: "def",
 				Version:  1234,
 			}
-			remoteDoc, _, _, err := rt2Collection.PutExistingCurrentVersion(rt2Ctx, newDoc, incomingHLV, nil, nil, false, db.ConflictResolvers{}, false)
+			opts = db.PutDocOptions{
+				NewDoc:    newDoc,
+				NewDocHLV: incomingHLV,
+			}
+			remoteDoc, _, _, err := rt2Collection.PutExistingCurrentVersion(rt2Ctx, opts)
 			require.NoError(t, err)
 
 			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, testCase.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -2028,7 +2028,7 @@ func TestActiveReplicatorHLVConflictLocalWinsWhenNonWinningRevHasLessRevisionsLo
 	requiredAdditionalRevs := localGeneration - remoteGeneration
 	// we will create 10 additional revs to inject into remote  doc's history to catch up with local rev tree
 	previousRevID := rt2Version.RevTreeID
-	generatedRevs := make([]string, 0, 0)
+	generatedRevs := make([]string, 0)
 	for i := 0; i < requiredAdditionalRevs; i++ {
 		remoteGeneration++
 		previousRevID = db.CreateRevIDWithBytes(remoteGeneration, previousRevID, []byte("{}"))

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -177,7 +177,7 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 				assert.Equal(t, nonWinningRevPreConflict.CV.Value, rt1Doc.HLV.MergeVersions[nonWinningRevPreConflict.CV.SourceID])
 				require.Len(t, rt1Doc.HLV.PreviousVersions, 0)
 
-				// check tombstoned leaf parent is the current rev of remote doc
+				// check tombstoned leaf previous local active rev and active rev is above generated rev ID
 				docHistoryLeaves := rt1Doc.History.GetLeaves()
 				require.Len(t, docHistoryLeaves, 2)
 				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, localWinsVersion.RevTreeID, rt1Version.RevTreeID)
@@ -1335,7 +1335,7 @@ func TestActiveReplicatorAttachmentHandling(t *testing.T) {
 				base.RequireKeysEqual(t, []string{"hello.txt", "world.txt"}, attMeta)
 
 				expectedBodyBytes := base.MustJSONMarshal(t, remoteDocBodyPreConflict)
-				require.JSONEq(t, string(expectedBodyBytes), string(actualBody), "Doc body does not match expected for local wins")
+				require.JSONEq(t, string(expectedBodyBytes), string(actualBody), "Doc body does not match expected for remote wins")
 			} else {
 				// local wins, so we expect the local attachment to be present
 				// local wins:

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -1478,7 +1478,8 @@ func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
 
 			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
 				// here local revIDs gets promoted back to active as the local rev tree is 3-... but remote is 2-...
-				version.RevTreeID = "3-83cfc92a9f5b96a5a7df0e5d01c64cfb"
+				newRev := db.CreateRevIDWithBytes(3, rt1Version.RevTreeID, []byte(db.DeletedDocument))
+				version.RevTreeID = newRev
 				rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
 				docHistoryLeaves := rt1Doc.History.GetLeaves()
 				require.Len(t, docHistoryLeaves, 2)

--- a/rest/replicatortest/replicator_revtree_test.go
+++ b/rest/replicatortest/replicator_revtree_test.go
@@ -254,7 +254,7 @@ func TestActiveReplicatorNoHLVConflictConflictInRevTree(t *testing.T) {
 	lastSequence, err := rt1collection.LastSequence(rt1ctx)
 	require.NoError(t, err)
 
-	// start pull again, will conflict for hlv but resolve for remote wins and assert that the rev tree
+	// start pull again
 	require.NoError(t, ar.Start(ctx1))
 
 	changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", lastSequence), "", true)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -3926,7 +3926,6 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflict(t *testing.T) {
 	base.LongRunningTest(t)
-	t.Skip("CBG-4791: test need rev tree reconciliation changes")
 
 	// scenarios
 	conflictResolutionTests := []struct {
@@ -3942,6 +3941,8 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 		expectedResolutionType    db.ConflictResolutionType
 		skipActiveLeafAssertion   bool
 		skipBodyAssertion         bool
+		newCVGenerated            bool
+		SupportedSubProtocol      string // potentially temporary until clarity on conflicting tombstones
 	}{
 		{
 			name:                   "remoteWins",
@@ -3953,6 +3954,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			expectedLocalBody:      `{"source": "remote"}`,
 			expectedLocalVersion:   rest.NewDocVersionFromFakeRev("1-b"),
 			expectedResolutionType: db.ConflictResolutionRemote,
+			SupportedSubProtocol:   db.CBMobileReplicationV4.SubprotocolString(),
 		},
 		{
 			name:               "merge",
@@ -3968,6 +3970,8 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			expectedLocalBody:      `{"source": "merged"}`,
 			expectedLocalVersion:   rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"merged"}`))), // rev for merged body, with parent 1-b
 			expectedResolutionType: db.ConflictResolutionMerge,
+			newCVGenerated:         true,
+			SupportedSubProtocol:   db.CBMobileReplicationV4.SubprotocolString(),
 		},
 		{
 			name:                   "localWins",
@@ -3979,6 +3983,8 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			expectedLocalBody:      `{"source": "local"}`,
 			expectedLocalVersion:   rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"local"}`))), // rev for local body, transposed under parent 1-b
 			expectedResolutionType: db.ConflictResolutionLocal,
+			newCVGenerated:         true,
+			SupportedSubProtocol:   db.CBMobileReplicationV4.SubprotocolString(),
 		},
 		{
 			name:                    "twoTombstonesRemoteWin",
@@ -3991,6 +3997,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			expectedLocalVersion:    rest.NewDocVersionFromFakeRev("1-b"),
 			skipActiveLeafAssertion: true,
 			skipBodyAssertion:       base.TestUseXattrs(),
+			SupportedSubProtocol:    db.CBMobileReplicationV3.SubprotocolString(),
 		},
 		{
 			name:                    "twoTombstonesLocalWin",
@@ -4003,6 +4010,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			expectedLocalVersion:    rest.NewDocVersionFromFakeRev("1-b"),
 			skipActiveLeafAssertion: true,
 			skipBodyAssertion:       base.TestUseXattrs(),
+			SupportedSubProtocol:    db.CBMobileReplicationV3.SubprotocolString(),
 		},
 	}
 
@@ -4012,7 +4020,13 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)
 
 			// Passive
-			rt2 := rest.NewRestTester(t, nil)
+			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "passivedb",
+					},
+				},
+			})
 			defer rt2.Close()
 			username := "alice"
 			rt2.CreateUser(username, []string{"*"})
@@ -4026,14 +4040,20 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			srv := httptest.NewServer(rt2.TestPublicHandler())
 			defer srv.Close()
 
-			passiveDBURL, err := url.Parse(srv.URL + "/db")
+			passiveDBURL, err := url.Parse(srv.URL + "/passivedb")
 			require.NoError(t, err)
 
 			// Add basic auth creds to target db URL
 			passiveDBURL.User = url.UserPassword(username, rest.RestTesterDefaultUserPassword)
 
 			// Active
-			rt1 := rest.NewRestTester(t, nil)
+			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: "activedb",
+					},
+				},
+			})
 			defer rt1.Close()
 			ctx1 := rt1.Context()
 
@@ -4061,6 +4081,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 				Continuous:                 true,
 				ReplicationStatsMap:        replicationStats,
 				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+				SupportedBLIPProtocols:     []string{test.SupportedSubProtocol},
 			})
 			require.NoError(t, err)
 			defer func() { assert.NoError(t, ar.Stop()) }()
@@ -4100,7 +4121,20 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
 			doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
-			rest.RequireDocVersionEqual(t, test.expectedLocalVersion, doc.ExtractDocVersion())
+			actualVersion := doc.ExtractDocVersion()
+			if test.SupportedSubProtocol == db.CBMobileReplicationV4.SubprotocolString() {
+				if test.newCVGenerated {
+					test.expectedLocalVersion.CV = db.Version{
+						SourceID: rt1.GetDatabase().EncodedSourceID,
+						Value:    doc.Cas,
+					}
+				} else {
+					test.expectedLocalVersion.CV = rt2Version.CV
+				}
+			} else {
+				actualVersion.CV = db.Version{}
+			}
+			rest.RequireDocVersionEqual(t, test.expectedLocalVersion, actualVersion)
 
 			// This is skipped for tombstone tests running with xattr as xattr tombstones don't have a body to assert
 			// against
@@ -4143,7 +4177,6 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 
 	base.LongRunningTest(t)
-	t.Skip("CBG-4791: need rev tree reconciliation changes")
 
 	// scenarios
 	conflictResolutionTests := []struct {
@@ -4157,6 +4190,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 		expectedBody          string
 		expectedVersion       rest.DocVersion
 		expectedPushResolved  bool
+		newCVGenerated        bool
 	}{
 		{
 			name:                 "remoteWins",
@@ -4183,6 +4217,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			expectedBody:         `{"source": "merged"}`,
 			expectedVersion:      rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"merged"}`))), // rev for merged body, with parent 1-b
 			expectedPushResolved: true,
+			newCVGenerated:       true,
 		},
 		{
 			name:                 "localWins",
@@ -4194,6 +4229,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			expectedBody:         `{"source": "local"}`,
 			expectedVersion:      rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"local"}`))), // rev for local body, transposed under parent 1-b
 			expectedPushResolved: true,
+			newCVGenerated:       true,
 		},
 		{
 			name:                  "localWinsRemoteTombstone",
@@ -4206,6 +4242,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			expectedBody:          `{"source": "local"}`,
 			expectedVersion:       rest.NewDocVersionFromFakeRev(db.CreateRevIDWithBytes(3, "2-b", []byte(`{"source":"local"}`))), // rev for local body, transposed under parent 2-b
 			expectedPushResolved:  true,
+			newCVGenerated:        true,
 		},
 	}
 
@@ -4325,6 +4362,14 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 
 			doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
+			if test.newCVGenerated {
+				test.expectedVersion.CV = db.Version{
+					SourceID: rt1.GetDatabase().EncodedSourceID,
+					Value:    doc.Cas,
+				}
+			} else {
+				test.expectedVersion.CV = rt2Version.CV
+			}
 			rest.RequireDocVersionEqual(t, test.expectedVersion, doc.ExtractDocVersion())
 			requireBodyEqual(t, test.expectedBody, doc)
 			t.Logf("Doc %s is %+v", docID, doc)
@@ -5690,7 +5735,6 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 	base.LongRunningTest(t)
-	t.Skip("CBG-4791: requires rev tree reconciliation")
 
 	createVersion := func(generation int, parentRevID string, body db.Body) rest.DocVersion {
 		rev, err := db.CreateRevID(generation, parentRevID, body)
@@ -5930,6 +5974,10 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
 			doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
 			require.NoError(t, err)
+			test.expectedLocalVersion.CV = db.Version{
+				SourceID: rt1.GetDatabase().EncodedSourceID,
+				Value:    doc.Cas,
+			}
 			rest.RequireDocVersionEqual(t, test.expectedLocalVersion, doc.ExtractDocVersion())
 			ctx := base.TestCtx(t)
 			t.Logf("doc.Body(): %v", doc.Body(ctx))

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2830,11 +2830,3 @@ func AssertRevTreeAfterHLVConflictResolution(t *testing.T, doc *db.Document, exp
 	// should only have one active leaf
 	require.Equal(t, 1, activeLeafCount)
 }
-
-func StripInternalProperties(t *testing.T, body db.Body) db.Body {
-	delete(body, db.BodyRev)
-	delete(body, db.BodyId)
-	delete(body, db.BodyCV)
-	delete(body, db.BodyAttachments)
-	return body
-}


### PR DESCRIPTION
CBG-4791

- PR will reconcile rev tree on conflicts
- This includes when HLV is not in conflict but the underlying rev tree is, in this case we:
    - Tombstone local revision, write incoming rev tree as active branch
- The rev tree logic follows much the same as old style conflict resolution with the addition of HLV handling. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/63/
