### PR TITLE
CBG-4579: Add uint64 support to few metrics in sgw

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -475,7 +475,7 @@ type CacheStats struct {
 	HighSeqCached *SgwUIntStat `json:"high_seq_cached"`
 	// The highest contiguous sequence number that has been cached.
 	HighSeqStable         *SgwUIntStat `json:"high_seq_stable"`
-	NonMobileIgnoredCount *SgwIntStat `json:"non_mobile_ignored_count"`
+	NonMobileIgnoredCount *SgwIntStat  `json:"non_mobile_ignored_count"`
 	// The total number of active channels.
 	NumActiveChannels *SgwIntStat `json:"num_active_channels"`
 	// The total number of skipped sequences. This is a cumulative value.

--- a/base/stats.go
+++ b/base/stats.go
@@ -472,9 +472,9 @@ type CacheStats struct {
 	// The highest sequence number cached.
 	//
 	// There may be skipped sequences lower than high_seq_cached.
-	HighSeqCached *SgwIntStat `json:"high_seq_cached"`
+	HighSeqCached *SgwUIntStat `json:"high_seq_cached"`
 	// The highest contiguous sequence number that has been cached.
-	HighSeqStable         *SgwIntStat `json:"high_seq_stable"`
+	HighSeqStable         *SgwUIntStat `json:"high_seq_stable"`
 	NonMobileIgnoredCount *SgwIntStat `json:"non_mobile_ignored_count"`
 	// The total number of active channels.
 	NumActiveChannels *SgwIntStat `json:"num_active_channels"`
@@ -606,9 +606,9 @@ type DatabaseStats struct {
 	ReplicationBytesReceived *SgwIntStat `json:"replication_bytes_received"`
 	ReplicationBytesSent     *SgwIntStat `json:"replication_bytes_sent"`
 	// The compaction_attachment_start_time.
-	CompactionAttachmentStartTime *SgwIntStat `json:"compaction_attachment_start_time"`
+	CompactionAttachmentStartTime *SgwUIntStat `json:"compaction_attachment_start_time"`
 	// The compaction_tombstone_start_time.
-	CompactionTombstoneStartTime *SgwIntStat `json:"compaction_tombstone_start_time"`
+	CompactionTombstoneStartTime *SgwUIntStat `json:"compaction_tombstone_start_time"`
 	// The total number of writes that left the document in a conflicted state. Includes new conflicts, and mutations that don’t resolve existing conflicts.
 	ConflictWriteCount *SgwIntStat `json:"conflict_write_count"`
 	// The total number of instances during import when the document cas had changed, but the document was not imported because the document body had not changed.
@@ -630,7 +630,7 @@ type DatabaseStats struct {
 	// The total size of xattrs written (in bytes).
 	DocWritesXattrBytes *SgwIntStat `json:"doc_writes_xattr_bytes"`
 	// Highest sequence number seen on the caching DCP feed.
-	HighSeqFeed *SgwIntStat `json:"high_seq_feed"`
+	HighSeqFeed *SgwUIntStat `json:"high_seq_feed"`
 	// The number of attachments compacted
 	NumAttachmentsCompacted *SgwIntStat `json:"num_attachments_compacted"`
 	// The total number of documents read via Couchbase Lite 2.x replication since Sync Gateway node startup.
@@ -653,19 +653,19 @@ type DatabaseStats struct {
 	// The total amount of bytes read over the public REST api
 	PublicRestBytesRead *SgwIntStat `json:"public_rest_bytes_read"`
 	// The value of the last sequence number assigned. Callers using Set should be holding a mutex or ensure concurrent updates to this value are otherwise safe.
-	LastSequenceAssignedValue *SgwIntStat `json:"last_sequence_assigned_value"` // TODO: CBG-4579 - Replace with SgwUintStat stat
+	LastSequenceAssignedValue *SgwUIntStat `json:"last_sequence_assigned_value"` // TODO: CBG-4579 - Replace with SgwUintStat stat
 	// The total number of sequence numbers assigned.
-	SequenceAssignedCount *SgwIntStat `json:"sequence_assigned_count"`
+	SequenceAssignedCount *SgwUIntStat `json:"sequence_assigned_count"`
 	// The total number of high sequence lookups.
 	SequenceGetCount *SgwIntStat `json:"sequence_get_count"`
 	// The total number of times the sequence counter document has been incremented.
 	SequenceIncrCount *SgwIntStat `json:"sequence_incr_count"`
 	// The total number of unused, reserved sequences released by Sync Gateway.
-	SequenceReleasedCount *SgwIntStat `json:"sequence_released_count"`
+	SequenceReleasedCount *SgwUIntStat `json:"sequence_released_count"`
 	// The value of the last sequence number reserved (which may not yet be assigned). Callers using Set should be holding a mutex or ensure concurrent updates to this value are otherwise safe.
-	LastSequenceReservedValue *SgwIntStat `json:"last_sequence_reserved_value"` // TODO: CBG-4579 - Replace with SgwUintStat stat
+	LastSequenceReservedValue *SgwUIntStat `json:"last_sequence_reserved_value"` // TODO: CBG-4579 - Replace with SgwUintStat stat
 	// The total number of sequences reserved by Sync Gateway.
-	SequenceReservedCount *SgwIntStat `json:"sequence_reserved_count"`
+	SequenceReservedCount *SgwUIntStat `json:"sequence_reserved_count"`
 	// The total number of corrupt sequences above the MaxSequencesToRelease threshold seen at the sequence allocator
 	CorruptSequenceCount *SgwIntStat `json:"corrupt_sequence_count"`
 	// The total number of warnings relating to the channel name size.
@@ -986,6 +986,11 @@ type SgwIntStat struct {
 	AtomicInt
 }
 
+type SgwUIntStat struct {
+	SgwStat
+	AtomicUInt
+}
+
 // uint64 is used here because atomic ints do not support floats. Floats are encoded to uint64
 type SgwFloatStat struct {
 	SgwStat
@@ -1077,6 +1082,48 @@ func (s *SgwIntStat) MarshalJSON() ([]byte, error) {
 
 func (s *SgwIntStat) String() string {
 	return strconv.FormatInt(s.Value(), 10)
+}
+
+func NewUIntStat(subsystem, key, unit, description, addedVersion, deprecatedVersion, stability string, labelKeys, labelVals []string, statValueType prometheus.ValueType, initialValue uint64) (*SgwUIntStat, error) {
+	stat, err := newSGWStat(subsystem, key, unit, description, addedVersion, deprecatedVersion, stability, labelKeys, labelVals, statValueType)
+	if err != nil {
+		return nil, err
+	}
+
+	wrappedStat := &SgwUIntStat{
+		SgwStat: *stat,
+	}
+
+	wrappedStat.Set(initialValue)
+
+	if !SkipPrometheusStatsRegistration {
+		err := prometheus.Register(wrappedStat)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return wrappedStat, nil
+}
+
+func (s *SgwUIntStat) FormatString() string {
+	return StatFormatInt
+}
+
+func (s *SgwUIntStat) Describe(ch chan<- *prometheus.Desc) {
+	ch <- s.statDesc
+}
+
+func (s *SgwUIntStat) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(s.statDesc, s.statValueType, float64(s.Value()))
+}
+
+func (s *SgwUIntStat) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatUint(s.Value(), 10)), nil
+}
+
+func (s *SgwUIntStat) String() string {
+	return strconv.FormatUint(s.Value(), 10)
 }
 
 func NewFloatStat(subsystem, key, unit, description, addedVersion, deprecatedVersion, stability string, labelKeys, labelVals []string, statValueType prometheus.ValueType, initialValue float64) (*SgwFloatStat, error) {
@@ -1387,11 +1434,11 @@ func (d *DbStats) initCacheStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.HighSeqCached, err = NewIntStat(SubsystemCacheKey, "high_seq_cached", StatUnitNoUnits, HighSeqCachedDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.HighSeqCached, err = NewUIntStat(SubsystemCacheKey, "high_seq_cached", StatUnitNoUnits, HighSeqCachedDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.HighSeqStable, err = NewIntStat(SubsystemCacheKey, "high_seq_stable", StatUnitNoUnits, HighStableSeqCachedDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.HighSeqStable, err = NewUIntStat(SubsystemCacheKey, "high_seq_stable", StatUnitNoUnits, HighStableSeqCachedDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1684,11 +1731,11 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.CompactionAttachmentStartTime, err = NewIntStat(SubsystemDatabaseKey, "compaction_attachment_start_time", StatUnitUnixTimestamp, CompactionAttachmentStartTimeDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.CompactionAttachmentStartTime, err = NewUIntStat(SubsystemDatabaseKey, "compaction_attachment_start_time", StatUnitUnixTimestamp, CompactionAttachmentStartTimeDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.CompactionTombstoneStartTime, err = NewIntStat(SubsystemDatabaseKey, "compaction_tombstone_start_time", StatUnitUnixTimestamp, CompactionTombstoneStartTimeDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
+	resUtil.CompactionTombstoneStartTime, err = NewUIntStat(SubsystemDatabaseKey, "compaction_tombstone_start_time", StatUnitUnixTimestamp, CompactionTombstoneStartTimeDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1728,7 +1775,7 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.HighSeqFeed, err = NewIntStat(SubsystemDatabaseKey, "high_seq_feed", StatUnitNoUnits, HighSeqFeedDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.HighSeqFeed, err = NewUIntStat(SubsystemDatabaseKey, "high_seq_feed", StatUnitNoUnits, HighSeqFeedDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1776,11 +1823,11 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.SequenceAssignedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_assigned_count", StatUnitNoUnits, SequenceAssignedCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SequenceAssignedCount, err = NewUIntStat(SubsystemDatabaseKey, "sequence_assigned_count", StatUnitNoUnits, SequenceAssignedCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.LastSequenceAssignedValue, err = NewIntStat(SubsystemDatabaseKey, "last_sequence_assigned_value", StatUnitNoUnits, LastSequenceAssignedValueDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.LastSequenceAssignedValue, err = NewUIntStat(SubsystemDatabaseKey, "last_sequence_assigned_value", StatUnitNoUnits, LastSequenceAssignedValueDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
@@ -1792,15 +1839,15 @@ func (d *DbStats) initDatabaseStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.SequenceReleasedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_released_count", StatUnitNoUnits, SequenceReleasedCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SequenceReleasedCount, err = NewUIntStat(SubsystemDatabaseKey, "sequence_released_count", StatUnitNoUnits, SequenceReleasedCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.SequenceReservedCount, err = NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", StatUnitNoUnits, SequenceReservedCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.SequenceReservedCount, err = NewUIntStat(SubsystemDatabaseKey, "sequence_reserved_count", StatUnitNoUnits, SequenceReservedCountDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}
-	resUtil.LastSequenceReservedValue, err = NewIntStat(SubsystemDatabaseKey, "last_sequence_reserved_value", StatUnitNoUnits, LastSequenceReservedValueDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.LastSequenceReservedValue, err = NewUIntStat(SubsystemDatabaseKey, "last_sequence_reserved_value", StatUnitNoUnits, LastSequenceReservedValueDesc, StatAddedVersion3dot2dot4, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -1091,6 +1091,7 @@ func (s *SgwIntStat) String() string {
 // Prometheus registration fails.
 //
 // Parameters:
+//
 //	subsystem: The Prometheus subsystem segment (e.g. resource_utilization, database) used to build the fully qualified metric name.
 //	key: The short metric key appended to the subsystem to form the final metric name.
 //	unit: The unit of measurement (e.g. bytes, seconds). Used for metadata export tooling.

--- a/base/stats.go
+++ b/base/stats.go
@@ -1091,17 +1091,17 @@ func (s *SgwIntStat) String() string {
 // Prometheus registration fails.
 //
 // Parameters:
-//   subsystem: The Prometheus subsystem segment (e.g. resource_utilization, database) used to build the fully qualified metric name.
-//   key: The short metric key appended to the subsystem to form the final metric name.
-//   unit: The unit of measurement (e.g. bytes, seconds). Used for metadata export tooling.
-//   description: Human-readable help text for the metric. Must be non-empty.
-//   addedVersion: The Sync Gateway version the stat was introduced. Must be non-empty.
-//   deprecatedVersion: The version the stat was deprecated, or empty if not deprecated.
-//   stability: The stability level (committed, volatile, or internal). Must be non-empty.
-//   labelKeys: Slice of label keys for constant labels. Must align index-wise with labelVals.
-//   labelVals: Slice of label values corresponding to labelKeys. Length must match labelKeys.
-//   statValueType: The Prometheus value type (counter or gauge) controlling exposition semantics.
-//   initialValue: The initial uint64 value assigned to the stat's atomic counter.
+//	subsystem: The Prometheus subsystem segment (e.g. resource_utilization, database) used to build the fully qualified metric name.
+//	key: The short metric key appended to the subsystem to form the final metric name.
+//	unit: The unit of measurement (e.g. bytes, seconds). Used for metadata export tooling.
+//	description: Human-readable help text for the metric. Must be non-empty.
+//	addedVersion: The Sync Gateway version the stat was introduced. Must be non-empty.
+//	deprecatedVersion: The version the stat was deprecated, or empty if not deprecated.
+//	stability: The stability level (committed, volatile, or internal). Must be non-empty.
+//	labelKeys: Slice of label keys for constant labels. Must align index-wise with labelVals.
+//	labelVals: Slice of label values corresponding to labelKeys. Length must match labelKeys.
+//	statValueType: The Prometheus value type (counter or gauge) controlling exposition semantics.
+//	initialValue: The initial uint64 value assigned to the stat's atomic counter.
 //
 // Behavior:
 //   - Validates required metadata (description, addedVersion, stability).
@@ -1111,10 +1111,12 @@ func (s *SgwIntStat) String() string {
 //   - Returns (*SgwUint64Stat, error) where error is non-nil on validation or registration failure.
 //
 // Concurrency:
-//   The underlying value uses atomic.Uint64 for safe concurrent mutation by callers.
+//
+//	The underlying value uses atomic.Uint64 for safe concurrent mutation by callers.
 //
 // Errors:
-//   Returned if required fields are missing or if prometheus.Register fails (e.g. duplicate registration).
+//
+//	Returned if required fields are missing or if prometheus.Register fails (e.g. duplicate registration).
 func NewUIntStat(subsystem, key, unit, description, addedVersion, deprecatedVersion, stability string, labelKeys, labelVals []string, statValueType prometheus.ValueType, initialValue uint64) (*SgwUint64Stat, error) {
 	stat, err := newSGWStat(subsystem, key, unit, description, addedVersion, deprecatedVersion, stability, labelKeys, labelVals, statValueType)
 	if err != nil {
@@ -1168,14 +1170,10 @@ func (s *SgwUint64Stat) SetIfMax(value uint64) {
 			return
 		}
 
-		if s.CompareAndSwap(cur, value){
+		if s.CompareAndSwap(cur, value) {
 			return
 		}
 	}
-}
-
-func (s *SgwUint64Stat) Add(value uint64){
-	s.Add(value)
 }
 
 func (s *SgwUint64Stat) Value() uint64 {

--- a/base/stats.go
+++ b/base/stats.go
@@ -1130,7 +1130,7 @@ func (s *SgwUint64Stat) String() string {
 	return strconv.FormatUint(s.Value(), 10)
 }
 
-// Set updates the existing value. This satifies the AtomicUint interface but code can prefer SgwUint64Stat.Store to match atomic.Uint64.
+// Set updates the existing value. This satisfies the AtomicUint interface but code can prefer SgwUint64Stat.Store to match atomic.Uint64.
 func (s *SgwUint64Stat) Set(value uint64) {
 	s.Store(value)
 }
@@ -1148,7 +1148,7 @@ func (s *SgwUint64Stat) SetIfMax(value uint64) {
 	}
 }
 
-// Value returns the value. This satifies the AtomicUint interface but new code should prefer SgwUint64Stat.Load to match atomic.Uint64 interface.
+// Value returns the value. This satisfies the AtomicUint interface but new code should prefer SgwUint64Stat.Load to match atomic.Uint64 interface.
 func (s *SgwUint64Stat) Value() uint64 {
 	return s.Load()
 }

--- a/base/util.go
+++ b/base/util.go
@@ -1253,36 +1253,6 @@ func (ai *AtomicInt) Value() int64 {
 	return atomic.LoadInt64(&ai.val)
 }
 
-type AtomicUInt struct {
-	val uint64
-}
-
-func (aui *AtomicUInt) Set(value uint64) {
-	atomic.StoreUint64(&aui.val, value)
-}
-
-func (aui *AtomicUInt) SetIfMax(value uint64) {
-	for {
-		cur := atomic.LoadUint64(&aui.val)
-		if cur >= value {
-			return
-		}
-
-		if atomic.CompareAndSwapUint64(&aui.val, cur, value) {
-			return
-		}
-	}
-}
-
-// Add adds the given value to the atomic int.
-func (aui *AtomicUInt) Add(value uint64) {
-	atomic.AddUint64(&aui.val, value)
-}
-
-func (aui *AtomicUInt) Value() uint64 {
-	return atomic.LoadUint64(&aui.val)
-}
-
 type SafeTerminator struct {
 	terminator       chan struct{}
 	terminatorClosed AtomicBool

--- a/base/util.go
+++ b/base/util.go
@@ -1253,6 +1253,36 @@ func (ai *AtomicInt) Value() int64 {
 	return atomic.LoadInt64(&ai.val)
 }
 
+type AtomicUInt struct {
+	val uint64
+}
+
+func (aui *AtomicUInt) Set(value uint64) {
+	atomic.StoreUint64(&aui.val, value)
+}
+
+func (aui *AtomicUInt) SetIfMax(value uint64) {
+	for {
+		cur := atomic.LoadUint64(&aui.val)
+		if cur >= value {
+			return
+		}
+
+		if atomic.CompareAndSwapUint64(&aui.val, cur, value) {
+			return
+		}
+	}
+}
+
+// Add adds the given value to the atomic int.
+func (aui *AtomicUInt) Add(value uint64) {
+	atomic.AddUint64(&aui.val, value)
+}
+
+func (aui *AtomicUInt) Value() uint64 {
+	return atomic.LoadUint64(&aui.val)
+}
+
 type SafeTerminator struct {
 	terminator       chan struct{}
 	terminatorClosed AtomicBool

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -50,7 +50,7 @@ func NewAttachmentCompactionManager(metadataStore base.DataStore, metaKeys *base
 
 func (a *AttachmentCompactionManager) Init(ctx context.Context, options map[string]any, clusterStatus []byte) error {
 	database := options["database"].(*Database)
-	database.DbStats.Database().CompactionAttachmentStartTime.Set(time.Now().UTC().Unix())
+	database.DbStats.Database().CompactionAttachmentStartTime.Set(uint64(time.Now().UTC().Unix()))
 
 	newRunInit := func() error {
 		uniqueUUID, err := uuid.NewRandom()

--- a/db/background_mgr_tombstone_compaction.go
+++ b/db/background_mgr_tombstone_compaction.go
@@ -36,7 +36,7 @@ func NewTombstoneCompactionManager() *BackgroundManager {
 
 func (t *TombstoneCompactionManager) Init(ctx context.Context, options map[string]any, clusterStatus []byte) error {
 	database := options["database"].(*Database)
-	database.DbStats.Database().CompactionTombstoneStartTime.Set(time.Now().UTC().Unix())
+	database.DbStats.Database().CompactionTombstoneStartTime.Set(uint64(time.Now().UTC().Unix()))
 
 	return nil
 }

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -101,10 +101,10 @@ func (c *changeCache) updateStats(ctx context.Context) {
 	// grab skipped sequence stats
 	skippedSequenceListStats := c.skippedSeqs.getStats()
 
-	c.db.DbStats.Database().HighSeqFeed.SetIfMax(int64(c.internalStats.highSeqFeed))
+	c.db.DbStats.Database().HighSeqFeed.SetIfMax(c.internalStats.highSeqFeed)
 	c.db.DbStats.Cache().PendingSeqLen.Set(int64(c.internalStats.pendingSeqLen))
 	c.db.DbStats.CBLReplicationPull().MaxPending.SetIfMax(int64(c.internalStats.maxPending))
-	c.db.DbStats.Cache().HighSeqStable.Set(int64(c._getMaxStableCached(ctx)))
+	c.db.DbStats.Cache().HighSeqStable.Set(c._getMaxStableCached(ctx))
 	c.db.DbStats.Cache().NumCurrentSeqsSkipped.Set(skippedSequenceListStats.NumCurrentSkippedSequencesStat)
 	c.db.DbStats.Cache().NumSkippedSeqs.Set(skippedSequenceListStats.NumCumulativeSkippedSequencesStat)
 	c.db.DbStats.Cache().SkippedSequenceSkiplistNodes.Set(skippedSequenceListStats.ListLengthStat)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1511,7 +1511,7 @@ func TestUnusedSequencesInSyncData(t *testing.T) {
 
 	// assert that only 2 sequences have been cached (unused sequences are not cached)
 	db.UpdateCalculatedStats(ctx)
-	assert.Equal(t, int64(6), db.DbStats.Cache().HighSeqCached.Value())
+	assert.Equal(t, uint64(6), db.DbStats.Cache().HighSeqCached.Value())
 	assert.Equal(t, int64(2), db.DbStats.Database().DCPCachingCount.Value())
 }
 
@@ -2292,7 +2292,7 @@ func TestReleasedSequenceRangeHandlingEverythingSkipped(t *testing.T) {
 		testChangeCache.updateStats(ctx)
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.SkippedSequenceSkiplistNodes.Value())
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
-		assert.Equal(c, int64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 		assert.Equal(c, uint64(21), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
 		assert.Equal(c, uint64(20), testChangeCache._getMaxStableCached(ctx))
@@ -2353,7 +2353,7 @@ func TestReleasedSequenceRangeHandlingEverythingPending(t *testing.T) {
 		assert.Equal(c, int64(1), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
 		assert.Equal(c, uint64(2), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(1), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(1), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 }
 
@@ -2417,7 +2417,7 @@ func TestReleasedSequenceRangeHandlingEverythingPendingAndProcessPending(t *test
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(25), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(25), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 		assert.Equal(c, uint64(26), testChangeCache.nextSequence)
 	}, time.Second*10, time.Millisecond*100)
 }
@@ -2488,7 +2488,7 @@ func TestReleasedSequenceRangeHandlingEverythingPendingLowPendingCapacity(t *tes
 		assert.Equal(c, int64(1), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
 		assert.Equal(c, uint64(26), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(25), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(25), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	// add a new contiguous sequence
@@ -2503,7 +2503,7 @@ func TestReleasedSequenceRangeHandlingEverythingPendingLowPendingCapacity(t *tes
 	// assert we update cache as expected
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(26), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(26), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 		assert.Equal(c, uint64(27), testChangeCache.nextSequence)
 	}, time.Second*10, time.Millisecond*100)
 
@@ -2518,7 +2518,7 @@ func TestReleasedSequenceRangeHandlingEverythingPendingLowPendingCapacity(t *tes
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
 		assert.Equal(c, uint64(31), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(30), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(30), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 }
 
@@ -2571,7 +2571,7 @@ func TestReleasedSequenceRangeHandlingSingleSequence(t *testing.T) {
 		assert.Equal(c, int64(1), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
 		assert.Equal(c, uint64(1), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(0), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	// process change that should overload pending and push sequence 1 to skipped
@@ -2590,7 +2590,7 @@ func TestReleasedSequenceRangeHandlingSingleSequence(t *testing.T) {
 		assert.Equal(c, int64(1), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
 		assert.Equal(c, uint64(3), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(2), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(2), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	// process single unused sequence range that should empty skipped list
@@ -2603,7 +2603,7 @@ func TestReleasedSequenceRangeHandlingSingleSequence(t *testing.T) {
 		assert.Equal(c, int64(1), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
 		assert.Equal(c, uint64(3), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(2), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(2), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 }
 
@@ -2672,7 +2672,7 @@ func TestReleasedSequenceRangeHandlingEdgeCase1(t *testing.T) {
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, uint64(21), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 }
 
@@ -2728,7 +2728,7 @@ func TestReleasedSequenceRangeHandlingEdgeCase2(t *testing.T) {
 		assert.Equal(c, int64(19), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.PendingSeqLen.Value())
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	// process unusedSeq range with pending seq equal to end
@@ -2742,7 +2742,7 @@ func TestReleasedSequenceRangeHandlingEdgeCase2(t *testing.T) {
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, uint64(21), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(20), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 }
 
@@ -2810,7 +2810,7 @@ func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) 
 		assert.Equal(c, int64(16), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, uint64(19), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(18), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(18), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	// process unusedSeq range with range containing duplicate sipped sequences
@@ -2825,7 +2825,7 @@ func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) 
 		assert.Equal(c, int64(9), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, uint64(19), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(18), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(18), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	// Skipped should contain: (1-9) before processing this range
@@ -2839,7 +2839,7 @@ func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) 
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, uint64(19), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(18), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(18), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	// assert a new contiguous sequence is processed correctly
@@ -2859,7 +2859,7 @@ func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) 
 		assert.Equal(c, int64(0), dbContext.DbStats.CacheStats.NumCurrentSeqsSkipped.Value())
 		assert.Equal(c, uint64(20), testChangeCache.nextSequence)
 		dbContext.UpdateCalculatedStats(ctx)
-		assert.Equal(c, int64(19), dbContext.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(19), dbContext.DbStats.CacheStats.HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 }
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1592,7 +1592,7 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 
 	expectedReleasedSequenceCount := otherClusterSequenceOffset
 	releasedSequenceCount := db.DbStats.Database().SequenceReleasedCount.Value() - startReleasedSequenceCount
-	assert.Equal(t, int64(expectedReleasedSequenceCount), releasedSequenceCount)
+	assert.Equal(t, uint64(expectedReleasedSequenceCount), releasedSequenceCount)
 }
 
 // TestReleaseSequenceOnDocWrite:
@@ -1639,7 +1639,7 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	// due to duplicate sequence at the cache with an unused sequence. See steps in ticket CBG-4067 as example.
 	_ = getChanges(t, collection, base.SetOf("*"), getChangesOptionsWithZeroSeq(t))
 
-	assert.Equal(t, int64(0), db.DbStats.Database().SequenceReleasedCount.Value())
+	assert.Equal(t, uint64(0), db.DbStats.Database().SequenceReleasedCount.Value())
 
 	// write doc that will return timeout but will actually be persisted successfully on server
 	// this mimics what was seen before
@@ -1652,8 +1652,8 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	// assert that no sequences were released + a sequence was cached
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		db.UpdateCalculatedStats(ctx)
-		assert.Equal(t, int64(0), db.DbStats.Database().SequenceReleasedCount.Value())
-		assert.Equal(t, int64(1), db.DbStats.Cache().HighSeqCached.Value())
+		assert.Equal(t, uint64(0), db.DbStats.Database().SequenceReleasedCount.Value())
+		assert.Equal(t, uint64(1), db.DbStats.Cache().HighSeqCached.Value())
 	}, time.Second*10, time.Millisecond*100)
 
 	// get cached changes + assert the document is present
@@ -1672,7 +1672,7 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	// assert that a sequence was released after the above write error
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		db.UpdateCalculatedStats(ctx)
-		assert.Equal(t, int64(1), db.DbStats.Database().SequenceReleasedCount.Value())
+		assert.Equal(t, uint64(1), db.DbStats.Database().SequenceReleasedCount.Value())
 	}, time.Second*10, time.Millisecond*100)
 }
 

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -31,7 +31,7 @@ func (db *DatabaseContext) UpdateCalculatedStats(ctx context.Context) {
 	channelCache := db.changeCache.getChannelCache()
 	if channelCache != nil {
 		db.DbStats.Cache().ChannelCacheMaxEntries.Set(int64(channelCache.MaxCacheSize(ctx)))
-		db.DbStats.Cache().HighSeqCached.Set(int64(channelCache.GetHighCacheSequence()))
+		db.DbStats.Cache().HighSeqCached.Set(channelCache.GetHighCacheSequence())
 	}
 
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1600,7 +1600,7 @@ func TestUpdatePrincipalCASRetry(t *testing.T) {
 			// Ensure we released the sequences for all the CAS retries we expected to make
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				sequenceReleasedCountAfter := db.sequences.dbStats.SequenceReleasedCount.Value()
-				assert.Equal(c, int64(expectedReleasedSequences), sequenceReleasedCountAfter-sequenceReleasedCountBefore)
+				assert.Equal(c, uint64(expectedReleasedSequences), sequenceReleasedCountAfter-sequenceReleasedCountBefore)
 			}, 5*time.Second, 100*time.Millisecond)
 		})
 	}
@@ -2349,8 +2349,8 @@ func TestRecentSequenceHandlingForSkippedSequences(t *testing.T) {
 	db.UpdateCalculatedStats(ctx)
 	assert.Equal(t, int64(3), db.DbStats.Cache().NumCurrentSeqsSkipped.Value())
 	assert.Equal(t, int64(0), db.DbStats.Cache().PendingSeqLen.Value())
-	assert.Equal(t, int64(6), db.DbStats.Cache().HighSeqCached.Value())
-	assert.Equal(t, int64(2), db.DbStats.Cache().HighSeqStable.Value())
+	assert.Equal(t, uint64(6), db.DbStats.Cache().HighSeqCached.Value())
+	assert.Equal(t, uint64(2), db.DbStats.Cache().HighSeqStable.Value())
 	assert.Equal(t, uint64(7), db.changeCache.getNextSequence())
 
 	// alter sync data on doc2 to create recent sequence history to plug gap in sequences that have been pushed to skipped

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -225,7 +225,7 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 	if targetSequence <= s.max {
 		releaseFrom := s.last + 1
 		s.last = targetSequence
-		s.dbStats.LastSequenceAssignedValue.Set(int64(targetSequence))
+		s.dbStats.LastSequenceAssignedValue.Set(targetSequence)
 		s.mutex.Unlock()
 		if releaseFrom < targetSequence {
 			released, err := s.releaseSequenceRange(ctx, releaseFrom, targetSequence-1)
@@ -303,7 +303,7 @@ func (s *sequenceAllocator) nextSequenceGreaterThan(ctx context.Context, existin
 	s.max = allocatedToSeq
 	s.last = allocatedToSeq - numberToAllocate + 1
 	sequence = s.last
-	s.dbStats.LastSequenceAssignedValue.Set(int64(sequence))
+	s.dbStats.LastSequenceAssignedValue.Set(sequence)
 	s.mutex.Unlock()
 
 	// Perform standard batch handling and stats updates
@@ -336,7 +336,7 @@ func (s *sequenceAllocator) _nextSequence(ctx context.Context) (sequence uint64,
 	s.last++
 	sequence = s.last
 	s.dbStats.SequenceAssignedCount.Add(1)
-	s.dbStats.LastSequenceAssignedValue.Set(int64(sequence))
+	s.dbStats.LastSequenceAssignedValue.Set(sequence)
 	return sequence, sequencesReserved, nil
 }
 
@@ -389,8 +389,8 @@ func (s *sequenceAllocator) _incrementSequence(numToReserve uint64) (uint64, err
 		return value, err
 	}
 	s.dbStats.SequenceIncrCount.Add(1)
-	s.dbStats.SequenceReservedCount.Add(int64(numToReserve))
-	s.dbStats.LastSequenceReservedValue.Set(int64(value))
+	s.dbStats.SequenceReservedCount.Add(numToReserve)
+	s.dbStats.LastSequenceReservedValue.Set(value)
 	return value, nil
 }
 
@@ -428,7 +428,7 @@ func (s *sequenceAllocator) releaseSequenceRange(ctx context.Context, fromSequen
 		return 0, err
 	}
 	count := toSequence - fromSequence + 1
-	s.dbStats.SequenceReleasedCount.Add(int64(count))
+	s.dbStats.SequenceReleasedCount.Add(count)
 	base.DebugfCtx(ctx, base.KeyCRUD, "Released unused sequences #%d-#%d", fromSequence, toSequence)
 	return count, nil
 }

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -238,11 +238,11 @@ func TestReleaseSequenceWait(t *testing.T) {
 
 func assertNewAllocatorStats(t *testing.T, stats *base.DatabaseStats, incrCount, reservedCount, assignedCount, releasedCount int64, lastAssignedValue, lastReservedValue uint64) {
 	assert.Equal(t, incrCount, stats.SequenceIncrCount.Value())
-	assert.Equal(t, reservedCount, stats.SequenceReservedCount.Value())
-	assert.Equal(t, assignedCount, stats.SequenceAssignedCount.Value())
-	assert.Equal(t, releasedCount, stats.SequenceReleasedCount.Value())
-	assert.Equal(t, int64(lastAssignedValue), stats.LastSequenceAssignedValue.Value())
-	assert.Equal(t, int64(lastReservedValue), stats.LastSequenceReservedValue.Value())
+	assert.Equal(t, uint64(reservedCount), stats.SequenceReservedCount.Value())
+	assert.Equal(t, uint64(assignedCount), stats.SequenceAssignedCount.Value())
+	assert.Equal(t, uint64(releasedCount), stats.SequenceReleasedCount.Value())
+	assert.Equal(t, lastAssignedValue, stats.LastSequenceAssignedValue.Value())
+	assert.Equal(t, lastReservedValue, stats.LastSequenceReservedValue.Value())
 }
 
 func TestNextSequenceGreaterThanSingleNode(t *testing.T) {


### PR DESCRIPTION
CBG-4579

Describe your PR here...
- Added `SgwUIntStat` to use `uint64` instead of `int64` for few metrics such as sequence and timestamps
- `int64` stats have a possibility of overflowing which would then make the number negative
- Fixed few type conversions in unit tests which use the updated metrics

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/141/
