### PR TITLE
CBG-4841 write legacy rev versions with special encoding

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1351,10 +1351,25 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	forceAllowConflictingTombstone := newDoc.Deleted && (!bh.conflictResolver.IsEmpty() || bh.clientType == BLIPClientTypeSGR2)
 	if bh.useHLV() && changeIsVector {
 		_, _, _, err = bh.collection.PutExistingCurrentVersion(bh.loggingCtx, newDoc, incomingHLV, rawBucketDoc, legacyRevList, isBlipRevTreeProperty, bh.conflictResolver)
-	} else if bh.conflictResolver.revTreeConflictResolver != nil {
-		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, newDoc, history, true, bh.conflictResolver.revTreeConflictResolver, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
 	} else {
-		_, _, err = bh.collection.PutExistingRev(bh.loggingCtx, newDoc, history, revNoConflicts, forceAllowConflictingTombstone, rawBucketDoc, ExistingVersionWithUpdateToHLV)
+		docUpdateEvent := ExistingVersionWithUpdateToHLV
+		if bh.useHLV() {
+			docUpdateEvent = ExistingVersionLegacyRev
+		}
+		opts := putDocOptions{
+			newDoc:                         newDoc,
+			revTreeHistory:                 history,
+			forceAllowConflictingTombstone: forceAllowConflictingTombstone,
+			existingDoc:                    rawBucketDoc,
+			docUpdateEvent:                 docUpdateEvent,
+		}
+		if bh.conflictResolver.revTreeConflictResolver != nil {
+			opts.conflictResolver = bh.conflictResolver.revTreeConflictResolver
+			opts.noConflicts = true
+		} else {
+			opts.noConflicts = revNoConflicts
+		}
+		_, _, err = bh.collection.PutExistingRevWithConflictResolution(bh.loggingCtx, opts)
 	}
 	if err != nil {
 		return err

--- a/db/crud.go
+++ b/db/crud.go
@@ -1031,7 +1031,7 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 		// no hlv update event for testing purposes only (used to simulate pre upgraded write)
 		return d, nil
 	default:
-		return nil, base.RedactErrorf("Unexpected docUpdateEvent %v in updateHLV for doc %s", docUpdateEvent, docUpdateEvent)
+		return nil, base.RedactErrorf("Unexpected docUpdateEvent %v in updateHLV for doc %s", docUpdateEvent, base.UD(d.ID))
 	}
 	d.SyncData.SetCV(d.HLV)
 	return d, nil
@@ -1479,7 +1479,7 @@ type putDocOptions struct {
 	revTreeHistory                 []string                 // list of rev tree IDs. The first entry must be the revtree ID that will be added.
 	docUpdateEvent                 DocUpdateType            // new write, existing write, import etc
 	noConflicts                    bool                     // If true, return 409 on any conflict writes
-	forceAllowConflictingTombstone bool                     // If true, allow an incoming tombstone with a conflicting revtree history to overwrite the existing tombstone document
+	forceAllowConflictingTombstone bool                     // If true, do not flag an incoming tombstone as a conflict if the existing document is a tombstone
 	conflictResolver               *ConflictResolver        // If provided, will be used to resolve conflicts if noConflicts is false and a conflict is detected
 	existingDoc                    *sgbucket.BucketDocument // optional, prevents fetching the document from the bucket
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1016,9 +1016,22 @@ func (db *DatabaseCollectionWithUser) updateHLV(ctx context.Context, d *Document
 		}
 		// update the cvCAS on the SGWrite event too
 		d.HLV.CurrentVersionCAS = expandMacroCASValueUint64
+	case ExistingVersionLegacyRev:
+		revTreeEncodedCV, err := LegacyRevToRevTreeEncodedVersion(d.GetRevTreeID())
+		if err != nil {
+			return nil, err
+		}
+		err = d.HLV.AddVersion(revTreeEncodedCV)
+		if err != nil {
+			return nil, err
+		}
+		// update the cvCAS on the SGWrite event too
+		d.HLV.CurrentVersionCAS = expandMacroCASValueUint64
 	case NoHLVUpdateForTest:
 		// no hlv update event for testing purposes only (used to simulate pre upgraded write)
 		return d, nil
+	default:
+		return nil, base.RedactErrorf("Unexpected docUpdateEvent %v in updateHLV for doc %s", docUpdateEvent, docUpdateEvent)
 	}
 	d.SyncData.SetCV(d.HLV)
 	return d, nil
