### PR TITLE
CBG-4993 support views in test harness with CBS 8.0

### DIFF
--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -233,7 +233,7 @@ func (c *tbpCluster) insertBucket(name string, quotaMB int, conflictResolution X
 	body.Set("numReplicas", strconv.Itoa(numReplicas))
 	body.Set("ramQuotaMB", fmt.Sprintf("%d", quotaMB))
 	// for GSI, use default storage backend: magma for 8.0+ or couchstore for <8.0
-	// views isn't supported with magma
+	// views aren't supported with magma
 	if TestsDisableGSI() {
 		body.Set("storageBackend", "couchstore")
 	}

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -232,6 +232,11 @@ func (c *tbpCluster) insertBucket(name string, quotaMB int, conflictResolution X
 	body.Set("name", name)
 	body.Set("numReplicas", strconv.Itoa(numReplicas))
 	body.Set("ramQuotaMB", fmt.Sprintf("%d", quotaMB))
+	// for GSI, use default storage backend: magma for 8.0+ or couchstore for <8.0
+	// views isn't supported with magma
+	if TestsDisableGSI() {
+		body.Set("storageBackend", "couchstore")
+	}
 	output, status, err := c.MgmtRequest(
 		http.MethodPost,
 		"/pools/default/buckets",


### PR DESCRIPTION
CBG-4993 support views in test harness with CBS 8.0

allows a db bucket pool to initialize with server 8.0 without:

```
 {"unique_id":"32974477-4c1b-4b1f-98a6-b9e03006babf","endpoint":"http://localhost:8091","error_text":"{\"error\":\"no_ddocs_service\"}","status_code":400} - Aborting
```

