### PR TITLE
Reformat manifest XMLs according to EditorConfig

### DIFF
--- a/manifest/1.3.1.xml
+++ b/manifest/1.3.1.xml
@@ -12,106 +12,106 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="git://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="git://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="git://github.com/couchbasedeps/" name="couchbasedeps"/>
-  <remote fetch="git://github.com/elazarl/" name="elazarl"/>
-  <remote fetch="git://github.com/gorilla/" name="gorilla"/>
-  <remote fetch="git://github.com/natefinch/" name="natefinch"/>
-  <remote fetch="git://github.com/rcrowley/" name="rcrowley"/>
-  <remote fetch="git://github.com/samuel/" name="samuel"/>
-  <remote fetch="git://github.com/tleyden/" name="tleyden"/>
-  <remote fetch="git://github.com/mreiferson/" name="mreiferson"/>
-  <remote fetch="git://github.com/kardianos/" name="kardianos"/>
-  <remote fetch="git://github.com/coreos/" name="coreos"/>
-  <remote fetch="git://github.com/jonboulle/" name="jonboulle"/>
-  <remote fetch="ssh://github.com/couchbaselabs/" name="couchbaselabs_private"/>
+    <remote fetch="git://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="git://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="git://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="git://github.com/elazarl/" name="elazarl"/>
+    <remote fetch="git://github.com/gorilla/" name="gorilla"/>
+    <remote fetch="git://github.com/natefinch/" name="natefinch"/>
+    <remote fetch="git://github.com/rcrowley/" name="rcrowley"/>
+    <remote fetch="git://github.com/samuel/" name="samuel"/>
+    <remote fetch="git://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="git://github.com/mreiferson/" name="mreiferson"/>
+    <remote fetch="git://github.com/kardianos/" name="kardianos"/>
+    <remote fetch="git://github.com/coreos/" name="coreos"/>
+    <remote fetch="git://github.com/jonboulle/" name="jonboulle"/>
+    <remote fetch="ssh://github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="build" path="cbbuild" remote="couchbase" revision="b3bea7ac2aadd581ce6ac51d615fb36d02ea6fd5">
-    <annotation name="VERSION" value="1.3.1.5"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="build" path="cbbuild" remote="couchbase" revision="b3bea7ac2aadd581ce6ac51d615fb36d02ea6fd5">
+        <annotation name="VERSION" value="1.3.1.5" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/1.3.1.5"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/1.3.1.5"/>
 
-  <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private"
-  revision="46892da1827908e19f0e4f31600971e0dc30ba49"/>
+    <!-- Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private"
+             revision="46892da1827908e19f0e4f31600971e0dc30ba49"/>
 
-  <!-- Dependencies -->
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <!-- Dependencies -->
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+    <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="abc54237f3132bd9183155104b2ef72dd4b2e9fb"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="abc54237f3132bd9183155104b2ef72dd4b2e9fb"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
 
-  <project name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="8e3ecd19340dabed7ad4fea9d9944ab97b5f916d"/>
+    <project name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="8e3ecd19340dabed7ad4fea9d9944ab97b5f916d"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="06193ca74e834ca91bc28c7555205aedd8e7fa80"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="06193ca74e834ca91bc28c7555205aedd8e7fa80"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="67fb8fa4c62451372108f31c93034c07d9d9f4ab"/>
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="67fb8fa4c62451372108f31c93034c07d9d9f4ab"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="392e93091880de7d5ad8b83b99f90902cd98ce6e"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="392e93091880de7d5ad8b83b99f90902cd98ce6e"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="708054d61e5a2918b9f4e9700000ee611dcf03f5"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="708054d61e5a2918b9f4e9700000ee611dcf03f5"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="9b36453141c35697401168b07f2c09fcff7721ce"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="9b36453141c35697401168b07f2c09fcff7721ce"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="ffbe531a496e0f677b018f61c21b8be43588b77a"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="ffbe531a496e0f677b018f61c21b8be43588b77a"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="7006f7a1abbda37f3276216302f9eb7425e1dfa5"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="7006f7a1abbda37f3276216302f9eb7425e1dfa5"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="9313a67a9234d96f3073a979b22bea5b322b56d6"/>
+    <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="9313a67a9234d96f3073a979b22bea5b322b56d6"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="eebc98233c3e032eb6b9036575d51324ab5932e6"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="eebc98233c3e032eb6b9036575d51324ab5932e6"/>
 
-  <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
+    <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
 </manifest>
 

--- a/manifest/1.4.0.xml
+++ b/manifest/1.4.0.xml
@@ -9,66 +9,66 @@ licenses/APL2.txt.
 -->
 
 <manifest>
-  <remote fetch="https://github.com/coreos/" name="coreos" />
-  <remote fetch="https://github.com/couchbase/" name="couchbase" />
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps" />
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs" />
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
-  <remote fetch="https://github.com/elazarl/" name="elazarl" />
-  <remote fetch="https://github.com/gorilla/" name="gorilla" />
-  <remote fetch="https://github.com/jonboulle/" name="jonboulle" />
-  <remote fetch="https://github.com/kardianos/" name="kardianos" />
-  <remote fetch="https://github.com/mreiferson/" name="mreiferson" />
-  <remote fetch="https://github.com/natefinch/" name="natefinch" />
-  <remote fetch="https://github.com/rcrowley/" name="rcrowley" />
-  <remote fetch="https://github.com/samuel/" name="samuel" />
-  <remote fetch="https://github.com/tleyden/" name="tleyden" />
+    <remote fetch="https://github.com/coreos/" name="coreos"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
+    <remote fetch="https://github.com/elazarl/" name="elazarl"/>
+    <remote fetch="https://github.com/gorilla/" name="gorilla"/>
+    <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
+    <remote fetch="https://github.com/kardianos/" name="kardianos"/>
+    <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
+    <remote fetch="https://github.com/natefinch/" name="natefinch"/>
+    <remote fetch="https://github.com/rcrowley/" name="rcrowley"/>
+    <remote fetch="https://github.com/samuel/" name="samuel"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <default remote="couchbase" revision="master" />
+    <default remote="couchbase" revision="master"/>
 
