### PR TITLE
CBG-3594: Check if CORS config is actually empty before adding CORS response headers

### DIFF
--- a/auth/cors.go
+++ b/auth/cors.go
@@ -32,6 +32,12 @@ func (cors *CORSConfig) AddResponseHeaders(request *http.Request, response http.
 	}
 }
 
+// IsEmpty returns true if the CORS configuration is empty - used instead of a nil check since we always initialize the CORS config struct.
+func (cors *CORSConfig) IsEmpty() bool {
+	return cors == nil ||
+		(len(cors.Origin) == 0 && len(cors.LoginOrigin) == 0 && len(cors.Headers) == 0 && cors.MaxAge == 0)
+}
+
 func MatchedOrigin(allowOrigins []string, rqOrigins []string) string {
 	for _, rv := range rqOrigins {
 		for _, av := range allowOrigins {

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -286,6 +286,24 @@ func TestCORSUserNoAccess(t *testing.T) {
 	}
 }
 
+// TestCORSResponseHeadersEmptyConfig ensures that an empty CORS config results in no CORS headers being set on the response.
+func TestCORSResponseHeadersEmptyConfig(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	// RestTester initializes using defaultTestingCORSOrigin - override to empty for this test
+	rt.ServerContext().Config.API.CORS = &auth.CORSConfig{}
+	defer rt.Close()
+
+	reqHeaders := map[string]string{
+		"Origin": "http://example.com",
+	}
+	response := rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/", "", reqHeaders)
+	RequireStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+	assert.NotContains(t, response.Header(), "Access-Control-Allow-Origin")
+	assert.NotContains(t, response.Header(), "Access-Control-Allow-Credentials")
+	assert.NotContains(t, response.Header(), "Access-Control-Allow-Headers")
+}
+
 func TestCORSOriginPerDatabase(t *testing.T) {
 	// Override the default (example.com) CORS configuration in the DbConfig for /db:
 	const perDBMaxAge = 1234

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -339,7 +339,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 			if h.db != nil {
 				cors = h.db.CORS
 			}
-			if cors != nil {
+			if !cors.IsEmpty() {
 				cors.AddResponseHeaders(h.rq, h.response)
 			}
 		}

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -456,7 +456,7 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, serverType serverType, ro
 					cors = db.CORS
 				}
 			}
-			if cors != nil && privs != adminPrivs && privs != metricsPrivs {
+			if !cors.IsEmpty() && privs != adminPrivs && privs != metricsPrivs {
 				cors.AddResponseHeaders(rq, response)
 			}
 			if len(options) == 0 {


### PR DESCRIPTION
CBG-3594

Check if CORS config is actually before adding CORS response headers - the nil check isn't enough since we always initialize the CORS config struct.

Browsers will treat an empty CORS header value in the same way as an absent header (origin checks fail) - but the absence of CORS response headers may provide additional hints that CORS is not configured on the SG side.

## Before

```sh
$ curl -i -H 'Origin: localhost' http://demo:password@localhost:4984/db1/foobar
HTTP/1.1 404 Not Found
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers:
Access-Control-Allow-Origin:
Content-Type: application/json
Server: Couchbase Sync Gateway/4.1 branch/ commit/ EE
Date: Fri, 03 Oct 2025 12:46:50 GMT
Content-Length: 40

{"error":"not_found","reason":"missing"}
```

## After

```sh
$ curl -i -H 'Origin: localhost' http://demo:password@localhost:4984/db1/foobar
HTTP/1.1 404 Not Found
Content-Type: application/json
Server: Couchbase Sync Gateway/4.1 branch/ commit/ EE
Date: Fri, 03 Oct 2025 12:46:04 GMT
Content-Length: 40

{"error":"not_found","reason":"missing"}
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- not CB Server specific 