### PR TITLE
[4.0.0 backport] CBG-4913 fix the RTE algorithm

### DIFF
--- a/db/hybrid_logical_vector.go
+++ b/db/hybrid_logical_vector.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"iter"
 	"maps"
-	"math/bits"
 	"slices"
 	"sort"
 	"strconv"
@@ -981,12 +980,13 @@ func LegacyRevToRevTreeEncodedVersion(legacyRev string) (Version, error) {
 	// trim to 40 bits (10 hex characters)
 	if len(digest) > 10 {
 		digest = digest[:10]
+	} else if len(digest) < 10 {
+		digest += strings.Repeat("0", 10-len(digest))
 	}
 	value, err := strconv.ParseUint(digest, 16, 64)
 	if err != nil {
 		return Version{}, err
 	}
-	value = value << (40 - bits.Len64(value)) // right pad zeros
 	return Version{
 		SourceID: encodedRevTreeSourceID,
 		Value:    (uint64(generation) << 40) | value,

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -1712,6 +1712,10 @@ func TestLegacyRevToVersion(t *testing.T) {
 			legacyRev: "16777217-abcd",
 			version:   "1abcd000000@Revision+Tree+Encoding",
 		},
+		{
+			legacyRev: "1-345d1331e65b3d965502c924d70e12337e0ea966",
+			version:   "1345d1331e6@Revision+Tree+Encoding",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.legacyRev, func(t *testing.T) {


### PR DESCRIPTION
[4.0.0 backport] CBG-4913 fix the RTE algorithm

cherry-pick of 4a8ca0936436120893222b331dcc7d120589c13d