### PR TITLE
CBG-5065 sgcollect: remove tmpdir

### DIFF
--- a/tools/sgcollect.py
+++ b/tools/sgcollect.py
@@ -927,77 +927,75 @@ def main() -> NoReturn:
         do_upload(args[0], options.just_upload_into, options.upload_proxy)
 
     # Create a TaskRunner and run all of the OS tasks (collect top, netstat, etc)
-    # The output of the tasks will go directly into couchbase.log
-    runner = TaskRunner(
+    with TaskRunner(
         verbosity=options.verbosity,
         default_name="sync_gateway.log",
         tmp_dir=options.tmp_dir,
-    )
+    ) as runner:
+        if not options.product_only:
+            for task in make_os_tasks(["sync_gateway"]):
+                runner.run(task)
 
-    if not options.product_only:
-        for task in make_os_tasks(["sync_gateway"]):
+        # Output the Python version if verbosity was enabled
+        if options.verbosity:
+            log("Python version: %s" % sys.version)
+
+        # Find path to sg binary
+        sg_binary_path = discover_sg_binary_path(options, sg_url, auth_headers)
+
+        # Run SG specific tasks
+        for task in make_sg_tasks(
+            sg_url=sg_url,
+            auth_headers=auth_headers,
+            sync_gateway_config_path_option=options.sync_gateway_config,
+            sync_gateway_executable_path=options.sync_gateway_executable,
+            should_redact=should_redact,
+        ):
             runner.run(task)
 
-    # Output the Python version if verbosity was enabled
-    if options.verbosity:
-        log("Python version: %s" % sys.version)
-
-    # Find path to sg binary
-    sg_binary_path = discover_sg_binary_path(options, sg_url, auth_headers)
-
-    # Run SG specific tasks
-    for task in make_sg_tasks(
-        sg_url=sg_url,
-        auth_headers=auth_headers,
-        sync_gateway_config_path_option=options.sync_gateway_config,
-        sync_gateway_executable_path=options.sync_gateway_executable,
-        should_redact=should_redact,
-    ):
-        runner.run(task)
-
-    if (
-        sg_binary_path is not None
-        and sg_binary_path != ""
-        and os.path.exists(sg_binary_path)
-    ):
-        runner.collect_file(sg_binary_path)
-    else:
-        print(
-            "WARNING: unable to find Sync Gateway executable, omitting from result.  Go pprofs will not be accurate."
-        )
-
-    runner.run(get_sgcollect_info_options_task(options, args))
-
-    runner.close_all_files()
-
-    # Build redacted zip file
-    if should_redact:
-        log("Redacting log files to level: %s" % options.redact_level)
-        runner.redact_and_zip(
-            redact_zip_file, "sgcollect_info", options.salt_value, platform.node()
-        )
-
-    # Build the actual zip file
-    runner.zip(zip_filename, "sgcollect_info", platform.node())
-
-    if options.redact_level != "none":
-        print("Zipfile built: {0}".format(redact_zip_file))
-
-    print("Zipfile built: {0}".format(zip_filename))
-
-    if not upload_url:
-        sys.exit(0)
-    # Upload the zip to the URL to S3 if required
-    try:
-        if should_redact:
-            exit_code = do_upload(redact_zip_file, upload_url, options.upload_proxy)
+        if (
+            sg_binary_path is not None
+            and sg_binary_path != ""
+            and os.path.exists(sg_binary_path)
+        ):
+            runner.collect_file(sg_binary_path)
         else:
-            exit_code = do_upload(zip_filename, upload_url, options.upload_proxy)
-    finally:
-        if not options.keep_zip:
-            delete_zip(zip_filename)
-            delete_zip(redact_zip_file)
-    sys.exit(exit_code)
+            print(
+                "WARNING: unable to find Sync Gateway executable, omitting from result.  Go pprofs will not be accurate."
+            )
+
+        runner.run(get_sgcollect_info_options_task(options, args))
+
+        runner.close_all_files()
+
+        # Build redacted zip file
+        if should_redact:
+            log("Redacting log files to level: %s" % options.redact_level)
+            runner.redact_and_zip(
+                redact_zip_file, "sgcollect_info", options.salt_value, platform.node()
+            )
+
+        try:
+            # Build the actual zip file
+            runner.zip(zip_filename, "sgcollect_info", platform.node())
+
+            if options.redact_level != "none":
+                print("Zipfile built: {0}".format(redact_zip_file))
+
+            print("Zipfile built: {0}".format(zip_filename))
+
+            if not upload_url:
+                sys.exit(0)
+            # Upload the zip to the URL to S3 if required
+            if should_redact:
+                exit_code = do_upload(redact_zip_file, upload_url, options.upload_proxy)
+            else:
+                exit_code = do_upload(zip_filename, upload_url, options.upload_proxy)
+            sys.exit(exit_code)
+        finally:
+            if not options.keep_zip and upload_url:
+                delete_zip(zip_filename)
+                delete_zip(redact_zip_file)
 
 
 def ud(value, should_redact=True):

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -282,8 +282,8 @@ class TaskRunner(object):
 
     def __exit__(
         self,
-        exc_type: Optional[BaseException],
-        exc_value: Optional[BaseException],
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[type[BaseException]],
         traceback: Optional[types.TracebackType],
     ):
         self.close_all_files()


### PR DESCRIPTION
CBG-5065 sgcollect: remove tmpdir

- Removes tmpdir on any exception. This fixes an accidental regression in https://github.com/couchbase/sync_gateway/commit/d8f6cfe287abc7b4dba15c90f24e1d7a8ca2af10 which removed the `atexit` handling. Using a context manager is more robust than `atexit` since it will cover SIGTERM exiting as well.
- Handle removing zipfile in a `finally` statement earlier if it fails in `runner.redact_and_zip` or `runner.zip`

Most changes are whitespace only to indent.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`