### PR TITLE
CBG-3399: Fix flaky test `TestUserXattrDeleteWithRevCache`

### DIFF
--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -111,6 +111,7 @@ func TestUserXattrRevCache(t *testing.T) {
 }
 
 func TestUserXattrDeleteWithRevCache(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
@@ -131,6 +132,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			Name:             "rt1",
 			ImportPartitions: base.Ptr(uint16(2)), // temporarily config to 2 import partitions (default 1 for rest tester) pending CBG-3438 + CBG-3439
 			AutoImport:       true,
 			UserXattrKey:     &xattrKey,
@@ -142,6 +144,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+			Name:             "rt2",
 			ImportPartitions: base.Ptr(uint16(2)), // temporarily config to 2 import partitions (default 1 for rest tester) pending CBG-3438 + CBG-3439
 			AutoImport:       true,
 			UserXattrKey:     &xattrKey,
@@ -153,7 +156,7 @@ func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	dataStore := rt2.GetSingleDataStore()
 
 	ctx = rt2.Context()
-	a := rt2.ServerContext().Database(ctx, "db").Authenticator(ctx)
+	a := rt2.ServerContext().Database(ctx, rt2.GetDatabase().Name).Authenticator(ctx)
 
 	userDEF, err := a.NewUser("userDEF", "letmein", channels.BaseSetOf(t, "DEF"))
 	require.NoError(t, err)


### PR DESCRIPTION
CBG-3399

Describe your PR here...
- The sequence was being incremented within the `MaxSequenceIncrFrequency`, so the sequence increment in batches
- This would lead to few sequences not being released within a second, due to which the changes were not being loaded
- This would cause the test to fail sometimes
- Fixed this by calling the `SuspendSequenceBatching`
- Added names to different rest testers for improved logging

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/190/
