### PR TITLE
Create 4.0.3 builds (and bump Go version)

### DIFF
--- a/manifest/4.0/4.0.2.1.xml
+++ b/manifest/4.0/4.0.2.1.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="4.0.3" keep="true"/>
+        <annotation name="VERSION" value="4.0.2.1" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/4.0.3"/>
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="fe8e012e0ea2846cec1c3486da9927e58ff0c041"/>
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -788,11 +788,11 @@
             "trigger_blackduck": true
         },
         "manifest/4.0.xml": {
-            "go_version": "1.24.4",
+            "go_version": "1.24.11",
             "interval": 120,
             "production": true,
-            "release": "4.0.2.1",
-            "release_name": "Couchbase Sync Gateway 4.0.2.1",
+            "release": "4.0.3",
+            "release_name": "Couchbase Sync Gateway 4.0.3",
             "start_build": 1,
             "trigger_blackduck": true
         },
@@ -844,6 +844,16 @@
             "release": "4.0.2",
             "release_name": "Couchbase Sync Gateway 4.0.2",
             "start_build": 4,
+            "trigger_blackduck": true
+        },
+        "manifest/4.0/4.0.2.1.xml": {
+            "do-build": false,
+            "go_version": "1.24.4",
+            "interval": 1440,
+            "production": true,
+            "release": "4.0.2.1",
+            "release_name": "Couchbase Sync Gateway 4.0.2.1",
+            "start_build": 2,
             "trigger_blackduck": true
         },
         "manifest/default.xml": {

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -836,16 +836,6 @@
             "start_build": 2,
             "trigger_blackduck": true
         },
-        "manifest/4.0/4.0.2.xml": {
-            "do-build": false,
-            "go_version": "1.24.4",
-            "interval": 1440,
-            "production": true,
-            "release": "4.0.2",
-            "release_name": "Couchbase Sync Gateway 4.0.2",
-            "start_build": 4,
-            "trigger_blackduck": true
-        },
         "manifest/4.0/4.0.2.1.xml": {
             "do-build": false,
             "go_version": "1.24.4",
@@ -854,6 +844,16 @@
             "release": "4.0.2.1",
             "release_name": "Couchbase Sync Gateway 4.0.2.1",
             "start_build": 2,
+            "trigger_blackduck": true
+        },
+        "manifest/4.0/4.0.2.xml": {
+            "do-build": false,
+            "go_version": "1.24.4",
+            "interval": 1440,
+            "production": true,
+            "release": "4.0.2",
+            "release_name": "Couchbase Sync Gateway 4.0.2",
+            "start_build": 4,
             "trigger_blackduck": true
         },
         "manifest/default.xml": {


### PR DESCRIPTION
CBG-5087

- Create 4.0.3 builds
- Bump Go version to latest 1.24.x

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a