### PR TITLE
CBG-5017 Resync: allow legacy rev documents to be resynced

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -149,7 +149,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		collectionCtx := databaseCollection.AddCollectionContext(ctx)
 		_, unusedSequences, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
-		}).resyncDocument(collectionCtx, docID, key, regenerateSequences, []uint64{})
+		}).ResyncDocument(collectionCtx, docID, key, regenerateSequences, []uint64{})
 
 		databaseCollection.releaseSequences(collectionCtx, unusedSequences)
 

--- a/db/database.go
+++ b/db/database.go
@@ -1854,6 +1854,10 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 			if db.useMou() {
 				doc.MetadataOnlyUpdate = computeMetadataOnlyUpdate(doc.Cas, doc.RevSeqNo, doc.MetadataOnlyUpdate)
 			}
+			doc, err = db.updateHLV(ctx, doc, Import, false)
+			if err != nil {
+				return sgbucket.UpdatedDoc{}, err
+			}
 
 			_, rawSyncXattr, rawVvXattr, rawMouXattr, rawGlobalXattr, err := updatedDoc.MarshalWithXattrs()
 			updatedDoc := sgbucket.UpdatedDoc{

--- a/db/database.go
+++ b/db/database.go
@@ -1856,24 +1856,14 @@ func (db *DatabaseCollectionWithUser) ResyncDocument(ctx context.Context, docid,
 			if db.useMou() {
 				doc.MetadataOnlyUpdate = computeMetadataOnlyUpdate(doc.Cas, doc.RevSeqNo, doc.MetadataOnlyUpdate)
 			}
-			// If legacy rev, don't update HLV
-			if _, ok := currentXattrs[base.VvXattrName]; ok {
-				doc, err = db.updateHLV(ctx, doc, Import, false)
-				if err != nil {
-					return sgbucket.UpdatedDoc{}, err
-				}
-			}
 
-			_, rawSyncXattr, rawVvXattr, rawMouXattr, rawGlobalXattr, err := updatedDoc.MarshalWithXattrs()
+			_, rawSyncXattr, _, rawMouXattr, rawGlobalXattr, err := updatedDoc.MarshalWithXattrs()
 			updatedDoc := sgbucket.UpdatedDoc{
 				Doc: nil, // Resync does not require document body update
 				Xattrs: map[string][]byte{
 					base.SyncXattrName: rawSyncXattr,
 				},
 				Expiry: updatedExpiry,
-			}
-			if rawVvXattr != nil {
-				updatedDoc.Xattrs[base.VvXattrName] = rawVvXattr
 			}
 			if db.useMou() {
 				updatedDoc.Xattrs[base.MouXattrName] = rawMouXattr

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3657,61 +3657,99 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 }
 
 func Test_resyncDocument(t *testing.T) {
-	if !base.TestUseXattrs() {
-		t.Skip("Walrus doesn't support xattr")
-	}
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
 	db.Options.EnableXattr = true
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
-	syncFn := `
+	testCases := []struct {
+		name   string
+		useHLV bool
+	}{
+		{
+			name:   "pre-4.0",
+			useHLV: true,
+		},
+		{
+			name:   "has_hlv",
+			useHLV: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			startingSyncFnCount := int(db.DbStats.Database().SyncFunctionCount.Value())
+			syncFn := `
 	function sync(doc, oldDoc){
 		channel("channel." + "ABC");
 	}
 `
-	_, err := collection.UpdateSyncFun(ctx, syncFn)
-	require.NoError(t, err)
+			_, err := collection.UpdateSyncFun(ctx, syncFn)
+			require.NoError(t, err)
 
-	docID := uuid.NewString()
+			docID := uuid.NewString()
 
-	updateBody := make(map[string]any)
-	updateBody["val"] = "value"
-	_, doc, err := collection.Put(ctx, docID, updateBody)
-	require.NoError(t, err)
-	assert.NotNil(t, doc)
+			updateBody := make(map[string]any)
+			updateBody["val"] = "value"
+			if tc.useHLV {
+				_, _, err := collection.Put(ctx, docID, updateBody)
+				require.NoError(t, err)
+			} else {
+				collection.CreateDocNoHLV(t, ctx, docID, updateBody)
+			}
 
-	syncFn = `
+			syncFn = `
 		function sync(doc, oldDoc){
 			channel("channel." + "ABC12332423234");
 		}
 	`
-	_, err = collection.UpdateSyncFun(ctx, syncFn)
-	require.NoError(t, err)
+			_, err = collection.UpdateSyncFun(ctx, syncFn)
+			require.NoError(t, err)
 
-	_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10})
-	require.NoError(t, err)
-	err = collection.WaitForPendingChanges(ctx)
-	require.NoError(t, err)
+			preResyncDoc, err := collection.GetDocument(ctx, docID, DocUnmarshalAll)
+			require.NoError(t, err)
+			if !tc.useHLV {
+				require.Nil(t, preResyncDoc.HLV)
+			}
+			_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10})
+			require.NoError(t, err)
+			err = collection.WaitForPendingChanges(ctx)
+			require.NoError(t, err)
 
