### PR TITLE
CBG-4989 create stat for panic on import / http handlers

### DIFF
--- a/base/devmode.go
+++ b/base/devmode.go
@@ -25,10 +25,15 @@ func IsDevMode() bool {
 // The SG test harness will ensure AssertionFailCount is zero at the end of tests, even without devmode enabled.
 // Note: Callers MUST ensure code is safe to continue executing after the Assert (e.g. by returning an error) and MUST NOT be used like a panic that will halt.
 func AssertfCtx(ctx context.Context, format string, args ...any) {
+
 	SyncGatewayStats.GlobalStats.ResourceUtilization.AssertionFailCount.Add(1)
 	assertLogFn(ctx, AssertionFailedPrefix+format, args...)
 }
 
+// PanicRecoveryfCtx logs a warning message. This function is suitable for recovering from a panic in a location where
+// it is expected to continue operation, like HTTP handlers.
+// When compiled with the `cb_sg_devmode` build tag this function panics to fail the test harness for better dev-time visibility.
+// In all cases, the PanicCount stat is incremented.
 func PanicRecoveryfCtx(ctx context.Context, format string, args ...any) {
 	SyncGatewayStats.GlobalStats.ResourceUtilization.PanicCount.Add(1)
 	panicRecoveryLogFn(ctx, format, args...)

--- a/base/devmode.go
+++ b/base/devmode.go
@@ -28,3 +28,8 @@ func AssertfCtx(ctx context.Context, format string, args ...any) {
 	SyncGatewayStats.GlobalStats.ResourceUtilization.AssertionFailCount.Add(1)
 	assertLogFn(ctx, AssertionFailedPrefix+format, args...)
 }
+
+func PanicRecoveryfCtx(ctx context.Context, format string, args ...any) {
+	SyncGatewayStats.GlobalStats.ResourceUtilization.PanicCount.Add(1)
+	panicRecoveryLogFn(ctx, format, args...)
+}

--- a/base/devmode_off.go
+++ b/base/devmode_off.go
@@ -14,3 +14,5 @@ package base
 const cbSGDevModeBuildTagSet = false
 
 var assertLogFn logFn = ErrorfCtx
+
+var panicRecoveryLogFn logFn = WarnfCtx

--- a/base/devmode_on.go
+++ b/base/devmode_on.go
@@ -14,3 +14,5 @@ package base
 const cbSGDevModeBuildTagSet = true
 
 var assertLogFn logFn = PanicfCtx
+
+var panicRecoveryLogFn logFn = PanicfCtx

--- a/base/stats.go
+++ b/base/stats.go
@@ -313,6 +313,10 @@ func (g *GlobalStat) initResourceUtilizationStats() error {
 	if err != nil {
 		return err
 	}
+	resUtil.PanicCount, err = NewIntStat(ResourceUtilizationSubsystem, "panic_count", StatUnitNoUnits, PanicCountDesc, StatAddedVersion4dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, nil, nil, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
 	resUtil.CpuPercentUtil, err = NewFloatStat(ResourceUtilizationSubsystem, "process_cpu_percent_utilization", StatUnitPercent, ProcessCPUPercentUtilDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersion3dot2dot0, StatStabilityCommitted, nil, nil, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
@@ -400,6 +404,8 @@ type ResourceUtilization struct {
 	WarnCount *SgwIntStat `json:"warn_count"`
 	// The total number of assertion failures logged. This is a good indicator of a bug and should be reported.
 	AssertionFailCount *SgwIntStat `json:"assertion_fail_count"`
+	// The total number of recovered panics.
+	PanicCount *SgwIntStat `json:"panic_recover_count"`
 	// The total uptime.
 	Uptime *SgwDurStat `json:"uptime"`
 }

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -67,7 +67,7 @@ const (
 	WarnCountDesc          = "The total number of warnings logged."
 	AssertionFailCountDesc = "The total number of assertion failures logged. This is a good indicator of a bug and should be reported."
 
-	PanicCountDesc = "The number of panics that have occurred in the process."
+	PanicCountDesc = "The number of recovered panics that have occurred in the process."
 	UptimeDesc     = "The total uptime."
 )
 

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -67,7 +67,8 @@ const (
 	WarnCountDesc          = "The total number of warnings logged."
 	AssertionFailCountDesc = "The total number of assertion failures logged. This is a good indicator of a bug and should be reported."
 
-	UptimeDesc = "The total uptime."
+	PanicCountDesc = "The number of panics that have occurred in the process."
+	UptimeDesc     = "The total uptime."
 )
 
 // error stat

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -135,7 +135,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool {
 	docID := string(event.Key)
 	defer func() {
 		if r := recover(); r != nil {
-			base.WarnfCtx(ctx, "[%s] Unexpected panic importing document %s - skipping import: \n %s", r, base.UD(docID), debug.Stack())
+			base.PanicRecoveryfCtx(ctx, "[%s] Unexpected panic importing document %s - skipping import: \n %s", r, base.UD(docID), debug.Stack())
 			if il.importStats != nil {
 				il.importStats.ImportErrorCount.Add(1)
 			}
@@ -202,7 +202,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 			il.importStats.ImportErrorCount.Add(1)
 			return
 		}
-		var cv cvExtractor
+		var cv *rawHLV
 		vv := rawDoc.Xattrs[base.VvXattrName]
 		if len(vv) > 0 {
 			cv = base.Ptr(rawHLV(vv))

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -131,7 +131,7 @@ func makeHandlerWithOptions(server *ServerContext, privs handlerPrivs, accessPer
 		ctx := rq.Context()
 		defer func() {
 			if r := recover(); r != nil {
-				base.PanicRecoveryfCtx(ctx, "Unexpected panic in HTTP handler: \n %s", debug.Stack())
+				base.PanicRecoveryfCtx(ctx, "Unexpected panic in HTTP handler:\n%s", debug.Stack())
 				panic(r)
 			}
 		}()


### PR DESCRIPTION
CBG-4989 create stat for panic

- fix the panic which occurs when there is a _sync.rev.ver and _sync.rev.src but no _vv 
- fail test harness for unexpected panic
- add middleware for catching a panic in an HTTP handler CBG-4988

I am not set on creating a new stat, because there's already a stat for `sgw_replication_sgr_num_handlers_panicked` but the name implies it really only covers panics in blip handlers. I'm happy to pull out the changes to the panic handler but I used it to make sure that I could find 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/160/
