### PR TITLE
CBG-4899: fix flaky test TestChangesFeedExitDisconnect

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3363,6 +3363,11 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 		defer rt.Close()
 		const alice = "alice"
 		rt.CreateUser(alice, []string{"*"})
+		rt.CreateTestDoc("doc1")
+		rt.WaitForPendingChanges()
+		collection, ctx := rt.GetSingleTestDatabaseCollection()
+		err := collection.FlushChannelCache(ctx)
+		require.NoError(t, err)
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt,
 			&BlipTesterClientOpts{Username: alice},
 		)


### PR DESCRIPTION
CBG-4899

Describe your PR here...
- The test failed because the multichangesfeed query was never run, due to which the blip context never closed, as the query did not error out
- This fix ensures that the multichangesfeed is always run and fails, which would lead to the blip context closing successfully

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/131/
