### PR TITLE
CBG-4870 avoid test flakes

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2046,7 +2046,7 @@ func TestSendReplacementRevision(t *testing.T) {
 					_ = btcRunner.SingleCollection(btc.id).WaitForVersion(docID, version2)
 
 					// rev message with a replacedRev property referring to the originally requested rev
-					msg2, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version2)
+					msg2, ok := btcRunner.SingleCollection(btc.id).GetPullRevMessage(docID, version2)
 					require.True(t, ok)
 					assert.Equal(t, db.MessageRev, msg2.Profile())
 					assert.Equal(t, version2.RevTreeID, msg2.Properties[db.RevMessageRev])
@@ -2054,7 +2054,7 @@ func TestSendReplacementRevision(t *testing.T) {
 
 					// the blip test framework records a message entry for the originally requested rev as well, but it should point to the message sent for rev 2
 					// this is an artifact of the test framework to make assertions for tests not explicitly testing replacement revs easier
-					msg1, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version1)
+					msg1, ok := btcRunner.SingleCollection(btc.id).GetPullRevMessage(docID, version1)
 					require.True(t, ok)
 					assert.Equal(t, msg1, msg2)
 
@@ -2066,11 +2066,11 @@ func TestSendReplacementRevision(t *testing.T) {
 					assert.Nil(t, data)
 
 					// no message for rev 2
-					_, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version2)
+					_, ok := btcRunner.SingleCollection(btc.id).GetPullRevMessage(docID, version2)
 					require.False(t, ok)
 
 					// norev message for the requested rev
-					msg, ok := btcRunner.SingleCollection(btc.id).GetBlipRevMessage(docID, version1)
+					msg, ok := btcRunner.SingleCollection(btc.id).GetPullRevMessage(docID, version1)
 					require.True(t, ok)
 					assert.Equal(t, db.MessageNoRev, msg.Profile())
 
@@ -2119,7 +2119,7 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"hello":"alice"}`, string(data))
 
-		msg, ok := btcRunner.GetBlipRevMessage(client.id, docID, version2)
+		msg, ok := btcRunner.GetPullRevMessage(client.id, docID, version2)
 		require.True(t, ok)
 		client.AssertOnBlipHistory(t, msg, version1)
 	})
@@ -2175,7 +2175,7 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 		data := btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"hello":"world!"}`, string(data))
 
-		msg, ok := btcRunner.GetBlipRevMessage(client.id, docID, version2)
+		msg, ok := btcRunner.GetPullRevMessage(client.id, docID, version2)
 		require.True(t, ok)
 
 		client.AssertOnBlipHistory(t, msg, version1)
@@ -3180,10 +3180,10 @@ func TestImportInvalidSyncGetsNoRev(t *testing.T) {
 		require.NoError(t, err)
 
 		btcRunner.StartOneshotPull(btc.id)
-		msg := btcRunner.WaitForBlipRevMessage(btc.id, docID, version)
+		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, version)
 		require.Equal(t, db.MessageNoRev, msg.Profile())
 
-		msg = btcRunner.WaitForBlipRevMessage(btc.id, docID2, version2)
+		msg = btcRunner.WaitForPullRevMessage(btc.id, docID2, version2)
 		require.Equal(t, db.MessageNoRev, msg.Profile())
 	})
 }
@@ -3300,7 +3300,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 
 				btcRunner.StartOneshotPull(btc2.id)
 
-				msg := btcRunner.WaitForBlipRevMessage(btc2.id, docID, revID)
+				msg := btcRunner.WaitForPullRevMessage(btc2.id, docID, revID)
 				require.Equal(t, db.MessageNoRev, msg.Profile())
 			})
 		}
