### PR TITLE
CBG-5023: refactor memory tracking around deltas at the cache

### DIFF
--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -1048,7 +1048,8 @@ func (rc *LRURevisionCache) evictBasedOffMemoryUsage(ctx context.Context) int64 
 }
 
 // _decrRevCacheMemoryUsage atomically decreases overall memory usage for cache and the actual rev cache objects usage.
-// You should be holding rev cache lock in using this function to avoid eviction processes over evicting items
+// You should be holding rev cache lock in using this function to avoid eviction processes over evicting items. NOTE:
+// This function should be called with bytes count of the rev cache value and its associated delta (if it exists).
 func (rc *LRURevisionCache) _decrRevCacheMemoryUsage(ctx context.Context, bytesCount int64) {
 	// We need to keep track of the current LRURevisionCache memory usage AND the overall usage of the cache. We need
 	// overall memory usage for the stat added to show rev cache usage plus we need the current rev cache capacity of the

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2526,18 +2526,18 @@ func TestUpdateDeltaRevCacheMemoryStatPanicMultipleEntries(t *testing.T) {
 	// Thread 1: UpdateDelta - start
 	go func() {
 		for i := 0; i < 1000; i++ {
-			cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta2)
+			cache.UpdateDelta(ctx, "doc2", "1-abc", testCollectionID, revCacheDelta2)
 		}
 		wg.Done()
 	}()
 	// Thread 1: UpdateDelta - end
 	go func() {
 		for i := 0; i < 1000; i++ {
-			cache.RemoveWithRev(ctx, "doc1", "1-abc", testCollectionID)
+			cache.RemoveWithRev(ctx, "doc2", "1-abc", testCollectionID)
 			if i == 999 {
 				break
 			}
-			_, err = cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+			_, err = cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, RevCacheIncludeDelta)
 			require.NoError(t, err, "Error adding to cache")
 		}
 		wg.Done()


### PR DESCRIPTION
CBG-5023

**In progress**

The overall problem here is given we have to measure the size of a delta now we have issues with inconsistency with memory stats when rev cache state changes underneath the update delta process. 

Problem 1: 
- Thread 1: loading from bucket and in doing so is setting the item bytes on the value itself 
- Thread 2: is trying to update the delta on this value (this thread will acquire rev cache lock when thread 1 is done creating the value and over onto populating the value from the bucket)
- Issue arises that thread 2 will update our stats with size of delta and also update the value bytes size itself with size of delta then thread 1 goes to increment the stats with the memory footprint of the value (at this point it has been updated to increment the size of delta) 
    - Thus at this stage we end up double counting the delta size (once in update delta process and then once in increment memory stats post load from bucket) 

Problem 2: 
- Thread 1: calls update delta
- Thread 2: calls remove item, this thread will wait until rev cache mutex is released from thread 1, once this has taken place this thread will proceed with removing the value and reading decrementing overall memory footprint of cache with this values memory value
	- The issue arises here, thread 2 is removing the value underneath the update delta process, so thread 2 is decrementing the overall memory stats by the values footprint, this could be before or after thread 1 has updated the values memory footprint 
	- This means UpdateDelta thread (thread 1) is updating the stats with different view than what thread 2 is doing, we can end up with inconsistent stats here
	- This case is the case we think was hit in https://jira.issues.couchbase.com/browse/CBG-5020 

Overall delta sync is incompatible with memory based eviction as it stands. Enough workload through this path will lead to stats being incorrect. The problem we have is we cannot let the `UpdateDelta` process release the rev cache lock, given this is why we sometimes can end up with a value being removed underneath the UpdateDelta process. But we also cannot acquire the rev cache value lock here as we already have the rev cache lock (this should be avoided due to risk of deadlock). 

With recent changes that went in I tried using the new delta lock on the value, the issue here is holding this lock and rev cache lock seemed to lead to some deadlock scenarios in testing. 

Summary of changes:
- Have rev cache lock be held for the whole update delta process. This stops this particular value being removed under the update delta process. We need this to stop the removal process decrementing by some amount that doesn't reflect what the UpdateDelta process is incrementing by. 
- Have update delta process not follow through if the value itself hasn't been loaded/stored into yet. This is using the atomic boolean we have on the value. It is not safe to continue if some other thread is altering the value struct (during load or store functions).
- I have changed the decrement memory stats function. This function will decrement the memory value of the value itself AND the delta (if one exists). 
- Change to make `itemBytes` on the rev cache value just be a count of the rev cache items bytes (not the delta if one exists on the value). This means the increment memory stats function will ONLY increment memory stats by the values memory footprint (and not the delta) and we now leave the delta memory tracking to `UpdateDelta` 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/196/
