### PR TITLE
Add dry-run logging output to OpenAPI specs

### DIFF
--- a/docs/api/paths/diagnostic/keyspace-import_filter.yaml
+++ b/docs/api/paths/diagnostic/keyspace-import_filter.yaml
@@ -46,8 +46,20 @@ post:
               error:
                 description: Errors thrown by the Import filter.
                 type: string
-
-
+              logging:
+                description: Logging emitted by the import filter during evaluation.
+                type: object
+                properties:
+                  errors:
+                    description: Error messages logged by the import filter.
+                    type: array
+                    items:
+                      type: string
+                  info:
+                    description: Info messages logged by the import filter.
+                    type: array
+                    items:
+                      type: string
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   parameters:

--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -70,11 +70,23 @@ post:
                     additionalProperties:
                       x-additionalPropertiesName: channel
                       type: string
-
               exception:
                 description: Errors thrown by the sync function.
                 type: string
-
+              logging:
+                description: Logging emitted by the sync function during evaluation.
+                type: object
+                properties:
+                  errors:
+                    description: Error messages logged by the sync function.
+                    type: array
+                    items:
+                      type: string
+                  info:
+                    description: Info messages logged by the sync function.
+                    type: array
+                    items:
+                      type: string
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   parameters:


### PR DESCRIPTION
This was something I forgot with the original sync function dry-run logging PR #7938 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a