### PR TITLE
[3.3.3 backport] CBG-5094: race detector: SkipList impl RemoveSkipped() / getOldestSkippedSequence() 

### DIFF
--- a/db/skipped_sequence.go
+++ b/db/skipped_sequence.go
@@ -114,12 +114,7 @@ func (s *SkippedSequenceSkiplist) PushSkippedSequenceEntry(entry skiplist.Skippe
 
 // getOldest returns the start sequence of the first element in the skipped sequence list
 func (s *SkippedSequenceSkiplist) getOldest() uint64 {
-	elem := s.list.Front()
-	if elem != nil {
-		return elem.Key().Start
-	}
-	// list empty
-	return 0
+	return s.list.FrontKey().Start
 }
 
 // getStats will return all associated stats with the skipped sequence list

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -697,7 +697,7 @@ func TestGetOldestSkippedSequence(t *testing.T) {
 			expected:  2,
 		},
 		{
-			name:     "empty_slice",
+			name:     "empty_list",
 			empty:    true,
 			expected: 0,
 		},

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/couchbase/gomemcached v0.2.1
 	github.com/couchbase/goutils v0.1.2
 	github.com/couchbase/sg-bucket v0.0.0-20250522135601-8c9a5acda2c2
-	github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892
+	github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac
 	github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338
 	github.com/couchbaselabs/gocbconnstr v1.0.5
 	github.com/couchbaselabs/rosmar v0.0.0-20240610211258-c856107e8e78

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.3
 require (
 	dario.cat/mergo v1.0.0
 	github.com/KimMachineGun/automemlimit v0.7.2
+	github.com/coder/websocket v1.8.12
 	github.com/coreos/go-oidc/v3 v3.13.0
 	github.com/couchbase/cbgt v1.3.10-0.20250613155824-1f75a127519e
 	github.com/couchbase/clog v0.1.0
@@ -46,7 +47,6 @@ require (
 	github.com/aws/aws-sdk-go v1.44.299 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/coder/websocket v1.8.12 // indirect
 	github.com/couchbase/blance v0.1.5 // indirect
 	github.com/couchbase/cbauth v0.1.11 // indirect
 	github.com/couchbase/go-couchbase v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/couchbase/tools-common/types v1.0.0 h1:C9MjHmTPcZyPo2Yp9Dt86WeZH+2XQg
 github.com/couchbase/tools-common/types v1.0.0/go.mod h1:r700V2xUuJqBGNG2aWbQYn5S0sJdqO3TLIa2AIQVaGU=
 github.com/couchbase/tools-common/utils v1.0.0 h1:6mWXqWWj7aM0Kp2LWpSKEu9pLAYm7il3gWdqpvxnJV4=
 github.com/couchbase/tools-common/utils v1.0.0/go.mod h1:i6cN5Z5hB9vQRLxe2j1v6Nu8bv+pKl9BFXjbQUHSah8=
-github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892 h1:LOejWK/W0fU/KTtq30qnb3damJyaQLNZdaB9psK0ed8=
-github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892/go.mod h1:fxGN9x1k//Vpl+GIeIENqNgysUmCKHb+bCV2AzXO5R4=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac h1:6ekMSvH+AJkT30hMfZtto+M7viRNHCSbJgMwCvO4p64=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac/go.mod h1:ssmbsFABKtkHCeT2fN/xeRUnvmsOihRL9CAh3BDzfhU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/couchbase/tools-common/utils v1.0.0 h1:6mWXqWWj7aM0Kp2LWpSKEu9pLAYm7i
 github.com/couchbase/tools-common/utils v1.0.0/go.mod h1:i6cN5Z5hB9vQRLxe2j1v6Nu8bv+pKl9BFXjbQUHSah8=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892 h1:LOejWK/W0fU/KTtq30qnb3damJyaQLNZdaB9psK0ed8=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250612112434-65f227bb1892/go.mod h1:fxGN9x1k//Vpl+GIeIENqNgysUmCKHb+bCV2AzXO5R4=
+github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac h1:6ekMSvH+AJkT30hMfZtto+M7viRNHCSbJgMwCvO4p64=
+github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac/go.mod h1:ssmbsFABKtkHCeT2fN/xeRUnvmsOihRL9CAh3BDzfhU=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
 github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8 h1:MQfvw4BiLTuyR69FuA5Kex+tXUeLkH+/ucJfVL1/hkM=


### PR DESCRIPTION
[CBG-5094](https://jira.issues.couchbase.com/browse/CBG-5094)

Backports race condition from fetching oldest skipped sequence

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/215/


[CBG-5094]: https://couchbasecloud.atlassian.net/browse/CBG-5094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