### PR TITLE
Refresh LongRunningTest for faster `-short` test suite runs

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -789,6 +789,8 @@ func TestConcurrentUserWrites(t *testing.T) {
 }
 
 func TestAuthenticateTrustedJWT(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth, base.KeyAccess, base.KeyHTTP)
 	ctx := base.TestCtx(t)
 	testBucket := base.GetTestBucket(t)

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -29,6 +29,8 @@ func dummyCallbackURL(_ string, _ bool) string {
 const anyError = "SGW_TEST_ANY_ERROR"
 
 func TestJWTVerifyToken(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
 
 	test := func(provider *LocalJWTAuthProvider, token string, expectedError string) func(t *testing.T) {

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -59,6 +59,8 @@ func TestUserAuthenticateDisabled(t *testing.T) {
 }
 
 func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
+	base.LongRunningTest(t)
+
 	const (
 		username      = "alice"
 		oldPassword   = "hunter2"

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -876,13 +876,11 @@ func RequireAllAssertions(t *testing.T, assertionResults ...bool) {
 
 // LongRunningTest skips the test if running in -short mode, and logs if the test completed quickly under other circumstances.
 func LongRunningTest(t *testing.T) {
-	const (
-		shortTestThreshold = time.Second
-	)
 	if testing.Short() {
 		t.Skip("skipping long running test in short mode")
 		return
 	}
+	const shortTestThreshold = 250 * time.Millisecond
 	start := time.Now()
 	t.Cleanup(func() {
 		testDuration := time.Since(start)

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -942,7 +942,6 @@ func createDocWithInBodyAttachment(t *testing.T, ctx context.Context, docID stri
 // Check for regression of CBG-1980 caused by DCP closing timing issue for the mark and sweep stage
 // May sometimes fail if docsToCreate is not high enough
 func TestAttachmentCompactIncorrectStat(t *testing.T) {
-	base.LongRunningTest(t)
 
 	const docsToCreate = 10_000
 	if base.UnitTestUrlIsWalrus() {

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -1446,6 +1446,8 @@ func TestGetAttVersion(t *testing.T) {
 }
 
 func TestLargeAttachments(t *testing.T) {
+	base.LongRunningTest(t)
+
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -79,7 +79,6 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("rosmar does not support DCP client, pending CBG-4249")
 	}
-	base.LongRunningTest(t)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -176,7 +176,6 @@ func TestResyncManagerDCPStopInMidWay(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
-	base.LongRunningTest(t)
 
 	docsToCreate := 1000
 	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
@@ -337,7 +336,6 @@ func TestResyncManagerDCPRunTwice(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
-	base.LongRunningTest(t)
 
 	docsToCreate := 1000
 	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, false)
@@ -395,7 +393,6 @@ func TestResyncManagerDCPResumeStoppedProcess(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
-	base.LongRunningTest(t)
 
 	docsToCreate := 5000
 	db, ctx := setupTestDBForResyncWithDocs(t, docsToCreate, true)
@@ -468,7 +465,7 @@ func TestResyncManagerDCPResumeStoppedProcessChangeCollections(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Test requires Couchbase Server")
 	}
-	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug)
 	base.TestRequiresCollections(t)
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -229,6 +229,7 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 // Verify that a continuous changes feed hitting an error when building its late sequence feed will roll back to
 // its low sequence value, then recover and successfully send subsequent late sequences.
 func TestLateSequenceErrorRecovery(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyChanges, base.KeyCache)
 
@@ -350,6 +351,7 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 // Verify that a continuous changes that has an active late feed serves the expected results if the
 // channel cache associated with the late feed is compacted out of the cache
 func TestLateSequenceHandlingDuringCompact(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache)
 
@@ -576,6 +578,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 
 // Test backfill of late arriving sequences to a continuous changes feed
 func TestContinuousChangesBackfill(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyChanges, base.KeyDCP)
 
@@ -1023,6 +1026,8 @@ func TestChannelQueryCancellation(t *testing.T) {
 //	base.Infof(base.KeyChanges, "Simulate slow processing time for channel %s - sleeping for 100 ms", channel)
 //	time.Sleep(100 * time.Millisecond)
 func TestChannelRace(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges)
 
 	db, ctx := setupTestDBWithCacheOptions(t, shortWaitCache())
@@ -1122,6 +1127,7 @@ func TestChannelRace(t *testing.T) {
 
 // Test that housekeeping goroutines get terminated when change cache is stopped
 func TestStopChangeCache(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyDCP)
 
@@ -1337,6 +1343,7 @@ func readNextFromFeed(feed <-chan (*ChangeEntry), timeout time.Duration) (*Chang
 //
 // Verify that notifyChange for channel ABC was sent.
 func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
+	base.LongRunningTest(t)
 
 	// Enable relevant logging
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyCache, base.KeyChanges)
@@ -1667,6 +1674,8 @@ func TestMaxChannelCacheConfig(t *testing.T) {
 
 // Validates InsertPendingEntries timing
 func TestChangeCache_InsertPendingEntries(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache, base.KeyChanges)
 
 	cacheOptions := DefaultCacheOptions()
@@ -2168,6 +2177,8 @@ func TestProcessSkippedEntryStats(t *testing.T) {
 //   - Push a sequence higher than expected to cache
 //   - Assert that the skipped slice eventually ends up with 0 length and the number of abandoned sequences are as expected
 func TestSkippedSequenceCompact(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
@@ -2224,6 +2235,8 @@ func TestSkippedSequenceCompact(t *testing.T) {
 // TestReleasedSequenceRangeHandlingEverythingSkipped:
 //   - Test release of an unused sequence range when all sequences in the range are skipped sequences
 func TestReleasedSequenceRangeHandlingEverythingSkipped(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	ctx := base.TestCtx(t)
@@ -2414,6 +2427,8 @@ func TestReleasedSequenceRangeHandlingEverythingPendingAndProcessPending(t *test
 //   - Then add another pending entry to take over pending capacity and assert that the range is processed correctly
 //   - Then add another range to completely unblock pending
 func TestReleasedSequenceRangeHandlingEverythingPendingLowPendingCapacity(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	ctx := base.TestCtx(t)
@@ -2512,6 +2527,8 @@ func TestReleasedSequenceRangeHandlingEverythingPendingLowPendingCapacity(t *tes
 //   - Assert this single range is processed off pending after new entry is added taking pending over the limit
 //   - Test release of another single range that is now skipped and assert that skipped is emptied
 func TestReleasedSequenceRangeHandlingSingleSequence(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	ctx := base.TestCtx(t)
@@ -2735,6 +2752,8 @@ func TestReleasedSequenceRangeHandlingEdgeCase2(t *testing.T) {
 //   - Empty skipped through unused sequence release
 //   - Add new contiguous sequence and assert it is processed correctly
 func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	ctx := base.TestCtx(t)
@@ -2859,6 +2878,8 @@ func getChanges(t *testing.T, collection *DatabaseCollectionWithUser, channels b
 }
 
 func TestBroadcastFrequencyAfterSkippedCompact(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	ctx := base.TestCtx(t)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1515,6 +1515,8 @@ func TestUpdatePrincipal(t *testing.T) {
 }
 
 func TestUpdatePrincipalCASRetry(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth, base.KeyCRUD)
 
 	// ensure we don't batch sequences so that the number of released sequences is deterministic
@@ -3364,6 +3366,7 @@ func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
 }
 
 func TestTombstoneCompactionStopWithManager(t *testing.T) {
+	base.LongRunningTest(t)
 
 	if !base.TestUseXattrs() {
 		t.Skip("Compaction requires xattrs")
@@ -3511,6 +3514,8 @@ func TestGetRoleIDs(t *testing.T) {
 }
 
 func Test_updateAllPrincipalsSequences(t *testing.T) {
+	base.LongRunningTest(t)
+
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
@@ -3550,6 +3555,8 @@ func Test_updateAllPrincipalsSequences(t *testing.T) {
 }
 
 func Test_invalidateAllPrincipalsCache(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
 	defer db.Close(ctx)
@@ -3775,6 +3782,8 @@ func Test_getUpdatedDocument(t *testing.T) {
 
 // Regression test for CBG-2058.
 func TestImportCompactPanic(t *testing.T) {
+	base.LongRunningTest(t)
+
 	if !base.TestUseXattrs() {
 		t.Skip("requires xattrs")
 	}

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -166,6 +166,8 @@ func TestDBStateChangeEvent(t *testing.T) {
 // Test sending many events with slow-running execution to validate they get dropped after hitting
 // the max concurrent goroutines
 func TestSlowExecutionProcessing(t *testing.T) {
+	base.LongRunningTest(t)
+
 	ctx := base.TestCtx(t)
 	terminator := make(chan bool)
 	defer close(terminator)
@@ -436,7 +438,6 @@ func InitWebhookTest() (*httptest.Server, *WebhookRequest) {
 }
 
 func TestWebhookBasic(t *testing.T) {
-	base.LongRunningTest(t)
 
 	terminator := make(chan bool)
 	defer close(terminator)
@@ -529,7 +530,6 @@ func TestWebhookOverflows(t *testing.T) {
 	if true { // Modify conditions or re-enable once CBG-2281 is fixed
 		t.Skip("Test skipped")
 	}
-	base.LongRunningTest(t)
 
 	terminator := make(chan bool)
 	defer close(terminator)

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -173,6 +173,8 @@ func addUserAlice(t *testing.T, db *db.Database) auth.User {
 
 // Unit test for JS user functions.
 func TestUserFunctions(t *testing.T) {
+	base.LongRunningTest(t)
+
 	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, &kUserFunctionConfig)
 	defer db.Close(ctx)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestFeedImport(t *testing.T) {
+	base.LongRunningTest(t)
 
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
@@ -932,6 +933,8 @@ func TestImportFeedInvalidInlineSyncMetadata(t *testing.T) {
 }
 
 func TestImportFeedInvalidSyncMetadata(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyMigrate)
 	base.SkipImportTestsIfNotEnabled(t)
 	bucket := base.GetTestBucket(t)
@@ -1008,6 +1011,8 @@ func TestImportFeedInvalidSyncMetadata(t *testing.T) {
 }
 
 func TestOnDemandImportPanicInvalidSyncData(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyMigrate)
 	base.SkipImportTestsIfNotEnabled(t)
 
@@ -1376,6 +1381,8 @@ func getSyncAndMou(t *testing.T, collection *DatabaseCollectionWithUser, key str
 }
 
 func TestImportCancelOnDocWithCorruptSequenceOverImportFeed(t *testing.T) {
+	base.LongRunningTest(t)
+
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
 	}

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -251,7 +251,6 @@ func TestInitializeIndexes(t *testing.T) {
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
-	base.LongRunningTest(t)
 
 	defaultCollection := base.DefaultScopeAndCollectionName()
 	namedCollection := base.ScopeAndCollectionName{Scope: "placeHolderScope", Collection: "placeHolderCollection"}
@@ -424,7 +423,6 @@ func testGetIndexesMeta(t *testing.T, database *db.Database, indexInitOptions db
 
 // TestInitializeIndexesConcurrentMultiNode simulates a large multi-node SG cluster starting up and racing to create indexes.
 func TestInitializeIndexesConcurrentMultiNode(t *testing.T) {
-	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -208,6 +208,8 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 }
 
 func TestReleaseSequenceWait(t *testing.T) {
+	base.LongRunningTest(t)
+
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
@@ -765,6 +767,8 @@ func TestFiveNodeRollbackMiddleNodesDetects(t *testing.T) {
 //
 // Ensures we don't release more sequences than would be expected based on allocator batch size
 func TestVariableRateAllocators(t *testing.T) {
+	base.LongRunningTest(t)
+
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestPublicChanGuestAccess(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := NewRestTester(t,
 		&RestTesterConfig{
 			SyncFn: channels.DocChannelsSyncFunction,
@@ -67,6 +69,7 @@ func TestPublicChanGuestAccess(t *testing.T) {
 }
 
 func TestStarAccess(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges)
 
@@ -298,6 +301,8 @@ func TestUserHasDocAccessDocNotFound(t *testing.T) {
 
 // CBG-2143: Make sure the REST API is returning forbidden errors if when unsupported config option is set
 func TestForceAPIForbiddenErrors(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyHTTP)
 	testCases := []struct {
 		forceForbiddenErrors bool

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -477,7 +477,6 @@ func TestAdminAuthWithX509(t *testing.T) {
 }
 
 func TestAdminAPIAuth(t *testing.T) {
-	base.LongRunningTest(t)
 
 	// Don't really care about the log level but this test hits the logging endpoint so this is used to reset the logging
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -540,6 +540,7 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 // Tests that the users returned in the config endpoint have the correct names
 // Reproduces #2223
 func TestDBGetConfigNamesAndDefaultLogging(t *testing.T) {
+	base.LongRunningTest(t)
 
 	p := "password"
 	rt := rest.NewRestTester(t,
@@ -681,7 +682,6 @@ func TestDCPResyncCollectionsStatus(t *testing.T) {
 
 func TestResyncUsingDCPStream(t *testing.T) {
 	base.TestRequiresDCPResync(t)
-	base.LongRunningTest(t)
 
 	testCases := []struct {
 		docsCreated int
@@ -748,7 +748,6 @@ func TestResyncUsingDCPStream(t *testing.T) {
 
 func TestResyncUsingDCPStreamReset(t *testing.T) {
 	base.TestRequiresDCPResync(t)
-	base.LongRunningTest(t)
 
 	syncFn := `
 	function(doc) {
@@ -944,7 +943,7 @@ func TestResyncErrorScenariosUsingDCPStream(t *testing.T) {
 //   - assert the db returns to the server context and is removed from corrupt database tracking AND that the bucket name
 //     on the config now matches the rest tester bucket name
 func TestCorruptDbConfigHandling(t *testing.T) {
-	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyConfig)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
@@ -1025,6 +1024,7 @@ func TestCorruptDbConfigHandling(t *testing.T) {
 //   - assert that the db config is picked up as an invalid db config
 //   - assert that a call to the db endpoint will fail with correct error message
 func TestBadConfigInsertionToBucket(t *testing.T) {
+	base.LongRunningTest(t)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: base.GetTestBucket(t),
@@ -1256,6 +1256,8 @@ func TestMultipleBucketWithBadDbConfigScenario2(t *testing.T) {
 //   - persist that db config to another bucket
 //   - assert that is picked up as an invalid db config
 func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	ctx := base.TestCtx(t)
@@ -1312,6 +1314,7 @@ func TestMultipleBucketWithBadDbConfigScenario3(t *testing.T) {
 //
 //	Validates db is removed when polling detects that the config is not found
 func TestConfigPollingRemoveDatabase(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyConfig)
 	testCases := []struct {
@@ -1557,7 +1560,6 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 // DB should should only be brought online once
 // there should be no errors
 func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
@@ -1599,7 +1601,6 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 // BD should should only be brought online once
 // there should be no errors
 func TestDBOnlineWithTwoDelays(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	rt := rest.NewRestTester(t, nil)
@@ -2269,6 +2270,8 @@ func TestHandleSGCollect(t *testing.T) {
 }
 
 func TestConfigRedaction(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{Users: map[string]*auth.PrincipalConfig{"alice": {Password: base.Ptr("password")}}}}})
 	defer rt.Close()
 
@@ -2896,6 +2899,8 @@ func TestPutDbConfigChangeName(t *testing.T) {
 }
 
 func TestSwitchDbConfigCollectionName(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
 
@@ -3152,6 +3157,8 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 
 // TestDbConfigPersistentSGVersions ensures that cluster-wide config updates are not applied to older nodes to avoid pushing invalid configuration.
 func TestDbConfigPersistentSGVersions(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyConfig)
 
 	// Start SG with no databases
@@ -3255,6 +3262,7 @@ func TestDbConfigPersistentSGVersions(t *testing.T) {
 }
 
 func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
+	base.LongRunningTest(t)
 
 	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{
@@ -3305,6 +3313,8 @@ func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
 }
 
 func TestSetFunctionsWhileDbOffline(t *testing.T) {
+	base.LongRunningTest(t)
+
 	importFilter := "function(doc){ return true; }"
 	syncFunc := "function(doc){ channel(doc.channels); }"
 

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -27,6 +27,8 @@ import (
 // TestCollectionsPutDocInKeyspace creates a collection and starts up a RestTester instance on it.
 // Ensures that various keyspaces can or can't be used to insert a doc in the collection.
 func TestCollectionsPutDocInKeyspace(t *testing.T) {
+	base.LongRunningTest(t)
+
 	const (
 		username = "alice"
 		password = "pass"
@@ -277,6 +279,8 @@ func TestMultiCollectionDCP(t *testing.T) {
 }
 
 func TestMultiCollectionChannelAccess(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
@@ -966,6 +970,8 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 //   - Fetch runtime config and assert the scope config matches what we expect
 //   - Assert we can perform crud operations against each collection 1 and 2
 func TestRaceBetweenConfigPollAndDbConfigUpdate(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	base.TestRequiresCollections(t)
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -80,6 +80,8 @@ func TestRoot(t *testing.T) {
 }
 
 func TestPublicRESTStatCount(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
@@ -917,6 +919,8 @@ func TestBulkDocsMalformedDocs(t *testing.T) {
 // TestBulkGetEfficientBodyCompression makes sure that the multipart writer of the bulk get response is efficiently compressing the document bodies.
 // This is to catch a case where document bodies are marshalled with random property ordering, and reducing compression ratio between multiple doc body instances.
 func TestBulkGetEfficientBodyCompression(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	const (
@@ -1436,6 +1440,8 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 }
 
 func TestAddingLargeDoc(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	defer func() { rosmar.MaxDocSize = 0 }()
@@ -1792,6 +1798,8 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 // SG restart isn't race-safe, so disabling the test for now.  Should be possible to reinstate this as a proper unit test
 // once we add the ability to take a bucket offline/online.
 func TestLongpollWithWildcard(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyHTTP)
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`}
@@ -2909,7 +2917,7 @@ func TestNullDocHandlingForMutable1xBody(t *testing.T) {
 //   - Test updating the config to disable the use of xattrs in this database through replacing + upserting the config
 //   - Assert error code is returned and response contains error string
 func TestDatabaseXattrConfigHandlingForDBConfigUpdate(t *testing.T) {
-	base.LongRunningTest(t)
+
 	const (
 		dbName  = "db1"
 		errResp = "sync gateway requires enable_shared_bucket_access=true"
@@ -3248,6 +3256,8 @@ func TestAllDbs(t *testing.T) {
 
 // TestBufferFlush will test for http.ResponseWriter implements Flusher interface
 func TestBufferFlush(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
 	})

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2213,6 +2213,7 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 }
 
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
@@ -2269,6 +2270,8 @@ func TestAttachmentDeleteOnExpiry(t *testing.T) {
 //   - Tests document update through blip to a doc with attachment metadata defined in sync data
 //   - Assert that the c doc update this way will migrate the attachment metadata from sync data to global sync data
 func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeySync)
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
@@ -2320,6 +2323,8 @@ func TestUpdateViaBlipMigrateAttachment(t *testing.T) {
 }
 
 func TestUpdateExistingAttachment(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -2378,6 +2383,8 @@ func TestUpdateExistingAttachment(t *testing.T) {
 // TestPushUnknownAttachmentAsStub sets revpos to an older generation, for an attachment that doesn't exist on the server.
 // Verifies that getAttachment is triggered, and attachment is properly persisted.
 func TestPushUnknownAttachmentAsStub(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -2416,6 +2423,8 @@ func TestPushUnknownAttachmentAsStub(t *testing.T) {
 }
 
 func TestAttachmentWithErroneousRevPos(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -2584,6 +2593,8 @@ func TestPutInvalidAttachment(t *testing.T) {
 // validates that proveAttachment isn't being invoked when the attachment is already present and the
 // digest doesn't change, regardless of revpos.
 func TestCBLRevposHandling(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeySGTest, base.KeySyncMsg, base.KeySync)
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
@@ -2884,6 +2895,8 @@ func TestAttachmentMigrationToGlobalXattrOnUpdate(t *testing.T) {
 }
 
 func TestBlipPushRevWithAttachment(t *testing.T) {
+	base.LongRunningTest(t)
+
 	btcRunner := NewBlipTesterClientRunner(t)
 
 	btcRunner.Run(func(t *testing.T) {

--- a/rest/attachmentmigrationtest/attachment_migration_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_test.go
@@ -60,7 +60,7 @@ func TestChangeDbCollectionsRestartMigrationJob(t *testing.T) {
 	}
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	tb := base.GetTestBucket(t)
 	rtConfig := &rest.RestTesterConfig{

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -711,6 +711,8 @@ func TestRedactConfigAsStr(t *testing.T) {
 }
 
 func TestEffectiveUserID(t *testing.T) {
+	base.LongRunningTest(t)
+
 	tempdir := t.TempDir()
 	base.ResetGlobalTestLogging(t)
 	base.InitializeMemoryLoggers()

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -32,6 +32,8 @@ import (
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
 func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
@@ -99,6 +101,8 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
 func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
@@ -163,6 +167,8 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 
 // TestBlipProveAttachmentV2 ensures that CBL's proveAttachment for deduplication is working correctly even for v2 attachments which aren't de-duped on the server side.
 func TestBlipProveAttachmentV2(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
@@ -219,6 +225,8 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 
 // TestBlipProveAttachmentV2Push ensures that CBL's attachment deduplication is ignored for push replications - resulting in new server-side digests and duplicated attachment data (v2 attachment format).
 func TestBlipProveAttachmentV2Push(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
@@ -266,6 +274,8 @@ func TestBlipProveAttachmentV2Push(t *testing.T) {
 }
 
 func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -501,6 +511,8 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 
 // TestBlipAttachNameChange tests CBL handling - attachments with changed names are sent as stubs, and not new attachments
 func TestBlipAttachNameChange(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync, base.KeySyncMsg, base.KeyWebSocket, base.KeyWebSocketFrame, base.KeyHTTP, base.KeyCRUD)
 
 	rtConfig := &RestTesterConfig{
@@ -552,6 +564,8 @@ func TestBlipAttachNameChange(t *testing.T) {
 
 // TestBlipLegacyAttachNameChange ensures that CBL name changes for legacy attachments are handled correctly
 func TestBlipLegacyAttachNameChange(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -597,6 +611,7 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 
 // TestBlipLegacyAttachDocUpdate ensures that CBL updates for documents associated with legacy attachments are handled correctly
 func TestBlipLegacyAttachDocUpdate(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := &RestTesterConfig{
@@ -669,6 +684,8 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 }
 
 func TestPushDocWithNonRootAttachmentProperty(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,

--- a/rest/blip_api_collections_test.go
+++ b/rest/blip_api_collections_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestBlipGetCollections(t *testing.T) {
+	base.LongRunningTest(t)
+
 	// FIXME as part of CBG-2203 to enable subtest checkpointExistsWithErrorInNonDefaultCollection
 	base.TestRequiresCollections(t)
 
@@ -238,6 +240,8 @@ func TestBlipGetCollectionsAndSetCheckpoint(t *testing.T) {
 }
 
 func TestCollectionsReplication(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 
 	rtConfig := &RestTesterConfig{
@@ -263,6 +267,8 @@ func TestCollectionsReplication(t *testing.T) {
 }
 
 func TestBlipReplicationMultipleCollections(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -301,6 +307,8 @@ func TestBlipReplicationMultipleCollections(t *testing.T) {
 }
 
 func TestBlipReplicationMultipleCollectionsMismatchedDocSizes(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -157,6 +157,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Make several updates
 // Wait until we get the expected updates
 func TestContinuousChangesSubscription(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 
@@ -945,6 +946,8 @@ function(doc, oldDoc) {
 // Start subChanges w/ continuous=true, batchsize=20
 // Start sending rev messages for documents that grant access to themselves for the active replication's user
 func TestConcurrentRefreshUser(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 	// Initialize restTester here, so that we can use custom sync function, and later modify user
 	syncFunction := `
@@ -1172,7 +1175,6 @@ func TestBlipSendConcurrentRevs(t *testing.T) {
 //
 //	Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
-	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)
 
@@ -1820,6 +1822,8 @@ func TestMissingNoRev(t *testing.T) {
 // TestSendReplacementRevision ensures that an alternative revision is sent instead of a norev when a client opts for replacement revs.
 // Create doc with rev 1-..., make the client request changes, and then update the document underneath the client's changes request to force a norev, with 2-... being sent as an optional replacement
 func TestSendReplacementRevision(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeyCRUD, base.KeySync, base.KeySyncMsg)
 
 	userChannels := []string{"ABC", "DEF"}
@@ -1951,6 +1955,7 @@ func TestSendReplacementRevision(t *testing.T) {
 
 // TestBlipPullRevMessageHistory tests that a simple pull replication contains history in the rev message.
 func TestBlipPullRevMessageHistory(t *testing.T) {
+	base.LongRunningTest(t)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -1997,6 +2002,8 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 //   - Making use of HLV agent to mock a doc from a HLV aware peer coming over replicator
 //   - Update this same doc through sync gateway then assert that the history is populated with the old current version
 func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
@@ -2050,6 +2057,8 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 }
 
 func TestBlipClientSendDelete(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
@@ -2078,6 +2087,7 @@ func TestBlipClientSendDelete(t *testing.T) {
 
 // Reproduces CBG-617 (a client using activeOnly for the initial replication, and then still expecting to get subsequent tombstones afterwards)
 func TestActiveOnlyContinuous(t *testing.T) {
+	base.LongRunningTest(t)
 
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
@@ -2160,6 +2170,8 @@ func TestNoRevSetSeq(t *testing.T) {
 }
 
 func TestRemovedMessageWithAlternateAccess(t *testing.T) {
+	base.LongRunningTest(t)
+
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
@@ -2241,6 +2253,8 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 //	  Revocation should not be issued because the user currently has access to channel B, even though they didn't
 //	  have access to the removal revision (rev 2).  CBG-2277
 func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testing.T) {
+	base.LongRunningTest(t)
+
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
@@ -2313,7 +2327,6 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 // Asserts on stats to test for regression of CBG-1824: Make sure SubChangesOneShotActive gets decremented when one shot
 // sub changes request has completed
 func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
@@ -2429,6 +2442,7 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 }
 
 func TestBlipInternalPropertiesHandling(t *testing.T) {
+	base.LongRunningTest(t)
 
 	testCases := []struct {
 		name                        string
@@ -2693,8 +2707,8 @@ func TestSendRevAsReadOnlyGuest(t *testing.T) {
 // Tests changes made in CBG-2151 to return errors from sendRevision unless it's a document not found error,
 // in which case a noRev should be sent.
 func TestSendRevisionNoRevHandling(t *testing.T) {
-
 	base.LongRunningTest(t)
+
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("Skip LeakyBucket test when running in integration")
 	}
@@ -2774,6 +2788,8 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 }
 
 func TestUnsubChanges(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
@@ -2824,6 +2840,7 @@ func TestUnsubChanges(t *testing.T) {
 
 // TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the replication.
 func TestRequestPlusPull(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyDCP, base.KeyChanges, base.KeyHTTP)
 	defer db.SuspendSequenceBatching()() // Required for slow sequence simulation
@@ -2881,6 +2898,7 @@ func TestRequestPlusPull(t *testing.T) {
 
 // TestRequestPlusPull tests that a one-shot pull replication waits for pending changes when request plus is set on the db config.
 func TestRequestPlusPullDbConfig(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyDCP, base.KeyChanges, base.KeyHTTP)
 	defer db.SuspendSequenceBatching()() // Required for slow sequence simulation
@@ -3004,6 +3022,8 @@ func TestBlipRefreshUser(t *testing.T) {
 }
 
 func TestImportInvalidSyncGetsNoRev(t *testing.T) {
+	base.LongRunningTest(t)
+
 	if !base.TestUseXattrs() {
 		t.Skip("Test performs import, not valid for non-xattr mode")
 	}
@@ -3064,6 +3084,8 @@ func TestImportInvalidSyncGetsNoRev(t *testing.T) {
 //     then SGW will detect the document needs to be imported when the rev is requested.  Should triggers norev handling
 //     in the case where the import was unsuccessful
 func TestOnDemandImportBlipFailure(t *testing.T) {
+	base.LongRunningTest(t)
+
 	if !base.TestUseXattrs() {
 		t.Skip("Test performs import, not valid for non-xattr mode")
 	}
@@ -3177,6 +3199,7 @@ func TestOnDemandImportBlipFailure(t *testing.T) {
 // TestBlipDatabaseClose verifies that the client connection is closed when the database is closed.
 // Starts a continuous pull replication then updates the db to trigger a close.
 func TestBlipDatabaseClose(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 	btcRunner := NewBlipTesterClientRunner(t)
@@ -3308,6 +3331,7 @@ func TestBlipMergeVersions(t *testing.T) {
 
 // Starts a continuous pull replication then updates the db to trigger a close.
 func TestChangesFeedExitDisconnect(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)
 	btcRunner := NewBlipTesterClientRunner(t)
@@ -3351,6 +3375,8 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 }
 
 func TestBlipPushRevOnResurrection(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache, base.KeySGTest)
 	btcRunner := NewBlipTesterClientRunner(t)
 
@@ -3433,6 +3459,8 @@ func TestBlipPullConflict(t *testing.T) {
 }
 
 func TestTombstoneCount(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -281,6 +281,8 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 // TestBlipDeltaSyncNewAttachmentPull tests that adding a new attachment in SG and replicated via delta sync adds the attachment
 // to the temporary "allowedAttachments" map.
 func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
@@ -368,6 +370,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 // TestBlipDeltaSyncPull tests that a simple pull replication uses deltas in EE,
 // and checks that full body replication still happens in CE.
 func TestBlipDeltaSyncPull(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
@@ -544,6 +547,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 
 // TestBlipDeltaSyncPullRemoved tests a simple pull replication that drops a document out of the user's channel.
 func TestBlipDeltaSyncPullRemoved(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
@@ -609,6 +613,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 // │     Client 1 ├─┤         ▼      continuous      ▼  ├─■
 // └──────────────┘ └───────────────────────────────────┘
 func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
@@ -714,6 +719,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 // │     Client 2 ├───────────┤ ▼ oneshot ├──────────┤ ▼ oneshot ├─■
 // └──────────────┘           └───────────┘          └───────────┘
 func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)
 
@@ -954,6 +960,8 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 // TestBlipDeltaSyncPush tests that a simple push replication handles deltas in EE,
 // and checks that full body replication is still supported in CE.
 func TestBlipDeltaSyncPush(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeySGTest, base.KeySyncMsg, base.KeySync)
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -1082,6 +1090,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 // TestBlipNonDeltaSyncPush tests that a client that doesn't support deltas can push to a SG that supports deltas (either CE or EE)
 func TestBlipNonDeltaSyncPush(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	sgUseDeltas := base.IsEnterpriseEdition()
@@ -1138,6 +1147,8 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 }
 
 func TestBlipDeltaNoAccessPush(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeySyncMsg, base.KeyWebSocket, base.KeySGTest)
 	const (
 		username = "alice"

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestReplicationBroadcastTickerChange(t *testing.T) {
+	base.LongRunningTest(t)
+
 	if !base.TestUseXattrs() {
 		t.Skip("Skipping test that requires xattrs")
 	}
@@ -93,6 +95,8 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 
 // TestBlipClientPushAndPullReplication sets up a bidi replication for a BlipTesterClient, writes documents on SG and the client and ensures they replicate.
 func TestBlipClientPushAndPullReplication(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 
 	rtConfig := RestTesterConfig{

--- a/rest/blip_channel_filter_test.go
+++ b/rest/blip_channel_filter_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestChannelFilterRemovalFromChannel(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyChanges, base.KeyCache, base.KeyCRUD, base.KeyHTTP)
 	btcRunner := NewBlipTesterClientRunner(t)
 	btcRunner.Run(func(t *testing.T) {

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -970,6 +970,8 @@ func TestLegacyRevNotInConflict(t *testing.T) {
 }
 
 func TestLegacyRevBlipTesterClient(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeySGTest, base.KeyCRUD, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCRUD)
 	rtConfig := RestTesterConfig{GuestEnabled: true}
 	btcRunner := NewBlipTesterClientRunner(t)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -25,6 +25,8 @@ import (
 // Then Sync Gateway restarts to ensure that a subsequent bootstrap picks up the
 // database created in the first step.
 func TestBootstrapRESTAPISetup(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	config := BootstrapStartupConfigForTest(t) // share config between both servers in test to share a groupID

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestBytesReadDocOperations(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -2327,6 +2327,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 
 // Tests query backfill with limit
 func TestChangesQueryBackfillWithLimit(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)
 

--- a/rest/changestest/changes_collection_test.go
+++ b/rest/changestest/changes_collection_test.go
@@ -133,6 +133,7 @@ func TestMultiCollectionChangesUser(t *testing.T) {
 }
 
 func TestMultiCollectionChangesMultiChannelOneShot(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyChanges, base.KeyCache, base.KeyCRUD)
 	numCollections := 2

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2937,6 +2937,8 @@ func makeScopesConfigWithDefault(scopeName string, collections []string) *Scopes
 //   - Delete the invalid db config form the bucket
 //   - Force config poll reload and assert the invalid db is cleared
 func TestInvalidDbConfigNoLongerPresentInBucket(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -23,6 +23,8 @@ import (
 const accessControlAllowOrigin = "Access-Control-Allow-Origin"
 
 func TestCORSDynamicSet(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,

--- a/rest/diagnostic_api_test.go
+++ b/rest/diagnostic_api_test.go
@@ -724,6 +724,8 @@ func TestGetAllChannelsByUserWithSingleNamedCollection(t *testing.T) {
 }
 
 func TestGetAllChannelsByUserWithMultiCollections(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 
 	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true}, 2)

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -65,6 +65,8 @@ func TestGetAlldocChannels(t *testing.T) {
 }
 
 func TestGetDocDryRuns(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SkipImportTestsIfNotEnabled(t)
 	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
@@ -711,6 +713,8 @@ func TestGetUserDocAccessSpanWithSingleNamedCollection(t *testing.T) {
 }
 
 func TestGetUserDocAccessSpanWithMultiCollections(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 
 	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true, SyncFn: `function(doc) {channel(doc.channel);}`}, 2)

--- a/rest/functionsapitest/user_functions_queries_test.go
+++ b/rest/functionsapitest/user_functions_queries_test.go
@@ -74,6 +74,8 @@ func TestUserFunctions(t *testing.T) {
 }
 
 func TestJSFunctionAsGuest(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		GuestEnabled:      true,
 		EnableUserQueries: true,

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestMultiCollectionImportFilter(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SkipImportTestsIfNotEnabled(t)
 	base.RequireNumTestDataStores(t, 3)
@@ -261,6 +262,7 @@ const collectionsDbConfigUpsertScopes = `{
 	}`
 
 func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	base.SkipImportTestsIfNotEnabled(t)
@@ -354,6 +356,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 }
 
 func TestMultiCollectionImportRemoveCollection(t *testing.T) {
+	base.LongRunningTest(t)
 
 	defer db.SuspendSequenceBatching()()
 	base.SkipImportTestsIfNotEnabled(t)

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -699,6 +699,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 // Test scenario where another actor updates a different xattr on a document.  Sync Gateway
 // should detect and not import/create new revision during feed-based import
 func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SkipImportTestsIfNotEnabled(t)
 
@@ -822,6 +823,7 @@ type treeHistory struct {
 
 // Test migration of a 1.4 doc with large inline revisions.  Validate they get migrated out of the body
 func TestMigrateLargeInlineRevisions(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SkipImportTestsIfNotEnabled(t)
 
@@ -2115,6 +2117,8 @@ func TestImportOnWriteMigration(t *testing.T) {
 }
 
 func TestImportFilterTimeout(t *testing.T) {
+	base.LongRunningTest(t)
+
 	importFilter := `function(doc) { while(true) { } }`
 
 	rtConfig := rest.RestTesterConfig{DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{ImportFilter: &importFilter, AutoImport: false, JavascriptTimeoutSecs: base.Ptr(uint32(1))}}}
@@ -2633,6 +2637,8 @@ func TestPrevRevNoPopulationImportFeed(t *testing.T) {
 //   - Wait for the doc to arrive over the import feed and assert that once doc was imported the attachment metadata
 //     was migrated from sync data xattr to global xattr
 func TestMigrationOfAttachmentsOnImport(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SkipImportTestsIfNotEnabled(t)
 
 	rtConfig := rest.RestTesterConfig{

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -40,7 +40,6 @@ func TestChangeIndexPartitions(t *testing.T) {
 	}
 
 	// requires index init for many subtests
-	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyQuery, base.KeyHTTP)
 
@@ -276,7 +275,6 @@ func TestChangeIndexPartitionsDbOffline(t *testing.T) {
 	}
 
 	// requires index init
-	base.LongRunningTest(t)
 
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
@@ -303,7 +301,6 @@ func TestChangeIndexPartitionsStartStopAndRestart(t *testing.T) {
 	}
 
 	// requires index init
-	base.LongRunningTest(t)
 
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
@@ -355,7 +352,6 @@ func TestChangeIndexSeparatePrincipalIndexes(t *testing.T) {
 	}
 
 	// requires index init
-	base.LongRunningTest(t)
 
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 func TestLocalJWTAuthenticationE2E(t *testing.T) {
-	base.LongRunningTest(t)
 
 	const (
 		testIssuer             = "test_issuer"
@@ -165,7 +164,6 @@ func TestLocalJWTAuthenticationE2E(t *testing.T) {
 
 func TestLocalJWTAuthenticationEdgeCases(t *testing.T) {
 
-	base.LongRunningTest(t)
 	testRSAKeypair, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	testRSAJWK := jose.JSONWebKey{

--- a/rest/logging_test.go
+++ b/rest/logging_test.go
@@ -19,7 +19,7 @@ import (
 func TestHTTPLoggingRedaction(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
-	base.LongRunningTest(t)
+
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -383,6 +383,8 @@ func (s *mockAuthServer) keysHandler(w http.ResponseWriter, r *http.Request) {
 // Verifies OpenID Connect callback URL in redirect link is returned in the Location
 // header for both oidc and _oidc_challenge requests.
 func TestGetOIDCCallbackURL(t *testing.T) {
+	base.LongRunningTest(t)
+
 	type test struct {
 		name         string
 		authURL      string
@@ -533,8 +535,8 @@ func (m mockProviderChannelsClaim) Apply(provider *auth.OIDCProvider) {
 
 // E2E test that checks OpenID Connect Authorization Code Flow.
 func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
-
 	base.LongRunningTest(t)
+
 	type test struct {
 		name                string
 		providers           auth.OIDCProviderMap
@@ -2109,8 +2111,8 @@ func TestCallbackStateClientCookies(t *testing.T) {
 // E2E test that checks OpenID Connect Authorization Code Flow with the specified username_claim
 // as Sync Gateway username.
 func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
-
 	base.LongRunningTest(t)
+
 	var (
 		defaultProvider = "foo"
 		authURL         = "/db/_oidc?provider=foo&offline=true"
@@ -2366,6 +2368,8 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 // CBG-1378 - test when OIDC provider is not reachable, and then becomes reachable
 // at a later request
 func TestEventuallyReachableOIDCClient(t *testing.T) {
+	base.LongRunningTest(t)
+
 	// Modified copy of TestOpenIDConnectImplicitFlow
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	unreachableAddr := "http://0.0.0.0"
@@ -2586,6 +2590,7 @@ func TestOpenIDConnectRolesChannelsClaims(t *testing.T) {
 
 // Checks that we correctly handle the removal of an OIDC provider while it's in use
 func TestOpenIDConnectProviderRemoval(t *testing.T) {
+	base.LongRunningTest(t)
 
 	const (
 		providerName    = "foo"
@@ -2806,6 +2811,8 @@ func TestOpenIDConnectIssuerChange(t *testing.T) {
 }
 
 func TestPutDBConfigOIDC(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	sc, closeFn := StartBootstrapServer(t)

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -210,8 +210,8 @@ func TestProviderOIDCAuthWithTlsSkipVerifyEnabled(t *testing.T) {
 }
 
 func TestProviderOIDCAuthWithTlsSkipVerifyDisabled(t *testing.T) {
-
 	base.LongRunningTest(t)
+
 	restTesterConfig := restTesterConfigWithTestProviderEnabled()
 	restTesterConfig.DatabaseConfig.Unsupported.OidcTlsSkipVerify = false
 	restTester := NewRestTester(t, &restTesterConfig)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -338,6 +338,8 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 }
 
 func TestImportFilterEndpoint(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SkipImportTestsIfNotEnabled(t) // import tests don't work without xattrs
 
 	rt := NewRestTesterPersistentConfig(t)
@@ -545,6 +547,8 @@ func TestPersistentConfigRegistryRollbackAfterDbConfigRollback(t *testing.T) {
 // TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback simulates a vbucket rollback for the dbconfig,
 // leaving the registry version ahead of the config - but also with a collection conflict occurring in the subsequent rollback.
 func TestPersistentConfigRegistryRollbackCollectionConflictAfterDbConfigRollback(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 3)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyConfig)
@@ -1371,6 +1375,8 @@ func makeDbConfig(bucketName string, dbName string, scopesConfig ScopesConfig) D
 }
 
 func TestPersistentConfigNoBucketField(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyConfig)

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -35,6 +35,7 @@ import (
 //   - The replicator also remaps local collections to different ones on the remote.
 //   - The replicator also filters to a subset of channels for each of the replicated collections.
 func TestActiveReplicatorMultiCollection(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 	base.TestRequiresCollections(t)
@@ -416,6 +417,8 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 }
 
 func TestReplicatorMissingCollections(t *testing.T) {
+	base.LongRunningTest(t)
+
 	const numCollections = 2
 	base.RequireNumTestDataStores(t, numCollections)
 	base.RequireNumTestBuckets(t, 2)

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	testCases := []struct {
 		name            string
@@ -193,6 +195,8 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 }
 
 func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	// Passive
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
@@ -347,6 +351,8 @@ func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 }
 
 func TestActiveReplicatorLocalWinsCases(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	const (
@@ -634,6 +640,8 @@ func TestActiveReplicatorLocalWinsCases(t *testing.T) {
 }
 
 func TestActiveReplicatorRemoteWinsCases(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	const (
@@ -934,6 +942,8 @@ func TestActiveReplicatorRemoteWinsCases(t *testing.T) {
 }
 
 func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	testCases := []struct {
@@ -1211,6 +1221,8 @@ func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
 }
 
 func TestActiveReplicatorAttachmentHandling(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	testCases := []struct {
@@ -1369,6 +1381,8 @@ func TestActiveReplicatorAttachmentHandling(t *testing.T) {
 }
 
 func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	testCases := []struct {
@@ -1613,6 +1627,8 @@ func TestActiveReplicatorInvalidCustomResolver(t *testing.T) {
 }
 
 func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	activeStartingCV := db.Version{SourceID: "activeRT", Value: 12234}
@@ -1819,6 +1835,8 @@ func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
 }
 
 func TestActiveReplicatorHLVConflictWhenNonWinningRevHasMoreRevisions(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	testCases := []struct {
@@ -1971,6 +1989,8 @@ func TestActiveReplicatorHLVConflictWhenNonWinningRevHasMoreRevisions(t *testing
 }
 
 func TestActiveReplicatorHLVConflictLocalWinsWhenNonWinningRevHasLessRevisionsLocalIsTombstoned(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	// Passive
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
@@ -2087,6 +2107,8 @@ func TestActiveReplicatorHLVConflictLocalWinsWhenNonWinningRevHasLessRevisionsLo
 }
 
 func TestActiveReplicatorHLVConflictWithBothLocalAndRemoteTombstones(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	// Passive
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
@@ -2191,6 +2213,8 @@ func TestActiveReplicatorHLVConflictWithBothLocalAndRemoteTombstones(t *testing.
 }
 
 func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 

--- a/rest/replicatortest/replicator_revtree_test.go
+++ b/rest/replicatortest/replicator_revtree_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestActiveReplicatorRevTreeReconciliation(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	testCases := []struct {
 		name            string
@@ -166,6 +168,8 @@ func TestActiveReplicatorRevTreeReconciliation(t *testing.T) {
 }
 
 func TestActiveReplicatorNoHLVConflictConflictInRevTree(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	// Passive
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
@@ -283,6 +287,8 @@ func TestActiveReplicatorNoHLVConflictConflictInRevTree(t *testing.T) {
 }
 
 func TestActiveReplicatorRevtreeLargeDiffInSize(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	testCases := []struct {

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -467,7 +467,6 @@ func TestReplicationsFromConfig(t *testing.T) {
 // - Creates a continuous push replication on rt1 via the REST API
 // - Validates documents are replicated to rt2
 func TestPushReplicationAPI(t *testing.T) {
-	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
@@ -547,6 +546,8 @@ func TestPullReplicationAPI(t *testing.T) {
 }
 
 func TestStopServerlessConnectionLimitingDuringReplications(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
@@ -588,6 +589,8 @@ func TestStopServerlessConnectionLimitingDuringReplications(t *testing.T) {
 }
 
 func TestServerlessConnectionLimitingOneshotFeed(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
@@ -627,6 +630,8 @@ func TestServerlessConnectionLimitingOneshotFeed(t *testing.T) {
 }
 
 func TestServerlessConnectionLimitingContinuous(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
@@ -685,6 +690,7 @@ func TestServerlessConnectionLimitingContinuous(t *testing.T) {
 //   - Creates a continuous pull replication on rt1 via the REST API
 //   - Validates stop/start/reset actions on the replicationStatus endpoint
 func TestReplicationStatusActions(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
@@ -1006,7 +1012,6 @@ func TestReplicationRebalancePush(t *testing.T) {
 //   - Validates documents are replicated to rt1
 //   - Validates replication status count when replication is local and non-local
 func TestPullOneshotReplicationAPI(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
@@ -1066,7 +1071,6 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 //
 //	WriteUpdateWithXattr.  Have been unable to reproduce the same with a leaky bucket UpdateCallback.
 func TestReplicationConcurrentPush(t *testing.T) {
-	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -1797,6 +1801,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 
 // Repros CBG-2416
 func TestDBReplicationStatsTeardown(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 	// Test tests Prometheus stat registration
@@ -1865,7 +1870,6 @@ func TestDBReplicationStatsTeardown(t *testing.T) {
 }
 
 func TestTakeDbOfflineOngoingPushReplication(t *testing.T) {
-	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
@@ -1966,6 +1970,8 @@ func TestPushReplicationAPIUpdateDatabase(t *testing.T) {
 
 // TestActiveReplicatorHeartbeats uses an ActiveReplicator with another RestTester instance to connect, and waits for several websocket ping/pongs.
 func TestActiveReplicatorHeartbeats(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyWebSocket, base.KeyWebSocketFrame)
 
 	username := "alice"
@@ -2100,6 +2106,8 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 //
 // - Issues a few pulls to ensure the replicator is resuming correctly from a compound sequence checkpoint, and that we're emptying the expected/processed lists appropriately.
 func TestActiveReplicatorPullSkippedSequence(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyCRUD, base.KeyChanges, base.KeyReplicate)
@@ -2292,6 +2300,8 @@ func TestReplicatorReconnectBehaviour(t *testing.T) {
 //   - asserts the replicator enters a reconnecting state and eventually enters a running state again
 //   - puts some docs on the remote rest tester and assert the replicator pulls these docs to prove reconnect was successful
 func TestReconnectReplicator(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	testCases := []struct {
@@ -2358,6 +2368,8 @@ func TestReconnectReplicator(t *testing.T) {
 }
 
 func TestReplicatorReconnectTimeout(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)
 	passiveRT := rest.NewRestTester(t, &rest.RestTesterConfig{
@@ -2429,6 +2441,8 @@ func TestReplicatorReconnectTimeout(t *testing.T) {
 //   - wait some time for the background task to increment TotalSyncTime stat
 //   - assert on the TotalSyncTime stat being incremented
 func TestTotalSyncTimeStat(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)
 
@@ -2464,6 +2478,8 @@ func TestTotalSyncTimeStat(t *testing.T) {
 //   - assert on the TotalSyncTime stat being incremented
 //   - put doc to end changes feed connection
 func TestChangesEndpointTotalSyncTime(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channel);}`,
 	})
@@ -2824,6 +2840,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 //   - Insert the second batch of docs into rt2.
 //   - Starts the pull replication again and asserts that the checkpoint is used.
 func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -2977,6 +2994,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 //   - Creates identical documents on rt1 and rt2.
 //   - Starts a pull replication to ensure that even ignored revisions are checkpointed.
 func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -3325,6 +3343,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 //   - Insert the second batch of docs into rt1.
 //   - Starts the push replication again and asserts that the checkpoint is used.
 func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -3479,6 +3498,8 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 //   - Starts 3 RestTesters, one to create documents, and two running pull replications from the central cluster
 //   - Replicators running on the edges have identical IDs (e.g. edge-repl)
 func TestActiveReplicatorEdgeCheckpointNameCollisions(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 3)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
@@ -3800,8 +3821,6 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 //   - Drops the document out of the channel so the replicator in rt1 pulls a _removed revision.
 func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
-
-	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -4134,7 +4153,6 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 //   - Uses an ActiveReplicator configured for pushAndPull from rt2.
 //   - verifies expected conflict resolution, and that expected result is replicated to both peers
 func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	type conflictWinner int
@@ -4541,6 +4559,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 //   - Recreates rt1 with a new bucket (to simulate a flush).
 //   - Starts the replication again, and ensures that documents are re-replicated to it.
 func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 3)
 
@@ -4695,6 +4714,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 //   - Recreates rt2 with a new bucket (to simulate a flush).
 //   - Starts the replication again, and ensures that post-flush, documents are re-replicated to it.
 func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 3)
 
@@ -4860,6 +4880,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 //   - Manually rolls back the bucket to the first document.
 //   - Starts the replication again, and ensures that documents are re-replicated to it.
 func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -5019,6 +5040,8 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 //   - Modifies the checkpoint rev ID in the target bucket.
 //   - Checkpoints again to ensure it is retried on error.
 func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)
 
@@ -5227,6 +5250,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 //   - Insert the second batch of docs into rt2.
 //   - Starts the pull replication again with a config change, validate checkpoint is reset
 func TestActiveReplicatorPullModifiedHash(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -5532,6 +5556,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 // TestActiveReplicatorReconnectOnStartEventualSuccess ensures an active replicator with invalid creds retries,
 // but succeeds once the user is created on the remote.
 func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -5613,6 +5638,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 
 // TestActiveReplicatorReconnectSendActions ensures ActiveReplicator reconnect retry loops exit when the replicator is stopped
 func TestActiveReplicatorReconnectSendActions(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -5701,7 +5727,6 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 //   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
 func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	createVersion := func(generation int, parentRevID string, body db.Body) rest.DocVersion {
@@ -5975,7 +6000,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 	}
 }
 func TestSGR2TombstoneConflictHandling(t *testing.T) {
-	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	t.Skip("CBG-4782: needs rework for version vectors, may be able ot get to work after rev tree reconciliation is done")
 
@@ -6202,9 +6227,10 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 // This test ensures that the local tombstone revision wins over non-tombstone revision
 // whilst applying default conflict resolution policy through pushAndPull replication.
 func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
+	base.LongRunningTest(t)
 
 	// CBG-4799: tests wil be refactored to allow for easier switch between rev tree and version vector
-	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
@@ -6329,9 +6355,10 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 // This test ensures that the remote tombstone revision wins over non-tombstone revision
 // whilst applying default conflict resolution policy through pushAndPull replication.
 func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
+	base.LongRunningTest(t)
 
 	// CBG-4799: tests wil be refactored to allow for easier switch between rev tree and version vector
-	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
@@ -7050,6 +7077,7 @@ func TestUnprocessableDeltas(t *testing.T) {
 
 // CBG-1428 - check for regression of ISGR not ignoring _removed:true bodies when purgeOnRemoval is disabled
 func TestReplicatorIgnoreRemovalBodies(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
 
@@ -7196,6 +7224,8 @@ func TestUnderscorePrefixSupport(t *testing.T) {
 
 // TestActiveReplicatorBlipsync uses an ActiveReplicator with another RestTester instance to connect and cleanly disconnect.
 func TestActiveReplicatorBlipsync(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 
 	passiveDBName := "passivedb"
@@ -7263,6 +7293,8 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 }
 
 func TestBlipSyncNonUpgradableConnection(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
@@ -7295,6 +7327,8 @@ func TestBlipSyncNonUpgradableConnection(t *testing.T) {
 // Test that the username and password fields in the replicator still work and get redacted appropriately.
 // This should log a deprecation notice.
 func TestReplicatorDeprecatedCredentials(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	passiveRT := rest.NewRestTester(t,
@@ -7361,6 +7395,8 @@ func TestReplicatorDeprecatedCredentials(t *testing.T) {
 
 // CBG-1581: Ensure activeReplicatorCommon does final checkpoint on stop/disconnect
 func TestReplicatorCheckpointOnStop(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	activeRT, passiveRT, remoteURL := rest.SetupSGRPeers(t)

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestActiveReplicatorPushPullLegacyRev(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
@@ -82,6 +84,8 @@ func TestActiveReplicatorPushPullLegacyRev(t *testing.T) {
 }
 
 func TestActiveReplicatorBiDirectionalPreUpgradedDocOnPeer(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 	const username = "alice"
 
@@ -239,6 +243,8 @@ func TestActiveReplicatorBiDirectionalPreUpgradedDocOnPeer(t *testing.T) {
 // | Expected Result | 2-abc,1-abc | none | 2-abc,1-abc | none |  |  |  |  |  |
 // +-----------------+-------------+------+-------------+------+--+--+--+--+--+
 func TestActiveReplicatorBiDirectionalPreUpgradedDocOnBothSidesAlreadyKnownRev(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
@@ -332,6 +338,8 @@ func TestActiveReplicatorBiDirectionalPreUpgradedDocOnBothSidesAlreadyKnownRev(t
 }
 
 func TestActiveReplicatorBiDirectionalPreUpgradedRevInHistory(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
@@ -518,6 +526,8 @@ func TestActiveReplicatorBiDirectionalPreUpgradedRevInHistory(t *testing.T) {
 //	Update this doc on passive to create 100@passiveSource
 //	Pull this rev and assert that the rev is not conflicting
 func TestActiveReplicatorPushPullNewDocLegacyRevAndAllowUpdateAfter(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
@@ -711,6 +721,8 @@ func TestActiveReplicatorPushConflictingPreUpgradedVersion(t *testing.T) {
 }
 
 func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
@@ -891,6 +903,8 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 }
 
 func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -154,7 +154,6 @@ func dbConfigForTestBucket(tb *base.TestBucket) DbConfig {
 }
 
 func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
-	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1500,6 +1500,8 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 }
 
 func TestReplicatorRevocations(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive
@@ -1563,6 +1565,8 @@ func TestReplicatorRevocations(t *testing.T) {
 }
 
 func TestReplicatorRevocationsNoRev(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive
@@ -1630,6 +1634,8 @@ func TestReplicatorRevocationsNoRev(t *testing.T) {
 }
 
 func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive
@@ -1703,6 +1709,8 @@ func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 }
 
 func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) // CBG-1981
@@ -1825,6 +1833,8 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 }
 
 func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
+	base.LongRunningTest(t)
+
 	defer db.SuspendSequenceBatching()()
 
 	base.RequireNumTestBuckets(t, 2)
@@ -1920,6 +1930,8 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 }
 
 func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	// Passive
@@ -1998,6 +2010,8 @@ func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 }
 
 func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) // CBG-1981
@@ -2091,6 +2105,8 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 }
 
 func TestReplicatorRevocationsFromZero(t *testing.T) {
+	base.LongRunningTest(t)
+
 	defer db.SuspendSequenceBatching()()
 
 	base.RequireNumTestBuckets(t, 2)
@@ -2201,6 +2217,8 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 }
 
 func TestRevocationMessage(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	btcRunner := NewBlipTesterClientRunner(t)
@@ -2307,6 +2325,8 @@ func TestRevocationMessage(t *testing.T) {
 }
 
 func TestRevocationNoRev(t *testing.T) {
+	base.LongRunningTest(t)
+
 	defer db.SuspendSequenceBatching()()
 
 	btcRunner := NewBlipTesterClientRunner(t)
@@ -2368,6 +2388,8 @@ func TestRevocationNoRev(t *testing.T) {
 }
 
 func TestRevocationGetSyncDataError(t *testing.T) {
+	base.LongRunningTest(t)
+
 	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	btcRunner := NewBlipTesterClientRunner(t)
@@ -2439,6 +2461,8 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 
 // Regression test for CBG-2183.
 func TestBlipRevokeNonExistentRole(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	btcRunner := NewBlipTesterClientRunner(t)
@@ -2482,6 +2506,8 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 }
 
 func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	defer db.SuspendSequenceBatching()()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -815,6 +815,8 @@ func TestDisableScopesInLegacyConfig(t *testing.T) {
 
 // TestOfflineDatabaseStartup ensures that background processes are not actually running when starting up a database in offline mode.
 func TestOfflineDatabaseStartup(t *testing.T) {
+	base.LongRunningTest(t)
+
 	if !base.TestUseXattrs() {
 		t.Skip("TestOfflineDatabaseStartup requires xattrs for document import")
 	}

--- a/rest/stats_context_test.go
+++ b/rest/stats_context_test.go
@@ -68,6 +68,8 @@ func TestDescriptionPopulation(t *testing.T) {
 }
 
 func TestMemoryProfile(t *testing.T) {
+	base.LongRunningTest(t)
+
 	stats := statsContext{heapProfileCollectionThreshold: 1, heapProfileEnabled: true} // set to a very low value to ensure collection
 
 	outputDir := t.TempDir()

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -388,6 +388,8 @@ func TestSyncFunctionException(t *testing.T) {
 }
 
 func TestSyncFnTimeout(t *testing.T) {
+	base.LongRunningTest(t)
+
 	syncFn := `function(doc) { while(true) {} }`
 
 	rtConfig := RestTesterConfig{SyncFn: syncFn, DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{JavascriptTimeoutSecs: base.Ptr(uint32(1))}}}
@@ -496,7 +498,7 @@ func TestResyncStopUsingDCPStream(t *testing.T) {
 
 func TestResyncRegenerateSequences(t *testing.T) {
 	base.TestRequiresDCPResync(t)
-	base.LongRunningTest(t)
+
 	syncFn := `
 	function(doc) {
 		if (doc.userdoc){
@@ -658,6 +660,8 @@ func TestResyncPersistence(t *testing.T) {
 }
 
 func TestExpiryUpdateSyncFunction(t *testing.T) {
+	base.LongRunningTest(t)
+
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -24,6 +24,8 @@ import (
 // TestDefaultMetadataID creates an database using the named collections on the default scope, then modifies that database to use
 // only the default collection. Verifies that metadata documents are still accessible.
 func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
 	rtConfig := &rest.RestTesterConfig{
@@ -70,6 +72,8 @@ func TestDefaultMetadataIDNamedToDefault(t *testing.T) {
 // TestDefaultMetadataID creates an upgraded database using the defaultMetadataID, then modifies that database to use
 // named collections in the default scope. Verifies that metadata documents are still accessible.
 func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
 	rtConfig := &rest.RestTesterConfig{
@@ -115,6 +119,8 @@ func TestDefaultMetadataIDDefaultToNamed(t *testing.T) {
 // TestDefaultMetadataID creates an upgraded database using the defaultMetadataID, then modifies that database to use
 // named collections in the default scope. Verifies that metadata documents are still accessible.
 func TestUpgradeDatabasePreHelium(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
 
@@ -179,6 +185,7 @@ func getDbConfigFromLegacyConfig(rt *rest.RestTester) string {
 
 }
 func TestLegacyMetadataID(t *testing.T) {
+	base.LongRunningTest(t)
 
 	tb1 := base.GetTestBucket(t)
 	// Create a non-persistent rest tester.  Standard RestTester
@@ -212,6 +219,7 @@ func TestLegacyMetadataID(t *testing.T) {
 // TestMetadataIDRenameDatabase verifies that resync is not required when deleting and recreating a database (with a
 // different name) targeting only the default collection.
 func TestMetadataIDRenameDatabase(t *testing.T) {
+	base.LongRunningTest(t)
 
 	// Create a persistent rest tester with default collection.
 	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
@@ -244,6 +252,7 @@ func TestMetadataIDRenameDatabase(t *testing.T) {
 
 // Verifies that matching metadataIDs are computed if two config groups for the same database are upgraded
 func TestMetadataIDWithConfigGroups(t *testing.T) {
+	base.LongRunningTest(t)
 
 	tb1 := base.GetTestBucket(t)
 	// Create a non-persistent rest tester.  Standard RestTester

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -29,6 +29,7 @@ import (
 
 // TestUsersAPI tests pagination of QueryPrincipals
 func TestUsersAPI(t *testing.T) {
+	base.LongRunningTest(t)
 
 	// Create rest tester with low pagination limit
 	rtConfig := &RestTesterConfig{
@@ -79,6 +80,7 @@ func TestUsersAPI(t *testing.T) {
 
 // TestUsersAPIDetails tests users endpoint with name_only=false when using views (unsupported combination, should return 400)
 func TestUsersAPIDetailsViews(t *testing.T) {
+	base.LongRunningTest(t)
 
 	if !base.TestsDisableGSI() {
 		t.Skip("This test only works with UseViews=true")
@@ -771,7 +773,6 @@ func TestPrincipalForbidUpdatingChannels(t *testing.T) {
 
 // Test user access grant while that user has an active changes feed.  (see issue #880)
 func TestUserAccessRace(t *testing.T) {
-
 	base.LongRunningTest(t)
 
 	// This test only runs against Walrus due to known sporadic failures.
@@ -913,6 +914,7 @@ function(doc, oldDoc) {
 
 // Test user delete while that user has an active changes feed (see issue 809)
 func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
+	base.LongRunningTest(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyChanges, base.KeyCache, base.KeyHTTP)
 
@@ -1192,6 +1194,8 @@ func TestRemovingUserXattr(t *testing.T) {
 }
 
 func TestGetUserCollectionAccess(t *testing.T) {
+	base.LongRunningTest(t)
+
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
@@ -1364,6 +1368,8 @@ func requireJWTChannels(t *testing.T, expectedChannels base.Set, principalConfig
 }
 
 func TestPutUserCollectionAccess(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestDataStores(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	testBucket := base.GetTestBucket(t)

--- a/topologytest/multi_actor_conflict_test.go
+++ b/topologytest/multi_actor_conflict_test.go
@@ -10,6 +10,8 @@ package topologytest
 
 import (
 	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
 )
 
 // TestMultiActorConflictCreate
@@ -18,6 +20,8 @@ import (
 //  3. wait for documents to exist with a matching CV for Couchbase Lite peers, and a full HLV match for non Couchbase
 //     Lite peers. The body should match.
 func TestMultiActorConflictCreate(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -40,6 +44,8 @@ func TestMultiActorConflictCreate(t *testing.T) {
 //  7. wait for documents to exist with a matching CV for Couchbase Lite peers, and a full HLV match for non Couchbase
 //     Lite peers. The body should match.
 func TestMultiActorConflictUpdate(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -68,6 +74,8 @@ func TestMultiActorConflictUpdate(t *testing.T) {
 // 6. start replications
 // 7. assert that the documents are deleted on all peers and have hlv sources equal to the number of active peers
 func TestMultiActorConflictDelete(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -103,6 +111,8 @@ func TestMultiActorConflictDelete(t *testing.T) {
 //  11. assert that the documents are resurrected on all peers and have matching hlvs for non Couchbase Lite peers and
 //     matching CV for Couchbase Lite peers.
 func TestMultiActorConflictResurrect(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -11,6 +11,8 @@ package topologytest
 import (
 	"fmt"
 	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
 )
 
 // TestMultiActorUpdate tests that a single actor can update a document that was created on a different peer.
@@ -20,6 +22,8 @@ import (
 // 4. update each document on a single peer, documents exist in pairwise create peer and update peer
 // 5. wait for the hlv for updated documents to synchronized
 func TestMultiActorUpdate(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -50,6 +54,8 @@ func TestMultiActorUpdate(t *testing.T) {
 // 4. delete each document on a single peer, documents exist in pairwise create peer and update peer
 // 5. wait for the hlv for updated documents to synchronized
 func TestMultiActorDelete(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -80,6 +86,8 @@ func TestMultiActorDelete(t *testing.T) {
 // 6. resurrect each document on a single peer
 // 7. wait for the hlv for updated documents to be synchronized
 func TestMultiActorResurrect(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)

--- a/topologytest/single_actor_test.go
+++ b/topologytest/single_actor_test.go
@@ -11,6 +11,8 @@ package topologytest
 import (
 	"fmt"
 	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
 )
 
 // TestSingleActorCreate tests creating a document with a single actor in different topologies.
@@ -18,6 +20,8 @@ import (
 // 2. create document on a single active peer (version1)
 // 3. wait for convergence on other peers
 func TestSingleActorCreate(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -41,6 +45,8 @@ func TestSingleActorCreate(t *testing.T) {
 // 4. update document on a single active peer (version2)
 // 5. wait for convergence on other peers
 func TestSingleActorUpdate(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -70,6 +76,8 @@ func TestSingleActorUpdate(t *testing.T) {
 // 4. delete document on a single active peer (version2)
 // 5. wait for convergence on other peers for a deleted document with correct hlv
 func TestSingleActorDelete(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)
@@ -100,6 +108,8 @@ func TestSingleActorDelete(t *testing.T) {
 // 6. resurrect document on a single active peer (version3)
 // 7. wait for convergence on other peers for a resurrected document with correct hlv
 func TestSingleActorResurrect(t *testing.T) {
+	base.LongRunningTest(t)
+
 	for _, topologySpec := range append(simpleTopologySpecifications, TopologySpecifications...) {
 		t.Run(topologySpec.description, func(t *testing.T) {
 			collectionName, topology := setupTests(t, topologySpec)

--- a/xdcr/attachment_test.go
+++ b/xdcr/attachment_test.go
@@ -31,6 +31,8 @@ import (
 // 6. Start replications
 // 7. Observe resolved conflict on both Actor A and Actor B, with the attachment still present
 func TestMultiActorLosingConflictUpdateRemovingAttachments(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -28,6 +28,8 @@ import (
 //   - Assert that doc and attachment doc are replicated, sync doc is not
 //   - Assert that the version vector is written on destination bucket for each replicated doc
 func TestMobileXDCRNoSyncDataCopied(t *testing.T) {
+	base.LongRunningTest(t)
+
 	ctx := base.TestCtx(t)
 	base.RequireNumTestBuckets(t, 2)
 	fromBucket := base.GetTestBucket(t)
@@ -153,6 +155,8 @@ func getTwoBucketDataStores(t *testing.T) (base.Bucket, sgbucket.DataStore, base
 }
 
 func TestReplicateVV(t *testing.T) {
+	base.LongRunningTest(t)
+
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
 	fromBucketSourceID, err := base.GetSourceID(ctx, fromBucket)
@@ -387,6 +391,8 @@ func TestVVObeyMou(t *testing.T) {
 }
 
 func TestVVMouImport(t *testing.T) {
+	base.LongRunningTest(t)
+
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeySGTest)
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)
@@ -533,6 +539,8 @@ func TestLWWAfterInitialReplication(t *testing.T) {
 }
 
 func TestReplicateXattrs(t *testing.T) {
+	base.LongRunningTest(t)
+
 	fromBucket, fromDs, toBucket, toDs := getTwoBucketDataStores(t)
 
 	testCases := []struct {
@@ -697,6 +705,8 @@ func TestXDCRBeforeAttachmentMigration(t *testing.T) {
 // TestVVMultiActor verifies that updates by multiple actors (updates to different clusters/buckets) are properly
 // reflected in the HLV (cv and pv).
 func TestVVMultiActor(t *testing.T) {
+	base.LongRunningTest(t)
+
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("This test can fail with CBS due to CBS-4334 since a document without xattrs will be written to the target bucket, even if it is otherwise up to date")
 	}


### PR DESCRIPTION
Refresh `LongRunningTest` list based on a new `gotestsum slowest` run for faster `-short` test suite runs.

## Methodology

```sh
$ gotestsum --jsonfile test-out.json -- -count=1 -p 1 ./...
$ gotestsum tool slowest --jsonfile test-out.json --threshold 250ms --skip-stmt='base.LongRunningTest(t)'
$ # and then some manual fixes and goimports
```

## Results
based on 250ms threshold
- All tests:
  - `DONE 4858 tests, 288 skipped in 448.183s`
- With `-short`:
  - `DONE 4026 tests, 532 skipped in 116.924s`