### PR TITLE
CBG-4895: Allow tuning of dcp_read_buffer and kv_buffer server connstr parameters

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -252,7 +252,7 @@ func ServerIsTLS(server string) bool {
 // Equivalent to the old regexp: `^(walrus:|file:|/|\.)`
 func ServerIsWalrus(server string) bool {
 	return strings.HasPrefix(server, "walrus:") ||
-		strings.HasPrefix(server, "rosmar:") ||
+		strings.HasPrefix(server, "rosmar") ||
 		strings.HasPrefix(server, "file:") ||
 		strings.HasPrefix(server, "/") ||
 		strings.HasPrefix(server, ".")

--- a/base/constants.go
+++ b/base/constants.go
@@ -252,7 +252,7 @@ func ServerIsTLS(server string) bool {
 // Equivalent to the old regexp: `^(walrus:|file:|/|\.)`
 func ServerIsWalrus(server string) bool {
 	return strings.HasPrefix(server, "walrus:") ||
-		strings.HasPrefix(server, "rosmar") ||
+		strings.HasPrefix(server, "rosmar:") ||
 		strings.HasPrefix(server, "file:") ||
 		strings.HasPrefix(server, "/") ||
 		strings.HasPrefix(server, ".")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3533,7 +3533,7 @@ func TestDisableAllowStarChannel(t *testing.T) {
 	base.DebugfCtx(t.Context(), base.KeySGTest, "additional logs")
 }
 
-func TestUnsupportedOptions( t *testing.T){
+func TestUnsupportedOptions(t *testing.T) {
 	RequireBucketSpecificCredentials(t)
 	tests := []struct {
 		name            string

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -601,7 +601,7 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 		server = serverConfig.Bootstrap.Server
 	}
 
-	if strings.HasPrefix(server, "couchbase") {
+	if !base.ServerIsWalrus(server) {
 		var params *base.GoCBConnStringParams
 		if serverConfig.IsServerless() {
 			params = base.DefaultServerlessGoCBConnStringParams()

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -601,7 +601,7 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 		server = serverConfig.Bootstrap.Server
 	}
 
-	if strings.HasPrefix(server, "couchbase") || strings.HasPrefix(server, "http") {
+	if strings.HasPrefix(server, "couchbase") {
 		var params *base.GoCBConnStringParams
 		if serverConfig.IsServerless() {
 			params = base.DefaultServerlessGoCBConnStringParams()

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -600,7 +600,12 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 	} else {
 		server = serverConfig.Bootstrap.Server
 	}
-	params := base.DefaultServerlessGoCBConnStringParams()
+	var params *base.GoCBConnStringParams
+	if serverConfig.IsServerless() {
+		params = base.DefaultServerlessGoCBConnStringParams()
+	} else {
+		params = base.DefaultGoCBConnStringParams()
+	}
 	if config.Unsupported != nil {
 		if config.Unsupported.DCPReadBuffer != 0 {
 			params.DcpBufferSize = config.Unsupported.DCPReadBuffer

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -600,22 +600,20 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 	} else {
 		server = serverConfig.Bootstrap.Server
 	}
-	if serverConfig.IsServerless() {
-		params := base.DefaultServerlessGoCBConnStringParams()
-		if config.Unsupported != nil {
-			if config.Unsupported.DCPReadBuffer != 0 {
-				params.DcpBufferSize = config.Unsupported.DCPReadBuffer
-			}
-			if config.Unsupported.KVBufferSize != 0 {
-				params.KvBufferSize = config.Unsupported.KVBufferSize
-			}
+	params := base.DefaultServerlessGoCBConnStringParams()
+	if config.Unsupported != nil {
+		if config.Unsupported.DCPReadBuffer != 0 {
+			params.DcpBufferSize = config.Unsupported.DCPReadBuffer
 		}
-		connStr, err := base.GetGoCBConnStringWithDefaults(server, params)
-		if err != nil {
-			return base.BucketSpec{}, err
+		if config.Unsupported.KVBufferSize != 0 {
+			params.KvBufferSize = config.Unsupported.KVBufferSize
 		}
-		server = connStr
 	}
+	connStr, err := base.GetGoCBConnStringWithDefaults(server, params)
+	if err != nil {
+		return base.BucketSpec{}, err
+	}
+	server = connStr
 
 	spec := config.MakeBucketSpec(server)
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -601,7 +601,7 @@ func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *St
 		server = serverConfig.Bootstrap.Server
 	}
 
-	if !base.ServerIsWalrus(server) {
+	if !base.ServerIsWalrus(server) && server != "" {
 		var params *base.GoCBConnStringParams
 		if serverConfig.IsServerless() {
 			params = base.DefaultServerlessGoCBConnStringParams()

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -595,13 +595,13 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(ctx context.Context, config 
 func GetBucketSpec(ctx context.Context, config *DatabaseConfig, serverConfig *StartupConfig) (base.BucketSpec, error) {
 
 	var server string
-	if config.Server != nil {
+	if config.Server != nil && *config.Server != "" {
 		server = *config.Server
 	} else {
 		server = serverConfig.Bootstrap.Server
 	}
 
-	if !base.ServerIsWalrus(server) && server != "" {
+	if !base.ServerIsWalrus(server) {
 		var params *base.GoCBConnStringParams
 		if serverConfig.IsServerless() {
 			params = base.DefaultServerlessGoCBConnStringParams()
@@ -718,10 +718,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	}
 	// set this early so we have dbName available in db-init related logging, before we have an actual database
 	ctx = base.DatabaseLogCtx(ctx, dbName, contextOptions.LoggingConfig)
-
-	if spec.Server == "" {
-		spec.Server = sc.Config.Bootstrap.Server
-	}
 
 	// Connect to bucket
 	base.InfofCtx(ctx, base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",


### PR DESCRIPTION
CBG-4895

Describe your PR here...
- Currently `dcp_read_buffer` and `kv_buffer` are only supported if CBS is serverless, need to enable them for regular CBS as well for perf tests in capella
-  remove serverless check for unsupported config options such as dcp_read_buffer and kv_buffer

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/142/
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/146/
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/147/
