### PR TITLE
CI: Add govulncheck / Bump main Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.5
@@ -46,7 +46,7 @@ jobs:
     name: addlicense
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.5
@@ -57,7 +57,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.5
@@ -84,7 +84,7 @@ jobs:
       MallocNanoZone: 0
     name: test (${{ matrix.name }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.5
@@ -104,7 +104,7 @@ jobs:
     env:
       GOPRIVATE: github.com/couchbaselabs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.5
@@ -123,7 +123,7 @@ jobs:
       GOPRIVATE: github.com/couchbaselabs
       SG_TEST_USE_DEFAULT_COLLECTION: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.5
@@ -139,14 +139,14 @@ jobs:
   python-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@v3
         with:
           args: 'format --check'
   python-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@v3
   test-sgcollect:
     runs-on: ${{ matrix.os }}
@@ -155,7 +155,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
       - name: Run test
         run: |
@@ -171,7 +171,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.5
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-latest
     name: build cache perf tool
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,9 @@ jobs:
         with:
           go-version: 1.25.5
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.0.2
+          version: v2.7
           args: --config=.golangci-strict.yml
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.5
       - name: go-build
         run: go build "./..."
 
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.5
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.5
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.5
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.5
       - name: Run Tests
         run: go test -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.5
       - name: Run Tests
         run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
@@ -174,7 +174,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.5
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.5
       - name: Build
         run: go build "./tools/cache_perf_tool"
   govulncheck:
@@ -197,5 +197,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-           go-version-input: 1.24.4
+           go-version-input: 1.25.5
            go-package: ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,3 +190,12 @@ jobs:
           go-version: 1.24.4
       - name: Build
         run: go build "./tools/cache_perf_tool"
+  govulncheck:
+    runs-on: ubuntu-latest
+    name: Run govulncheck
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+           go-version-input: 1.24.4
+           go-package: ./...

--- a/.github/workflows/manifestvalidation.yml
+++ b/.github/workflows/manifestvalidation.yml
@@ -39,7 +39,7 @@ jobs:
   manifest_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Ensure manifest product-config properties are sorted
         id: validate
         run: |

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     name: OpenAPI Validation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: r7kamura/redocly-problem-matchers@v1
       - uses: mhiew/redoc-lint-github-action@v4
         with:
@@ -58,7 +58,7 @@ jobs:
     name: 'yamllint'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: karancode/yamllint-github-action@master
         with:
           yamllint_file_or_dir: 'docs/api'

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify service script installation.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # build sync gateway since the executable is needed for service installation
       - uses: actions/setup-go@v5
         with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     }
 
     tools {
-        go '1.24.4'
+        go '1.25.5'
     }
 
     stages {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.24.3
+go 1.25.5
 
 require (
 	dario.cat/mergo v1.0.0

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -827,7 +827,7 @@
             "trigger_blackduck": true
         },
         "manifest/default.xml": {
-            "go_version": "1.24.4",
+            "go_version": "1.25.5",
             "interval": 30,
             "production": true,
             "release": "4.1.0",


### PR DESCRIPTION
- Add `govulncheck` to CI workflow
- Bump to latest Go version in `main`
- Bump `golangci-lint` action and tool due to Go version upgrade
- Tag `activeReplicatorCommon` async reconnect function with `go:norace` directive - fails reliably after Go version change in GH Actions

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/212/
