### PR TITLE
CBG-4879: fix for data race when invalidating cache for local wins

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -512,7 +512,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 			SourceID: syncData.RevAndVersion.CurrentSource,
 			Value:    base.HexCasToUint64(syncData.RevAndVersion.CurrentVersion),
 		}
-		collection.revisionCache.RemoveWithCV(ctx, docID, &vrs)
+		collection.revisionCache.RemoveCVOnly(ctx, docID, &vrs)
 	}
 
 	change := &LogEntry{

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -132,6 +132,10 @@ func (rc *BypassRevisionCache) RemoveRevOnly(ctx context.Context, docID, revID s
 	// no-op
 }
 
+func (rc *BypassRevisionCache) RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+	// no-op
+}
+
 func (rc *BypassRevisionCache) RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
 	// no-op
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -55,7 +55,11 @@ type RevisionCache interface {
 	// RemoveWithCV evicts a revision from the cache using its current version.
 	RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32)
 
+	// RemoveRevOnly removes the specified key from the revID lookup map in the cache
 	RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32)
+
+	// RemoveCVOnly removes the specified key from the HLV lookup map in the cache
+	RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta)
@@ -176,6 +180,10 @@ func (c *collectionRevisionCache) RemoveWithRev(ctx context.Context, docID, revI
 
 func (c *collectionRevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string) {
 	(*c.revCache).RemoveRevOnly(ctx, docID, revID, c.collectionID)
+}
+
+func (c *collectionRevisionCache) RemoveCVOnly(ctx context.Context, docID string, cv *Version) {
+	(*c.revCache).RemoveCVOnly(ctx, docID, cv, c.collectionID)
 }
 
 // RemoveWithCV is for per collection access to Remove method

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -648,7 +648,7 @@ func (rc *LRURevisionCache) _numberCapacityEviction() (numItemsEvicted int64, nu
 		if elem := rc.hlvCache[hlvKey]; elem != nil {
 			revValue := elem.Value.(*revCacheValue)
 			// we need to check if the value pointed to by the cv lookup map is the same value we're evicting, this is
-			// because we can have can currently have two items with the same docID and CV, but different revIDs due to
+			// because we can currently have two items with the same docID and CV, but different revIDs due to
 			// local wins conflict resolution not generating a new CV but generating a new revID.
 			if revValue.revID == value.revID {
 				// this cv lookup item matches the value we're evicting, so remove it
@@ -919,7 +919,7 @@ func (rc *LRURevisionCache) performEviction(ctx context.Context) {
 			if elem := rc.hlvCache[hlvKey]; elem != nil {
 				revValue := elem.Value.(*revCacheValue)
 				// we need to check if the value pointed to by the cv lookup map is the same value we're evicting, this is
-				// because we can have can currently have two items with the same docID and CV, but different revIDs due to
+				// because we can currently have two items with the same docID and CV, but different revIDs due to
 				// local wins conflict resolution not generating a new CV but generating a new revID.
 				if revValue.revID == value.revID {
 					// this cv lookup item matches the value we're evicting, so remove it

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -600,6 +600,7 @@ func (rc *LRURevisionCache) removeFromRevLookup(ctx context.Context, docID, revI
 	delete(rc.cache, key)
 }
 
+// removeFromCVLookup will only remove the entry from the CV lookup map, if present. Underlying element must stay in list for eviction to work.
 func (rc *LRURevisionCache) removeFromCVLookup(ctx context.Context, docID string, cv *Version, collectionID uint32) {
 	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
 	rc.lock.Lock()

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -97,6 +97,10 @@ func (sc *ShardedLRURevisionCache) RemoveRevOnly(ctx context.Context, docID, rev
 	sc.getShard(docID).RemoveRevOnly(ctx, docID, revID, collectionID)
 }
 
+func (sc *ShardedLRURevisionCache) RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+	sc.getShard(docID).RemoveCVOnly(ctx, docID, cv, collectionID)
+}
+
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	backingStores        map[uint32]RevisionCacheBackingStore
@@ -533,6 +537,10 @@ func (rc *LRURevisionCache) RemoveWithCV(ctx context.Context, docID string, cv *
 	rc.removeFromCacheByCV(ctx, docID, cv, collectionID)
 }
 
+func (rc *LRURevisionCache) RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+	rc.removeFromCVLookup(ctx, docID, cv, collectionID)
+}
+
 // RemoveRevOnly removes a rev from revision cache lookup map, if present.
 func (rc *LRURevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
 	// This will only remove the entry from the rev lookup map, not the lru list
@@ -587,9 +595,18 @@ func (rc *LRURevisionCache) removeFromRevLookup(ctx context.Context, docID, revI
 	key := IDAndRev{DocID: docID, RevID: revID, CollectionID: collectionID}
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
-	// only delete from rev lookup map, if we delete underlying element in list, the now elem in the HLV lookup map
+	// only delete from rev lookup map, if we delete underlying element in list, the elem in the HLV lookup map
 	// will never be evicted leading to potential unbounded growth of HLV lookup map
 	delete(rc.cache, key)
+}
+
+func (rc *LRURevisionCache) removeFromCVLookup(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	// only delete from cv lookup map, if we delete underlying element in list, the item left in the revID lookup map for
+	// this item will never be evicted leading to potential unbounded growth of revID lookup map
+	delete(rc.hlvCache, key)
 }
 
 // removeValue removes a value from the revision cache, if present and the value matches the the value. If there's an item in the revision cache with a matching docID and revID but the document is different, this item will not be removed from the rev cache.
@@ -627,7 +644,16 @@ func (rc *LRURevisionCache) _numberCapacityEviction() (numItemsEvicted int64, nu
 		}
 		hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Value, CollectionID: value.collectionID}
 		revKey := IDAndRev{DocID: value.id, RevID: value.revID, CollectionID: value.collectionID}
-		delete(rc.hlvCache, hlvKey)
+		if elem := rc.hlvCache[hlvKey]; elem != nil {
+			revValue := elem.Value.(*revCacheValue)
+			// we need to check if the value pointed to by the cv lookup map is the same value we're evicting, this is
+			// because we can have can currently have two items with the same docID and CV, but different revIDs due to
+			// local wins conflict resolution not generating a new CV but generating a new revID.
+			if revValue.revID == value.revID {
+				// this cv lookup item matches the value we're evicting, so remove it
+				delete(rc.hlvCache, hlvKey)
+			}
+		}
 		if elem := rc.cache[revKey]; elem != nil {
 			revValue := elem.Value.(*revCacheValue)
 			// we need to check if the value pointed to by the rev lookup map is the same value we're evicting, this is
@@ -888,7 +914,17 @@ func (rc *LRURevisionCache) performEviction(ctx context.Context) {
 			}
 			revKey := IDAndRev{DocID: value.id, RevID: value.revID, CollectionID: value.collectionID}
 			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Value, CollectionID: value.collectionID}
-			delete(rc.hlvCache, hlvKey)
+			// same below but for hlv lookup map
+			if elem := rc.hlvCache[hlvKey]; elem != nil {
+				revValue := elem.Value.(*revCacheValue)
+				// we need to check if the value pointed to by the cv lookup map is the same value we're evicting, this is
+				// because we can have can currently have two items with the same docID and CV, but different revIDs due to
+				// local wins conflict resolution not generating a new CV but generating a new revID.
+				if revValue.revID == value.revID {
+					// this cv lookup item matches the value we're evicting, so remove it
+					delete(rc.hlvCache, hlvKey)
+				}
+			}
 			if elem := rc.cache[revKey]; elem != nil {
 				revValue := elem.Value.(*revCacheValue)
 				// we need to check if the value pointed to by the rev lookup map is the same value we're evicting, this is


### PR DESCRIPTION
CBG-4879

- Remove just from cv map to invalidate the cv entry for documents that are a result of local wins
- The race is from reading revID from rev cache value for removal from the revID lookup in the caching goroutine whilst the write goroutine is populating the rev cache value on Put at the cache
- This means we have to do some extra checks at eviction time like we needed to do in #7640 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/99/
