### PR TITLE
CBG-4989 don't panic if no _vv but _sync.rev.ver on import

### DIFF
--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -202,7 +202,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 			il.importStats.ImportErrorCount.Add(1)
 			return
 		}
-		var cv cvExtractor
+		var cv *rawHLV
 		vv := rawDoc.Xattrs[base.VvXattrName]
 		if len(vv) > 0 {
 			cv = base.Ptr(rawHLV(vv))


### PR DESCRIPTION
CBG-4989 don't panic if no _vv but _sync.rev.ver on import

I don't think this critical because I'm not sure how you'd end up in this scenario outside of tests where you have `_sync.vv.ver` but not `_vv`. This will backport into 4.0.2 but isn't urgent.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
