### PR TITLE
CBG-4747: remove serialisation from caching process

### DIFF
--- a/channels/set.go
+++ b/channels/set.go
@@ -36,7 +36,7 @@ type ID struct {
 }
 
 func (c ID) String() string {
-	return base.UserDataPrefix + c.Name + base.UserDataSuffix
+	return c.Name
 }
 
 // NewID returns a new ChannelID
@@ -193,7 +193,7 @@ func (redactorSet RedactorSet) GetRedactionString(shouldRedact bool) string {
 	tmp := []byte("{")
 	iterationCount := 0
 	for setItem, _ := range redactorSet.set {
-		tmp = append(tmp, redactorSet.redactorFunc(setItem).String()...)
+		tmp = append(tmp, redactorSet.redactorFunc(setItem).Redact()...)
 		iterationCount++
 		if iterationCount != len(redactorSet.set) {
 			tmp = append(tmp, ", "...)

--- a/channels/set.go
+++ b/channels/set.go
@@ -35,6 +35,8 @@ type ID struct {
 	CollectionID uint32 // collection it belongs to
 }
 
+// String returns the channel name as a string, omitting the collection ID, so beware when using for logging purposes
+// that the collection name is logged from the context on the log line
 func (c ID) String() string {
 	return c.Name
 }

--- a/channels/set.go
+++ b/channels/set.go
@@ -11,7 +11,6 @@ package channels
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -32,21 +31,19 @@ const AllChannelWildcard = "*"    // wildcard for 'all channels'
 
 // ID represents a single channel inside a collection
 type ID struct {
-	Name          string // name of channel
-	CollectionID  uint32 // collection it belongs to
-	serialization string // private method for logging and matching inside changeWaiter notification
+	Name         string // name of channel
+	CollectionID uint32 // collection it belongs to
 }
 
 func (c ID) String() string {
-	return c.serialization
+	return base.UserDataPrefix + c.Name + base.UserDataSuffix
 }
 
 // NewID returns a new ChannelID
 func NewID(channelName string, collectionID uint32) ID {
 	return ID{
-		Name:          channelName,
-		CollectionID:  collectionID,
-		serialization: strconv.FormatUint(uint64(collectionID), 10) + "." + base.UserDataPrefix + channelName + base.UserDataSuffix,
+		Name:         channelName,
+		CollectionID: collectionID,
 	}
 }
 

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -9,7 +9,6 @@
 package channels
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -413,7 +412,6 @@ func TestSetString(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.output, test.input.String())
-			fmt.Println(base.UD(test.input), base.UD(test.input).Redact())
 			require.Contains(t, test.redactedOutput, base.UD(test.input).Redact())
 		})
 	}

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -9,6 +9,7 @@
 package channels
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -373,14 +374,14 @@ func TestSetString(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			output: "{1.<ud>A</ud>, 1.<ud>C</ud>, 2.<ud>B</ud>}",
+			output: "{<ud>A</ud>, <ud>B</ud>, <ud>C</ud>}",
 			redactedOutput: []string{
-				"{1.<ud>A</ud>, 1.<ud>C</ud>, 2.<ud>B</ud>}",
-				"{1.<ud>A</ud>, 2.<ud>B</ud>, 1.<ud>C</ud>}",
-				"{1.<ud>C</ud>, 1.<ud>A</ud>, 2.<ud>B</ud>}",
-				"{1.<ud>C</ud>, 2.<ud>B</ud>, 1.<ud>A</ud>}",
-				"{2.<ud>B</ud>, 1.<ud>A</ud>, 1.<ud>C</ud>}",
-				"{2.<ud>B</ud>, 1.<ud>C</ud>, 1.<ud>A</ud>}",
+				"{<ud>A</ud>, <ud>C</ud>, <ud>B</ud>}",
+				"{<ud>A</ud>, <ud>B</ud>, <ud>C</ud>}",
+				"{<ud>C</ud>, <ud>A</ud>, <ud>B</ud>}",
+				"{<ud>C</ud>, <ud>B</ud>, <ud>A</ud>}",
+				"{<ud>B</ud>, <ud>A</ud>, <ud>C</ud>}",
+				"{<ud>B</ud>, <ud>C</ud>, <ud>A</ud>}",
 			},
 		},
 		{
@@ -390,14 +391,14 @@ func TestSetString(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			output: "{1.<ud>C</ud>, 2.<ud>A</ud>, 2.<ud>B</ud>}",
+			output: "{<ud>A</ud>, <ud>B</ud>, <ud>C</ud>}",
 			redactedOutput: []string{
-				"{2.<ud>A</ud>, 1.<ud>C</ud>, 2.<ud>B</ud>}",
-				"{2.<ud>A</ud>, 2.<ud>B</ud>, 1.<ud>C</ud>}",
-				"{1.<ud>C</ud>, 2.<ud>A</ud>, 2.<ud>B</ud>}",
-				"{1.<ud>C</ud>, 2.<ud>B</ud>, 2.<ud>A</ud>}",
-				"{2.<ud>B</ud>, 2.<ud>A</ud>, 1.<ud>C</ud>}",
-				"{2.<ud>B</ud>, 1.<ud>C</ud>, 2.<ud>A</ud>}",
+				"{<ud>A</ud>, <ud>C</ud>, <ud>B</ud>}",
+				"{<ud>A</ud>, <ud>B</ud>, <ud>C</ud>}",
+				"{<ud>C</ud>, <ud>A</ud>, <ud>B</ud>}",
+				"{<ud>C</ud>, <ud>B</ud>, <ud>A</ud>}",
+				"{<ud>B</ud>, <ud>A</ud>, <ud>C</ud>}",
+				"{<ud>B</ud>, <ud>C</ud>, <ud>A</ud>}",
 			},
 		},
 		{
@@ -405,13 +406,14 @@ func TestSetString(t *testing.T) {
 			input: Set{
 				NewID("A", 1): present{},
 			},
-			output:         "{1.<ud>A</ud>}",
-			redactedOutput: []string{"{1.<ud>A</ud>}"},
+			output:         "{<ud>A</ud>}",
+			redactedOutput: []string{"{<ud>A</ud>}"},
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.output, test.input.String())
+			fmt.Println(base.UD(test.input), base.UD(test.input).Redact())
 			require.Contains(t, test.redactedOutput, base.UD(test.input).Redact())
 		})
 	}

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -373,7 +373,7 @@ func TestSetString(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			output: "{<ud>A</ud>, <ud>B</ud>, <ud>C</ud>}",
+			output: "{A, B, C}",
 			redactedOutput: []string{
 				"{<ud>A</ud>, <ud>C</ud>, <ud>B</ud>}",
 				"{<ud>A</ud>, <ud>B</ud>, <ud>C</ud>}",
@@ -390,7 +390,7 @@ func TestSetString(t *testing.T) {
 				NewID("B", 2): present{},
 				NewID("C", 1): present{},
 			},
-			output: "{<ud>A</ud>, <ud>B</ud>, <ud>C</ud>}",
+			output: "{A, B, C}",
 			redactedOutput: []string{
 				"{<ud>A</ud>, <ud>C</ud>, <ud>B</ud>}",
 				"{<ud>A</ud>, <ud>B</ud>, <ud>C</ud>}",
@@ -405,7 +405,7 @@ func TestSetString(t *testing.T) {
 			input: Set{
 				NewID("A", 1): present{},
 			},
-			output:         "{<ud>A</ud>}",
+			output:         "{A}",
 			redactedOutput: []string{"{<ud>A</ud>}"},
 		},
 	}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -53,8 +53,8 @@ type changeListener struct {
 // unusedSeqChannelID marks the unused sequence key for the channel cache. This is a marker that is global to all collections.
 var unusedSeqChannelID = channels.NewID(unusedSeqKey, unusedSeqCollectionID)
 
-// principalDocCollectionChannelID is the channel ID for principal documents (users, roles).
-const principalDocCollectionChannelID = 0
+// principalDocCollectionIDForChannelID is the collection ID for construction of channel ID for principal documents (users, roles).
+const principalDocCollectionIDForChannelID = 0
 
 type DocChangedFunc func(event sgbucket.FeedEvent, docType DocumentType)
 
@@ -184,7 +184,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 	docType := listener.DocumentType(event.Key)
 	if docType == DocTypeUser || docType == DocTypeRole {
 		// defer to notify after callback completion
-		key := channels.NewID(string(event.Key), principalDocCollectionChannelID)
+		key := channels.NewID(string(event.Key), principalDocCollectionIDForChannelID)
 		defer listener.notifyKey(listener.ctx, key)
 	}
 
@@ -427,10 +427,10 @@ func (listener *changeListener) NewWaiterWithChannels(chans channels.Set, user a
 	}
 	var userKeys []channels.ID
 	if user != nil {
-		usrID := channels.NewID(listener.metaKeys.UserKey(user.Name()), principalDocCollectionChannelID)
+		usrID := channels.NewID(listener.metaKeys.UserKey(user.Name()), principalDocCollectionIDForChannelID)
 		userKeys = []channels.ID{usrID}
 		for role := range user.RoleNames() {
-			userKeys = append(userKeys, channels.NewID(listener.metaKeys.RoleKey(role), principalDocCollectionChannelID))
+			userKeys = append(userKeys, channels.NewID(listener.metaKeys.RoleKey(role), principalDocCollectionIDForChannelID))
 		}
 		waitKeys = append(waitKeys, userKeys...)
 	}
@@ -510,9 +510,9 @@ func (waiter *ChangeWaiter) RefreshUserKeys(user auth.User, metaKeys *base.Metad
 		if len(waiter.userKeys) == 1 && len(user.RoleNames()) == 0 {
 			return
 		}
-		waiter.userKeys = []channels.ID{channels.NewID(metaKeys.UserKey(user.Name()), principalDocCollectionChannelID)}
+		waiter.userKeys = []channels.ID{channels.NewID(metaKeys.UserKey(user.Name()), principalDocCollectionIDForChannelID)}
 		for role := range user.RoleNames() {
-			waiter.userKeys = append(waiter.userKeys, channels.NewID(metaKeys.RoleKey(role), principalDocCollectionChannelID))
+			waiter.userKeys = append(waiter.userKeys, channels.NewID(metaKeys.RoleKey(role), principalDocCollectionIDForChannelID))
 		}
 		waiter.lastUserCount = waiter.listener.CurrentCount(waiter.userKeys)
 

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -53,6 +53,9 @@ type changeListener struct {
 // unusedSeqChannelID marks the unused sequence key for the channel cache. This is a marker that is global to all collections.
 var unusedSeqChannelID = channels.NewID(unusedSeqKey, unusedSeqCollectionID)
 
+// principalDocCollectionChannelID is the channel ID for principal documents (users, roles).
+const principalDocCollectionChannelID = 0
+
 type DocChangedFunc func(event sgbucket.FeedEvent, docType DocumentType)
 
 func (listener *changeListener) Init(name string, groupID string, db *DatabaseContext) {
@@ -181,7 +184,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 	docType := listener.DocumentType(event.Key)
 	if docType == DocTypeUser || docType == DocTypeRole {
 		// defer to notify after callback completion
-		key := channels.NewID(string(event.Key), 0)
+		key := channels.NewID(string(event.Key), principalDocCollectionChannelID)
 		defer listener.notifyKey(listener.ctx, key)
 	}
 
@@ -424,10 +427,10 @@ func (listener *changeListener) NewWaiterWithChannels(chans channels.Set, user a
 	}
 	var userKeys []channels.ID
 	if user != nil {
-		usrID := channels.NewID(listener.metaKeys.UserKey(user.Name()), 0)
+		usrID := channels.NewID(listener.metaKeys.UserKey(user.Name()), principalDocCollectionChannelID)
 		userKeys = []channels.ID{usrID}
 		for role := range user.RoleNames() {
-			userKeys = append(userKeys, channels.NewID(listener.metaKeys.RoleKey(role), 0))
+			userKeys = append(userKeys, channels.NewID(listener.metaKeys.RoleKey(role), principalDocCollectionChannelID))
 		}
 		waitKeys = append(waitKeys, userKeys...)
 	}
@@ -507,9 +510,9 @@ func (waiter *ChangeWaiter) RefreshUserKeys(user auth.User, metaKeys *base.Metad
 		if len(waiter.userKeys) == 1 && len(user.RoleNames()) == 0 {
 			return
 		}
-		waiter.userKeys = []channels.ID{channels.NewID(metaKeys.UserKey(user.Name()), 0)}
+		waiter.userKeys = []channels.ID{channels.NewID(metaKeys.UserKey(user.Name()), principalDocCollectionChannelID)}
 		for role := range user.RoleNames() {
-			waiter.userKeys = append(waiter.userKeys, channels.NewID(metaKeys.RoleKey(role), 0))
+			waiter.userKeys = append(waiter.userKeys, channels.NewID(metaKeys.RoleKey(role), principalDocCollectionChannelID))
 		}
 		waiter.lastUserCount = waiter.listener.CurrentCount(waiter.userKeys)
 

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -41,7 +41,7 @@ type changeListener struct {
 	FeedArgs                 sgbucket.FeedArguments // The Tap Args (backfill, etc)
 	counter                  uint64                 // Event counter; increments on every doc update
 	_terminateCheckCounter   uint64                 // Termination Event counter; increments on every notifyCheckForTermination
-	keyCounts                map[string]uint64      // Latest count at which each doc key was updated
+	keyCounts                map[channels.ID]uint64 // Latest count at which each doc key was updated
 	OnChangeCallback         DocChangedFunc
 	terminator               chan bool          // Signal to cause DCP feed to exit
 	broadcastChangesDoneChan chan struct{}      // Channel to signal that broadcast changes goroutine has terminated
@@ -59,7 +59,7 @@ func (listener *changeListener) Init(name string, groupID string, db *DatabaseCo
 	listener.bucketName = name
 	listener.counter = 1
 	listener._terminateCheckCounter = 0
-	listener.keyCounts = map[string]uint64{}
+	listener.keyCounts = map[channels.ID]uint64{}
 	listener.tapNotifier = sync.NewCond(&sync.Mutex{})
 	listener.sgCfgPrefix = db.MetadataKeys.SGCfgPrefix(groupID)
 	listener.metaKeys = db.MetadataKeys
@@ -251,7 +251,7 @@ func (listener *changeListener) Notify(ctx context.Context, keys channels.Set) {
 	listener.tapNotifier.L.Lock()
 	listener.counter++
 	for key := range keys {
-		listener.keyCounts[key.String()] = listener.counter
+		listener.keyCounts[key] = listener.counter
 	}
 	base.DebugfCtx(ctx, base.KeyChanges, "Listener keys %q for %s have changed, count=%d",
 		base.UD(keys), base.MD(listener.bucketName), listener.counter)
@@ -310,9 +310,10 @@ func tickerValForBroadcastSpeed(skippedSequencePresent bool) time.Duration {
 
 // Changes the counter, notifying waiting clients. Only use for a key update.
 func (listener *changeListener) notifyKey(ctx context.Context, key string) {
+	mapKey := channels.NewID(key, 0)
 	listener.tapNotifier.L.Lock()
 	listener.counter++
-	listener.keyCounts[key] = listener.counter
+	listener.keyCounts[mapKey] = listener.counter
 	base.DebugfCtx(ctx, base.KeyChanges, "Notifying that %q changed (key=%q) count=%d",
 		base.MD(listener.bucketName), base.UD(key), listener.counter)
 	listener.tapNotifier.Broadcast()
@@ -340,7 +341,7 @@ func (listener *changeListener) NotifyCheckForTermination(ctx context.Context, k
 }
 
 // Waits until either the counter, or terminateCheckCounter exceeds the given value. Returns the new counters.
-func (listener *changeListener) Wait(ctx context.Context, keys []string, counter uint64, terminateCheckCounter uint64) (uint64, uint64) {
+func (listener *changeListener) Wait(ctx context.Context, keys []channels.ID, counter uint64, terminateCheckCounter uint64) (uint64, uint64) {
 	listener.tapNotifier.L.Lock()
 	defer listener.tapNotifier.L.Unlock()
 	base.DebugfCtx(ctx, base.KeyChanges, "No new changes to send to change listener.  Waiting for %q's count to pass %d",
@@ -367,13 +368,13 @@ func (listener *changeListener) Wait(ctx context.Context, keys []string, counter
 }
 
 // Returns the max value of the counter for all the given keys
-func (listener *changeListener) CurrentCount(keys []string) uint64 {
+func (listener *changeListener) CurrentCount(keys []channels.ID) uint64 {
 	listener.tapNotifier.L.Lock()
 	defer listener.tapNotifier.L.Unlock()
 	return listener._currentCount(keys)
 }
 
-func (listener *changeListener) _currentCount(keys []string) uint64 {
+func (listener *changeListener) _currentCount(keys []channels.ID) uint64 {
 	var max uint64 = 0
 	for _, key := range keys {
 		if count := listener.keyCounts[key]; count > max {
@@ -389,8 +390,8 @@ func (listener *changeListener) _currentCount(keys []string) uint64 {
 // listener's counter to increment from the value at the last call.
 type ChangeWaiter struct {
 	listener                  *changeListener
-	keys                      []string
-	userKeys                  []string
+	keys                      []channels.ID
+	userKeys                  []channels.ID
 	lastCounter               uint64
 	lastTerminateCheckCounter uint64
 	lastUserCount             uint64
@@ -398,14 +399,14 @@ type ChangeWaiter struct {
 }
 
 // NewWaiter a new ChangeWaiter that will wait for changes for the given document keys, and will optionally track unused sequences.
-func (listener *changeListener) NewWaiter(keys []string, trackUnusedSequences bool) *ChangeWaiter {
+func (listener *changeListener) NewWaiter(keys []channels.ID, trackUnusedSequences bool) *ChangeWaiter {
 	listener.tapNotifier.L.Lock()
 	defer listener.tapNotifier.L.Unlock()
 	return listener._newWaiter(keys, trackUnusedSequences)
 }
 
 // _newWaiter a new ChangeWaiter that will wait for changes for the given document keys, and will optionally track unused sequences.
-func (listener *changeListener) _newWaiter(keys []string, trackUnusedSequences bool) *ChangeWaiter {
+func (listener *changeListener) _newWaiter(keys []channels.ID, trackUnusedSequences bool) *ChangeWaiter {
 	return &ChangeWaiter{
 		listener:                  listener,
 		keys:                      keys,
@@ -417,15 +418,16 @@ func (listener *changeListener) _newWaiter(keys []string, trackUnusedSequences b
 
 // NewWaiterWithChannels creates ChangeWaiter for a given channel and user, and will optionally track unused sequences.
 func (listener *changeListener) NewWaiterWithChannels(chans channels.Set, user auth.User, trackUnusedSequences bool) *ChangeWaiter {
-	waitKeys := make([]string, 0, 5)
+	waitKeys := make([]channels.ID, 0, 5)
 	for channel := range chans {
-		waitKeys = append(waitKeys, channel.String())
+		waitKeys = append(waitKeys, channel)
 	}
-	var userKeys []string
+	var userKeys []channels.ID
 	if user != nil {
-		userKeys = []string{listener.metaKeys.UserKey(user.Name())}
+		usrID := channels.NewID(listener.metaKeys.UserKey(user.Name()), 0)
+		userKeys = []channels.ID{usrID}
 		for role := range user.RoleNames() {
-			userKeys = append(userKeys, listener.metaKeys.RoleKey(role))
+			userKeys = append(userKeys, channels.NewID(listener.metaKeys.RoleKey(role), 0))
 		}
 		waitKeys = append(waitKeys, userKeys...)
 	}
@@ -480,12 +482,12 @@ func (waiter *ChangeWaiter) RefreshUserCount() bool {
 func (waiter *ChangeWaiter) UpdateChannels(collectionID uint32, timedSet channels.TimedSet) {
 	// This capacity is not right can not accommodate channels without iteration.
 	initialCapacity := len(waiter.userKeys)
-	updatedKeys := make([]string, 0, initialCapacity)
+	updatedKeys := make([]channels.ID, 0, initialCapacity)
 	for channelName, _ := range timedSet {
-		updatedKeys = append(updatedKeys, channels.NewID(channelName, collectionID).String())
+		updatedKeys = append(updatedKeys, channels.NewID(channelName, collectionID))
 	}
 	if waiter.trackUnusedSequences {
-		updatedKeys = append(updatedKeys, unusedSeqChannelID.String())
+		updatedKeys = append(updatedKeys, unusedSeqChannelID)
 	}
 	if len(waiter.userKeys) > 0 {
 		updatedKeys = append(updatedKeys, waiter.userKeys...)
@@ -505,9 +507,9 @@ func (waiter *ChangeWaiter) RefreshUserKeys(user auth.User, metaKeys *base.Metad
 		if len(waiter.userKeys) == 1 && len(user.RoleNames()) == 0 {
 			return
 		}
-		waiter.userKeys = []string{metaKeys.UserKey(user.Name())}
+		waiter.userKeys = []channels.ID{channels.NewID(metaKeys.UserKey(user.Name()), 0)}
 		for role := range user.RoleNames() {
-			waiter.userKeys = append(waiter.userKeys, metaKeys.RoleKey(role))
+			waiter.userKeys = append(waiter.userKeys, channels.NewID(metaKeys.RoleKey(role), 0))
 		}
 		waiter.lastUserCount = waiter.listener.CurrentCount(waiter.userKeys)
 

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 	base.LongRunningTest(t)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	base.RequireNumTestBuckets(t, 2)
 	testCases := []struct {

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 	base.LongRunningTest(t)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	base.RequireNumTestBuckets(t, 2)
 	testCases := []struct {


### PR DESCRIPTION
CBG-4747

- Draft of proposal to move serialisation off the critical path at the cache but also change the change listener to be keyed by ID struct not string to avid serialisation at the change waiter level 
- Supplementary doc to do with this PR -> https://docs.google.com/document/d/1LiUy_jvr3HjIYYB9uY3GPUQ_2CWXr80NdeVi3YJZ5Ns/edit?usp=sharing 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/165/