-  <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" revision="3d39b57188c372649beedd5c13c9003156d5a055" />
-  <project name="build" path="cbbuild" revision="388ec72a70fc0925823d726609a209201052567b">
-    <annotation name="RELEASE" value="1.4.0.2" />
-    <annotation name="VERSION" value="1.4.0.2" />
-    <annotation name="PRODUCT_BRANCH" value="master" />
-    <annotation name="PRODUCT" value="sync_gateway" />
-    <annotation name="BLD_NUM" value="@BLD_NUM@" />
-    <annotation name="RELEASE" value="@RELEASE@" />
-  </project>
-  <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" revision="8e3ecd19340dabed7ad4fea9d9944ab97b5f916d" />
-  <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" revision="1323b92ac2619c29d50e588e59d7a6b4839da629" />
-  <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" revision="06193ca74e834ca91bc28c7555205aedd8e7fa80" />
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d" />
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" revision="eebc98233c3e032eb6b9036575d51324ab5932e6" />
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="708054d61e5a2918b9f4e9700000ee611dcf03f5" />
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf" />
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="ffbe531a496e0f677b018f61c21b8be43588b77a" />
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150" />
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8" />
-  <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47" />
-  <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd" />
-  <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544" />
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864" />
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368" />
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78" />
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" revision="67fb8fa4c62451372108f31c93034c07d9d9f4ab" />
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5" />
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6" />
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="dd45e6a67c53f673bb49ca8a001fd3a63ceb640e" />
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="9b36453141c35697401168b07f2c09fcff7721ce" />
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="7006f7a1abbda37f3276216302f9eb7425e1dfa5" />
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc" />
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc" />
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f" />
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde" />
-  <project name="retriever" path="godeps/src/github.com/couchbase/retriever" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020" />
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f" />
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" revision="a22e64010d08574baa33332695abb27c8e50d251" />
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="24b8252856d71a541cbfeb2203cf7c0ce3634b2b" />
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="7fe4854f1e98ea2ec0ab548bd763030cc133b61b" upstream="master" />
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" revision="release/1.4.0.2" upstream="master" />
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" remote="couchbaselabs" revision="4195073f3c64830ca5bad14016dc5de732211c32" />
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e" />
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a" />
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="4a98979fe7e3cd5e6bb8d06be3e73bc00172d6f2" />
+    <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
+    <project name="build" path="cbbuild" revision="388ec72a70fc0925823d726609a209201052567b">
+        <annotation name="RELEASE" value="1.4.0.2"/>
+        <annotation name="VERSION" value="1.4.0.2"/>
+        <annotation name="PRODUCT_BRANCH" value="master"/>
+        <annotation name="PRODUCT" value="sync_gateway"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@"/>
+        <annotation name="RELEASE" value="@RELEASE@"/>
+    </project>
+    <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" revision="8e3ecd19340dabed7ad4fea9d9944ab97b5f916d"/>
+    <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
+    <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" revision="06193ca74e834ca91bc28c7555205aedd8e7fa80"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" revision="eebc98233c3e032eb6b9036575d51324ab5932e6"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="708054d61e5a2918b9f4e9700000ee611dcf03f5"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="ffbe531a496e0f677b018f61c21b8be43588b77a"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
+    <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
+    <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
+    <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" revision="67fb8fa4c62451372108f31c93034c07d9d9f4ab"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="dd45e6a67c53f673bb49ca8a001fd3a63ceb640e"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="9b36453141c35697401168b07f2c09fcff7721ce"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="7006f7a1abbda37f3276216302f9eb7425e1dfa5"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="retriever" path="godeps/src/github.com/couchbase/retriever" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" revision="a22e64010d08574baa33332695abb27c8e50d251"/>
+    <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="24b8252856d71a541cbfeb2203cf7c0ce3634b2b"/>
+    <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="7fe4854f1e98ea2ec0ab548bd763030cc133b61b" upstream="master"/>
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" revision="release/1.4.0.2" upstream="master"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" remote="couchbaselabs" revision="4195073f3c64830ca5bad14016dc5de732211c32"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="4a98979fe7e3cd5e6bb8d06be3e73bc00172d6f2"/>
 </manifest>

--- a/manifest/1.4.1.xml
+++ b/manifest/1.4.1.xml
@@ -9,61 +9,61 @@ licenses/APL2.txt.
 -->
 
 <manifest>
-  <remote fetch="https://github.com/coreos/" name="coreos" />
-  <remote fetch="https://github.com/couchbase/" name="couchbase" />
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps" />
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs" />
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
-  <remote fetch="https://github.com/elazarl/" name="elazarl" />
-  <remote fetch="https://github.com/gorilla/" name="gorilla" />
-  <remote fetch="https://github.com/jonboulle/" name="jonboulle" />
-  <remote fetch="https://github.com/kardianos/" name="kardianos" />
-  <remote fetch="https://github.com/mreiferson/" name="mreiferson" />
-  <remote fetch="https://github.com/natefinch/" name="natefinch" />
-  <remote fetch="https://github.com/rcrowley/" name="rcrowley" />
-  <remote fetch="https://github.com/samuel/" name="samuel" />
-  <remote fetch="https://github.com/tleyden/" name="tleyden" />
+    <remote fetch="https://github.com/coreos/" name="coreos"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
+    <remote fetch="https://github.com/elazarl/" name="elazarl"/>
+    <remote fetch="https://github.com/gorilla/" name="gorilla"/>
+    <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
+    <remote fetch="https://github.com/kardianos/" name="kardianos"/>
+    <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
+    <remote fetch="https://github.com/natefinch/" name="natefinch"/>
+    <remote fetch="https://github.com/rcrowley/" name="rcrowley"/>
+    <remote fetch="https://github.com/samuel/" name="samuel"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <default remote="couchbase" revision="master" />
+    <default remote="couchbase" revision="master"/>
 
-  <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" revision="3d39b57188c372649beedd5c13c9003156d5a055" />
-  <project name="build" path="cbbuild" revision="388ec72a70fc0925823d726609a209201052567b">
-    <annotation name="VERSION" value="1.4.1.3" />
-  </project>
-  <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" revision="8e3ecd19340dabed7ad4fea9d9944ab97b5f916d" />
-  <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" revision="1323b92ac2619c29d50e588e59d7a6b4839da629" />
-  <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" revision="06193ca74e834ca91bc28c7555205aedd8e7fa80" />
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d" />
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" revision="eebc98233c3e032eb6b9036575d51324ab5932e6" />
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="708054d61e5a2918b9f4e9700000ee611dcf03f5" />
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf" />
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="ffbe531a496e0f677b018f61c21b8be43588b77a" />
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150" />
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8" />
-  <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47" />
-  <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd" />
-  <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544" />
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864" />
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368" />
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78" />
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" revision="67fb8fa4c62451372108f31c93034c07d9d9f4ab" />
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5" />
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6" />
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="dd45e6a67c53f673bb49ca8a001fd3a63ceb640e" />
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="9b36453141c35697401168b07f2c09fcff7721ce" />
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="7006f7a1abbda37f3276216302f9eb7425e1dfa5" />
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc" />
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc" />
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f" />
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde" />
-  <project name="retriever" path="godeps/src/github.com/couchbase/retriever" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020" />
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f" />
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" revision="a22e64010d08574baa33332695abb27c8e50d251" />
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="24b8252856d71a541cbfeb2203cf7c0ce3634b2b" />
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="7fe4854f1e98ea2ec0ab548bd763030cc133b61b" upstream="master" />
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" revision="release/1.4.1.3" upstream="master" />
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" remote="couchbaselabs" revision="4195073f3c64830ca5bad14016dc5de732211c32" />
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e" />
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a" />
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="4a98979fe7e3cd5e6bb8d06be3e73bc00172d6f2" />
+    <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
+    <project name="build" path="cbbuild" revision="388ec72a70fc0925823d726609a209201052567b">
+        <annotation name="VERSION" value="1.4.1.3"/>
+    </project>
+    <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" revision="8e3ecd19340dabed7ad4fea9d9944ab97b5f916d"/>
+    <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
+    <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" revision="06193ca74e834ca91bc28c7555205aedd8e7fa80"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" revision="eebc98233c3e032eb6b9036575d51324ab5932e6"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="708054d61e5a2918b9f4e9700000ee611dcf03f5"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="ffbe531a496e0f677b018f61c21b8be43588b77a"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
+    <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
+    <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
+    <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" revision="67fb8fa4c62451372108f31c93034c07d9d9f4ab"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="dd45e6a67c53f673bb49ca8a001fd3a63ceb640e"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="9b36453141c35697401168b07f2c09fcff7721ce"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="7006f7a1abbda37f3276216302f9eb7425e1dfa5"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="retriever" path="godeps/src/github.com/couchbase/retriever" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" revision="a22e64010d08574baa33332695abb27c8e50d251"/>
+    <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="24b8252856d71a541cbfeb2203cf7c0ce3634b2b"/>
+    <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="7fe4854f1e98ea2ec0ab548bd763030cc133b61b" upstream="master"/>
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" revision="release/1.4.1.3" upstream="master"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" remote="couchbaselabs" revision="4195073f3c64830ca5bad14016dc5de732211c32"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="4a98979fe7e3cd5e6bb8d06be3e73bc00172d6f2"/>
 </manifest>

