### PR TITLE
CBG-4902: Fix Flaky Test `TestBlipOneShotChangesSubscription`

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -384,7 +384,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 	assert.True(t, receivedCaughtUpChange)
 
 	require.Equal(t, int64(1), bt.restTester.GetDatabase().DbStats.CBLReplicationPullStats.NumPullReplTotalOneShot.Value())
-	require.Equal(t, int64(0), bt.restTester.GetDatabase().DbStats.CBLReplicationPullStats.NumPullReplActiveOneShot.Value())
+	base.RequireWaitForStat(t, bt.restTester.GetDatabase().DbStats.CBLReplicationPullStats.NumPullReplActiveOneShot.Value, 0)
 }
 
 // Test subChanges w/ docID filter


### PR DESCRIPTION
CBG-4902

Describe your PR here...
- The `NumPullReplActiveOneShot`'s decrement is deferred, so updated the require condition to wait for the metric to be eventually updated to the desired value

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
