### PR TITLE
CBG-4316:  Remove allow_conflicts option

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/couchbase/cbgt"
@@ -2487,4 +2488,8 @@ func PurgeDCPCheckpoints(ctx context.Context, database *DatabaseContext, checkpo
 	metadata := base.NewDCPMetadataCS(ctx, datastore, numVbuckets, base.DefaultNumWorkers, checkpointPrefix)
 	metadata.Purge(ctx, base.DefaultNumWorkers)
 	return nil
+}
+
+func (db *DatabaseContext) EnableAllowConflicts(tb testing.TB) {
+	db.Options.AllowConflicts = base.Ptr(true)
 }

--- a/db/database_error.go
+++ b/db/database_error.go
@@ -23,6 +23,7 @@ var DatabaseErrorMap = map[databaseErrorCode]string{
 	DatabaseSGRClusterError:            "Error with fetching SGR cluster definition",
 	DatabaseCreateReplicationError:     "Error creating replication during database init",
 	DatabaseOnlineProcessError:         "Error attempting to start online process",
+	DatabaseAllowConflictsError:        "Allow conflicts is set to true",
 }
 
 type databaseErrorCode uint8
@@ -37,6 +38,7 @@ const (
 	DatabaseSGRClusterError            databaseErrorCode = 6
 	DatabaseCreateReplicationError     databaseErrorCode = 7
 	DatabaseOnlineProcessError         databaseErrorCode = 8
+	DatabaseAllowConflictsError        databaseErrorCode = 9
 )
 
 func NewDatabaseError(code databaseErrorCode) *DatabaseError {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2217,9 +2217,10 @@ func TestHandleGetRevTree(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := rt.NewDbConfig()
-	dbConfig.AllowConflicts = base.Ptr(true)
 
 	rest.RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 
 	// Create three revisions of the user foo with different status and updated_at values;
 	reqBodyJson := `{"new_edits": false, "docs": [

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -2219,8 +2219,7 @@ func TestHandleGetRevTree(t *testing.T) {
 	dbConfig := rt.NewDbConfig()
 
 	rest.RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	// Create three revisions of the user foo with different status and updated_at values;
 	reqBodyJson := `{"new_edits": false, "docs": [

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3431,11 +3431,11 @@ func TestAllowConflictsConfig(t *testing.T) {
 
 }
 
-// TestDBWithAllowConflictsInvalid verifies that the database configuration does not allow
+// TestDBWithAllowConflicts verifies that the database configuration does not allow
 // the `AllowConflicts` property to be set to true. This test ensures that a config loaded
 // will add the database to invalid configs. The config will be fixed when a database is
 // created without `allow_conflicts`
-func TestDBWithAllowConflictsInvalid(t *testing.T) {
+func TestDBWithAllowConflicts(t *testing.T) {
 
 	ctx := t.Context()
 
@@ -3474,7 +3474,5 @@ func TestDBWithAllowConflictsInvalid(t *testing.T) {
 	rt.CreateDatabase(dbName, dbConfig)
 	resp = rt.SendAdminRequest(http.MethodGet, allDBsURL, "")
 	RequireStatus(t, resp, http.StatusOK)
-	dbs := resp.Body.String()
-	base.InfofCtx(ctx, base.KeySGTest, "response body: %s", dbs)
 	require.Equal(t, fmt.Sprintf(`[{"db_name":"%s","bucket":"%s","state":"Online"}]`, rt.GetDatabase().Name, rt.GetDatabase().Bucket.GetName()), resp.Body.String())
 }

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -790,8 +790,9 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := rt.NewDbConfig()
-	dbConfig.AllowConflicts = base.Ptr(true)
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 
 	// Create a document
 	version := rt.CreateTestDoc("doc1")
@@ -846,8 +847,9 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := rt.NewDbConfig()
-	dbConfig.AllowConflicts = base.Ptr(true)
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 
 	version := rt.CreateTestDoc("doc1")
 
@@ -2052,16 +2054,12 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 }
 
 func TestAttachmentRemovalWithConflicts(t *testing.T) {
-	rt := NewRestTester(t, &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{
-			DbConfig: DbConfig{
-				AllowConflicts: base.Ptr(true),
-			},
-		},
-	})
+	rt := NewRestTester(t, nil)
 
 	defer rt.Close()
 
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 	const docID = "doc"
 	// Create doc rev 1
 	version := rt.PutDoc(docID, `{"test": "x"}`)
@@ -2123,8 +2121,9 @@ func TestAttachmentsMissing(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := rt.NewDbConfig()
-	dbConfig.AllowConflicts = base.Ptr(true)
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 
 	docID := t.Name()
 	version1 := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
@@ -2149,8 +2148,9 @@ func TestAttachmentsMissingNoBody(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := rt.NewDbConfig()
-	dbConfig.AllowConflicts = base.Ptr(true)
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 
 	docID := t.Name()
 	version1 := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
@@ -2440,8 +2440,9 @@ func TestProveAttachmentNotFound(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := rt.NewDbConfig()
-	dbConfig.AllowConflicts = base.Ptr(true)
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 	rt.SetAdminParty(true)
 
 	bt := NewBlipTesterFromSpecWithRT(rt, nil)

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -691,7 +691,6 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := rt.NewDbConfig()
-	dbConfig.AllowConflicts = base.Ptr(true)
 
 	// TODO: CBG-4840 Only requires delta sync until restoration of non-delta sync RevTree ID revision body backups"
 	if !base.IsEnterpriseEdition() {
@@ -700,6 +699,7 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	dbConfig.DeltaSync = &DeltaSyncConfig{Enabled: base.Ptr(true), RevMaxAgeSeconds: base.Ptr(uint32(300))}
 
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 	// Create Doc
 	version := rt.CreateTestDoc("doc1")
 
@@ -797,8 +797,7 @@ func TestConflictingBranchAttachments(t *testing.T) {
 
 	dbConfig := rt.NewDbConfig()
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	// Create a document
 	version := rt.CreateTestDoc("doc1")
@@ -854,8 +853,7 @@ func TestAttachmentsWithTombstonedConflict(t *testing.T) {
 
 	dbConfig := rt.NewDbConfig()
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	version := rt.CreateTestDoc("doc1")
 
@@ -2064,8 +2062,7 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 
 	defer rt.Close()
 
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 	const docID = "doc"
 	// Create doc rev 1
 	version := rt.PutDoc(docID, `{"test": "x"}`)
@@ -2128,8 +2125,7 @@ func TestAttachmentsMissing(t *testing.T) {
 
 	dbConfig := rt.NewDbConfig()
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	docID := t.Name()
 	version1 := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
@@ -2155,8 +2151,7 @@ func TestAttachmentsMissingNoBody(t *testing.T) {
 
 	dbConfig := rt.NewDbConfig()
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	docID := t.Name()
 	version1 := rt.PutDoc(docID, `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}}`)
@@ -2447,8 +2442,7 @@ func TestProveAttachmentNotFound(t *testing.T) {
 
 	dbConfig := rt.NewDbConfig()
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 	rt.SetAdminParty(true)
 
 	bt := NewBlipTesterFromSpecWithRT(rt, nil)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -49,8 +49,10 @@ import (
 func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
-	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{allowConflicts: true, GuestEnabled: true})
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{GuestEnabled: true})
 	defer bt.Close()
+	dbName := bt.restTester.GetDatabase().Name
+	bt.restTester.EnableAllowConflicts(dbName)
 
 	// Verify Sync Gateway will accept the doc revision that is about to be sent
 	var changeList [][]interface{}
@@ -1675,10 +1677,12 @@ func TestPutRevConflictsMode(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
 	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		allowConflicts:     true,
 		connectingUsername: "user1",
 	})
 	defer bt.Close()
+
+	dbName := bt.restTester.GetDatabase().Name
+	bt.restTester.EnableAllowConflicts(dbName)
 
 	sent, _, resp, err := bt.SendRev("foo", "1-abc", []byte(`{"key": "val"}`), blip.Properties{})
 	assert.True(t, sent)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -51,8 +51,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
 	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{GuestEnabled: true})
 	defer bt.Close()
-	dbName := bt.restTester.GetDatabase().Name
-	bt.restTester.EnableAllowConflicts(dbName)
+	bt.restTester.GetDatabase().EnableAllowConflicts(bt.TB())
 
 	// Verify Sync Gateway will accept the doc revision that is about to be sent
 	var changeList [][]interface{}
@@ -1681,8 +1680,7 @@ func TestPutRevConflictsMode(t *testing.T) {
 	})
 	defer bt.Close()
 
-	dbName := bt.restTester.GetDatabase().Name
-	bt.restTester.EnableAllowConflicts(dbName)
+	bt.restTester.GetDatabase().EnableAllowConflicts(bt.TB())
 
 	sent, _, resp, err := bt.SendRev("foo", "1-abc", []byte(`{"key": "val"}`), blip.Properties{})
 	assert.True(t, sent)

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -211,8 +211,7 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
 
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	wg.Add(2)
 	const docID = "doc1"

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -206,11 +206,13 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 					},
 				},
 			},
-			AllowConflicts: base.Ptr(true),
 		},
 		}}
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
+
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 
 	wg.Add(2)
 	const docID = "doc1"

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1519,8 +1519,7 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 	// Create user:
 	ctx := rt.Context()
 	a := rt.ServerContext().Database(ctx, "db").Authenticator(ctx)
@@ -1640,8 +1639,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	rt := rest.NewRestTesterDefaultCollection(t, &rtConfig)
 	defer rt.Close()
 
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 	// Create user1
 	rt.CreateUser("user1", []string{"alpha"})
 	rt.CreateUser("user2", []string{"beta"})
@@ -1764,8 +1762,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	testDB := rt.GetDatabase()
 	testDB.RevsLimit = 3
-	dbName := testDB.Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 	defer rt.Close()
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
 
@@ -2703,8 +2700,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 	ctx := rt.Context()
 	testDb := rt.ServerContext().Database(ctx, "db")
 
@@ -2868,8 +2864,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
 	defer rt.Close()
 
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	// Create user:
 	ctx := rt.Context()
@@ -3042,8 +3037,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	// /it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
 	// defer it.Close()
@@ -3179,8 +3173,7 @@ func TestChangesIncludeConflicts(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	// Create conflicted document documents
 	response := rt.SendAdminRequest("PUT", "/{{.keyspace}}/conflictedDoc", `{"channel":["PBS"]}`)

--- a/rest/config.go
+++ b/rest/config.go
@@ -1133,6 +1133,10 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		multiError = multiError.Append(fmt.Errorf("user_xattr_key can only be a maximum of 15 characters"))
 	}
 
+	if dbConfig.AllowConflicts != nil && *dbConfig.AllowConflicts {
+		multiError = multiError.Append(fmt.Errorf("allow_conflicts cannot be set to true"))
+	}
+
 	return multiError.ErrorOrNil()
 }
 

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -207,6 +207,14 @@ func TestDatabaseConfigValidation(t *testing.T) {
 			},
 			expectedError: "incompatible with enable_shared_bucket_access=false",
 		},
+		{
+			name: "allowing conflicts with allow_conflicts=true",
+			dbConfig: DbConfig{
+				Name:           "db",
+				AllowConflicts: base.Ptr(true),
+			},
+			expectedError: "allow_conflicts cannot be set to true",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -986,6 +986,14 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		return nil, replicationErr
 	}
 
+	if config.AllowConflicts != nil {
+		base.WarnfCtx(ctx, "AllowConflicts options is no longer supported. Do not use it in the config")
+		if *config.AllowConflicts {
+			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError((db.DatabaseAllowConflictsError)))
+			return nil, errors.New("Allow conflicts is true")
+		}
+	}
+
 	// startOnlineProcesses will be set to true if the database should be started, either synchronously or asynchronously
 	startOnlineProcesses := true
 	needsResync := len(collectionsRequiringResync) > 0

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -987,10 +987,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 
 	if config.AllowConflicts != nil {
-		base.WarnfCtx(ctx, "AllowConflicts options is no longer supported. Do not use it in the config")
+		base.WarnfCtx(ctx, "allow_conflicts option is no longer supported. Do not use it in the config")
 		if *config.AllowConflicts {
 			sc._handleInvalidDatabaseConfig(ctx, spec.BucketName, config, db.NewDatabaseError((db.DatabaseAllowConflictsError)))
-			return nil, errors.New("Allow conflicts is true")
+			return nil, errors.New("allow_conflicts options is set to true, please remove allow_conflicts option from the database config")
 		}
 	}
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -239,6 +239,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	assert.Equal(t, rosmar.InMemoryURL, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
 
+	// config with disallowed allow_conflicts=true
 	dbConfig = DbConfig{
 		Name:           "imdb1",
 		AllowConflicts: base.Ptr(true),
@@ -246,7 +247,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	}
 	_, err = serverContext.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig})
 