--- a/manifest/1.5.0.xml
+++ b/manifest/1.5.0.xml
@@ -27,13 +27,13 @@ licenses/APL2.txt.
     <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
     <remote fetch="https://github.com/satori/" name="satori"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="build" path="cbbuild" remote="couchbase" revision="2693c160e604c17daa838c151b35ffcf7ddcc1b6">
-        <annotation name="VERSION" value="1.5.0"     keep="true"/>
+        <annotation name="VERSION" value="1.5.0" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/1.5.1.xml
+++ b/manifest/1.5.1.xml
@@ -27,13 +27,13 @@ licenses/APL2.txt.
     <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
     <remote fetch="https://github.com/satori/" name="satori"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="build" path="cbbuild" remote="couchbase" revision="2693c160e604c17daa838c151b35ffcf7ddcc1b6">
-        <annotation name="VERSION" value="1.5.1"     keep="true"/>
+        <annotation name="VERSION" value="1.5.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/1.5.2.xml
+++ b/manifest/1.5.2.xml
@@ -27,13 +27,13 @@ licenses/APL2.txt.
     <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
     <remote fetch="https://github.com/satori/" name="satori"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="build" path="cbbuild" remote="couchbase" revision="2693c160e604c17daa838c151b35ffcf7ddcc1b6">
-        <annotation name="VERSION" value="1.5.2"     keep="true"/>
+        <annotation name="VERSION" value="1.5.2" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/2.0.0.xml
+++ b/manifest/2.0.0.xml
@@ -29,13 +29,13 @@ licenses/APL2.txt.
     <remote fetch="https://github.com/pkg/" name="pkg"/>
     <remote fetch="https://github.com/go-sourcemap/" name="go-sourcemap"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="build" path="cbbuild" remote="couchbase" revision="3bc4afccb8de2beed33c2d994b273d312b9a2a64">
-        <annotation name="VERSION" value="2.0.0"     keep="true"/>
+        <annotation name="VERSION" value="2.0.0" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/2.1.0.xml
+++ b/manifest/2.1.0.xml
@@ -12,134 +12,134 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
-  <remote fetch="https://github.com/elazarl/" name="elazarl"/>
-  <remote fetch="https://github.com/natefinch/" name="natefinch"/>
-  <remote fetch="https://github.com/rcrowley/" name="rcrowley"/>
-  <remote fetch="https://github.com/samuel/" name="samuel"/>
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
-  <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
-  <remote fetch="https://github.com/coreos/" name="coreos"/>
-  <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
-  <remote fetch="https://github.com/satori/" name="satori"/>
-  <remote fetch="https://github.com/pkg/" name="pkg"/>
-  <remote fetch="https://github.com/go-sourcemap/" name="go-sourcemap"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/elazarl/" name="elazarl"/>
+    <remote fetch="https://github.com/natefinch/" name="natefinch"/>
+    <remote fetch="https://github.com/rcrowley/" name="rcrowley"/>
+    <remote fetch="https://github.com/samuel/" name="samuel"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
+    <remote fetch="https://github.com/coreos/" name="coreos"/>
+    <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
+    <remote fetch="https://github.com/satori/" name="satori"/>
+    <remote fetch="https://github.com/pkg/" name="pkg"/>
+    <remote fetch="https://github.com/go-sourcemap/" name="go-sourcemap"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="build" path="cbbuild" remote="couchbase" revision="b12f0bd55f1f135e5dd190af28d672b90759440f">
-    <annotation name="VERSION" value="2.1.0"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
-
-
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/2.1.0"/>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="build" path="cbbuild" remote="couchbase" revision="b12f0bd55f1f135e5dd190af28d672b90759440f">
+        <annotation name="VERSION" value="2.1.0" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b9e59151693215e85b8fd41339d7e152e55f4dd3"/>
-
-  <!-- Dependencies specific to Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>
-
-  <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
-
-  <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
-
-  <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="aedb0776e80d25a79d4b17c1f322a75a2c52a518"/>
-
-  <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/2.1.0"/>
 
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <!-- Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b9e59151693215e85b8fd41339d7e152e55f4dd3"/>
 
-  <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+    <!-- Dependencies specific to Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="61b5ac22b62ad0e06bd461c8989cfb49a4d3169e"/>
+    <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="16db1f1fe037412f12738fa4d8448c549c4edd77"/>
+    <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="aedb0776e80d25a79d4b17c1f322a75a2c52a518"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="eb0048566506484772bb1be22c1cf0c8cd9def05"/>
+    <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="7b68c492c29f3f952a00a4ba97dac14cc4b2b57e"/>
 
-  <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="61b5ac22b62ad0e06bd461c8989cfb49a4d3169e"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e774e379a0452bfff199a69e053dc565918d680c"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="16db1f1fe037412f12738fa4d8448c549c4edd77"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="eb0048566506484772bb1be22c1cf0c8cd9def05"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="7b68c492c29f3f952a00a4ba97dac14cc4b2b57e"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e774e379a0452bfff199a69e053dc565918d680c"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="bd91bbf73e9a4a801adbfb97133c992678533126"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="8968c61983e8f51a91b8c0ef25bf739278c89634"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="b0907c1dc06bfb60354416769e40bb07b4367d88"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="bd91bbf73e9a4a801adbfb97133c992678533126"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="8968c61983e8f51a91b8c0ef25bf739278c89634"/>
 
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="b0907c1dc06bfb60354416769e40bb07b4367d88"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="238f46bf38971b117d90e70cba9bd4682428a8b6"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="pkg" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="go-sourcemap" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="dec09d789f3dba190787f8b4454c7d3c936fed9e"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <!-- gozip tools -->
-  <project name="ns_server" path="godeps/src/github.com/couchbase/ns_server" remote="couchbase" revision="6d835931f574f25e3781192c09e45a3ee30deb51"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="238f46bf38971b117d90e70cba9bd4682428a8b6"/>
+
+    <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
+
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="pkg" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="go-sourcemap" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="dec09d789f3dba190787f8b4454c7d3c936fed9e"/>
+
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+
+    <!-- gozip tools -->
+    <project name="ns_server" path="godeps/src/github.com/couchbase/ns_server" remote="couchbase" revision="6d835931f574f25e3781192c09e45a3ee30deb51"/>
 
 </manifest>

