### PR TITLE
CBG-4945: Fix default sync function dry run

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1718,7 +1718,8 @@ func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, 
 		}
 	} else {
 		if syncFn == "" {
-			syncFn = channels.DocChannelsSyncFunction
+			scopeAndCollectionName := db.ScopeAndCollectionName()
+			syncFn = channels.GetDefaultSyncFunction(scopeAndCollectionName.Scope, scopeAndCollectionName.Collection)
 		}
 		jsTimeout := time.Duration(base.DefaultJavascriptTimeoutSecs) * time.Second
 		syncRunner, err := channels.NewSyncRunner(ctx, syncFn, jsTimeout)

--- a/db/crud.go
+++ b/db/crud.go
@@ -1711,12 +1711,15 @@ func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, 
 	}
 	var output *channels.ChannelMapperOutput
 	var syncErr error
-	if syncFn == "" {
+	if syncFn == "" && db.ChannelMapper != nil {
 		output, err = db.ChannelMapper.MapToChannelsAndAccess(ctx, mutableBody, string(oldDoc._rawBody), metaMap, syncOptions)
 		if err != nil {
 			return nil, &base.SyncFnDryRunError{Err: err}
 		}
 	} else {
+		if syncFn == "" {
+			syncFn = channels.DocChannelsSyncFunction
+		}
 		jsTimeout := time.Duration(base.DefaultJavascriptTimeoutSecs) * time.Second
 		syncRunner, err := channels.NewSyncRunner(ctx, syncFn, jsTimeout)
 		if err != nil {

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -1214,12 +1214,16 @@ func TestSyncFuncDryRun(t *testing.T) {
 			expectedOutput:  SyncFnDryRun{},
 			expectedStatus:  http.StatusBadRequest,
 		},
+		// Since the tests run in named Scopes and Collections therefore the
+		// default sync function is:
+		// function(doc){channel("<collection_name>");}
+		// therefore the channels returned will be named collections
 		{
 			name:        "no_custom_sync_func-default_db_sync_func-doc_body-no_existing_doc-no_doc_id",
 			document:    map[string]any{"channels": "chanNew"},
 			existingDoc: false,
 			expectedOutput: SyncFnDryRun{
-				Channels: base.SetFromArray([]string{"chanNew"}),
+				Channels: base.SetFromArray([]string{"sg_test_0"}),
 				Access:   channels.AccessMap{},
 				Roles:    channels.AccessMap{},
 			},
@@ -1232,7 +1236,7 @@ func TestSyncFuncDryRun(t *testing.T) {
 			existingDocID:   "doc22",
 			existingDocBody: `{"channels": "chanNew"}`,
 			expectedOutput: SyncFnDryRun{
-				Channels: base.SetFromArray([]string{"chanNew"}),
+				Channels: base.SetFromArray([]string{"sg_test_0"}),
 				Access:   channels.AccessMap{},
 				Roles:    channels.AccessMap{},
 			},

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -1214,6 +1214,30 @@ func TestSyncFuncDryRun(t *testing.T) {
 			expectedOutput:  SyncFnDryRun{},
 			expectedStatus:  http.StatusBadRequest,
 		},
+		{
+			name:        "no_custom_sync_func-default_db_sync_func-doc_body-no_existing_doc-no_doc_id",
+			document:    map[string]any{"channels": "chanNew"},
+			existingDoc: false,
+			expectedOutput: SyncFnDryRun{
+				Channels: base.SetFromArray([]string{"chanNew"}),
+				Access:   channels.AccessMap{},
+				Roles:    channels.AccessMap{},
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:            "no_custom_sync_func-default_db_sync_func-no_doc_body-existing_doc-doc_id",
+			docID:           "doc22",
+			existingDoc:     true,
+			existingDocID:   "doc22",
+			existingDocBody: `{"channels": "chanNew"}`,
+			expectedOutput: SyncFnDryRun{
+				Channels: base.SetFromArray([]string{"chanNew"}),
+				Access:   channels.AccessMap{},
+				Roles:    channels.AccessMap{},
+			},
+			expectedStatus: http.StatusOK,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
CBG-4945

Describe your PR here...
- Upstream [PR](https://github.com/couchbase/sync_gateway/pull/7935)- CBG-4412
- This PR fixes the behaviour of sync function dry run when the default sync function is used

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [x] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/206/
