### PR TITLE
CBG-4811: logging changes for versions

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1375,7 +1375,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				if len(opts.RevTreeHistory) > 0 && !opts.AlignRevTrees {
 					parent, currentRevIndex, err := db.revTreeConflictCheck(ctx, opts.RevTreeHistory, doc, opts.NewDoc.Deleted)
 					if err != nil {
-						base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %#v, local version %#v, and conflict found in rev tree history", base.UD(doc.ID), opts.NewDocHLV.ExtractCurrentVersionFromHLV(), doc.HLV.ExtractCurrentVersionFromHLV())
+						base.DebugfCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, and conflict found in rev tree history", base.UD(doc.ID))
 						return nil, nil, false, nil, err
 					}
 					_, err = doc.addNewerRevisionsToRevTreeHistory(opts.NewDoc, currentRevIndex, parent, opts.RevTreeHistory)
@@ -1385,7 +1385,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 					revTreeAlignedForCBL = true // we have aligned the rev tree for CBL push here so skip later in function
 					doc.HLV.UpdateWithIncomingHLV(opts.NewDocHLV)
 				} else {
-					base.DebugfCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %#v, local version %#v", base.UD(doc.ID), opts.NewDocHLV.ExtractCurrentVersionFromHLV(), doc.HLV.ExtractCurrentVersionFromHLV())
+					base.DebugfCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s", base.UD(doc.ID))
 					if opts.ConflictResolver == nil {
 						// cancel rest of update, HLV is in conflict and no resolver is present
 						return nil, nil, false, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")

--- a/db/crud.go
+++ b/db/crud.go
@@ -1375,7 +1375,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				if len(opts.RevTreeHistory) > 0 && !opts.AlignRevTrees {
 					parent, currentRevIndex, err := db.revTreeConflictCheck(ctx, opts.RevTreeHistory, doc, opts.NewDoc.Deleted)
 					if err != nil {
-						base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %s, local version %s, and conflict found in rev tree history", base.UD(doc.ID), opts.NewDocHLV.GetCurrentVersionString(), doc.HLV.GetCurrentVersionString())
+						base.InfofCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %#v, local version %#v, and conflict found in rev tree history", base.UD(doc.ID), opts.NewDocHLV.ExtractCurrentVersionFromHLV(), doc.HLV.ExtractCurrentVersionFromHLV())
 						return nil, nil, false, nil, err
 					}
 					_, err = doc.addNewerRevisionsToRevTreeHistory(opts.NewDoc, currentRevIndex, parent, opts.RevTreeHistory)
@@ -1385,7 +1385,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 					revTreeAlignedForCBL = true // we have aligned the rev tree for CBL push here so skip later in function
 					doc.HLV.UpdateWithIncomingHLV(opts.NewDocHLV)
 				} else {
-					base.DebugfCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %v, local version %v", base.UD(doc.ID), opts.NewDocHLV.ExtractCurrentVersionFromHLV(), doc.HLV.ExtractCurrentVersionFromHLV())
+					base.DebugfCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, incoming version %#v, local version %#v", base.UD(doc.ID), opts.NewDocHLV.ExtractCurrentVersionFromHLV(), doc.HLV.ExtractCurrentVersionFromHLV())
 					if opts.ConflictResolver == nil {
 						// cancel rest of update, HLV is in conflict and no resolver is present
 						return nil, nil, false, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1699,6 +1699,30 @@ func TestPutRevConflictsMode(t *testing.T) {
 
 }
 
+func TestSendBranchedTreeNoConflicts(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		connectingUsername: "user1",
+	})
+	defer bt.Close()
+
+	//bt.restTester.GetDatabase().EnableAllowConflicts(bt.TB())
+
+	sent, _, resp, err := bt.SendRevWithHistory("doc1", "2-abc", []string{"1-abc"}, []byte(`{"key": "val"}`), blip.Properties{})
+	assert.True(t, sent)
+	require.NoError(t, err)                            // no error
+	assert.Equal(t, "", resp.Properties["Error-Code"]) // no error
+
+	sent, _, resp, err = bt.SendRevWithHistory("doc1", "3-def", []string{"2-def", "1-abc"}, []byte(`{"key": "val"}`), blip.Properties{})
+	assert.True(t, sent)
+	require.NoError(t, err)                            // no error
+	assert.Equal(t, "", resp.Properties["Error-Code"]) // no error
+
+	doc := bt.restTester.GetDocument("doc1")
+	fmt.Println(doc.History)
+}
+
 // TestPutRevV4:
 //   - Create blip tester to run with V4 protocol
 //   - Use send rev with CV defined in rev field and history field with PV/MV defined

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1699,30 +1699,6 @@ func TestPutRevConflictsMode(t *testing.T) {
 
 }
 
-func TestSendBranchedTreeNoConflicts(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
-	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		connectingUsername: "user1",
-	})
-	defer bt.Close()
-
-	//bt.restTester.GetDatabase().EnableAllowConflicts(bt.TB())
-
-	sent, _, resp, err := bt.SendRevWithHistory("doc1", "2-abc", []string{"1-abc"}, []byte(`{"key": "val"}`), blip.Properties{})
-	assert.True(t, sent)
-	require.NoError(t, err)                            // no error
-	assert.Equal(t, "", resp.Properties["Error-Code"]) // no error
-
-	sent, _, resp, err = bt.SendRevWithHistory("doc1", "3-def", []string{"2-def", "1-abc"}, []byte(`{"key": "val"}`), blip.Properties{})
-	assert.True(t, sent)
-	require.NoError(t, err)                            // no error
-	assert.Equal(t, "", resp.Properties["Error-Code"]) // no error
-
-	doc := bt.restTester.GetDocument("doc1")
-	fmt.Println(doc.History)
-}
-
 // TestPutRevV4:
 //   - Create blip tester to run with V4 protocol
 //   - Use send rev with CV defined in rev field and history field with PV/MV defined


### PR DESCRIPTION
CBG-4811

Small PR to make some changes to how versions are logged to use GoString() interface instead of String() interface.

Some logging has not changed given I feel like it makes more sense we log in transport format for replication communication. Such as:
```
2025-09-17T13:44:45.445Z [DBG] Changes+: c:TestActiveReplicatorMultiCollection-push db:rt1_active col:sg_test_0 MultiChangesFeed sending <ud>{Seq:1, ID:active-doc1, Changes:[map[cv:186615cf67fb0000@Gtq2Kq2aBVMhTdta1sBE9w]]}</ud> <ud>  (to ADMIN)</ud

2025-09-17T13:44:45.447Z [DBG] Sync+: c:TestActiveReplicatorMultiCollection-push db:rt1_active col:sg_test_0 Sending rev "<ud>active-doc1</ud>" 186615cf67fb0000@Gtq2Kq2aBVMhTdta1sBE9w based on 0 known, digests: []

2025-09-17T13:45:58.984Z [DBG] SyncMsg+: c:TestActiveReplicatorRemoteWinsCases/local_doc_has_MV_defined_before_conflict_res-pull db:activedb col:sg_test_0 #3: Type:rev Id:<ud>doc1_</ud> Collection:0 Rev:186615e099660000@1tnlc9bYt6RQa0QFcyHoQA Sequence:2

2025-09-17T13:46:40.072Z [DBG] Sync+: c:[5dafa359] db:passivedb Peer didn't want revision <ud>doc1_merge</ud> / 186615ea285f0000@Gtq2Kq2aBVMhTdta1sBE9w (seq:3)
``` 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