--- a/manifest/2.5.xml
+++ b/manifest/2.5.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase" revision="53fe2af5d7cf5201f3d7fbe76391d62e652c153f"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="72d5b6031e2bcc209c8bb22521ac9d03916fbe40">
-        <annotation name="VERSION" value="2.5.1.1"     keep="true"/>
+        <annotation name="VERSION" value="2.5.1.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/2.5/2.5.0.xml
+++ b/manifest/2.5/2.5.0.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase" revision="53fe2af5d7cf5201f3d7fbe76391d62e652c153f"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="72d5b6031e2bcc209c8bb22521ac9d03916fbe40">
-        <annotation name="VERSION" value="2.5.0"     keep="true"/>
+        <annotation name="VERSION" value="2.5.0" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/2.5/2.5.1.xml
+++ b/manifest/2.5/2.5.1.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase" revision="53fe2af5d7cf5201f3d7fbe76391d62e652c153f"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="72d5b6031e2bcc209c8bb22521ac9d03916fbe40">
-        <annotation name="VERSION" value="2.5.1"     keep="true"/>
+        <annotation name="VERSION" value="2.5.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/2.6.xml
+++ b/manifest/2.6.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" revision="d519f77629dcfd769c425267752fca095906d7bc" remote="couchbase">
-        <annotation name="VERSION" value="2.6.1.1"   keep="true"/>
+        <annotation name="VERSION" value="2.6.1.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/2.6/2.6.0.xml
+++ b/manifest/2.6/2.6.0.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" revision="b2139268084eab6e8225819ebee1ebe4175348e0" remote="couchbase">
-        <annotation name="VERSION" value="2.6.0"     keep="true"/>
+        <annotation name="VERSION" value="2.6.0" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/2.6/2.6.1.xml
+++ b/manifest/2.6/2.6.1.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" revision="d519f77629dcfd769c425267752fca095906d7bc" remote="couchbase">
-        <annotation name="VERSION" value="2.6.1"     keep="true"/>
+        <annotation name="VERSION" value="2.6.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/2.7.xml
+++ b/manifest/2.7.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="6b173f045016bf510d6d2076c97fb54d7df01a69">
-        <annotation name="VERSION" value="2.7.4"     keep="true"/>
+        <annotation name="VERSION" value="2.7.4" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="3ef76e777eaccded6a314950d1bc4b9326c75c28" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="3ef76e777eaccded6a314950d1bc4b9326c75c28" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="3ef76e777eaccded6a314950d1bc4b9326c75c28"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="3ef76e777eaccded6a314950d1bc4b9326c75c28"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="45bfb9040dc54c0344f8182b5ae527cc88db2dac"/>
 
@@ -115,11 +115,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.7/2.7.0.xml
+++ b/manifest/2.7/2.7.0.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="2cfa322faebe58200b02e53f343ebe70b494a975">
-        <annotation name="VERSION" value="2.7.0"     keep="true"/>
+        <annotation name="VERSION" value="2.7.0" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="d5dc4f6170174357adee38c22e81721d1918b09e" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="d5dc4f6170174357adee38c22e81721d1918b09e" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="d5dc4f6170174357adee38c22e81721d1918b09e"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="d5dc4f6170174357adee38c22e81721d1918b09e"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="45bfb9040dc54c0344f8182b5ae527cc88db2dac"/>
 
@@ -115,11 +115,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="439bf6fbbb47569e5a79fa3c2698ac797643259f"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="68cf89ddc17d5fed0c1424083439585bec964590"/>

--- a/manifest/2.7/2.7.1.xml
+++ b/manifest/2.7/2.7.1.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="6b173f045016bf510d6d2076c97fb54d7df01a69">
-        <annotation name="VERSION" value="2.7.1"     keep="true"/>
+        <annotation name="VERSION" value="2.7.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="45bfb9040dc54c0344f8182b5ae527cc88db2dac"/>
 
@@ -115,11 +115,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="439bf6fbbb47569e5a79fa3c2698ac797643259f"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="68cf89ddc17d5fed0c1424083439585bec964590"/>

--- a/manifest/2.7/2.7.2.xml
+++ b/manifest/2.7/2.7.2.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="6b173f045016bf510d6d2076c97fb54d7df01a69">
-        <annotation name="VERSION" value="2.7.2"     keep="true"/>
+        <annotation name="VERSION" value="2.7.2" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="45bfb9040dc54c0344f8182b5ae527cc88db2dac"/>
 
@@ -115,11 +115,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="439bf6fbbb47569e5a79fa3c2698ac797643259f"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="68cf89ddc17d5fed0c1424083439585bec964590"/>

--- a/manifest/2.7/2.7.3.xml
+++ b/manifest/2.7/2.7.3.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="6b173f045016bf510d6d2076c97fb54d7df01a69">
-        <annotation name="VERSION" value="2.7.3"     keep="true"/>
+        <annotation name="VERSION" value="2.7.3" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="45bfb9040dc54c0344f8182b5ae527cc88db2dac"/>
 
@@ -115,11 +115,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="439bf6fbbb47569e5a79fa3c2698ac797643259f"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="68cf89ddc17d5fed0c1424083439585bec964590"/>

