### PR TITLE
[4.0.1 backport] CBG-4972 don't set SameSite:None without Secure

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -948,7 +948,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 	} else {
 		dbcontext.CORS = sc.Config.API.CORS
 	}
-	if !dbcontext.CORS.IsEmpty() {
+	if !dbcontext.CORS.IsEmpty() && dbcontext.Options.SecureCookieOverride {
 		dbcontext.SameSiteCookieMode = http.SameSiteNoneMode
 	}
 	if config.Unsupported != nil && config.Unsupported.SameSiteCookie != nil {

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -25,8 +25,13 @@ import (
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTesterPersistentConfigNoDB(t)
 	defer rt.Close()
+
+	// force TLS mode to test SameSite=None cookie attribute
+	rt.ServerContext().Config.API.HTTPS.TLSCertPath = "/pretend/valid/cert"
+
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 
 	reqHeaders := map[string]string{
 		"Origin": "http://example.com",


### PR DESCRIPTION
[4.0.1 backport] CBG-4972 don't set SameSite:None without Secure

https://github.com/couchbase/sync_gateway/commit/e886b0844fa5d462f5d29fcf0aa9d45fc75148a2
