### PR TITLE
CBG-4928: Update log messages on changes feed being cancelled

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -41,7 +41,7 @@ var (
 	ErrNotFound              = &sgError{"Not Found"}
 	ErrUpdateCancel          = &sgError{"Cancel update"}
 	ErrImportCancelledPurged = HTTPErrorf(http.StatusNotFound, "Import Cancelled Due to Purge")
-	ErrChannelFeed           = &sgError{"Failed to build channel feed"}
+	ErrChannelFeed           = &sgError{"Error while building channel feed"}
 	ErrTimeout               = &sgError{"Operation timed out"}
 	ErrPathNotFound          = sgbucket.ErrPathNotFound
 	ErrPathExists            = sgbucket.ErrPathExists

--- a/base/error.go
+++ b/base/error.go
@@ -41,7 +41,7 @@ var (
 	ErrNotFound              = &sgError{"Not Found"}
 	ErrUpdateCancel          = &sgError{"Cancel update"}
 	ErrImportCancelledPurged = HTTPErrorf(http.StatusNotFound, "Import Cancelled Due to Purge")
-	ErrChannelFeed           = &sgError{"Error while building channel feed"}
+	ErrChannelFeed           = &sgError{"Failed to build channel feed"}
 	ErrTimeout               = &sgError{"Operation timed out"}
 	ErrPathNotFound          = sgbucket.ErrPathNotFound
 	ErrPathExists            = sgbucket.ErrPathExists

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -629,7 +629,7 @@ func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]a
 		bh.replicationStats.SendChangesCount.Add(int64(len(changeArray)))
 		// Spawn a goroutine to await the client's response:
 		go func(bh *blipHandler, sender *blip.Sender, response *blip.Message, changeArray [][]any, sendTime time.Time, dbCollection *DatabaseCollectionWithUser) {
-			if err := bh.handleChangesResponse(bh.loggingCtx, sender, response, changeArray, sendTime, dbCollection, bh.collectionIdx); err != nil {
+			if err := bh.handleChangesResponse(bh.loggingCtx, sender, response, changeArray, sendTime, dbCollection, bh.collectionIdx); err != nil && !errors.Is(err, ErrClosedBLIPSender) {
 				base.WarnfCtx(bh.loggingCtx, "Error from bh.handleChangesResponse: %v", err)
 				if bh.fatalErrorCallback != nil {
 					bh.fatalErrorCallback(err)

--- a/db/changes.go
+++ b/db/changes.go
@@ -995,8 +995,10 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 							feeds[i] = nil
 						} else {
 							// On feed error, send the error and exit changes processing
-							if options.ChangesCtx.Err() != nil {
-								base.WarnfCtx(ctx, "MultiChangesFeed got error reading changes feed: %v", current[i].Err)
+							if current[i].Err == base.ErrChannelFeed {
+								if options.ChangesCtx.Err() == nil {
+									base.WarnfCtx(ctx, "MultiChangesFeed got error reading changes feed: %v", current[i].Err)
+								}
 								select {
 								case <-options.ChangesCtx.Done():
 								case output <- current[i]:

--- a/db/changes.go
+++ b/db/changes.go
@@ -480,7 +480,7 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelID().Name), paginationOptions)
 			changes, err := singleChannelCache.GetChanges(ctx, paginationOptions)
 			if err != nil {
-				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelID().Name), err)
+				base.InfofCtx(ctx, base.KeyChanges, "Could not retrieve changes for channel %q: %v", base.UD(singleChannelCache.ChannelID().Name), err)
 				change := ChangeEntry{
 					Err: base.ErrChannelFeed,
 				}
@@ -996,7 +996,7 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 						} else {
 							// On feed error, send the error and exit changes processing
 							if current[i].Err == base.ErrChannelFeed {
-								base.WarnfCtx(ctx, "MultiChangesFeed got error reading changes feed: %v", current[i].Err)
+								base.InfofCtx(ctx, base.KeyChanges, "Could not read changes feed: %v", current[i].Err)
 								select {
 								case <-options.ChangesCtx.Done():
 								case output <- current[i]:

--- a/db/changes.go
+++ b/db/changes.go
@@ -480,7 +480,7 @@ func (db *DatabaseCollectionWithUser) changesFeed(ctx context.Context, singleCha
 			base.TracefCtx(ctx, base.KeyChanges, "Querying channel %q with options: %+v", base.UD(singleChannelCache.ChannelID().Name), paginationOptions)
 			changes, err := singleChannelCache.GetChanges(ctx, paginationOptions)
 			if err != nil {
-				base.InfofCtx(ctx, base.KeyChanges, "Could not retrieve changes for channel %q: %v", base.UD(singleChannelCache.ChannelID().Name), err)
+				base.WarnfCtx(ctx, "Error retrieving changes for channel %q: %v", base.UD(singleChannelCache.ChannelID().Name), err)
 				change := ChangeEntry{
 					Err: base.ErrChannelFeed,
 				}
@@ -995,8 +995,8 @@ func (col *DatabaseCollectionWithUser) SimpleMultiChangesFeed(ctx context.Contex
 							feeds[i] = nil
 						} else {
 							// On feed error, send the error and exit changes processing
-							if current[i].Err == base.ErrChannelFeed {
-								base.InfofCtx(ctx, base.KeyChanges, "Could not read changes feed: %v", current[i].Err)
+							if options.ChangesCtx.Err() != nil {
+								base.WarnfCtx(ctx, "MultiChangesFeed got error reading changes feed: %v", current[i].Err)
 								select {
 								case <-options.ChangesCtx.Done():
 								case output <- current[i]:

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -413,7 +413,7 @@ func (c *singleChannelCacheImpl) GetChanges(ctx context.Context, options Changes
 	// Check whether the changes process has been terminated while we waited for the view lock, to avoid the view
 	// overhead in that case (and prevent feedback loop on query backlog)
 	if options.ChangesCtx.Err() != nil {
-		return nil, fmt.Errorf("Changes feed cancelled while waiting for view lock")
+		return nil, fmt.Errorf("Changes feed cancelled")
 	}
 
 	// Now query the view. We set the max sequence equal to cacheValidFrom, so we'll get one

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -410,10 +410,9 @@ func (c *singleChannelCacheImpl) GetChanges(ctx context.Context, options Changes
 		return resultFromCache, nil
 	}
 
-	// Check whether the changes process has been terminated while we waited for the view lock, to avoid the view
-	// overhead in that case (and prevent feedback loop on query backlog)
+	// Check whether the changes process has been terminated before running a query
 	if options.ChangesCtx.Err() != nil {
-		return nil, fmt.Errorf("Changes feed cancelled")
+		return nil, fmt.Errorf("Changes feed cancelled %w", options.ChangesCtx.Err())
 	}
 
 	// Now query the view. We set the max sequence equal to cacheValidFrom, so we'll get one


### PR DESCRIPTION
CBG-4928

Describe your PR here...
- Currently SGW logs the changes feed cancellation messages at warn level with "error" in the message
- These are not necessarily errors, therefore the message level and messages have been updated appropriately
- The other part of this ticket is implemented in #7878 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
