### PR TITLE
Remove RetryLoopCas since RetryLoop behaves identically

### DIFF
--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -148,7 +148,7 @@ func (c *Collection) SubdocGetRaw(ctx context.Context, k string, subdocKey strin
 		return false, nil, uint64(res.Cas())
 	}
 
-	err, casOut := RetryLoopCas(ctx, "SubdocGetRaw", worker, DefaultRetrySleeper())
+	err, casOut := RetryLoop(ctx, "SubdocGetRaw", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocGetRaw with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
@@ -181,7 +181,7 @@ func (c *Collection) SubdocWrite(ctx context.Context, k string, subdocKey string
 		return false, err, 0
 	}
 
-	err, casOut := RetryLoopCas(ctx, "SubdocWrite", worker, DefaultRetrySleeper())
+	err, casOut := RetryLoop(ctx, "SubdocWrite", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocWrite with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
@@ -310,7 +310,7 @@ func (c *Collection) subdocGetBodyAndXattrs(ctx context.Context, k string, xattr
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "subdocGetBodyAndXattrs", worker, DefaultRetrySleeper())
+	err, cas = RetryLoop(ctx, "subdocGetBodyAndXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "subdocGetBodyAndXattrs %v", UD(k).Redact())
 	}

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -61,7 +61,7 @@ func (c *Collection) WriteWithXattrs(ctx context.Context, k string, exp uint32, 
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "WriteWithXattrs", worker, DefaultRetrySleeper())
+	err, cas = RetryLoop(ctx, "WriteWithXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "WriteWithXattrs with key %v", UD(k).Redact())
 	}
@@ -111,7 +111,7 @@ func (c *Collection) WriteTombstoneWithXattrs(ctx context.Context, k string, exp
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoopCas(ctx, "WriteTombstoneWithXattrs", worker, DefaultRetrySleeper())
+	err, cas = RetryLoop(ctx, "WriteTombstoneWithXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "Error during WriteTombstoneXattrs with key %v", UD(k).Redact())
 		return cas, err
@@ -138,7 +138,7 @@ func (c *Collection) WriteTombstoneWithXattrs(ctx context.Context, k string, exp
 			return false, nil, casOut
 		}
 
-		err, cas = RetryLoopCas(ctx, "UpdateXattrDeleteBodySecondOp", worker, DefaultRetrySleeper())
+		err, cas = RetryLoop(ctx, "UpdateXattrDeleteBodySecondOp", worker, DefaultRetrySleeper())
 		if err != nil {
 			err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr delete op with key %v", UD(k).Redact())
 			return cas, err
@@ -165,7 +165,7 @@ func (c *Collection) WriteResurrectionWithXattrs(ctx context.Context, k string, 
 	}
 
 	// Kick off retry loop
-	err, cas := RetryLoopCas(ctx, "WriteResurrectionWithXattrs", worker, DefaultRetrySleeper())
+	err, cas := RetryLoop(ctx, "WriteResurrectionWithXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "WriteResurrectionWithXattrs with key %v", UD(k).Redact())
 	}
@@ -297,7 +297,7 @@ func SetXattrs(ctx context.Context, store *Collection, k string, xvs map[string]
 		return false, writeErr, 0
 	}
 
-	err, casOut = RetryLoopCas(ctx, "SetXattr", worker, DefaultRetrySleeper())
+	err, casOut = RetryLoop(ctx, "SetXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SetXattr with key %v", UD(k).Redact())
 	}


### PR DESCRIPTION
Remove RetryLoopCas since RetryLoop behaves identically since https://github.com/couchbase/sync_gateway/commit/cb348a83269c172d7442e0f6103fd49c8eb208d7

Allows removing duplicate code. 
