### PR TITLE
[4.0.2 backport] CBG-5026 allow legacy rev documents to be resynced

### DIFF
--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -149,7 +149,7 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]interface
 		collectionCtx := databaseCollection.AddCollectionContext(ctx)
 		_, unusedSequences, err := (&DatabaseCollectionWithUser{
 			DatabaseCollection: databaseCollection,
-		}).resyncDocument(collectionCtx, docID, key, regenerateSequences, []uint64{})
+		}).ResyncDocument(collectionCtx, docID, key, regenerateSequences, []uint64{})
 
 		databaseCollection.releaseSequences(collectionCtx, unusedSequences)
 

--- a/rest/legacy_rev_test.go
+++ b/rest/legacy_rev_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResyncLegacyRev makes sure that running resync on a legacy rev will send future blip messages as a legacy rev and not as an HLV
+func TestResyncLegacyRev(t *testing.T) {
+	rt := NewRestTesterPersistentConfig(t)
+	defer rt.Close()
+
+	const (
+		alice       = "alice"
+		channelName = "A"
+	)
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+	// default collection will use channel Name and named collection will use collection.Name
+	rt.CreateUser(alice, []string{channelName, collection.Name})
+
+	docID := db.SafeDocumentName(t, t.Name())
+	doc := rt.CreateDocNoHLV(docID, db.Body{"channels": channelName})
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T) {
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: alice})
+		defer btc.Close()
+
+		btcRunner.StartOneshotPull(btc.id)
+
+		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, DocVersion{RevTreeID: doc.GetRevTreeID()})
+		require.Equal(t, msg.Properties[db.RevMessageRev], doc.GetRevTreeID())
+	})
+	previousChannel := collection.Name
+	if base.IsDefaultCollection(collection.ScopeName, collection.Name) {
+		previousChannel = "A"
+	}
+
+	_, err := collection.UpdateSyncFun(ctx, fmt.Sprintf(`function() {channel("B", "%s")}`, previousChannel))
+	require.NoError(t, err)
+
+	// use ResyncDocument and TakeDbOffline/Online instead of /ks/_config/sync && /db/_resync to work under rosmar which
+	// doesn't yet support DCP resync or updating config on an existing bucket.
+	regenerateSequences := false
+	var unusedSequences []uint64
+	_, _, err = collection.ResyncDocument(ctx, docID, docID, regenerateSequences, unusedSequences)
+	require.NoError(t, err)
+
+	rt.TakeDbOffline()
+	rt.TakeDbOnline()
+
+	resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_raw/"+docID, "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	btcRunner = NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T) {
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, &BlipTesterClientOpts{Username: alice})
+		defer btc.Close()
+
+		btcRunner.StartOneshotPull(btc.id)
+
+		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, DocVersion{RevTreeID: doc.GetRevTreeID()})
+		// make sure second rev message after resync is still legacy rev format
+		require.Equal(t, msg.Properties[db.RevMessageRev], doc.GetRevTreeID())
+	})
+}

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1976,7 +1976,7 @@ func (btcc *BlipTesterCollectionClient) WaitForPullRevMessage(docID string, vers
 			return
 		}
 		var lookupVersion DocVersion
-		if btcc.UseHLV() {
+		if btcc.UseHLV() && !version.CV.IsEmpty() {
 			lookupVersion = DocVersion{CV: version.CV}
 		} else {
 			lookupVersion = DocVersion{RevTreeID: version.RevTreeID}


### PR DESCRIPTION
[4.0.2 backport] CBG-5026 allow legacy rev documents to be resynced

backport of https://github.com/couchbase/sync_gateway/commit/693e4b55bc80478471db883068c2ba330f084794, very small conflict in database_test.go