--- a/manifest/2.8.xml
+++ b/manifest/2.8.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="sgw-2.8">
-        <annotation name="VERSION" value="2.8.4"   keep="true"/>
+        <annotation name="VERSION" value="2.8.4" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="a01296b76db4c54811679634f70ce6a5683dbda2"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.0.1.xml
+++ b/manifest/2.8/2.8.0.1.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="5547da1aeb276479ba3adc9cd25bf9795640d976">
-        <annotation name="VERSION" value="2.8.0.1"     keep="true"/>
+        <annotation name="VERSION" value="2.8.0.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.0.xml
+++ b/manifest/2.8/2.8.0.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="5547da1aeb276479ba3adc9cd25bf9795640d976">
-        <annotation name="VERSION" value="2.8.0"     keep="true"/>
+        <annotation name="VERSION" value="2.8.0" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.1.xml
+++ b/manifest/2.8/2.8.1.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="5547da1aeb276479ba3adc9cd25bf9795640d976">
-        <annotation name="VERSION" value="2.8.1"     keep="true"/>
+        <annotation name="VERSION" value="2.8.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.2.xml
+++ b/manifest/2.8/2.8.2.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="5547da1aeb276479ba3adc9cd25bf9795640d976">
-        <annotation name="VERSION" value="2.8.2"     keep="true"/>
+        <annotation name="VERSION" value="2.8.2" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.3.1.xml
+++ b/manifest/2.8/2.8.3.1.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="sgw-2.8">
-        <annotation name="VERSION" value="2.8.3.1"   keep="true"/>
+        <annotation name="VERSION" value="2.8.3.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="a01296b76db4c54811679634f70ce6a5683dbda2"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.3.2.xml
+++ b/manifest/2.8/2.8.3.2.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="sgw-2.8">
-        <annotation name="VERSION" value="2.8.3.2"   keep="true"/>
+        <annotation name="VERSION" value="2.8.3.2" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="a01296b76db4c54811679634f70ce6a5683dbda2"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.3.3.xml
+++ b/manifest/2.8/2.8.3.3.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="sgw-2.8">
-        <annotation name="VERSION" value="2.8.3.3"   keep="true"/>
+        <annotation name="VERSION" value="2.8.3.3" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="a01296b76db4c54811679634f70ce6a5683dbda2"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.3.4.xml
+++ b/manifest/2.8/2.8.3.4.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="sgw-2.8">
-        <annotation name="VERSION" value="2.8.3.4"   keep="true"/>
+        <annotation name="VERSION" value="2.8.3.4" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="a01296b76db4c54811679634f70ce6a5683dbda2"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/2.8/2.8.3.xml
+++ b/manifest/2.8/2.8.3.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="0fc38ccd909e027412260c1d5905cfcd50c268d4">
-        <annotation name="VERSION" value="2.8.3"     keep="true"/>
+        <annotation name="VERSION" value="2.8.3" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -46,8 +46,8 @@ licenses/APL2.txt.
 
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
 
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="a01296b76db4c54811679634f70ce6a5683dbda2"/>
 
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/3.0.xml
+++ b/manifest/3.0.xml
@@ -12,151 +12,151 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.0.9"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.0.9" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.9"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.9"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
-  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
+    <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/3.0/3.0.0.xml
+++ b/manifest/3.0/3.0.0.xml
@@ -12,148 +12,148 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
-    <annotation name="VERSION" value="3.0.0"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
+        <annotation name="VERSION" value="3.0.0" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="46803d1a55f989f8c203c717081200c0c2630d62"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="46803d1a55f989f8c203c717081200c0c2630d62"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fc018ef7de83003867f1111968f2add63145c39c"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fc018ef7de83003867f1111968f2add63145c39c"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.4"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.4"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3c4edeb16c47cdb3bcd1eeab3b3c5c87832d4923"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3c4edeb16c47cdb3bcd1eeab3b3c5c87832d4923"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c182affec369e30f25d3eb8cd8a478dee585ae7d"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="d3accfda2168b0e253f98cff3ef81586e8b88d9f"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="60555c9708c786597e6b07bf846d0dc5c2a46f54"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="546f1fd8d7df61d94633b254641f9f8f48248ada"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="869cfc74c3b4eea1f80f29819f1dab68ed3c780e"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="d7df74196a9e781ede915320c11c378c1b2f3a1f"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="b5d812f8a3706043e23a9cd5babf2e5423744d30"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c182affec369e30f25d3eb8cd8a478dee585ae7d"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="d3accfda2168b0e253f98cff3ef81586e8b88d9f"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="60555c9708c786597e6b07bf846d0dc5c2a46f54"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="546f1fd8d7df61d94633b254641f9f8f48248ada"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="869cfc74c3b4eea1f80f29819f1dab68ed3c780e"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="d7df74196a9e781ede915320c11c378c1b2f3a1f"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="b5d812f8a3706043e23a9cd5babf2e5423744d30"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
 </manifest>

--- a/manifest/3.0/3.0.1.xml
+++ b/manifest/3.0/3.0.1.xml
@@ -12,148 +12,148 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
-    <annotation name="VERSION" value="3.0.1"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
+        <annotation name="VERSION" value="3.0.1" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="34cf114efc68e604853388eb37c16b853f3e2203"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="34cf114efc68e604853388eb37c16b853f3e2203"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fc018ef7de83003867f1111968f2add63145c39c"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fc018ef7de83003867f1111968f2add63145c39c"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.4"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.4"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3c4edeb16c47cdb3bcd1eeab3b3c5c87832d4923"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3c4edeb16c47cdb3bcd1eeab3b3c5c87832d4923"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c182affec369e30f25d3eb8cd8a478dee585ae7d"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="d3accfda2168b0e253f98cff3ef81586e8b88d9f"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="60555c9708c786597e6b07bf846d0dc5c2a46f54"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="546f1fd8d7df61d94633b254641f9f8f48248ada"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="869cfc74c3b4eea1f80f29819f1dab68ed3c780e"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="d7df74196a9e781ede915320c11c378c1b2f3a1f"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="b5d812f8a3706043e23a9cd5babf2e5423744d30"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c182affec369e30f25d3eb8cd8a478dee585ae7d"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="d3accfda2168b0e253f98cff3ef81586e8b88d9f"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="60555c9708c786597e6b07bf846d0dc5c2a46f54"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="546f1fd8d7df61d94633b254641f9f8f48248ada"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="869cfc74c3b4eea1f80f29819f1dab68ed3c780e"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="d7df74196a9e781ede915320c11c378c1b2f3a1f"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="b5d812f8a3706043e23a9cd5babf2e5423744d30"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
 </manifest>

--- a/manifest/3.0/3.0.2.xml
+++ b/manifest/3.0/3.0.2.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="a5d50edde6a7525bdff32f8ba3127a47ac2b291e">
-        <annotation name="VERSION" value="3.0.2"     keep="true"/>
+        <annotation name="VERSION" value="3.0.2" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -45,12 +45,12 @@ licenses/APL2.txt.
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
     <!-- gocb v2 -->
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
     <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-    <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
     <!-- gocb v1 -->
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
     <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/3.0/3.0.3.xml
