### PR TITLE
CBG-4856 do not create merge versions for remote wins/local wins

### DIFF
--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -22,12 +22,12 @@ import (
 
 // Bits in LogEntry.Flags
 const (
-	Deleted  = 1 << iota // This rev is a deletion
-	Removed              // Doc was removed from this channel
-	Hidden               // This rev is not the default (hidden by a conflict)
-	Conflict             // Document is in conflict at this time
-	Branched             // Revision tree is branched
-	Added                // Doc was added to this channel
+	Deleted           = 1 << iota // This rev is a deletion
+	Removed                       // Doc was removed from this channel
+	Hidden                        // This rev is not the default (hidden by a conflict)
+	Conflict                      // Document is in conflict at this time
+	Branched                      // Revision tree is branched
+	VVUpdateWithoutCV             // This rev is the result of a local/remote wins conflict resolution and has an updated vv but not a CV update
 
 )
 

--- a/channels/log_entry.go
+++ b/channels/log_entry.go
@@ -22,13 +22,13 @@ import (
 
 // Bits in LogEntry.Flags
 const (
-	Deleted           = 1 << iota // This rev is a deletion
-	Removed                       // Doc was removed from this channel
-	Hidden                        // This rev is not the default (hidden by a conflict)
-	Conflict                      // Document is in conflict at this time
-	Branched                      // Revision tree is branched
-	VVUpdateWithoutCV             // This rev is the result of a local/remote wins conflict resolution and has an updated vv but not a CV update
-
+	Deleted     = 1 << iota // This rev is a deletion
+	Removed                 // Doc was removed from this channel
+	Hidden                  // This rev is not the default (hidden by a conflict)
+	Conflict                // Document is in conflict at this time
+	Branched                // Revision tree is branched
+	Added                   // Doc was added to this channel
+	UnchangedCV             // This rev has updated metadata but the CV doesn't change
 )
 
 // LogEntry stores information about a change to a document in a cache.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -927,7 +927,7 @@ func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sen
 		if !bsc.useHLV() {
 			history = toHistory(redactedRev.History, knownRevs, maxHistory)
 		} else {
-			history = append(history, redactedRev.hlvHistory)
+			history = append(history, redactedRev.HlvHistory)
 		}
 		if bsc.sendRevTreeProperty() {
 			revTreeProperty = append(revTreeProperty, redactedRev.RevID)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -752,8 +752,8 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 	if !bsc.useHLV() || localIsLegacyRev {
 		history = toHistory(docRev.History, knownRevs, maxHistory)
 	} else {
-		if docRev.hlvHistory != "" {
-			history = append(history, docRev.hlvHistory)
+		if docRev.HlvHistory != "" {
+			history = append(history, docRev.HlvHistory)
 		}
 	}
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -506,8 +506,8 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 		collection.revisionCache.RemoveRevOnly(ctx, docID, syncData.GetRevTreeID())
 	}
 	// remove the local doc from the revision cache if the change is a result of a conflict resolution that resulted
-	// in local/remote wins, given the HLV will have been updated but CV not changed
-	if syncData.Flags&channels.VVUpdateWithoutCV != 0 {
+	// in local wins, given the HLV will have been updated but CV not changed
+	if syncData.Flags&channels.UnchangedCV != 0 {
 		vrs := Version{
 			SourceID: syncData.RevAndVersion.CurrentSource,
 			Value:    base.HexCasToUint64(syncData.RevAndVersion.CurrentVersion),

--- a/db/crud.go
+++ b/db/crud.go
@@ -2153,7 +2153,7 @@ func (doc *Document) updateWinningRevAndSetDocFlags(ctx context.Context) {
 	doc.setFlag(channels.Deleted, doc.History[revtreeID].Deleted)
 	doc.setFlag(channels.Conflict, inConflict)
 	doc.setFlag(channels.Branched, branched)
-	doc.setFlag(channels.VVUpdateWithoutCV, doc.localWinsConflict)
+	doc.setFlag(channels.UnchangedCV, doc.localWinsConflict)
 	if doc.hasFlag(channels.Deleted) {
 		doc.SyncData.TombstonedAt = time.Now().Unix()
 	} else {

--- a/db/document.go
+++ b/db/document.go
@@ -282,12 +282,13 @@ type Document struct {
 	rawUserXattr       []byte              // Raw user xattr as retrieved from the bucket
 	MetadataOnlyUpdate *MetadataOnlyUpdate // Contents of _mou xattr, marshalled/unmarshalled with document from xattrs
 
-	HLV            *HybridLogicalVector // Contents of _vv xattr,
-	Deleted        bool
-	DocExpiry      uint32
-	RevID          string
-	inlineSyncData bool
-	RevSeqNo       uint64 // Server rev seq no for a document
+	HLV               *HybridLogicalVector // Contents of _vv xattr,
+	Deleted           bool
+	DocExpiry         uint32
+	RevID             string
+	inlineSyncData    bool
+	localWinsConflict bool   // True if this document is the result of a local-wins conflict resolution
+	RevSeqNo          uint64 // Server rev seq no for a document
 }
 
 // GlobalSyncData is the structure for the system xattr that is migrated with XDCR.

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1093,7 +1093,7 @@ func TestHLVInvalidateMV(t *testing.T) {
 	}
 }
 
-func TestAddVersion(t *testing.T) {
+func TestHLVAddVersion(t *testing.T) {
 	testCases := []struct {
 		name        string
 		initialHLV  string
@@ -1246,7 +1246,7 @@ func TestAddVersion(t *testing.T) {
 	}
 }
 
-func TestIsInConflict(t *testing.T) {
+func TestHLVIsInConflict(t *testing.T) {
 	testCases := []struct {
 		name        string
 		localHLV    string
@@ -1580,67 +1580,67 @@ func TestLocalWinsConflictResolutionForHLV(t *testing.T) {
 			name:        "local doc has MV remote does not",
 			localHLV:    "20@abc,10@def,11@efg;5@foo",
 			remoteHLV:   "10@xyz;8@foo,9@bar",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@xyz,20@abc;10@def,11@efg,8@foo,9@bar",
+			expectedHLV: "20@abc,10@def,11@efg;10@xyz,8@foo,9@bar",
 		},
 		{
 			name:        "local doc has no MV and remote does",
 			localHLV:    "20@abc;5@foo",
 			remoteHLV:   "11@xyz,10@def,11@efg;7@foo",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,11@xyz,20@abc;10@def,11@efg,7@foo",
+			expectedHLV: "20@abc;11@xyz,10@def,11@efg,7@foo",
 		},
 		{
 			name:        "local HLV had CV in common with remote HLV PV",
 			localHLV:    "20@abc;5@foo",
 			remoteHLV:   "11@xyz;7@foo,10@abc",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,11@xyz,20@abc;7@foo",
+			expectedHLV: "20@abc;11@xyz,7@foo",
 		},
 		{
 			name:        "remote HLV had CV in common with local HLV PV",
 			localHLV:    "20@abc;5@foo,10@xyz",
 			remoteHLV:   "11@xyz;7@foo",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,20@abc,11@xyz;7@foo",
+			expectedHLV: "20@abc;11@xyz,7@foo",
 		},
 		{
 			name:        "local hlv has MV entry less than remote hlv",
 			localHLV:    "10@abc,1@def,3@efg;1@foo",
 			remoteHLV:   "2@xyz,8@def,9@efg;1@foo",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,2@xyz,10@abc;8@def,9@efg,1@foo",
+			expectedHLV: "10@abc;2@xyz,8@def,9@efg,1@foo",
 		},
 		{
 			name:        "local hlv has PV entry less than remote hlv PV entry",
 			localHLV:    "10@abc;1@foo,3@def",
 			remoteHLV:   "2@xyz;8@def,9@efg,4@foo",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,2@xyz,10@abc;4@foo,8@def,9@efg",
+			expectedHLV: "10@abc;2@xyz,4@foo,8@def,9@efg",
 		},
 		{
 			name:        "local hlv has MV entry greater than remote hlv",
 			localHLV:    "10@abc,10@def,11@efg;1@foo",
 			remoteHLV:   "2@xyz,8@def,9@efg;1@bar",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,2@xyz;11@efg,1@foo,1@bar,10@def",
+			expectedHLV: "10@abc,10@def,11@efg;2@xyz,1@bar,1@foo",
 		},
 		{
 			name:        "local hlv has PV entry greater than remote hlv PV entry",
 			localHLV:    "10@abc;10@foo,11@def",
 			remoteHLV:   "2@xyz;8@def,9@efg",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,2@xyz;11@def,9@efg,10@foo",
+			expectedHLV: "10@abc;2@xyz,11@def,9@efg,10@foo",
 		},
 		{
 			name:        "both local and remote have mv and no common sources",
 			localHLV:    "10@abc,10@def,11@efg;1@foo",
 			remoteHLV:   "2@xyz,8@lmn,9@pqr;1@bar",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,2@xyz;10@def,11@efg,8@lmn,9@pqr,1@bar,1@foo",
+			expectedHLV: "10@abc,10@def,11@efg;2@xyz,8@lmn,9@pqr,1@bar,1@foo",
 		},
 		{
-			name:        "both lcoal and remote have no common sources in PV",
+			name:        "both local and remote have no common sources in PV",
 			localHLV:    "10@abc;1@foo",
 			remoteHLV:   "20@xyz;2@bar",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,20@xyz;1@foo,2@bar",
+			expectedHLV: "10@abc;20@xyz,1@foo,2@bar",
 		},
 		{
 			name:        "local hlv has cv less than remote hlv",
 			localHLV:    "10@abc;1@foo",
 			remoteHLV:   "20@xyz;2@foo",
-			expectedHLV: "FFFFFFFFFFFFFFFF@testSource,10@abc,20@xyz;2@foo",
+			expectedHLV: "10@abc;20@xyz,2@foo",
 		},
 	}
 	for _, tc := range testCases {
@@ -1650,7 +1650,7 @@ func TestLocalWinsConflictResolutionForHLV(t *testing.T) {
 			remoteHLV, _, err := extractHLVFromBlipString(tc.remoteHLV)
 			require.NoError(t, err)
 
-			localWinsHLV, err := localWinsConflictResolutionForHLV(t.Context(), localHLV, remoteHLV, "testDoc", "testSource")
+			localWinsHLV, err := localWinsConflictResolutionForHLV(t.Context(), localHLV, remoteHLV, "testDoc")
 			require.NoError(t, err)
 
 			expectedHLV, _, err := extractHLVFromBlipString(tc.expectedHLV)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -47,7 +47,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.ToHistoryForHLV()
+		docRev.HlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)
@@ -74,7 +74,7 @@ func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.ToHistoryForHLV()
+		docRev.HlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)
@@ -101,7 +101,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 	}
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.hlvHistory = hlv.ToHistoryForHLV()
+		docRev.HlvHistory = hlv.ToHistoryForHLV()
 	}
 
 	rc.bypassStat.Add(1)

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -208,7 +208,7 @@ type DocumentRevision struct {
 	Removed     bool  // True if the revision is a removal.
 	MemoryBytes int64 // storage of the doc rev bytes measurement, includes size of delta when present too
 	CV          *Version
-	hlvHistory  string
+	HlvHistory  string
 }
 
 // MutableBody returns a deep copy of the given document revision as a plain body (without any special properties)
@@ -390,7 +390,7 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 		AttachmentStorageMeta: toRevAttStorageMeta,
 		ToChannels:            toRevision.Channels,
 		RevisionHistory:       toRevision.History.parseAncestorRevisions(fromRevID),
-		HlvHistory:            toRevision.hlvHistory,
+		HlvHistory:            toRevision.HlvHistory,
 		ToDeleted:             deleted,
 	}
 	revDelta.CalculateDeltaBytes()

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -729,7 +729,7 @@ func (value *revCacheValue) asDocumentRevision(delta *RevisionDelta) (DocumentRe
 		Attachments: value.attachments.ShallowCopy(), // Avoid caller mutating the stored attachments
 		Deleted:     value.deleted,
 		Removed:     value.removed,
-		hlvHistory:  value.hlvHistory,
+		HlvHistory:  value.hlvHistory,
 	}
 	// only populate CV if we have a value
 	if !value.cv.IsEmpty() {
@@ -802,7 +802,7 @@ func (value *revCacheValue) store(docRev DocumentRevision) {
 		value.deleted = docRev.Deleted
 		value.err = nil
 		value.itemBytes.Store(docRev.MemoryBytes)
-		value.hlvHistory = docRev.hlvHistory
+		value.hlvHistory = docRev.HlvHistory
 	}
 	value.lock.Unlock()
 	value.canEvict.Store(true) // now we have stored the doc revision in the cache, we can allow eviction

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -355,11 +355,7 @@ func (btcc *BlipTesterCollectionClient) _resolveConflictLWW(incomingHLV *db.Hybr
 		updatedHLV.UpdateWithIncomingHLV(incomingHLV)
 		return incomingBody, *updatedHLV
 	}
-	newCV := db.Version{
-		SourceID: btcc.parent.SourceID,
-		Value:    uint64(btcc.hlc.Now()),
-	}
-	require.NoError(btcc.TB(), updatedHLV.MergeWithIncomingHLV(newCV, incomingHLV))
+	incomingHLV.UpdateWithIncomingHLV(updatedHLV)
 	return latestLocalRev.body, *updatedHLV
 }
 

--- a/topologytest/main_test.go
+++ b/topologytest/main_test.go
@@ -20,15 +20,6 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 )
 
-func skipMobileJenkinsCBG4826(t *testing.T) {
-	// these tests fail on slow machines but could flake under any machine
-	mobileJenkins := "https://mobile.jenkins.couchbase.com/"
-	if os.Getenv("JENKINS_URL") == mobileJenkins {
-		t.Skipf("Skipping topology tests on %s until CBG-4856 is resolved. There are race conditions which occur on slow machines and are pending investigation", mobileJenkins)
-
-	}
-}
-
 func TestMain(m *testing.M) {
 	ctx := context.Background() // start of test process
 	runTests, _ := strconv.ParseBool(os.Getenv(base.TbpEnvTopologyTests))

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -18,7 +18,6 @@ import (
 //  3. wait for documents to exist with a matching CV for Couchbase Lite peers, and a full HLV match for non Couchbase
 //     Lite peers. The body should match.
 func TestMultiActorConflictCreate(t *testing.T) {
-	skipMobileJenkinsCBG4826(t)
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -41,7 +40,6 @@ func TestMultiActorConflictCreate(t *testing.T) {
 //  7. wait for documents to exist with a matching CV for Couchbase Lite peers, and a full HLV match for non Couchbase
 //     Lite peers. The body should match.
 func TestMultiActorConflictUpdate(t *testing.T) {
-	skipMobileJenkinsCBG4826(t)
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -70,7 +68,6 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 // 6. start replications
 // 7. assert that the documents are deleted on all peers and have hlv sources equal to the number of active peers
 func TestMultiActorConflictDelete(t *testing.T) {
-	skipMobileJenkinsCBG4826(t)
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -106,7 +103,6 @@ func TestMultiActorConflictDelete(t *testing.T) {
 //  11. assert that the documents are resurrected on all peers and have matching hlvs for non Couchbase Lite peers and
 //     matching CV for Couchbase Lite peers.
 func TestMultiActorConflictResurrect(t *testing.T) {
-	skipMobileJenkinsCBG4826(t)
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)


### PR DESCRIPTION
CBG-4856 do not create merge versions for remote wins/local wins

- Only create new merge versions if there is a change in body.
- The way the ISGR  tests are modified is a bit messy but out of scope for this change.
- Fix an edge case merging two vv: 	`"10@abc,1@def,3@efg;1@foo"` and   `"2@xyz,8@def,9@efg;1@foo"`, this is the change in `UpdateHistory`

This change and https://github.com/couchbase/couchbase-lite-core/pull/2352 should match behavior

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/92/