@@ -1449,24 +1462,45 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 
 // Adds an existing revision to a document along with its history (list of rev IDs.)
 func (db *DatabaseCollectionWithUser) PutExistingRev(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, forceAllConflicts bool, existingDoc *sgbucket.BucketDocument, docUpdateEvent DocUpdateType) (doc *Document, newRevID string, err error) {
-	return db.PutExistingRevWithConflictResolution(ctx, newDoc, docHistory, noConflicts, nil, forceAllConflicts, existingDoc, docUpdateEvent)
+	opts := putDocOptions{
+		newDoc:                         newDoc,
+		revTreeHistory:                 docHistory,
+		noConflicts:                    noConflicts,
+		forceAllowConflictingTombstone: forceAllConflicts,
+		existingDoc:                    existingDoc,
+		docUpdateEvent:                 docUpdateEvent,
+	}
+	return db.PutExistingRevWithConflictResolution(ctx, opts)
 }
 
-// PutExistingRevWithConflictResolution Adds an existing revision to a document along with its history (list of rev IDs.)
+// putDocOptions encapsulates the options for putting a document revision.
+type putDocOptions struct {
+	newDoc                         *Document                // the next contents of the incoming document
+	revTreeHistory                 []string                 // list of rev tree IDs. The first entry must be the revtree ID that will be added.
+	docUpdateEvent                 DocUpdateType            // new write, existing write, import etc
+	noConflicts                    bool                     // If true, return 409 on any conflict writes
+	forceAllowConflictingTombstone bool                     // If true, allow an incoming tombstone with a conflicting revtree history to overwrite the existing tombstone document
+	conflictResolver               *ConflictResolver        // If provided, will be used to resolve conflicts if noConflicts is false and a conflict is detected
+	existingDoc                    *sgbucket.BucketDocument // optional, prevents fetching the document from the bucket
+}
+
+// PutExistingRevWithConflictResolution adds an existing revision to a document along with its history.
 // If this new revision would result in a conflict:
 //  1. If noConflicts == false, the revision will be added to the rev tree as a conflict
 //  2. If noConflicts == true and a conflictResolverFunc is not provided, a 409 conflict error will be returned
 //  3. If noConflicts == true and a conflictResolverFunc is provided, conflicts will be resolved and the result added to the document.
