### PR TITLE
CBG-4892: Add eccv to cluster_info endpoint

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -2294,7 +2294,7 @@ type ClusterInfo struct {
 
 type BucketInfo struct {
 	Registry                     *GatewayRegistry `json:"registry,omitempty"`
-	EnableCrossClusterVersioning bool            `json:"enable_cross_cluster_versioning"`
+	EnableCrossClusterVersioning bool             `json:"enable_cross_cluster_versioning"`
 }
 
 // Get SG cluster information.  Iterates over all buckets associated with the server, and returns cluster

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -2293,7 +2293,7 @@ type ClusterInfo struct {
 }
 
 type BucketInfo struct {
-	Registry                     GatewayRegistry `json:"registry,omitempty"`
+	Registry                     *GatewayRegistry `json:"registry,omitempty"`
 	EnableCrossClusterVersioning bool            `json:"enable_cross_cluster_versioning"`
 }
 
@@ -2325,7 +2325,7 @@ func (h *handler) handleGetClusterInfo() error {
 			}
 
 			bucketInfo := BucketInfo{
-				Registry:                     *registry,
+				Registry:                     registry,
 				EnableCrossClusterVersioning: eccv[bucketName],
 			}
 			clusterInfo.Buckets[bucketName] = bucketInfo

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -2293,7 +2293,8 @@ type ClusterInfo struct {
 }
 
 type BucketInfo struct {
-	Registry GatewayRegistry `json:"registry"`
+	Registry                     GatewayRegistry `json:"registry"`
+	EnableCrossClusterVersioning bool            `json:"enable_cross_cluster_versioning"`
 }
 
 // Get SG cluster information.  Iterates over all buckets associated with the server, and returns cluster
@@ -2322,8 +2323,11 @@ func (h *handler) handleGetClusterInfo() error {
 				continue
 			}
 
+			eccv := h.server.getBucketCCVSettings(bucketName)
+
 			bucketInfo := BucketInfo{
-				Registry: *registry,
+				Registry:                     *registry,
+				EnableCrossClusterVersioning: eccv,
 			}
 			clusterInfo.Buckets[bucketName] = bucketInfo
 		}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3588,7 +3588,6 @@ func TestECCV(t *testing.T) {
 			err := base.JSONUnmarshal(resp.Body.Bytes(), &clusterInfo)
 			require.NoError(t, err)
 			assert.True(t, clusterInfo.Buckets[bucketName].EnableCrossClusterVersioning)
-			//RequireStatus(t, rt.SendAdminRequest(http.MethodDelete, fmt.Sprintf("/%s/", tests.dbName), ""), http.StatusOK)
 		})
 	}
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3564,6 +3564,8 @@ func TestECCV(t *testing.T) {
 	var clusterInfo ClusterInfoResponse
 	err := base.JSONUnmarshal(resp.Body.Bytes(), &clusterInfo)
 	assert.NoError(t, err)
+}
+
 func TestUnsupportedServerConfigOptions(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2328,3 +2328,13 @@ func (sc *ServerContext) getClusterUUID(ctx context.Context) (string, error) {
 	}
 	return base.ParseClusterUUID(output)
 }
+
+func (sc *ServerContext) getBucketCCVSettings(bucketName string) bool {
+	for _, _db := range sc.databases_ {
+		if _db.BucketSpec.BucketName == bucketName {
+			return _db.CachedCCVEnabled.Load()
+		}
+
+	}
+	return false
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2331,12 +2331,11 @@ func (sc *ServerContext) getClusterUUID(ctx context.Context) (string, error) {
 	return base.ParseClusterUUID(output)
 }
 
-func (sc *ServerContext) getBucketCCVSettings(bucketName string) bool {
+func (sc *ServerContext) getBucketCCVSettings() map[string]bool {
+	bucketCCVSettings := make(map[string]bool)
 	for _, _db := range sc.databases_ {
-		if _db.BucketSpec.BucketName == bucketName {
-			return _db.CachedCCVEnabled.Load()
-		}
-
+		bucketName := _db.BucketSpec.BucketName
+		bucketCCVSettings[bucketName] = _db.CachedCCVEnabled.Load()
 	}
-	return false
+	return bucketCCVSettings
 }


### PR DESCRIPTION
CBG-4892

Describe your PR here...
- Add ECCV values for each bucket as a response for `_cluster_info` endpoint
- This endpoint would be used  by `sgcollect_info` to display this setting of a bucket


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/150/
