### PR TITLE
CBG-3690 don't re-read document for resync

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -134,7 +134,7 @@ const (
 	// VirtualXattrRevSeqNo is used to fetch rev seq no from documents virtual xattr
 	VirtualXattrRevSeqNo = "$document.revid"
 
-	// VirtualExpiry is used to fetch the expiry from  documents
+	// VirtualExpiry is used to fetch the expiry from documents
 	VirtualExpiry = "$document.exptime"
 
 	// VirtualDocumentXattr is used to fetch the documents virtual xattr

--- a/base/constants.go
+++ b/base/constants.go
@@ -133,6 +133,10 @@ const (
 
 	// VirtualXattrRevSeqNo is used to fetch rev seq no from documents virtual xattr
 	VirtualXattrRevSeqNo = "$document.revid"
+
+	// VirtualExpiry is used to fetch the expiry from  documents
+	VirtualExpiry = "$document.exptime"
+
 	// VirtualDocumentXattr is used to fetch the documents virtual xattr
 	VirtualDocumentXattr = "$document"
 

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -124,7 +124,6 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 
 	callback := func(event sgbucket.FeedEvent) bool {
 		docID := string(event.Key)
-		key := realDocID(docID)
 		base.TracefCtx(ctx, base.KeyAll, "[%s] Received DCP event %d for doc %v", resyncLoggingID, event.Opcode, base.UD(docID))
 
 		// Ignore documents without xattrs if possible, to avoid processing unnecessary documents
@@ -132,7 +131,8 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			return true
 		}
 		// Don't want to process raw binary docs
-		// The binary check should suffice but for additional safety also check for empty bodies
+		// The binary check should suffice but for additional safety also check for empty bodies. This will also avoid
+		// processing tombstones.
 		if event.DataType == base.MemcachedDataTypeRaw || len(event.Value) == 0 {
 			return true
 		}
@@ -147,9 +147,14 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		databaseCollection := db.CollectionByID[event.CollectionID]
 		databaseCollection.collectionStats.ResyncNumProcessed.Add(1)
 		collectionCtx := databaseCollection.AddCollectionContext(ctx)
-		_, unusedSequences, err := (&DatabaseCollectionWithUser{
+		doc, err := bucketDocumentFromFeed(event)
+		if err != nil {
+			base.WarnfCtx(collectionCtx, "[%s] Error getting document from DCP event for doc %q: %v", resyncLoggingID, base.UD(docID), err)
+			return false
+		}
+		unusedSequences, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
-		}).ResyncDocument(collectionCtx, docID, key, regenerateSequences, []uint64{})
+		}).ResyncDocument(collectionCtx, docID, doc, regenerateSequences)
 
 		databaseCollection.releaseSequences(collectionCtx, unusedSequences)
 
@@ -159,6 +164,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			databaseCollection.collectionStats.ResyncNumChanged.Add(1)
 		} else if err != base.ErrUpdateCancel {
 			base.WarnfCtx(collectionCtx, "[%s] Error updating doc %q: %v", resyncLoggingID, base.UD(docID), err)
+			return false
 		}
 		return true
 	}

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -152,11 +152,9 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 			base.WarnfCtx(collectionCtx, "[%s] Error getting document from DCP event for doc %q: %v", resyncLoggingID, base.UD(docID), err)
 			return false
 		}
