### PR TITLE
CBG-5024 Remove non multisubdoc xattr support

### DIFF
--- a/base/collection_xattr_test.go
+++ b/base/collection_xattr_test.go
@@ -537,320 +537,316 @@ func TestWriteTombstoneWithXattrs(t *testing.T) {
 			cas:            incorrectCas,
 			writeErrorFunc: RequireDocNotFoundError,
 		},
-	}
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		tests = append(tests, []testCase{
-			// alive document with multiple xattrs
-			/* CBG-3918, should be a cas mismatch error
-			{
-				name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        zeroCas,
-				deleteBody: true,
-				writeErrorFunc: requireCasMismatchError,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+		// alive document with multiple xattrs
+		/* CBG-3918, should be a cas mismatch error
+		{
+			name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			*/
-			{
-				name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     true,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=correct,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        previousCas,
-				deleteBody: true,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+			cas:        zeroCas,
+			deleteBody: true,
+			writeErrorFunc: requireCasMismatchError,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		*/
+		{
+			name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			{
-				name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            zeroCas,
-				deleteBody:     false,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     false,
-				writeErrorFunc: requireCasMismatchError,
-			},
-			{
-				name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=correct,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        previousCas,
-				deleteBody: false,
-				finalBody:  []byte(`{"foo": "bar"}`),
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+			cas:            incorrectCas,
+			deleteBody:     true,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body+_xattr1,xattrsToUpdate=_xattr1+_xattr2,cas=correct,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			// alive document with no xattrs
-			/* CBG-3918, should be a cas mismatch error
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        zeroCas,
-				deleteBody: true,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        previousCas,
+			deleteBody: true,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		{
+			name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			*/
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     true,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=correct,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        previousCas,
-				deleteBody: true,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+			cas:            zeroCas,
+			deleteBody:     false,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=0,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            zeroCas,
-				deleteBody:     false,
-				writeErrorFunc: requireCasMismatchError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=incorrect,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     false,
-				writeErrorFunc: requireCasMismatchError,
-			},
-			{
-				name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=correct,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        previousCas,
-				deleteBody: false,
-				finalBody:  []byte(`{"foo": "bar"}`),
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+			cas:            incorrectCas,
+			deleteBody:     false,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body+_xattr1+_xattr2,xattrsToUpdate=_xattr1+_xattr2,cas=correct,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			// tombstone with multiple xattrs
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            zeroCas,
-				deleteBody:     true,
-				writeErrorFunc: RequireDocNotFoundError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     true,
-				writeErrorFunc: RequireDocNotFoundError,
+			cas:        previousCas,
+			deleteBody: false,
+			finalBody:  []byte(`{"foo": "bar"}`),
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,cas=0,deleteBody=false",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:        zeroCas,
-				deleteBody: false,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
+		},
+		// alive document with no xattrs
+		/* CBG-3918, should be a cas mismatch error
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        zeroCas,
+			deleteBody: true,
+			writeErrorFunc: requireCasMismatchError,
+			},
+		},
+		*/
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            incorrectCas,
+			deleteBody:     true,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=correct,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        previousCas,
+			deleteBody: true,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=0,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            zeroCas,
+			deleteBody:     false,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=incorrect,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            incorrectCas,
+			deleteBody:     false,
+			writeErrorFunc: requireCasMismatchError,
+		},
+		{
+			name: "previousDoc=body,xattrsToUpdate=_xattr1,cas=correct,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+			},
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        previousCas,
+			deleteBody: false,
+			finalBody:  []byte(`{"foo": "bar"}`),
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		// tombstone with multiple xattrs
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1+_xattr2,cas=0,deleteBody=true",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            zeroCas,
+			deleteBody:     true,
+			writeErrorFunc: RequireDocNotFoundError,
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1+_xattr2,cas=incorrect,deleteBody=true",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            incorrectCas,
+			deleteBody:     true,
+			writeErrorFunc: RequireDocNotFoundError,
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1,cas=0,deleteBody=false",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:        zeroCas,
+			deleteBody: false,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1,cas=incorrect,deleteBody=false",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			cas:            incorrectCas,
+			deleteBody:     false,
+			writeErrorFunc: RequireDocNotFoundError,
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=false",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			xattrsToDelete: []string{"_xattr2"},
+			cas:            zeroCas,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+		},
+		{
+			name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=true",
+			previousDoc: nil,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			xattrsToDelete: []string{"_xattr2"},
+			cas:            zeroCas,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			deleteBody:     true,
+			writeErrorFunc: RequireDocNotFoundError,
+		},
+		{
+			name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=false",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,cas=incorrect,deleteBody=false",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				cas:            incorrectCas,
-				deleteBody:     false,
-				writeErrorFunc: RequireDocNotFoundError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=false",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				xattrsToDelete: []string{"_xattr2"},
-				cas:            zeroCas,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
+			xattrsToDelete: []string{"_xattr2"},
+			cas:            previousCas,
+			deleteBody:     false,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+			},
+			finalBody: []byte(`{"foo": "bar"}`),
+		},
+		{
+			name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=true",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
 			},
-			{
-				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=true",
-				previousDoc: nil,
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				xattrsToDelete: []string{"_xattr2"},
-				cas:            zeroCas,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				deleteBody:     true,
-				writeErrorFunc: RequireDocNotFoundError,
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
 			},
-			{
-				name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=false",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				xattrsToDelete: []string{"_xattr2"},
-				cas:            previousCas,
-				deleteBody:     false,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				finalBody: []byte(`{"foo": "bar"}`),
+			xattrsToDelete: []string{"_xattr2"},
+			cas:            previousCas,
+			deleteBody:     true,
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
 			},
-			{
-				name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=true",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
-				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-				xattrsToDelete: []string{"_xattr2"},
-				cas:            previousCas,
-				deleteBody:     true,
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-				},
-			},
-		}...)
+		},
 	}
 
 	for _, test := range tests {
@@ -999,75 +995,70 @@ func TestWriteUpdateWithXattrs(t *testing.T) {
 			},
 			finalXattrs: map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
 		},
