### PR TITLE
CBG-2234 rationalize close behavior

### DIFF
--- a/base/gocb_dcp_client.go
+++ b/base/gocb_dcp_client.go
@@ -250,7 +250,7 @@ func (dc *GoCBDCPClient) configureOneShot() error {
 	return nil
 }
 
-// Start returns an error and a channel to indicate when the DCPClient is done.
+// Start returns an error if the initial connection fails and channel to indicate when the DCPClient is completed. The channel will return an error if there was an abnormal close.
 func (dc *GoCBDCPClient) Start() (doneChan chan error, err error) {
 	err = dc.initAgent(dc.spec)
 	if err != nil {
@@ -277,7 +277,7 @@ func (dc *GoCBDCPClient) Start() (doneChan chan error, err error) {
 	return dc.doneChannel, nil
 }
 
-// Close is used externally to stop the DCP client. If the client was already closed due to error, returns that error
+// Close is used externally to stop the DCP client. This triggers a shutdown, but does not wait for completion.
 func (dc *GoCBDCPClient) Close() {
 	dc.close()
 }

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -132,7 +132,7 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 		case dcpCloseError := <-doneChan:
 			// This is a close because DCP client closed on its own, which should never happen since once
 			// DCP feed is started, there is nothing that will close it
-			InfofCtx(ctx, KeyDCP, "DCP Feed %q closed unexpectedly with %s", dcpCloseError)
+			InfofCtx(ctx, KeyDCP, "DCP Feed %q closed unexpectedly with %v", dcpCloseError)
 			// FIXME: close dbContext here
 			break
 		case <-args.Terminator:

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -124,39 +124,21 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
-		ErrorfCtx(ctx, "Failed to start DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), err)
-		// simplify in CBG-2234
-		closeErr := dcpClient.Close()
-		ErrorfCtx(ctx, "Finished called async close error from DCP Feed %q for bucket %q", feedName, MD(bucketName))
-		if closeErr != nil {
-			ErrorfCtx(ctx, "Close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), closeErr)
-		}
-		asyncCloseErr := <-doneChan
-		ErrorfCtx(ctx, "Finished calling async close error from DCP Feed %q for bucket %q: %v", feedName, MD(bucketName), asyncCloseErr)
 		return err
 	}
 	InfofCtx(ctx, KeyDCP, "Started DCP Feed %q for bucket %q", feedName, MD(bucketName))
 	go func() {
 		select {
 		case dcpCloseError := <-doneChan:
-			// simplify close in CBG-2234
 			// This is a close because DCP client closed on its own, which should never happen since once
 			// DCP feed is started, there is nothing that will close it
-			InfofCtx(ctx, KeyDCP, "Forced closed DCP Feed %q for %q", feedName, MD(bucketName))
-			// wait for channel close
-			<-doneChan
-			if dcpCloseError != nil {
-				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseError)
-			}
+			InfofCtx(ctx, KeyDCP, "DCP Feed %q closed unexpectedly with %s", dcpCloseError)
 			// FIXME: close dbContext here
 			break
 		case <-args.Terminator:
 			InfofCtx(ctx, KeyDCP, "Closing DCP Feed %q for bucket %q based on termination notification", feedName, MD(bucketName))
-			dcpCloseErr := dcpClient.Close()
-			if dcpCloseErr != nil {
-				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
-			}
-			dcpCloseErr = <-doneChan
+			dcpClient.Close()
+			dcpCloseErr := <-doneChan
 			if dcpCloseErr != nil {
 				WarnfCtx(ctx, "Error on closing DCP Feed %q for %q: %v", feedName, MD(bucketName), dcpCloseErr)
 			}

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -667,22 +667,7 @@ func TestAttachmentProcessError(t *testing.T) {
 	err := testDB1.AttachmentCompactionManager.Start(ctx1, map[string]any{"database": testDB1})
 	assert.NoError(t, err)
 
-	var status AttachmentManagerResponse
-	err = WaitForConditionWithOptions(t, func() bool {
-		rawStatus, err := testDB1.AttachmentCompactionManager.GetStatus(ctx1)
-		assert.NoError(t, err)
-		err = base.JSONUnmarshal(rawStatus, &status)
-		assert.NoError(t, err)
-
-		if status.State == BackgroundProcessStateError {
-			return true
-		}
-
-		return false
-	}, 200, 1000)
-	require.NoError(t, err)
-
-	assert.Equal(t, status.State, BackgroundProcessStateError)
+	RequireBackgroundManagerState(t, testDB1.AttachmentCompactionManager, BackgroundProcessStateError)
 }
 
 func TestAttachmentDifferentVBUUIDsBetweenPhases(t *testing.T) {

--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -189,16 +189,15 @@ func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string
 	doneChan, err := dcpClient.Start()
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to start attachment migration DCP feed: %v", migrationLoggingID, err)
-		_ = dcpClient.Close()
 		return err
 	}
 	base.TracefCtx(ctx, base.KeyAll, "[%s] DCP client started for Attachment Migration.", migrationLoggingID)
 
 	select {
-	case <-doneChan:
-		err = dcpClient.Close()
+	case err := <-doneChan:
 		if err != nil {
-			base.WarnfCtx(ctx, "[%s] Failed to close attachment migration DCP client after attachment migration process was finished %v", migrationLoggingID, err)
+			base.WarnfCtx(ctx, "[%s] Attachment migration DCP client closed unexpectedly: %v", migrationLoggingID, err)
+			return err
 		}
 		updatedDsNames := make(map[base.ScopeAndCollectionName]struct{}, len(db.CollectionByID))
 		// set sync info metadata version
@@ -225,15 +224,8 @@ func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string
 		}
 		base.InfofCtx(ctx, base.KeyAll, msg)
 	case <-terminator.Done():
-		err = dcpClient.Close()
-		if err != nil {
-			base.WarnfCtx(ctx, "[%s] Failed to close attachment migration DCP client after attachment migration process was terminated %v", migrationLoggingID, err)
-			return err
-		}
-		err = <-doneChan
-		if err != nil {
-			return err
-		}
+		dcpClient.Close()
+		<-doneChan // ignore DCP close error, we just want to terminate the process
 		msg := fmt.Sprintf("[%s] Attachment Migration was terminated. %d/%d docs changed", migrationLoggingID, a.docsChanged.Load(), a.docsProcessed.Load())
 		failedDocs := a.docsFailed.Load()
 		if failedDocs > 0 {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -294,11 +294,9 @@ func purgeWithDCPFeed(ctx context.Context, bucket base.Bucket, tbp *base.TestBuc
 			tbp.Logf(ctx, "purgeDCPFeed finished with error: %v", err)
 		}
 	case <-timeout:
+		dcpClient.Close()
+		<-doneChan
 		return fmt.Errorf("timeout waiting for purge DCP feed to complete")
-	}
-	closeErr := dcpClient.Close()
-	if closeErr != nil {
-		tbp.Logf(ctx, "error closing purge DCP feed: %v", closeErr)
 	}
 
 	tbp.Logf(ctx, "Finished purge DCP feed ... Total docs purged: %d", purgedDocCount.Load())


### PR DESCRIPTION
CBG-2234 rationalize close behavior in preparation for abstracted DCP client for DCP

Having `GoCBDCPClient.Close` return an error if it was already closed, but no error if it wasn't already closed was very confusing. This meant the initial error from `Close` were logged, but then you'd have to wait again for another error. This pattern will not work well with another implementation, so remove this separately.

- `DCPClient.Close` is an asynchronous function, since it can be called from the callback function, and would block. e.g. if `ProcessFeedEvent` calls `Close` then it could deadlock, so it was 
- Change `Start` to not return a `doneChan` if there is an error. This also means that `DCPClient.Close` is not required to be called when `Start` fails.
- Always wait for `doneChan` in tests

This is prep for CBG-5013 to make communication with a dcp client easier to understand.

1. You can call `Close` any number of times.
2. Finishing is indicated by `doneChannel` from `Start`. It will return an err (or nil) a single time, and then the channel is closed. This means one caller can find the error.

For this code, consider if this cleanup will negatively affect unrelated backports. Not all of this code is well tested since it is primarily around error handling, but it also could have been buggy before!.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/197/
