### PR TITLE
CBG-5032 Add revcache value lock for synchronized delta generation

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -563,7 +563,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		// If the revision we're generating a delta to is a tombstone, mark it as such and don't bother generating a delta
 		if deleted {
-			revCacheDelta := newRevCacheDelta([]byte(base.EmptyDocument), fromRev, &toRevision, deleted, nil)
+			revCacheDelta := newRevCacheDelta([]byte(base.EmptyDocument), fromRev, toRevision, deleted, nil)
 			if fromRevIsCV {
 				db.revisionCache.UpdateDeltaCV(ctx, docID, &fromRevVrs, revCacheDelta)
 			} else {
@@ -605,7 +605,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		if err != nil {
 			return nil, nil, err
 		}
-		revCacheDelta := newRevCacheDelta(deltaBytes, fromRev, &toRevision, deleted, toRevAttStorageMeta)
+		revCacheDelta := newRevCacheDelta(deltaBytes, fromRev, toRevision, deleted, toRevAttStorageMeta)
 
 		// Write the newly calculated delta back into the cache before returning
 		if fromRevIsCV {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1036,24 +1036,39 @@ func BenchmarkDeltaSyncConcurrentClientCachePopulation(b *testing.B) {
 		concurrentClients int
 	}{
 		{
-			name:              "SmallDoc_FewClients",
+			name:              "100KBDoc_100Clients",
 			docSize:           100 * 1024,
 			concurrentClients: 100,
 		},
 		{
-			name:              "SmallDoc_ManyClients",
+			name:              "100KBDoc_1000Clients",
 			docSize:           100 * 1024,
 			concurrentClients: 1000,
 		},
 		{
-			name:              "LargeDoc_FewClients",
+			name:              "100KBDoc_5000Clients",
+			docSize:           100 * 1024,
+			concurrentClients: 5000,
+		},
+		{
+			name:              "5MBDoc_10Clients",
+			docSize:           5 * 1024 * 1024,
+			concurrentClients: 10,
+		},
+		{
+			name:              "5MBDoc_100Clients",
 			docSize:           5 * 1024 * 1024,
 			concurrentClients: 100,
 		},
 		{
-			name:              "LargeDoc_ManyClients",
+			name:              "5MBDoc_1000Clients",
 			docSize:           5 * 1024 * 1024,
 			concurrentClients: 1000,
+		},
+		{
+			name:              "5MBDoc_5000Clients",
+			docSize:           5 * 1024 * 1024,
+			concurrentClients: 5000,
 		},
 	}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1074,6 +1074,11 @@ func BenchmarkDeltaSyncConcurrentClientCachePopulation(b *testing.B) {
 		concurrentClients int
 	}{
 		{
+			name:              "100KBDoc_1Client",
+			docSize:           100 * 1024,
+			concurrentClients: 1,
+		},
+		{
 			name:              "100KBDoc_100Clients",
 			docSize:           100 * 1024,
 			concurrentClients: 100,
@@ -1087,6 +1092,11 @@ func BenchmarkDeltaSyncConcurrentClientCachePopulation(b *testing.B) {
 			name:              "100KBDoc_5000Clients",
 			docSize:           100 * 1024,
 			concurrentClients: 5000,
+		},
+		{
+			name:              "5MBDoc_1Client",
+			docSize:           5 * 1024 * 1024,
+			concurrentClients: 1,
 		},
 		{
 			name:              "5MBDoc_10Clients",

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1075,10 +1075,8 @@ func BenchmarkDeltaSyncConcurrentClientCachePopulation(b *testing.B) {
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
 			docID := "doc1_" + test.name
-			rev1, _, err := collection.Put(ctx, docID, Body{"foo": "bar", "bar": "buzz", "quux": strings.Repeat("a", test.docSize)})
-			require.NoError(b, err, "Error creating doc")
-			rev2, _, err := collection.Put(ctx, docID, Body{"foo": "bar", "quux": strings.Repeat("b", test.docSize), BodyRev: rev1})
-			require.NoError(b, err, "Error updating doc")
+			rev1, _, _ := collection.Put(ctx, docID, Body{"foo": "bar", "bar": "buzz", "quux": strings.Repeat("a", test.docSize)})
+			rev2, _, _ := collection.Put(ctx, docID, Body{"foo": "bar", "quux": strings.Repeat("b", test.docSize), BodyRev: rev1})
 
 			for b.Loop() {
 				wg := sync.WaitGroup{}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1026,10 +1026,6 @@ func BenchmarkDeltaSyncConcurrentClientCachePopulation(b *testing.B) {
 		b.Skip("Delta sync only supported in EE")
 	}
 
-	db, ctx := SetupTestDBWithOptions(b, DatabaseContextOptions{DeltaSyncOptions: DeltaSyncOptions{Enabled: true, RevMaxAgeSeconds: 300}})
-	defer db.Close(ctx)
-	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, b, db)
-
 	tests := []struct {
 		name              string
 		docSize           int
@@ -1074,6 +1070,10 @@ func BenchmarkDeltaSyncConcurrentClientCachePopulation(b *testing.B) {
 
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
+			db, ctx := SetupTestDBWithOptions(b, DatabaseContextOptions{DeltaSyncOptions: DeltaSyncOptions{Enabled: true, RevMaxAgeSeconds: 300}})
+			defer db.Close(ctx)
+			collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, b, db)
+
 			docID := "doc1_" + test.name
 			rev1, _, _ := collection.Put(ctx, docID, Body{"foo": "bar", "bar": "buzz", "quux": strings.Repeat("a", test.docSize)})
 			rev2, _, _ := collection.Put(ctx, docID, Body{"foo": "bar", "quux": strings.Repeat("b", test.docSize), BodyRev: rev1})

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -212,9 +212,9 @@ type DocumentRevision struct {
 	Channels    base.Set
 	Expiry      *time.Time
 	Attachments AttachmentsMeta
-	_Delta      *RevisionDelta
-	DeltaLock   *sync.RWMutex
-	Deleted     bool
+	Delta                  *RevisionDelta
+	RevCacheValueDeltaLock *sync.RWMutex // shared mutex for the revcache value to avoid concurrent delta generation
+	Deleted                bool
 	Removed     bool  // True if the revision is a removal.
 	MemoryBytes int64 // storage of the doc rev bytes measurement, includes size of delta when present too
 	CV          *Version

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -207,18 +207,18 @@ type DocumentRevision struct {
 	DocID string
 	RevID string
 	// BodyBytes contains the raw document, with no special properties.
-	BodyBytes   []byte
-	History     Revisions
-	Channels    base.Set
-	Expiry      *time.Time
-	Attachments AttachmentsMeta
+	BodyBytes              []byte
+	History                Revisions
+	Channels               base.Set
+	Expiry                 *time.Time
+	Attachments            AttachmentsMeta
 	Delta                  *RevisionDelta
 	RevCacheValueDeltaLock *sync.RWMutex // shared mutex for the revcache value to avoid concurrent delta generation
 	Deleted                bool
-	Removed     bool  // True if the revision is a removal.
-	MemoryBytes int64 // storage of the doc rev bytes measurement, includes size of delta when present too
-	CV          *Version
-	HlvHistory  string
+	Removed                bool  // True if the revision is a removal.
+	MemoryBytes            int64 // storage of the doc rev bytes measurement, includes size of delta when present too
+	CV                     *Version
+	HlvHistory             string
 }
 
 // MutableBody returns a deep copy of the given document revision as a plain body (without any special properties)

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -392,7 +392,7 @@ type RevisionDelta struct {
 	totalDeltaBytes       int64                   // totalDeltaBytes is the total bytes for channels, revisions and body on the delta itself
 }
 
-func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision *DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {
+func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {
 	revDelta := RevisionDelta{
 		ToRevID:               toRevision.RevID,
 		ToCV:                  toRevision.CV.String(),

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -211,7 +212,8 @@ type DocumentRevision struct {
 	Channels    base.Set
 	Expiry      *time.Time
 	Attachments AttachmentsMeta
-	Delta       *RevisionDelta
+	_Delta      *RevisionDelta
+	DeltaLock   *sync.RWMutex
 	Deleted     bool
 	Removed     bool  // True if the revision is a removal.
 	MemoryBytes int64 // storage of the doc rev bytes measurement, includes size of delta when present too
@@ -390,7 +392,7 @@ type RevisionDelta struct {
 	totalDeltaBytes       int64                   // totalDeltaBytes is the total bytes for channels, revisions and body on the delta itself
 }
 
-func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {
+func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision *DocumentRevision, deleted bool, toRevAttStorageMeta []AttachmentStorageMeta) RevisionDelta {
 	revDelta := RevisionDelta{
 		ToRevID:               toRevision.RevID,
 		ToCV:                  toRevision.CV.String(),

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -213,7 +213,7 @@ type DocumentRevision struct {
 	Expiry                 *time.Time
 	Attachments            AttachmentsMeta
 	Delta                  *RevisionDelta
-	RevCacheValueDeltaLock *sync.RWMutex // shared mutex for the revcache value to avoid concurrent delta generation
+	RevCacheValueDeltaLock *sync.Mutex // shared mutex for the revcache value to avoid concurrent delta generation
 	Deleted                bool
 	Removed                bool  // True if the revision is a removal.
 	MemoryBytes            int64 // storage of the doc rev bytes measurement, includes size of delta when present too

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -136,7 +136,7 @@ type revCacheValue struct {
 	itemBytes    atomic.Int64
 	collectionID uint32
 	canEvict     atomic.Bool
-	deltaLock    sync.RWMutex // synchronizes GetDelta across multiple clients for each fromRevision
+	deltaLock    sync.Mutex // synchronizes GetDelta across multiple clients for each fromRevision
 }
 
 // Creates a revision cache with the given capacity and an optional loader function.

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -797,22 +797,22 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	// Retrieve from cache
 	retrievedRev, err := cache.GetWithRev(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error retrieving from cache")
-	assert.Equal(t, "rev2", retrievedRev._Delta.ToRevID)
-	assert.Equal(t, firstDelta, retrievedRev._Delta.DeltaBytes)
+	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
+	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Update delta again, validate data in retrievedRev isn't mutated
 	cache.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevisionDelta{ToRevID: "rev3", DeltaBytes: secondDelta})
-	assert.Equal(t, "rev2", retrievedRev._Delta.ToRevID)
-	assert.Equal(t, firstDelta, retrievedRev._Delta.DeltaBytes)
+	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
+	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Retrieve again, validate delta is correct
 	updatedRev, err := cache.GetWithRev(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error retrieving from cache")
-	assert.Equal(t, "rev3", updatedRev._Delta.ToRevID)
-	assert.Equal(t, secondDelta, updatedRev._Delta.DeltaBytes)
+	assert.Equal(t, "rev3", updatedRev.Delta.ToRevID)
+	assert.Equal(t, secondDelta, updatedRev.Delta.DeltaBytes)
 
-	assert.Equal(t, "rev2", retrievedRev._Delta.ToRevID)
-	assert.Equal(t, firstDelta, retrievedRev._Delta.DeltaBytes)
+	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
+	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 }
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -850,7 +850,7 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 			assert.NoError(t, err, "Error adding to cache")
 
 			revCacheMem := memoryBytesCounted.Value()
-			revCacheDelta := newRevCacheDelta(firstDelta, "1-abc", &docRev, false, nil)
+			revCacheDelta := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
 			cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
 			// assert that rev cache memory increases by expected amount
 			newMem := revCacheMem + revCacheDelta.totalDeltaBytes
@@ -858,14 +858,14 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 			oldDeltaSize := revCacheDelta.totalDeltaBytes
 
 			newMem = memoryBytesCounted.Value()
-			revCacheDelta = newRevCacheDelta(secondDelta, "1-abc", &docRev, false, nil)
+			revCacheDelta = newRevCacheDelta(secondDelta, "1-abc", docRev, false, nil)
 			cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
 
 			// assert the overall memory stat is correctly updated (by the diff between the old delta and the new delta)
 			newMem += revCacheDelta.totalDeltaBytes - oldDeltaSize
 			assert.Equal(t, newMem, memoryBytesCounted.Value())
 
-			revCacheDelta = newRevCacheDelta(thirdDelta, "1-abc", &docRev, false, nil)
+			revCacheDelta = newRevCacheDelta(thirdDelta, "1-abc", docRev, false, nil)
 			cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
 
 			// assert that eviction took place and as result stat is now 0 (only item in cache was doc1)
@@ -1266,7 +1266,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
 
 			// Test Update Delta, assert stat increases as expected
-			revDelta := newRevCacheDelta([]byte(`"rev":"delta"`), "1-abc", &newDocRev, false, nil)
+			revDelta := newRevCacheDelta([]byte(`"rev":"delta"`), "1-abc", newDocRev, false, nil)
 			expMem = prevMemStat + revDelta.totalDeltaBytes
 			if testCase.UseCVCache {
 				db.revisionCache.UpdateDeltaCV(ctx, "doc3", &revDoc3.CV, collctionID, revDelta)
@@ -2463,7 +2463,7 @@ func TestUpdateDeltaRevCacheMemoryStatPanicSingleEntry(t *testing.T) {
 	docRev, err := cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	require.NoError(t, err, "Error adding to cache")
 
-	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", &docRev, false, nil)
+	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
 
 	// Thread 1: UpdateDelta - start
 	value := cache.getValue(ctx, "doc1", "1-abc", testCollectionID, false)
@@ -2509,7 +2509,7 @@ func TestUpdateDeltaRevCacheMemoryStatPanicMultipleEntries(t *testing.T) {
 	docRev2, err := cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	require.NoError(t, err, "Error adding to cache")
 
-	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", &docRev2, false, nil)
+	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev2, false, nil)
 
 	// Thread 1: UpdateDelta - start
 	value := cache.getValue(ctx, "doc2", "1-abc", testCollectionID, false)


### PR DESCRIPTION
CBG-5032

Adds a new shared mutex on RevCache Value that is shared by concurrent GetDelta callers to syncronise delta generation between multiple clients on the same fromRev.

Benchmark:
```
$ benchstat main.bench 5032.bench
goos: darwin
goarch: arm64
pkg: github.com/couchbase/sync_gateway/db
cpu: Apple M1 Pro
                                                                 │     main.bench      │             5032.bench              │
                                                                 │       sec/op        │    sec/op     vs base               │
DeltaSyncConcurrentClientCachePopulation/100KBDoc_100Clients-10        140.9µ ±    24%   134.3µ ± 73%        ~ (p=1.000 n=6)
DeltaSyncConcurrentClientCachePopulation/100KBDoc_1000Clients-10      1585.2µ ± 63266%   953.5µ ± 25%  -39.85% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/100KBDoc_5000Clients-10       6.621m ±   486%   4.091m ± 15%  -38.22% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_10Clients-10           13.74µ ±    14%   14.21µ ±  4%        ~ (p=0.132 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_100Clients-10         222.12µ ±    13%   94.23µ ± 12%  -57.57% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_1000Clients-10     5732323.2µ ±    51%   754.7µ ±  3%  -99.99% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_5000Clients-10      7395.462m ±    87%   3.767m ±  3%  -99.95% (p=0.002 n=6)
geomean                                                                5.682m            411.4µ        -92.76%

                                                                 │       main.bench       │              5032.bench              │
                                                                 │          B/op          │     B/op      vs base                │
DeltaSyncConcurrentClientCachePopulation/100KBDoc_100Clients-10        155.21Ki ±     17%   61.87Ki ± 1%   -60.14% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/100KBDoc_1000Clients-10       5237.2Ki ± 144638%   616.1Ki ± 0%   -88.24% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/100KBDoc_5000Clients-10       19.262Mi ±   1598%   3.004Mi ± 0%   -84.40% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_10Clients-10           15.783Ki ±     12%   7.080Ki ± 0%   -55.14% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_100Clients-10         1592.98Ki ±     13%   67.08Ki ± 2%   -95.79% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_1000Clients-10     67408876.2Ki ±     51%   659.3Ki ± 0%  -100.00% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_5000Clients-10      79174.452Mi ±     83%   3.219Mi ± 0%  -100.00% (p=0.002 n=6)
geomean                                                                 21.11Mi             275.7Ki        -98.72%

                                                                 │    main.bench    │              5032.bench              │
                                                                 │    allocs/op     │  allocs/op   vs base                 │
DeltaSyncConcurrentClientCachePopulation/100KBDoc_100Clients-10       702.0 ±    0%    701.0 ± 0%   -0.14% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/100KBDoc_1000Clients-10     7.078k ± 1745%   7.003k ± 0%   -1.06% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/100KBDoc_5000Clients-10     35.30k ±   14%   35.02k ± 0%   -0.81% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_10Clients-10          71.00 ±    0%    71.00 ± 0%        ~ (p=1.000 n=6) ¹
DeltaSyncConcurrentClientCachePopulation/5MBDoc_100Clients-10         703.5 ±    0%    701.0 ± 0%   -0.36% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_1000Clients-10     137.184k ±   49%   7.001k ± 0%  -94.90% (p=0.002 n=6)
DeltaSyncConcurrentClientCachePopulation/5MBDoc_5000Clients-10      193.38k ±   70%   35.02k ± 0%  -81.89% (p=0.002 n=6)
geomean                                                              5.843k           2.982k       -48.96%
¹ all samples are equal
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/181/
