### PR TITLE
CBG-4924 ignore updating local rev if BlipTesterCollectionClient is closed

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -952,6 +952,11 @@ func (btcc *BlipTesterCollectionClient) getAttachment(digest string) (attachment
 func (btcc *BlipTesterCollectionClient) updateLastReplicatedRev(docID string, version DocVersion, msg *blip.Message) {
 	btcc.seqLock.Lock()
 	defer btcc.seqLock.Unlock()
+	// If this fires after a replication is completed, ignore it since BlipTesterCollectionClient.Close will zero
+	// out all documents
+	if btcc.ctx.Err() != nil {
+		return
+	}
 	doc, ok := btcc._getClientDoc(docID)
 	require.True(btcc.TB(), ok, "docID %q not found in _seqFromDocID", docID)
 	doc._latestServerVersion = version


### PR DESCRIPTION
CBG-4924 ignore updating local rev if BlipTesterCollectionClient is closed

This fixes a wide variety of test failures that look like `docID "doc" not found in _seqFromDocID`.

The way this test failure manifests is:

1. `BlipTesterCollectionClient.StartPush()`
2. `BlipTesterCollectionClient.AddRev()`
3. `RestTester.WaitForVersion()` <- polls REST endpoint for document existence
4. Test ends, starts cleanup
5. `BlipTesterCollectionClient.Close` (zeros `_seqFromDocID`)
6. `BlipTesterCollectionClient.updateLastReplicatedRev` is called in response to `Rev` message sent to the server. In this function is the failure.

It is more common for this to be the ordering:

1. `BlipTesterCollectionClient.StartPush()`
2. `BlipTesterCollectionClient.AddRev()`
3. `RestTester.WaitForVersion()` <- polls REST endpoint for document existence
4. `BlipTesterCollectionClient.updateLastReplicatedRev` is called in response to `Rev` message sent to the server. In this function is the failure.
5.  Test ends, starts cleanup
6. `BlipTesterCollectionClient.Close` (zeros `_seqFromDocID`)

But the ordering is agnostic between `WaitForVersion` and `updateLastReplicatedRev` and depends on the timing inside `WaitForVersion` and how quickly blip is sending rev messages back.

I had a real difficult time reproducing this but I could reproduce by manually adding a sleep before `updateLastReplicatedRev` which is perfectly valid.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/154/
