### PR TITLE
[3.3.0.2 backport] CBG-4964 create cookie with SameSite=None if CORS enabled

### DIFF
--- a/auth/session.go
+++ b/auth/session.go
@@ -135,7 +135,7 @@ func (auth *Authenticator) GetSession(sessionID string) (*LoginSession, error) {
 	return &session, nil
 }
 
-func (auth *Authenticator) MakeSessionCookie(session *LoginSession, secureCookie bool, httpOnly bool) *http.Cookie {
+func (auth *Authenticator) MakeSessionCookie(session *LoginSession, secureCookie bool, httpOnly bool, sameSite http.SameSite) *http.Cookie {
 	if session == nil {
 		return nil
 	}
@@ -145,6 +145,8 @@ func (auth *Authenticator) MakeSessionCookie(session *LoginSession, secureCookie
 		Expires:  session.Expiration,
 		Secure:   secureCookie,
 		HttpOnly: httpOnly,
+		// as of go 1.25, http.SameSiteDefaultMode will omit SameSite attribute from the cookie
+		SameSite: sameSite,
 	}
 }
 

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -116,14 +116,14 @@ func TestMakeSessionCookie(t *testing.T) {
 		Ttl:        24 * time.Hour,
 	}
 
-	cookie := auth.MakeSessionCookie(mockSession, false, false)
+	cookie := auth.MakeSessionCookie(mockSession, false, false, http.SameSiteDefaultMode)
 	assert.Equal(t, DefaultCookieName, cookie.Name)
 	assert.Equal(t, sessionID, cookie.Value)
 	assert.NotEmpty(t, cookie.Expires)
 
 	// Cookies should not be created with uninitialized session
 	mockSession = nil
-	cookie = auth.MakeSessionCookie(mockSession, false, false)
+	cookie = auth.MakeSessionCookie(mockSession, false, false, http.SameSiteDefaultMode)
 	assert.Empty(t, cookie)
 }
 
@@ -143,16 +143,16 @@ func TestMakeSessionCookieProperties(t *testing.T) {
 		Ttl:        24 * time.Hour,
 	}
 
-	unsecuredCookie := auth.MakeSessionCookie(mockSession, false, false)
+	unsecuredCookie := auth.MakeSessionCookie(mockSession, false, false, http.SameSiteDefaultMode)
 	assert.False(t, unsecuredCookie.Secure)
 
-	securedCookie := auth.MakeSessionCookie(mockSession, true, false)
+	securedCookie := auth.MakeSessionCookie(mockSession, true, false, http.SameSiteDefaultMode)
 	assert.True(t, securedCookie.Secure)
 
-	httpOnlyFalseCookie := auth.MakeSessionCookie(mockSession, false, false)
+	httpOnlyFalseCookie := auth.MakeSessionCookie(mockSession, false, false, http.SameSiteDefaultMode)
 	assert.False(t, httpOnlyFalseCookie.HttpOnly)
 
-	httpOnlyCookie := auth.MakeSessionCookie(mockSession, false, true)
+	httpOnlyCookie := auth.MakeSessionCookie(mockSession, false, true, http.SameSiteDefaultMode)
 	assert.True(t, httpOnlyCookie.HttpOnly)
 }
 
