### PR TITLE
[3.3.1 only] CBG-4941 block BLIP_3+CBMobile_4 from connecting

### DIFF
--- a/db/blip_subprotocol.go
+++ b/db/blip_subprotocol.go
@@ -24,13 +24,10 @@ const (
 	// Version Vectors/HLV
 	CBMobileReplicationV4
 
-	// _nextCBMobileSubprotocolVersions reserved for maxCBMobileSubprotocolVersion
-	_nextCBMobileSubprotocolVersions
-
 	// minCBMobileSubprotocolVersion is the minimum supported subprotocol version by SG
 	minCBMobileSubprotocolVersion = CBMobileReplicationV2
 	// maxCBMobileSubprotocolVersion is the maximum supported subprotocol version by SG
-	maxCBMobileSubprotocolVersion = _nextCBMobileSubprotocolVersions - 1
+	maxCBMobileSubprotocolVersion = CBMobileReplicationV3
 )
 
 const cbMobileBLIPSubprotocolPrefix = "CBMobile_"


### PR DESCRIPTION
[3.3.1 only] CBG-4941 block BLIP_3+CBMobile_4 from connecting

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/152/