### PR TITLE
CBG-4726: Validate disabling xattrs

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2958,6 +2958,7 @@ func TestDatabaseXattrConfigHandlingForDBConfigUpdate(t *testing.T) {
 
 // TestCreateDBWithXattrsDisbaled:
 //   - Test that you cannot create a database with xattrs disabled
+//   - Test that an existing database cannot be loaded with xattrs disabled after upgrade
 //   - Assert error code is returned and response contains error string
 func TestCreateDBWithXattrsDisbaled(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
@@ -2975,6 +2976,15 @@ func TestCreateDBWithXattrsDisbaled(t *testing.T) {
 	resp := rt.CreateDatabase(dbName, dbConfig)
 	RequireStatus(t, resp, http.StatusInternalServerError)
 	assert.Contains(t, resp.Body.String(), errResp)
+
+	dbConfig = rt.NewDbConfig()
+	resp = rt.CreateDatabase(dbName, dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	rt.RestTesterServerContext.dbConfigs[dbName].DatabaseConfig.EnableXattrs = base.Ptr(false)
+
+	_, err := rt.RestTesterServerContext.ReloadDatabase(t.Context(), dbName, false)
+	assert.Error(t, err, errResp)
 }
 
 // TestPvDeltaReadAndWrite:

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2956,11 +2956,11 @@ func TestDatabaseXattrConfigHandlingForDBConfigUpdate(t *testing.T) {
 	}
 }
 
-// TestCreateDBWithXattrsDisbaled:
+// TestCreateDBWithXattrsDisabled:
 //   - Test that you cannot create a database with xattrs disabled
 //   - Test that an existing database cannot be loaded with xattrs disabled after upgrade
 //   - Assert error code is returned and response contains error string
-func TestCreateDBWithXattrsDisbaled(t *testing.T) {
+func TestCreateDBWithXattrsDisabled(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,
 	})


### PR DESCRIPTION
CBG-4726

Describe your PR here...
- Validated disabling xattrs
- Added additional test case to check for the case when an existing config is loaded with disabled xattrs (upgrade scenario)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
