### PR TITLE
[4.0.0 backport] modify revs_limit API docs

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1577,9 +1577,7 @@ Database:
           $ref: '#/Replication'
     revs_limit:
       description: |-
-        The maximum depth a document's revision tree can grow too.
-
-        The minimum is `20` if conflicts are allowed and 0 if not. It is not recommended to go below `100` when conflicts are allowed. The default is `100` if conflicts are allowed and `50` if not.
+        The maximum depth a document's revision tree can grow to.
       type: number
       default: 50
       minimum: 0

--- a/examples/database_config/collections-with-custom-scope.json
+++ b/examples/database_config/collections-with-custom-scope.json
@@ -34,5 +34,7 @@
       }
     }
   },
-  "num_index_replicas": 0
+  "index": {
+    "num_replicas": 0
+  }
 }

--- a/examples/database_config/collections-with-default-collection.json
+++ b/examples/database_config/collections-with-default-collection.json
@@ -34,5 +34,7 @@
       }
     }
   },
-  "num_index_replicas": 0
+  "index": {
+    "num_replicas": 0
+  }
 }

--- a/examples/database_config/ee-basic-delta-sync.json
+++ b/examples/database_config/ee-basic-delta-sync.json
@@ -5,7 +5,7 @@
     "enabled": true,
     "rev_max_age_seconds": 86400
   },
-  "revs_limit": 20,
-  "allow_conflicts": false,
-  "num_index_replicas": 0
+  "index": {
+    "num_replicas": 0
+  }
 }

--- a/examples/database_config/ee-cache-config.json
+++ b/examples/database_config/ee-cache-config.json
@@ -13,13 +13,12 @@
       "max_wait_pending": 5,
       "max_num_pending": 10000,
       "max_wait_skipped": 60,
-      "enable_star_channel": true,
       "max_length": 500,
       "min_length": 50,
       "expiry_seconds": 60
     }
   },
-  "revs_limit": 20,
-  "allow_conflicts": false,
-  "num_index_replicas": 0
+  "index": {
+    "num_replicas": 0
+  }
 }

--- a/examples/database_config/events-webhook.json
+++ b/examples/database_config/events-webhook.json
@@ -20,7 +20,7 @@
       }
     ]
   },
-  "revs_limit": 20,
-  "allow_conflicts": false,
-  "num_index_replicas": 0
+  "index": {
+    "num_replicas": 0
+  }
 }

--- a/examples/database_config/import-filter.json
+++ b/examples/database_config/import-filter.json
@@ -11,7 +11,7 @@
       return true
     }
   `,
-  "revs_limit": 20,
-  "allow_conflicts": false,
-  "num_index_replicas": 0
+  "index": {
+    "num_replicas": 0
+  }
 }

--- a/examples/database_config/openid-connect.json
+++ b/examples/database_config/openid-connect.json
@@ -13,7 +13,7 @@
       }
     }
   },
-  "revs_limit": 20,
-  "allow_conflicts": false,
-  "num_index_replicas": 0
+  "index": {
+    "num_replicas": 0
+  }
 }

--- a/examples/database_config/sync-function.json
+++ b/examples/database_config/sync-function.json
@@ -22,7 +22,7 @@
       }
     }
   `,
-  "revs_limit": 20,
-  "allow_conflicts": false,
-  "num_index_replicas": 0
+  "index": {
+    "num_replicas": 0
+  }
 }

--- a/examples/legacy_config/basic-couchbase-bucket.json
+++ b/examples/legacy_config/basic-couchbase-bucket.json
@@ -12,9 +12,9 @@
       "password": "password",
       "bucket": "default",
       "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } },
-      "allow_conflicts": false,
-      "revs_limit": 20,
-      "num_index_replicas": 0
+      "index": {
+        "num_replicas": 0
+      }
     }
   }
 }

--- a/examples/legacy_config/basic-sync-function.json
+++ b/examples/legacy_config/basic-sync-function.json
@@ -32,9 +32,7 @@
       expiry(doc.expiry)
 	}
       }
