### PR TITLE
CBG-4966 create a one time session id for blipsync

### DIFF
--- a/auth/session.go
+++ b/auth/session.go
@@ -90,9 +90,6 @@ func (auth *Authenticator) AuthenticateOneTimeSession(ctx context.Context, sessi
 	if err != nil && !base.IsDocNotFoundError(err) {
 		base.InfofCtx(ctx, base.KeyAuth, "Error deleting one-time session %s: %v, it will expire due to TTL soon", base.UD(sessionID), err)
 	}
-	if err != nil {
-		return nil, err
-	}
 	return user, nil
 }
 

--- a/auth/session.go
+++ b/auth/session.go
@@ -95,7 +95,7 @@ func (auth *Authenticator) AuthenticateOneTimeSession(ctx context.Context, sessi
 			// If the delete error comes from another source, still treat this as an error, expecting the client to retry
 			// due to a temporary KV issue.
 			if !base.IsDocNotFoundError(err) {
-				base.InfofCtx(ctx, base.KeyAuth, "Error deleting one-time session %s. Not allowing login: %v", base.UD(sessionID), err)
+				base.InfofCtx(ctx, base.KeyAuth, "Unable to delete one-time session %s. Not allowing login: %v", base.UD(sessionID), err)
 			}
 			return nil, base.HTTPErrorf(http.StatusUnauthorized, "Session Invalid")
 		}

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package auth
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -23,50 +24,66 @@ import (
 )
 
 func TestCreateSession(t *testing.T) {
-	const username = "Alice"
-	const invalidSessionTTLError = "400 Invalid session time-to-live"
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAuth)
-	ctx := base.TestCtx(t)
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close(ctx)
-	dataStore := testBucket.GetSingleDataStore()
-	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	for _, oneTime := range []bool{true, false} {
+		t.Run(fmt.Sprintf("oneTime=%t", oneTime), func(t *testing.T) {
+			const username = "Alice"
+			const invalidSessionTTLError = "400 Invalid session time-to-live"
+			ctx := base.TestCtx(t)
+			testBucket := base.GetTestBucket(t)
+			defer testBucket.Close(ctx)
+			dataStore := testBucket.GetSingleDataStore()
+			auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
 
-	user, err := auth.NewUser(username, "password", base.Set{})
-	require.NoError(t, err)
-	require.NotNil(t, user)
-	require.NoError(t, auth.Save(user))
+			user, err := auth.NewUser(username, "password", base.Set{})
+			require.NoError(t, err)
+			require.NotNil(t, user)
+			require.NoError(t, auth.Save(user))
 
-	// Create session with a username and valid TTL of 2 hours.
-	session, err := auth.CreateSession(ctx, user, 2*time.Hour)
-	require.NoError(t, err)
+			// Create session with a username and valid TTL of 2 hours.
+			session, err := auth.CreateSession(ctx, user, 2*time.Hour, oneTime)
+			require.NoError(t, err)
 
-	assert.Equal(t, username, session.Username)
-	assert.Equal(t, 2*time.Hour, session.Ttl)
-	assert.NotEmpty(t, session.ID)
-	assert.NotEmpty(t, session.Expiration)
+			assert.Equal(t, username, session.Username)
+			assert.Equal(t, 2*time.Hour, session.Ttl)
+			assert.NotEmpty(t, session.ID)
+			assert.NotEmpty(t, session.Expiration)
+			if oneTime {
+				require.NotNil(t, session.OneTime)
+				require.True(t, *session.OneTime)
+			} else {
+				assert.Empty(t, session.OneTime)
+			}
 
-	// Once the session is created, the details should be persisted on the bucket
-	// and it must be accessible anytime later within the session expiration time.
-	session, err = auth.GetSession(session.ID)
-	assert.NoError(t, err)
+			// Once the session is created, the details should be persisted on the bucket
+			// and it must be accessible anytime later within the session expiration time.
+			session, _, err = auth.GetSession(session.ID)
+			assert.NoError(t, err)
 
-	assert.Equal(t, username, session.Username)
-	assert.Equal(t, 2*time.Hour, session.Ttl)
-	assert.NotEmpty(t, session.ID)
-	assert.NotEmpty(t, session.Expiration)
+			assert.Equal(t, username, session.Username)
+			assert.Equal(t, 2*time.Hour, session.Ttl)
+			assert.NotEmpty(t, session.ID)
+			assert.NotEmpty(t, session.Expiration)
+			if oneTime {
+				require.NotNil(t, session.OneTime)
+				require.True(t, *session.OneTime)
+			} else {
+				assert.Empty(t, session.OneTime)
+			}
 
-	// Session must not be created with zero TTL; it's illegal.
-	session, err = auth.CreateSession(ctx, user, time.Duration(0))
-	assert.Nil(t, session)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), invalidSessionTTLError)
+			// Session must not be created with zero TTL; it's illegal.
+			session, err = auth.CreateSession(ctx, user, time.Duration(0), oneTime)
+			assert.Nil(t, session)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), invalidSessionTTLError)
 
