### PR TITLE
CBG-4286: Add sg prefix to dcp feed names

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -298,7 +298,7 @@ func GenerateDcpStreamName(feedID string) (string, error) {
 	commitTruncated := StringPrefix(GitCommit, 7)
 
 	return fmt.Sprintf(
-		"%v-v-%v-commit-%v-uuid-%v",
+		"sg:%v-v-%v-commit-%v-uuid-%v",
 		feedID,
 		ProductAPIVersion,
 		commitTruncated,


### PR DESCRIPTION
CBG-4286

Describe your PR here...
- Added prefix to DCP feed names as per KV conventions

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
