### PR TITLE
CBG-4967 don't set SameSite:None without Secure

### DIFF
--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -414,18 +414,35 @@ func TestCORSLoginOriginPerDatabase(t *testing.T) {
 		name               string
 		unsupportedOptions *db.UnsupportedOptions
 		sameSite           http.SameSite
+		useTLS             bool
 	}{
 		{
-			name:               "No unsupported options",
+			name:               "No unsupported options with TLS",
 			unsupportedOptions: nil,
 			sameSite:           http.SameSiteNoneMode,
+			useTLS:             true,
 		},
 		{
-			name: "With unsupported options",
+			name:               "No unsupported options without TLS",
+			unsupportedOptions: nil,
+			sameSite:           0, // go 1.25 doesn't have a constant for not present when reading from Set-Cookie, this could turn into SameSiteDefaultMode (1) in future
+			useTLS:             false,
+		},
+		{
+			name: "With unsupported options and TLS",
 			unsupportedOptions: &db.UnsupportedOptions{
 				SameSiteCookie: base.Ptr("Strict"),
 			},
 			sameSite: http.SameSiteStrictMode,
+			useTLS:   true,
+		},
+		{
+			name: "With unsupported options and no TLS",
+			unsupportedOptions: &db.UnsupportedOptions{
+				SameSiteCookie: base.Ptr("Strict"),
+			},
+			sameSite: http.SameSiteStrictMode, // forces strict mode even though this would result in an unusable cookie
+			useTLS:   false,
 		},
 	}
 	for _, dbTestCases := range testCases {
@@ -433,6 +450,13 @@ func TestCORSLoginOriginPerDatabase(t *testing.T) {
 			// Override the default (example.com) CORS configuration in the DbConfig for /db:
 			rt := NewRestTesterPersistentConfigNoDB(t)
 			defer rt.Close()
+
+			// fake TLS on public port
+			if dbTestCases.useTLS {
+				rt.ServerContext().Config.API.HTTPS.TLSCertPath = "/pretend/valid/cert"
+			} else {
+				require.Empty(t, rt.ServerContext().Config.API.HTTPS.TLSCertPath)
+			}
 
 			dbConfig := rt.NewDbConfig()
 			dbConfig.Unsupported = dbTestCases.unsupportedOptions
@@ -482,7 +506,7 @@ func TestCORSLoginOriginPerDatabase(t *testing.T) {
 						cookie, err := http.ParseSetCookie(resp.Header().Get("Set-Cookie"))
 						require.NoError(t, err)
 						require.NotEmpty(t, cookie.Path)
-						require.Equal(t, dbTestCases.sameSite, cookie.SameSite)
+						require.Equal(t, dbTestCases.sameSite, cookie.SameSite, "Cookie=%#+v", cookie)
 						reqHeaders["Cookie"] = fmt.Sprintf("%s=%s", cookie.Name, cookie.Value)
 					}
 					resp = rt.SendRequestWithHeaders(http.MethodDelete, "/{{.db}}/_session", "", reqHeaders)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -947,7 +947,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	} else {
 		dbcontext.CORS = sc.Config.API.CORS
 	}
-	if !dbcontext.CORS.IsEmpty() {
+	if !dbcontext.CORS.IsEmpty() && dbcontext.Options.SecureCookieOverride {
 		dbcontext.SameSiteCookieMode = http.SameSiteNoneMode
 	}
 	if config.Unsupported != nil && config.Unsupported.SameSiteCookie != nil {

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -25,8 +25,13 @@ import (
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTesterPersistentConfigNoDB(t)
 	defer rt.Close()
+
+	// force TLS mode to test SameSite=None cookie attribute
+	rt.ServerContext().Config.API.HTTPS.TLSCertPath = "/pretend/valid/cert"
+
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 
 	reqHeaders := map[string]string{
 		"Origin": "http://example.com",


### PR DESCRIPTION
CBG-4967 don't set SameSite:None without Secure

This was a mistake in 30ee4fe90dfb8834c4f2754a9c334f54db602de2. As per https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie

> None
> Send the cookie with both cross-site and same-site requests. The Secure attribute must also be set when using this value.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

