### PR TITLE
CBG-4746: Deduplicate channel set outside processEntry

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -662,8 +662,6 @@ func (c *changeCache) processUnusedRange(ctx context.Context, fromSequence, toSe
 		c._pushRangeToPending(fromSequence, toSequence, timeReceived)
 		// unblock any pending sequences we can after new range(s) have been pushed to pending
 		changedChannels = append(changedChannels, c._addPendingLogs(ctx)...)
-		//channelSet := channels.SetFromArrayNoValidate(changedChannels)
-		//allChangedChannels = allChangedChannels.Update(channelSet)
 		c.internalStats.pendingSeqLen = len(c.pendingLogs)
 	} else {
 		// An unused sequence range than includes c.nextSequence in the middle of the range

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -596,11 +596,12 @@ func (c *changeCache) releaseUnusedSequence(ctx context.Context, sequence uint64
 
 	// Since processEntry may unblock pending sequences, if there were any changed channels we need
 	// to notify any change listeners that are working changes feeds for these channels
+	var channelSet channels.Set
 	changedChannels := c.processEntry(ctx, change)
-	channelSet := channels.SetFromArrayNoValidate(changedChannels)
 	if changedChannels == nil {
 		channelSet = channels.SetOfNoValidate(unusedSeqChannelID)
 	} else {
+		channelSet = channels.SetFromArrayNoValidate(changedChannels)
 		channelSet.Add(unusedSeqChannelID)
 	}
 	if c.notifyChange != nil && len(channelSet) > 0 {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -277,8 +277,9 @@ func (c *changeCache) InsertPendingEntries(ctx context.Context) error {
 	// Trigger _addPendingLogs to process any entries that have been pending too long:
 	c.lock.Lock()
 	changedChannels := c._addPendingLogs(ctx)
-	if c.notifyChange != nil && len(changedChannels) > 0 {
-		c.notifyChange(ctx, changedChannels)
+	channelSet := channels.SetFromArrayNoValidate(changedChannels)
+	if c.notifyChange != nil && len(channelSet) > 0 {
+		c.notifyChange(ctx, channelSet)
 	}
 	c.lock.Unlock()
 
@@ -450,7 +451,8 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 				UnusedSequence: true,
 			}
 			changedChannels := c.processEntry(ctx, change)
-			changedChannelsCombined = changedChannelsCombined.Update(changedChannels)
+			channelSet := channels.SetFromArrayNoValidate(changedChannels)
+			changedChannelsCombined = changedChannelsCombined.Update(channelSet)
 		}
 		base.DebugfCtx(ctx, base.KeyCache, "Received unused sequences in unused_sequences property for (%q / %q): %v", base.UD(docID), syncData.GetRevTreeID(), syncData.UnusedSequences)
 	}
@@ -498,7 +500,8 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 				}
 
 				changedChannels := c.processEntry(ctx, change)
-				changedChannelsCombined = changedChannelsCombined.Update(changedChannels)
+				channelSet := channels.SetFromArrayNoValidate(changedChannels)
+				changedChannelsCombined = changedChannelsCombined.Update(channelSet)
 			}
 		}
 		if len(seqsCached) > 0 {
@@ -544,7 +547,8 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 	}
 
 	changedChannels := c.processEntry(ctx, change)
