### PR TITLE
CBG-4747: remove serialisation on critical path

### DIFF
--- a/channels/set.go
+++ b/channels/set.go
@@ -32,9 +32,8 @@ const AllChannelWildcard = "*"    // wildcard for 'all channels'
 
 // ID represents a single channel inside a collection
 type ID struct {
-	Name          string // name of channel
-	CollectionID  uint32 // collection it belongs to
-	serialization string // private method for logging and matching inside changeWaiter notification
+	Name         string // name of channel
+	CollectionID uint32 // collection it belongs to
 }
 
 func (c ID) String() string {

--- a/channels/set.go
+++ b/channels/set.go
@@ -38,15 +38,14 @@ type ID struct {
 }
 
 func (c ID) String() string {
-	return c.serialization
+	return strconv.FormatUint(uint64(c.CollectionID), 10) + "." + base.UserDataPrefix + c.Name + base.UserDataSuffix
 }
 
 // NewID returns a new ChannelID
 func NewID(channelName string, collectionID uint32) ID {
 	return ID{
-		Name:          channelName,
-		CollectionID:  collectionID,
-		serialization: strconv.FormatUint(uint64(collectionID), 10) + "." + base.UserDataPrefix + channelName + base.UserDataSuffix,
+		Name:         channelName,
+		CollectionID: collectionID,
 	}
 }
 


### PR DESCRIPTION
CBG-4747

- Remove serialisation on channel ID struct, pay for it at logging time
- This is to get some perf results form Dragos on how this looks

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