-	// Session must not be created with negative TTL; it's illegal.
-	session, err = auth.CreateSession(ctx, user, time.Duration(-1))
-	assert.Nil(t, session)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), invalidSessionTTLError)
+			// Session must not be created with negative TTL; it's illegal.
+			session, err = auth.CreateSession(ctx, user, time.Duration(-1), oneTime)
+			assert.Nil(t, session)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), invalidSessionTTLError)
+		})
+	}
 }
 
 func TestDeleteSession(t *testing.T) {
@@ -91,7 +108,7 @@ func TestDeleteSession(t *testing.T) {
 	assert.NoError(t, dataStore.Set(auth.DocIDForSession(mockSession.ID), noSessionExpiry, nil, mockSession))
 	assert.NoError(t, auth.DeleteSession(ctx, mockSession.ID, ""))
 
-	session, err := auth.GetSession(mockSession.ID)
+	session, _, err := auth.GetSession(mockSession.ID)
 	assert.Nil(t, session)
 	base.RequireDocNotFoundError(t, err)
 }
@@ -239,11 +256,12 @@ func TestCreateSessionChangePassword(t *testing.T) {
 			require.NotNil(t, user)
 			require.NoError(t, auth.Save(user))
 
+			oneTime := false
 			// Create session with a username and valid TTL of 2 hours.
-			session, err := auth.CreateSession(ctx, user, 2*time.Hour)
+			session, err := auth.CreateSession(ctx, user, 2*time.Hour, oneTime)
 			require.NoError(t, err)
 
-			session, err = auth.GetSession(session.ID)
+			session, _, err = auth.GetSession(session.ID)
 			require.NoError(t, err)
 
 			request, err := http.NewRequest(http.MethodGet, "", nil)
@@ -295,11 +313,11 @@ func TestUserWithoutSessionUUID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, user)
 
-	// Create session with a username and valid TTL of 2 hours.
-	session, err := auth.CreateSession(ctx, user, 2*time.Hour)
+	oneTime := false
+	session, err := auth.CreateSession(ctx, user, 2*time.Hour, oneTime)
 	require.NoError(t, err)
 
-	session, err = auth.GetSession(session.ID)
+	session, _, err = auth.GetSession(session.ID)
 	require.NoError(t, err)
 
 	request, err := http.NewRequest(http.MethodGet, "", nil)
@@ -325,11 +343,11 @@ func TestUserDeleteAllSessions(t *testing.T) {
 	require.NotNil(t, user)
 	require.NoError(t, auth.Save(user))
 
-	// Create session with a username and valid TTL of 2 hours.
-	session, err := auth.CreateSession(ctx, user, 2*time.Hour)
+	oneTime := false
+	session, err := auth.CreateSession(ctx, user, 2*time.Hour, oneTime)
 	require.NoError(t, err)
 
-	session, err = auth.GetSession(session.ID)
+	session, _, err = auth.GetSession(session.ID)
 	require.NoError(t, err)
 
 	request, err := http.NewRequest(http.MethodGet, "", nil)
@@ -347,4 +365,41 @@ func TestUserDeleteAllSessions(t *testing.T) {
 
 	_, err = auth.AuthenticateCookie(request, recorder)
 	require.EqualError(t, err, "401 Session no longer valid for user")
+}
+
+func TestCreateOneTimeSession(t *testing.T) {
+	ctx := base.TestCtx(t)
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close(ctx)
+	dataStore := testBucket.GetSingleDataStore()
+	auth := NewTestAuthenticator(t, dataStore, nil, DefaultAuthenticatorOptions(ctx))
+	const username = "Alice"
+	user, err := auth.NewUser(username, "password", base.Set{})
+	require.NoError(t, err)
+	require.NoError(t, auth.Save(user))
+
+	oneTime := true
+	session, err := auth.CreateSession(ctx, user, 2*time.Hour, oneTime)
+	require.NoError(t, err)
+
+	session, user, err = auth.GetSession(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, username, session.Username)
+	require.Equal(t, username, user.Name())
+
+	// make sure this can be retrieved again if not through AuthenticateOneTimeSession
+	session, user, err = auth.GetSession(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, username, session.Username)
+	require.Equal(t, username, user.Name())
+
+	// now test AuthenticateOneTimeSession deletes it
+	user, err = auth.AuthenticateOneTimeSession(ctx, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, username, user.Name())
+
+	// make sure session is deleted
+	session, _, err = auth.GetSession(session.ID)
+	require.Nil(t, session)
+	base.RequireDocNotFoundError(t, err)
 }

--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -37,6 +37,9 @@ post:
             password:
               description: Password of the user to generate the session for.
               type: string
+            one_time:
+              description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes.
+              type: boolean
   responses:
     '200':
       description: Session created successfully. Returned body is dependant on if using Public or Admin APIs
@@ -78,6 +81,9 @@ post:
                 required:
                   - channels
                   - name
+              one_time_session_id:
+                description: The id of a single use session.
+                type: boolean
             required:
               - authentication_handlers
               - ok

--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -24,6 +24,12 @@ post:
     Generates a login session for the user based on the credentials provided in the request body or if that fails (due to invalid credentials or none provided at all), generates the new session for the currently authenticated user instead. On a successful session creation, a session cookie is stored to keep the user authenticated for future API calls.
 
     If CORS is enabled, the origin must match an allowed login origin otherwise an error will be returned.
+  parameters:
+    - name: one_time
+      description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes if not used.
+      in: query
+      schema:
+        type: boolean
   requestBody:
     description: The body can depend on if using the Public or Admin APIs.
     content:
@@ -37,9 +43,6 @@ post:
             password:
               description: Password of the user to generate the session for.
               type: string
-            one_time:
-              description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes.
-              type: boolean
   responses:
     '200':
       description: Session created successfully. Returned body is dependant on if using Public or Admin APIs
@@ -84,6 +87,7 @@ post:
               one_time_session_id:
                 description: The id of a single use session.
                 type: string
+                example: c5af80a039db4ed9d2b6865576b6999935282689
             required:
               - authentication_handlers
               - ok

--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -83,7 +83,7 @@ post:
                   - name
               one_time_session_id:
                 description: The id of a single use session.
-                type: boolean
+                type: string
             required:
               - authentication_handlers
               - ok

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -22,6 +22,11 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+const (
+	secWebSocketProtocolHeader = "Sec-WebSocket-Protocol"
+	blipSessionIDPrefix        = "SyncGatewaySession="
+)
+
 // HTTP handler for incoming BLIP sync WebSocket request (/db/_blipsync)
 func (h *handler) handleBLIPSync() error {
 	needRelease, err := h.server.incrementConcurrentReplications(h.rqCtx)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	secWebSocketProtocolHeader = "Sec-WebSocket-Protocol"
-	blipSessionIDPrefix        = "SyncGatewaySession="
+	blipSessionIDPrefix        = "SyncGatewaySession_"
 )
 
 // HTTP handler for incoming BLIP sync WebSocket request (/db/_blipsync)

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -188,8 +188,7 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			ws.Close(websocket.StatusNormalClosure, "test complete")
-
+			require.NoError(t, ws.Close(websocket.StatusNormalClosure, "test complete"))
 		})
 	}
 

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -85,7 +85,7 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 	const username = "alice"
 	rt.CreateUser(username, []string{"*"})
 