-	changedChannelsCombined = changedChannelsCombined.Update(changedChannels)
+	channelSet := channels.SetFromArrayNoValidate(changedChannels)
+	changedChannelsCombined = changedChannelsCombined.Update(channelSet)
 
 	// Notify change listeners for all of the changed channels
 	if c.notifyChange != nil && len(changedChannelsCombined) > 0 {
@@ -593,13 +597,14 @@ func (c *changeCache) releaseUnusedSequence(ctx context.Context, sequence uint64
 	// Since processEntry may unblock pending sequences, if there were any changed channels we need
 	// to notify any change listeners that are working changes feeds for these channels
 	changedChannels := c.processEntry(ctx, change)
+	channelSet := channels.SetFromArrayNoValidate(changedChannels)
 	if changedChannels == nil {
-		changedChannels = channels.SetOfNoValidate(unusedSeqChannelID)
+		channelSet = channels.SetOfNoValidate(unusedSeqChannelID)
 	} else {
-		changedChannels.Add(unusedSeqChannelID)
+		channelSet.Add(unusedSeqChannelID)
 	}
-	if c.notifyChange != nil && len(changedChannels) > 0 {
-		c.notifyChange(ctx, changedChannels)
+	if c.notifyChange != nil && len(channelSet) > 0 {
+		c.notifyChange(ctx, channelSet)
 	}
 }
 
@@ -619,7 +624,8 @@ func (c *changeCache) releaseUnusedSequenceRange(ctx context.Context, fromSequen
 			UnusedSequence: true,
 		}
 		changedChannels := c.processEntry(ctx, change)
-		allChangedChannels = allChangedChannels.Update(changedChannels)
+		channelSet := channels.SetFromArrayNoValidate(changedChannels)
+		allChangedChannels = allChangedChannels.Update(channelSet)
 		if c.notifyChange != nil {
 			c.notifyChange(ctx, allChangedChannels)
 		}
@@ -648,7 +654,8 @@ func (c *changeCache) processUnusedRange(ctx context.Context, fromSequence, toSe
 		c._pushRangeToPending(fromSequence, toSequence, timeReceived)
 		// unblock any pending sequences we can after new range(s) have been pushed to pending
 		changedChannels := c._addPendingLogs(ctx)
-		allChangedChannels = allChangedChannels.Update(changedChannels)
+		channelSet := channels.SetFromArrayNoValidate(changedChannels)
+		allChangedChannels = allChangedChannels.Update(channelSet)
 		c.internalStats.pendingSeqLen = len(c.pendingLogs)
 	} else {
 		// An unused sequence range than includes c.nextSequence in the middle of the range
@@ -732,13 +739,15 @@ func (c *changeCache) processPrincipalDoc(ctx context.Context, docID string, doc
 	base.InfofCtx(ctx, base.KeyChanges, "Received #%d (%q)", change.Sequence, base.UD(change.DocID))
 
 	changedChannels := c.processEntry(ctx, change)
-	if c.notifyChange != nil && len(changedChannels) > 0 {
-		c.notifyChange(ctx, changedChannels)
+	channelSet := channels.SetFromArrayNoValidate(changedChannels)
+
+	if c.notifyChange != nil && len(channelSet) > 0 {
+		c.notifyChange(ctx, channelSet)
 	}
 }
 
 // Handles a newly-arrived LogEntry.
-func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channels.Set {
+func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) []channels.ID {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.logsDisabled {
@@ -773,12 +782,12 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channe
 	}
 	c.receivedSeqs[sequence] = struct{}{}
 
-	var changedChannels channels.Set
+	var changedChannels []channels.ID
 	if sequence == c.nextSequence || c.nextSequence == 0 {
 		// This is the expected next sequence so we can add it now:
 		changedChannels = c._addToCache(ctx, change)
 		// Also add any pending sequences that are now contiguous:
-		changedChannels = changedChannels.Update(c._addPendingLogs(ctx))
+		changedChannels = append(changedChannels, c._addPendingLogs(ctx)...)
 	} else if sequence > c.nextSequence {
 		// There's a missing sequence (or several), so put this one on ice until it arrives:
 		heap.Push(&c.pendingLogs, change)
@@ -795,7 +804,7 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channe
 
 		if numPending > c.options.CachePendingSeqMaxNum {
 			// Too many pending; add the oldest one:
-			changedChannels = c._addPendingLogs(ctx)
+			changedChannels = append(changedChannels, c._addPendingLogs(ctx)...)
 		}
 	} else if sequence > c.initialSequence {
 		// Out-of-order sequence received!
@@ -807,7 +816,7 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channe
 			base.DebugfCtx(ctx, base.KeyCache, "  Received previously skipped out-of-order change (seq %d, expecting %d) doc %q / %q ", sequence, c.nextSequence, base.UD(change.DocID), change.RevID)
 		}
 
-		changedChannels = changedChannels.Update(c._addToCache(ctx, change))
+		changedChannels = append(changedChannels, c._addToCache(ctx, change)...)
 		// Add to cache before removing from skipped, to ensure lowSequence doesn't get incremented until results are available
 		// in cache
 		err := c.RemoveSkipped(sequence)
@@ -820,7 +829,7 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) channe
 
 // Adds an entry to the appropriate channels' caches, returning the affected channels.  lateSequence
 // flag indicates whether it was a change arriving out of sequence
-func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) channels.Set {
+func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) []channels.ID {
 
 	if change.Sequence >= c.nextSequence {
 		c.nextSequence = change.Sequence + 1
@@ -860,8 +869,8 @@ func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) channel
 // Add the first change(s) from pendingLogs if they're the next sequence.  If not, and we've been
 // waiting too long for nextSequence, move nextSequence to skipped queue.
 // Returns the channels that changed.
-func (c *changeCache) _addPendingLogs(ctx context.Context) channels.Set {
-	var changedChannels channels.Set
+func (c *changeCache) _addPendingLogs(ctx context.Context) []channels.ID {
+	var changedChannels []channels.ID
 	var isNext bool
 
 	for len(c.pendingLogs) > 0 {
@@ -870,7 +879,7 @@ func (c *changeCache) _addPendingLogs(ctx context.Context) channels.Set {
 
 		if isNext {
 			oldestPending = c._popPendingLog(ctx)
-			changedChannels = changedChannels.Update(c._addToCache(ctx, oldestPending))
+			changedChannels = append(changedChannels, c._addToCache(ctx, oldestPending)...)
 		} else if oldestPending.Sequence < c.nextSequence {
 			// oldest pending is lower than next sequence, should be ignored
 			base.InfofCtx(ctx, base.KeyCache, "Oldest entry in pending logs %v (%d, %d) is earlier than cache next sequence (%d), ignoring as sequence has already been cached", base.UD(oldestPending.DocID), oldestPending.Sequence, oldestPending.EndSequence, c.nextSequence)

--- a/tools/cache_perf_tool/dcpDataGeneration.go
+++ b/tools/cache_perf_tool/dcpDataGeneration.go
@@ -41,7 +41,7 @@ func (dcp *dcpDataGen) vBucketCreation(ctx context.Context) {
 	delayIndex := 0
 	// vBucket creation logic
 	for i := range 1024 {
-		time.Sleep(500 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
+		time.Sleep(100 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
 		if i == 520 {
 			go dcp.syncSeqVBucketCreation(ctx, uint16(i), 2*time.Second) // sync seq hot vBucket so high delay
 		} else {


### PR DESCRIPTION
CBG-4746

- Changed delay slightly in tool to allow toll to run faster
- Switch to return list of channel ID not maps from `processEntry` then deduplicate the channel IDs outside `processEntry` mutex

Before:
<img width="979" height="325" alt="Screenshot 2025-11-03 at 11 09 17" src="https://github.com/user-attachments/assets/f547207e-bf79-41a5-94f7-9e6cc0107282" />


After:
<img width="869" height="318" alt="Screenshot 2025-11-03 at 11 08 57" src="https://github.com/user-attachments/assets/483f0762-bce0-4e97-a666-68d4b2f4930c" />


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/153/