-func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx context.Context, newDoc *Document, docHistory []string, noConflicts bool, conflictResolver *ConflictResolver, forceAllowConflictingTombstone bool, existingDoc *sgbucket.BucketDocument, docUpdateEvent DocUpdateType) (doc *Document, newRevID string, err error) {
-	newRev := docHistory[0]
+func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx context.Context, opts putDocOptions) (doc *Document, newRevID string, err error) {
+	newRev := opts.revTreeHistory[0]
 	generation, _ := ParseRevID(ctx, newRev)
 	if generation < 0 {
 		return nil, "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 
+	newDoc := opts.newDoc
+	docHistory := opts.revTreeHistory
 	allowImport := db.UseXattrs()
 	updateRevCache := true
-	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, docUpdateEvent, existingDoc, false, updateRevCache, func(doc *Document) (resultDoc *Document, resultAttachmentData updatedAttachments, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(ctx, newDoc.ID, allowImport, &newDoc.DocExpiry, nil, opts.docUpdateEvent, opts.existingDoc, false, updateRevCache, func(doc *Document) (resultDoc *Document, resultAttachmentData updatedAttachments, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -1507,13 +1541,13 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithConflictResolution(ctx c
 		// Conflict-free mode check
 
 		// We only bypass conflict resolution for incoming tombstones if the local doc is also a tombstone
-		allowConflictingTombstone := forceAllowConflictingTombstone && doc.IsDeleted()
+		allowConflictingTombstone := opts.forceAllowConflictingTombstone && doc.IsDeleted()
 
-		if !allowConflictingTombstone && db.IsIllegalConflict(ctx, doc, parent, newDoc.Deleted, noConflicts, docHistory) {
-			if conflictResolver == nil {
+		if !allowConflictingTombstone && db.IsIllegalConflict(ctx, doc, parent, newDoc.Deleted, opts.noConflicts, docHistory) {
+			if opts.conflictResolver == nil {
 				return nil, nil, false, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 			}
-			_, updatedHistory, err := db.resolveConflict(ctx, doc, newDoc, docHistory, conflictResolver)
+			_, updatedHistory, err := db.resolveConflict(ctx, doc, newDoc, docHistory, opts.conflictResolver)
 			if err != nil {
 				base.InfofCtx(ctx, base.KeyCRUD, "Error resolving conflict for %s: %v", base.UD(doc.ID), err)
 				return nil, nil, false, nil, err

--- a/db/database.go
+++ b/db/database.go
@@ -53,6 +53,7 @@ const (
 	Import DocUpdateType = iota
 	NewVersion
 	ExistingVersion
+	ExistingVersionLegacyRev
 	ExistingVersionWithUpdateToHLV
 	NoHLVUpdateForTest
 )

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"math/bits"
 	"slices"
 	"sort"
 	"strconv"
@@ -23,6 +24,10 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
+
+// encodedRevTreeSourceID is a base64 encoded value representing a revision that came from a 4.x client with a
+// revtree ID.
+const encodedRevTreeSourceID = "Revision+Tree+Encoding"
 
 type HLVVersions map[string]uint64 // map of source ID to version uint64 version value
 
@@ -518,7 +523,7 @@ func extractHLVFromBlipString(versionVectorStr string) (*HybridLogicalVector, []
 		return nil, nil, err
 	}
 	if legacyRevs != nil {
-		return nil, nil, fmt.Errorf("invalid hlv in changes message received, legacy revID found in cv: %q", vectorFields[0])
+		return nil, nil, fmt.Errorf("invalid hlv in changes message received, legacy revIDs found in cv %s", versionVectorStr)
 	}
 	for i, v := range cvmvList {
 		switch i {
@@ -626,7 +631,7 @@ func isLegacyRev(rev string) bool {
 	return true
 }
 
-// Helper functions for version source and value encoding
+// EncodeSource encodes a source ID in base64 for storage.
 func EncodeSource(source string) string {
 	return base64.StdEncoding.EncodeToString([]byte(source))
 }
@@ -900,4 +905,26 @@ func remoteWinsConflictResolutionForHLV(ctx context.Context, docID string, local
 
 	base.DebugfCtx(ctx, base.KeyVV, "resolved conflict for doc %s in favour of remote wins, resulting HLV: %v", base.UD(docID), newHLV)
 	return newHLV, nil
+}
+
+// LegacyRevToRevTreeEncodedVersion creates a version that has a specific source ID that can be recognized, and the value is
+// able to be the revision + digest.
+func LegacyRevToRevTreeEncodedVersion(legacyRev string) (Version, error) {
+	generation, digest, err := parseRevID(legacyRev)
+	if err != nil {
+		return Version{}, err
+	}
+	// trim to 40 bits (10 hex characters)
+	if len(digest) > 10 {
+		digest = digest[:10]
+	}
+	value, err := strconv.ParseUint(digest, 16, 64)
+	if err != nil {
+		return Version{}, err
+	}
+	value = value << (40 - bits.Len64(value)) // right pad zeros
+	return Version{
+		SourceID: encodedRevTreeSourceID,
+		Value:    (uint64(generation) << 40) | value,
+	}, nil
 }

--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -907,8 +907,10 @@ func remoteWinsConflictResolutionForHLV(ctx context.Context, docID string, local
 	return newHLV, nil
 }
 
-// LegacyRevToRevTreeEncodedVersion creates a version that has a specific source ID that can be recognized, and the value is
-// able to be the revision + digest.
+// LegacyRevToRevTreeEncodedVersion creates a version that has a specific source ID that can be recognized. The version is made up of:
+//
+// - The upper 24 bits of the version are the generation.
+// - The lower 40 bits of the version are the first 40 bits of the digest, which is right padded.
 func LegacyRevToRevTreeEncodedVersion(legacyRev string) (Version, error) {
 	generation, digest, err := parseRevID(legacyRev)
 	if err != nil {

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1674,6 +1674,18 @@ func TestLegacyRevToVersion(t *testing.T) {
 			legacyRev: "12345-e0c8012361e94df6a1e1c2977169480e",
 			version:   "3039e0c8012361@Revision+Tree+Encoding",
 		},
+		{
+			legacyRev: "16777215-abcd",
+			version:   "ffffffabcd000000@Revision+Tree+Encoding",
+		},
+		{
+			legacyRev: "16777216-abcd",
+			version:   "abcd000000@Revision+Tree+Encoding",
+		},
+		{
+			legacyRev: "16777217-abcd",
+			version:   "1abcd000000@Revision+Tree+Encoding",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.legacyRev, func(t *testing.T) {

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1660,3 +1660,26 @@ func TestLocalWinsConflictResolutionForHLV(t *testing.T) {
 		})
 	}
 }
+
+func TestLegacyRevToVersion(t *testing.T) {
+	testCases := []struct {
+		legacyRev string
+		version   string
+	}{
+		{
+			legacyRev: "1-abcd",
+			version:   "1abcd000000@Revision+Tree+Encoding",
+		},
+		{
+			legacyRev: "12345-e0c8012361e94df6a1e1c2977169480e",
+			version:   "3039e0c8012361@Revision+Tree+Encoding",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.legacyRev, func(t *testing.T) {
+			version, err := LegacyRevToRevTreeEncodedVersion(tc.legacyRev)
+			require.NoError(t, err)
+			assert.Equal(t, tc.version, version.String())
+		})
+	}
+}

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -82,12 +82,11 @@ func TestActiveReplicatorPullLegacyRev(t *testing.T) {
 	doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
 
+	encodedCV, err := db.LegacyRevToRevTreeEncodedVersion(legacyRev)
+	require.NoError(t, err)
 	expVersion := rest.DocVersion{
 		RevTreeID: legacyRev,
-		CV: db.Version{
-			SourceID: rt1.GetDatabase().EncodedSourceID,
-			Value:    doc.Cas,
-		},
+		CV:        encodedCV,
 	}
 	rest.RequireDocVersionEqual(t, expVersion, doc.ExtractDocVersion())
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2759,6 +2759,16 @@ func SafeDatabaseName(t *testing.T, name string) string {
 	return dbName
 }
 
+// SafeDocumentName returns a document name free of any special characters for use in tests.
+func SafeDocumentName(t *testing.T, name string) string {
+	docName := strings.ToLower(name)
+	for _, c := range []string{" ", "<", ">", "/", "="} {
+		docName = strings.ReplaceAll(docName, c, "_")
+	}
+	require.Less(t, len(docName), 251, "Document name %s is too long, must be less than 251 characters", name)
+	return docName
+}
+
 func JsonToMap(t *testing.T, jsonStr string) map[string]interface{} {
 	result := make(map[string]interface{})
 	err := json.Unmarshal([]byte(jsonStr), &result)

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -591,7 +591,7 @@ func (btr *BlipTesterReplicator) handleChanges(ctx context.Context, btc *BlipTes
 					changesVersion, err := db.ParseVersion(revID)
 					require.NoError(btr.TB(), err, "error converting revID %q to version: %v", revID, err)
 					localHLV := btcc.getHLV(docID)
-					if localHLV == nil && localHLV.GetCurrentVersionString() == "" {
+					if localHLV == nil {
 						knownRevs[i] = []interface{}{} // sending empty array means we've not seen the doc before, but still want it
 						continue
 					} else if localHLV.DominatesSource(changesVersion) {
@@ -1279,7 +1279,7 @@ func (e proposeChangeBatchEntry) MarshalJSON() ([]byte, error) {
 }
 
 func (e proposeChangeBatchEntry) GoString() string {
-	return fmt.Sprintf("proposeChangeBatchEntry{docID: %q, version:%v,revTreeIDHistory:%v, hlvHistory:%#v, seq:%d, latestServerVersion:%v, isDelete:%t}", e.docID, e.version, e.revTreeIDHistory, e.hlvHistory, e.seq, e.latestServerVersion, e.isDelete)
+	return fmt.Sprintf("proposeChangeBatchEntry{docID:%q, version:%v,revTreeIDHistory:%v, hlvHistory:%#v, seq:%d, latestServerVersion:%v, isDelete:%t}", e.docID, e.version, e.revTreeIDHistory, e.hlvHistory, e.seq, e.latestServerVersion, e.isDelete)
 }
 
 // StartPushWithOpts will begin a push replication with the given options between the client and server

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -293,7 +293,11 @@ func (cd *clientDoc) _proposeChangesEntryForDoc() *proposeChangeBatchEntry {
 			// skip current rev
 			continue
 		}
-		revTreeIDHistory = append(revTreeIDHistory, cd._revisionsBySeq[seq].version.RevTreeID)
+		revtreeID := cd._revisionsBySeq[seq].version.RevTreeID
+		if revtreeID == "" {
+			continue
+		}
+		revTreeIDHistory = append(revTreeIDHistory, revtreeID)
 	}
 	return &proposeChangeBatchEntry{docID: cd.id, version: latestRev.version, revTreeIDHistory: revTreeIDHistory, hlvHistory: *latestRev.HLV.Copy(), latestServerVersion: cd._latestServerVersion, seq: cd._latestSeq, isDelete: latestRev.isDelete}
 }
@@ -583,9 +587,9 @@ func (btr *BlipTesterReplicator) handleChanges(ctx context.Context, btc *BlipTes
 				// Build up a list of revisions known to the client for each change
 				// The first element of each revision list must be the parent revision of the change
 				revList := make([]string, 0, revsLimit)
-				if btc.UseHLV() {
+				if !base.IsRevTreeID(revID) {
 					changesVersion, err := db.ParseVersion(revID)
-					require.NoError(btr.TB(), err, "error parsing version %q: %v", revID, err)
+					require.NoError(btr.TB(), err, "error converting revID %q to version: %v", revID, err)
 					localHLV := btcc.getHLV(docID)
 					if localHLV == nil {
 						knownRevs[i] = []interface{}{} // sending empty array means we've not seen the doc before, but still want it
@@ -1209,13 +1213,23 @@ type proposeChangeBatchEntry struct {
 	isDelete            bool
 }
 
+// historyStr returns the string representation of history.
+// Currently Couchbase Lite sends the full history in proposeChanges requests, but CBL-4461 might change this.
+// Sends history with hlv history appended with legacy revtree id history.
 func (e proposeChangeBatchEntry) historyStr() string {
-	if e.useHLV() {
-		return e.hlvHistory.ToHistoryForHLV()
-	}
 	sb := strings.Builder{}
-	for i, revTreeID := range e.revTreeIDHistory {
-		if i > 0 {
+	needComma := false
+	if e.useHLV() {
+		hlvHistory := e.hlvHistory.ToHistoryForHLV()
+		if hlvHistory != "" {
+			sb.WriteString(hlvHistory)
+			needComma = true
+		}
+	}
+	for _, revTreeID := range e.revTreeIDHistory {
+		if !needComma {
+			needComma = true
+		} else {
 			sb.WriteString(",")
 		}
 		sb.WriteString(revTreeID)
@@ -1254,8 +1268,9 @@ func (e proposeChangeBatchEntry) MarshalJSON() ([]byte, error) {
 	}
 	fmt.Fprintf(output, `["%s","%s"`, e.docID, rev)
 	if e.latestServerVersion.RevTreeID != "" || e.latestServerVersion.CV.Value != 0 {
-		if e.useHLV() {
-			fmt.Fprintf(output, `,"%s"`, e.latestServerVersion.CV.String())
+		cv := e.latestServerVersion.CV.String()
+		if cv != "" {
+			fmt.Fprintf(output, `,"%s"`, cv)
 		} else {
 			fmt.Fprintf(output, `,"%s"`, e.latestServerVersion.RevTreeID)
 		}
@@ -1265,7 +1280,7 @@ func (e proposeChangeBatchEntry) MarshalJSON() ([]byte, error) {
 }
 
 func (e proposeChangeBatchEntry) GoString() string {
-	return fmt.Sprintf("proposeChangeBatchEntry{docID: %q, version:%v,revTreeIDHistory:%v,hlvHistory:%v,seq:%d,latestServerVersion:%v,isDelete: %t}", e.docID, e.version, e.revTreeIDHistory, e.hlvHistory, e.seq, e.latestServerVersion, e.isDelete)
+	return fmt.Sprintf("proposeChangeBatchEntry{docID: %q, version:%v,revTreeIDHistory:%v, hlvHistory:%#v, seq:%d, latestServerVersion:%v, isDelete:%t}", e.docID, e.version, e.revTreeIDHistory, e.hlvHistory, e.seq, e.latestServerVersion, e.isDelete)
 }
 
 // StartPushWithOpts will begin a push replication with the given options between the client and server
@@ -1542,40 +1557,48 @@ func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) {
 	btr.storeMessage(msg)
 }
 
+// blipTesterUpsertOptions contains options for adding a document to a local BlipTesterCollectionClient
+type blipTesterUpsertOptions struct {
+	parentVersion *DocVersion
+	body          []byte
+	isDelete      bool
+	legacyRev     bool // if true, create a legacy revtree revision even if client is using HLV
+}
+
 // upsertDoc will create or update the doc based on whether parentVersion is passed or not. Enforces MVCC update.
-func (btcc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *DocVersion, body []byte, isDelete bool) *clientDocRev {
+func (btcc *BlipTesterCollectionClient) upsertDoc(docID string, opts blipTesterUpsertOptions) *clientDocRev {
 	btcc.seqLock.Lock()
 	defer btcc.seqLock.Unlock()
 	oldSeq, ok := btcc._seqFromDocID[docID]
 	var doc *clientDoc
 	if ok {
-		require.NotNil(btcc.TB(), parentVersion, "docID: %v already exists on the client with seq: %v - expecting to create doc based on not nil parentVersion", docID, oldSeq)
+		require.NotNil(btcc.TB(), opts.parentVersion, "docID: %v already exists on the client with seq: %v - expecting to create doc based on not nil parentVersion", docID, oldSeq)
 		doc, ok = btcc._seqStore[oldSeq]
 		require.True(btcc.TB(), ok, "seq %q for docID %q found but no doc in _seqStore", oldSeq, docID)
 	} else {
-		require.Nil(btcc.TB(), parentVersion, "docID: %v was not found on the client - expecting to create doc based on nil parentVersion, parentVersion=%v", docID, parentVersion)
+		require.Nil(btcc.TB(), opts.parentVersion, "docID: %v was not found on the client - expecting to create doc based on nil parentVersion, parentVersion=%v", docID, opts.parentVersion)
 		doc = newClientDocument(docID, 0, nil)
 	}
 
 	var newGen int = 1
 	var hlv db.HybridLogicalVector
-	if parentVersion != nil {
+	if opts.parentVersion != nil {
 		// grab latest version for this doc and make sure we're doing an upsert on top of it to avoid branching revisions
 		latestRev := doc._latestRev(btcc.TB())
 		latestVersion := latestRev.version
-		require.True(btcc.TB(), parentVersion.CV == latestVersion.CV || parentVersion.RevTreeID == latestVersion.RevTreeID, "latest version for docID: %v is %v, expected parentVersion: %v", docID, latestVersion, parentVersion)
-		if btcc.UseHLV() {
+		require.True(btcc.TB(), opts.parentVersion.CV == latestVersion.CV || opts.parentVersion.RevTreeID == latestVersion.RevTreeID, "latest version for docID: %v is %v, expected parentVersion: %v", docID, latestVersion, opts.parentVersion)
+		if btcc.UseHLV() && !opts.legacyRev {
 			hlv = latestRev.HLV
 		} else {
-			parentGen, _ := db.ParseRevID(btcc.ctx, parentVersion.RevTreeID)
+			parentGen, _ := db.ParseRevID(btcc.ctx, opts.parentVersion.RevTreeID)
 			newGen = parentGen + 1
 		}
 	}
 
-	body = btcc.ProcessInlineAttachments(body, newGen)
+	body := btcc.ProcessInlineAttachments(opts.body, newGen)
 
 	var docVersion DocVersion
-	if btcc.UseHLV() {
+	if btcc.UseHLV() && !opts.legacyRev {
 		newVersion := db.Version{SourceID: btcc.parent.SourceID, Value: uint64(btcc.hlc.Now())}
 		require.NoError(btcc.TB(), hlv.AddVersion(newVersion))
 		docVersion = DocVersion{CV: *hlv.ExtractCurrentVersionFromHLV()}
@@ -1586,7 +1609,7 @@ func (btcc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *D
 	}
 
 	newSeq := btcc._nextSequence()
-	rev := clientDocRev{clientSeq: newSeq, version: docVersion, body: body, HLV: hlv, isDelete: isDelete}
+	rev := clientDocRev{clientSeq: newSeq, version: docVersion, body: body, HLV: hlv, isDelete: opts.isDelete}
 	doc._addNewRev(rev)
 
 	btcc._seqStore[newSeq] = doc
@@ -1602,20 +1625,50 @@ func (btcc *BlipTesterCollectionClient) upsertDoc(docID string, parentVersion *D
 // Delete creates a tombstone for the document and returns a the current DocVersion and hlv. If the BlipTesterCollectionClient is using revtrees, hlv will be nil.
 func (btcc *BlipTesterCollectionClient) Delete(docID string, parentVersion *DocVersion) (DocVersion, *db.HybridLogicalVector) {
 	require.NotNil(btcc.TB(), parentVersion, "parentVersion must be provided for delete operation")
-	newRev := btcc.upsertDoc(docID, parentVersion, []byte(`{}`), true)
+	newRev := btcc.upsertDoc(docID, blipTesterUpsertOptions{
+		parentVersion: parentVersion,
+		body:          []byte(`{}`),
+		isDelete:      true,
+		legacyRev:     false,
+	})
 	return newRev.version, &newRev.HLV
 }
 
 // AddRev creates a revision on the client. This creates a new revision from the parentVersion and returns the new DocVersion.
 // The rev ID is always: "N-abc", where N is rev generation for predictability.
 func (btcc *BlipTesterCollectionClient) AddRev(docID string, parentVersion *DocVersion, body []byte) DocVersion {
-	newRev := btcc.upsertDoc(docID, parentVersion, body, false)
+	newRev := btcc.upsertDoc(docID, blipTesterUpsertOptions{
+		parentVersion: parentVersion,
+		body:          body,
+		isDelete:      false,
+		legacyRev:     false,
+	})
+	return newRev.version
+}
+
+// AddRevTreeRev creates a revision on the client in legacy revision tree format. This is used to create legacy
+// revisions to push to CBL.
+func (btcc *BlipTesterCollectionClient) AddRevTreeRev(docID string, parentVersion *DocVersion, body []byte) DocVersion {
+	if !btcc.UseHLV() {
+		require.FailNow(btcc.TB(), "AddRevTreeRev should only be used when client is using HLV to add legacy revs")
+	}
+	newRev := btcc.upsertDoc(docID, blipTesterUpsertOptions{
+		parentVersion: parentVersion,
+		body:          body,
+		isDelete:      false,
+		legacyRev:     true, // force legacy revtree even though client is using HLV
+	})
 	return newRev.version
 }
 
 // AddHLVRev creates a revision on the client. This returns an HLV in addition to DocVersion and is otherwise identical to AddRev
 func (btc *BlipTesterCollectionClient) AddHLVRev(docID string, parentVersion *DocVersion, body []byte) (DocVersion, *db.HybridLogicalVector) {
-	newRev := btc.upsertDoc(docID, parentVersion, body, false)
+	newRev := btc.upsertDoc(docID, blipTesterUpsertOptions{
+		parentVersion: parentVersion,
+		body:          body,
+		isDelete:      false,
+		legacyRev:     false,
+	})
 	return newRev.version, &newRev.HLV
 }
 
@@ -1691,10 +1744,10 @@ func (btcc *BlipTesterCollectionClient) GetVersion(docID string, docVersion DocV
 	}
 	lastKnownVersion := doc._latestRev(btcc.TB()).version
 	var lookupVersion DocVersion
-	if btcc.UseHLV() {
-		lookupVersion = DocVersion{CV: docVersion.CV}
-	} else {
+	if docVersion.CV.IsEmpty() || !btcc.UseHLV() {
 		lookupVersion = DocVersion{RevTreeID: docVersion.RevTreeID}
+	} else {
+		lookupVersion = DocVersion{CV: docVersion.CV}
 	}
 	revSeq, ok := doc._seqsByVersions[lookupVersion]
 	if !ok {
@@ -1972,6 +2025,11 @@ func (btcRunner *BlipTestClientRunner) AddRev(clientID uint32, docID string, ver
 	return btcRunner.SingleCollection(clientID).AddRev(docID, version, body)
 }
 
+// AddRevTreeRev creates a revision on the client in revtree format. This revision can not have any HLV revisions.
+func (btcRunner *BlipTestClientRunner) AddRevTreeRev(clientID uint32, docID string, version *DocVersion, body []byte) DocVersion {
+	return btcRunner.SingleCollection(clientID).AddRevTreeRev(docID, version, body)
+}
+
 func (btcrunner *BlipTestClientRunner) DeleteDoc(clientID uint32, docID string, version *DocVersion) DocVersion {
 	vrs, _ := btcrunner.SingleCollection(clientID).Delete(docID, version)
 	return vrs
@@ -2086,7 +2144,7 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 		base.DebugfCtx(ctx, base.KeySGTest, "Resolved conflict for docID %q, incomingHLV:%#v, existingHLV:%#v, updatedHLV:%#v", docID, opts.incomingHLV, doc._latestRev(btcc.TB()).HLV, updatedHLV)
 	} else {
 		base.DebugfCtx(ctx, base.KeySGTest, "No conflict")
-		if btcc.UseHLV() {
+		if opts.incomingHLV != nil {
 			// Add the incoming HLV to the local HLV, regardless of winner
 			updatedHLV.UpdateWithIncomingHLV(opts.incomingHLV)
 		}
@@ -2155,7 +2213,7 @@ func (btc *BlipTesterClient) AssertDeltaSrcProperty(t *testing.T, msg *blip.Mess
 func (btc *BlipTesterClient) getVersionsFromRevMessage(msg *blip.Message) (*db.HybridLogicalVector, DocVersion) {
 	revID := msg.Properties[db.RevMessageRev]
 	require.NotEmpty(btc.TB(), revID, "revID is empty in message %#+v", msg.Properties)
-	if !btc.UseHLV() {
+	if base.IsRevTreeID(revID) {
 		return nil, DocVersion{RevTreeID: revID}
 	}
 	hlv, _, err := db.GetHLVFromRevMessage(msg)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -190,9 +190,13 @@ func (rt *RestTester) WaitForVersion(docID string, version DocVersion) {
 		if version.RevTreeID != "" {
 			assert.Equal(c, version.RevTreeID, body.ExtractRev())
 		}
-		if !version.CV.IsEmpty() {
-			assert.Equal(c, version.CV.String(), body[db.BodyCV].(string))
+		if version.CV.IsEmpty() {
+			return
 		}
+		if !assert.Contains(c, body, db.BodyCV) {
+			return
+		}
+		assert.Equal(c, version.CV.String(), body[db.BodyCV].(string))
 	}, 10*time.Second, 50*time.Millisecond)
 }
 


### PR DESCRIPTION
CBG-4841 write legacy rev versions with special encoding

- Writes legacy revs using encoding defined by `LegacyRevToRevTreeEncodedVersion` in https://github.com/couchbase/couchbase-lite-core/pull/2335
- If a document is pushed via blip with V4 subprotocol but a legacy revid, it will have that revid, but use an HLV that has `encoded@Revision+Tree+Encoding`. If pushed via V3 protocol, it will get a revid like 123@cbs1
- Added new test for behavior in `TestLegacyRevBlipTesterClient`, but check if there are cases I am not handling here.
 
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/69/
