### PR TITLE
CBG-4928 do not log warning for closed blip sender

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -629,7 +629,7 @@ func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]a
 		bh.replicationStats.SendChangesCount.Add(int64(len(changeArray)))
 		// Spawn a goroutine to await the client's response:
 		go func(bh *blipHandler, sender *blip.Sender, response *blip.Message, changeArray [][]any, sendTime time.Time, dbCollection *DatabaseCollectionWithUser) {
-			if err := bh.handleChangesResponse(bh.loggingCtx, sender, response, changeArray, sendTime, dbCollection, bh.collectionIdx); err != nil {
+			if err := bh.handleChangesResponse(bh.loggingCtx, sender, response, changeArray, sendTime, dbCollection, bh.collectionIdx); err != nil && !errors.Is(err, ErrClosedBLIPSender) {
 				base.WarnfCtx(bh.loggingCtx, "Error from bh.handleChangesResponse: %v", err)
 				if bh.fatalErrorCallback != nil {
 					bh.fatalErrorCallback(err)


### PR DESCRIPTION
CBG-4928 do not log warning for closed blip sender

This should prevent a log message as below when a blip connection is closed and it can not longer send changes. I believe a blip connection could be closed due to normal network disconnections: 

```
[WRN] c:[231d979a] db:db col:col2 Error from bh.handleChangesResponse: use of closed BLIP sender -- db.(*blipHandler).sendBatchOfChanges.func1() at blip_handler.go:614
```

It is OK to not enter fatalErrorCallback https://github.com/couchbase/sync_gateway/blob/b8b689bb534be1670f71808945ebbbc90a3eaecf/db/active_replicator_push.go#L211-L213 since if the sender is closed it will enter https://github.com/couchbase/sync_gateway/blob/main/db/active_replicator.go#L238 which will close and reconnect.

This was hard to unit test, but is observed in real world logs, so pushing this change to avoid unexpected logs. In order to test this, I believe you have to have the sender closed at the right time.

NOTE: this is only one part of CBG-4928 and there is a second part needed to address:

```
[WRN] c:[393a64c4] db:db col:col1 Error retrieving changes for channel "<ud>b2</ud>": Changes feed cancelled while waiting for view lock -- db.(*DatabaseCollectionWithUser).changesFeed.func1() at changes.go:437
[WRN] c:[393a64c4] db:db col:col1 MultiChangesFeed got error reading changes feed: Error while building channel feed -- db.(*DatabaseCollectionWithUser).SimpleMultiChangesFeed.func1() at changes.go:914
```