### PR TITLE
CBG-4840: Backup temporary revisions only by revtree ID

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -79,14 +79,11 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	require.NoError(t, err)
 
 	// rev 1 should be backed up even without delta sync now (by revTree ID - but not CV)
-	rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid1)
-	require.NoError(t, err)
-	assert.Contains(t, string(rev1OldBody), "hello.txt")
-
-	// CVs don't get temporary revision backups - since 4.x clients support replacementRevs
-	_, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
-	require.Error(t, err)
-	assert.Equal(t, "404 missing", err.Error())
+	if !deltasEnabled {
+		rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		require.NoError(t, err)
+		assert.Contains(t, string(rev1OldBody), "hello.txt")
+	}
 
 	// again, only backup current winning revision if delta sync
 	if deltasEnabled {

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -52,12 +52,21 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "1-12ff9ce1dd501524378fe092ce9aee8f", revid1)
 
-	rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+	// current revision backups depend on delta sync (to support deltas to SDK updates)
 	if deltasEnabled {
+		rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		require.NoError(t, err)
+		assert.Contains(t, string(rev1OldBody), "hello.txt")
+
+		rev1OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	} else {
-		// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
+		_, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		require.Error(t, err)
+		assert.Equal(t, "404 missing", err.Error())
+
+		_, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}
@@ -66,22 +75,34 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	var rev2Body Body
 	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
 	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
-	docRev2, _, err := collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", revid1}, true, ExistingVersionWithUpdateToHLV)
+	docRev2, revid2, err := collection.PutExistingRevWithBody(ctx, docID, rev2Body, []string{"2-abc", revid1}, true, ExistingVersionWithUpdateToHLV)
 	require.NoError(t, err)
 
-	// now in any case - we'll have rev 1 backed up
-	rev1OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+	// rev 1 should be backed up even without delta sync now (by revTree ID - but not CV)
+	rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 	require.NoError(t, err)
 	assert.Contains(t, string(rev1OldBody), "hello.txt")
-	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
 
-	// and rev 2 should be present only for the xattrs and deltas case
-	rev2OldBody, err := collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+	// CVs don't get temporary revision backups - since 4.x clients support replacementRevs
+	_, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+	require.Error(t, err)
+	assert.Equal(t, "404 missing", err.Error())
+
+	// again, only backup current winning revision if delta sync
 	if deltasEnabled {
+		rev2OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid2)
+		require.NoError(t, err)
+		assert.Contains(t, string(rev2OldBody), "hello.txt")
+
+		rev2OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 	} else {
-		// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
+		_, err := collection.getOldRevisionJSON(ctx, docID, revid2)
+		require.Error(t, err)
+		assert.Equal(t, "404 missing", err.Error())
+
+		_, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}
@@ -100,7 +121,7 @@ func TestAttachments(t *testing.T) {
 	assert.NoError(t, base.JSONUnmarshal([]byte(rev1input), &body))
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-	rev1id, docRev1, err := collection.Put(ctx, "doc1", body)
+	rev1id, _, err := collection.Put(ctx, "doc1", body)
 	require.NoError(t, err)
 
 	log.Printf("Retrieve doc...")
@@ -191,8 +212,7 @@ func TestAttachments(t *testing.T) {
 	}, atts)
 
 	log.Printf("Expire body of rev 1, then add a child...") // test fix of #498
-	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
-	err = collection.dataStore.Delete(oldRevisionKey("doc1", base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString()))))
+	err = collection.dataStore.Delete(oldRevisionKey("doc1", rev1id))
 	assert.NoError(t, err, "Couldn't compact old revision")
 	rev2Bstr := `{"_attachments": {"bye.txt": {"stub":true,"revpos":1,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}, "_rev": "2-f000"}`
 	var body2B Body
