### PR TITLE
Remove goutils logger

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -12,13 +12,10 @@ package base
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/couchbase/clog"
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbase/gocbcore/v10"
-	"github.com/couchbase/goutils/logging"
 	"github.com/couchbaselabs/rosmar"
 )
 
@@ -36,7 +33,6 @@ func initExternalLoggers() {
 		gocbcore.SetLogger(GoCBCoreLogger{})
 	}
 
-	logging.SetLogger(CBGoUtilsLogger{})
 	clog.SetLoggerCallback(ClogCallback)
 	// Set the clog level to DEBUG and do filtering for debug inside ClogCallback functions
 	clog.SetLevel(clog.LevelDebug)
@@ -157,98 +153,6 @@ func ClogCallback(level, format string, v ...any) string {
 		logTo(context.TODO(), LevelTrace, KeyDCP, format, v...)
 	}
 	return ""
-}
-
-// **************************************************************
-// Implementation for github.com/couchbase/goutils/logging.Logger
-// **************************************************************
-type CBGoUtilsLogger struct{}
-
-var _ logging.Logger = CBGoUtilsLogger{}
-
-func (CBGoUtilsLogger) SetLevel(l logging.Level) {
-	// no-op
-}
-
-// CBGoUtilsLogger.Level returns a compatible go-couchbase/golog Log Level for
-// the given logging config LogLevel
-func (CBGoUtilsLogger) Level() logging.Level {
-	logger := consoleLogger.Load()
-	if logger == nil || logger.LogLevel == nil {
-		return logging.INFO
-	}
-	switch *logger.LogLevel {
-	case LevelTrace:
-		return logging.TRACE
-	case LevelDebug:
-		return logging.DEBUG
-	case LevelInfo:
-		return logging.INFO
-	case LevelWarn:
-		return logging.WARN
-	case LevelError:
-		return logging.ERROR
-	case LevelNone:
-		return logging.NONE
-	default:
-		return logging.NONE
-	}
-}
-
-func (CBGoUtilsLogger) Fatalf(fmt string, args ...any) {
-	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-	FlushLogBuffers()
-	os.Exit(1)
-}
-
-func (CBGoUtilsLogger) Severef(fmt string, args ...any) {
-	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-}
-
-func (CBGoUtilsLogger) Errorf(fmt string, args ...any) {
-	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-}
-
-func (CBGoUtilsLogger) Warnf(fmt string, args ...any) {
-	logTo(context.TODO(), LevelWarn, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-}
-
-func (CBGoUtilsLogger) Infof(fmt string, args ...any) {
-	logTo(context.TODO(), LevelInfo, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-}
-
-func (CBGoUtilsLogger) Requestf(rlevel logging.Level, fmt string, args ...any) {
-	logTo(context.TODO(), LevelTrace, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-}
-
-func (CBGoUtilsLogger) Tracef(fmt string, args ...any) {
-	logTo(context.TODO(), LevelTrace, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-}
-
-func (CBGoUtilsLogger) Debugf(fmt string, args ...any) {
-	logTo(context.TODO(), LevelDebug, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-}
-
-func (CBGoUtilsLogger) Logf(level logging.Level, fmt string, args ...any) {
-	logTo(context.TODO(), LevelInfo, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
-}
-
-// go-couchbase/gomemcached don't use Pair/Map logs, so these are all stubs
-
-func (l CBGoUtilsLogger) Loga(level logging.Level, f func() string) { l.warnNotImplemented("Loga", f) }
-func (l CBGoUtilsLogger) Debuga(f func() string)                    { l.warnNotImplemented("Debuga", f) }
-func (l CBGoUtilsLogger) Tracea(f func() string)                    { l.warnNotImplemented("Tracea", f) }
-func (l CBGoUtilsLogger) Requesta(rlevel logging.Level, f func() string) {
-	l.warnNotImplemented("Requesta", f)
-}
-func (l CBGoUtilsLogger) Infoa(f func() string)   { l.warnNotImplemented("Infoa", f) }
-func (l CBGoUtilsLogger) Warna(f func() string)   { l.warnNotImplemented("Warna", f) }
-func (l CBGoUtilsLogger) Errora(f func() string)  { l.warnNotImplemented("Errora", f) }
-func (l CBGoUtilsLogger) Severea(f func() string) { l.warnNotImplemented("Severea", f) }
-func (l CBGoUtilsLogger) Fatala(f func() string)  { l.warnNotImplemented("Fatala", f) }
-
-func (CBGoUtilsLogger) warnNotImplemented(name string, f func() string) {
-	WarnfCtx(context.Background(), fmt.Sprintf("CBGoUtilsLogger: %s not implemented! %s", name, f()))
 }
 
 // **************************************************************************

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/couchbase/gocb/v2 v2.11.1
 	github.com/couchbase/gocbcore/v10 v10.8.1
 	github.com/couchbase/gomemcached v0.2.1
-	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20250522135601-8c9a5acda2c2
 	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
@@ -50,6 +49,7 @@ require (
 	github.com/couchbase/go-couchbase v0.1.1 // indirect
 	github.com/couchbase/gocbcoreps v0.1.4 // indirect
 	github.com/couchbase/goprotostellar v1.0.2 // indirect
+	github.com/couchbase/goutils v0.1.2 // indirect
 	github.com/couchbase/tools-common/cloud/v5 v5.0.3 // indirect
 	github.com/couchbase/tools-common/fs v1.0.2 // indirect
 	github.com/couchbase/tools-common/testing v1.0.1 // indirect


### PR DESCRIPTION
Remove goutils logger

This is just a proposal. I can see the benefit of leaving this in if cbgt decides to use this for something else. However, they have their own logging utility so this seems unlikely.

I believe this was used only from go-couchbase. This drops a direct dependency to an indirect dependency from cbgt only. It is used by cbgt to access cbauth which Sync Gateway is never going to use. https://github.com/couchbase/cbgt/blob/74dbd1c34db313c2b65a65f6e3cecca7eacb00b3/cbauth.go#L24 / https://github.com/couchbase/cbauth

Inspired from https://github.com/couchbase/sync_gateway/pull/7881