### PR TITLE
CBG-4413: Add logging capture to Sync Function diagnostic API

### DIFF
--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -116,12 +116,10 @@ type SyncRunner struct {
 	expiry            *uint32             // document expiry (in seconds) specified via expiry() callback
 }
 
-func NewSyncRunner(ctx context.Context, funcSource string, timeout time.Duration) (*SyncRunner, error) {
+func NewSyncRunnerWithLogging(ctx context.Context, funcSource string, timeout time.Duration, errorLogFunc, infoLogFunc func(string)) (*SyncRunner, error) {
 	funcSource = wrappedFuncSource(funcSource)
 	runner := &SyncRunner{}
-	err := runner.InitWithLogging(funcSource, timeout,
-		func(s string) { base.ErrorfCtx(ctx, base.KeyJavascript.String()+": Sync %s", base.UD(s)) },
-		func(s string) { base.InfofCtx(ctx, base.KeyJavascript, "Sync %s", base.UD(s)) })
+	err := runner.InitWithLogging(funcSource, timeout, errorLogFunc, infoLogFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -210,6 +208,12 @@ func NewSyncRunner(ctx context.Context, funcSource string, timeout time.Duration
 		return output, err
 	}
 	return runner, nil
+}
+
+func NewSyncRunner(ctx context.Context, funcSource string, timeout time.Duration) (*SyncRunner, error) {
+	errorLogFunc := func(s string) { base.ErrorfCtx(ctx, base.KeyJavascript.String()+": Sync %s", base.UD(s)) }
+	infoLogFunc := func(s string) { base.InfofCtx(ctx, base.KeyJavascript, "Sync %s", base.UD(s)) }
+	return NewSyncRunnerWithLogging(ctx, funcSource, timeout, errorLogFunc, infoLogFunc)
 }
 
 func (runner *SyncRunner) SetFunction(funcSource string) (bool, error) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1697,7 +1697,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context
 // SyncFnDryrun Runs the given document body through a sync function and returns expiry, channels doc was placed in,
 // access map for users, roles, handler errors and sync fn exceptions.
 // If syncFn is provided, it will be used instead of the one configured on the database.
-func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, oldDoc *Document, syncFn string) (*channels.ChannelMapperOutput, error) {
+func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, oldDoc *Document, syncFn string, errorLogFunc, infoLogFunc func(string)) (*channels.ChannelMapperOutput, error) {
 
 	mutableBody, metaMap, _, err := db.prepareSyncFn(oldDoc, newDoc)
 	if err != nil {
@@ -1722,7 +1722,7 @@ func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, 
 			syncFn = channels.GetDefaultSyncFunction(scopeAndCollectionName.Scope, scopeAndCollectionName.Collection)
 		}
 		jsTimeout := time.Duration(base.DefaultJavascriptTimeoutSecs) * time.Second
-		syncRunner, err := channels.NewSyncRunner(ctx, syncFn, jsTimeout)
+		syncRunner, err := channels.NewSyncRunnerWithLogging(ctx, syncFn, jsTimeout, errorLogFunc, infoLogFunc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create sync runner: %v", err)
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1698,7 +1698,6 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context
 // access map for users, roles, handler errors and sync fn exceptions.
 // If syncFn is provided, it will be used instead of the one configured on the database.
 func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, oldDoc *Document, syncFn string, errorLogFunc, infoLogFunc func(string)) (*channels.ChannelMapperOutput, error) {
-
 	mutableBody, metaMap, _, err := db.prepareSyncFn(oldDoc, newDoc)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyDiagnostic, "Failed to prepare to run sync function: %v", err)
@@ -1709,32 +1708,30 @@ func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, 
 	if err != nil {
 		return nil, err
 	}
-	var output *channels.ChannelMapperOutput
-	var syncErr error
-	if syncFn == "" && db.ChannelMapper != nil {
-		output, err = db.ChannelMapper.MapToChannelsAndAccess(ctx, mutableBody, string(oldDoc._rawBody), metaMap, syncOptions)
-		if err != nil {
-			return nil, &base.SyncFnDryRunError{Err: err}
-		}
-	} else {
-		if syncFn == "" {
+
+	// fetch configured sync function if one is not provided
+	if syncFn == "" {
+		if db.ChannelMapper != nil {
+			syncFn = db.ChannelMapper.Function()
+		} else {
 			scopeAndCollectionName := db.ScopeAndCollectionName()
 			syncFn = channels.GetDefaultSyncFunction(scopeAndCollectionName.Scope, scopeAndCollectionName.Collection)
 		}
-		jsTimeout := time.Duration(base.DefaultJavascriptTimeoutSecs) * time.Second
-		syncRunner, err := channels.NewSyncRunnerWithLogging(ctx, syncFn, jsTimeout, errorLogFunc, infoLogFunc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create sync runner: %v", err)
-		}
-		jsOutput, err := syncRunner.Call(ctx, mutableBody, string(oldDoc._rawBody), metaMap, syncOptions)
-		if err != nil {
-
-			return nil, &base.SyncFnDryRunError{Err: err}
-		}
-		output = jsOutput.(*channels.ChannelMapperOutput)
 	}
 
-	return output, syncErr
+	// create new sync runner instance for this dry run
+	jsTimeout := time.Duration(base.DefaultJavascriptTimeoutSecs) * time.Second
+	syncRunner, err := channels.NewSyncRunnerWithLogging(ctx, syncFn, jsTimeout, errorLogFunc, infoLogFunc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sync runner: %v", err)
+	}
+
+	jsOutput, err := syncRunner.Call(ctx, mutableBody, sgbucket.JSONString(oldDoc._rawBody), metaMap, syncOptions)
+	if err != nil {
+		return nil, &base.SyncFnDryRunError{Err: err}
+	}
+
+	return jsOutput.(*channels.ChannelMapperOutput), nil
 }
 
 // revTreeConflictCheck checks for conflicts in the rev tree history and returns the parent revid, currentRevIndex

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -21,12 +21,18 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 )
 
+type SyncFnDryRunLogging struct {
+	Errors []string `json:"errors"`
+	Info   []string `json:"info"`
+}
+
 type SyncFnDryRun struct {
-	Channels  base.Set           `json:"channels"`
-	Access    channels.AccessMap `json:"access"`
-	Roles     channels.AccessMap `json:"roles"`
-	Exception string             `json:"exception"`
-	Expiry    *uint32            `json:"expiry,omitempty"`
+	Channels  base.Set            `json:"channels"`
+	Access    channels.AccessMap  `json:"access"`
+	Roles     channels.AccessMap  `json:"roles"`
+	Exception string              `json:"exception"`
+	Expiry    *uint32             `json:"expiry,omitempty"`
+	Logging   SyncFnDryRunLogging `json:"logging"`
 }
 
 type ImportFilterDryRun struct {
@@ -144,7 +150,16 @@ func (h *handler) handleSyncFnDryRun() error {
 	newRev := db.CreateRevIDWithBytes(generation, matchRev, rawDocBytes)
 	newDoc.RevID = newRev
 
-	output, err := h.collection.SyncFnDryrun(h.ctx(), newDoc, oldDoc, syncDryRunPayload.Function)
+	logErrors := make([]string, 0)
+	logInfo := make([]string, 0)
+	errorLogFn := func(s string) {
+		logErrors = append(logErrors, s)
+	}
+	infoLogFn := func(s string) {
+		logInfo = append(logInfo, s)
+	}
+
+	output, err := h.collection.SyncFnDryrun(h.ctx(), newDoc, oldDoc, syncDryRunPayload.Function, errorLogFn, infoLogFn)
 	if err != nil {
 		var syncFnDryRunErr *base.SyncFnDryRunError
 		if !errors.As(err, &syncFnDryRunErr) {
@@ -154,6 +169,7 @@ func (h *handler) handleSyncFnDryRun() error {
 		errMsg := syncFnDryRunErr.Error()
 		resp := SyncFnDryRun{
 			Exception: errMsg,
+			Logging:   SyncFnDryRunLogging{Errors: logErrors, Info: logInfo},
 		}
 		h.writeJSON(resp)
 		return nil
@@ -169,6 +185,7 @@ func (h *handler) handleSyncFnDryRun() error {
 		output.Roles,
 		errorMsg,
 		output.Expiry,
+		SyncFnDryRunLogging{Errors: logErrors, Info: logInfo},
 	}
 	h.writeJSON(resp)
 	return nil

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -30,7 +30,7 @@ type SyncFnDryRun struct {
 	Channels  base.Set            `json:"channels"`
 	Access    channels.AccessMap  `json:"access"`
 	Roles     channels.AccessMap  `json:"roles"`
-	Exception string              `json:"exception"`
+	Exception string              `json:"exception,omitempty"`
 	Expiry    *uint32             `json:"expiry,omitempty"`
 	Logging   SyncFnDryRunLogging `json:"logging"`
 }
@@ -89,7 +89,7 @@ func (h *handler) handleSyncFnDryRun() error {
 	}
 
 	if syncDryRunPayload.Doc == nil && docid == "" {
-		return base.HTTPErrorf(http.StatusBadRequest, "no docid or document provided")
+		return base.HTTPErrorf(http.StatusBadRequest, "no doc_id or document provided")
 	}
 
 	oldDoc := &db.Document{ID: docid}

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -1049,6 +1049,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Access:   channels.AccessMap{"user": channels.BaseSetOf(t, "dynamicChan5412")},
 				Roles:    channels.AccessMap{},
 				Expiry:   base.Ptr(uint32(10)),
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1062,6 +1066,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Channels: base.SetFromArray([]string{}),
 				Access:   channels.AccessMap{},
 				Roles:    channels.AccessMap{"user": channels.BaseSetOf(t, "role1")},
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1076,6 +1084,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Access:   channels.AccessMap{"user": channels.BaseSetOf(t, "dynamicChan5412")},
 				Roles:    channels.AccessMap{},
 				Expiry:   base.Ptr(uint32(10)),
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1090,6 +1102,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Access:   channels.AccessMap{"user": channels.BaseSetOf(t, "dynamicChan5412")},
 				Roles:    channels.AccessMap{},
 				Expiry:   base.Ptr(uint32(10)),
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1106,6 +1122,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Access:   channels.AccessMap{"user": channels.BaseSetOf(t, "dynamicChan5412")},
 				Roles:    channels.AccessMap{},
 				Expiry:   base.Ptr(uint32(10)),
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1120,6 +1140,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Access:    channels.AccessMap{},
 				Roles:     channels.AccessMap{},
 				Exception: "403 user num too low",
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1134,6 +1158,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 			existingDocBody: `{"user":{"num":123, "name":["user1"]}, "channel":"channel1"}`,
 			expectedOutput: SyncFnDryRun{
 				Exception: "Error returned from Sync Function: TypeError: Cannot access member '0' of undefined",
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1151,6 +1179,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Access:    channels.AccessMap{"user1": channels.BaseSetOf(t, "channel2")},
 				Roles:     channels.AccessMap{},
 				Exception: "",
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1167,6 +1199,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Access:    channels.AccessMap{},
 				Roles:     channels.AccessMap{},
 				Exception: "",
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1205,6 +1241,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Channels: base.SetFromArray([]string{"channel2"}),
 				Access:   channels.AccessMap{},
 				Roles:    channels.AccessMap{},
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1221,6 +1261,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Channels: base.SetFromArray([]string{"chanOld"}),
 				Access:   channels.AccessMap{},
 				Roles:    channels.AccessMap{},
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1244,6 +1288,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Channels: base.SetFromArray([]string{defaultChannelName}),
 				Access:   channels.AccessMap{},
 				Roles:    channels.AccessMap{},
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -1257,13 +1305,48 @@ func TestSyncFuncDryRun(t *testing.T) {
 				Channels: base.SetFromArray([]string{defaultChannelName}),
 				Access:   channels.AccessMap{},
 				Roles:    channels.AccessMap{},
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{},
+					Info:   []string{},
+				},
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:            "logging",
+			docID:           "logging",
+			existingDoc:     true,
+			existingDocID:   "logging",
+			existingDocBody: `{"channel": "chanLog", "logerror": true, "loginfo": true}`,
+			syncFunction: `function(doc) {
+				channel(doc.channel);
+				if (doc.logerror) {
+					console.error("This is a console.error log from logerror");
+				} else {
+					console.log("This is a console.log log from logerror");
+				}
+				if (doc.loginfo) {
+					console.log("This is a console.log log from loginfo");
+				} else {
+					console.error("This is a console.error log from logerror");
+				}
+				console.log("one more info for good measure...");
+			}`,
+			expectedOutput: SyncFnDryRun{
+				Channels: base.SetFromArray([]string{"chanLog"}),
+				Access:   channels.AccessMap{},
+				Roles:    channels.AccessMap{},
+				Logging: SyncFnDryRunLogging{
+					Errors: []string{"This is a console.error log from logerror"},
+					Info:   []string{"This is a console.log log from loginfo", "one more info for good measure..."},
+				},
 			},
 			expectedStatus: http.StatusOK,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		rt.Run(test.name, func(t *testing.T) {
 			dbConfig := rt.NewDbConfig()
 			dbConfig.Sync = &test.dbSyncFunction
 			RequireStatus(t, rt.SendAdminRequest("PUT", "/{{.keyspace}}/_config/sync", test.dbSyncFunction), http.StatusOK)


### PR DESCRIPTION
CBG-4413

Captures log output from sync function execution to be piped back into the diagnostic API response
- Also fixes regression in SyncRunner pool use from Diagnostic API
- Refactor tests for clearer test cases and improved reliability

Example:

```javascript
function(doc){
	console.log("this is my doc: "+JSON.stringify(doc));
	console.error("oops!");
	channel(doc.channels);
}
```

```shell
$ curl http://localhost:4987/db1/_sync -H 'Content-Type: application/json' -d '{"doc":{"foo":"bar","channels":["asdf"]}}' | jq
{
  "channels": [
    "asdf"
  ],
  "access": {},
  "roles": {},
  "logging": {
    "errors": [
      "oops!"
    ],
    "info": [
      "this is my doc: {\"_id\":\"\",\"_rev\":\"1-4f209ea9d3dd051b91697a7d5dbf78a6\",\"channels\":[\"asdf\"],\"foo\":\"bar\"}"
    ]
  }
}
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/209/
