### PR TITLE
CBG-4762 make msg ordering agnostic in test

### DIFF
--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -324,13 +324,8 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 			},
 		}, db.GetAttachmentsFromInlineBody(t, data))
 
-		// message #3 is the getAttachment message that is sent in-between rev processing
-		msg := client.pullReplication.WaitForMessage(3)
-		assert.NotEqual(t, blip.ErrorType, msg.Type(), "Expected non-error blip message type")
-
 		// Check EE is delta, and CE is full-body replication
-		// msg, ok = client.pullReplication.WaitForMessage(5)
-		msg = btcRunner.WaitForBlipRevMessage(client.id, doc1ID, version2)
+		msg := btcRunner.WaitForBlipRevMessage(client.id, doc1ID, version2)
 		// Delta sync only works for Version vectors, CBG-3748 (backwards compatibility for revID)
 		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
 		if sgCanUseDeltas {
@@ -448,7 +443,6 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 
 // TestBlipDeltaSyncPullResend tests that a simple pull replication that uses a delta a client rejects will resend the revision in full.
 func TestBlipDeltaSyncPullResend(t *testing.T) {
-
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Enterprise-only test for delta sync")
 	}
@@ -497,24 +491,54 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		data = btcRunner.WaitForVersion(client.id, docID, docVersion2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":1234567890123}]}`, string(data))
 
-		msg := client.pullReplication.WaitForMessage(5)
-		t.Logf("allMessages: %s\n", client.pullReplication.GetAllMessagesSummary())
+		// Find the two rev messages. Since there will be two rev messages associated with this version, can not use
+		// WaitForBlipRevMessage or GetBlipRevMessage.
+		// The ordering of messages stored by blip client is not 100% guaranteed, so find the
+		// messages by type and sort by serial number.
+		// 1. rev with deltaSrc (rejected)
+		// 2. rev without deltaSrc (accepted)
+		expectedDocVersion2RevID := docVersion2.RevTreeID
+		if client.UseHLV() {
+			expectedDocVersion2RevID = docVersion2.CV.String()
+		}
+		var revMsgs []*blip.Message
+		for _, msg := range client.pullReplication.GetMessages() {
+			if msg.Profile() != db.RevMessageRev {
+				continue
+			}
+			if msg.Properties[db.RevMessageID] != docID {
+				continue
+			}
+			if msg.Properties[db.RevMessageRev] != expectedDocVersion2RevID {
+				continue
+			}
+			revMsgs = append(revMsgs, msg)
+		}
+		require.Len(t, revMsgs, 2, client.pullReplication.GetAllMessagesSummary())
+		var serialNumber []blip.MessageNumber
+		for _, msg := range revMsgs {
+			serialNumber = append(serialNumber, msg.SerialNumber())
+		}
+		revMsg1 := revMsgs[0]
+		revMsg2 := revMsgs[1]
+		if serialNumber[0] > serialNumber[1] {
+			revMsg1 = revMsgs[1]
+			revMsg2 = revMsgs[0]
+		}
 
 		// Check the request was initially sent with the correct deltaSrc property
-		client.AssertDeltaSrcProperty(t, msg, docVersion1)
+		client.AssertDeltaSrcProperty(t, revMsg1, docVersion1)
 
 		// Check the request body was the actual delta
-		msgBody, err := msg.Body()
+		msgBody, err := revMsg1.Body()
 		assert.NoError(t, err)
 		assert.Equal(t, `{"greetings":{"2-":[{"howdy":1234567890123}]}}`, string(msgBody))
 		assert.Equal(t, deltaSentCount+1, rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
 
-		msg = btcRunner.WaitForBlipRevMessage(client.id, docID, docVersion2)
-
 		// Check the resent request was NOT sent with a deltaSrc property
-		assert.Equal(t, "", msg.Properties[db.RevMessageDeltaSrc])
+		assert.Equal(t, "", revMsg2.Properties[db.RevMessageDeltaSrc])
 		// Check the request body was NOT the delta
-		msgBody, err = msg.Body()
+		msgBody, err = revMsg2.Body()
 		assert.NoError(t, err)
 		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":1234567890123}]}}`, string(msgBody))
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":1234567890123}]}`, string(msgBody))
@@ -568,8 +592,10 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		data = btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"_removed":true}`, string(data))
 
-		msg := client.pullReplication.WaitForMessage(5)
+		msg, ok := btcRunner.GetBlipRevMessage(client.id, docID, version)
+		require.True(t, ok)
 		msgBody, err := msg.Body()
+
 		assert.NoError(t, err)
 		assert.Equal(t, `{"_removed":true}`, string(msgBody))
 	})
@@ -642,7 +668,9 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		data = btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{}`, string(data))
 
-		msg := client.pullReplication.WaitForMessage(5)
+		msg, ok := btcRunner.GetBlipRevMessage(client.id, docID, version)
+		require.True(t, ok)
+
 		msgBody, err := msg.Body()
 		assert.NoError(t, err)
 		assert.Equal(t, `{}`, string(msgBody))
@@ -758,17 +786,17 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 		if !assert.Equal(t, db.MessageRev, msg.Profile()) {
 			t.Logf("unexpected profile for message %v in %v",
-				msg.SerialNumber(), client1.pullReplication.GetMessages())
+				msg.SerialNumber(), client1.pullReplication.GetAllMessagesSummary())
 		}
 		msgBody, err := msg.Body()
 		assert.NoError(t, err)
 		if !assert.Equal(t, `{}`, string(msgBody)) {
 			t.Logf("unexpected body for message %v in %v",
-				msg.SerialNumber(), client1.pullReplication.GetMessages())
+				msg.SerialNumber(), client1.pullReplication.GetAllMessagesSummary())
 		}
 		if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
 			t.Logf("unexpected deleted property for message %v in %v",
-				msg.SerialNumber(), client1.pullReplication.GetMessages())
+				msg.SerialNumber(), client1.pullReplication.GetAllMessagesSummary())
 		}
 
 		// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
