### PR TITLE
CBG-4673 Retry intermittent design doc operations

### DIFF
--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -732,7 +732,9 @@ func removeObsoleteDesignDocs(ctx context.Context, viewStore sgbucket.ViewStore,
 					err = viewStore.DeleteDDoc(ddocName)
 					return isRetriableDesignDocError(err), err, nil
 				}, getDesignDocRetrySleeperFunc())
-				if removeDDocErr == nil {
+				if removeDDocErr != nil {
+					base.WarnfCtx(ctx, "Unexpected error when removing design doc %q: %s", ddocName, removeDDocErr)
+				} else {
 					removedDesignDocs = append(removedDesignDocs, ddocName)
 				}
 			} else {
@@ -810,6 +812,7 @@ func isRetriableDesignDocError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// Retry for all errors (The view service sporadically returns 500 status codes with Erlang errors (for unknown reasons) - E.g: 500 {"error":"case_clause","reason":"false"})
+	// Retry for all errors except missing
+	// (The view service sporadically returns 500 status codes with Erlang errors (for unknown reasons) - E.g: 500 {"error":"case_clause","reason":"false"})
 	return !IsMissingDDocError(err)
 }


### PR DESCRIPTION
CBG-4673 Retry intermittent design doc operations

This prevents test flakes.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/194/ (ran for 45 minutes without failing before timing out)