-    `,
-    "allow_conflicts": false,
-    "revs_limit": 20
+    `
     }
   }
 }

--- a/examples/legacy_config/config-server.json
+++ b/examples/legacy_config/config-server.json
@@ -12,9 +12,7 @@
       "username": "username",
       "password": "password",
       "bucket": "default",
-      "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } }
     }
   }
 }

--- a/examples/legacy_config/config-shared-bucket-filter.json
+++ b/examples/legacy_config/config-shared-bucket-filter.json
@@ -7,7 +7,6 @@
       "password": "password",
       "bucket": "default",
       "import_docs": true,
-      "enable_shared_bucket_access":true,
       "import_filter": `
 		function(doc) {
 		  if (doc.type != "mobile") {
@@ -15,9 +14,7 @@
 		  }
 		  return true
 		}
-		`,
-    "allow_conflicts": false,
-    "revs_limit": 20
+		`
     }
   }
 }

--- a/examples/legacy_config/config-shared-bucket.json
+++ b/examples/legacy_config/config-shared-bucket.json
@@ -6,10 +6,7 @@
       "username": "username",
       "password": "password",
       "bucket": "default",
-      "import_docs": true,
-      "enable_shared_bucket_access":true,
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "import_docs": true
     }
   }
 }

--- a/examples/legacy_config/cors.json
+++ b/examples/legacy_config/cors.json
@@ -17,9 +17,7 @@
       "username": "username",
       "password": "password",
       "bucket": "default",
-      "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } }
     }
   }
 }

--- a/examples/legacy_config/democlusterconfig.json
+++ b/examples/legacy_config/democlusterconfig.json
@@ -18,9 +18,7 @@
       "bucket":"gaggle",
       "users": {
         "GUEST": {"disabled": false, "admin_channels": ["*"]}
-      },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      }
     },
     "connect2014": {
       "server": "couchbase://localhost",
@@ -100,12 +98,10 @@
           channel("public")
         }
       }
-      `,
-      "allow_conflicts": false,
-      "revs_limit": 20
+      `
     },
     "connect2015": {
-      "server":"http://172.23.121.38:8091",
+      "server":"couchbase://172.23.121.38:8091",
       "bucket":"connect2015",
       "users": {
         "GUEST": {"disabled": true}
@@ -180,21 +176,17 @@
           channel("public")
         }
       }
-      `,
-      "allow_conflicts": false,
-      "revs_limit": 20
+      `
     },
     "grocery-sync": {
-      "server":"http://172.23.121.38:8091",
+      "server":"couchbase://172.23.121.38:8091",
       "bucket":"grocery-sync",
       "users": {
         "GUEST": {"disabled": false, "all_channels": ["*"], "admin_channels": ["*"]}
-      },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      }
     },
     "todolite": {
-      "server":"http://172.23.121.38:8091",
+      "server":"couchbase://172.23.121.38:8091",
       "bucket":"todolite",
       "users": {
         "GUEST": {"disabled": true}
@@ -248,9 +240,7 @@
           access(user, "profiles"); // TODO this should use roles
         }
       }
-    `,
-    "allow_conflicts": false,
-    "revs_limit": 20
+    `
     }
   }
 }

--- a/examples/legacy_config/ee-cache-config.json
+++ b/examples/legacy_config/ee-cache-config.json
@@ -21,8 +21,6 @@
           ]
         }
       },
-      "allow_conflicts": false,
-      "revs_limit": 20,
       "cache":{
         "channel_cache":{
           "max_number": 50000,
@@ -33,8 +31,7 @@
           "expiry_seconds":60,
           "max_wait_pending":5,
           "max_num_pending":10000,
-          "max_wait_skipped":60,
-          "enable_star_channel":true
+          "max_wait_skipped":60
         },
         "rev_cache":{
           "size":5000,

--- a/examples/legacy_config/ee_basic-delta-sync.json
+++ b/examples/legacy_config/ee_basic-delta-sync.json
@@ -12,8 +12,6 @@
       "password": "password",
       "bucket": "default",
       "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } },
-      "allow_conflicts": false,
-      "revs_limit": 20,
       "delta_sync": {
         "enabled": true,
         "rev_max_age_seconds": 86400

--- a/examples/legacy_config/events_webhook.json
+++ b/examples/legacy_config/events_webhook.json
@@ -29,9 +29,7 @@
               }`
           }
         ]
