### PR TITLE
CBG-4932 improve ResyncManger test flakes

### DIFF
--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -10,10 +10,8 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sync"
-	"testing"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -406,25 +404,6 @@ func (b *BackgroundManager) GetRunState() BackgroundProcessState {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	return b.State
-}
-
-// For test use only
-// Returns empty string if background process is not cluster aware
-func (b *BackgroundManager) GetHeartbeatDocID(t testing.TB) string {
-	if b.isClusterAware() {
-		return b.clusterAwareOptions.HeartbeatDocID()
-	}
-	return ""
-}
-
-// For test use only
-// Returns error if background process is not cluster aware
-func (b *BackgroundManager) GetHeartbeatDoc(t testing.TB) ([]byte, error) {
-	if b.isClusterAware() {
-		b, _, err := b.clusterAwareOptions.metadataStore.GetRaw(b.GetHeartbeatDocID(t))
-		return b, err
-	}
-	return nil, fmt.Errorf("background process is not cluster aware")
 }
 
 func (b *BackgroundManager) SetError(err error) {

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -55,7 +55,7 @@ func TestAttachmentMigrationTaskMixMigratedAndNonMigratedDocs(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for task to complete
-	RequireBackgroundManagerState(t, ctx, attachMigrationMgr, BackgroundProcessStateCompleted)
+	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateCompleted)
 
 	// assert that the subset (5) of the docs were changed, all created docs were processed (10)
 	stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
@@ -118,7 +118,7 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 		}
 	}()
 
-	RequireBackgroundManagerState(t, ctx, attachMigrationMgr, BackgroundProcessStateStopped)
+	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateStopped)
 
 	stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
 	require.Less(t, stats.DocsProcessed, int64(4000))
@@ -132,7 +132,7 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 	err = attachMigrationMgr.Start(ctx, nil)
 	require.NoError(t, err)
 
-	RequireBackgroundManagerState(t, ctx, attachMigrationMgr, BackgroundProcessStateCompleted)
+	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateCompleted)
 
 	stats = getAttachmentMigrationStats(t, attachMigrationMgr.Process)
 	require.GreaterOrEqual(t, stats.DocsProcessed, int64(4000))
@@ -169,7 +169,7 @@ func TestAttachmentMigrationManagerNoDocsToMigrate(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for task to complete
-	RequireBackgroundManagerState(t, ctx, attachMigrationMgr, BackgroundProcessStateCompleted)
+	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateCompleted)
 
 	// assert that the two added docs above were processed but not changed
 	stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)
@@ -227,7 +227,7 @@ func TestMigrationManagerDocWithSyncAndGlobalAttachmentMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for task to complete
-	RequireBackgroundManagerState(t, ctx, attachMigrationMgr, BackgroundProcessStateCompleted)
+	RequireBackgroundManagerState(t, attachMigrationMgr, BackgroundProcessStateCompleted)
 
 	// assert that the two added docs above were processed but not changed
 	stats := getAttachmentMigrationStats(t, attachMigrationMgr.Process)

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -236,7 +236,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			}
 			err = db.invalidateAllPrincipals(ctx, collectionNames, endSeq)
 			if err != nil {
-				return fmt.Errorf("Could not invalid principal documents: %w", err)
+				return fmt.Errorf("Could not invalidate principal documents: %w", err)
 			}
 
 		}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -234,7 +234,10 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			for _, databaseCollection := range db.CollectionByID {
 				collectionNames = append(collectionNames, databaseCollection.ScopeAndCollectionName())
 			}
