### PR TITLE
CBG-3748 follow-up: Remove test skips / re-enable some BLIP legacy rev delta sync codepaths

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -52,13 +52,12 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "1-12ff9ce1dd501524378fe092ce9aee8f", revid1)
 
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 	rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	if deltasEnabled {
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	} else {
-		// current revs aren't backed up unless both xattrs and deltas are enabled
+		// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}
@@ -71,19 +70,18 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	require.NoError(t, err)
 
 	// now in any case - we'll have rev 1 backed up
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 	rev1OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	require.NoError(t, err)
 	assert.Contains(t, string(rev1OldBody), "hello.txt")
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 
 	// and rev 2 should be present only for the xattrs and deltas case
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 	rev2OldBody, err := collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	if deltasEnabled {
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 	} else {
-		// current revs aren't backed up unless both xattrs and deltas are enabled
+		// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}
@@ -193,7 +191,7 @@ func TestAttachments(t *testing.T) {
 	}, atts)
 
 	log.Printf("Expire body of rev 1, then add a child...") // test fix of #498
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	err = collection.dataStore.Delete(oldRevisionKey("doc1", base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString()))))
 	assert.NoError(t, err, "Couldn't compact old revision")
 	rev2Bstr := `{"_attachments": {"bye.txt": {"stub":true,"revpos":1,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}, "_rev": "2-f000"}`

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -387,8 +387,7 @@ func (bsc *BlipSyncContext) handleChangesResponse(ctx context.Context, sender *b
 
 			var err error
 
-			// fallback to sending full revisions for non hlv aware peers, CBG-3748
-			if deltaSrcRevID != "" && bsc.useHLV() {
+			if deltaSrcRevID != "" {
 				err = bsc.sendRevAsDelta(ctx, sender, docID, rev, deltaSrcRevID, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx)
 			} else {
 				err = bsc.sendRevision(ctx, sender, docID, rev, seq, knownRevs, maxHistory, handleChangesResponseDbCollection, collectionIdx, legacyRev)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1082,6 +1082,8 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 
 func TestGetAvailableRevAttachments(t *testing.T) {
 	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
 	db.Options.StoreLegacyRevTreeData = true
 
 	// TODO: CBG-4840 Only requires delta sync until restoration of non-delta sync RevTree ID revision body backups"
@@ -1090,7 +1092,6 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 	}
 	db.Options.DeltaSyncOptions = DeltaSyncOptions{Enabled: true, RevMaxAgeSeconds: 300}
 
-	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a

--- a/db/database.go
+++ b/db/database.go
@@ -70,13 +70,13 @@ const (
 	DefaultSGReplicateEnabled               = true
 	DefaultSGReplicateWebsocketPingInterval = time.Minute * 5
 	DefaultCompactInterval                  = 24 * time.Hour
+	DefaultStoreLegacyRevTreeData           = true // for 4.0, this is opt-out - we can switch to opt-in at a later date
 )
 
 // Default values for delta sync
 var (
 	DefaultDeltaSyncEnabled   = false
 	DefaultDeltaSyncRevMaxAge = uint32(60 * 60 * 24) // 24 hours in seconds
-	DefaultStoreLegacyRevs    = true                 // for 4.0, this is opt-out - we can switch to opt-in at a later date
 )
 
 var (
@@ -206,6 +206,7 @@ type DatabaseContextOptions struct {
 	NumIndexPartitions            *uint32           // Number of partitions for GSI indexes, if not set will default to 1
 	ImportVersion                 uint64            // Version included in import DCP checkpoints, incremented when collections added to db
 	DisablePublicAllDocs          bool              // Disable public access to the _all_docs endpoint for this database
+	StoreLegacyRevTreeData        bool              // Whether to store additional data for legacy rev tree support in delta sync and replication backup revs
 }
 
 type ConfigPrincipals struct {
@@ -241,7 +242,6 @@ type UserViewsOptions struct {
 type DeltaSyncOptions struct {
 	Enabled          bool   // Whether delta sync is enabled (EE only)
 	RevMaxAgeSeconds uint32 // The number of seconds deltas for old revs are available for
-	StoreLegacyRevs  bool   // Whether to store additional data to allow legacy RevTree ID support for delta sync
 }
 
 type APIEndpoints struct {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -198,7 +198,7 @@ func (c *DatabaseCollection) deltaSyncRevMaxAgeSeconds() uint32 {
 
 // storeLegacyRevTreeData returns true if legacy revision tree pointer data is stored. This is controlled at the database level.
 func (c *DatabaseCollection) storeLegacyRevTreeData() bool {
-	return c.dbCtx.Options.DeltaSyncOptions.StoreLegacyRevs
+	return c.dbCtx.Options.StoreLegacyRevTreeData
 }
 
 // eventMgr manages nofication events. This is controlled at database level.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -820,7 +820,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 		ShardCount:   DefaultRevisionCacheShardCount,
 	}
 	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStat)
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	cv := docRev2.HLV.GetCurrentVersionString()
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", base.Crc32cHashString([]byte(cv)))
 	assert.NoError(t, err, "Purge old revision JSON")
@@ -848,7 +848,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	assert.Equal(t, expectedResult, body)
 
 	// Ensure revision is unavailable for a non-leaf revision that isn't available via the rev cache, and wasn't a channel removal
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	cv = docRev1.HLV.GetCurrentVersionString()
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", base.Crc32cHashString([]byte(cv)))
 	assert.NoError(t, err, "Purge old revision JSON")
@@ -941,7 +941,7 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 
 	// Flush the revision cache and purge the old revision backup.
 	db.FlushRevisionCacheForTest()
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	require.NoError(t, err, "Error purging old revision JSON")
 
@@ -1270,7 +1270,7 @@ func TestGetRemoved(t *testing.T) {
 		ShardCount:   DefaultRevisionCacheShardCount,
 	}
 	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStat)
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -1280,7 +1280,7 @@ func TestGetRemoved(t *testing.T) {
 	require.Nil(t, body)
 
 	// Ensure revision is unavailable for a non-leaf revision that isn't available via the rev cache, and wasn't a channel removal
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -1346,7 +1346,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 		ShardCount:   DefaultRevisionCacheShardCount,
 	}
 	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStats)
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -1356,7 +1356,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	require.Nil(t, body)
 
 	// Ensure revision is unavailable for a non-leaf revision that isn't available via the rev cache, and wasn't a channel removal
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -978,8 +978,8 @@ func TestDeltaSyncWhenFromRevIsLegacyRevTreeID(t *testing.T) {
 	db.Options.DeltaSyncOptions = DeltaSyncOptions{
 		Enabled:          true,
 		RevMaxAgeSeconds: 300,
-		StoreLegacyRevs:  true,
 	}
+	db.Options.StoreLegacyRevTreeData = true
 
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -623,10 +623,17 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 }
 
 func TestBypassRevisionCache(t *testing.T) {
-	t.Skip("Revs are backed up by hash of CV now, test needs to fetch backup rev by revID, CBG-3748 (backwards compatibility for revID)")
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 
 	db, ctx := setupTestDB(t)
+	db.Options.StoreLegacyRevTreeData = true
+
+	// TODO: CBG-4840 Only requires delta sync until restoration of non-delta sync RevTree ID revision body backups"
+	if !base.IsEnterpriseEdition() {
+		t.Skip("CBG-4840 - temp skip see above comment")
+	}
+	db.Options.DeltaSyncOptions = DeltaSyncOptions{Enabled: true, RevMaxAgeSeconds: 300}
+
 	defer db.Close(ctx)
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -626,6 +626,8 @@ func TestBypassRevisionCache(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 
 	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
 	db.Options.StoreLegacyRevTreeData = true
 
 	// TODO: CBG-4840 Only requires delta sync until restoration of non-delta sync RevTree ID revision body backups"
@@ -633,8 +635,6 @@ func TestBypassRevisionCache(t *testing.T) {
 		t.Skip("CBG-4840 - temp skip see above comment")
 	}
 	db.Options.DeltaSyncOptions = DeltaSyncOptions{Enabled: true, RevMaxAgeSeconds: 300}
-
-	defer db.Close(ctx)
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	backingStoreMap := CreateTestSingleBackingStoreMap(collection, testCollectionID)

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -121,11 +121,11 @@ func TestBackupOldRevision(t *testing.T) {
 	assert.Equal(t, "404 missing", err.Error())
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {
+		// TODO: CBG-4840 - Revs are backed only up by hash of CV for non-delta sync cases
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}
@@ -136,16 +136,16 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// now in all cases we'll have rev 1 backed up (for at least 5 minutes)
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	require.NoError(t, err)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
 	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {
+		// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1892,7 +1892,7 @@ func TestGetRemovedDoc(t *testing.T) {
 
 	// Delete any temp revisions in case this prevents the bug from showing up (didn't make a difference)
 	tempRevisionDocID := base.RevPrefix + "foo:5:3-cde"
-	err = rt.GetSingleDataStore().Delete(tempRevisionDocID)
+	_ = rt.GetSingleDataStore().Delete(tempRevisionDocID)
 	// TODO: CBG-4840 - Requires restoration of non-delta sync RevTree revision backups
 	// assert.NoError(t, err, "Unexpected Error")
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2019,7 +2019,7 @@ func TestSendReplacementRevision(t *testing.T) {
 						updatedVersion <- rt.UpdateDoc(docID, version1, fmt.Sprintf(`{"foo":"buzz","channels":["%s"]}`, test.replacementRevChannel))
 
 						// also purge revision backup and flush cache to ensure request for rev 1-... cannot be fulfilled
-						// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+						// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 						cvHash := base.Crc32cHashString([]byte(version1.CV.String()))
 						err := collection.PurgeOldRevisionJSON(ctx, docID, cvHash)
 						require.NoError(t, err)

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1822,8 +1822,7 @@ func TestPutRevV4(t *testing.T) {
 // Actual:
 // - Same as Expected (this test is unable to repro SG #3281, but is being left in as a regression test)
 func TestGetRemovedDoc(t *testing.T) {
-	t.Skip("Revs are backed up by hash of CV now, test needs to fetch backup rev by revID, CBG-3748 (backwards compatibility for revID)")
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
@@ -1894,7 +1893,8 @@ func TestGetRemovedDoc(t *testing.T) {
 	// Delete any temp revisions in case this prevents the bug from showing up (didn't make a difference)
 	tempRevisionDocID := base.RevPrefix + "foo:5:3-cde"
 	err = rt.GetSingleDataStore().Delete(tempRevisionDocID)
-	assert.NoError(t, err, "Unexpected Error")
+	// TODO: CBG-4840 - Requires restoration of non-delta sync RevTree revision backups
+	// assert.NoError(t, err, "Unexpected Error")
 
 	// Try to get rev 3 via BLIP API and assert that _removed == true
 	resultDoc, err = bt2.GetDocAtRev("foo", "3-cde")

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -326,8 +326,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 
 		// Check EE is delta, and CE is full-body replication
 		msg := btcRunner.WaitForBlipRevMessage(client.id, doc1ID, version2)
-		// Delta sync only works for Version vectors, CBG-3748 (backwards compatibility for revID)
-		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
+		sgCanUseDeltas := base.IsEnterpriseEdition()
 		if sgCanUseDeltas {
 			// Check the request was sent with the correct deltaSrc property
 			client.AssertDeltaSrcProperty(t, msg, version)
@@ -412,8 +411,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		msg := btcRunner.WaitForBlipRevMessage(client.id, docID, version2)
 
 		// Check EE is delta, and CE is full-body replication
-		// Delta sync only works for Version vectors, CBG-3748 (backwards compatibility for revID)
-		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
+		sgCanUseDeltas := base.IsEnterpriseEdition()
 		if sgCanUseDeltas {
 			// Check the request was sent with the correct deltaSrc property
 			client.AssertDeltaSrcProperty(t, msg, version)
@@ -458,7 +456,6 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		GuestEnabled: true,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // delta sync not implemented for rev tree replication, CBG-3748
 	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t,
 			&rtConfig)
@@ -687,8 +684,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 			deltasRequestedEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasRequested.Value()
 			deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 		}
-		// delta sync not implemented for rev tree replication, CBG-3748
-		sgCanUseDelta := base.IsEnterpriseEdition() && client.UseHLV()
+		sgCanUseDelta := base.IsEnterpriseEdition()
 		if sgCanUseDelta {
 			assert.Equal(t, deltaCacheHitsStart, deltaCacheHitsEnd)
 			assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
@@ -832,8 +828,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 			deltasSentEnd = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 		}
 
-		// delta sync not implemented for rev tree replication, CBG-3748
-		sgCanUseDelta := base.IsEnterpriseEdition() && client1.UseHLV()
+		sgCanUseDelta := base.IsEnterpriseEdition()
 		if sgCanUseDelta {
 			assert.Equal(t, deltaCacheHitsStart+1, deltaCacheHitsEnd)
 			assert.Equal(t, deltaCacheMissesStart+1, deltaCacheMissesEnd)
@@ -879,7 +874,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		defer client.Close()
 
 		client.ClientDeltas = true
-		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
+		sgCanUseDeltas := base.IsEnterpriseEdition()
 		btcRunner.StartPull(client.id)
 
 		// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
@@ -906,7 +901,6 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 		// Check EE is delta
 		// Check the request was sent with the correct deltaSrc property
-		// delta sync not implemented for rev tree replication, CBG-3748
 		if sgCanUseDeltas {
 			client.AssertDeltaSrcProperty(t, msg, version1)
 		} else {
@@ -947,7 +941,6 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		updatedDeltaCacheHits := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheHit.Value()
 		updatedDeltaCacheMisses := rt.GetDatabase().DbStats.DeltaSync().DeltaCacheMiss.Value()
 
-		// delta sync not implemented for rev tree replication, CBG-3748
 		if sgCanUseDeltas {
 			assert.Equal(t, deltaCacheHits+1, updatedDeltaCacheHits)
 			assert.Equal(t, deltaCacheMisses, updatedDeltaCacheMisses)
@@ -982,7 +975,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer client.Close()
 		client.ClientDeltas = true
-		sgCanUseDeltas := base.IsEnterpriseEdition() && client.UseHLV()
+		sgCanUseDeltas := base.IsEnterpriseEdition()
 
 		btcRunner.StartPull(client.id)
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1874,7 +1874,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	// Flush the rev cache, and issue changes again to ensure successful handling for rev cache misses
 	rt.GetDatabase().FlushRevisionCacheForTest()
 	// Also nuke temporary revision backup of doc_pruned.  Validates that the body for the pruned revision is generated correctly when no longer resident in the rev cache
-	// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 	cvHash := base.Crc32cHashString([]byte(cvs[0]))
 	err = collection.PurgeOldRevisionJSON(ctx, "doc_pruned", cvHash)
 	require.NoError(t, err)

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -174,7 +174,7 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 			Enabled:          base.Ptr(db.DefaultDeltaSyncEnabled),
 			RevMaxAgeSeconds: base.Ptr(db.DefaultDeltaSyncRevMaxAge),
 		},
-		StoreLegacyRevTreeData:           base.Ptr(db.DefaultStoreLegacyRevs),
+		StoreLegacyRevTreeData:           base.Ptr(db.DefaultStoreLegacyRevTreeData),
 		CompactIntervalDays:              base.Ptr(float32(db.DefaultCompactInterval.Hours() / 24)),
 		SGReplicateEnabled:               base.Ptr(db.DefaultSGReplicateEnabled),
 		SGReplicateWebsocketPingInterval: base.Ptr(int(db.DefaultSGReplicateWebsocketPingInterval.Seconds())),

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -216,7 +216,7 @@ func TestXattrImportOldDocRevHistory(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		version = rt.UpdateDoc(docID, version, fmt.Sprintf(`{"val":%d}`, i))
 		// Purge old revision JSON to simulate expiry, and to verify import doesn't attempt multiple retrievals
-		// Revs are backed up by hash of CV now, switch to fetch by this till CBG-3748 (backwards compatibility for revID)
+		// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 		cvHash := base.Crc32cHashString([]byte(cv))
 		purgeErr := collection.PurgeOldRevisionJSON(ctx, docID, cvHash)
 		require.NoError(t, purgeErr)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1212,7 +1212,6 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	deltaSyncOptions := db.DeltaSyncOptions{
 		Enabled:          db.DefaultDeltaSyncEnabled,
 		RevMaxAgeSeconds: db.DefaultDeltaSyncRevMaxAge,
-		StoreLegacyRevs:  db.DefaultStoreLegacyRevs,
 	}
 
 	if config.DeltaSync != nil {
@@ -1229,11 +1228,6 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 			deltaSyncOptions.RevMaxAgeSeconds = *revMaxAge
 		}
 
-	}
-
-	// Database-level legacy revtree storage toggle (renamed from delta_sync.store_legacy_revs)
-	if storeLegacy := config.StoreLegacyRevTreeData; storeLegacy != nil {
-		deltaSyncOptions.StoreLegacyRevs = *storeLegacy
 	}
 	base.InfofCtx(ctx, base.KeyAll, "delta_sync enabled=%t with rev_max_age_seconds=%d for database %s", deltaSyncOptions.Enabled, deltaSyncOptions.RevMaxAgeSeconds, dbName)
 
@@ -1427,6 +1421,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		MaxConcurrentRevs:           sc.Config.Replicator.MaxConcurrentRevs,
 		NumIndexReplicas:            config.numIndexReplicas(),
 		DisablePublicAllDocs:        disablePublicAllDocs,
+		StoreLegacyRevTreeData:      base.ValDefault(config.StoreLegacyRevTreeData, db.DefaultStoreLegacyRevTreeData),
 	}
 
 	if config.Index != nil && config.Index.NumPartitions != nil {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -374,6 +374,9 @@ func (rt *RestTester) Bucket() base.Bucket {
 		if rt.AllowConflicts {
 			rt.DatabaseConfig.AllowConflicts = base.Ptr(true)
 		}
+		if rt.DatabaseConfig.StoreLegacyRevTreeData == nil {
+			rt.DatabaseConfig.StoreLegacyRevTreeData = base.Ptr(db.DefaultStoreLegacyRevTreeData)
+		}
 
 		rt.DatabaseConfig.SGReplicateEnabled = base.Ptr(rt.RestTesterConfig.SgReplicateEnabled)
 


### PR DESCRIPTION
CBG-3748

Follow-up missed in #7718

- Remove test skips
- Restore disabled BLIP replication codepaths for delta sync when using legacy revs
- Remaining test cases still skipped until we store legacy rev revision body backups (non-delta sync case - tracked with another ticket)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/68/