+++ b/manifest/3.0/3.0.3.xml
@@ -12,148 +12,148 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="d2569fec40181ee4727a49a891e2e4c1b36c6d81">
-    <annotation name="VERSION" value="3.0.3"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="d2569fec40181ee4727a49a891e2e4c1b36c6d81">
+        <annotation name="VERSION" value="3.0.3" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="8187d9ac99353876f66ae329e436eda0b1fa3f3e"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="8187d9ac99353876f66ae329e436eda0b1fa3f3e"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fc018ef7de83003867f1111968f2add63145c39c"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fc018ef7de83003867f1111968f2add63145c39c"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.4"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.4"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3c4edeb16c47cdb3bcd1eeab3b3c5c87832d4923"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3c4edeb16c47cdb3bcd1eeab3b3c5c87832d4923"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c182affec369e30f25d3eb8cd8a478dee585ae7d"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="d3accfda2168b0e253f98cff3ef81586e8b88d9f"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="60555c9708c786597e6b07bf846d0dc5c2a46f54"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="546f1fd8d7df61d94633b254641f9f8f48248ada"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="869cfc74c3b4eea1f80f29819f1dab68ed3c780e"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="d7df74196a9e781ede915320c11c378c1b2f3a1f"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="b5d812f8a3706043e23a9cd5babf2e5423744d30"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c182affec369e30f25d3eb8cd8a478dee585ae7d"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="d3accfda2168b0e253f98cff3ef81586e8b88d9f"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="60555c9708c786597e6b07bf846d0dc5c2a46f54"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="546f1fd8d7df61d94633b254641f9f8f48248ada"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="869cfc74c3b4eea1f80f29819f1dab68ed3c780e"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="d7df74196a9e781ede915320c11c378c1b2f3a1f"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="b5d812f8a3706043e23a9cd5babf2e5423744d30"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="1ecb1f411c1f2ce65a2db6ea4a8ae927182d342e"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
 </manifest>

--- a/manifest/3.0/3.0.4.1.xml
+++ b/manifest/3.0/3.0.4.1.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-        <annotation name="VERSION" value="3.0.4.1"     keep="true"/>
+        <annotation name="VERSION" value="3.0.4.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -45,12 +45,12 @@ licenses/APL2.txt.
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
     <!-- gocb v2 -->
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
     <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-    <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
     <!-- gocb v1 -->
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
     <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/3.0/3.0.4.xml
+++ b/manifest/3.0/3.0.4.xml
@@ -18,14 +18,14 @@ licenses/APL2.txt.
 
     <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-        <annotation name="VERSION" value="3.0.4"     keep="true"/>
+        <annotation name="VERSION" value="3.0.4" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
@@ -45,12 +45,12 @@ licenses/APL2.txt.
     <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
     <!-- gocb v2 -->
-    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
     <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-    <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
     <!-- gocb v1 -->
-    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
     <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
     <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
@@ -119,11 +119,11 @@ licenses/APL2.txt.
 
     <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
     <!-- Enterprise edition dependencies -->
     <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>

--- a/manifest/3.0/3.0.5.xml
+++ b/manifest/3.0/3.0.5.xml
@@ -12,151 +12,151 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.0.5"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.0.5" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="6e81f0eeb2b986258266a50b891d30b0f08fe82b"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="6e81f0eeb2b986258266a50b891d30b0f08fe82b"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
-  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
+    <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/3.0/3.0.6.xml
+++ b/manifest/3.0/3.0.6.xml
@@ -12,151 +12,151 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.0.6"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.0.6" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="cbca7fb9d513481543e9b7839935bf117d6fa53b"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="cbca7fb9d513481543e9b7839935bf117d6fa53b"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
-  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
+    <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/3.0/3.0.7.xml
+++ b/manifest/3.0/3.0.7.xml
@@ -12,151 +12,151 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.0.7"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.0.7" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="a525ca4eb8a1c71afe7fa879ab1afa254d46cd8a"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="a525ca4eb8a1c71afe7fa879ab1afa254d46cd8a"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
-  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
+    <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/3.0/3.0.8.1.xml
+++ b/manifest/3.0/3.0.8.1.xml
@@ -12,151 +12,151 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.0.8.1"   keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.0.8.1" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="3b4d8e6e38e357d86acd04839fe08d28c09ad97f"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="3b4d8e6e38e357d86acd04839fe08d28c09ad97f"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
-  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
+    <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/3.0/3.0.8.2.xml
+++ b/manifest/3.0/3.0.8.2.xml
@@ -12,151 +12,151 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.0.8.2"   keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.0.8.2" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.8.2"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.8.2"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
-  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
+    <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/3.0/3.0.8.xml
+++ b/manifest/3.0/3.0.8.xml
@@ -12,151 +12,151 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.0.8"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.0.8" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.8"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/3.0.8"/>
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2ce555a2ee7ae25aa3420d96a576002d797809c8"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
-  <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
-  <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
+    <!-- gocb v2 -->
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba"/>
+    <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
+    <project name="golang-snappy" path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a"/>
 
-  <!-- gocb v1 -->
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
+    <!-- gocb v1 -->
+    <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="178bb7ca1abbce08f5c6f94f5ca8c53ba0aa20aa"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.6.0"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <!--OpenID Connect, OAuth2 dependencies-->
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
-  <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
-  <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
-  <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
+    <!--OpenID Connect, OAuth2 dependencies-->
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="8d771559cf6e5111c9b9159810d0e4538e7cdc82"/>
+    <project name="go-jose" path="godeps/src/gopkg.in/square/go-jose.v2" remote="couchbasedeps" revision="4ef0f1b175ccd65472d154e1207c4d7b8102545f"/>
+    <project name="oauth2" path="godeps/src/golang.org/x/oauth2" remote="couchbasedeps" revision="bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"/>
+    <project name="cachecontrol" path="godeps/src/github.com/pquerna/cachecontrol" remote="couchbasedeps" revision="1555304b9b35fdd2b425bccf1a5613677705e7d0"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="215cbac22bd7d160b16eebc1fd0d3fbe13e92051"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
-  <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
+    <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="ca12da6727d4fb25c91d282beadc7706e28dfbc4"/>
 
-  <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
+    <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8"/>
 
-  <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222" />
+    <project name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="82614adbe4d480de5675d8eee9b21a180a779222"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d" />
+    <project name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="dee209f2455f101a5e4e593dea94872d2c62d85d"/>
 
-  <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
-  <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2ed3f45fde8f1745eece72968cf673da69f0fd24"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
+    <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="024077e996b048517130b21ea6bf12aa23055d3d"/>
+    <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+    <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="2b33151c9bbc5231aea69b8861c540102b087070"/>
 
-  <!-- gosigar -->
-  <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
-  <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
-  <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
 
-  <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
 
-  <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
-  <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
+    <project name="fgprof" path="godeps/src/github.com/felixge/fgprof" remote="couchbasedeps" revision="033348e0f0e4a38fea34ec259398ee3d336c716a"/>
+    <project name="pprof" path="godeps/src/github.com/google/pprof" remote="couchbasedeps" revision="03e1cf38a040dd596c700aa260c3eddc2bf38987"/>
 
