### PR TITLE
CBG-4942 obey db scope for CORS.LoginOrigin

### DIFF
--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -9,6 +9,7 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -398,6 +399,74 @@ func TestCORSOriginPerDatabase(t *testing.T) {
 						require.Equal(t, strconv.Itoa(rt.ServerContext().Config.API.CORS.MaxAge), response.Header().Get("Access-Control-Max-Age"))
 					}
 				}
+			}
+
+		})
+	}
+}
+
+func TestCORSLoginOriginPerDatabase(t *testing.T) {
+	// Override the default (example.com) CORS configuration in the DbConfig for /db:
+	rt := NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+	dbConfig := rt.NewDbConfig()
+	dbConfig.CORS = &auth.CORSConfig{
+		Origin:      []string{"http://couchbase.com", "http://staging.couchbase.com"},
+		LoginOrigin: []string{"http://couchbase.com"},
+		Headers:     []string{},
+	}
+	RequireStatus(t, rt.CreateDatabase("dbloginorigin", dbConfig), http.StatusCreated)
+
+	const username = "alice"
+	rt.CreateUser(username, nil)
+
+	testCases := []struct {
+		name              string
+		origin            string
+		responseCode      int
+		responseErrorBody string
+	}{
+		{
+			name:         "CORS login origin allowed couchbase",
+			origin:       "http://couchbase.com",
+			responseCode: http.StatusOK,
+		},
+		{
+			name:              "CORS login origin not allowed staging",
+			origin:            "http://staging.couchbase.com",
+			responseCode:      http.StatusBadRequest,
+			responseErrorBody: "No CORS",
+		},
+	}
+	for _, test := range testCases {
+		rt.Run(test.name, func(t *testing.T) {
+			reqHeaders := map[string]string{
+				"Origin":        test.origin,
+				"Authorization": GetBasicAuthHeader(t, username, RestTesterDefaultUserPassword),
+			}
+			resp := rt.SendRequestWithHeaders(http.MethodPost, "/{{.db}}/_session", "", reqHeaders)
+			RequireStatus(t, resp, test.responseCode)
+			if test.responseErrorBody != "" {
+				require.Contains(t, resp.Body.String(), test.responseErrorBody)
+				// the access control headers are returned based on Origin and not LoginOrigin which could be considered a bug
+				require.Equal(t, test.origin, resp.Header().Get(accessControlAllowOrigin))
+			} else {
+				require.Equal(t, test.origin, resp.Header().Get(accessControlAllowOrigin))
+			}
+			if test.responseCode == http.StatusOK {
+				cookie, err := http.ParseSetCookie(resp.Header().Get("Set-Cookie"))
+				require.NoError(t, err)
+				require.NotEmpty(t, cookie.Path)
+				reqHeaders["Cookie"] = fmt.Sprintf("%s=%s", cookie.Name, cookie.Value)
+			}
+			resp = rt.SendRequestWithHeaders(http.MethodDelete, "/{{.db}}/_session", "", reqHeaders)
+			RequireStatus(t, resp, test.responseCode)
+			if test.responseErrorBody != "" {
+				require.Contains(t, resp.Body.String(), test.responseErrorBody)
+				// the access control headers are returned based on Origin and not LoginOrigin which could be considered a bug
+				require.Equal(t, test.origin, resp.Header().Get(accessControlAllowOrigin))
+			} else {
+				require.Equal(t, test.origin, resp.Header().Get(accessControlAllowOrigin))
 			}
 
 		})

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -26,18 +25,14 @@ type FacebookResponse struct {
 
 // POST /_facebook creates a facebook-based login session and sets its cookie.
 func (h *handler) handleFacebookPOST() error {
-	// CORS not allowed for login #115 #762
-	originHeader := h.rq.Header["Origin"]
-	if len(originHeader) > 0 {
-		matched := auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
-		if matched == "" {
-			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
-		}
+	err := h.checkLoginCORS()
+	if err != nil {
+		return err
 	}
 	var params struct {
 		AccessToken string `json:"access_token"`
 	}
-	err := h.readJSONInto(&params)
+	err = h.readJSONInto(&params)
 	if err != nil {
 		return err
 	}

--- a/rest/google.go
+++ b/rest/google.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"slices"
 
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -29,20 +28,16 @@ type GoogleResponse struct {
 
 // POST /_google creates a google-based login session and sets its cookie.
 func (h *handler) handleGooglePOST() error {
-	// CORS not allowed for login #115 #762
-	originHeader := h.rq.Header["Origin"]
-	if len(originHeader) > 0 {
-		matched := auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
-		if matched == "" {
-			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
-		}
+	err := h.checkLoginCORS()
+	if err != nil {
+		return err
 	}
 
 	var params struct {
 		IDToken string `json:"id_token"`
 	}
 
-	err := h.readJSONInto(&params)
+	err = h.readJSONInto(&params)
 	if err != nil {
 		return err
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -336,10 +336,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 	defer func() {
 		// Now that we know the DB, add CORS headers to the response:
 		if h.privs != adminPrivs && h.privs != metricsPrivs {
-			cors := h.server.Config.API.CORS
-			if h.db != nil {
-				cors = h.db.CORS
-			}
+			cors := h.getCORSConfig()
 			if !cors.IsEmpty() {
 				cors.AddResponseHeaders(h.rq, h.response)
 			}
@@ -1783,4 +1780,12 @@ func (h *handler) pathTemplateContains(pattern string) bool {
 		return false
 	}
 	return strings.Contains(pathTemplate, pattern)
+}
+
+// getCORSConfig will return the CORS config for the handler's database if set, otherwise it will return the server CORS config
+func (h *handler) getCORSConfig() *auth.CORSConfig {
+	if h.db != nil {
+		return h.db.CORS
+	}
+	return h.server.Config.API.CORS
 }

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -326,8 +326,8 @@ func (h *handler) formatSessionResponse(user auth.User) db.Body {
 
 }
 
-// checkLoginCORS validates the auth.CORSConfig.LoginOrigin section of CORS for requests. The auth.CORSConfig.Origin is
-// checked in addition to this.
+// checkLoginCORS validates the auth.CORSConfig.LoginOrigin section of CORS for requests.
+// Note: Validation of the general Origin header against auth.CORSConfig.Origin happens separately in validateAndWriteHeaders.
 func (h *handler) checkLoginCORS() error {
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -36,16 +36,9 @@ func (h *handler) handleSessionGET() error {
 
 // POST /_session creates a login session and sets its cookie
 func (h *handler) handleSessionPOST() error {
-	// CORS not allowed for login #115 #762
-	originHeader := h.rq.Header["Origin"]
-	if len(originHeader) > 0 {
-		matched := ""
-		if h.server.Config.API.CORS != nil {
-			matched = auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
-		}
-		if matched == "" {
-			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
-		}
+	err := h.checkLoginCORS()
+	if err != nil {
+		return err
 	}
 
 	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkPublicAuth calls out into AuthenticateUntrustedJWT.
@@ -100,18 +93,10 @@ func (h *handler) getUserFromSessionRequestBody() (auth.User, error) {
 
 // DELETE /_session logs out the current session
 func (h *handler) handleSessionDELETE() error {
-	// CORS not allowed for login #115 #762
-	originHeader := h.rq.Header["Origin"]
-	if len(originHeader) > 0 {
-		matched := ""
-		if h.server.Config.API.CORS != nil {
-			matched = auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
-		}
-		if matched == "" {
-			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
-		}
+	err := h.checkLoginCORS()
+	if err != nil {
+		return err
 	}
-
 	cookie := h.db.Authenticator(h.ctx()).DeleteSessionForCookie(h.ctx(), h.rq)
 	if cookie == nil {
 		return base.HTTPErrorf(http.StatusNotFound, "no session")
@@ -339,4 +324,17 @@ func (h *handler) formatSessionResponse(user auth.User) db.Body {
 	response := db.Body{"ok": true, "userCtx": userCtx, "authentication_handlers": handlers}
 	return response
 
+}
+
+// checkLoginCORS validates the auth.CORSConfig.LoginOrigin section of CORS for requests. The auth.CORSConfig.Origin is
+// checked in addition to this.
+func (h *handler) checkLoginCORS() error {
+	originHeader := h.rq.Header["Origin"]
+	if len(originHeader) > 0 {
+		cors := h.getCORSConfig()
+		if cors.IsEmpty() || auth.MatchedOrigin(cors.LoginOrigin, originHeader) == "" {
+			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
CBG-4942 obey db scope for CORS.LoginOrigin

This was an oversight made in https://github.com/couchbase/sync_gateway/commit/6abfd62abe4108570ce28ef48db6d0c49eca804c where the following public endpoints require don't support DB scoped CORS.

- `POST /db/_session`
- `DELETE /db/_session`
- `POST /db/_facebook`
- `POST /db/_google`

These endpoints first do a check on `CORS.Origin` to decide whether to return `Access-Control-Allow-Origin` which is what the browser will use. However, these endpoints do a secondary check on `CORS.LoginOrigin` and will return a 400 if the `Origin` header is not in the request. This might end up being redundant, but I am not changing the behavior at this time, only allowing use of bootstrap level CORS configuration or db level CORS configuration. 

It is also confusing if `http://example.com` is matched in `CORS.Origin` but not in `CORS.LoginOrigin` since it will return a 400 but also `Access-Control-Allow-Origin: http://example.com`. I have left this behavior alone.

The session endpoints are tested but the `/db/_facebook` and `/db/_google` are not due to difficulty of testing deprecated functionality.
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api` (will update in `CBG-4948`) ticket.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/145/
