### PR TITLE
CBG-4914 use standard rosmar SourceID when not using go test

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
@@ -548,7 +547,7 @@ func GetSourceID(ctx context.Context, bucket Bucket) (string, error) {
 	gocbBucket, err := AsGocbV2Bucket(bucket)
 	if err != nil {
 		// for rosmar bucket and testing, use the bucket name as the source ID to make it easier to identify the source
-		if testing.Testing() {
+		if underGoTest() {
 			return bucket.GetName(), nil
 		}
 		serverUUID := ""

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1011,3 +1011,8 @@ func RequireXattrNotFound(t testing.TB, dataStore sgbucket.DataStore, docID stri
 	require.Error(t, err, fmt.Sprintf("Expected xattr %q to not be found on document %q but has contents %s", xattrName, docID, xattrs[xattrName]))
 	RequireXattrNotFoundError(t, err)
 }
+
+// underGoTest returns true if the tests are being run via 'go test'
+func underGoTest() bool {
+	return testing.Testing()
+}


### PR DESCRIPTION
CBG-4914 use a 128-bit integer for rosmar SourceID when not using go test

This allows running e2e tests under rosmar. This is a workaround until https://jira.issues.couchbase.com/browse/CBL-7506 gets implemented.