@@ -248,7 +248,7 @@ func TestCreateSessionChangePassword(t *testing.T) {
 
 			request, err := http.NewRequest(http.MethodGet, "", nil)
 			require.NoError(t, err)
-			request.AddCookie(auth.MakeSessionCookie(session, true, true))
+			request.AddCookie(auth.MakeSessionCookie(session, true, true, http.SameSiteDefaultMode))
 
 			recorder := httptest.NewRecorder()
 			_, err = auth.AuthenticateCookie(request, recorder)
@@ -304,7 +304,7 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 
 	request, err := http.NewRequest(http.MethodGet, "", nil)
 	require.NoError(t, err)
-	request.AddCookie(auth.MakeSessionCookie(session, true, true))
+	request.AddCookie(auth.MakeSessionCookie(session, true, true, http.SameSiteDefaultMode))
 
 	recorder := httptest.NewRecorder()
 	_, err = auth.AuthenticateCookie(request, recorder)
@@ -334,7 +334,7 @@ func TestUserDeleteAllSessions(t *testing.T) {
 
 	request, err := http.NewRequest(http.MethodGet, "", nil)
 	require.NoError(t, err)
-	request.AddCookie(auth.MakeSessionCookie(session, true, true))
+	request.AddCookie(auth.MakeSessionCookie(session, true, true, http.SameSiteDefaultMode))
 	recorder := httptest.NewRecorder()
 
 	_, err = auth.AuthenticateCookie(request, recorder)

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1306,6 +1306,15 @@ Database:
         oidc_tls_skip_verify:
           description: Enable self-signed certificates for OIDC testing.
           type: boolean
+        same_site_cookie:
+          description: |-
+            Override the session cookie SameSite behavior. By default, a session cookie will have SameSite:None if CORS is enabled, and will have no SameSite attribute if CORS is not enabled.  Setting this property to`Default` will omit the SameSite attribute from the cookie.
+          type: string
+          enum:
+            - "Default"
+            - "Lax"
+            - "None"
+            - "Strict"
         sgr_tls_skip_verify:
           description: Enable self-signed certificates for SG-replicate testing.
           type: boolean

--- a/rest/config.go
+++ b/rest/config.go
@@ -1080,6 +1080,13 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		}
 	}
 
+	if dbConfig.Unsupported != nil {
+		_, err := dbConfig.Unsupported.GetSameSiteCookieMode()
+		if err != nil {
+			multiError = multiError.Append(err)
+		}
+	}
+
 	if validateReplications {
 		for name, r := range dbConfig.Replications {
 			if name == "" {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -922,6 +922,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	} else {
 		dbcontext.CORS = sc.Config.API.CORS
 	}
+	if !dbcontext.CORS.IsEmpty() {
+		dbcontext.SameSiteCookieMode = http.SameSiteNoneMode
+	}
+	if config.Unsupported != nil && config.Unsupported.SameSiteCookie != nil {
+		var err error
+		dbcontext.SameSiteCookieMode, err = config.Unsupported.GetSameSiteCookieMode()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if config.RevsLimit != nil {
 		dbcontext.RevsLimit = *config.RevsLimit

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -125,7 +125,7 @@ func (h *handler) makeSessionWithTTL(user auth.User, expiry time.Duration) (sess
 	if err != nil {
 		return "", err
 	}
-	cookie := auth.MakeSessionCookie(session, h.db.Options.SecureCookieOverride, h.db.Options.SessionCookieHttpOnly)
+	cookie := auth.MakeSessionCookie(session, h.db.Options.SecureCookieOverride, h.db.Options.SessionCookieHttpOnly, h.db.SameSiteCookieMode)
 	base.AddDbPathToCookie(h.rq, cookie)
 	http.SetCookie(h.response, cookie)
 	return session.ID, nil

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2808,6 +2808,15 @@ func RequireGocbDCPResync(t *testing.T) {
 	}
 }
 
+// SafeDatabaseName returns a database name free of any special characters for use in tests.
+func SafeDatabaseName(t *testing.T, name string) string {
+	dbName := strings.ToLower(name)
+	for _, c := range []string{" ", "<", ">", "/", "="} {
+		dbName = strings.ReplaceAll(dbName, c, "_")
+	}
+	return dbName
+}
+
 // reloadDatabaseWithConfigLoadFromBucket forces reload of db as if it was being picked up from the bucket
 func (sc *ServerContext) reloadDatabaseWithConfigLoadFromBucket(nonContextStruct base.NonCancellableContext, config DatabaseConfig) error {
 	sc.lock.Lock()


### PR DESCRIPTION
[3.3.0.2 backport] CBG-4964 create cookie with SameSite=None if CORS enabled

cherry-pick of 30ee4fe90dfb8834c4f2754a9c334f54db602de2, minimal conflicts in `database.go`