@@ -3410,7 +3410,7 @@ func TestBlipMergeVersions(t *testing.T) {
 		btcRunner.StartPull(btc.id)
 		btcRunner.WaitForDoc(btc.id, docID)
 
-		revMsg := btcRunner.WaitForBlipRevMessage(btc.id, docID, DocVersion{CV: db.Version{SourceID: "CBL1", Value: 3}})
+		revMsg := btcRunner.WaitForPullRevMessage(btc.id, docID, DocVersion{CV: db.Version{SourceID: "CBL1", Value: 3}})
 
 		require.Equal(t, "3@CBL1", revMsg.Properties[db.RevMessageRev])
 		// mv is not ordered so either string is valid

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -325,7 +325,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 		}, db.GetAttachmentsFromInlineBody(t, data))
 
 		// Check EE is delta, and CE is full-body replication
-		msg := btcRunner.WaitForBlipRevMessage(client.id, doc1ID, version2)
+		msg := btcRunner.WaitForPullRevMessage(client.id, doc1ID, version2)
 		sgCanUseDeltas := base.IsEnterpriseEdition()
 		if sgCanUseDeltas {
 			// Check the request was sent with the correct deltaSrc property
@@ -408,7 +408,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 
 		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":1234567890123}]}`, string(data))
-		msg := btcRunner.WaitForBlipRevMessage(client.id, docID, version2)
+		msg := btcRunner.WaitForPullRevMessage(client.id, docID, version2)
 
 		// Check EE is delta, and CE is full-body replication
 		sgCanUseDeltas := base.IsEnterpriseEdition()
@@ -589,7 +589,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 		data = btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{"_removed":true}`, string(data))
 
-		msg, ok := btcRunner.GetBlipRevMessage(client.id, docID, version)
+		msg, ok := btcRunner.GetPullRevMessage(client.id, docID, version)
 		require.True(t, ok)
 		msgBody, err := msg.Body()
 
@@ -665,7 +665,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		data = btcRunner.WaitForVersion(client.id, docID, version)
 		assert.Equal(t, `{}`, string(data))
 
-		msg, ok := btcRunner.GetBlipRevMessage(client.id, docID, version)
+		msg, ok := btcRunner.GetPullRevMessage(client.id, docID, version)
 		require.True(t, ok)
 
 		msgBody, err := msg.Body()
@@ -778,7 +778,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 		data = btcRunner.WaitForVersion(client1.id, docID, version)
 		assert.Equal(t, `{}`, string(data))
-		msg := btcRunner.WaitForBlipRevMessage(client1.id, docID, version)
+		msg := btcRunner.WaitForPullRevMessage(client1.id, docID, version)
 
 		if !assert.Equal(t, db.MessageRev, msg.Profile()) {
 			t.Logf("unexpected profile for message %v in %v",
@@ -799,7 +799,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		btcRunner.StartOneshotPull(client2.id)
 		data = btcRunner.WaitForVersion(client2.id, docID, version)
 		assert.Equal(t, `{}`, string(data))
-		msg = btcRunner.WaitForBlipRevMessage(client2.id, docID, version)
+		msg = btcRunner.WaitForPullRevMessage(client2.id, docID, version)
 
 		if !assert.Equal(t, db.MessageRev, msg.Profile()) {
 			t.Logf("unexpected profile for message %v in %v",
@@ -897,7 +897,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 		data = btcRunner.WaitForVersion(client.id, docID, version2)
 		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
-		msg := btcRunner.WaitForBlipRevMessage(client.id, docID, version2)
+		msg := btcRunner.WaitForPullRevMessage(client.id, docID, version2)
 
 		// Check EE is delta
 		// Check the request was sent with the correct deltaSrc property
@@ -921,7 +921,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
 		client2.ClientDeltas = true
 		btcRunner.StartOneshotPull(client2.id)
-		msg2 := btcRunner.WaitForBlipRevMessage(client2.id, docID, version2)
+		msg2 := btcRunner.WaitForPullRevMessage(client2.id, docID, version2)
 
 		// Check the request was sent with the correct deltaSrc property
 		if sgCanUseDeltas {
@@ -989,7 +989,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		btcRunner.StartPushWithOpts(client.id, BlipTesterPushOptions{Continuous: false})
 
 		// Check EE is delta, and CE is full-body replication
-		msg := client.pushReplication.WaitForBlipRevMessage(docID, newRev)
+		msg := btcRunner.WaitForPushRevMessage(client.id, docID, newRev)
 
 		if base.IsEnterpriseEdition() && sgCanUseDeltas {
 			// Check the request was sent with the correct deltaSrc property
@@ -1119,7 +1119,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 		version2 := btcRunner.AddRev(client.id, docID, &version1, []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 		// MSG1: proposeChanges
 		// MSG2: rev
-		msg := client.pushReplication.WaitForBlipRevMessage(docID, version2)
+		msg := btcRunner.WaitForPushRevMessage(client.id, docID, version2)
 		require.Equal(t, db.MessageRev, msg.Profile())
 
 		// wait for the reply, indicating the message was written

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -2229,7 +2229,7 @@ func TestRevocationMessage(t *testing.T) {
 		btcRunner.StartOneshotPull(btc.id)
 
 		// Wait for doc revision to come over
-		_ = btcRunner.WaitForBlipRevMessage(btc.id, "doc", version)
+		_ = btcRunner.WaitForPullRevMessage(btc.id, "doc", version)
 
 		// Remove role from user
 		revocationTester.removeRole("user", "foo")

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -195,8 +195,8 @@ type clientDocRev struct {
 	HLV         db.HybridLogicalVector // The full HLV for the revision, populated when mode = HLV
 	body        []byte
 	isDelete    bool
-	pullMessage *blip.Message // rev or norev message associated with this revision is successfully pushed and the response is received
-	pushMessage *blip.Message // rev or norev message associated with this revision is successfully pulled and written to BlipTesterCollectionClient
+	pullMessage *blip.Message // rev or norev message associated with this revision is successfully pulled and the response is received and processed by BlipTesterCollectionClient
+	pushMessage *blip.Message // rev or norev message associated with this revision is successfully pushed to Sync Gateway and a response has been received
 }
 
 // clientDoc represents a document stored on the client - it may also contain older versions of the document.
@@ -1988,7 +1988,7 @@ func (btcc *BlipTesterCollectionClient) WaitForPullRevMessage(docID string, vers
 		}
 		rev, ok := doc._revisionsBySeq[seq]
 		require.True(btcc.TB(), ok, "seq %q for docID %q found but no rev in _seqStore. This should be impossible in design of BlipTesterCollectionClient", seq, docID)
-		if !assert.NotNil(c, rev.pullMessage, "pullMessage for %s %v is nil for docID:%+v, version: %+v", docID, version) {
+		if !assert.NotNil(c, rev.pullMessage, "pullMessage for is nil for docID:%+v, version: %+v", docID, version) {
 			return
 		}
 		msg = rev.pullMessage

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -190,12 +190,13 @@ type clientSeq uint64
 
 // clientDocRev represents a revision of a document stored on this client, including any metadata associated with this specific revision.
 type clientDocRev struct {
-	clientSeq clientSeq
-	version   DocVersion
-	HLV       db.HybridLogicalVector // The full HLV for the revision, populated when mode = HLV
-	body      []byte
-	isDelete  bool
-	message   *blip.Message // rev or norev message associated with this revision when replicated
+	clientSeq   clientSeq
+	version     DocVersion
+	HLV         db.HybridLogicalVector // The full HLV for the revision, populated when mode = HLV
+	body        []byte
+	isDelete    bool
+	pullMessage *blip.Message // rev or norev message associated with this revision is successfully pushed and the response is received
+	pushMessage *blip.Message // rev or norev message associated with this revision is successfully pulled and written to BlipTesterCollectionClient
 }
 
 // clientDoc represents a document stored on the client - it may also contain older versions of the document.
@@ -955,7 +956,8 @@ func (btcc *BlipTesterCollectionClient) updateLastReplicatedRev(docID string, ve
 	require.True(btcc.TB(), ok, "docID %q not found in _seqFromDocID", docID)
 	doc._latestServerVersion = version
 	rev := doc._revisionsBySeq[doc._seqsByVersions[version]]
-	rev.message = msg
+	rev.pushMessage = msg
+	doc._revisionsBySeq[doc._seqsByVersions[version]] = rev
 }
 
 // newBlipTesterReplication creates a new BlipTesterReplicator with the given id and BlipTesterClient. Used to instantiate a push or pull replication for the client.
@@ -1887,18 +1889,6 @@ func (btcc *BlipTesterCollectionClient) WaitForDoc(docID string) (data []byte) {
 	return data
 }
 
-// GetMessage returns the message stored in the Client under the given serial number
-func (btr *BlipTesterReplicator) GetMessage(serialNumber blip.MessageNumber) (msg *blip.Message, found bool) {
-	btr.messagesLock.RLock()
-	defer btr.messagesLock.RUnlock()
-
-	if msg, ok := btr.messages[serialNumber]; ok {
-		return msg, ok
-	}
-
-	return nil, false
-}
-
 // GetMessages returns a map of all messages stored in the Client keyed by serial number. These messages are mutable, but the response of the messages has been received so they should be effectively immutable.
 func (btr *BlipTesterReplicator) GetMessages() map[blip.MessageNumber]*blip.Message {
 	btr.messagesLock.RLock()
@@ -1933,61 +1923,81 @@ func (btr *BlipTesterReplicator) GetAllMessagesSummary() string {
 	return output.String()
 }
 
-// WaitForBlipRevMessage blocks until the given doc ID and rev ID has been stored by the replicator, and returns the message when found. If message body is not found after 10 seconds, test will fail.
-// Consider usage of BlipTesterCollectionClient.WaitForBlipRevMessage if you do not need to verify a specific push or pull message.
-func (btr *BlipTesterReplicator) WaitForBlipRevMessage(docID string, version DocVersion) (msg *blip.Message) {
-	require.EventuallyWithT(btr.TB(), func(c *assert.CollectT) {
-		// make copy of map, since the replicator could be writing to it while we're iterating
-		for _, m := range btr.GetMessages() {
-			if m.Profile() != db.MessageRev {
-				continue
-			}
-			if m.Properties[db.RevMessageID] != docID {
-				continue
-			}
-			revID := m.Properties[db.RevMessageRev]
-			if version.RevTreeID != "" {
-				if assert.Equal(c, version.RevTreeID, revID) {
-					msg = m
-					break
-				}
-				continue
-			}
-			assert.False(c, version.CV.IsEmpty(), "version.CV and version.RevTree are empty for docID: %s, revID: %s", docID, revID)
-			if assert.Equal(c, version.CV.String(), revID) {
-				msg = m
-				break
-			}
-		}
-		assert.NotNil(c, msg, "Could not find docID:%s version:%#v", docID, version)
-	}, 10*time.Second, 5*time.Millisecond, "BlipTesterReplicator timed out waiting for BLIP message: docID:%s version:%#v", docID, version)
-	require.NotNil(btr.TB(), msg, "Could not find docID:%s version:%#v", docID, version)
-	return msg
-}
-
 func (btr *BlipTesterReplicator) storeMessage(msg *blip.Message) {
 	btr.messagesLock.Lock()
 	defer btr.messagesLock.Unlock()
 	btr.messages[msg.SerialNumber()] = msg
 }
 
-// WaitForBlipRevMessage will return the blip message associated with a specified doc version after the revision
-// is stored locally for the BlipTesterCollectionClient. This will find a pull rev message correctly, but may not
-// find the relevant push replication rev message.
-// See btc.pushReplication.WaitForBlipRevMessage.
+// WaitForPushRevMessage will return the blip message associated with a specified doc version after the revision
+// is pushed successfully.
 // If the message is not found after 10 seconds, the test will fail.
-func (btc *BlipTesterCollectionClient) WaitForBlipRevMessage(docID string, docVersion DocVersion) (msg *blip.Message) {
-	require.EventuallyWithT(btc.TB(), func(c *assert.CollectT) {
-		var ok bool
-		msg, ok = btc.GetBlipRevMessage(docID, docVersion)
-		assert.True(c, ok, "Could not find docID:%+v, Version: %+v", docID, docVersion)
-	}, 10*time.Second, 5*time.Millisecond, "BlipTesterClient timed out waiting for BLIP message docID: %v, Version: %v", docID, docVersion)
-	require.NotNil(btc.TB(), msg, "msg is nil for docID:%+v, version: %+v", docID, docVersion)
+func (btcc *BlipTesterCollectionClient) WaitForPushRevMessage(docID string, version DocVersion) *blip.Message {
+	var msg *blip.Message
+	require.EventuallyWithT(btcc.TB(), func(c *assert.CollectT) {
+		btcc.seqLock.RLock()
+		defer btcc.seqLock.RUnlock()
+		doc, ok := btcc._getClientDoc(docID)
+		if !assert.True(c, ok, "docID %q not found", docID) {
+			return
+		}
+		var lookupVersion DocVersion
+		if btcc.UseHLV() {
+			lookupVersion = DocVersion{CV: version.CV}
+		} else {
+			lookupVersion = DocVersion{RevTreeID: version.RevTreeID}
+		}
+
+		seq, ok := doc._seqsByVersions[lookupVersion]
+		if !assert.True(c, ok, "Found %s but not %v version", docID, version) {
+			return
+		}
+		rev, ok := doc._revisionsBySeq[seq]
+		require.True(btcc.TB(), ok, "seq %q for docID %q found but no rev in _seqStore. This should be impossible in design of BlipTesterCollectionClient", seq, docID)
+		if !assert.NotNil(c, rev.pushMessage, "pushMessage for %s %v is not present", docID, version) {
+			return
+		}
+		msg = rev.pushMessage
+
+	}, 10*time.Second, 5*time.Millisecond, "BlipTesterClient timed out waiting for push rev message")
 	return msg
 }
 
-// GetBlipRevMessage returns the rev message that wrote the given docID/DocVersion on the client.
-func (btcc *BlipTesterCollectionClient) GetBlipRevMessage(docID string, version DocVersion) (msg *blip.Message, found bool) {
+// WaitForPullRevMessage will return the blip message associated with a specified doc version after the revision
+// is stored locally for the BlipTesterCollectionClient.
+// If the message is not found after 10 seconds, the test will fail.
+func (btcc *BlipTesterCollectionClient) WaitForPullRevMessage(docID string, version DocVersion) *blip.Message {
+	var msg *blip.Message
+	require.EventuallyWithT(btcc.TB(), func(c *assert.CollectT) {
+		btcc.seqLock.RLock()
+		defer btcc.seqLock.RUnlock()
+		doc, ok := btcc._getClientDoc(docID)
+		if !assert.True(c, ok, "docID %q not found", docID) {
+			return
+		}
+		var lookupVersion DocVersion
+		if btcc.UseHLV() {
+			lookupVersion = DocVersion{CV: version.CV}
+		} else {
+			lookupVersion = DocVersion{RevTreeID: version.RevTreeID}
+		}
+
+		seq, ok := doc._seqsByVersions[lookupVersion]
+		if !assert.True(c, ok, "Found %s but not %v version", docID, version) {
+			return
+		}
+		rev, ok := doc._revisionsBySeq[seq]
+		require.True(btcc.TB(), ok, "seq %q for docID %q found but no rev in _seqStore. This should be impossible in design of BlipTesterCollectionClient", seq, docID)
+		if !assert.NotNil(c, rev.pullMessage, "pullMessage for %s %v is nil for docID:%+v, version: %+v", docID, version) {
+			return
+		}
+		msg = rev.pullMessage
+	}, 10*time.Second, 5*time.Millisecond, "BlipTesterClient timed out waiting for pull rev message")
+	return msg
+}
+
+// GetPullRevMessage returns the last successful rev message that wrote the given docID/DocVersion on the client.
+func (btcc *BlipTesterCollectionClient) GetPullRevMessage(docID string, version DocVersion) (msg *blip.Message, found bool) {
 	btcc.seqLock.RLock()
 	defer btcc.seqLock.RUnlock()
 
@@ -2001,12 +2011,11 @@ func (btcc *BlipTesterCollectionClient) GetBlipRevMessage(docID string, version 
 
 		if seq, ok := doc._seqsByVersions[lookupVersion]; ok {
 			if rev, ok := doc._revisionsBySeq[seq]; ok {
-				require.NotNil(btcc.TB(), rev.message, "rev.message is nil for docID:%+v, version: %+v", docID, version)
-				return rev.message, true
+				require.NotNil(btcc.TB(), rev.pullMessage, "rev.pullMessage is nil for docID:%+v, version: %+v", docID, version)
+				return rev.pullMessage, true
 			}
 		}
 	}
-
 	return nil, false
 }
 
@@ -2032,14 +2041,19 @@ func (btcRunner *BlipTestClientRunner) WaitForDoc(clientID uint32, docID string)
 	return btcRunner.SingleCollection(clientID).WaitForDoc(docID)
 }
 
-// WaitForBlipRevMessage blocks until the given doc ID and rev ID has been stored by the client, and returns the message when found. If document is not found after 10 seconds, test will fail.
-func (btcRunner *BlipTestClientRunner) WaitForBlipRevMessage(clientID uint32, docID string, version DocVersion) *blip.Message {
-	return btcRunner.SingleCollection(clientID).WaitForBlipRevMessage(docID, version)
+// WaitForPullRevMessage blocks until the given doc ID and rev ID has been stored by the client as part of a pull replication and returns the message when found. If document is not found after 10 seconds, test will fail.
+func (btcRunner *BlipTestClientRunner) WaitForPullRevMessage(clientID uint32, docID string, version DocVersion) *blip.Message {
+	return btcRunner.SingleCollection(clientID).WaitForPullRevMessage(docID, version)
 }
 
-// GetBlipRevMessage returns the rev message that wrote the given docID/DocVersion on the client.
-func (btcRunner *BlipTestClientRunner) GetBlipRevMessage(clientID uint32, docID string, version DocVersion) (msg *blip.Message, found bool) {
-	return btcRunner.SingleCollection(clientID).GetBlipRevMessage(docID, version)
+// WaitForPushRevMessage blocks until the given doc ID and rev ID has been stored by the client as part of a push replication and returns the message when found. If document is not found after 10 seconds, test will fail.
+func (btcRunner *BlipTestClientRunner) WaitForPushRevMessage(clientID uint32, docID string, version DocVersion) *blip.Message {
+	return btcRunner.SingleCollection(clientID).WaitForPushRevMessage(docID, version)
+}
+
+// GetPullRevMessage returns the rev message that wrote the given docID/DocVersion on the client.
+func (btcRunner *BlipTestClientRunner) GetPullRevMessage(clientID uint32, docID string, version DocVersion) (msg *blip.Message, found bool) {
+	return btcRunner.SingleCollection(clientID).GetPullRevMessage(docID, version)
 }
 
 func (btcRunner *BlipTestClientRunner) StartOneshotPull(clientID uint32) {
@@ -2179,12 +2193,12 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 	newVersion.CV = *updatedHLV.ExtractCurrentVersionFromHLV()
 	// ConflictResolver is currently on BlipTesterClient, but might be per replication in the future.
 	docRev := clientDocRev{
-		clientSeq: newClientSeq,
-		isDelete:  opts.isDelete,
-		message:   opts.msg,
-		body:      newBody,
-		HLV:       updatedHLV,
-		version:   newVersion,
+		clientSeq:   newClientSeq,
+		isDelete:    opts.isDelete,
+		pullMessage: opts.msg,
+		body:        newBody,
+		HLV:         updatedHLV,
+		version:     newVersion,
 	}
 
 	if !hasLocalDoc {


### PR DESCRIPTION
- TestBlipNonDeltaSyncPush could exit before the rev was completely processed by BlipTesterCollectionClient, causing a failure to find version
- Remove BlipTestReplicator.WaitForBlipRevMessage, which is what caused this failure. The message is stored by the replicator as soon as it is sent, but this is before the response is procssed by the BlipTesterCollectionClient
- switch behavior on BlipTesterCollectionClient to separate push messages and pull messages, obviates need to query BlipTesterReplicator messages which could trigger race conditions again. This also solves a problem where you have two messages for some revs (e.g. delta sync failure, followed by full body replication)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/93/