-	syncData, err := collection.GetDocSyncData(ctx, docID)
-	assert.NoError(t, err)
+			postResyncDoc, _, err := collection.getDocWithXattrs(ctx, docID, collection.syncGlobalSyncMouRevSeqNoAndUserXattrKeys(), DocUnmarshalAll)
+			assert.NoError(t, err)
 
-	assert.Len(t, syncData.ChannelSet, 2)
-	assert.Len(t, syncData.Channels, 2)
-	found := false
+			assert.Len(t, postResyncDoc.ChannelSet, 2)
+			assert.Len(t, postResyncDoc.Channels, 2)
+			found := false
 
-	for _, chSet := range syncData.ChannelSet {
-		if chSet.Name == "channel.ABC12332423234" {
-			found = true
-			break
-		}
+			for _, chSet := range postResyncDoc.ChannelSet {
+				if chSet.Name == "channel.ABC12332423234" {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found)
+
+			require.NoError(t, err)
+			require.NotNil(t, postResyncDoc.HLV)
+			require.Equal(t, Version{
+				SourceID: db.EncodedSourceID,
+				Value:    preResyncDoc.Cas,
+			}, Version{
+				SourceID: postResyncDoc.HLV.SourceID,
+				Value:    postResyncDoc.HLV.Version,
+			})
+			require.NotNil(t, postResyncDoc.MetadataOnlyUpdate)
+			require.Equal(t, MetadataOnlyUpdate{
+				HexCAS:           base.CasToString(postResyncDoc.Cas),
+				PreviousHexCAS:   base.CasToString(preResyncDoc.Cas),
+				PreviousRevSeqNo: preResyncDoc.RevSeqNo,
+			}, *postResyncDoc.MetadataOnlyUpdate)
+			assert.Equal(t, startingSyncFnCount+2, int(db.DbStats.Database().SyncFunctionCount.Value()))
+		})
 	}
