### PR TITLE
[3.2.7 backport] CBG-4971 create a one time session id for blipsync

### DIFF
--- a/docs/api/paths/public/db-_session.yaml
+++ b/docs/api/paths/public/db-_session.yaml
@@ -24,6 +24,12 @@ post:
     Generates a login session for the user based on the credentials provided in the request body or if that fails (due to invalid credentials or none provided at all), generates the new session for the currently authenticated user instead. On a successful session creation, a session cookie is stored to keep the user authenticated for future API calls.
 
     If `Origin` header is passed to this endpoint, the `Origin` header must match both the `cors.login_origin` and `cors.origin` configuration options.
+  parameters:
+    - name: one_time
+      description: Sets the session to only be valid for a single authentication. This session will expire in 5 minutes if not used.
+      in: query
+      schema:
+        type: boolean
   requestBody:
     description: When name and password are included in the request body, the session will be created for the specified user.  Otherwise the session will be created for the authenticated user making the request.
     required: false
@@ -40,8 +46,19 @@ post:
               description: Password of the user to generate the session for. Omit this value to generate a session for the authenticated user.
               type: string
   responses:
-    "200":
-      $ref: ../../components/responses.yaml#/User-session-information
+    '200':
+      description: Session created successfully. Returned body is dependant on if using Public or Admin APIs
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: ../../components/schemas.yaml#/User-session-information
+              - type: object
+                properties:
+                  one_time_session_id:
+                    description: The id of a single use session if `one_time=true` query parameter was used.
+                    type: string
+                    example: c5af80a039db4ed9d2b6865576b6999935282689
     "400":
       $ref: ../../components/responses.yaml#/Invalid-CORS-LoginOrigin
     "401":

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -22,6 +22,11 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+const (
+	secWebSocketProtocolHeader = "Sec-WebSocket-Protocol"
+	blipSessionIDPrefix        = "SyncGatewaySession_"
+)
+
 // HTTP handler for incoming BLIP sync WebSocket request (/db/_blipsync)
 func (h *handler) handleBLIPSync() error {
 	needRelease, err := h.server.incrementConcurrentReplications(h.rqCtx)

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -11,13 +11,9 @@ package rest
 import (
 	"fmt"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 
-	"github.com/coder/websocket"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -123,71 +119,4 @@ func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
 		secWebSocketProtocolHeader: blipSessionIDPrefix + sessionResp.SessionID,
 	})
 	RequireStatus(t, resp, http.StatusUnauthorized)
-
-	srv := httptest.NewServer(rt.TestPublicHandler())
-	defer srv.Close()
-
-	// Construct URL to connect to blipsync target endpoint
-	destURL := fmt.Sprintf("%s/%s/_blipsync", srv.URL, rt.GetDatabase().Name)
-	u, err := url.Parse(destURL)
-	require.NoError(t, err)
-	u.Scheme = "ws"
-
-	blipProtocolPrefix := "BLIP_3+"
-	testCases := []struct {
-		name      string
-		protocols []string
-		error     string
-	}{
-		{
-			name:  "No Protocols",
-			error: "expected handshake response status code 101 but got 500",
-		},
-		{
-			name: "V4 Protocol",
-			protocols: []string{
-				blipProtocolPrefix + db.CBMobileReplicationV4.SubprotocolString(),
-			},
-		},
-		{
-			name: "V3 Protocol",
-			protocols: []string{
-				blipProtocolPrefix + db.CBMobileReplicationV3.SubprotocolString(),
-			},
-		},
-		{
-			name: "Multiple Protocols",
-			protocols: []string{
-				"some-other-protocol",
-				blipProtocolPrefix + db.CBMobileReplicationV4.SubprotocolString(),
-				blipProtocolPrefix + db.CBMobileReplicationV3.SubprotocolString(),
-			},
-		},
-	}
-	for _, tc := range testCases {
-		rt.Run(tc.name, func(t *testing.T) {
-			// Create new one-time session for each sub-test
-			resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "{}", username)
-			RequireStatus(t, resp, http.StatusOK)
-
-			var sessionResp struct {
-				SessionID string `json:"one_time_session_id"`
-			}
-
-			require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &sessionResp))
-			require.NotEmpty(t, sessionResp.SessionID, "Expected non-empty session ID for %s", resp.BodyString())
-
-			protocols := []string{blipSessionIDPrefix + sessionResp.SessionID}
-			protocols = append(protocols, tc.protocols...)
-			ctx := rt.Context()
-			ws, _, err := websocket.Dial(ctx, destURL, &websocket.DialOptions{Subprotocols: protocols})
-			if tc.error != "" {
-				require.ErrorContains(t, err, tc.error)
-				return
-			}
-			require.NoError(t, err)
-			require.NoError(t, ws.Close(websocket.StatusNormalClosure, "test complete"))
-		})
-	}
-
 }

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -10,9 +10,16 @@ package rest
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/coder/websocket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHostOnlyCORS(t *testing.T) {
@@ -69,4 +76,118 @@ func TestHostOnlyCORS(t *testing.T) {
 			assert.Equal(t, test.output, output)
 		})
 	}
