### PR TITLE
CBG-4932 fix backward assertion in resync test

### DIFF
--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -275,7 +275,7 @@ func TestResyncManagerDCPStart(t *testing.T) {
 
 		cs, err := db.DbStats.CollectionStat(scopeName, collectionName)
 		require.NoError(t, err)
-		assert.GreaterOrEqual(t, int64(docsToCreate), cs.ResyncNumProcessed.Value())
+		assert.GreaterOrEqual(t, cs.ResyncNumProcessed.Value(), int64(docsToCreate))
 		assert.Equal(t, int64(docsToCreate), cs.ResyncNumChanged.Value())
 
 		deltaOk := assert.InDelta(t, int64(docsToCreate), db.DbStats.Database().SyncFunctionCount.Value(), 2)


### PR DESCRIPTION
CBG-4932 fix backward assertion in test

This was missed in https://github.com/couchbase/sync_gateway/commit/48b968c9bfd9def56a3466677acf227bbd30d44c