### PR TITLE
CBG-4930: Add Revtree to RevMessage's stringer function

### DIFF
--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -393,11 +393,6 @@ func (rm *RevMessage) Rev() (rev string, found bool) {
 	return rev, found
 }
 
-func (rm *RevMessage) RevTree() (revTree string, found bool) {
-	revTree, found = rm.Properties[RevMessageTreeHistory]
-	return revTree, found
-}
-
 func (rm *RevMessage) Deleted() bool {
 	deleted, found := rm.Properties[RevMessageDeleted]
 	if !found {
@@ -461,6 +456,10 @@ func (rm *RevMessage) String() string {
 
 	if id, foundId := rm.ID(); foundId {
 		buffer.WriteString(fmt.Sprintf("Id:%v ", base.UD(id).Redact()))
+	}
+
+	if rev, foundRev := rm.Rev(); foundRev {
+		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
 	}
 
 	if coll, ok := rm.Collection(); ok {

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -454,6 +454,7 @@ func (rm *RevMessage) SetProperties(properties blip.Properties) {
 	maps.Copy(rm.Properties, properties)
 }
 
+// The RevMessage Stringer function will not return Rev and RevHistory property
 func (rm *RevMessage) String() string {
 
 	buffer := bytes.NewBufferString("")
@@ -464,14 +465,6 @@ func (rm *RevMessage) String() string {
 
 	if coll, ok := rm.Collection(); ok {
 		buffer.WriteString(fmt.Sprintf("Collection:%v ", coll))
-	}
-
-	if rev, foundRev := rm.Rev(); foundRev {
-		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
-	}
-
-	if revTree, foundRevTree := rm.RevTree(); foundRevTree {
-		buffer.WriteString(fmt.Sprintf("RevTree:%v ", revTree))
 	}
 
 	if rm.HasDeletedProperty() {

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -393,6 +393,11 @@ func (rm *RevMessage) Rev() (rev string, found bool) {
 	return rev, found
 }
 
+func (rm *RevMessage) RevTree() (revTree string, found bool) {
+	revTree, found = rm.Properties[RevMessageTreeHistory]
+	return revTree, found
+}
+
 func (rm *RevMessage) Deleted() bool {
 	deleted, found := rm.Properties[RevMessageDeleted]
 	if !found {
@@ -463,6 +468,10 @@ func (rm *RevMessage) String() string {
 
 	if rev, foundRev := rm.Rev(); foundRev {
 		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
+	}
+
+	if revTree, foundRevTree := rm.RevTree(); foundRevTree {
+		buffer.WriteString(fmt.Sprintf("RevTree:%v ", revTree))
 	}
 
 	if rm.HasDeletedProperty() {

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -458,12 +458,12 @@ func (rm *RevMessage) String() string {
 		buffer.WriteString(fmt.Sprintf("Id:%v ", base.UD(id).Redact()))
 	}
 
-	if rev, foundRev := rm.Rev(); foundRev {
-		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
-	}
-
 	if coll, ok := rm.Collection(); ok {
 		buffer.WriteString(fmt.Sprintf("Collection:%v ", coll))
+	}
+
+	if rev, foundRev := rm.Rev(); foundRev {
+		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
 	}
 
 	if rm.HasDeletedProperty() {


### PR DESCRIPTION
CBG-4930

Describe your PR here...
- Added `RevTree` to `RevMessage`'s stringer function

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/149/