+}
+
+func TestOneTimeSessionBlipSyncAuthentication(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	const username = "alice"
+	rt.CreateUser(username, []string{"*"})
+
+	resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "", username)
+	RequireStatus(t, resp, http.StatusOK)
+
+	var sessionResp struct {
+		SessionID string `json:"one_time_session_id"`
+	}
+
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &sessionResp))
+
+	require.NotEmpty(t, sessionResp.SessionID, "Expected non-empty session ID for %s", resp.BodyString())
+
+	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/_blipsync", "", nil)
+	RequireStatus(t, resp, http.StatusUnauthorized)
+
+	resp = rt.SendUserRequest(http.MethodGet, "/{{.db}}/_blipsync", "", username)
+	RequireStatus(t, resp, http.StatusUpgradeRequired)
+
+	// no header should show database not found
+	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/_blipsync", "", nil)
+	RequireStatus(t, resp, http.StatusUnauthorized)
+
+	// invalid token is header not known
+	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/_blipsync", "", map[string]string{
+		secWebSocketProtocolHeader: blipSessionIDPrefix + "badtoken",
+	})
+	RequireStatus(t, resp, http.StatusUnauthorized)
+
+	// first request will succeed
+	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/_blipsync", "", map[string]string{
+		secWebSocketProtocolHeader: blipSessionIDPrefix + sessionResp.SessionID,
+	})
+	RequireStatus(t, resp, http.StatusUpgradeRequired)
+
+	// one time token is expired
+	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/_blipsync", "", map[string]string{
+		secWebSocketProtocolHeader: blipSessionIDPrefix + sessionResp.SessionID,
+	})
+	RequireStatus(t, resp, http.StatusUnauthorized)
+
+	srv := httptest.NewServer(rt.TestPublicHandler())
+	defer srv.Close()
+
+	// Construct URL to connect to blipsync target endpoint
+	destURL := fmt.Sprintf("%s/%s/_blipsync", srv.URL, rt.GetDatabase().Name)
+	u, err := url.Parse(destURL)
+	require.NoError(t, err)
+	u.Scheme = "ws"
+
+	blipProtocolPrefix := "BLIP_3+"
+	testCases := []struct {
+		name      string
+		protocols []string
+		error     string
+	}{
+		{
+			name:  "No Protocols",
+			error: "expected handshake response status code 101 but got 500",
+		},
+		{
+			name: "V4 Protocol",
+			protocols: []string{
+				blipProtocolPrefix + db.CBMobileReplicationV4.SubprotocolString(),
+			},
+		},
+		{
+			name: "V3 Protocol",
+			protocols: []string{
+				blipProtocolPrefix + db.CBMobileReplicationV3.SubprotocolString(),
+			},
+		},
+		{
+			name: "Multiple Protocols",
+			protocols: []string{
+				"some-other-protocol",
+				blipProtocolPrefix + db.CBMobileReplicationV4.SubprotocolString(),
+				blipProtocolPrefix + db.CBMobileReplicationV3.SubprotocolString(),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		rt.Run(tc.name, func(t *testing.T) {
+			// Create new one-time session for each sub-test
+			resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "{}", username)
+			RequireStatus(t, resp, http.StatusOK)
+
+			var sessionResp struct {
+				SessionID string `json:"one_time_session_id"`
+			}
+
+			require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &sessionResp))
+			require.NotEmpty(t, sessionResp.SessionID, "Expected non-empty session ID for %s", resp.BodyString())
+
+			protocols := []string{blipSessionIDPrefix + sessionResp.SessionID}
+			protocols = append(protocols, tc.protocols...)
+			ctx := rt.Context()
+			ws, _, err := websocket.Dial(ctx, destURL, &websocket.DialOptions{Subprotocols: protocols})
+			if tc.error != "" {
+				require.ErrorContains(t, err, tc.error)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, ws.Close(websocket.StatusNormalClosure, "test complete"))
+		})
+	}
+
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -1038,7 +1038,7 @@ func (h *handler) getWebsocketToken() string {
 	protocolHeaders := h.rq.Header.Get(secWebSocketProtocolHeader)
 	var outputHeaders []string
 	var sessionID string
-	for header := range strings.SplitSeq(protocolHeaders, ",") {
+	for _, header := range strings.Split(protocolHeaders, ",") {
 		trimmedHeader := strings.TrimSpace(header)
 		if !strings.HasPrefix(trimmedHeader, blipSessionIDPrefix) {
 			outputHeaders = append(outputHeaders, header)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -992,6 +992,17 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 		}
 	}
 
+	// check smuggled websocket token before cookie, since this is sure to be more explicit than cookie
+	if h.isBlipSync() {
+		sessionID := h.getWebsocketToken()
+		if sessionID != "" {
+			var err error
+			auditFields = base.AuditFields{base.AuditFieldAuthMethod: "websocket_token"}
+			h.user, err = dbCtx.Authenticator(h.ctx()).AuthenticateOneTimeSession(h.ctx(), sessionID)
+			return err
+		}
+	}
+
 	// Check cookie
 	auditFields = base.AuditFields{base.AuditFieldAuthMethod: "cookie"}
 	h.user, err = dbCtx.Authenticator(h.ctx()).AuthenticateCookie(h.rq, h.response)
@@ -1017,6 +1028,30 @@ func (h *handler) checkPublicAuth(dbCtx *db.DatabaseContext) (err error) {
 	}
 
 	return nil
+}
+
+// verifyWebsocketToken checks for a valid websocket token in the request headers. If present, invalidate the token so it can't be reused.
+//
+// Returns a nil error if there is no token on the header but no user object. If the header is found,
+func (h *handler) getWebsocketToken() string {
+	// go blip expects only one Sec-WebSocket-Protocol header, with comma separated values
+	protocolHeaders := h.rq.Header.Get(secWebSocketProtocolHeader)
+	var outputHeaders []string
+	var sessionID string
+	for header := range strings.SplitSeq(protocolHeaders, ",") {
+		trimmedHeader := strings.TrimSpace(header)
+		if !strings.HasPrefix(trimmedHeader, blipSessionIDPrefix) {
+			outputHeaders = append(outputHeaders, header)
+			continue
+		}
+		sessionID = strings.TrimPrefix(trimmedHeader, blipSessionIDPrefix)
+	}
+	if sessionID == "" {
+		return ""
+	}
+	// Remove the websocket protocol so it doesn't get logged in BlipWebsocketServer.handshake
+	h.rq.Header.Set(secWebSocketProtocolHeader, strings.Join(outputHeaders, ","))
+	return sessionID
 }
 
 func checkJWTIssuerStillValid(ctx context.Context, dbCtx *db.DatabaseContext, user auth.User) *auth.PrincipalConfig {

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -279,7 +279,8 @@ func (h *handler) createSessionForTrustedIdToken(rawIDToken string, provider *au
 
 	if !provider.DisableSession {
 		sessionTTL := tokenExpiryTime.Sub(time.Now())
-		sessionID, err := h.makeSessionWithTTL(user, sessionTTL)
+		oneTime := false
+		sessionID, err := h.makeSessionWithTTL(user, sessionTTL, oneTime)
 		return user.Name(), sessionID, err
 	}
 	return user.Name(), "", nil

--- a/rest/session_test.go
+++ b/rest/session_test.go
@@ -726,3 +726,25 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	assert.NoError(t, err, "Couldn't parse session expiration datetime")
 	assert.True(t, expires.Sub(time.Now()).Hours() <= 24, "Couldn't validate session expiration")
 }
+
+func TestOneTimeSessionWithCookie(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	username := "alice"
+	rt.CreateUser(username, []string{"*"})
+
+	resp := rt.SendUserRequest(http.MethodPost, "/{{.db}}/_session?one_time=true", "", username)
+	RequireStatus(t, resp, http.StatusOK)
+
+	headers := map[string]string{
+		"Cookie": resp.Header().Get("Set-Cookie"),
+	}
+
+	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/", "", headers)
+	RequireStatus(t, resp, http.StatusOK)
+
+	// Second request should fail since it's a one-time session
+	resp = rt.SendRequestWithHeaders(http.MethodGet, "/{{.db}}/", "", headers)
+	RequireStatus(t, resp, http.StatusUnauthorized)
+}


### PR DESCRIPTION
[3.2.7 backport] CBG-4971 create a one time session id for blipsync

clean backport of [f4f2e44](https://github.com/couchbase/sync_gateway/commit/f4f2e445b8d64f914616f68f46afb60e32411f8f)