-	}
-
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		tests = append(tests, []testCase{
-			{
-				name: "previousDoc=body+_xattr1,_xattr2,updatedDoc=_xattr1",
-				previousDoc: &sgbucket.BucketDocument{
-					Body: []byte(`{"foo": "bar"}`),
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-						"_xattr2": []byte(`{"e" : "f"}`),
-					},
-				},
-				updatedDoc: sgbucket.UpdatedDoc{
-					Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
-					IsTombstone: true,
-				},
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c" : "d"}`),
+		{
+			name: "previousDoc=body+_xattr1,_xattr2,updatedDoc=_xattr1",
+			previousDoc: &sgbucket.BucketDocument{
+				Body: []byte(`{"foo": "bar"}`),
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 					"_xattr2": []byte(`{"e" : "f"}`),
 				},
 			},
-			{
-				name: "previousDoc=_xattr1,xattr2,updatedDoc=_xattr1",
-				previousDoc: &sgbucket.BucketDocument{
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-						"_xattr2": []byte(`{"e" : "f"}`),
-					},
-				},
-				updatedDoc: sgbucket.UpdatedDoc{
-					Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
-					IsTombstone: true,
-				},
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c" : "d"}`),
+			updatedDoc: sgbucket.UpdatedDoc{
+				Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
+				IsTombstone: true,
+			},
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c" : "d"}`),
+				"_xattr2": []byte(`{"e" : "f"}`),
+			},
+		},
+		{
+			name: "previousDoc=_xattr1,xattr2,updatedDoc=_xattr1",
+			previousDoc: &sgbucket.BucketDocument{
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 					"_xattr2": []byte(`{"e" : "f"}`),
 				},
 			},
-			{
-				name: "previousDoc=_xattr1,xattr2,updatedDoc=tombstone+_xattr1",
-				previousDoc: &sgbucket.BucketDocument{
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-						"_xattr2": []byte(`{"e" : "f"}`),
-					},
-				},
-				updatedDoc: sgbucket.UpdatedDoc{
-					IsTombstone: true,
-					Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)}},
-				finalXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c" : "d"}`),
+			updatedDoc: sgbucket.UpdatedDoc{
+				Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)},
+				IsTombstone: true,
+			},
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c" : "d"}`),
+				"_xattr2": []byte(`{"e" : "f"}`),
+			},
+		},
+		{
+			name: "previousDoc=_xattr1,xattr2,updatedDoc=tombstone+_xattr1",
+			previousDoc: &sgbucket.BucketDocument{
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 					"_xattr2": []byte(`{"e" : "f"}`),
 				},
 			},
-			{
-				name: "delete xattr on tombstone resurection",
-				previousDoc: &sgbucket.BucketDocument{
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"foo": "bar"}`),
-					},
-				},
-				updatedDoc: sgbucket.UpdatedDoc{
-					Doc:            []byte(`{"foo": "bar"}`),
-					XattrsToDelete: []string{"xattr1"},
-				},
-				errorsIs: sgbucket.ErrDeleteXattrOnTombstone,
+			updatedDoc: sgbucket.UpdatedDoc{
+				IsTombstone: true,
+				Xattrs:      map[string][]byte{"_xattr1": []byte(`{"c" : "d"}`)}},
+			finalXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c" : "d"}`),
+				"_xattr2": []byte(`{"e" : "f"}`),
 			},
