### PR TITLE
CBG-4915: Fix flakiness of `TestMultiActorLosingConflictUpdateRemovingAttachments`

### DIFF
--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -237,6 +237,11 @@ func (rt *RestTester) WaitForVersionRevIDOnly(docID string, version DocVersion) 
 	rt.WaitForVersion(docID, version)
 }
 
+func (rt *RestTester) WaitForVersionHLVOnly(docID string, version DocVersion) {
+	version.RevTreeID = ""
+	rt.WaitForVersion(docID, version)
+}
+
 // WaitForTombstone waits for a the document version to exist and be tombstoned. If the document is not found, the test will fail.
 func (rt *RestTester) WaitForTombstone(docID string, deleteVersion DocVersion) {
 	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -237,6 +237,7 @@ func (rt *RestTester) WaitForVersionRevIDOnly(docID string, version DocVersion) 
 	rt.WaitForVersion(docID, version)
 }
 
+// WaitForCV waits for the document's current version to match the expectedVersion. Fails the test harness. WaitForVersion should be used in the general case to test revtree and and cv behavior.
 func (rt *RestTester) WaitForVersionHLVOnly(docID string, version DocVersion) {
 	version.RevTreeID = ""
 	rt.WaitForVersion(docID, version)

--- a/xdcr/attachment_test.go
+++ b/xdcr/attachment_test.go
@@ -144,6 +144,4 @@ func TestMultiActorLosingConflictUpdateRemovingAttachments(t *testing.T) {
 	attBResp = rtB.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/"+docID+"/"+attachmentID, "")
 	rest.AssertStatus(t, attBResp, http.StatusOK)
 
-	require.NoError(t, xdcrAtoB.Stop(ctx))
-	require.NoError(t, xdcrBtoA.Stop(ctx))
 }

--- a/xdcr/attachment_test.go
+++ b/xdcr/attachment_test.go
@@ -77,12 +77,8 @@ func TestMultiActorLosingConflictUpdateRemovingAttachments(t *testing.T) {
 	rest.RequireStatus(t, attAResp, http.StatusOK)
 
 	// wait for doc to replicate to rtB
-	var rtBVersion rest.DocVersion
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		rtBVersion, _ = rtB.GetDoc(docID)
-		assert.Equal(c, rtAVersion.CV.String(), rtBVersion.CV.String())
-		assert.Equal(c, rtAVersion.RevTreeID, rtBVersion.RevTreeID)
-	}, time.Second*5, time.Millisecond*100)
+	rtB.WaitForVersion(docID, rtAVersion)
+	rtBVersion, _ := rtB.GetDoc(docID)
 
 	// wait for XDCR stats to ensure attachment data also made it over
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/xdcr/attachment_test.go
+++ b/xdcr/attachment_test.go
@@ -129,7 +129,7 @@ func TestMultiActorLosingConflictUpdateRemovingAttachments(t *testing.T) {
 	}, time.Second*5, time.Millisecond*100)
 
 	// wait for doc (resolved conflict) to replicate back to rtA
-	rtA.WaitForVersion(docID, rtBVersion)
+	rtA.WaitForVersionHLVOnly(docID, rtBVersion)
 
 	// check attachment metadata exists
 	docA := rtA.GetDocument(docID)

--- a/xdcr/attachment_test.go
+++ b/xdcr/attachment_test.go
@@ -129,10 +129,7 @@ func TestMultiActorLosingConflictUpdateRemovingAttachments(t *testing.T) {
 	}, time.Second*5, time.Millisecond*100)
 
 	// wait for doc (resolved conflict) to replicate back to rtA
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		currentRtAVersion, _ := rtA.GetDoc(docID)
-		assert.Equal(c, rtBVersion.CV.String(), currentRtAVersion.CV.String())
-	}, time.Second*10, time.Millisecond*100)
+	rtA.WaitForVersion(docID, rtBVersion)
 
 	// check attachment metadata exists
 	docA := rtA.GetDocument(docID)

--- a/xdcr/attachment_test.go
+++ b/xdcr/attachment_test.go
@@ -97,7 +97,7 @@ func TestMultiActorLosingConflictUpdateRemovingAttachments(t *testing.T) {
 	rest.RequireStatus(t, attBResp, http.StatusOK)
 
 	// update doc on A, removing attachment
-	rtAVersion = rtA.UpdateDoc(docID, rtAVersion, `{"key":"value2"}`)
+	_ = rtA.UpdateDoc(docID, rtAVersion, `{"key":"value2"}`)
 
 	// update doc on B, changing body but keeping attachment stub (twice to ensure MWW resolves this as the winner as well as LWW)
 	rtBVersion = rtB.UpdateDoc(docID, rtBVersion, `{"key":"value3","_attachments":{"`+attachmentID+`":{"stub":true}}}`)


### PR DESCRIPTION
CBG-4915

Describe your PR here...
- The test was flaky because the test would progress from the `require.EventuallyWithT` even though the condition is not completely met
- Refactored the code to use `RestTester`'s `WaitForVersion` method instead

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