@@ -779,17 +807,17 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 		if !assert.Equal(t, db.MessageRev, msg.Profile()) {
 			t.Logf("unexpected profile for message %v in %v",
-				msg.SerialNumber(), client2.pullReplication.GetMessages())
+				msg.SerialNumber(), client2.pullReplication.GetAllMessagesSummary())
 		}
 		msgBody, err = msg.Body()
 		assert.NoError(t, err)
 		if !assert.Equal(t, `{}`, string(msgBody)) {
 			t.Logf("unexpected body for message %v in %v",
-				msg.SerialNumber(), client2.pullReplication.GetMessages())
+				msg.SerialNumber(), client2.pullReplication.GetAllMessagesSummary())
 		}
 		if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
 			t.Logf("unexpected deleted property for message %v in %v",
-				msg.SerialNumber(), client2.pullReplication.GetMessages())
+				msg.SerialNumber(), client2.pullReplication.GetAllMessagesSummary())
 		}
 
 		var deltaCacheHitsEnd int64
@@ -950,7 +978,6 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		rt := NewRestTester(t,
 			&rtConfig)
 		defer rt.Close()
-		collection, _ := rt.GetSingleTestDatabaseCollection()
 
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
@@ -969,7 +996,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		btcRunner.StartPushWithOpts(client.id, BlipTesterPushOptions{Continuous: false})
 
 		// Check EE is delta, and CE is full-body replication
-		msg := client.waitForReplicationMessage(collection, 2)
+		msg := client.pushReplication.WaitForBlipRevMessage(docID, newRev)
 
 		if base.IsEnterpriseEdition() && sgCanUseDeltas {
 			// Check the request was sent with the correct deltaSrc property
@@ -1080,7 +1107,6 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		rt := NewRestTester(t,
 			&rtConfig)
 		defer rt.Close()
-		collection, _ := rt.GetSingleTestDatabaseCollection()
 
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
@@ -1100,7 +1126,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		version2 := btcRunner.AddRev(client.id, docID, &version1, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 		// MSG1: proposeChanges
 		// MSG2: rev
-		msg := client.waitForReplicationMessage(collection, 2)
+		msg := client.pushReplication.WaitForBlipRevMessage(docID, version2)
 		require.Equal(t, db.MessageRev, msg.Profile())
 
 		// wait for the reply, indicating the message was written

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -178,7 +178,7 @@ func (rt *RestTester) GetDatabaseRoot(dbname string) DatabaseRoot {
 // WaitForVersion retries a GET for a given document version until it returns 200 or 201 for a given document and revision. If version is not found, the test will fail.
 func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 	if version.RevTreeID == "" {
-		require.NotEqual(rt.TB(), "", version.CV.String(), "Expected CV if RevTreeID in WaitForVersion")
+		require.NotEqual(rt.TB(), "", version.CV.String(), "Expected CV if RevTreeID is empty for version %#v in WaitForVersion", version)
 	}
 	require.EventuallyWithT(rt.TB(), func(c *assert.CollectT) {
 		rawResponse := rt.SendAdminRequest("GET", "/{{.keyspace}}/"+docID, "")


### PR DESCRIPTION
CBG-4762 make msg ordering agnostic in test

In `TestBlipMergeVersions`, the ordering as stored by blip tester can be:

1. subChanges
2. rev
3. changes

but is usually

1. subChanges
2. changes
3. rev

It is hard say when a message should be stored by `BlipTesterCollectionClient` and they are currently stored in defer after the message is processed. However, a `rev` message can be received before the `handleChanges` routine is done.

There are other flakes related to `WaitForMessage` and other functions that get via message ID, so I removed all the functions and get the messages based on the contents of the message rather than the order the message is received.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/66/
