### PR TITLE
Revert "Remove RetryLoopCas since RetryLoop behaves identically (#7823)"

### DIFF
--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -148,7 +148,7 @@ func (c *Collection) SubdocGetRaw(ctx context.Context, k string, subdocKey strin
 		return false, nil, uint64(res.Cas())
 	}
 
-	err, casOut := RetryLoop(ctx, "SubdocGetRaw", worker, DefaultRetrySleeper())
+	err, casOut := RetryLoopCas(ctx, "SubdocGetRaw", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocGetRaw with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
@@ -181,7 +181,7 @@ func (c *Collection) SubdocWrite(ctx context.Context, k string, subdocKey string
 		return false, err, 0
 	}
 
-	err, casOut := RetryLoop(ctx, "SubdocWrite", worker, DefaultRetrySleeper())
+	err, casOut := RetryLoopCas(ctx, "SubdocWrite", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SubdocWrite with key %s and subdocKey %s", UD(k).Redact(), UD(subdocKey).Redact())
 	}
@@ -310,7 +310,7 @@ func (c *Collection) subdocGetBodyAndXattrs(ctx context.Context, k string, xattr
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoop(ctx, "subdocGetBodyAndXattrs", worker, DefaultRetrySleeper())
+	err, cas = RetryLoopCas(ctx, "subdocGetBodyAndXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "subdocGetBodyAndXattrs %v", UD(k).Redact())
 	}

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -61,7 +61,7 @@ func (c *Collection) WriteWithXattrs(ctx context.Context, k string, exp uint32, 
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoop(ctx, "WriteWithXattrs", worker, DefaultRetrySleeper())
+	err, cas = RetryLoopCas(ctx, "WriteWithXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "WriteWithXattrs with key %v", UD(k).Redact())
 	}
@@ -111,7 +111,7 @@ func (c *Collection) WriteTombstoneWithXattrs(ctx context.Context, k string, exp
 	}
 
 	// Kick off retry loop
-	err, cas = RetryLoop(ctx, "WriteTombstoneWithXattrs", worker, DefaultRetrySleeper())
+	err, cas = RetryLoopCas(ctx, "WriteTombstoneWithXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "Error during WriteTombstoneXattrs with key %v", UD(k).Redact())
 		return cas, err
@@ -138,7 +138,7 @@ func (c *Collection) WriteTombstoneWithXattrs(ctx context.Context, k string, exp
 			return false, nil, casOut
 		}
 
-		err, cas = RetryLoop(ctx, "UpdateXattrDeleteBodySecondOp", worker, DefaultRetrySleeper())
+		err, cas = RetryLoopCas(ctx, "UpdateXattrDeleteBodySecondOp", worker, DefaultRetrySleeper())
 		if err != nil {
 			err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr delete op with key %v", UD(k).Redact())
 			return cas, err
@@ -165,7 +165,7 @@ func (c *Collection) WriteResurrectionWithXattrs(ctx context.Context, k string, 
 	}
 
 	// Kick off retry loop
-	err, cas := RetryLoop(ctx, "WriteResurrectionWithXattrs", worker, DefaultRetrySleeper())
+	err, cas := RetryLoopCas(ctx, "WriteResurrectionWithXattrs", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "WriteResurrectionWithXattrs with key %v", UD(k).Redact())
 	}
@@ -297,7 +297,7 @@ func SetXattrs(ctx context.Context, store *Collection, k string, xvs map[string]
 		return false, writeErr, 0
 	}
 
-	err, casOut = RetryLoop(ctx, "SetXattr", worker, DefaultRetrySleeper())
+	err, casOut = RetryLoopCas(ctx, "SetXattr", worker, DefaultRetrySleeper())
 	if err != nil {
 		err = pkgerrors.Wrapf(err, "SetXattr with key %v", UD(k).Redact())
 	}

--- a/base/util.go
+++ b/base/util.go
@@ -427,6 +427,8 @@ type RetrySleeper func(retryCount int) (shouldContinue bool, timeTosleepMs int)
 // even if it returns shouldRetry = true.
 type RetryWorker[T any] func() (shouldRetry bool, err error, value T)
 
+type RetryCasWorker func() (shouldRetry bool, err error, value uint64)
+
 type RetryTimeoutError struct {
 	description string
 	attempts    int
@@ -483,6 +485,37 @@ func RetryLoop[T any](ctx context.Context, description string, worker RetryWorke
 	}
 }
 
+// A version of RetryLoop that returns a strongly typed cas as uint64, to avoid interface conversion overhead for
+// high throughput operations.
+func RetryLoopCas(ctx context.Context, description string, worker RetryCasWorker, sleeper RetrySleeper) (error, uint64) {
+
+	numAttempts := 1
+
+	for {
+		shouldRetry, err, value := worker()
+		if !shouldRetry {
+			if err != nil {
+				return err, value
+			}
+			return nil, value
+		}
+		shouldContinue, sleepMs := sleeper(numAttempts)
+		if !shouldContinue {
+			if err == nil {
+				err = NewRetryTimeoutError(description, numAttempts)
+			}
+			WarnfCtx(ctx, "RetryLoopCas for %v giving up after %v attempts", description, numAttempts)
+			return err, value
+		}
+		DebugfCtx(ctx, KeyAll, "RetryLoopCas retrying %v after %v ms.", description, sleepMs)
+
+		<-time.After(time.Millisecond * time.Duration(sleepMs))
+
+		numAttempts += 1
+
+	}
+}
+
 // SleeperFuncCtx wraps the given RetrySleeper with a context, so it can be cancelled, or have a deadline.
 func SleeperFuncCtx(sleeperFunc RetrySleeper, ctx context.Context) RetrySleeper {
 	return func(retryCount int) (bool, int) {
@@ -514,7 +547,7 @@ func CreateDoublingSleeperFunc(maxNumAttempts, initialTimeToSleepMs int) RetrySl
 
 }
 
-// CreateDoublingSleeperDurationFunc creates a RetrySleeper that will double the retry time on every iteration with
+// Create a RetrySleeper that will double the retry time on every iteration with
 // initial sleep time and a total max wait no longer than maxWait
 func CreateDoublingSleeperDurationFunc(initialTimeToSleepMs int, maxWait time.Duration) RetrySleeper {
 
@@ -555,7 +588,7 @@ func CreateLinearSleeperFunc(totalTime, timeToSleep time.Duration) RetrySleeper 
 	return CreateSleeperFunc(int(totalTime.Seconds()/timeToSleep.Seconds()), int(timeToSleep.Milliseconds()))
 }
 
-// CreateMaxDoublingSleeperFunc creates a RetrySleeper that will double the retry time on every iteration, with each sleep not exceeding maxSleepPerRetryMs.
+// Create a RetrySleeper that will double the retry time on every iteration, with each sleep not exceeding maxSleepPerRetryMs.
 func CreateMaxDoublingSleeperFunc(maxNumAttempts, initialTimeToSleepMs int, maxSleepPerRetryMs int) RetrySleeper {
 
 	timeToSleepMs := initialTimeToSleepMs


### PR DESCRIPTION
This reverts commit 7d685c1455314cf1fb2c09d06f0cb9c2108c2b50.

I do not not know why `RetryLoopCas` and `RetryLoop` behave different for `TestWriteUpdateWithXattrs` (gocb only), I can not spot this by eye, but I just intended to have a simple code cleanup and this change isn't worth risk.
