### PR TITLE
CBG-4905: update defualt resolver for blip tester

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -349,9 +349,7 @@ func (btcc *BlipTesterCollectionClient) _resolveConflict(incomingHLV *db.HybridL
 }
 
 func (btcc *BlipTesterCollectionClient) _resolveConflictLWW(incomingHLV *db.HybridLogicalVector, incomingBody []byte, incomingIsDelete bool, latestLocalRev *clientDocRev) (body []byte, hlv db.HybridLogicalVector, isTombstone bool) {
-	fmt.Println("incoming hlv in resolver", incomingHLV)
 	latestLocalHLV := latestLocalRev.HLV
-	fmt.Println("local hlv in resolver", latestLocalHLV)
 	updatedHLV := latestLocalRev.HLV.Copy()
 	localDeleted := latestLocalRev.isDelete
 	if localDeleted && !incomingIsDelete {

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -339,25 +339,38 @@ func (cd *clientDoc) _hasConflict(t testing.TB, incomingHLV *db.HybridLogicalVec
 	return false
 }
 
-func (btcc *BlipTesterCollectionClient) _resolveConflict(incomingHLV *db.HybridLogicalVector, incomingBody []byte, localDoc *clientDocRev) (body []byte, hlv db.HybridLogicalVector) {
+func (btcc *BlipTesterCollectionClient) _resolveConflict(incomingHLV *db.HybridLogicalVector, incomingBody []byte, incomingIsDelete bool, localDoc *clientDocRev) (body []byte, hlv db.HybridLogicalVector, isTombstone bool) {
 	switch btcc.parent.ConflictResolver {
 	case ConflictResolverLastWriteWins:
-		return btcc._resolveConflictLWW(incomingHLV, incomingBody, localDoc)
+		return btcc._resolveConflictLWW(incomingHLV, incomingBody, incomingIsDelete, localDoc)
 	}
 	btcc.TB().Fatalf("Unknown conflict resolver %q - cannot resolve detected conflict", btcc.parent.ConflictResolver)
-	return nil, db.HybridLogicalVector{}
+	return nil, db.HybridLogicalVector{}, isTombstone
 }
 
-func (btcc *BlipTesterCollectionClient) _resolveConflictLWW(incomingHLV *db.HybridLogicalVector, incomingBody []byte, latestLocalRev *clientDocRev) (body []byte, hlv db.HybridLogicalVector) {
+func (btcc *BlipTesterCollectionClient) _resolveConflictLWW(incomingHLV *db.HybridLogicalVector, incomingBody []byte, incomingIsDelete bool, latestLocalRev *clientDocRev) (body []byte, hlv db.HybridLogicalVector, isTombstone bool) {
+	fmt.Println("incoming hlv in resolver", incomingHLV)
 	latestLocalHLV := latestLocalRev.HLV
+	fmt.Println("local hlv in resolver", latestLocalHLV)
 	updatedHLV := latestLocalRev.HLV.Copy()
+	localDeleted := latestLocalRev.isDelete
+	if localDeleted && !incomingIsDelete {
+		// resolve in favour of local document
+		incomingHLV.UpdateWithIncomingHLV(updatedHLV)
+		return latestLocalRev.body, *updatedHLV, true
+	}
+	if incomingIsDelete && !localDeleted {
+		// resolve in favour of remote document
+		updatedHLV.UpdateWithIncomingHLV(incomingHLV)
+		return incomingBody, *updatedHLV, true
+	}
 	// resolve conflict in favor of remote document
 	if incomingHLV.Version > latestLocalHLV.Version {
 		updatedHLV.UpdateWithIncomingHLV(incomingHLV)
-		return incomingBody, *updatedHLV
+		return incomingBody, *updatedHLV, incomingIsDelete
 	}
 	incomingHLV.UpdateWithIncomingHLV(updatedHLV)
-	return latestLocalRev.body, *updatedHLV
+	return latestLocalRev.body, *updatedHLV, latestLocalRev.isDelete
 }
 
 type BlipTesterCollectionClient struct {
@@ -2180,6 +2193,7 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 	btcc.seqLock.Lock()
 	defer btcc.seqLock.Unlock()
 	newClientSeq := btcc._nextSequence()
+	isTombstone := false
 
 	newBody := opts.body
 	newVersion := opts.incomingVersion
@@ -2187,7 +2201,10 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 	updatedHLV := doc._getLatestHLVCopy(btcc.TB())
 	require.NotNil(btcc.TB(), updatedHLV, "updatedHLV should not be nil for docID %q", docID)
 	if doc._hasConflict(btcc.TB(), opts.incomingHLV) {
-		newBody, updatedHLV = btcc._resolveConflict(opts.incomingHLV, opts.body, doc._latestRev(btcc.TB()))
+		newBody, updatedHLV, isTombstone = btcc._resolveConflict(opts.incomingHLV, opts.body, opts.isDelete, doc._latestRev(btcc.TB()))
+		if isTombstone {
+			opts.isDelete = true
+		}
 		base.DebugfCtx(ctx, base.KeySGTest, "Resolved conflict for docID %q, incomingHLV:%#v, existingHLV:%#v, updatedHLV:%#v", docID, opts.incomingHLV, doc._latestRev(btcc.TB()).HLV, updatedHLV)
 	} else {
 		base.DebugfCtx(ctx, base.KeySGTest, "No conflict")

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -112,7 +112,7 @@ func TestMultiActorResurrect(t *testing.T) {
 							// peer then cbl will resolve in favor if its own tombstone.
 							if resurrectPeer.Type() == PeerTypeCouchbaseServer {
 								if strings.Contains(topologySpec.description, "CBL") {
-									if conflictNotExpectedOnCBL(deletePeer, resurrectPeer, deletePeerName, resurrectPeerName) {
+									if conflictNotExpectedOnCBL(deletePeer, resurrectPeer) {
 										// if no cbl conflict is expected we can wait on CV and body
 										waitForCVAndBody(t, collectionName, docID, resurrectVersion, topology)
 									} else {

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -110,13 +110,12 @@ func TestMultiActorResurrect(t *testing.T) {
 							// if cbs resurrect, if delete AND resurrecting peer is server side peer (cbs or sgw) the all docs will converge for version expected
 							// if cbs resurrect and delete AND resurrecting peer is NOT server side peer (lite), then need to wait for tombstone convergence first
 							if resurrectPeer.Type() == PeerTypeCouchbaseServer {
-								// almost has it, need to think if lite
-								l := IsServerSidePeer([]Peer{deletePeer, resurrectPeer})
-								if !l { //if deletePeer.Type() == PeerTypeCouchbaseLite { //|| createPeer.Type() == PeerTypeCouchbaseLite { //strings.Contains(deletePeer.Type().String(), "Couchbase Lite Peer") {
+								if conflictNotExpectedOnCBL([]Peer{createPeer, deletePeer, resurrectPeer}, []string{deletePeerName, createPeerName}, resurrectPeerName) { //allActorsServerSide([]Peer{createPeer, deletePeer, resurrectPeer}) || conflictNotExpectedOnCBL(deletePeer, []string{deletePeerName, createPeerName}, resurrectPeerName) {
+									// no cbl conflict?
+									waitForCVAndBody(t, collectionName, docID, resurrectVersion, topology)
+								} else {
 									fmt.Println("waiting for converging tombstones")
 									waitForConvergingTombstones(t, collectionName, docID, topology)
-								} else {
-									waitForCVAndBody(t, collectionName, docID, resurrectVersion, topology)
 								}
 								//waitForCVAndBody(t, collectionName, docID, resurrectVersion, topology)
 							} else {

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -107,9 +107,9 @@ func TestMultiActorResurrect(t *testing.T) {
 
 							resBody := fmt.Appendf(nil, `{"activePeer": "%s", "createPeer": "%s", "deletePeer": "%s", "resurrectPeer": "%s", "topology": "%s", "action": "resurrect"}`, resurrectPeerName, createPeerName, deletePeer, resurrectPeer, topology.specDescription)
 							resurrectVersion := resurrectPeer.WriteDocument(collectionName, docID, resBody)
-							// in the case of a Couchbase Server resurrection, the hlv is lost since all system xattrs are lost on a resurrection
-							// if cbs resurrect, if delete AND resurrecting peer is server side peer (cbs or sgw) the all docs will converge for version expected
-							// if cbs resurrect and delete AND resurrecting peer is NOT server side peer (lite), then need to wait for tombstone convergence first
+							// in the case of a Couchbase Server resurrection, the hlv is lost since all system xattrs are
+							// lost on a resurrection so the resurrecting version may conflict with a version on cbl
+							// peer then cbl will resolve in favour if its own tombstone.
 							if resurrectPeer.Type() == PeerTypeCouchbaseServer {
 								if strings.Contains(topologySpec.description, "CBL") {
 									if conflictNotExpectedOnCBL(deletePeer, resurrectPeer, deletePeerName, resurrectPeerName) {

--- a/topologytest/multi_actor_no_conflict_test.go
+++ b/topologytest/multi_actor_no_conflict_test.go
@@ -109,7 +109,7 @@ func TestMultiActorResurrect(t *testing.T) {
 							resurrectVersion := resurrectPeer.WriteDocument(collectionName, docID, resBody)
 							// in the case of a Couchbase Server resurrection, the hlv is lost since all system xattrs are
 							// lost on a resurrection so the resurrecting version may conflict with a version on cbl
-							// peer then cbl will resolve in favour if its own tombstone.
+							// peer then cbl will resolve in favor if its own tombstone.
 							if resurrectPeer.Type() == PeerTypeCouchbaseServer {
 								if strings.Contains(topologySpec.description, "CBL") {
 									if conflictNotExpectedOnCBL(deletePeer, resurrectPeer, deletePeerName, resurrectPeerName) {

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -127,6 +127,21 @@ func (p Peers) SortedPeers() iter.Seq2[string, Peer] {
 	}
 }
 
+func (p Peers) PeerList() []string {
+	peerNames := slices.Collect(maps.Keys(p))
+	return peerNames
+}
+
+func IsServerSidePeer(p []Peer) bool {
+	for _, v := range p {
+		if v.Type() == PeerTypeCouchbaseServer || v.Type() == PeerTypeSyncGateway {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 // NonImportSortedPeers returns a sorted iterator peers that will not cause import operations. For example:
 //   - cbs1 <-> sg1 <-> cbl1 would return sg1 and cbl1, but not cbs1
 //   - cbs1 <-> cbs2 would return cbs1 and cbs2
@@ -243,6 +258,10 @@ func (to Topology) ActivePeers() iter.Seq2[string, Peer] {
 // SortedPeers returns a sorted list of peers by name, for deterministic output.
 func (to Topology) SortedPeers() iter.Seq2[string, Peer] {
 	return to.peers.SortedPeers()
+}
+
+func (to Topology) PeersInTopology() []string {
+	return to.peers.PeerList()
 }
 
 // CompareRevTreeOnly is true for a given topology when comparing only revtree is correct.

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -132,7 +132,7 @@ func (p Peers) PeerList() []string {
 	return peerNames
 }
 
-func IsServerSidePeer(p []Peer) bool {
+func allActorsServerSide(p []Peer) bool {
 	for _, v := range p {
 		if v.Type() == PeerTypeCouchbaseServer || v.Type() == PeerTypeSyncGateway {
 			continue
@@ -140,6 +140,23 @@ func IsServerSidePeer(p []Peer) bool {
 		return false
 	}
 	return true
+}
+
+func deleteHasSGWSource(deletingPeer Peer) bool {
+	if deletingPeer.Type() == PeerTypeCouchbaseServer || deletingPeer.Type() == PeerTypeSyncGateway {
+		return true
+	}
+	return false
+}
+
+func conflictNotExpectedOnCBL(peers []Peer, createDelPeerNames []string, resPeerName string) bool {
+	if createDelPeerNames[1] == "sg1" && resPeerName == "cbs1" {
+		return true
+	}
+	if createDelPeerNames[1] == "cbs1" && resPeerName == "cbs1" {
+		return true
+	}
+	return false
 }
 
 // NonImportSortedPeers returns a sorted iterator peers that will not cause import operations. For example:

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -134,17 +134,13 @@ func peerIsServerSide(p Peer) bool {
 
 // conflictNotExpectedOnCBL will return true if no conflict is expected for delete and resurrect operations for
 // topologies with cbl peer in them and false for expected conflict
-func conflictNotExpectedOnCBL(deletePeer Peer, resurrectPeer Peer, delPeerName string, resPeerName string) bool {
-	if delPeerName == "cbl1" {
+func conflictNotExpectedOnCBL(deletePeer Peer, resurrectPeer Peer) bool {
+	if deletePeer.Type() == PeerTypeCouchbaseLite {
 		// cbl delete will mean cbs resurrect has a conflict
 		return false
 	}
 	if peerIsServerSide(deletePeer) && peerIsServerSide(resurrectPeer) {
-		if strings.Contains(delPeerName, "1") && strings.Contains(resPeerName, "2") {
-			// conflict expected due to different backing bucket (sourceID)
-			return false
-		}
-		if strings.Contains(delPeerName, "2") && strings.Contains(resPeerName, "1") {
+		if deletePeer.SourceID() != resurrectPeer.SourceID() {
 			// conflict expected due to different backing bucket (sourceID)
 			return false
 		}

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -129,10 +129,7 @@ func (p Peers) SortedPeers() iter.Seq2[string, Peer] {
 
 // peerIsServerSide returns true if the peer is a Couchbase Server or Sync Gateway peer.
 func peerIsServerSide(p Peer) bool {
-	if p.Type() == PeerTypeCouchbaseServer || p.Type() == PeerTypeSyncGateway {
-		return true
-	}
-	return false
+	return p.Type() == PeerTypeCouchbaseServer || p.Type() == PeerTypeSyncGateway
 }
 
 // conflictNotExpectedOnCBL will return true if no conflict is expected for delete and resurrect operations for

--- a/topologytest/peer_test.go
+++ b/topologytest/peer_test.go
@@ -127,11 +127,6 @@ func (p Peers) SortedPeers() iter.Seq2[string, Peer] {
 	}
 }
 
-func (p Peers) PeerList() []string {
-	peerNames := slices.Collect(maps.Keys(p))
-	return peerNames
-}
-
 // peerIsServerSide returns true if the peer is a Couchbase Server or Sync Gateway peer.
 func peerIsServerSide(p Peer) bool {
 	if p.Type() == PeerTypeCouchbaseServer || p.Type() == PeerTypeSyncGateway {
@@ -149,12 +144,10 @@ func conflictNotExpectedOnCBL(deletePeer Peer, resurrectPeer Peer, delPeerName s
 	}
 	if peerIsServerSide(deletePeer) && peerIsServerSide(resurrectPeer) {
 		if strings.Contains(delPeerName, "1") && strings.Contains(resPeerName, "2") {
-			fmt.Println("conflict expected due to different backing bucket")
 			// conflict expected due to different backing bucket (sourceID)
 			return false
 		}
 		if strings.Contains(delPeerName, "2") && strings.Contains(resPeerName, "1") {
-			fmt.Println("conflict expected due to different backing bucket")
 			// conflict expected due to different backing bucket (sourceID)
 			return false
 		}
@@ -281,10 +274,6 @@ func (to Topology) ActivePeers() iter.Seq2[string, Peer] {
 // SortedPeers returns a sorted list of peers by name, for deterministic output.
 func (to Topology) SortedPeers() iter.Seq2[string, Peer] {
 	return to.peers.SortedPeers()
-}
-
-func (to Topology) PeersInTopology() []string {
-	return to.peers.PeerList()
 }
 
 // CompareRevTreeOnly is true for a given topology when comparing only revtree is correct.


### PR DESCRIPTION
CBG-4905

- Alter blip tester client to account for local or remote tombstones when resolving conflict. 
- Required changes to the resurrection testing to account for CBL peer resolving in favour of a tombstone 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/183/