-	assert.Error(t, err)
+	assert.Error(t, err, "No error after setting AllowConflicts to true")
 }
 
 func TestStatsLoggerStopped(t *testing.T) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -238,6 +238,15 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	assert.NoError(t, err, "No error while trying to get the existing database name")
 	assert.Equal(t, rosmar.InMemoryURL, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
+
+	dbConfig = DbConfig{
+		Name:           "imdb1",
+		AllowConflicts: base.Ptr(true),
+		BucketConfig:        BucketConfig{Server: &server, Bucket: &bucketName},
+	}
+	_, err = serverContext.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig})
+
+	assert.Error(t, err)
 }
 
 func TestStatsLoggerStopped(t *testing.T) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -242,7 +242,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	dbConfig = DbConfig{
 		Name:           "imdb1",
 		AllowConflicts: base.Ptr(true),
-		BucketConfig:        BucketConfig{Server: &server, Bucket: &bucketName},
+		BucketConfig:   bucketConfig,
 	}
 	_, err = serverContext.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig})
 

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -261,8 +261,7 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 	rtConfig := RestTesterConfig{SyncFn: syncFn}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	dbName := rt.GetDatabase().Name
-	rt.EnableAllowConflicts(dbName)
+	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 
 	// rev 1-a
 	version1a := rt.PutDoc(testDocID, `{"`+testdataKey+`":1}`)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -258,9 +258,11 @@ func TestSyncFnDocBodyPropertiesSwitchActiveTombstone(t *testing.T) {
 		}
 	}`
 
-	rtConfig := RestTesterConfig{SyncFn: syncFn, AllowConflicts: true}
+	rtConfig := RestTesterConfig{SyncFn: syncFn}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
+	dbName := rt.GetDatabase().Name
+	rt.EnableAllowConflicts(dbName)
 
 	// rev 1-a
 	version1a := rt.PutDoc(testDocID, `{"`+testdataKey+`":1}`)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2638,6 +2638,10 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 	return config
 }
 
+func (rt *RestTester) EnableAllowConflicts(dbName string) {
+	rt.RestTesterServerContext.databases_[dbName].Options.AllowConflicts = base.Ptr(true)
+}
+
 func setChannelsAllCollections(dbConfig DbConfig, principal *auth.PrincipalConfig, channels ...string) {
 	if dbConfig.Scopes == nil {
 		principal.ExplicitChannels = base.SetOf(channels...)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2641,10 +2641,6 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 	return config
 }
 
-func (rt *RestTester) EnableAllowConflicts(dbName string) {
-	rt.RestTesterServerContext.databases_[dbName].Options.AllowConflicts = base.Ptr(true)
-}
-
 func setChannelsAllCollections(dbConfig DbConfig, principal *auth.PrincipalConfig, channels ...string) {
 	if dbConfig.Scopes == nil {
 		principal.ExplicitChannels = base.SetOf(channels...)


### PR DESCRIPTION
CBG-4316

Describe your PR here...
- Removed allow_conflicts option
- Users cannot create a database with `allow_conflicts=true`
- Any existing config loaded with `allow_conflicts=true` will result in the database going offline with an error
- Added test cases to validate `allow_conflicts=true` cannot be set
- Added workaround to existing test cases to enable allow conflicts

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/65/
