### PR TITLE
Create 3.3.3 builds (and bump Go version)

### DIFF
--- a/manifest/3.3/3.3.2.2.xml
+++ b/manifest/3.3/3.3.2.2.xml
@@ -18,13 +18,13 @@ licenses/APL2.txt.
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
     <project name="build" path="cbbuild" remote="couchbase" revision="b1dc2359603ab411ce0788854ea879ce804c9055">
-        <annotation name="VERSION" value="3.3.3" keep="true"/>
+        <annotation name="VERSION" value="3.3.2.2" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="release/3.3.3"/>
+    <project name="sync_gateway" path="sync_gateway" remote="couchbase" revision="49c17726b4de5644268b811dc624ba0b14ad0c98"/>
 
 </manifest>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -719,11 +719,11 @@
             "trigger_blackduck": true
         },
         "manifest/3.3.xml": {
-            "go_version": "1.24.4",
+            "go_version": "1.24.11",
             "interval": 120,
             "production": true,
-            "release": "3.3.2.2",
-            "release_name": "Couchbase Sync Gateway 3.3.2.2",
+            "release": "3.3.3",
+            "release_name": "Couchbase Sync Gateway 3.3.3",
             "start_build": 1,
             "trigger_blackduck": true
         },
@@ -774,6 +774,16 @@
             "production": true,
             "release": "3.3.2.1",
             "release_name": "Couchbase Sync Gateway 3.3.2.1",
+            "start_build": 2,
+            "trigger_blackduck": true
+        },
+        "manifest/3.3/3.3.2.2.xml": {
+            "do-build": false,
+            "go_version": "1.24.4",
+            "interval": 1440,
+            "production": true,
+            "release": "3.3.2.2",
+            "release_name": "Couchbase Sync Gateway 3.3.2.2",
             "start_build": 2,
             "trigger_blackduck": true
         },


### PR DESCRIPTION
CBG-5058

- Create 3.3.3 builds
- Bump Go version to latest 1.24.x

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a