### PR TITLE
[3.3.2 backport] CBG-5030 Avoid panic during eviction based on out-of-sync stats 

### DIFF
--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -1585,4 +1586,91 @@ func TestRevCacheOnDemandImportNoCache(t *testing.T) {
 	// rev2 is not in cache but is on server
 	_, exists = collection.revisionCache.Peek(ctx, docID, doc.CurrentRev)
 	require.False(t, exists)
+}
+
+// TestUpdateDeltaRevCacheMemoryStatPanic:
+//   - Test will interleave underlying rev cache operations for UpdateDelta process and Remove item process to reproduce a race between
+//     threads updating a delta (and that thread updating the cache memory stats) and the underlying value being removed/evicted from the cache
+func TestUpdateDeltaRevCacheMemoryStatPanicSingleEntry(t *testing.T) {
+	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
+	cacheOptions := &RevisionCacheOptions{
+		MaxItemCount: 5000,
+		MaxBytes:     500,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+
+	firstDelta := bytes.Repeat([]byte("a"), 1000)
+	ctx := base.TestCtx(t)
+
+	// Trigger load into cache.
+	docRev, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	require.NoError(t, err, "Error adding to cache")
+
+	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
+
+	// Thread 1: UpdateDelta - start
+	value := cache.getValue(ctx, "doc1", "1-abc", testCollectionID, false)
+	if value != nil {
+		// Thread 2: Remove - start - drop value underneath UpdateDelta thread
+		cache.Remove(ctx, "doc1", "1-abc", testCollectionID)
+		// Thread 2: Remove - end
+		outGoingBytes := value.updateDelta(revCacheDelta2)
+		if outGoingBytes != 0 {
+			cache.currMemoryUsage.Add(outGoingBytes)
+			cache.cacheMemoryBytesStat.Add(outGoingBytes)
+		}
+		// check for memory based eviction
+		cache.revCacheMemoryBasedEviction(ctx)
+	}
+	// Thread 1: UpdateDelta - end
+
+	assert.Equal(t, 0, cache.lruList.Len())
+	assert.Equal(t, int64(0), memoryBytesCounted.Value())
+}
+
+// TestUpdateDeltaRevCacheMemoryStatPanic:
+//   - Test will interleave underlying rev cache operations for UpdateDelta process and Remove item process to reproduce a race between
+//     threads updating a delta (and that thread updating the cache memory stats) and the underlying value being removed/evicted from the cache
+func TestUpdateDeltaRevCacheMemoryStatPanicMultipleEntries(t *testing.T) {
+	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
+	cacheOptions := &RevisionCacheOptions{
+		MaxItemCount: 5000,
+		MaxBytes:     500,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+
+	firstDelta := bytes.Repeat([]byte("a"), 1000)
+	ctx := base.TestCtx(t)
+
+	// Trigger load into cache.  Add one revision (doc1) without a delta that's less than 500 bytes, then a
+	// revision (doc2) with a delta update that will exceed memory limit
+	// when added.  Both should be removed and cache memory stats should be zero.
+	_, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	require.NoError(t, err, "Error adding to cache")
+
+	docRev2, err := cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	require.NoError(t, err, "Error adding to cache")
+
+	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev2, false, nil)
+
+	// Thread 1: UpdateDelta - start
+	value := cache.getValue(ctx, "doc2", "1-abc", testCollectionID, false)
+	if value != nil {
+		// Thread 2: Remove - start - drop value underneath UpdateDelta thread
+		cache.Remove(ctx, "doc2", "1-abc", testCollectionID)
+		// Thread 2: Remove - end
+		outGoingBytes := value.updateDelta(revCacheDelta2)
+		if outGoingBytes != 0 {
+			cache.currMemoryUsage.Add(outGoingBytes)
+			cache.cacheMemoryBytesStat.Add(outGoingBytes)
+		}
+		// check for memory based eviction
+		cache.revCacheMemoryBasedEviction(ctx)
+	}
+	// Thread 1: UpdateDelta - end
+
+	assert.Equal(t, 0, cache.lruList.Len())
+	assert.Equal(t, int64(0), memoryBytesCounted.Value())
 }


### PR DESCRIPTION
CBG-5030
If a revision cache shard is found to be empty while attempting eviction, reset memory usage stat for the shard to zero.
