### PR TITLE
[4.0.0 backport] CBG-4916 use standard rosmar SourceID when not using go test

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -540,18 +540,22 @@ func RequireNoBucketTTL(ctx context.Context, b Bucket) error {
 
 // GetSourceID returns the source ID for a bucket.
 func GetSourceID(ctx context.Context, bucket Bucket) (string, error) {
-	// for rosmar bucket and testing, use the bucket name as the source ID to make it easier to identify the source
+	bucketUUID, err := bucket.UUID()
+	if err != nil {
+		return "", err
+	}
 	gocbBucket, err := AsGocbV2Bucket(bucket)
 	if err != nil {
-		return bucket.GetName(), nil
+		// for rosmar bucket and testing, use the bucket name as the source ID to make it easier to identify the source
+		if underGoTest() {
+			return bucket.GetName(), nil
+		}
+		serverUUID := ""
+		return CreateEncodedSourceID(bucketUUID, serverUUID)
 	}
 
 	// If not overwriting the source ID, for rosmar, serverUUID would be ""
 	serverUUID, err := GetServerUUID(ctx, gocbBucket)
-	if err != nil {
-		return "", err
-	}
-	bucketUUID, err := bucket.UUID()
 	if err != nil {
 		return "", err
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1013,3 +1013,8 @@ func RequireXattrNotFound(t testing.TB, dataStore sgbucket.DataStore, docID stri
 	require.Error(t, err, fmt.Sprintf("Expected xattr %q to not be found on document %q but has contents %s", xattrName, docID, xattrs[xattrName]))
 	RequireXattrNotFoundError(t, err)
 }
+
+// underGoTest returns true if the tests are being run via 'go test'
+func underGoTest() bool {
+	return testing.Testing()
+}


### PR DESCRIPTION
[4.0.0 backport] CBG-4916 use standard rosmar SourceID when not using go test

cherry-pick of https://github.com/couchbase/sync_gateway/commit/ab8dacd869ac8f67b50d8b6885399721ed2afac9