-
-	assert.True(t, found)
-	assert.Equal(t, 2, int(db.DbStats.Database().SyncFunctionCount.Value()))
-
 }
 
 func Test_getUpdatedDocument(t *testing.T) {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3668,12 +3668,12 @@ func Test_resyncDocument(t *testing.T) {
 		useHLV bool
 	}{
 		{
-			name:   "pre-4.0",
-			useHLV: true,
+			name:   "pre 4.0",
+			useHLV: false,
 		},
 		{
-			name:   "has_hlv",
-			useHLV: false,
+			name:   "has hlv",
+			useHLV: true,
 		},
 	}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3712,7 +3712,7 @@ func Test_resyncDocument(t *testing.T) {
 			if !tc.useHLV {
 				require.Nil(t, preResyncDoc.HLV)
 			}
-			_, _, err = collection.resyncDocument(ctx, docID, realDocID(docID), false, []uint64{10})
+			_, _, err = collection.ResyncDocument(ctx, docID, realDocID(docID), false, []uint64{10})
 			require.NoError(t, err)
 			err = collection.WaitForPendingChanges(ctx)
 			require.NoError(t, err)
@@ -3733,14 +3733,18 @@ func Test_resyncDocument(t *testing.T) {
 			assert.True(t, found)
 
 			require.NoError(t, err)
-			require.NotNil(t, postResyncDoc.HLV)
-			require.Equal(t, Version{
-				SourceID: db.EncodedSourceID,
-				Value:    preResyncDoc.Cas,
-			}, Version{
-				SourceID: postResyncDoc.HLV.SourceID,
-				Value:    postResyncDoc.HLV.Version,
-			})
+			if tc.useHLV {
+				require.NotNil(t, postResyncDoc.HLV)
+				require.Equal(t, Version{
+					SourceID: db.EncodedSourceID,
+					Value:    preResyncDoc.Cas,
+				}, Version{
+					SourceID: postResyncDoc.HLV.SourceID,
+					Value:    postResyncDoc.HLV.Version,
+				})
+			} else {
+				require.Nil(t, postResyncDoc.HLV)
+			}
 			require.NotNil(t, postResyncDoc.MetadataOnlyUpdate)
 			require.Equal(t, MetadataOnlyUpdate{
 				HexCAS:           base.CasToString(postResyncDoc.Cas),

--- a/rest/legacy_rev_test.go
+++ b/rest/legacy_rev_test.go
@@ -1,0 +1,65 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResyncLegacyRev makes sure that running resync on a legacy rev will send future blip messages as a legacy rev and not as an HLV
+func TestResyncLegacyRev(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	const (
+		alice = "alice"
+	)
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+	rt.CreateUser(alice, []string{collection.Name})
+
+	docID := db.SafeDocumentName(t, t.Name())
+	doc := rt.CreateDocNoHLV(docID, db.Body{"foo": "bar"})
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // requires hlv
+	btcRunner.Run(func(t *testing.T) {
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: alice})
+		defer btc.Close()
+
+		btcRunner.StartOneshotPull(btc.id)
+
+		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, DocVersion{RevTreeID: doc.GetRevTreeID()})
+		require.Equal(t, msg.Properties[db.RevMessageRev], doc.GetRevTreeID())
+	})
+	_, err := collection.UpdateSyncFun(ctx, fmt.Sprintf(`function() {channel("A", "%s")}`, collection.Name))
+	require.NoError(t, err)
+
+	// use ResyncDocument and TakeDbOffline/Online instead of /ks/_config/sync && /db/_resync to work under rosmar which
+	// doesn't yet support DCP resync or updating config on an existing bucket.
+	regenerateSequences := false
+	var unusedSequences []uint64
+	_, _, err = collection.ResyncDocument(ctx, docID, docID, regenerateSequences, unusedSequences)
+	require.NoError(t, err)
+
+	rt.TakeDbOffline()
+	rt.TakeDbOnline()
+
+	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	t.Logf("=== After resync ===")
+	btcRunner = NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // r
+	btcRunner.Run(func(t *testing.T) {
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: alice})
+		defer btc.Close()
+
+		btcRunner.StartOneshotPull(btc.id)
+
+		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, DocVersion{RevTreeID: doc.GetRevTreeID()})
+		require.Equal(t, msg.Properties[db.RevMessageRev], doc.GetRevTreeID())
+	})
+}

--- a/rest/legacy_rev_test.go
+++ b/rest/legacy_rev_test.go
@@ -24,7 +24,6 @@ func TestResyncLegacyRev(t *testing.T) {
 	doc := rt.CreateDocNoHLV(docID, db.Body{"foo": "bar"})
 
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // requires hlv
 	btcRunner.Run(func(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: alice})
 		defer btc.Close()
@@ -50,9 +49,7 @@ func TestResyncLegacyRev(t *testing.T) {
 	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, "")
 	RequireStatus(t, resp, http.StatusOK)
 
-	t.Logf("=== After resync ===")
 	btcRunner = NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true // r
 	btcRunner.Run(func(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: alice})
 		defer btc.Close()
@@ -60,6 +57,7 @@ func TestResyncLegacyRev(t *testing.T) {
 		btcRunner.StartOneshotPull(btc.id)
 
 		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, DocVersion{RevTreeID: doc.GetRevTreeID()})
+		// make sure second rev message after resync is still legacy rev format
 		require.Equal(t, msg.Properties[db.RevMessageRev], doc.GetRevTreeID())
 	})
 }

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1982,7 +1982,7 @@ func (btcc *BlipTesterCollectionClient) WaitForPullRevMessage(docID string, vers
 			return
 		}
 		var lookupVersion DocVersion
-		if btcc.UseHLV() {
+		if btcc.UseHLV() && !version.CV.IsEmpty() {
 			lookupVersion = DocVersion{CV: version.CV}
 		} else {
 			lookupVersion = DocVersion{RevTreeID: version.RevTreeID}


### PR DESCRIPTION
CBG-5017 Resync: allow legacy rev documents to be resynced

Do not write an HLV if the document doesn't have an HLV before. This does update `_mou` as it would in Sync Gateway 3.3

This fixes the error message:

```
Error updating doc %s: _vv: nil xattr value not allowed 
```
and allows a legacy rev to be resynced.


## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/185/