-  <!-- prometheus -->
-  <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
-  <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
-  <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
-  <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
-  <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
-  <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
-  <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
-  <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
-  <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
+    <!-- prometheus -->
+    <project name="golang_protobuf_extensions" path="godeps/src/github.com/matttproud/golang_protobuf_extensions" remote="couchbasedeps" revision="c12348ce28de40eed0136aa2b644d0ee0650e56c"/>
+    <project name="client_golang" path="godeps/src/github.com/prometheus/client_golang" remote="couchbasedeps" revision="989baa30fe956631907493ccee1f8e7708660d96"/>
+    <project name="client_model" path="godeps/src/github.com/prometheus/client_model" remote="couchbasedeps" revision="7bc5445566f0fe75b15de23e6b93886e982d7bf9"/>
+    <project name="common" path="godeps/src/github.com/prometheus/common" remote="couchbasedeps" revision="2af6d036253eee1a9a08c6ddf6be6d67537bcdff"/>
+    <project name="procfs" path="godeps/src/github.com/prometheus/procfs" remote="couchbasedeps" revision="f436cbb89ece38bf080d446b3ca27053b305eaac"/>
+    <project name="perks" path="godeps/src/github.com/beorn7/perks" remote="couchbasedeps" revision="37c8de3658fcb183f997c4e13e8337516ab753e6"/>
+    <project name="xxhash" path="godeps/src/github.com/cespare/xxhash" remote="couchbasedeps" revision="e7a6b52374f7e2abfb8abb27249d53a1997b09a7"/>
+    <project name="protobuf" path="godeps/src/github.com/golang/protobuf" remote="couchbasedeps" revision="ae97035608a719c7a1c1c41bed0ae0744bdb0c6f"/>
+    <project name="protobuf-go" path="godeps/src/google.golang.org/protobuf" remote="couchbasedeps" revision="f2d1f6cbe10b90d22296ea09a7217081c2798009"/>
 
-  <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
+    <project name="mergo" path="godeps/src/github.com/imdario/mergo" remote="couchbasedeps" revision="b968a17bce53738e37f30fd352eb2f7f69ed58a7"/>
 
-  <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
-  <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
+    <project name="websocket" path="godeps/src/nhooyr.io/websocket" remote="couchbasedeps" revision="8dee580a7f74cf1713400307b4eee514b927870f"/>
+    <project name="compress" path="godeps/src/github.com/klauspost/compress" remote="couchbasedeps" revision="4b4f3c94fdf8c3a6c725e2ff110d9b44f88823ed"/>
 
 </manifest>

--- a/manifest/3.1.xml
+++ b/manifest/3.1.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-    <annotation name="VERSION" value="3.1.12"  keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
+        <annotation name="VERSION" value="3.1.12" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.1.12"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.1.12"/>
 
 </manifest>

--- a/manifest/3.1/3.1.0.xml
+++ b/manifest/3.1/3.1.0.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.1.0"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.1.0" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="2a9837d8971e15e56ffe9374322b566316bce160" />
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="2a9837d8971e15e56ffe9374322b566316bce160"/>
 
 </manifest>

--- a/manifest/3.1/3.1.1.1.xml
+++ b/manifest/3.1/3.1.1.1.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.1.1.1"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.1.1.1" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="4c0d32181f496fdbb46c50048f8a7104001338c1"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="4c0d32181f496fdbb46c50048f8a7104001338c1"/>
 
 </manifest>

--- a/manifest/3.1/3.1.1.xml
+++ b/manifest/3.1/3.1.1.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.1.1"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.1.1" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="d26ad3152657c473269f571e4b754c17a27a70ac"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="d26ad3152657c473269f571e4b754c17a27a70ac"/>
 
 </manifest>

--- a/manifest/3.1/3.1.10.1.xml
+++ b/manifest/3.1/3.1.10.1.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.1.10.1"     keep="true"/>
+        <annotation name="VERSION" value="3.1.10.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.1/3.1.10.xml
+++ b/manifest/3.1/3.1.10.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-    <annotation name="VERSION" value="3.1.10"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
+        <annotation name="VERSION" value="3.1.10" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="dba529ace8af1779d04b3a2a15aad8137dbd9ed3"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="dba529ace8af1779d04b3a2a15aad8137dbd9ed3"/>
 
 </manifest>

--- a/manifest/3.1/3.1.11.1.xml
+++ b/manifest/3.1/3.1.11.1.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-    <annotation name="VERSION" value="3.1.11.1"  keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
+        <annotation name="VERSION" value="3.1.11.1" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="c0d563d076085343e751667a73a5ccdc961c7a9e"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="c0d563d076085343e751667a73a5ccdc961c7a9e"/>
 
 </manifest>

--- a/manifest/3.1/3.1.11.xml
+++ b/manifest/3.1/3.1.11.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.1.11"     keep="true"/>
+        <annotation name="VERSION" value="3.1.11" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.1/3.1.2.xml
+++ b/manifest/3.1/3.1.2.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.1.2"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.1.2" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="5aaa2d5b2ccf13cb38ded87d8ef5c62b2ea65efc"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="5aaa2d5b2ccf13cb38ded87d8ef5c62b2ea65efc"/>
 
 </manifest>

--- a/manifest/3.1/3.1.3.1.xml
+++ b/manifest/3.1/3.1.3.1.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-        <annotation name="VERSION" value="3.1.3.1"     keep="true"/>
+        <annotation name="VERSION" value="3.1.3.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.1/3.1.3.xml
+++ b/manifest/3.1/3.1.3.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-    <annotation name="VERSION" value="3.1.3"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
+        <annotation name="VERSION" value="3.1.3" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="52b979cc701a7264a784eaaeea526a9305f97416"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="52b979cc701a7264a784eaaeea526a9305f97416"/>
 
 </manifest>

--- a/manifest/3.1/3.1.4.xml
+++ b/manifest/3.1/3.1.4.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="844e2484067053d7af88e706a814766265bf03df">
-        <annotation name="VERSION" value="3.1.4"     keep="true"/>
+        <annotation name="VERSION" value="3.1.4" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.1/3.1.5.xml
+++ b/manifest/3.1/3.1.5.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
-    <annotation name="VERSION" value="3.1.5"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
+        <annotation name="VERSION" value="3.1.5" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="04ccf3d401e8b935a1c037ede1d7b9bc708efe46"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="04ccf3d401e8b935a1c037ede1d7b9bc708efe46"/>
 
 </manifest>

--- a/manifest/3.1/3.1.6.xml
+++ b/manifest/3.1/3.1.6.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
-        <annotation name="VERSION" value="3.1.6"     keep="true"/>
+        <annotation name="VERSION" value="3.1.6" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.1/3.1.7.xml
+++ b/manifest/3.1/3.1.7.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
-        <annotation name="VERSION" value="3.1.7"     keep="true"/>
+        <annotation name="VERSION" value="3.1.7" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.1/3.1.8.xml
+++ b/manifest/3.1/3.1.8.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
-        <annotation name="VERSION" value="3.1.8"     keep="true"/>
+        <annotation name="VERSION" value="3.1.8" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.1/3.1.9.xml
+++ b/manifest/3.1/3.1.9.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
-    <annotation name="VERSION" value="3.1.9"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="92d1600df77539f894d467740ca193643351f057">
+        <annotation name="VERSION" value="3.1.9" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="3cbb24ad82f84d51ac1106394b37852f4440ec97"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="3cbb24ad82f84d51ac1106394b37852f4440ec97"/>
 
 </manifest>

