### PR TITLE
CBG-4923: Prevent Excessive conflict logging in PutCurrentVersion

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1363,6 +1363,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				if err != nil {
 					return nil, nil, false, nil, err
 				}
+				doc.RevConflict = true
 				base.DebugfCtx(ctx, base.KeyVV, "No existing HLV for existing doc %s, generated implicit CV from rev tree id, updated CV %#v", base.UD(doc.ID), doc.HLV.ExtractCurrentVersionFromHLV())
 			}
 		}

--- a/db/document.go
+++ b/db/document.go
@@ -289,6 +289,7 @@ type Document struct {
 	inlineSyncData    bool
 	localWinsConflict bool   // True if this document is the result of a local-wins conflict resolution
 	RevSeqNo          uint64 // Server rev seq no for a document
+	RevConflict       bool
 }
 
 // GlobalSyncData is the structure for the system xattr that is migrated with XDCR.
@@ -1494,8 +1495,7 @@ func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWit
 	}
 	// we need to check if local CV version was generated from a revID if so we need to perform conflict check on rev tree history
 	if doc.HLV.HasRevEncodedCV() {
-		_, _, isConflictErr := db.revTreeConflictCheck(ctx, putOpts.RevTreeHistory, doc, putOpts.NewDoc.Deleted)
-		if isConflictErr != nil {
+		if doc.RevConflict {
 			return HLVConflict
 		}
 		return HLVNoConflict

--- a/db/document.go
+++ b/db/document.go
@@ -289,7 +289,6 @@ type Document struct {
 	inlineSyncData    bool
 	localWinsConflict bool   // True if this document is the result of a local-wins conflict resolution
 	RevSeqNo          uint64 // Server rev seq no for a document
-	RevConflict       bool
 }
 
 // GlobalSyncData is the structure for the system xattr that is migrated with XDCR.
@@ -1487,7 +1486,7 @@ func (doc *Document) ExtractDocVersion() DocVersion {
 }
 
 // IsInConflict is true if the incoming HLV is in conflict with the current document.
-func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWithUser, incomingHLV *HybridLogicalVector, putOpts PutDocOptions) HLVConflictStatus {
+func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWithUser, incomingHLV *HybridLogicalVector, putOpts PutDocOptions, revTreeConflictCheck, revTreeConflictCheckStatus bool) HLVConflictStatus {
 	// If there is no SyncData, then the document can not be in conflict.
 	if doc.SyncData.Sequence == 0 {
 		return HLVNoConflict
@@ -1495,8 +1494,17 @@ func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWit
 	}
 	// we need to check if local CV version was generated from a revID if so we need to perform conflict check on rev tree history
 	if doc.HLV.HasRevEncodedCV() {
-		if doc.RevConflict {
-			return HLVConflict
+		if revTreeConflictCheck {
+			if revTreeConflictCheckStatus {
+				return HLVConflict
+			} else {
+				return HLVNoConflict
+			}
+		} else {
+			_, _, isConflictErr := db.revTreeConflictCheck(ctx, putOpts.RevTreeHistory, doc, putOpts.NewDoc.Deleted)
+			if isConflictErr != nil {
+				return HLVConflict
+			}
 		}
 		return HLVNoConflict
 	}


### PR DESCRIPTION
CBG-4923

Describe your PR here...
- Added additional property in document struct to store the revision conflict check to prevent multiple `revTreeConflictCheck`
- Tested this out using the topology test `TestActiveReplicatorConflictPreUpgradedVersionOneSide`

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/155/
