### PR TITLE
CBG-4921: TestUserXattrRevCache flake fix

### DIFF
--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,11 @@ import (
 
 func TestUserXattrRevCache(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	// need to disable sequence batching given two rest testers allocating sequence batches
+	// can mean that the changes feed has to wait for sequences from another to be released to
+	// maintain ordering
+	defer db.SuspendSequenceBatching()()
 
 	ctx := base.TestCtx(t)
 	docKey := t.Name()
@@ -49,7 +55,6 @@ func TestUserXattrRevCache(t *testing.T) {
 
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
-
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 			AutoImport:       true,
 			UserXattrKey:     &xattrKey,


### PR DESCRIPTION
CBG-4921

- We need to avoid sequence batching for this test given the import on rosmar can arrive over import feed on both nodes
- The test fails because the sequence arrived over dcp but is pushed to pending given a sequence in the other nodes sequence batch much arrive first (but `WaitForChanges` doesn't wait long enough for that sequence to be released) see logs below
Sequence batch increased:
```
2025-10-23T15:41:07.948+01:00 [DBG] CRUD+: t:TestUserXattrRevCache db:db col:sg_test_0 Increased sequence batch to 2
```
Then doc in question imported:
```
2025-10-23T15:41:07.951+01:00 [DBG] CRUD+: t:TestUserXattrRevCache db:db col:sg_test_0 Stored doc "<ud>TestUserXattrRevCache</ud>" / "1-ca9ad22802b66f662ff171f226211d5c" as #4
2025-10-23T15:41:07.951+01:00 [DBG] Import+: t:TestUserXattrRevCache db:db col:sg_test_0 Imported <ud>TestUserXattrRevCache</ud> 
```
Sequcne arrives over DCP but is deferred (waiting for a sequcne in other nodes sequcne batch):
```
2025-10-23T15:41:07.951+01:00 [DBG] Changes+: t:TestUserXattrRevCache db:db col:sg_test_0 Received #4 after   0ms ("<ud>TestUserXattrRevCache</ud>" / "1-ca9ad22802b66f662ff171f226211d5c")
2025-10-23T15:41:07.951+01:00 [DBG] Cache+: t:TestUserXattrRevCache db:db col:sg_test_0   Deferring #4 (1 now waiting for #2...#3) doc "<ud>TestUserXattrRevCache</ud>" / "1-ca9ad22802b66f662ff171f226211d5c"
```

Thus this doc won't show on changes feed when `WaitForChanges` is called.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