--- a/manifest/3.2.xml
+++ b/manifest/3.2.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.6"     keep="true"/>
+        <annotation name="VERSION" value="3.2.6" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.0.xml
+++ b/manifest/3.2/3.2.0.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.0"     keep="true"/>
+        <annotation name="VERSION" value="3.2.0" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.1.xml
+++ b/manifest/3.2/3.2.1.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.1"     keep="true"/>
+        <annotation name="VERSION" value="3.2.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.2.1.xml
+++ b/manifest/3.2/3.2.2.1.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.2.1"     keep="true"/>
+        <annotation name="VERSION" value="3.2.2.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.2.xml
+++ b/manifest/3.2/3.2.2.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.2"     keep="true"/>
+        <annotation name="VERSION" value="3.2.2" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.3.xml
+++ b/manifest/3.2/3.2.3.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.3"     keep="true"/>
+        <annotation name="VERSION" value="3.2.3" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.4.1.xml
+++ b/manifest/3.2/3.2.4.1.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.4.1"     keep="true"/>
+        <annotation name="VERSION" value="3.2.4.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.4.xml
+++ b/manifest/3.2/3.2.4.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.4"     keep="true"/>
+        <annotation name="VERSION" value="3.2.4" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.5.1.xml
+++ b/manifest/3.2/3.2.5.1.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.5.1"     keep="true"/>
+        <annotation name="VERSION" value="3.2.5.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.2/3.2.5.xml
+++ b/manifest/3.2/3.2.5.xml
@@ -18,7 +18,7 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.2.5"     keep="true"/>
+        <annotation name="VERSION" value="3.2.5" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>

--- a/manifest/3.3.xml
+++ b/manifest/3.3.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.3.0"     keep="true"/>
+        <annotation name="VERSION" value="3.3.0" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.3.0" />
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.3.0"/>
 
 </manifest>

--- a/manifest/4.0.xml
+++ b/manifest/4.0.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-    <annotation name="VERSION" value="4.0.0"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
+        <annotation name="VERSION" value="4.0.0" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/4.0.0" />
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/4.0.0"/>
 
 </manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -12,19 +12,19 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <default remote="couchbase" revision="master"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="product-texts" path="product-texts" remote="couchbase"/>
-  <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-    <annotation name="VERSION" value="4.1.0"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
+        <annotation name="VERSION" value="4.1.0" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway -->
-   <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="main" />
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="main"/>
 
 </manifest>

--- a/manifest/dev.xml
+++ b/manifest/dev.xml
@@ -12,124 +12,124 @@ licenses/APL2.txt.
 
 <manifest>
 
-  <remote fetch="https://github.com/couchbase/" name="couchbase"/>
-  <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
-  <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
-  <remote fetch="https://github.com/elazarl/" name="elazarl"/>
-  <remote fetch="https://github.com/gorilla/" name="gorilla"/>
-  <remote fetch="https://github.com/natefinch/" name="natefinch"/>
-  <remote fetch="https://github.com/rcrowley/" name="rcrowley"/>
-  <remote fetch="https://github.com/samuel/" name="samuel"/>
-  <remote fetch="https://github.com/tleyden/" name="tleyden"/>
-  <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
-  <remote fetch="https://github.com/kardianos/" name="kardianos"/>
-  <remote fetch="https://github.com/coreos/" name="coreos"/>
-  <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
-  <remote fetch="https://github.com/satori/" name="satori"/>
-  <remote fetch="https://github.com/brett19/" name="brett19"/>
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/elazarl/" name="elazarl"/>
+    <remote fetch="https://github.com/gorilla/" name="gorilla"/>
+    <remote fetch="https://github.com/natefinch/" name="natefinch"/>
+    <remote fetch="https://github.com/rcrowley/" name="rcrowley"/>
+    <remote fetch="https://github.com/samuel/" name="samuel"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
+    <remote fetch="https://github.com/kardianos/" name="kardianos"/>
+    <remote fetch="https://github.com/coreos/" name="coreos"/>
+    <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
+    <remote fetch="https://github.com/satori/" name="satori"/>
+    <remote fetch="https://github.com/brett19/" name="brett19"/>
 
-  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private"/>
 
-  <default remote="couchbase" revision="master"/>
+    <default remote="couchbase" revision="master"/>
 
-  <!-- Build Scripts (required on CI servers) -->
-  <project name="build" path="cbbuild" remote="couchbase">
-    <annotation name="VERSION" value="0.0.0"     keep="true"/>
-    <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
-    <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
-  </project>
-
-
-  <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/1.5.0"/>
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="build" path="cbbuild" remote="couchbase">
+        <annotation name="VERSION" value="0.0.0" keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
 
 
-  <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="bc9e483a80f72ff744b5008af1135b6e2dbfd531"/>
-
-  <!-- Dependencies specific to Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>
-
-  <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
-
-  <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
-
-  <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="aedb0776e80d25a79d4b17c1f322a75a2c52a518"/>
-
-  <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/1.5.0"/>
 
 
-  <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
-  <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+    <!-- Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="bc9e483a80f72ff744b5008af1135b6e2dbfd531"/>
 
-  <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+    <!-- Dependencies specific to Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
+    <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a24c61bd2da6e4930a415e550d68086f7e8c7f75"/>
+    <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="195945aa8fd23ea4772883396fd6b31730035eff"/>
+    <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="aedb0776e80d25a79d4b17c1f322a75a2c52a518"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="6382451e5ef472cd19e4eba6e82e3c1957e4cc09"/>
+    <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="brett19" revision="09f6c000be1a6ec15600d6fc317dfbb8f7763653"/>
 
-  <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+    <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a24c61bd2da6e4930a415e550d68086f7e8c7f75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="cafd6f12f21d446d49ec1dfb16b7cdc878e5b907"/>
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="195945aa8fd23ea4772883396fd6b31730035eff"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="6382451e5ef472cd19e4eba6e82e3c1957e4cc09"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="brett19" revision="09f6c000be1a6ec15600d6fc317dfbb8f7763653"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+    <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
 
-  <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="dd45e6a67c53f673bb49ca8a001fd3a63ceb640e"/>
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
 
-  <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f"/>
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="cafd6f12f21d446d49ec1dfb16b7cdc878e5b907"/>
 
-  <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="8968c61983e8f51a91b8c0ef25bf739278c89634"/>
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
-  <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="dd45e6a67c53f673bb49ca8a001fd3a63ceb640e"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="1490c89b7299046c431e442b6231db28a3b5c0bc"/>
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="ef844635a21403c0a5115bfdbbfb416cc57dae51"/>
+    <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
-  <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
 
-  <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="8968c61983e8f51a91b8c0ef25bf739278c89634"/>
 
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+    <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="1490c89b7299046c431e442b6231db28a3b5c0bc"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="ef844635a21403c0a5115bfdbbfb416cc57dae51"/>
 
-  <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
+    <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 
-  <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
+
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
+
+    <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 
 </manifest>


### PR DESCRIPTION
Just reformat manifest XMLs for uniform indentation described by `.editorconfig`

No other non-whitespace changes 