-			db.invalidateAllPrincipals(ctx, collectionNames, endSeq)
+			err = db.invalidateAllPrincipals(ctx, collectionNames, endSeq)
+			if err != nil {
+				return fmt.Errorf("Could not invalid principal documents: %w", err)
+			}
 
 		}
 

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -630,6 +630,7 @@ func waitForResyncState(t testing.TB, db *Database, desiredState BackgroundProce
 
 // waitForResyncDocsProcessed waits until the resync manager has processed more than the specified count of documents.
 func waitForResyncDocsProcessed(t testing.TB, db *Database, count int64) {
+	// this intentionally uses a very short poll interval to catch progress as quickly as possible
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		stats := getResyncStats(t, db)
 		assert.Greater(c, stats.DocsProcessed, count)

--- a/db/database.go
+++ b/db/database.go
@@ -1916,15 +1916,19 @@ func (db *DatabaseCollectionWithUser) resyncDocument(ctx context.Context, docid,
 }
 
 // invalidateAllPrincipals invalidates computed channels and roles for all users/roles, for the specified collections:
-func (dbCtx *DatabaseContext) invalidateAllPrincipals(ctx context.Context, collectionNames base.ScopeAndCollectionNames, endSeq uint64) {
+func (dbCtx *DatabaseContext) invalidateAllPrincipals(ctx context.Context, collectionNames base.ScopeAndCollectionNames, endSeq uint64) error {
 	base.InfofCtx(ctx, base.KeyAll, "Invalidating channel caches of users/roles...")
-	users, roles, _ := dbCtx.AllPrincipalIDs(ctx)
+	users, roles, err := dbCtx.AllPrincipalIDs(ctx)
+	if err != nil {
+		return err
+	}
 	for _, name := range users {
 		dbCtx.invalUserRolesAndChannels(ctx, name, collectionNames, endSeq)
 	}
 	for _, name := range roles {
 		dbCtx.invalRoleChannels(ctx, name, collectionNames, endSeq)
 	}
+	return nil
 }
 
 // invalUserChannels invalidates a user's computed channels for the specified collections

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -428,11 +428,6 @@ func (c *DatabaseCollection) invalRoleChannels(ctx context.Context, rolename str
 	c.dbCtx.invalRoleChannels(ctx, rolename, base.ScopeAndCollectionNames{c.ScopeAndCollectionName()}, invalSeq)
 }
 
-// invalidateAllPrincipals invalidates computed channels and roles for collection c, for all users and roles
-func (c *DatabaseCollection) invalidateAllPrincipals(ctx context.Context, endSeq uint64) {
-	c.dbCtx.invalidateAllPrincipals(ctx, base.ScopeAndCollectionNames{c.ScopeAndCollectionName()}, endSeq)
-}
-
 func (c *DatabaseCollection) useMou() bool {
 	return c.dbCtx.UseMou()
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -3590,7 +3590,7 @@ func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Greater(t, endSeq, uint64(0))
 
-	collection.invalidateAllPrincipals(ctx, endSeq)
+	require.NoError(t, db.invalidateAllPrincipals(ctx, base.ScopeAndCollectionNames{sgbucket.DataStoreNameImpl{Scope: collection.ScopeName, Collection: collection.Name}}, endSeq))
 	err = collection.WaitForPendingChanges(ctx)
 	assert.NoError(t, err)
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -938,8 +938,8 @@ func MoveAttachmentXattrFromGlobalToSync(t *testing.T, dataStore base.DataStore,
 func RequireBackgroundManagerState(t testing.TB, mgr *BackgroundManager, expState BackgroundProcessState) BackgroundManagerStatus {
 	waitTime := 10 * time.Second
 	if !base.UnitTestUrlIsWalrus() {
-		// Increase wait time for CI tests against Couchbase Server with GSI disabled (views), some queries take a
-		// longer time to run
+		// Increase wait time for CI tests against Couchbase Server, they can take longer to run.
+		// Generally everything runs in 10 seconds, but when it does not, it is not worth flagging the failures.
 		waitTime = 30 * time.Second
 	}
 	ctx := base.TestCtx(t)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -933,8 +933,7 @@ func MoveAttachmentXattrFromGlobalToSync(t *testing.T, dataStore base.DataStore,
 	require.NoError(t, err)
 }
 
-// RequireBackgroundManagerState waits for a BackgroundManager to reach a given state within 10 seconds or fails test
-// harness.
+// RequireBackgroundManagerState waits for a BackgroundManager to reach a given state or fails test harness.
 func RequireBackgroundManagerState(t testing.TB, mgr *BackgroundManager, expState BackgroundProcessState) BackgroundManagerStatus {
 	waitTime := 10 * time.Second
 	if !base.UnitTestUrlIsWalrus() {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -968,7 +968,9 @@ func RequireBackgroundManagerState(t testing.TB, mgr *BackgroundManager, expStat
 		assert.Equal(c, expState, status.State, "BackgroundManager did not reach expected state in %d seconds. Current status: %s", int(waitTime.Seconds()), string(rawStatus))
 	}, waitTime, time.Millisecond*10)
 
-	WaitForBackgroundManagerHeartbeatDocRemoval(t, mgr)
+	if slices.Contains([]BackgroundProcessState{BackgroundProcessStateCompleted, BackgroundProcessStateStopped, BackgroundProcessStateError}, expState) {
+		WaitForBackgroundManagerHeartbeatDocRemoval(t, mgr)
+	}
 	return *status
 }
 

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -281,12 +281,7 @@ func TestRequireResync(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", string(resyncPayload))
 	rest.RequireStatus(t, resp, http.StatusOK)
 
-	db2, err := rt.ServerContext().GetDatabase(rt.Context(), db2Name)
-	require.NoError(t, err)
-	rest.WaitAndAssertBackgroundManagerState(t, db.BackgroundProcessStateCompleted,
-		func(t testing.TB) db.BackgroundProcessState {
-			return db2.ResyncManager.GetRunState()
-		})
+	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
 
 	resp = rt.SendAdminRequest("GET", "/_all_dbs?verbose=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -280,8 +280,9 @@ func TestRequireResync(t *testing.T) {
 
 	resp = rt.SendAdminRequest("POST", "/"+db2Name+"/_resync?action=start&regenerate_sequences=true", string(resyncPayload))
 	rest.RequireStatus(t, resp, http.StatusOK)
-
-	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
+	db2, err := rt.ServerContext().GetDatabase(rt.Context(), db2Name)
+	require.NoError(t, err)
+	db.RequireBackgroundManagerState(t, db2.ResyncManager, db.BackgroundProcessStateCompleted)
 
 	resp = rt.SendAdminRequest("GET", "/_all_dbs?verbose=true", "")
 	rest.RequireStatus(t, resp, http.StatusOK)

--- a/rest/attachmentmigrationtest/attachment_migration_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_test.go
@@ -385,6 +385,6 @@ func getAttachmentMigrationManagerStatus(rt *rest.RestTester) db.AttachmentMigra
 // waitForAttachmentMigrationState waits for the AttachmentMigrationManager to reach the expected state and then returns
 // its status.
 func waitForAttachmentMigrationState(rt *rest.RestTester, expectedState db.BackgroundProcessState) db.AttachmentMigrationManagerResponse {
-	db.RequireBackgroundManagerState(rt.TB(), rt.Context(), rt.GetDatabase().AttachmentMigrationManager, expectedState)
+	db.RequireBackgroundManagerState(rt.TB(), rt.GetDatabase().AttachmentMigrationManager, expectedState)
 	return getAttachmentMigrationManagerStatus(rt)
 }

--- a/rest/attachmentmigrationtest/attachment_migration_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_test.go
@@ -121,7 +121,7 @@ func TestChangeDbCollectionsRestartMigrationJob(t *testing.T) {
 
 	dbCtx = rt.GetDatabase()
 	scNames = append(scNames, base.ScopeAndCollectionName{Scope: scope, Collection: collection2})
-	assert.ElementsMatch(t, scNames, dbCtx.RequireAttachmentMigration)
+	require.ElementsMatch(t, scNames, dbCtx.RequireAttachmentMigration)
 	mgrStatus := waitForAttachmentMigrationState(rt, db.BackgroundProcessStateCompleted)
 
 	// assert that number of docs precessed is greater than the total docs added, this will be because when updating

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2318,27 +2318,6 @@ func WaitAndAssertConditionTimeout(t *testing.T, timeout time.Duration, fn func(
 	}
 }
 
-func WaitAndAssertBackgroundManagerState(t testing.TB, expected db.BackgroundProcessState, getStateFunc func(t testing.TB) db.BackgroundProcessState) bool {
-	t.Helper()
-	err, actual := base.RetryLoop(base.TestCtx(t), t.Name()+"-WaitAndAssertBackgroundManagerState", func() (shouldRetry bool, err error, value db.BackgroundProcessState) {
-		actual := getStateFunc(t)
-		return expected != actual, nil, actual
-	}, base.CreateMaxDoublingSleeperFunc(30, 100, 1000))
-	return assert.NoErrorf(t, err, "expected background manager state %v, but got: %v", expected, actual)
-}
-
-func WaitAndAssertBackgroundManagerExpiredHeartbeat(t testing.TB, bm *db.BackgroundManager) bool {
-	t.Helper()
-	err, b := base.RetryLoop(base.TestCtx(t), t.Name()+"-assertNoHeartbeatDoc", func() (shouldRetry bool, err error, value []byte) {
-		b, err := bm.GetHeartbeatDoc(t)
-		return !base.IsDocNotFoundError(err), err, b
-	}, base.CreateMaxDoublingSleeperFunc(30, 100, 1000))
-	if b != nil {
-		return assert.NoErrorf(t, err, "expected heartbeat doc to expire, but found one with contents: %s", b)
-	}
-	return assert.Truef(t, base.IsDocNotFoundError(err), "expected heartbeat doc to expire, but got a different error: %v", err)
-}
-
 type DocVersion = db.DocVersion
 
 // RequireDocVersionNotNil calls t.Fail if two document version is not specified.

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"context"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -97,6 +98,10 @@ func (rt *RestTester) WaitForAttachmentMigrationStatus(t *testing.T, state db.Ba
 		require.NoError(c, err)
 		assert.Equal(c, state, response.State)
 	}, time.Second*20, time.Millisecond*100)
+	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, state) {
+		db.WaitForBackgroundManagerHeartbeatDocRemoval(t, rt.GetDatabase().AttachmentMigrationManager)
+		return response
+	}
 
 	return response
 }

--- a/rest/utilities_testing_attachment.go
+++ b/rest/utilities_testing_attachment.go
@@ -98,10 +98,10 @@ func (rt *RestTester) WaitForAttachmentMigrationStatus(t *testing.T, state db.Ba
 		require.NoError(c, err)
 		assert.Equal(c, state, response.State)
 	}, time.Second*20, time.Millisecond*100)
+	// Wait for heartbeat doc removal if the state change will result in its removal. Allows calling start
+	// immediately after db.BackgroundProcessStateStopped without error.
 	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, state) {
 		db.WaitForBackgroundManagerHeartbeatDocRemoval(t, rt.GetDatabase().AttachmentMigrationManager)
-		return response
 	}
-
 	return response
 }

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -410,7 +411,9 @@ func (rt *RestTester) WaitForResyncDCPStatus(status db.BackgroundProcessState) d
 
 		assert.Equal(c, status, resyncStatus.State)
 	}, time.Second*10, time.Millisecond*10)
-	db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().ResyncManager)
+	if !slices.Contains([]db.BackgroundProcessState{db.BackgroundProcessStateRunning, db.BackgroundProcessStateStopping}, status) {
+		db.WaitForBackgroundManagerHeartbeatDocRemoval(rt.TB(), rt.GetDatabase().ResyncManager)
+	}
 	return resyncStatus
 }
 


### PR DESCRIPTION
- the problem seems to be that some tests take a long time to run, mostly after churn of the bucket pool to do query operations after resync finishes
- clean up to use test functions for waiting


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/175/ (known independent test failure)