-      },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      }
     }
   }
 }

--- a/examples/legacy_config/logging-with-redaction.json
+++ b/examples/legacy_config/logging-with-redaction.json
@@ -9,9 +9,7 @@
       "username": "username",
       "password": "password",
       "bucket": "default",
-      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}},
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
     }
   }
 }

--- a/examples/legacy_config/logging-with-rotation.json
+++ b/examples/legacy_config/logging-with-rotation.json
@@ -33,9 +33,7 @@
       "username": "username",
       "password": "password",
       "bucket": "default",
-      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}},
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
     }
   }
 }

--- a/examples/legacy_config/openid-connect.json
+++ b/examples/legacy_config/openid-connect.json
@@ -23,9 +23,7 @@
                 "register":true
             }
           }
-        },
-        "allow_conflicts": false,
-        "revs_limit": 20
+        }
       }
    }
 }

--- a/examples/legacy_config/read-write-timeouts.json
+++ b/examples/legacy_config/read-write-timeouts.json
@@ -15,9 +15,7 @@
       "username": "username",
       "password": "password",
       "bucket": "default",
-      "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } }
     }
   }
 }

--- a/examples/legacy_config/replications-in-config.json
+++ b/examples/legacy_config/replications-in-config.json
@@ -11,8 +11,6 @@
       "username": "username",
       "password": "password",
       "bucket": "default",
-      "allow_conflicts": false,
-      "revs_limit": 20,
       "replications": {
         "push-continuous": {
           "direction": "push",
@@ -30,17 +28,13 @@
       "server": "couchbase://localhost",
       "username": "username",
       "password": "password",
-      "bucket": "default1",
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "bucket": "default1"
     },
     "db3": {
       "server": "couchbase://localhost",
       "username": "username",
       "password": "password",
-      "bucket": "default2",
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "bucket": "default2"
     },
     "db4": {
       "server": "couchbase://localhost",
@@ -67,9 +61,7 @@
               return conflict.RemoteDocument;
             }`
         }
-      },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      }
     },
     "db5": {
       "server": "couchbase://localhost",
@@ -81,9 +73,7 @@
           "disabled": false,
           "admin_channels": ["*"]
         }
-      },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      }
     },
     "db6": {
       "server": "couchbase://localhost",
@@ -102,17 +92,13 @@
           "filter": "sync_gateway/bychannel",
           "query_params":["ABC"]
         }
-      },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      }
     },
     "db7": {
       "server": "couchbase://localhost",
       "username": "username",
       "password": "password",
-      "bucket": "default6",
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "bucket": "default6"
     }
   }
 }

--- a/examples/legacy_config/ssl.json
+++ b/examples/legacy_config/ssl.json
@@ -9,15 +9,13 @@
   "SSLKey": "examples/ssl/privkey.pem",
   "databases": {
     "db": {
-      "server": "walrus:",
+      "server": "couchbase://localhost:8091",
       "users": {
         "GUEST": {
           "disabled": false,
           "admin_channels": ["*"]
         }
-      },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      }
     }
   }
 }

--- a/examples/legacy_config/users-roles.json
+++ b/examples/legacy_config/users-roles.json
@@ -18,9 +18,7 @@
           "password": "foo"
         }
       },
-      "roles": { "froods": { "admin_channels": ["hoopy"] } },
-      "allow_conflicts": false,
-      "revs_limit": 20
+      "roles": { "froods": { "admin_channels": ["hoopy"] } }
     }
   }
 }


### PR DESCRIPTION
This is a doc only fix that allows tagging of 4.0-docs more easily.
