### PR TITLE
CBG-4830 remove test data race

### DIFF
--- a/base/util_test_norace.go
+++ b/base/util_test_norace.go
@@ -14,6 +14,6 @@ package base
 import "testing"
 
 // IsRaceDetectorEnabled returns true if compiled with -race. Intended to be used for testing only.
-func IsRaceDetectorEnabled(t *testing.T) bool {
+func IsRaceDetectorEnabled(t testing.TB) bool {
 	return false
 }

--- a/base/util_test_race.go
+++ b/base/util_test_race.go
@@ -14,6 +14,6 @@ package base
 import "testing"
 
 // IsRaceDetectorEnabled returns true if compiled with -race. Intended to be used for testing only
-func IsRaceDetectorEnabled(t *testing.T) bool {
+func IsRaceDetectorEnabled(t testing.TB) bool {
 	return true
 }

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -810,9 +810,6 @@ func TestReplicationRebalancePull(t *testing.T) {
 	// Increase checkpoint persistence frequency for cross-node status verification
 	defer reduceTestCheckpointInterval(50 * time.Millisecond)()
 
-	// Disable sequence batching for multi-RT tests (pending CBG-1000)
-	defer db.SuspendSequenceBatching()()
-
 	activeRT, remoteRT, remoteURLString := rest.SetupSGRPeers(t)
 
 	// Create docs on remote
@@ -913,9 +910,6 @@ func TestReplicationRebalancePush(t *testing.T) {
 
 	// Increase checkpoint persistence frequency for cross-node status verification
 	defer reduceTestCheckpointInterval(50 * time.Millisecond)()
-
-	// Disable sequence batching for multi-RT tests (pending CBG-1000)
-	defer db.SuspendSequenceBatching()()
 
 	activeRT, remoteRT, remoteURLString := rest.SetupSGRPeers(t)
 
@@ -1075,13 +1069,6 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
-	// Disable sequence batching for multi-RT tests (pending CBG-1000)
-	defer db.SuspendSequenceBatching()()
-
-	// Increase checkpoint persistence frequency for cross-node status verification
-	defer reduceTestCheckpointInterval(50 * time.Millisecond)()
 
 	activeRT, remoteRT, remoteURLString := rest.SetupSGRPeers(t)
 	// Create push replications, verify running, also verify active replicators are created
@@ -1557,8 +1544,6 @@ func TestRequireReplicatorStoppedBeforeUpsert(t *testing.T) {
 func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
 	rt1, rt2, remoteURLString := rest.SetupSGRPeers(t)
 
 	// Add docs to two channels
@@ -1635,8 +1620,6 @@ func TestReplicationMultiCollectionChannelFilter(t *testing.T) {
 
 func TestReplicationConfigChange(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt1, rt2, remoteURLString := rest.SetupSGRPeers(t)
 
@@ -1723,9 +1706,6 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
-
-	// Disable sequence batching for multi-RT tests (pending CBG-1000)
-	defer db.SuspendSequenceBatching()()
 
 	activeRT, remoteRT, remoteURLString := rest.SetupSGRPeers(t)
 
@@ -2310,7 +2290,6 @@ func TestReplicatorReconnectBehaviour(t *testing.T) {
 //   - puts some docs on the remote rest tester and assert the replicator pulls these docs to prove reconnect was successful
 func TestReconnectReplicator(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	testCases := []struct {
 		name       string
@@ -2704,13 +2683,8 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 			// Increase checkpoint persistence frequency for cross-node status verification
 			defer reduceTestCheckpointInterval(50 * time.Millisecond)()
-
-			// Disable sequence batching for multi-RT tests (pending CBG-1000)
-			defer db.SuspendSequenceBatching()()
 
 			// Passive
 			rt2 := rest.NewRestTester(t,
@@ -3747,8 +3721,6 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 func TestActiveReplicatorPullTombstone(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	// Passive
 	rt2 := rest.NewRestTester(t,
@@ -5439,8 +5411,6 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 			for _, timeoutVal := range timeoutVals {
 				t.Run(test.name+" with timeout "+timeoutVal.String(), func(t *testing.T) {
 
-					base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 					// Passive
 					rt2 := rest.NewRestTester(t, nil)
 					defer rt2.Close()
@@ -5978,7 +5948,6 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 func TestSGR2TombstoneConflictHandling(t *testing.T) {
 	base.LongRunningTest(t)
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	t.Skip("CBG-4782: needs rework for version vectors, may be able ot get to work after rev tree reconciliation is done")
 
 	tombstoneTests := []struct {
@@ -6211,7 +6180,6 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	defaultConflictResolverWithTombstoneTests := []struct {
 		name             string   // A unique name to identify the unit test.
@@ -6339,7 +6307,6 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
 	}
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	defaultConflictResolverWithTombstoneTests := []struct {
 		name            string   // A unique name to identify the unit test.
@@ -6831,8 +6798,6 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 }
 
 func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	base.RequireNumTestBuckets(t, 2)
 	// Passive
 	rt2 := rest.NewRestTester(t, nil)
@@ -6898,7 +6863,6 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	// Passive //
 	passiveRT := rest.NewRestTester(t,
@@ -6977,10 +6941,11 @@ func TestUnprocessableDeltas(t *testing.T) {
 		t.Skipf("Requires EE for some delta sync")
 	}
 
+	// need Sync debugging due to AssertLogContains below
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)
 	base.RequireNumTestBuckets(t, 2)
 
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Passive //
 	passiveRT := rest.NewRestTester(t,
@@ -7061,7 +7026,6 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 
 	// Copies the behaviour of TestGetRemovedAsUser but with replication and no user
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Passive //
 	passiveRT := rest.NewRestTester(t, nil)
@@ -7419,7 +7383,6 @@ func TestGroupIDReplications(t *testing.T) {
 	}
 	base.RequireNumTestBuckets(t, 2)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	ctx := base.TestCtx(t)
 	// Create test buckets to replicate between
 	activeBucket := base.GetTestBucket(t)
@@ -7526,7 +7489,6 @@ func TestGroupIDReplications(t *testing.T) {
 
 // Reproduces panic seen in CBG-1053
 func TestAdhocReplicationStatus(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll, base.KeyReplicate)
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SgReplicateEnabled: true})
 	defer rt.Close()
 
@@ -7554,7 +7516,6 @@ func TestSpecifyUserDocsToReplicate(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	testCases := []struct {
 		direction string

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -897,9 +897,10 @@ func RequireChangeRev(t *testing.T, expected DocVersion, changeRev db.ChangeByVe
 	require.Equalf(t, expectedStr, changeRev[versionType], "Expected changeRev[%q]==%s, got %s", versionType, expected.RevTreeID, changeRev[versionType])
 }
 
+// WaitForChanges waits for the specific number of changes to appear. Fails the test harness if more or fewer changes appear.
 func (rt *RestTester) WaitForChanges(numChangesExpected int, changesURL, username string, useAdminPort bool) ChangesResults {
 	waitTime := 20 * time.Second // some tests rely on cbgt import which can be quite slow if it needs to rollback
-	if base.UnitTestUrlIsWalrus() {
+	if base.UnitTestUrlIsWalrus() && !base.IsRaceDetectorEnabled(rt.TB()) {
 		// rosmar will never take a long time, so have faster failures
 		waitTime = 1 * time.Second
 	}

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"github.com/couchbase/sync_gateway/db"
 )
 
 // TestISGRPeerOpts has configuration for ISGR peers in a test setup.
@@ -62,7 +61,6 @@ func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 // PassiveRT has user 'alice' created with star channel access and is listening on an HTTP port.
 func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 	ctx := base.TestCtx(t)
-	db.SuspendSequenceBatching()()
 	// Set up passive RestTester (rt2)
 	passiveTestBucket := base.GetTestBucket(t)
 	t.Cleanup(func() { passiveTestBucket.Close(ctx) })

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
 )
 
 // TestISGRPeerOpts has configuration for ISGR peers in a test setup.
@@ -61,6 +62,7 @@ func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 // PassiveRT has user 'alice' created with star channel access and is listening on an HTTP port.
 func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 	ctx := base.TestCtx(t)
+	db.SuspendSequenceBatching()()
 	// Set up passive RestTester (rt2)
 	passiveTestBucket := base.GetTestBucket(t)
 	t.Cleanup(func() { passiveTestBucket.Close(ctx) })


### PR DESCRIPTION
CBG-4830 remove test data race

I created this data race in https://github.com/couchbase/sync_gateway/pull/7743 when I switch `SetupSGRPeers` to use `t.Cleanup` instead of defer, to make it easier to work with. Since `SuspendSequenceBatching` modifies an unlocked global, if there are still writes when the RestTesters are being torn down, this variable is removed.

Since this line references a ticket long closed, removed disabling sequence batching.

Also removed some extraneous logging for `KeyAll`, which logs gocb/rosmar which we don't care about in tests.

```
WARNING: DATA RACE
14:39:22 Read at 0x0000034227b0 by goroutine 42324:
14:39:22   github.com/couchbase/sync_gateway/db.(*sequenceAllocator)._reserveSequenceBatch()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/sequence_allocator.go:349 +0x88
14:39:22   github.com/couchbase/sync_gateway/db.(*sequenceAllocator)._nextSequence()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/sequence_allocator.go:331 +0x84
14:39:22   github.com/couchbase/sync_gateway/db.(*sequenceAllocator).nextSequence()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/sequence_allocator.go:177 +0x58
14:39:22   github.com/couchbase/sync_gateway/db.(*DatabaseContext).assignSequence()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/crud.go:2332 +0x2d5
14:39:22   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).assignSequence()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/crud.go:2310 +0x116d
14:39:22   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).documentUpdateFunc()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/crud.go:2564 +0x10fc
14:39:22   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).updateAndReturnDoc.func1()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/crud.go:2684 +0x6e9
14:39:22   github.com/couchbaselabs/rosmar.(*Collection).WriteUpdateWithXattrs()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbaselabs/rosmar@v0.0.0-20250226134616-3b9ac157a3cd/collection+xattrs.go:262 +0x8b0
14:39:22   github.com/couchbase/sync_gateway/base.(*LeakyDataStore).WriteUpdateWithXattrs()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/base/leaky_datastore.go:293 +0x365
14:39:22   github.com/couchbase/sync_gateway/base.(*LeakyDataStore).WriteUpdateWithXattrs()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/base/leaky_datastore.go:293 +0x365
14:39:22   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).updateAndReturnDoc()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/crud.go:2662 +0x12c6
14:39:22   github.com/couchbase/sync_gateway/db.(*DatabaseCollectionWithUser).PutExistingCurrentVersion()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/crud.go:1276 +0x716
14:39:22   github.com/couchbase/sync_gateway/db.(*blipHandler).processRev()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/blip_handler.go:1358 +0x30c9
14:39:22   github.com/couchbase/sync_gateway/db.(*blipHandler).handleRev()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/blip_handler.go:1408 +0x3a4
14:39:22   github.com/couchbase/sync_gateway/db.init.collectionBlipHandler.func13()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/blip_handler.go:203 +0x5a2
14:39:22   github.com/couchbase/sync_gateway/db.init.userBlipHandler.func14()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/blip_handler.go:123 +0x70
14:39:22   github.com/couchbase/sync_gateway/db.NewBlipSyncContext.(*BlipSyncContext).register.func2()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/blip_sync_context.go:209 +0x310
14:39:22   github.com/couchbase/go-blip.(*Context).dispatchRequest()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/context.go:319 +0x29b
14:39:22   github.com/couchbase/go-blip.(*receiver).getPendingRequest.func1()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/receiver.go:275 +0x64
14:39:22   github.com/couchbase/go-blip.(*Message).asyncRead.func1()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/message.go:388 +0x127
14:39:22 
14:39:22 Previous write at 0x0000034227b0 by goroutine 42051:
14:39:22   github.com/couchbase/sync_gateway/rest/replicatortest.TestReplicationConcurrentPush.SuspendSequenceBatching.func2()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/util_testing.go:463 +0x30
14:39:22   runtime.deferreturn()
14:39:22       /home/couchbase/cbdeps/go1.24.4/src/runtime/panic.go:610 +0x5d
14:39:22   github.com/couchbase/sync_gateway/rest.(*RestTester).GetDocBodyFromKeyspace()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-b
....
14:39:22   github.com/couchbase/sync_gateway/rest/replicatortest.TestReplicationConcurrentPush()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/rest/replicatortest/replicator_test.go:1088 +0x2f0
14:39:22   github.com/couchbase/sync_gateway/rest.SetupSGRPeers()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/rest/utilities_testing_isgr.go:56 +0x2cf
14:39:22   github.com/couchbase/sync_gateway/rest/replicatortest.TestReplicationConcurrentPush()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/rest/replicatortest/replicator_test.go:1086 +0x2bb
14:39:22   testing.tRunner()
14:39:22       /home/couchbase/cbdeps/go1.24.4/src/testing/testing.go:1792 +0x225
14:39:22   testing.(*T).Run.gowrap1()
14:39:22       /home/couchbase/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x44
14:39:22 
14:39:22 Goroutine 42324 (running) created at:
14:39:22   github.com/couchbase/go-blip.(*Message).asyncRead()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/message.go:374 +0x24c
14:39:22   github.com/couchbase/go-blip.(*receiver).getPendingRequest()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/receiver.go:274 +0x2ec
14:39:22   github.com/couchbase/go-blip.(*receiver).processFrame()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/receiver.go:229 +0x1ca
14:39:22   github.com/couchbase/go-blip.(*receiver).handleIncomingFrame()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/receiver.go:218 +0xc16
14:39:22   github.com/couchbase/go-blip.(*receiver).parseLoop()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/receiver.go:115 +0x204
14:39:22   github.com/couchbase/go-blip.(*receiver).receiveLoop.gowrap2()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/godeps/pkg/mod/github.com/couchbase/go-blip@v0.0.0-20250325132327-d73efab2df06/receiver.go:70 +0x33
14:39:22 
14:39:22 Goroutine 42051 (running) created at:
14:39:22   testing.(*T).Run()
14:39:22       /home/couchbase/cbdeps/go1.24.4/src/testing/testing.go:1851 +0x8f2
14:39:22   testing.runTests.func1()
14:39:22       /home/couchbase/cbdeps/go1.24.4/src/testing/testing.go:2279 +0x85
14:39:22   testing.tRunner()
14:39:22       /home/couchbase/cbdeps/go1.24.4/src/testing/testing.go:1792 +0x225
14:39:22   testing.runTests()
14:39:22       /home/couchbase/cbdeps/go1.24.4/src/testing/testing.go:2277 +0x96c
14:39:22   testing.(*M).Run()
14:39:22       /home/couchbase/cbdeps/go1.24.4/src/testing/testing.go:2142 +0xeea
14:39:22   github.com/couchbase/sync_gateway/base.TestBucketPoolMain()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/base/main_test_bucket_pool.go:812 +0x6f8
14:39:22   github.com/couchbase/sync_gateway/db.TestBucketPoolWithIndexes()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/db/util_testing.go:524 +0x1c4
14:39:22   github.com/couchbase/sync_gateway/rest.TestBucketPoolRestWithIndexes()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/rest/utilities_testing.go:2806 +0x103
14:39:22   github.com/couchbase/sync_gateway/rest/replicatortest.TestMain()
14:39:22       /home/couchbase/jenkins/workspace/sgw-unix-build/4.0.0/community/sync_gateway/rest/replicatortest/main_test.go:24 +0x1ab
14:39:22   main.main()
14:39:22       _testmain.go:275 +0x16d
```
