### PR TITLE
CBG-5050: fix for no rev messages being sent as changes on blip tester client

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -113,6 +113,10 @@ func (btcc *BlipTesterCollectionClient) getProposeChangesForSeq(seq clientSeq) (
 	if !ok {
 		return nil, false
 	}
+	latestRev := doc._revisionsBySeq[doc._latestSeq]
+	if latestRev.noRev {
+		return nil, false
+	}
 	return doc._proposeChangesEntryForDoc(), true
 }
 
@@ -197,6 +201,7 @@ type clientDocRev struct {
 	isDelete    bool
 	pullMessage *blip.Message // rev or norev message associated with this revision is successfully pulled and the response is received and processed by BlipTesterCollectionClient
 	pushMessage *blip.Message // rev or norev message associated with this revision is successfully pushed to Sync Gateway and a response has been received
+	noRev       bool          // true if this revision was created via a norev message
 }
 
 // clientDoc represents a document stored on the client - it may also contain older versions of the document.
@@ -902,6 +907,7 @@ func (btr *BlipTesterReplicator) handleNoRev(ctx context.Context, btc *BlipTeste
 			incomingVersion: incomingVersion,
 			incomingHLV:     incomingHLV,
 			msg:             msg,
+			isNoRev:         true,
 		})
 	}
 
@@ -2185,6 +2191,7 @@ type revOptions struct {
 	replacedVersion           *DocVersion             // replacedVersion is the version of the revision that was replaced, to update the global structure of all docIDs<->rev
 	updateLatestServerVersion bool                    // updateLatestServerVersion is true if the latestServerVersion should be updated to the newVersion. This only keeps track of a single Sync Gateway.
 	incomingHLV               *db.HybridLogicalVector // the incoming hlv for the revision. This is nil if revtrees are used and non nil if HLVs are used.
+	isNoRev                   bool                    // isNoRev is true if this revision was created from a _no_rev message
 }
 
 // addRev adds a revision for a specific document.
@@ -2218,6 +2225,7 @@ func (btcc *BlipTesterCollectionClient) addRev(ctx context.Context, docID string
 		body:        newBody,
 		HLV:         updatedHLV,
 		version:     newVersion,
+		noRev:       opts.isNoRev,
 	}
 
 	if !hasLocalDoc {


### PR DESCRIPTION

CBG-5050

- Recent merge uncovered some issues with no rev messages being sent as changes to SGW and subsequent rev messages for these changes being sent with nil bodies. This was causing issues in SGW 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