-		}...)
+		},
+		{
+			name: "delete xattr on tombstone resurection",
+			previousDoc: &sgbucket.BucketDocument{
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"foo": "bar"}`),
+				},
+			},
+			updatedDoc: sgbucket.UpdatedDoc{
+				Doc:            []byte(`{"foo": "bar"}`),
+				XattrsToDelete: []string{"xattr1"},
+			},
+			errorsIs: sgbucket.ErrDeleteXattrOnTombstone,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1207,39 +1198,35 @@ func TestWriteWithXattrs(t *testing.T) {
 			xattrs:  map[string][]byte{"xattr1": nil},
 			errorIs: sgbucket.ErrNilXattrValue,
 		},
-	}
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		tests = append(tests, []testCase{
-			{
-				name:           "body=true,xattrs=nil,xattrsToDelete=xattr1,xattr2,cas=0",
-				body:           []byte(`{"foo": "bar"}`),
-				xattrsToDelete: []string{"xattr1", "xattr2"},
-				errorIs:        sgbucket.ErrDeleteXattrOnDocumentInsert,
-			},
-			{
-				name:           "body=true,xattrs=nil,xattrsToDelete=xattr1,xattr2,cas=incorrect",
-				body:           []byte(`{"foo": "bar"}`),
-				xattrsToDelete: []string{"xattr1", "xattr2"},
-				cas:            uint64(1),
-				errorFunc:      requireDocNotFoundOrCasMismatchError,
-			},
-			{
-				name:           "body=true,xattrs=xattr1,xattrsToDelete=xattr1,xattr2,cas=0",
-				body:           []byte(`{"foo": "bar"}`),
-				xattrs:         map[string][]byte{"xattr1": []byte(`{"a" : "b"}`)},
-				xattrsToDelete: []string{"xattr1", "xattr2"},
-				errorIs:        sgbucket.ErrDeleteXattrOnDocumentInsert,
-			},
+		{
+			name:           "body=true,xattrs=nil,xattrsToDelete=xattr1,xattr2,cas=0",
+			body:           []byte(`{"foo": "bar"}`),
+			xattrsToDelete: []string{"xattr1", "xattr2"},
+			errorIs:        sgbucket.ErrDeleteXattrOnDocumentInsert,
+		},
+		{
+			name:           "body=true,xattrs=nil,xattrsToDelete=xattr1,xattr2,cas=incorrect",
+			body:           []byte(`{"foo": "bar"}`),
+			xattrsToDelete: []string{"xattr1", "xattr2"},
+			cas:            uint64(1),
+			errorFunc:      requireDocNotFoundOrCasMismatchError,
+		},
+		{
+			name:           "body=true,xattrs=xattr1,xattrsToDelete=xattr1,xattr2,cas=0",
+			body:           []byte(`{"foo": "bar"}`),
+			xattrs:         map[string][]byte{"xattr1": []byte(`{"a" : "b"}`)},
+			xattrsToDelete: []string{"xattr1", "xattr2"},
+			errorIs:        sgbucket.ErrDeleteXattrOnDocumentInsert,
+		},
 
-			{
-				name:           "body=true,xattrs=xattr1,xattrsToDelete=xattr1,xattr2,cas=incorrect",
-				body:           []byte(`{"foo": "bar"}`),
-				xattrs:         map[string][]byte{"xattr1": []byte(`{"a" : "b"}`)},
-				xattrsToDelete: []string{"xattr1", "xattr2"},
-				cas:            uint64(1),
-				errorIs:        sgbucket.ErrUpsertAndDeleteSameXattr,
-			},
-		}...)
+		{
+			name:           "body=true,xattrs=xattr1,xattrsToDelete=xattr1,xattr2,cas=incorrect",
+			body:           []byte(`{"foo": "bar"}`),
+			xattrs:         map[string][]byte{"xattr1": []byte(`{"a" : "b"}`)},
+			xattrsToDelete: []string{"xattr1", "xattr2"},
+			cas:            uint64(1),
+			errorIs:        sgbucket.ErrUpsertAndDeleteSameXattr,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1413,23 +1400,19 @@ func TestWriteResurrectionWithXattrs(t *testing.T) {
 			updatedBody: []byte(`{"foo": "bar"}`),
 			errorFunc:   requireDocFoundOrCasMismatchError,
 		},
-	}
-	if bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		tests = append(tests, []testCase{
-			{
-				name: "previousDoc=_xattr1,xattrsToUpdate=_xattr1+_xattr2,updatedBody=body",
-				previousDoc: &sgbucket.BucketDocument{
-					Xattrs: map[string][]byte{
-						"_xattr1": []byte(`{"a" : "b"}`),
-					},
+		{
+			name: "previousDoc=_xattr1,xattrsToUpdate=_xattr1+_xattr2,updatedBody=body",
+			previousDoc: &sgbucket.BucketDocument{
+				Xattrs: map[string][]byte{
+					"_xattr1": []byte(`{"a" : "b"}`),
 				},
-				updatedXattrs: map[string][]byte{
-					"_xattr1": []byte(`{"c": "d"}`),
-					"_xattr2": []byte(`{"f": "g"}`),
-				},
-				updatedBody: []byte(`{"foo": "bar"}`),
 			},
-		}...)
+			updatedXattrs: map[string][]byte{
+				"_xattr1": []byte(`{"c": "d"}`),
+				"_xattr2": []byte(`{"f": "g"}`),
+			},
+			updatedBody: []byte(`{"foo": "bar"}`),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -630,10 +629,6 @@ func TestResyncMou(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyMigrate, base.KeyImport)
 	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
 	defer db.Close(ctx)
-
-	if !db.Bucket.IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		t.Skip("Test requires multi-xattr subdoc operations, CBS 7.6 or higher")
-	}
 
 	initialImportCount := db.DbStats.SharedBucketImport().ImportCount.Value()
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2773,7 +2773,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			}
 
 			updatedDoc.Xattrs = map[string][]byte{base.SyncXattrName: rawSyncXattr, base.VvXattrName: rawVvXattr}
-			if rawMouXattr != nil && db.useMou() {
+			if rawMouXattr != nil {
 				updatedDoc.Xattrs[base.MouXattrName] = rawMouXattr
 			}
 			if rawGlobalSync != nil {

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -325,10 +325,7 @@ func (c *DatabaseCollection) syncGlobalSyncAndUserXattrKeys() []string {
 
 // syncGlobalSyncMouRevSeqNoAndUserXattrKeys returns the xattr keys for the user, mou, revSeqNo and sync xattrs.
 func (c *DatabaseCollection) syncGlobalSyncMouRevSeqNoAndUserXattrKeys() []string {
-	xattrKeys := []string{base.SyncXattrName, base.VvXattrName}
-	if c.useMou() {
-		xattrKeys = append(xattrKeys, base.MouXattrName, base.GlobalXattrName)
-	}
+	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.MouXattrName, base.GlobalXattrName}
 	userXattrKey := c.userXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)
@@ -431,10 +428,6 @@ func (c *DatabaseCollection) invalRoleChannels(ctx context.Context, rolename str
 // invalidateAllPrincipals invalidates computed channels and roles for collection c, for all users and roles
 func (c *DatabaseCollection) invalidateAllPrincipals(ctx context.Context, endSeq uint64) {
 	c.dbCtx.invalidateAllPrincipals(ctx, base.ScopeAndCollectionNames{c.ScopeAndCollectionName()}, endSeq)
-}
-
-func (c *DatabaseCollection) useMou() bool {
-	return c.dbCtx.UseMou()
 }
 
 func (c *DatabaseCollection) ScopeAndCollectionName() base.ScopeAndCollectionName {

--- a/db/import.go
+++ b/db/import.go
@@ -93,7 +93,7 @@ func (db *DatabaseCollectionWithUser) ImportDoc(ctx context.Context, docid strin
 	} else {
 		if existingDoc.Deleted {
 			existingBucketDoc.Xattrs[base.SyncXattrName], err = base.JSONMarshal(existingDoc.SyncData)
-			if err == nil && existingDoc.MetadataOnlyUpdate != nil && db.useMou() {
+			if err == nil && existingDoc.MetadataOnlyUpdate != nil {
 				existingBucketDoc.Xattrs[base.MouXattrName], err = base.JSONMarshal(existingDoc.MetadataOnlyUpdate)
 			}
 			if existingDoc.HLV != nil {
@@ -337,7 +337,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 		}
 
 		// If this is a metadata-only update, set metadataOnlyUpdate based on old doc's cas and mou
-		if metadataOnlyUpdate && db.useMou() {
+		if metadataOnlyUpdate {
 			newDoc.MetadataOnlyUpdate = computeMetadataOnlyUpdate(doc.Cas, revNo, doc.MetadataOnlyUpdate)
 		}
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/couchbase/clog"
-	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
@@ -2585,10 +2584,6 @@ func TestPrevRevNoPopulationImportFeed(t *testing.T) {
 	defer rt.Close()
 	dataStore := rt.GetSingleDataStore()
 	ctx := base.TestCtx(t)
-
-	if !rt.Bucket().IsSupported(sgbucket.BucketStoreFeatureMultiXattrSubdocOperations) {
-		t.Skip("Test requires multi-xattr subdoc operations, CBS 7.6 or higher")
-	}
 
 	// Create doc via the SDK
 	mobileKey := t.Name()


### PR DESCRIPTION
CBG-5024 Remove non multisubdoc xattr support

Code cleanup of dead code pathways in post Sync Gateway 4.0. This does not do all the tasks described in CBG-5024 to make code review processes easier.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/176/
