### PR TITLE
CBG-4910: Add service type for wait until ready options

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2226,7 +2226,9 @@ func (sc *ServerContext) CheckSupportedCouchbaseVersion(ctx context.Context) err
 		return fmt.Errorf("failed to create cluster: %v", err)
 	}
 
-	err = cluster.WaitUntilReady(5*time.Second, &gocb.WaitUntilReadyOptions{})
+	err = cluster.WaitUntilReady(5*time.Second, &gocb.WaitUntilReadyOptions{
+		ServiceTypes: []gocb.ServiceType{gocb.ServiceTypeManagement},
+	})
 	if err != nil {
 		return fmt.Errorf("failed to wait for cluster to become ready: %v", err)
 	}


### PR DESCRIPTION
CBG-4910

Describe your PR here...
- Add Management Service as service option for `WaitUntilReadyOptions`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/133/
