### PR TITLE
[4.0.0.2 backport] CBG-4965 create cookie with SameSite=None if CORS enabled

### DIFF
--- a/auth/session.go
+++ b/auth/session.go
@@ -135,7 +135,7 @@ func (auth *Authenticator) GetSession(sessionID string) (*LoginSession, error) {
 	return &session, nil
 }
 
-func (auth *Authenticator) MakeSessionCookie(session *LoginSession, secureCookie bool, httpOnly bool) *http.Cookie {
+func (auth *Authenticator) MakeSessionCookie(session *LoginSession, secureCookie bool, httpOnly bool, sameSite http.SameSite) *http.Cookie {
 	if session == nil {
 		return nil
 	}
@@ -145,6 +145,8 @@ func (auth *Authenticator) MakeSessionCookie(session *LoginSession, secureCookie
 		Expires:  session.Expiration,
 		Secure:   secureCookie,
 		HttpOnly: httpOnly,
+		// as of go 1.25, http.SameSiteDefaultMode will omit SameSite attribute from the cookie
+		SameSite: sameSite,
 	}
 }
 

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -116,14 +116,14 @@ func TestMakeSessionCookie(t *testing.T) {
 		Ttl:        24 * time.Hour,
 	}
 
-	cookie := auth.MakeSessionCookie(mockSession, false, false)
+	cookie := auth.MakeSessionCookie(mockSession, false, false, http.SameSiteDefaultMode)
 	assert.Equal(t, DefaultCookieName, cookie.Name)
 	assert.Equal(t, sessionID, cookie.Value)
 	assert.NotEmpty(t, cookie.Expires)
 
 	// Cookies should not be created with uninitialized session
 	mockSession = nil
-	cookie = auth.MakeSessionCookie(mockSession, false, false)
+	cookie = auth.MakeSessionCookie(mockSession, false, false, http.SameSiteDefaultMode)
 	assert.Empty(t, cookie)
 }
 
@@ -143,16 +143,16 @@ func TestMakeSessionCookieProperties(t *testing.T) {
 		Ttl:        24 * time.Hour,
 	}
 
-	unsecuredCookie := auth.MakeSessionCookie(mockSession, false, false)
+	unsecuredCookie := auth.MakeSessionCookie(mockSession, false, false, http.SameSiteDefaultMode)
 	assert.False(t, unsecuredCookie.Secure)
 
-	securedCookie := auth.MakeSessionCookie(mockSession, true, false)
+	securedCookie := auth.MakeSessionCookie(mockSession, true, false, http.SameSiteDefaultMode)
 	assert.True(t, securedCookie.Secure)
 
-	httpOnlyFalseCookie := auth.MakeSessionCookie(mockSession, false, false)
+	httpOnlyFalseCookie := auth.MakeSessionCookie(mockSession, false, false, http.SameSiteDefaultMode)
 	assert.False(t, httpOnlyFalseCookie.HttpOnly)
 
-	httpOnlyCookie := auth.MakeSessionCookie(mockSession, false, true)
+	httpOnlyCookie := auth.MakeSessionCookie(mockSession, false, true, http.SameSiteDefaultMode)
 	assert.True(t, httpOnlyCookie.HttpOnly)
 }
 
