### PR TITLE
CBG-4981: fix panic in _config?include_runtime=true endpoint

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -512,15 +512,17 @@ func (h *handler) handleGetConfig() error {
 				return err
 			}
 
-			replications, err := database.SGReplicateMgr.GetReplications()
-			if err != nil {
-				return err
-			}
+			if database.SGReplicateMgr != nil {
+				replications, err := database.SGReplicateMgr.GetReplications()
+				if err != nil {
+					return err
+				}
 
-			dbConfig.Replications = make(map[string]*db.ReplicationConfig, len(replications))
+				dbConfig.Replications = make(map[string]*db.ReplicationConfig, len(replications))
 
-			for replicationName, replicationConfig := range replications {
-				dbConfig.Replications[replicationName] = replicationConfig.ReplicationConfig.Redacted(h.ctx())
+				for replicationName, replicationConfig := range replications {
+					dbConfig.Replications[replicationName] = replicationConfig.ReplicationConfig.Redacted(h.ctx())
+				}
 			}
 		}
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3730,7 +3730,9 @@ func TestGetConfigAfterFailToStartOnlineProcess(t *testing.T) {
 		},
 	}
 
-	// simulate regular startup
+	// Directly set the database state to DBStarting to simulate regular startup.
+	// This direct atomic manipulation is required in this test to simulate a state transition.
+	// This is safe in the context of this test.
 	atomic.StoreUint32(&rt.GetDatabase().State, db.DBStarting)
 	rt.WaitForDBState(db.RunStateString[db.DBStarting])
 


### PR DESCRIPTION
CBG-4981

- Have a nil check around sg replicate manager before attempting to fetch replications 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/167/
