### PR TITLE
CBG-4980: support /db/_flush for internal testing

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -25,7 +25,7 @@ import (
 // Manages retrieval of set of buckets, and generic interaction with bootstrap metadata documents from those buckets.
 type BootstrapConnection interface {
 	// GetConfigBuckets returns a list of bucket names where a bootstrap metadata documents could reside.
-	GetConfigBuckets() ([]string, error)
+	GetConfigBuckets(context.Context) ([]string, error)
 	// GetMetadataDocument fetches a bootstrap metadata document for a given bucket and key, along with the CAS of the config document.
 	GetMetadataDocument(ctx context.Context, bucket, key string, valuePtr any) (cas uint64, err error)
 	// InsertMetadataDocument saves a new bootstrap metadata document for a given bucket and key.
@@ -258,7 +258,7 @@ func (cc *CouchbaseCluster) getClusterConnection() (*gocb.Cluster, error) {
 
 }
 
-func (cc *CouchbaseCluster) GetConfigBuckets() ([]string, error) {
+func (cc *CouchbaseCluster) GetConfigBuckets(context.Context) ([]string, error) {
 	if cc == nil {
 		return nil, errors.New("nil CouchbaseCluster")
 	}

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -59,7 +59,7 @@ func TestBootstrapRefCounting(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, clusterConnection)
 
-	buckets, err := cluster.GetConfigBuckets()
+	buckets, err := cluster.GetConfigBuckets(ctx)
 	require.NoError(t, err)
 	// ensure these are sorted for determinstic bootstraping
 	sortedBuckets := make([]string, len(buckets))

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -471,9 +471,6 @@ func TestBaseBucket(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			baseBucket := GetBaseBucket(test.bucket)
-			_, ok := baseBucket.(*rosmar.Bucket)
-			assert.True(t, ok, "Base bucket is rosmar")
 			_, err := AsRosmarBucket(test.bucket)
 			require.NoError(t, err)
 		})

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -473,7 +473,9 @@ func TestBaseBucket(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			baseBucket := GetBaseBucket(test.bucket)
 			_, ok := baseBucket.(*rosmar.Bucket)
-			assert.True(t, ok, "Base bucket wasn't walrus bucket")
+			assert.True(t, ok, "Base bucket is rosmar")
+			_, err := AsRosmarBucket(test.bucket)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/base/collection.go
+++ b/base/collection.go
@@ -28,7 +28,6 @@ import (
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
-	"github.com/couchbaselabs/rosmar"
 	pkgerrors "github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -204,15 +203,6 @@ func AsGocbV2Bucket(bucket Bucket) (*GocbV2Bucket, error) {
 		return gocbv2Bucket, nil
 	}
 	return nil, fmt.Errorf("bucket is not a gocb bucket (type %T)", baseBucket)
-}
-
-// AsRosmar returns a bucket as a rosmar.Bucket, or an error if it is not one.
-func AsRosmarBucket(bucket Bucket) (*rosmar.Bucket, error) {
-	baseBucket := GetBaseBucket(bucket)
-	if rosmarBucket, ok := baseBucket.(*rosmar.Bucket); ok {
-		return rosmarBucket, nil
-	}
-	return nil, fmt.Errorf("bucket is not a rosmar bucket (type %T)", baseBucket)
 }
 
 func (b *GocbV2Bucket) GetName() string {

--- a/base/collection.go
+++ b/base/collection.go
@@ -28,6 +28,7 @@ import (
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbaselabs/rosmar"
 	pkgerrors "github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -196,12 +197,22 @@ var (
 	_ sgbucket.DynamicDataStoreBucket = &GocbV2Bucket{}
 )
 
+// AsGocbV2Bucket returns a bucket as a GocbV2Bucket, or an error if it is not one.
 func AsGocbV2Bucket(bucket Bucket) (*GocbV2Bucket, error) {
 	baseBucket := GetBaseBucket(bucket)
 	if gocbv2Bucket, ok := baseBucket.(*GocbV2Bucket); ok {
 		return gocbv2Bucket, nil
 	}
 	return nil, fmt.Errorf("bucket is not a gocb bucket (type %T)", baseBucket)
+}
+
+// AsRosmar returns a bucket as a rosmar.Bucket, or an error if it is not one.
+func AsRosmarBucket(bucket Bucket) (*rosmar.Bucket, error) {
+	baseBucket := GetBaseBucket(bucket)
+	if rosmarBucket, ok := baseBucket.(*rosmar.Bucket); ok {
+		return rosmarBucket, nil
+	}
+	return nil, fmt.Errorf("bucket is not a rosmar bucket (type %T)", baseBucket)
 }
 
 func (b *GocbV2Bucket) GetName() string {

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -37,7 +37,7 @@ func (c *RosmarCluster) GetConfigBuckets() ([]string, error) {
 
 // GetMetadataDocument returns a metadata document from the default collection for the specified bucket.
 func (c *RosmarCluster) GetMetadataDocument(ctx context.Context, location, docID string, valuePtr any) (cas uint64, err error) {
-	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, location, rosmar.CreateOrOpen)
 	if err != nil {
 		return 0, err
 	}
@@ -48,7 +48,7 @@ func (c *RosmarCluster) GetMetadataDocument(ctx context.Context, location, docID
 
 // InsertMetadataDocument inserts a metadata document, and fails if it already exists.
 func (c *RosmarCluster) InsertMetadataDocument(ctx context.Context, location, key string, value any) (newCAS uint64, err error) {
-	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, location, rosmar.CreateOrOpen)
 	if err != nil {
 		return 0, err
 	}
@@ -59,7 +59,7 @@ func (c *RosmarCluster) InsertMetadataDocument(ctx context.Context, location, ke
 
 // WriteMetadataDocument writes a metadata document, and fails on CAS mismatch
 func (c *RosmarCluster) WriteMetadataDocument(ctx context.Context, location, docID string, cas uint64, value any) (newCAS uint64, err error) {
-	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, location, rosmar.CreateOrOpen)
 	if err != nil {
 		return 0, err
 	}
@@ -72,7 +72,7 @@ func (c *RosmarCluster) WriteMetadataDocument(ctx context.Context, location, doc
 // trigger CAS update on the document, to block any racing updates. Does not retry on CAS failure.
 
 func (c *RosmarCluster) TouchMetadataDocument(ctx context.Context, location, docID string, property, value string, cas uint64) (newCAS uint64, err error) {
-	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, location, rosmar.CreateOrOpen)
 	if err != nil {
 		return 0, err
 	}
@@ -84,7 +84,7 @@ func (c *RosmarCluster) TouchMetadataDocument(ctx context.Context, location, doc
 
 // DeleteMetadataDocument deletes an existing bootstrap metadata document for a given bucket and key.
 func (c *RosmarCluster) DeleteMetadataDocument(ctx context.Context, location, key string, cas uint64) error {
-	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, location, rosmar.CreateOrOpen)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (c *RosmarCluster) DeleteMetadataDocument(ctx context.Context, location, ke
 
 // UpdateMetadataDocument updates a given document and retries on CAS mismatch.
 func (c *RosmarCluster) UpdateMetadataDocument(ctx context.Context, location, docID string, updateCallback func(bucketConfig []byte, rawBucketConfigCas uint64) (newConfig []byte, err error)) (newCAS uint64, err error) {
-	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, location, rosmar.CreateOrOpen)
 	if err != nil {
 		return 0, err
 	}
@@ -140,7 +140,7 @@ func (c *RosmarCluster) UpdateMetadataDocument(ctx context.Context, location, do
 
 // KeyExists checks whether a key exists in the default collection for the specified bucket
 func (c *RosmarCluster) KeyExists(ctx context.Context, location, docID string) (exists bool, err error) {
-	bucket, err := rosmar.OpenBucket(c.serverURL, location, rosmar.CreateOrOpen)
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, location, rosmar.CreateOrOpen)
 	if err != nil {
 		return false, err
 	}
@@ -152,7 +152,7 @@ func (c *RosmarCluster) KeyExists(ctx context.Context, location, docID string) (
 // GetDocument fetches a document from the default collection.  Does not use configPersistence - callers
 // requiring configPersistence handling should use GetMetadataDocument.
 func (c *RosmarCluster) GetDocument(ctx context.Context, bucketName, docID string, rv any) (exists bool, err error) {
-	bucket, err := rosmar.OpenBucket(c.serverURL, bucketName, rosmar.CreateOrOpen)
+	bucket, err := rosmar.OpenBucketIn(c.serverURL, bucketName, rosmar.CreateOrOpen)
 	if err != nil {
 		return false, err
 	}

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -43,7 +43,7 @@ func NewRosmarCluster(serverURL string) (*RosmarCluster, error) {
 		if runtime.GOOS == "windows" {
 			directory = strings.TrimPrefix(directory, "/")
 		}
-		err = os.MkdirAll(directory, 0750)
+		err = os.MkdirAll(directory, 0700)
 		if err != nil {
 			return nil, fmt.Errorf("could not create or access directory to open rosmar cluster %q: %w", serverURL, err)
 		}

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/rosmar"
@@ -38,6 +40,9 @@ func NewRosmarCluster(serverURL string) (*RosmarCluster, error) {
 			return nil, err
 		}
 		directory := u.Path
+		if runtime.GOOS == "windows" {
+			directory = strings.TrimPrefix(directory, "/")
+		}
 		err = os.MkdirAll(directory, 0750)
 		if err != nil {
 			return nil, fmt.Errorf("could not create or access directory to open rosmar cluster %q: %w", serverURL, err)

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -40,7 +40,7 @@ func NewRosmarCluster(serverURL string) (*RosmarCluster, error) {
 		directory := u.Path
 		err = os.MkdirAll(directory, 0750)
 		if err != nil {
-			return nil, fmt.Errorf("could not create or access directory for to open rosmar cluster %q: %w", serverURL, err)
+			return nil, fmt.Errorf("could not create or access directory to open rosmar cluster %q: %w", serverURL, err)
 		}
 		cluster.bucketDirectory = directory
 	}

--- a/base/rosmar_cluster.go
+++ b/base/rosmar_cluster.go
@@ -231,3 +231,12 @@ func (c *RosmarCluster) Close() {
 }
 
 func (c *RosmarCluster) SetConnectionStringServerless() error { return nil }
+
+// AsRosmarBucket returns a bucket as a rosmar.Bucket, or an error if it is not one.
+func AsRosmarBucket(bucket Bucket) (*rosmar.Bucket, error) {
+	baseBucket := GetBaseBucket(bucket)
+	if b, ok := baseBucket.(*rosmar.Bucket); ok {
+		return b, nil
+	}
+	return nil, fmt.Errorf("bucket is not a rosmar bucket (type %T)", baseBucket)
+}

--- a/docs/api/paths/admin/db-_flush.yaml
+++ b/docs/api/paths/admin/db-_flush.yaml
@@ -12,7 +12,7 @@ post:
   description: |-
     **This is unsupported**
 
-    This will purge *all* documents.
+    This will purge *all* documents and remove any other database that is backed by this bucket.
 
     The bucket will only be flushed if the unsupported database configuration option `enable_couchbase_bucket_flush` is set.
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -2307,7 +2307,7 @@ func (h *handler) handleGetClusterInfo() error {
 
 	if h.server.persistentConfig {
 
-		bucketNames, err := h.server.GetBucketNames()
+		bucketNames, err := h.server.GetBucketNames(h.ctx())
 		if err != nil {
 			return err
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -134,7 +134,6 @@ func (h *handler) handleCreateDB() error {
 			return err
 		}
 		cas, err := h.server.BootstrapContext.InsertConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, &persistedConfig)
-		fmt.Printf("err = %#+v", err)
 		if err != nil {
 			// unload the requested database config to prevent the cluster being in an inconsistent state
 			h.server._removeDatabase(contextNoCancel.Ctx, dbName)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -134,6 +134,7 @@ func (h *handler) handleCreateDB() error {
 			return err
 		}
 		cas, err := h.server.BootstrapContext.InsertConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, &persistedConfig)
+		fmt.Printf("err = %#+v", err)
 		if err != nil {
 			// unload the requested database config to prevent the cluster being in an inconsistent state
 			h.server._removeDatabase(contextNoCancel.Ctx, dbName)

--- a/rest/api.go
+++ b/rest/api.go
@@ -286,7 +286,7 @@ func (h *handler) handleFlush() error {
 				return err
 			}
 			defer bucket.Close(h.ctx())
-			// Flush the bucket (assuming it conforms to sgbucket.DeleteableStore interface
+			// Flush the bucket
 			gocbBucket, err := base.AsGocbV2Bucket(bucket)
 			if err != nil {
 				return err

--- a/rest/api.go
+++ b/rest/api.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/rosmar"
 	"github.com/felixge/fgprof"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -294,16 +293,16 @@ func (h *handler) handleFlush() error {
 			}
 			return gocbBucket.Flush(h.ctx())
 		}
-	} else if _, ok := base.GetBaseBucket(h.db.Bucket).(*rosmar.Bucket); ok {
+	} else if _, err := base.AsRosmarBucket(h.db.Bucket); err == nil {
 		deleteFunc = func(spec base.BucketSpec) error {
 			bucket, err := db.ConnectToBucket(h.ctx(), spec, false)
 			if err != nil {
 				return fmt.Errorf("could not open bucket in order to delete it: %w", err)
 			}
 
-			rosmarBucket, ok := base.GetBaseBucket(bucket).(*rosmar.Bucket)
-			if !ok {
-				return fmt.Errorf("bucket %T does not support rosmar delete", bucket)
+			rosmarBucket, err := base.AsRosmarBucket(bucket)
+			if err != nil {
+				return err
 			}
 			err = rosmarBucket.CloseAndDelete(h.ctx())
 			if err != nil {

--- a/rest/api.go
+++ b/rest/api.go
@@ -294,14 +294,14 @@ func (h *handler) handleFlush() error {
 			}
 			return gocbBucket.Flush(h.ctx())
 		}
-	} else if _, ok := h.db.Bucket.(*rosmar.Bucket); ok {
+	} else if _, ok := base.GetBaseBucket(h.db.Bucket).(*rosmar.Bucket); ok {
 		deleteFunc = func(spec base.BucketSpec) error {
 			bucket, err := db.ConnectToBucket(h.ctx(), spec, false)
 			if err != nil {
 				return fmt.Errorf("could not open bucket in order to delete it: %w", err)
 			}
 
-			rosmarBucket, ok := bucket.(*rosmar.Bucket)
+			rosmarBucket, ok := base.GetBaseBucket(bucket).(*rosmar.Bucket)
 			if !ok {
 				return fmt.Errorf("bucket %T does not support rosmar delete", bucket)
 			}

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -260,7 +261,7 @@ func TestBootstrapRosmarServer(t *testing.T) {
 		},
 		{
 			name:      "DiskBased",
-			rosmarURL: "rosmar://" + t.TempDir(),
+			rosmarURL: "rosmar://" + filepath.ToSlash(t.TempDir()),
 		},
 	}
 	for _, tc := range testCases {

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -246,4 +247,19 @@ func DevTestFetchConfigManual(t *testing.T) {
 
 	time.Sleep(15 * time.Second)
 
+}
+
+func TestRosmarServer(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelTrace)
+
+	config := BootstrapStartupConfigForTest(t) // share config between both servers in test to share a groupID
+	config.Bootstrap.Server = rosmar.InMemoryURL
+	sc, closeFn := StartServerWithConfig(t, &config)
+	defer closeFn()
+
+	resp := BootstrapAdminRequest(t, sc, http.MethodPut, "/db1/", `{}`)
+	resp.RequireStatus(http.StatusCreated)
+
+	resp = BootstrapAdminRequest(t, sc, http.MethodPost, "/db1/_flush", `{}`)
+	resp.RequireStatus(http.StatusOK)
 }

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -251,6 +252,12 @@ func DevTestFetchConfigManual(t *testing.T) {
 }
 
 func TestBootstrapRosmarServer(t *testing.T) {
+	tempDir := t.TempDir()
+	diskURL := "rosmar://" + tempDir
+	if runtime.GOOS == "windows" {
+		// rosmar requires prefix forward slash and forward slashes
+		diskURL = "rosmar:///" + filepath.ToSlash(tempDir)
+	}
 	testCases := []struct {
 		name      string
 		rosmarURL string
@@ -261,7 +268,7 @@ func TestBootstrapRosmarServer(t *testing.T) {
 		},
 		{
 			name:      "DiskBased",
-			rosmarURL: "rosmar://" + filepath.ToSlash(t.TempDir()),
+			rosmarURL: diskURL,
 		},
 	}
 	for _, tc := range testCases {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1749,7 +1749,7 @@ func (sc *ServerContext) _fetchAndLoadDatabase(nonContextStruct base.NonCancella
 // migrateV30Configs checks for configs stored in the 3.0 location, and migrates them to the db registry
 func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 	groupID := sc.Config.Bootstrap.ConfigGroupID
-	buckets, err := sc.BootstrapContext.Connection.GetConfigBuckets()
+	buckets, err := sc.BootstrapContext.Connection.GetConfigBuckets(ctx)
 	if err != nil {
 		return err
 	}
@@ -1782,7 +1782,8 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 	return nil
 }
 
-func (sc *ServerContext) findBucketWithCallback(callback func(bucket string) (exit bool, err error)) (err error) {
+// findBucketWithCallback ensures the bucket exists in the BootstrapContext and calls the callback function. Returns an erorr if the boostrap context can't find the bucket or the callback function returns an err and exit parameter for callback is true.
+func (sc *ServerContext) findBucketWithCallback(ctx context.Context, callback func(bucket string) (exit bool, err error)) (err error) {
 	// rewritten loop from FetchDatabase as part of CBG-2420 PR review
 	var buckets []string
 	if sc.Config.IsServerless() {
@@ -1791,7 +1792,7 @@ func (sc *ServerContext) findBucketWithCallback(callback func(bucket string) (ex
 			buckets = append(buckets, bucket)
 		}
 	} else {
-		buckets, err = sc.BootstrapContext.Connection.GetConfigBuckets()
+		buckets, err = sc.BootstrapContext.Connection.GetConfigBuckets(ctx)
 		if err != nil {
 			return fmt.Errorf("couldn't get buckets from cluster: %w", err)
 		}
@@ -1869,7 +1870,7 @@ func (sc *ServerContext) _fetchDatabase(ctx context.Context, dbName string) (fou
 		return foundInBucket, callbackErr
 	}
 
-	err = sc.findBucketWithCallback(callback)
+	err = sc.findBucketWithCallback(ctx, callback)
 
 	if err != nil {
 		return false, nil, err
@@ -1921,7 +1922,7 @@ func (sc *ServerContext) bucketNameFromDbName(ctx context.Context, dbName string
 		}
 		return false, nil
 	}
-	err := sc.findBucketWithCallback(callback)
+	err := sc.findBucketWithCallback(ctx, callback)
 	if err != nil {
 		return "", false
 	}
@@ -1951,7 +1952,7 @@ func (sc *ServerContext) fetchConfigsSince(ctx context.Context, refreshInterval 
 }
 
 // GetBucketNames returns a slice of the bucket names associated with the server context
-func (sc *ServerContext) GetBucketNames() (buckets []string, err error) {
+func (sc *ServerContext) GetBucketNames(ctx context.Context) (buckets []string, err error) {
 	if sc.Config.IsServerless() {
 		buckets = make([]string, len(sc.Config.BucketCredentials))
 		for bucket, _ := range sc.Config.BucketCredentials {
@@ -1968,7 +1969,7 @@ func (sc *ServerContext) GetBucketNames() (buckets []string, err error) {
 		//	}
 		// }
 	} else {
-		buckets, err = sc.BootstrapContext.Connection.GetConfigBuckets()
+		buckets, err = sc.BootstrapContext.Connection.GetConfigBuckets(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't get buckets from cluster: %w", err)
 		}
@@ -1979,7 +1980,7 @@ func (sc *ServerContext) GetBucketNames() (buckets []string, err error) {
 // FetchConfigs retrieves all database configs from the ServerContext's bootstrapConnection.
 func (sc *ServerContext) FetchConfigs(ctx context.Context, isInitialStartup bool) (dbNameConfigs map[string]DatabaseConfig, err error) {
 
-	buckets, err := sc.GetBucketNames()
+	buckets, err := sc.GetBucketNames(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1782,7 +1782,9 @@ func (sc *ServerContext) migrateV30Configs(ctx context.Context) error {
 	return nil
 }
 
-// findBucketWithCallback ensures the bucket exists in the BootstrapContext and calls the callback function. Returns an erorr if the boostrap context can't find the bucket or the callback function returns an err and exit parameter for callback is true.
+// findBucketWithCallback ensures the bucket exists in the BootstrapContext and calls the callback
+// function. Returns an error if the bootstrap context can't find the bucket or the callback function returns an
+// error and the exit return value for callback is true.
 func (sc *ServerContext) findBucketWithCallback(ctx context.Context, callback func(bucket string) (exit bool, err error)) (err error) {
 	// rewritten loop from FetchDatabase as part of CBG-2420 PR review
 	var buckets []string

--- a/rest/main.go
+++ b/rest/main.go
@@ -426,8 +426,7 @@ func setBootstrapConnectionOptsFromDbConfig(opts *bootstrapConnectionOpts, dbCon
 
 func createBootstrapConnectionWithOpts(ctx context.Context, opts bootstrapConnectionOpts) (base.BootstrapConnection, error) {
 	if base.ServerIsWalrus(opts.server) {
-		cluster := base.NewRosmarCluster(opts.server)
-		return cluster, nil
+		return base.NewRosmarCluster(opts.server)
 	}
 
 	var connStr string

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -2345,7 +2345,7 @@ func (sc *ServerContext) removeBucketAndRecreateDatabase(ctx context.Context, db
 			// If async init is running for the database, cancel it for an external remove.  (cannot be
 			// done in _removeDatabase, as this is called during reload)
 			if sc.DatabaseInitManager != nil && sc.DatabaseInitManager.HasActiveInitialization(otherDBName) {
-				sc.DatabaseInitManager.Cancel(dbName, fmt.Sprintf("flush db %s", otherDBName))
+				sc.DatabaseInitManager.Cancel(otherDBName, fmt.Sprintf("flush db %s with same backing bucket", dbName))
 			}
 			if !sc._removeDatabase(ctx, otherDBName) {
 				return base.RedactErrorf("could not remove database %s as part of flushing %s. Bucket %s is left in an unstable state", base.UD(otherDBName), base.UD(dbName), base.UD(*config.Bucket))


### PR DESCRIPTION
CBG-4980 support /db/_flush for internal testing

Also addresses:

- CBG-4982 Database recreation after flush doesn't work with persistent config
- CBG-4980 Couchbase Buckets aren't flushable

NOTE: _flush is a database call, so any other databases that are backed by the same bucket will be destroyed.

- /db/_flush for Couchbase Server buckets has been broken since 3.2 as part of https://github.com/couchbase/sync_gateway/commit/617b8732dc724fda92fd5d05fd5e79bd4e25e623
- /db/_flush for persistent config never worked correctly before this commit, because it would delete the database registry and only re-add the database from `AddDatabaseFromConfig`. It would also not block database polling while this happened which could result in a crash.

Behavior changes:

- Support the /db/_flush endpoint which will flush a gocb bucket or delete a rosmar bucket
- Support persistent and non persistent configuration by using `InsertConfig` or `AddDatabaseFromConfig`. Test to make sure config polling no-ops after calling /db/_flush
- Support using serialized rosmar buckets by calling `OpenBucketIn` in `RosmarCluster`. When using `rosmar.InMemoryURL`, `OpenBucket` and `OpenBucketIn` behave identically, but they do not otherwise.
- If a bucket was closed, `rosmar.Bucket.DefaultDataStore()` would just return nil, and we didn't do a nil check. Probably https://github.com/couchbaselabs/rosmar/blob/3b9ac157a3cd52c076649d31cbe385e76386787d/bucket_api.go#L122 should panic, or we change the `sg-bucket.Bucket.DefaultDataStore` API to return errors. I thought this was out of scope for this PR, and we might want to backport this to older releases where we might not want to switch rosmar.

When flushing or deleting a bucket, you need to create a copy of the bucket object.

## Possible Different Approach

Since `/db/_flush` is database scoped, but it flushes the entire bucket, this means other databases that are backed by the same bucket are deleted. I have considered removing this API entirely, and maybe replacing it with an API that is like `/_internal/rosmar/bucketName` that could delete a bucket that is either in memory or on disk. This would be more clear in the behavior but add an API that we don't to use outside of some E2E testing.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/156/