### PR TITLE
CBG-4988 log panics in http

### DIFF
--- a/base/devmode.go
+++ b/base/devmode.go
@@ -33,8 +33,8 @@ func AssertfCtx(ctx context.Context, format string, args ...any) {
 // PanicRecoveryfCtx logs a warning message. This function is suitable for recovering from a panic in a location where
 // it is expected to continue operation, like HTTP handlers.
 // When compiled with the `cb_sg_devmode` build tag this function panics to fail the test harness for better dev-time visibility.
-// In all cases, the ErrorCount stat is incremented.
+// In all cases, the WarnCount stat is incremented.
 func PanicRecoveryfCtx(ctx context.Context, format string, args ...any) {
-	SyncGatewayStats.GlobalStats.ResourceUtilization.ErrorCount.Add(1)
+	SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Add(1)
 	panicRecoveryLogFn(ctx, format, args...)
 }

--- a/base/devmode.go
+++ b/base/devmode.go
@@ -25,6 +25,16 @@ func IsDevMode() bool {
 // The SG test harness will ensure AssertionFailCount is zero at the end of tests, even without devmode enabled.
 // Note: Callers MUST ensure code is safe to continue executing after the Assert (e.g. by returning an error) and MUST NOT be used like a panic that will halt.
 func AssertfCtx(ctx context.Context, format string, args ...any) {
+
 	SyncGatewayStats.GlobalStats.ResourceUtilization.AssertionFailCount.Add(1)
 	assertLogFn(ctx, AssertionFailedPrefix+format, args...)
+}
+
+// PanicRecoveryfCtx logs a warning message. This function is suitable for recovering from a panic in a location where
+// it is expected to continue operation, like HTTP handlers.
+// When compiled with the `cb_sg_devmode` build tag this function panics to fail the test harness for better dev-time visibility.
+// In all cases, the ErrorCount stat is incremented.
+func PanicRecoveryfCtx(ctx context.Context, format string, args ...any) {
+	SyncGatewayStats.GlobalStats.ResourceUtilization.ErrorCount.Add(1)
+	panicRecoveryLogFn(ctx, format, args...)
 }

--- a/base/devmode.go
+++ b/base/devmode.go
@@ -35,6 +35,5 @@ func AssertfCtx(ctx context.Context, format string, args ...any) {
 // When compiled with the `cb_sg_devmode` build tag this function panics to fail the test harness for better dev-time visibility.
 // In all cases, the WarnCount stat is incremented.
 func PanicRecoveryfCtx(ctx context.Context, format string, args ...any) {
-	SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Add(1)
 	panicRecoveryLogFn(ctx, format, args...)
 }

--- a/base/devmode_off.go
+++ b/base/devmode_off.go
@@ -14,3 +14,5 @@ package base
 const cbSGDevModeBuildTagSet = false
 
 var assertLogFn logFn = ErrorfCtx
+
+var panicRecoveryLogFn logFn = WarnfCtx

--- a/base/devmode_on.go
+++ b/base/devmode_on.go
@@ -11,6 +11,14 @@
 
 package base
 
+import "context"
+
 const cbSGDevModeBuildTagSet = true
 
 var assertLogFn logFn = PanicfCtx
+
+func panicRecoveryLogFn(ctx context.Context, format string, args ...any) {
+	// add a warn count since the devmode=off path also adds a warn count
+	SyncGatewayStats.GlobalStats.ResourceUtilization.WarnCount.Add(1)
+	PanicfCtx(ctx, format, args...)
+}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -135,7 +135,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool {
 	docID := string(event.Key)
 	defer func() {
 		if r := recover(); r != nil {
-			base.WarnfCtx(ctx, "[%s] Unexpected panic importing document %s - skipping import: \n %s", r, base.UD(docID), debug.Stack())
+			base.PanicRecoveryfCtx(ctx, "[%s] Unexpected panic importing document %s - skipping import: \n %s", r, base.UD(docID), debug.Stack())
 			if il.importStats != nil {
 				il.importStats.ImportErrorCount.Add(1)
 			}

--- a/db/import_listener_test.go
+++ b/db/import_listener_test.go
@@ -25,10 +25,20 @@ func TestImportFeedEventRecover(t *testing.T) {
 		},
 	}
 	startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
+
 	// assert false to indicate that this checkpoint will not be incremented
-	require.False(t, listener.ProcessFeedEvent(sgbucket.FeedEvent{
-		Key:    []byte("example-doc"),
-		Opcode: sgbucket.FeedOpMutation,
-	}))
+	if base.IsDevMode() {
+		require.Panics(t, func() {
+			listener.ProcessFeedEvent(sgbucket.FeedEvent{
+				Key:    []byte("example-doc"),
+				Opcode: sgbucket.FeedOpMutation,
+			})
+		})
+	} else {
+		require.False(t, listener.ProcessFeedEvent(sgbucket.FeedEvent{
+			Key:    []byte("example-doc"),
+			Opcode: sgbucket.FeedOpMutation,
+		}))
+	}
 	require.Equal(t, startWarnCount+1, base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value())
 }

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -243,7 +243,7 @@ func TestHandlerRecoverLog(t *testing.T) {
 			defer closeFn()
 
 			ctx := base.TestCtx(t)
-			sc.WaitForRESTAPIs(ctx)
+			require.NoError(t, sc.WaitForRESTAPIs(ctx))
 			startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 			handler := makeHandlerWithOptions(sc, regularPrivs, nil, nil, func(_ *handler) error {
 				panic(tc.panicArg)

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -242,6 +242,8 @@ func TestHandlerRecoverLog(t *testing.T) {
 			sc, closeFn := StartServerWithConfig(t, &config)
 			defer closeFn()
 
+			ctx := base.TestCtx(t)
+			sc.WaitForRESTAPIs(ctx)
 			startWarnCount := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().WarnCount.Value()
 			handler := makeHandlerWithOptions(sc, regularPrivs, nil, nil, func(_ *handler) error {
 				panic(tc.panicArg)


### PR DESCRIPTION
CBG-4988 log panics in http in Sync Gateway

- This logs the panic in Sync Gateway as well as returning a "response" line. Previously there was no response since the response is logged after the request completes successfully. https://github.com/couchbase/sync_gateway/blob/d7f18c232232ac552bbadb2242bef6098841c1ea/rest/handler.go#L135
- Increments WarnCount since these panics are recoverable and not necessarily errors. The will fail a request, or importing a specific document, but not take down Sync Gateway process.

From go stdlibrary:

> If ServeHTTP panics, the server (the caller of ServeHTTP) assumes that the effect of the panic was isolated to the active request. It recovers the panic, logs a stack trace to the server error log, and either closes the network connection or sends an HTTP/2 RST_STREAM, depending on the HTTP protocol. To abort a handler so the client sees an interrupted response but the server doesn't log an error, panic with the value [ErrAbortHandler](https://pkg.go.dev/net/http#ErrAbortHandler).

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/164/
