### PR TITLE
CBG-4968: Avoid logging at debug in pruning of cache

### DIFF
--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -280,7 +280,7 @@ func (c *singleChannelCacheImpl) _pruneCacheLength(ctx context.Context) (pruned 
 	}
 
 	if pruned > 0 {
-		// Only enter trace log line if trace ius enabled, to avoid the cost of UD() calls
+		// Only enter trace log line if trace is enabled, to avoid the cost of UD() calls
 		if base.LogTraceEnabled(ctx, base.KeyCache) {
 			base.TracefCtx(ctx, base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelID))
 		}
@@ -309,7 +309,7 @@ func (c *singleChannelCacheImpl) pruneCacheAge(ctx context.Context) {
 		pruned++
 	}
 	if pruned > 0 {
-		// Only enter trace log line if trace ius enabled, to avoid the cost of UD() calls
+		// Only enter trace log line if trace is enabled, to avoid the cost of UD() calls
 		if base.LogTraceEnabled(ctx, base.KeyCache) {
 			base.TracefCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
 		}

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -280,7 +280,10 @@ func (c *singleChannelCacheImpl) _pruneCacheLength(ctx context.Context) (pruned 
 	}
 
 	if pruned > 0 {
-		base.DebugfCtx(ctx, base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelID))
+		// Only enter trace log line if trace ius enabled, to avoid the cost of UD() calls
+		if base.LogTraceEnabled(ctx, base.KeyCache) {
+			base.TracefCtx(ctx, base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelID))
+		}
 	}
 
 	return pruned
@@ -306,7 +309,10 @@ func (c *singleChannelCacheImpl) pruneCacheAge(ctx context.Context) {
 		pruned++
 	}
 	if pruned > 0 {
-		base.DebugfCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
+		// Only enter trace log line if trace ius enabled, to avoid the cost of UD() calls
+		if base.LogTraceEnabled(ctx, base.KeyCache) {
+			base.TracefCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
+		}
 	}
 
 }

--- a/tools/cache_perf_tool/dcpDataGeneration.go
+++ b/tools/cache_perf_tool/dcpDataGeneration.go
@@ -41,7 +41,7 @@ func (dcp *dcpDataGen) vBucketCreation(ctx context.Context) {
 	delayIndex := 0
 	// vBucket creation logic
 	for i := range 1024 {
-		time.Sleep(500 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
+		time.Sleep(100 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
 		if i == 520 {
 			go dcp.syncSeqVBucketCreation(ctx, uint16(i), 2*time.Second) // sync seq hot vBucket so high delay
 		} else {


### PR DESCRIPTION

CBG-4968

- Drop cache pruning logging to trace
- Only enter logging code if trace is enabled, this will stop unnecessary calls to UD() 

Before:
<img width="985" height="321" alt="Screenshot 2025-11-04 at 10 39 27" src="https://github.com/user-attachments/assets/772eff26-4dad-40a6-8d0c-490b338eba9b" />

(See the UD call under _pruneCacheLength and the convT)

After:
<img width="883" height="410" alt="Screenshot 2025-11-04 at 10 40 32" src="https://github.com/user-attachments/assets/d8f1c825-1402-4585-b702-5ca7bb777df7" />

(No UD and no convT)


## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