@@ -248,7 +248,7 @@ func TestCreateSessionChangePassword(t *testing.T) {
 
 			request, err := http.NewRequest(http.MethodGet, "", nil)
 			require.NoError(t, err)
-			request.AddCookie(auth.MakeSessionCookie(session, true, true))
+			request.AddCookie(auth.MakeSessionCookie(session, true, true, http.SameSiteDefaultMode))
 
 			recorder := httptest.NewRecorder()
 			_, err = auth.AuthenticateCookie(request, recorder)
@@ -304,7 +304,7 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 
 	request, err := http.NewRequest(http.MethodGet, "", nil)
 	require.NoError(t, err)
-	request.AddCookie(auth.MakeSessionCookie(session, true, true))
+	request.AddCookie(auth.MakeSessionCookie(session, true, true, http.SameSiteDefaultMode))
 
 	recorder := httptest.NewRecorder()
 	_, err = auth.AuthenticateCookie(request, recorder)
@@ -334,7 +334,7 @@ func TestUserDeleteAllSessions(t *testing.T) {
 
 	request, err := http.NewRequest(http.MethodGet, "", nil)
 	require.NoError(t, err)
-	request.AddCookie(auth.MakeSessionCookie(session, true, true))
+	request.AddCookie(auth.MakeSessionCookie(session, true, true, http.SameSiteDefaultMode))
 	recorder := httptest.NewRecorder()
 
 	_, err = auth.AuthenticateCookie(request, recorder)

--- a/db/database.go
+++ b/db/database.go
@@ -164,6 +164,7 @@ type DatabaseContext struct {
 	CachedCCVStartingCas         *base.VBucketCAS               // If set, the cached value of the CCV starting CAS value to avoid repeated lookups
 	CachedCCVEnabled             atomic.Bool                    // If set, the cached value of the CCV Enabled flag (this is not expected to transition from true->false, but could go false->true)
 	numVBuckets                  uint16                         // Number of vbuckets in the bucket
+	SameSiteCookieMode           http.SameSite
 }
 
 type Scope struct {
@@ -278,6 +279,7 @@ type UnsupportedOptions struct {
 	KVBufferSize                     int                      `json:"kv_buffer,omitempty"`                            // Enables user to set their own KV pool buffer
 	BlipSendDocsWithChannelRemoval   bool                     `json:"blip_send_docs_with_channel_removal,omitempty"`  // Enables sending docs with channel removals using channel filters
 	RejectWritesWithSkippedSequences bool                     `json:"reject_writes_with_skipped_sequences,omitempty"` // Reject writes if there are skipped sequences in the database
+	SameSiteCookie                   *string                  `json:"same_site_cookie,omitempty"`                     // Sets the SameSite attribute on session cookies.
 }
 
 type WarningThresholds struct {
@@ -433,6 +435,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		ServerUUID:           serverUUID,
 		UserFunctionTimeout:  defaultUserFunctionTimeout,
 		CachedCCVStartingCas: &base.VBucketCAS{},
+		SameSiteCookieMode:   http.SameSiteDefaultMode,
 	}
 	dbContext.numVBuckets, err = bucket.GetMaxVbno()
 	if err != nil {
@@ -2587,4 +2590,24 @@ func PurgeDCPCheckpoints(ctx context.Context, database *DatabaseContext, checkpo
 
 func (db *DatabaseContext) EnableAllowConflicts(tb testing.TB) {
 	db.Options.AllowConflicts = base.Ptr(true)
+}
+
+// GetSameSiteCookieMode returns the http.SameSite mode based on the unsupported database options. Returns an error if
+// an invalid string is set.
+func (o *UnsupportedOptions) GetSameSiteCookieMode() (http.SameSite, error) {
+	if o == nil || o.SameSiteCookie == nil {
+		return http.SameSiteDefaultMode, nil
+	}
+	switch *o.SameSiteCookie {
+	case "Lax":
+		return http.SameSiteLaxMode, nil
+	case "Strict":
+		return http.SameSiteStrictMode, nil
+	case "None":
+		return http.SameSiteNoneMode, nil
+	case "Default":
+		return http.SameSiteDefaultMode, nil
+	default:
+		return http.SameSiteDefaultMode, fmt.Errorf("unsupported_options.same_site_cookie option %q is not valid, choices are \"Lax\", \"Strict\", and \"None", *o.SameSiteCookie)
+	}
 }

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1698,6 +1698,15 @@ Database:
         remote_config_tls_skip_verify:
           description: Enable self-signed certificates for external JavaScript load.
           type: boolean
+        same_site_cookie:
+          description: |-
+            Override the session cookie SameSite behavior. By default, a session cookie will have SameSite:None if CORS is enabled, and will have no SameSite attribute if CORS is not enabled.  Setting this property to`Default` will omit the SameSite attribute from the cookie.
+          type: string
+          enum:
+            - "Default"
+            - "Lax"
+            - "None"
+            - "Strict"
         sgr_tls_skip_verify:
           description: Enable self-signed certificates for SG-replicate testing.
           type: boolean

--- a/rest/config.go
+++ b/rest/config.go
@@ -1083,6 +1083,13 @@ func (dbConfig *DbConfig) validateVersion(ctx context.Context, isEnterpriseEditi
 		}
 	}
 
+	if dbConfig.Unsupported != nil {
+		_, err := dbConfig.Unsupported.GetSameSiteCookieMode()
+		if err != nil {
+			multiError = multiError.Append(err)
+		}
+	}
+
 	if validateReplications {
 		for name, r := range dbConfig.Replications {
 			if name == "" {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3376,3 +3376,62 @@ func TestConfigUserXattrKeyValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateUnsupportedSameSiteCookies(t *testing.T) {
+	tests := []struct {
+		name                string
+		unsupportedSettings *db.UnsupportedOptions
+		error               string
+	}{
+		{
+			name:                "no unsupportedSettings present",
+			unsupportedSettings: &db.UnsupportedOptions{},
+			error:               "",
+		},
+		{
+			name:                "no samesite, unsupportedSettings present",
+			unsupportedSettings: &db.UnsupportedOptions{},
+			error:               "",
+		},
+		{
+			name:                "valid value Lax",
+			unsupportedSettings: &db.UnsupportedOptions{SameSiteCookie: base.Ptr("Lax")},
+			error:               "",
+		},
+		{
+			name:                "valid value Strict",
+			unsupportedSettings: &db.UnsupportedOptions{SameSiteCookie: base.Ptr("Strict")},
+			error:               "",
+		},
+		{
+			name:                "valid value None",
+			unsupportedSettings: &db.UnsupportedOptions{SameSiteCookie: base.Ptr("None")},
+			error:               "",
+		},
+		{
+			name:                "invalid value",
+			unsupportedSettings: &db.UnsupportedOptions{SameSiteCookie: base.Ptr("invalid value")},
+			error:               "unsupported_options.same_site_cookie option",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dbConfig := DbConfig{
+				Name:        "db",
+				Unsupported: test.unsupportedSettings,
+			}
+
+			validateReplications := false
+			validateOIDC := false
+			ctx := base.TestCtx(t)
+			err := dbConfig.validate(ctx, validateOIDC, validateReplications)
+			if test.error != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.error)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -948,6 +948,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	} else {
 		dbcontext.CORS = sc.Config.API.CORS
 	}
+	if !dbcontext.CORS.IsEmpty() {
+		dbcontext.SameSiteCookieMode = http.SameSiteNoneMode
+	}
+	if config.Unsupported != nil && config.Unsupported.SameSiteCookie != nil {
+		var err error
+		dbcontext.SameSiteCookieMode, err = config.Unsupported.GetSameSiteCookieMode()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if config.RevsLimit != nil {
 		dbcontext.RevsLimit = *config.RevsLimit

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -125,7 +125,7 @@ func (h *handler) makeSessionWithTTL(user auth.User, expiry time.Duration) (sess
 	if err != nil {
 		return "", err
 	}
-	cookie := auth.MakeSessionCookie(session, h.db.Options.SecureCookieOverride, h.db.Options.SessionCookieHttpOnly)
+	cookie := auth.MakeSessionCookie(session, h.db.Options.SecureCookieOverride, h.db.Options.SessionCookieHttpOnly, h.db.SameSiteCookieMode)
 	base.AddDbPathToCookie(h.rq, cookie)
 	http.SetCookie(h.response, cookie)
 	return session.ID, nil


### PR DESCRIPTION
[4.0.0.2 backport] CBG-4965 create cookie with SameSite=None if CORS enabled

clean cherry-pick of 30ee4fe90dfb8834c4f2754a9c334f54db602de2