@@ -718,7 +738,7 @@ func TestStoreAttachments(t *testing.T) {
 func TestMigrateBodyAttachments(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	const docKey = "TestAttachmentMigrate"
+	const docKey = "TestMigrateBodyAttachments"
 
 	setupFn := func(t *testing.T) (db *Database, ctx context.Context) {
 		db, ctx = setupTestDB(t)
@@ -968,7 +988,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 func TestMigrateBodyAttachmentsMerge(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD)
 
-	const docKey = "TestAttachmentMigrate"
+	const docKey = "TestMigrateBodyAttachmentsMerge"
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -1107,7 +1127,7 @@ func TestMigrateBodyAttachmentsMerge(t *testing.T) {
 // TestMigrateBodyAttachmentsMergeConflicting will set up a document with the same attachment name in both pre-2.5 and post-2.5 metadata, making sure that the metadata with the most recent revpos is chosen.
 func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
 
-	const docKey = "TestAttachmentMigrate"
+	const docKey = "TestMigrateBodyAttachmentsMergeConflicting"
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/crud.go
+++ b/db/crud.go
@@ -915,7 +915,7 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 	}
 
 	// Back up the revision JSON as a separate doc in the bucket:
-	db.backupRevisionJSON(ctx, doc.ID, doc.HLV.GetCurrentVersionString(), json)
+	db.backupRevisionJSON(ctx, doc.ID, ancestorRevId, json)
 
 	// Nil out the ancestor rev's body in the document struct:
 	if ancestorRevId == doc.GetRevTreeID() {
@@ -2962,7 +2962,7 @@ func (db *DatabaseCollectionWithUser) postWriteUpdateHLV(ctx context.Context, do
 	}
 	doc.SyncData.SetCV(doc.HLV)
 
-	// backup new revision to the bucket now we have a doc assigned a CV (post macro expansion) for delta generation purposes
+	// backup new revision to the bucket now we have a doc assigned a CV (post macro expansion) for future deltaSrc purposes
 	// we don't need to store revision body backups without delta sync in 4.0, since all clients know how to use the sendReplacementRevs feature
 	backupRev := db.deltaSyncEnabled() && db.deltaSyncRevMaxAgeSeconds() != 0
 	if db.UseXattrs() && backupRev {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1084,14 +1084,6 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	db.Options.StoreLegacyRevTreeData = true
-
-	// TODO: CBG-4840 Only requires delta sync until restoration of non-delta sync RevTree ID revision body backups"
-	if !base.IsEnterpriseEdition() {
-		t.Skip("CBG-4840 - temp skip see above comment")
-	}
-	db.Options.DeltaSyncOptions = DeltaSyncOptions{Enabled: true, RevMaxAgeSeconds: 300}
-
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a

--- a/db/database.go
+++ b/db/database.go
@@ -209,7 +209,7 @@ type DatabaseContextOptions struct {
 	NumIndexPartitions            *uint32           // Number of partitions for GSI indexes, if not set will default to 1
 	ImportVersion                 uint64            // Version included in import DCP checkpoints, incremented when collections added to db
 	DisablePublicAllDocs          bool              // Disable public access to the _all_docs endpoint for this database
-	StoreLegacyRevTreeData        bool              // Whether to store additional data for legacy rev tree support in delta sync and replication backup revs
+	StoreLegacyRevTreeData        *bool             // Whether to store additional data for legacy rev tree support in delta sync and replication backup revs
 }
 
 type ConfigPrincipals struct {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -198,7 +198,7 @@ func (c *DatabaseCollection) deltaSyncRevMaxAgeSeconds() uint32 {
 
 // storeLegacyRevTreeData returns true if legacy revision tree pointer data is stored. This is controlled at the database level.
 func (c *DatabaseCollection) storeLegacyRevTreeData() bool {
-	return c.dbCtx.Options.StoreLegacyRevTreeData
+	return base.ValDefault(c.dbCtx.Options.StoreLegacyRevTreeData, DefaultStoreLegacyRevTreeData)
 }
 
 // eventMgr manages nofication events. This is controlled at database level.

--- a/db/revision.go
+++ b/db/revision.go
@@ -261,7 +261,6 @@ func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, do
 	}
 
 	if !db.storeLegacyRevTreeData() {
-
 		// Not storing legacy revtree data - nothing to do
 		return
 	}
@@ -271,8 +270,8 @@ func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, do
 		return
 	}
 
-	// store the old document revision by revtree ID for in-flight replications
-	_ = db.setOldRevisionJSONBody(ctx, docId, oldRev, oldBody, db.oldRevExpirySeconds())
+	// store or refresh the old document revision by revtree ID for in-flight replications
+	_ = db.refreshOldRevisionJSON(ctx, docId, oldRev, oldBody, db.oldRevExpirySeconds())
 	return
 }
 

--- a/db/revision.go
+++ b/db/revision.go
@@ -253,40 +253,27 @@ func (c *DatabaseCollection) getOldRevisionJSON(ctx context.Context, docid strin
 	}
 }
 
-// Makes a backup of revision body for use by delta sync, and in-flight replications requesting an old revision.
-// Backup policy depends on whether delta sync and/or shared_bucket_access is enabled
-//
-//	delta=false || delta_rev_max_age_seconds=0
-//	   - old revision stored, with expiry OldRevExpirySeconds
-//	delta=true && shared_bucket_access=true
-//	   - new revision stored (as duplicate), with expiry rev_max_age_seconds
-//	delta=true && shared_bucket_access=false
-//	   - old revision stored, with expiry rev_max_age_seconds
+// Makes a backup of revision body for use by in-flight replications requesting an old revision (for clients not supporting replacementRevs)
 func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, docId, oldRev string, oldBody []byte) {
-	// Without delta sync, store the old rev for in-flight replication purposes
-	if !db.deltaSyncEnabled() || db.deltaSyncRevMaxAgeSeconds() == 0 {
-		if len(oldBody) > 0 {
-			oldRevHash := base.Crc32cHashString([]byte(oldRev))
-			_ = db.setOldRevisionJSONBody(ctx, docId, oldRevHash, oldBody, db.oldRevExpirySeconds())
-		}
+	if db.deltaSyncEnabled() && db.deltaSyncRevMaxAgeSeconds() > 0 {
+		// See postWriteUpdateHLV - we're writing a CV and RevTreeID backup there to support delta sync
 		return
 	}
 
-	// Otherwise, store the revs for delta generation purposes, with a longer expiry
+	if !db.storeLegacyRevTreeData() {
 
-	// Special handling for Xattrs so that SG still has revisions that were updated by an SDK write
-	if db.UseXattrs() {
-		// Refresh the expiry on the previous revision backup
-		oldRevHash := base.Crc32cHashString([]byte(oldRev))
-		_ = db.refreshOldRevisionJSON(ctx, docId, oldRevHash, oldBody, db.deltaSyncRevMaxAgeSeconds())
+		// Not storing legacy revtree data - nothing to do
 		return
 	}
 
-	// Non-xattr only need to store the previous revision, as all writes come through SG
-	if len(oldBody) > 0 {
-		oldRevHash := base.Crc32cHashString([]byte(oldRev))
-		_ = db.setOldRevisionJSONBody(ctx, docId, oldRevHash, oldBody, db.deltaSyncRevMaxAgeSeconds())
+	// skip backup if this was a deletion
+	if len(oldBody) == 0 {
+		return
 	}
+
+	// store the old document revision by revtree ID for in-flight replications
+	_ = db.setOldRevisionJSONBody(ctx, docId, oldRev, oldBody, db.oldRevExpirySeconds())
+	return
 }
 
 // setOldRevisionJSONBody stores the raw JSON body of a revision that has been archived to a separate doc.

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -627,14 +627,6 @@ func TestBypassRevisionCache(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
-	db.Options.StoreLegacyRevTreeData = true
-
-	// TODO: CBG-4840 Only requires delta sync until restoration of non-delta sync RevTree ID revision body backups"
-	if !base.IsEnterpriseEdition() {
-		t.Skip("CBG-4840 - temp skip see above comment")
-	}
-	db.Options.DeltaSyncOptions = DeltaSyncOptions{Enabled: true, RevMaxAgeSeconds: 300}
-
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	backingStoreMap := CreateTestSingleBackingStoreMap(collection, testCollectionID)
 

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -692,12 +692,6 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 
 	dbConfig := rt.NewDbConfig()
 
-	// TODO: CBG-4840 Only requires delta sync until restoration of non-delta sync RevTree ID revision body backups"
-	if !base.IsEnterpriseEdition() {
-		t.Skip("CBG-4840 - temp skip see above comment")
-	}
-	dbConfig.DeltaSync = &DeltaSyncConfig{Enabled: base.Ptr(true), RevMaxAgeSeconds: base.Ptr(uint32(300))}
-
 	RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 	rt.GetDatabase().EnableAllowConflicts(rt.TB())
 	// Create Doc

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1873,9 +1873,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	// Flush the rev cache, and issue changes again to ensure successful handling for rev cache misses
 	rt.GetDatabase().FlushRevisionCacheForTest()
 	// Also nuke temporary revision backup of doc_pruned.  Validates that the body for the pruned revision is generated correctly when no longer resident in the rev cache
-	// TODO: CBG-4840 - Revs are backed only up by hash of CV (not legacy rev IDs) for non-delta sync cases
-	cvHash := base.Crc32cHashString([]byte(cvs[0]))
-	err = collection.PurgeOldRevisionJSON(ctx, "doc_pruned", cvHash)
+	err = collection.PurgeOldRevisionJSON(ctx, "doc_pruned", prunedRevId)
 	require.NoError(t, err)
 
 	// since 4.0 we cannot differentiate between an old channel removal and a missing document - in this case the document body is not returned

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1806,11 +1806,9 @@ func TestChangesIncludeDocs(t *testing.T) {
 	assert.NoError(t, err, "Error updating doc")
 	// Generate more revs than revs_limit (3)
 	revid = prunedRevId
-	var cvs []string
 	for i := 0; i < 5; i++ {
 		docVersion := rt.UpdateDoc("doc_pruned", db.DocVersion{RevTreeID: revid}, `{"type": "pruned", "channels":["gamma"]}`)
 		revid = docVersion.RevTreeID
-		cvs = append(cvs, docVersion.CV.String())
 	}
 
 	// Doc w/ attachment

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7080,8 +7080,7 @@ func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
 	activeRT.WaitForVersion(docID, version3)
 
 	activeRT.GetDatabase().FlushRevisionCacheForTest()
-	cvHash := base.Crc32cHashString([]byte(version2.CV.String()))
-	err := collection.PurgeOldRevisionJSON(activeCtx, docID, cvHash)
+	err := collection.PurgeOldRevisionJSON(activeCtx, docID, version2.RevTreeID)
 	require.NoError(t, err)
 
 	ar, err := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{

--- a/rest/revision_old_revtree_test.go
+++ b/rest/revision_old_revtree_test.go
@@ -37,7 +37,7 @@ func TestGetOldRevisionBodyByRevTreeID(t *testing.T) {
 			name:                   "store_legacy_revtree_data=true, delta_sync=false",
 			storeLegacyRevTreeData: true,
 			deltaSyncEnabled:       false,
-			expectedToFindOldRev:   false, // TODO: CBG-4840 - Should be true - Requires restoration of non-delta sync rev storage
+			expectedToFindOldRev:   true,
 		},
 		{
 			name:                   "store_legacy_revtree_data=false, delta_sync=true",

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1440,7 +1440,7 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 		MaxConcurrentRevs:           sc.Config.Replicator.MaxConcurrentRevs,
 		NumIndexReplicas:            config.numIndexReplicas(),
 		DisablePublicAllDocs:        disablePublicAllDocs,
-		StoreLegacyRevTreeData:      base.ValDefault(config.StoreLegacyRevTreeData, db.DefaultStoreLegacyRevTreeData),
+		StoreLegacyRevTreeData:      base.Ptr(base.ValDefault(config.StoreLegacyRevTreeData, db.DefaultStoreLegacyRevTreeData)),
 	}
 
 	if config.Index != nil && config.Index.NumPartitions != nil {


### PR DESCRIPTION
CBG-4840

Restores temporary revision backup behaviour prior to #7237, by only storing revision tree IDs as body backups when delta sync is disabled (for supporting in-flight replications for clients that do not have the replacementRevs capability) - this is also now part of the `store_legacy_revtree_data` opt-out.

When delta sync is enabled, `postWriteUpdateHLV` continues to take the responsibility to backup the current revision by both CV and RevTreeID - since we only have the CV much later in the write processing (this was already done back in #7718)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/94/