-		unusedSequences, err := (&DatabaseCollectionWithUser{
+		err = (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
 		}).ResyncDocument(collectionCtx, docID, doc, regenerateSequences)
-
-		databaseCollection.releaseSequences(collectionCtx, unusedSequences)
 
 		if err == nil {
 			r.DocsChanged.Add(1)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2724,7 +2724,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		if expiry != nil {
 			initialExpiry = *expiry
 		}
-		casOut, err = db.dataStore.WriteUpdateWithXattrs(ctx, key, db.syncGlobalSyncMouRevSeqNoAndUserXattrKeys(), initialExpiry, existingDoc, opts, func(currentValue []byte, currentXattrs map[string][]byte, cas uint64) (updatedDoc sgbucket.UpdatedDoc, err error) {
+		casOut, err = db.dataStore.WriteUpdateWithXattrs(ctx, key, db.syncGlobalSyncMouAndUserXattrKeys(), initialExpiry, existingDoc, opts, func(currentValue []byte, currentXattrs map[string][]byte, cas uint64) (updatedDoc sgbucket.UpdatedDoc, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = db.unmarshalDocumentWithXattrs(ctx, docid, currentValue, currentXattrs, cas, DocUnmarshalAll); err != nil {
 				return

--- a/db/database.go
+++ b/db/database.go
@@ -1838,7 +1838,6 @@ func (db *DatabaseCollectionWithUser) ResyncDocument(ctx context.Context, docid 
 		if err != nil {
 			return sgbucket.UpdatedDoc{}, err
 		}
-		fmt.Printf("%+v\n", doc)
 		updatedDoc, shouldUpdate, updatedExpiry, _, updatedUnusedSequences, err = db.getResyncedDocument(ctx, doc, regenerateSequences, nil)
 		if err != nil {
 			return sgbucket.UpdatedDoc{}, err
@@ -1854,7 +1853,6 @@ func (db *DatabaseCollectionWithUser) ResyncDocument(ctx context.Context, docid 
 
 		// Update MetadataOnlyUpdate based on previous Cas, MetadataOnlyUpdate
 		doc.MetadataOnlyUpdate = computeMetadataOnlyUpdate(doc.Cas, doc.RevSeqNo, doc.MetadataOnlyUpdate)
-		fmt.Printf("updatedDoc= %+v\n", updatedDoc)
 		_, rawSyncXattr, _, rawMouXattr, rawGlobalXattr, err := updatedDoc.MarshalWithXattrs()
 		updatedDoc := sgbucket.UpdatedDoc{
 			Doc: nil, // Resync does not require document body update

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -323,9 +323,20 @@ func (c *DatabaseCollection) syncGlobalSyncAndUserXattrKeys() []string {
 	return xattrKeys
 }
 
+// syncGlobalSyncMouAndUserXattrKeys returns the xattr keys for the user, mou and sync xattrs.
+func (c *DatabaseCollection) syncGlobalSyncMouAndUserXattrKeys() []string {
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName,
+		base.MouXattrName, base.GlobalXattrName}
+	userXattrKey := c.userXattrKey()
+	if userXattrKey != "" {
+		xattrKeys = append(xattrKeys, userXattrKey)
+	}
+	return xattrKeys
+}
+
 // syncGlobalSyncMouRevSeqNoAndUserXattrKeys returns the xattr keys for the user, mou, revSeqNo and sync xattrs.
 func (c *DatabaseCollection) syncGlobalSyncMouRevSeqNoAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName, base.VvXattrName}
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.VirtualXattrRevSeqNo}
 	if c.useMou() {
 		xattrKeys = append(xattrKeys, base.MouXattrName, base.GlobalXattrName)
 	}

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -336,10 +336,7 @@ func (c *DatabaseCollection) syncGlobalSyncMouAndUserXattrKeys() []string {
 
 // syncGlobalSyncMouRevSeqNoAndUserXattrKeys returns the xattr keys for the user, mou, revSeqNo and sync xattrs.
 func (c *DatabaseCollection) syncGlobalSyncMouRevSeqNoAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.VirtualXattrRevSeqNo}
-	if c.useMou() {
-		xattrKeys = append(xattrKeys, base.MouXattrName, base.GlobalXattrName)
-	}
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.VirtualXattrRevSeqNo, base.MouXattrName, base.GlobalXattrName}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)

--- a/db/document.go
+++ b/db/document.go
@@ -612,21 +612,6 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, userXattrKey
 	return rawDoc, syncData, nil
 }
 
-func UnmarshalDocumentFromFeed(ctx context.Context, docid string, cas uint64, data []byte, dataType uint8, userXattrKey string) (doc *Document, err error) {
-	if dataType&base.MemcachedDataTypeXattr == 0 {
-		return unmarshalDocument(docid, data)
-	}
-	xattrKeys := []string{base.SyncXattrName}
-	if userXattrKey != "" {
-		xattrKeys = append(xattrKeys, userXattrKey)
-	}
-	body, xattrs, err := sgbucket.DecodeValueWithXattrs(xattrKeys, data)
-	if err != nil {
-		return nil, err
-	}
-	return unmarshalDocumentWithXattrs(ctx, docid, body, xattrs[base.SyncXattrName], xattrs[base.VvXattrName], xattrs[base.MouXattrName], xattrs[userXattrKey], xattrs[base.VirtualXattrRevSeqNo], nil, cas, DocUnmarshalAll)
-}
-
 func (doc *SyncData) HasValidSyncData() bool {
 
 	valid := doc != nil && doc.GetRevTreeID() != "" && (doc.Sequence > 0)
@@ -1577,4 +1562,19 @@ func (d DocVersion) CVOrRevTreeID() string {
 		return cv.String()
 	}
 	return d.RevTreeID
+}
+
+// bucketDocumentFromFeed converts a sgbucket.FeedEvent to a sgbucket.BucketDocument
+func bucketDocumentFromFeed(event sgbucket.FeedEvent) (*sgbucket.BucketDocument, error) {
+	body, xattrs, err := sgbucket.DecodeValueWithAllXattrs(event.Value)
+	if err != nil {
+		return nil, err
+	}
+	return &sgbucket.BucketDocument{
+		Body:        body,
+		Xattrs:      xattrs,
+		Cas:         event.Cas,
+		Expiry:      event.Expiry,
+		IsTombstone: event.Opcode == sgbucket.FeedOpDeletion,
+	}, nil
 }

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -1490,6 +1490,8 @@ func TestImportWithSyncCVAndNoVV(t *testing.T) {
 
 }
 
+// getBucketDocument reads the current version of a document and turns it into a sgbucket.BucketDocument. This is
+// intended for test use only, since this gets expiry as a separate option.
 func getBucketDocument(t *testing.T, collection *DatabaseCollection, docID string) *sgbucket.BucketDocument {
 	ctx := base.TestCtx(t)
 	xattrNames := append(collection.syncGlobalSyncMouRevSeqNoAndUserXattrKeys(), base.VirtualExpiry)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -477,14 +477,9 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 			assert.NoError(t, err, "Error writing doc w/ expiry")
 
 			// Get the existing bucket doc
-			_, existingBucketDoc, err := collection.GetDocWithXattrs(ctx, key, DocUnmarshalAll)
-			assert.NoError(t, err, fmt.Sprintf("Error retrieving doc w/ xattr: %v", err))
+			existingBucketDoc := getBucketDocument(t, collection.DatabaseCollection, key)
+			require.NoError(t, err)
 
-			body = Body{}
-			err = body.Unmarshal(existingBucketDoc.Body)
-			assert.NoError(t, err, "Error unmarshalling body")
-
-			// Set the expiry value
 			syncMetaExpiryUnix := syncMetaExpiry.Unix()
 			expiry := uint32(syncMetaExpiryUnix)
 
@@ -1493,4 +1488,25 @@ func TestImportWithSyncCVAndNoVV(t *testing.T) {
 
 	base.RequireWaitForStat(t, db.DbStats.Database().Crc32MatchCount.Value, 1)
 
+}
+
+func getBucketDocument(t *testing.T, collection *DatabaseCollection, docID string) *sgbucket.BucketDocument {
+	ctx := base.TestCtx(t)
+	xattrNames := append(collection.syncGlobalSyncMouRevSeqNoAndUserXattrKeys(), base.VirtualExpiry)
+	body, xattrs, cas, err := collection.dataStore.GetWithXattrs(ctx, docID, xattrNames)
+	require.NoError(t, err)
+	var expiry uint32
+	if expiryBytes, ok := xattrs[base.VirtualExpiry]; ok {
+		err := base.JSONUnmarshal(expiryBytes, &expiry)
+		require.NoError(t, err)
+		delete(xattrs, base.VirtualExpiry)
+	}
+
+	return &sgbucket.BucketDocument{
+		Body:        body,
+		Xattrs:      xattrs,
+		Cas:         cas,
+		Expiry:      expiry,
+		IsTombstone: len(body) == 0,
+	}
 }

--- a/rest/legacy_rev_test.go
+++ b/rest/legacy_rev_test.go
@@ -55,8 +55,7 @@ func TestResyncLegacyRev(t *testing.T) {
 	// use ResyncDocument and TakeDbOffline/Online instead of /ks/_config/sync && /db/_resync to work under rosmar which
 	// doesn't yet support DCP resync or updating config on an existing bucket.
 	regenerateSequences := false
-	var unusedSequences []uint64
-	_, _, err = collection.ResyncDocument(ctx, docID, docID, regenerateSequences, unusedSequences)
+	_, err = collection.ResyncDocument(ctx, docID, nil, regenerateSequences)
 	require.NoError(t, err)
 
 	rt.TakeDbOffline()

--- a/rest/legacy_rev_test.go
+++ b/rest/legacy_rev_test.go
@@ -55,7 +55,7 @@ func TestResyncLegacyRev(t *testing.T) {
 	// use ResyncDocument and TakeDbOffline/Online instead of /ks/_config/sync && /db/_resync to work under rosmar which
 	// doesn't yet support DCP resync or updating config on an existing bucket.
 	regenerateSequences := false
-	_, err = collection.ResyncDocument(ctx, docID, nil, regenerateSequences)
+	err = collection.ResyncDocument(ctx, docID, nil, regenerateSequences)
 	require.NoError(t, err)
 
 	rt.TakeDbOffline()


### PR DESCRIPTION
CBG-3690 don't re-read document for resync

- one fix to create hlv if none exists from https://github.com/couchbase/sync_gateway/pull/7890
- remove non xattr code pathway
- removed redundant args from resyncDocument and unused return param

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/171/ (unrelated flake in TestRemoveIndexesUseViewsTrueAndFalse)
