### PR TITLE
[4.0.0.1 backport] CBG-4943 obey db scope for CORS.LoginOrigin

### DIFF
--- a/auth/cors.go
+++ b/auth/cors.go
@@ -32,6 +32,12 @@ func (cors *CORSConfig) AddResponseHeaders(request *http.Request, response http.
 	}
 }
 
+// IsEmpty returns true if the CORS configuration is empty - used instead of a nil check since we always initialize the CORS config struct.
+func (cors *CORSConfig) IsEmpty() bool {
+	return cors == nil ||
+		(len(cors.Origin) == 0 && len(cors.LoginOrigin) == 0 && len(cors.Headers) == 0 && cors.MaxAge == 0)
+}
+
 func MatchedOrigin(allowOrigins []string, rqOrigins []string) string {
 	for _, rv := range rqOrigins {
 		for _, av := range allowOrigins {

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -9,6 +9,7 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -396,6 +397,74 @@ func TestCORSOriginPerDatabase(t *testing.T) {
 						require.Equal(t, strconv.Itoa(rt.ServerContext().Config.API.CORS.MaxAge), response.Header().Get("Access-Control-Max-Age"))
 					}
 				}
+			}
+
+		})
+	}
+}
+
+func TestCORSLoginOriginPerDatabase(t *testing.T) {
+	// Override the default (example.com) CORS configuration in the DbConfig for /db:
+	rt := NewRestTesterPersistentConfigNoDB(t)
+	defer rt.Close()
+	dbConfig := rt.NewDbConfig()
+	dbConfig.CORS = &auth.CORSConfig{
+		Origin:      []string{"http://couchbase.com", "http://staging.couchbase.com"},
+		LoginOrigin: []string{"http://couchbase.com"},
+		Headers:     []string{},
+	}
+	RequireStatus(t, rt.CreateDatabase("dbloginorigin", dbConfig), http.StatusCreated)
+
+	const username = "alice"
+	rt.CreateUser(username, nil)
+
+	testCases := []struct {
+		name              string
+		origin            string
+		responseCode      int
+		responseErrorBody string
+	}{
+		{
+			name:         "CORS login origin allowed couchbase",
+			origin:       "http://couchbase.com",
+			responseCode: http.StatusOK,
+		},
+		{
+			name:              "CORS login origin not allowed staging",
+			origin:            "http://staging.couchbase.com",
+			responseCode:      http.StatusBadRequest,
+			responseErrorBody: "No CORS",
+		},
+	}
+	for _, test := range testCases {
+		rt.Run(test.name, func(t *testing.T) {
+			reqHeaders := map[string]string{
+				"Origin":        test.origin,
+				"Authorization": GetBasicAuthHeader(t, username, RestTesterDefaultUserPassword),
+			}
+			resp := rt.SendRequestWithHeaders(http.MethodPost, "/{{.db}}/_session", "", reqHeaders)
+			RequireStatus(t, resp, test.responseCode)
+			if test.responseErrorBody != "" {
+				require.Contains(t, resp.Body.String(), test.responseErrorBody)
+				// the access control headers are returned based on Origin and not LoginOrigin which could be considered a bug
+				require.Equal(t, test.origin, resp.Header().Get(accessControlAllowOrigin))
+			} else {
+				require.Equal(t, test.origin, resp.Header().Get(accessControlAllowOrigin))
+			}
+			if test.responseCode == http.StatusOK {
+				cookie, err := http.ParseSetCookie(resp.Header().Get("Set-Cookie"))
+				require.NoError(t, err)
+				require.NotEmpty(t, cookie.Path)
+				reqHeaders["Cookie"] = fmt.Sprintf("%s=%s", cookie.Name, cookie.Value)
+			}
+			resp = rt.SendRequestWithHeaders(http.MethodDelete, "/{{.db}}/_session", "", reqHeaders)
+			RequireStatus(t, resp, test.responseCode)
+			if test.responseErrorBody != "" {
+				require.Contains(t, resp.Body.String(), test.responseErrorBody)
+				// the access control headers are returned based on Origin and not LoginOrigin which could be considered a bug
+				require.Equal(t, test.origin, resp.Header().Get(accessControlAllowOrigin))
+			} else {
+				require.Equal(t, test.origin, resp.Header().Get(accessControlAllowOrigin))
 			}
 
 		})

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -286,6 +286,24 @@ func TestCORSUserNoAccess(t *testing.T) {
 	}
 }
 
+// TestCORSResponseHeadersEmptyConfig ensures that an empty CORS config results in no CORS headers being set on the response.
+func TestCORSResponseHeadersEmptyConfig(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	// RestTester initializes using defaultTestingCORSOrigin - override to empty for this test
+	rt.ServerContext().Config.API.CORS = &auth.CORSConfig{}
+	defer rt.Close()
+
+	reqHeaders := map[string]string{
+		"Origin": "http://example.com",
+	}
+	response := rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/", "", reqHeaders)
+	RequireStatus(t, response, http.StatusUnauthorized)
+	require.Contains(t, response.Body.String(), ErrLoginRequired.Message)
+	assert.NotContains(t, response.Header(), "Access-Control-Allow-Origin")
+	assert.NotContains(t, response.Header(), "Access-Control-Allow-Credentials")
+	assert.NotContains(t, response.Header(), "Access-Control-Allow-Headers")
+}
+
 func TestCORSOriginPerDatabase(t *testing.T) {
 	// Override the default (example.com) CORS configuration in the DbConfig for /db:
 	const perDBMaxAge = 1234

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -26,18 +25,14 @@ type FacebookResponse struct {
 
 // POST /_facebook creates a facebook-based login session and sets its cookie.
 func (h *handler) handleFacebookPOST() error {
-	// CORS not allowed for login #115 #762
-	originHeader := h.rq.Header["Origin"]
-	if len(originHeader) > 0 {
-		matched := auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
-		if matched == "" {
-			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
-		}
+	err := h.checkLoginCORS()
+	if err != nil {
+		return err
 	}
 	var params struct {
 		AccessToken string `json:"access_token"`
 	}
-	err := h.readJSONInto(&params)
+	err = h.readJSONInto(&params)
 	if err != nil {
 		return err
 	}

--- a/rest/google.go
+++ b/rest/google.go
@@ -13,7 +13,6 @@ package rest
 import (
 	"net/http"
 
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -28,20 +27,16 @@ type GoogleResponse struct {
 
 // POST /_google creates a google-based login session and sets its cookie.
 func (h *handler) handleGooglePOST() error {
-	// CORS not allowed for login #115 #762
-	originHeader := h.rq.Header["Origin"]
-	if len(originHeader) > 0 {
-		matched := auth.MatchedOrigin(h.server.Config.API.CORS.LoginOrigin, originHeader)
-		if matched == "" {
-			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
-		}
+	err := h.checkLoginCORS()
+	if err != nil {
+		return err
 	}
 
 	var params struct {
 		IDToken string `json:"id_token"`
 	}
 
-	err := h.readJSONInto(&params)
+	err = h.readJSONInto(&params)
 	if err != nil {
 		return err
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -339,7 +339,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 			if h.db != nil {
 				cors = h.db.CORS
 			}
-			if cors != nil {
+			if !cors.IsEmpty() {
 				cors.AddResponseHeaders(h.rq, h.response)
 			}
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -335,10 +335,7 @@ func (h *handler) validateAndWriteHeaders(method handlerMethod, accessPermission
 	defer func() {
 		// Now that we know the DB, add CORS headers to the response:
 		if h.privs != adminPrivs && h.privs != metricsPrivs {
-			cors := h.server.Config.API.CORS
-			if h.db != nil {
-				cors = h.db.CORS
-			}
+			cors := h.getCORSConfig()
 			if !cors.IsEmpty() {
 				cors.AddResponseHeaders(h.rq, h.response)
 			}
@@ -1787,4 +1784,12 @@ func (h *handler) pathTemplateContains(pattern string) bool {
 		return false
 	}
 	return strings.Contains(pathTemplate, pattern)
+}
+
+// getCORSConfig will return the CORS config for the handler's database if set, otherwise it will return the server CORS config
+func (h *handler) getCORSConfig() *auth.CORSConfig {
+	if h.db != nil {
+		return h.db.CORS
+	}
+	return h.server.Config.API.CORS
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -456,7 +456,7 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, serverType serverType, ro
 					cors = db.CORS
 				}
 			}
-			if cors != nil && privs != adminPrivs && privs != metricsPrivs {
+			if !cors.IsEmpty() && privs != adminPrivs && privs != metricsPrivs {
 				cors.AddResponseHeaders(rq, response)
 			}
 			if len(options) == 0 {


### PR DESCRIPTION
[4.0.0.1 backport] CBG-4943 obey db scope for CORS.LoginOrigin

cherry-pick of 41f162775fc5a330e1cb2906e043c1210546304e and 748e41ba7b6b729c67d53e4ce2e9b794d02f127c