-	resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session", `{"one_time": true}`, username)
+	resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "", username)
 	RequireStatus(t, resp, http.StatusOK)
 
 	var sessionResp struct {
@@ -167,7 +167,7 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 	for _, tc := range testCases {
 		rt.Run(tc.name, func(t *testing.T) {
 			// Create new one-time session for each sub-test
-			resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session", `{"one_time": true}`, username)
+			resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "{}", username)
 			RequireStatus(t, resp, http.StatusOK)
 
 			var sessionResp struct {

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -138,12 +138,11 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 		name      string
 		protocols []string
 		error     string
-	}{ /*
-			{
-				name:  "No Protocols",
-				error: "expected handshake response status code 101 but got 500",
-			},
-		*/
+	}{
+		{
+			name:  "No Protocols",
+			error: "expected handshake response status code 101 but got 500",
+		},
 		{
 			name: "V4 Protocol",
 			protocols: []string{
@@ -180,7 +179,6 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 
 			protocols := []string{blipSessionIDPrefix + sessionResp.SessionID}
 			protocols = append(protocols, tc.protocols...)
-			fmt.Printf("protocols=%#+v\n", protocols)
 			ctx := rt.Context()
 			ws, _, err := websocket.Dial(ctx, destURL, &websocket.DialOptions{Subprotocols: protocols})
 			if tc.error != "" {

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -11,9 +11,13 @@ package rest
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/coder/websocket"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,4 +123,74 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 		secWebSocketProtocolHeader: blipSessionIDPrefix + sessionResp.SessionID,
 	})
 	RequireStatus(t, resp, http.StatusUnauthorized)
+
+	srv := httptest.NewServer(rt.TestPublicHandler())
+	defer srv.Close()
+
+	// Construct URL to connect to blipsync target endpoint
+	destURL := fmt.Sprintf("%s/%s/_blipsync", srv.URL, rt.GetDatabase().Name)
+	u, err := url.Parse(destURL)
+	require.NoError(t, err)
+	u.Scheme = "ws"
+
+	blipProtocolPrefix := "BLIP_3+"
+	testCases := []struct {
+		name      string
+		protocols []string
+		error     string
+	}{ /*
+			{
+				name:  "No Protocols",
+				error: "expected handshake response status code 101 but got 500",
+			},
+		*/
+		{
+			name: "V4 Protocol",
+			protocols: []string{
+				blipProtocolPrefix + db.CBMobileReplicationV4.SubprotocolString(),
+			},
+		},
+		{
+			name: "V3 Protocol",
+			protocols: []string{
+				blipProtocolPrefix + db.CBMobileReplicationV3.SubprotocolString(),
+			},
+		},
+		{
+			name: "Multiple Protocols",
+			protocols: []string{
+				"some-other-protocol",
+				blipProtocolPrefix + db.CBMobileReplicationV4.SubprotocolString(),
+				blipProtocolPrefix + db.CBMobileReplicationV3.SubprotocolString(),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		rt.Run(tc.name, func(t *testing.T) {
+			// Create new one-time session for each sub-test
+			resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session", `{"one_time": true}`, username)
+			RequireStatus(t, resp, http.StatusOK)
+
+			var sessionResp struct {
+				SessionID string `json:"one_time_session_id"`
+			}
+
+			require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &sessionResp))
+			require.NotEmpty(t, sessionResp.SessionID, "Expected non-empty session ID for %s", resp.BodyString())
+
+			protocols := []string{blipSessionIDPrefix + sessionResp.SessionID}
+			protocols = append(protocols, tc.protocols...)
+			fmt.Printf("protocols=%#+v\n", protocols)
+			ctx := rt.Context()
+			ws, _, err := websocket.Dial(ctx, destURL, &websocket.DialOptions{Subprotocols: protocols})
+			if tc.error != "" {
+				require.ErrorContains(t, err, tc.error)
+				return
+			}
+			require.NoError(t, err)
+			ws.Close(websocket.StatusNormalClosure, "test complete")
+
+		})
+	}
+
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1010,12 +1010,9 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	if h.isBlipSync() {
 		sessionID := h.getWebsocketToken()
 		if sessionID != "" {
+			var err error
 			auditFields = base.AuditFields{base.AuditFieldAuthMethod: "websocket_token"}
-			user, err := dbCtx.Authenticator(h.ctx()).AuthenticateOneTimeSession(h.ctx(), sessionID)
-			fmt.Printf("WebSocket Token Auth attempt for session ID %s resulted in user %v and err %v\n", base.UD(sessionID), h.user, err)
-			if err == nil {
-				h.user = user
-			}
+			h.user, err = dbCtx.Authenticator(h.ctx()).AuthenticateOneTimeSession(h.ctx(), sessionID)
 			return err
 		}
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1052,13 +1052,13 @@ func (h *handler) getWebsocketToken() string {
 	protocolHeaders := h.rq.Header.Get(secWebSocketProtocolHeader)
 	var outputHeaders []string
 	var sessionID string
-	for _, header := range strings.Split(protocolHeaders, ",") {
-		header := strings.TrimSpace(header)
-		if !strings.HasPrefix(header, blipSessionIDPrefix) {
+	for header := range strings.SplitSeq(protocolHeaders, ",") {
+		trimmedHeader := strings.TrimSpace(header)
+		if !strings.HasPrefix(trimmedHeader, blipSessionIDPrefix) {
 			outputHeaders = append(outputHeaders, header)
 			continue
 		}
-		sessionID = strings.TrimSpace(strings.TrimPrefix(header, blipSessionIDPrefix))
+		sessionID = strings.TrimPrefix(trimmedHeader, blipSessionIDPrefix)
 	}
 	if sessionID == "" {
 		return ""

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -279,7 +279,8 @@ func (h *handler) createSessionForTrustedIdToken(rawIDToken string, provider *au
 
 	if !provider.DisableSession {
 		sessionTTL := tokenExpiryTime.Sub(time.Now())
-		sessionID, err := h.makeSessionWithTTL(user, sessionTTL)
+		oneTime := false
+		sessionID, err := h.makeSessionWithTTL(user, sessionTTL, oneTime)
 		return user.Name(), sessionID, err
 	}
 	return user.Name(), "", nil

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -116,27 +116,6 @@ func (h *handler) getUserFromSessionRequestBody() (auth.User, error) {
 	return user, nil
 }
 
-// getUser returns a user object by authenticating the provided username and password.
-func (h *handler) getUser(username, password string) (auth.User, error) {
-	user, err := h.db.Authenticator(h.ctx()).GetUser(username)
-	if err != nil {
-		return nil, err
-	}
-
-	if user == nil {
-		base.InfofCtx(h.ctx(), base.KeyAuth, "Couldn't create session for user %q: not found", base.UD(username))
-		return nil, nil
-	}
-
-	authenticated, reason := user.AuthenticateWithReason(password)
-	if !authenticated {
-		base.InfofCtx(h.ctx(), base.KeyAuth, "Couldn't create session for user %q: %s", base.UD(username), reason)
-		return nil, nil
-	}
-
-	return user, nil
-}
-
 // DELETE /_session logs out the current session
 func (h *handler) handleSessionDELETE() error {
 	err := h.checkLoginCORS()

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -67,6 +67,7 @@ func (h *handler) handleSessionPOST() error {
 		if err != nil {
 			return err
 		}
+		user = h.user
 	} else if err != nil {
 		return err
 	} else {

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -21,7 +21,7 @@ import (
 const (
 	// defaultSessionTTL is the default time-to-live for login sessions
 	defaultSessionTTL = 24 * time.Hour
-	// oneTimeSessionTTL is the time-to-live for one-time login sessions, log enough to complete the authentication
+	// oneTimeSessionTTL is the time-to-live for one-time login sessions, long enough to complete the authentication
 	// flow, but disappear if they are unused
 	oneTimeSessionTTL = 5 * time.Minute
 )

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -9,7 +9,6 @@
 package rest
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -56,7 +55,6 @@ func (h *handler) handleSessionPOST() error {
 		return ErrLoginRequired
 	}
 	user, err := h.getUserFromSessionRequestBody()
-	fmt.Printf("user from body: %+v, err: %v\n", user, err)
 
 	ttl := defaultSessionTTL
 	if oneTime {

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -9,6 +9,8 @@
 package rest
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"time"
 
@@ -47,6 +49,12 @@ func (h *handler) handleSessionPOST() error {
 		return err
 	}
 
+	// NOTE: handleSessionPOST doesn't handle creating users from OIDC - checkPublicAuth calls out into AuthenticateUntrustedJWT.
+	// Therefore, if by this point `h.user` is guest, this isn't creating a session from OIDC.
+	if h.db.Options.DisablePasswordAuthentication && (h.user == nil || h.user.Name() == "") {
+		return ErrLoginRequired
+	}
+
 	body, err := h.readBody()
 	if err != nil {
 		return err
@@ -59,7 +67,7 @@ func (h *handler) handleSessionPOST() error {
 	}
 	user := h.user
 	if len(body) > 0 {
-		err := base.JSONUnmarshal(body, &params)
+		err := ReadJSONFromMIME(h.rq.Header, io.NopCloser(bytes.NewReader(body)), &params)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
CBG-4966 create a one time session id for blipsync

- Create a `one_time: true` parameter for public `/db/_session` end point that will return a one time session in `one_time_session_id` property
- If handler is `/ks/_blipsync` check `Sec-WebSocket-Protocol` header for a value `SyncGatewaySession={sessionID}`. If found, use this for auth. Modify `http.Request.Header` to remove this header to remove this from logging https://github.com/couchbase/go-blip/blob/main/context.go#L256. It isn't harmful to keep it in, it will just get logged if a client connects to blip that doesn't speak any of the supported protocols. At that point the session will be invalid.

I'm not sure I like the refactoring I did in `handleSessionPOST`, but `getUserFromSessionRequestBody` was hiding a lot of errors, including guest auth. There might be a less risky way to do that, and I'm open to going over it again.

Blocks https://github.com/couchbase/couchbase-lite-js/pull/67

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
