### PR TITLE
Reenable assertion in TestRoleAccessQuery for old Query bugfix

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -242,7 +242,7 @@ func (b *GocbV2Bucket) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 		}
 		return len(agent.N1qlEps()) > 0
 	case sgbucket.BucketStoreFeatureN1qlIfNotExistsDDL:
-		return IsMinimumVersion(b.clusterCompatMajorVersion, b.clusterCompatMinorVersion, 7, 1)
+		return b.IsMinimumVersion(7, 1)
 	// added in Couchbase Server 6.6
 	case sgbucket.BucketStoreFeatureCreateDeletedWithXattr:
 		status, err := b.bucket.Internal().CapabilityStatus(gocb.CapabilityCreateAsDeleted)
@@ -252,14 +252,19 @@ func (b *GocbV2Bucket) IsSupported(feature sgbucket.BucketStoreFeature) bool {
 		return status == gocb.CapabilityStatusSupported
 	case sgbucket.BucketStoreFeaturePreserveExpiry, sgbucket.BucketStoreFeatureCollections:
 		// TODO: Change to capability check when GOCBC-1218 merged
-		return IsMinimumVersion(b.clusterCompatMajorVersion, b.clusterCompatMinorVersion, 7, 0)
+		return b.IsMinimumVersion(7, 0)
 	case sgbucket.BucketStoreFeatureSystemCollections, sgbucket.BucketStoreFeatureMultiXattrSubdocOperations:
-		return IsMinimumVersion(b.clusterCompatMajorVersion, b.clusterCompatMinorVersion, 7, 6)
+		return b.IsMinimumVersion(7, 6)
 	case sgbucket.BucketStoreFeatureMobileXDCR:
 		return b.supportsHLV
 	default:
 		return false
 	}
+}
+
+// IsMinimumVersion returns whether the connected cluster is at least the specified major/minor version.
+func (b *GocbV2Bucket) IsMinimumVersion(requiredMajor, requiredMinor uint64) bool {
+	return IsMinimumVersion(b.clusterCompatMajorVersion, b.clusterCompatMinorVersion, requiredMajor, requiredMinor)
 }
 
 func (b *GocbV2Bucket) StartDCPFeed(ctx context.Context, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -327,7 +327,11 @@ func TestRoleAccessQuery(t *testing.T) {
 	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
 	usernames := []string{"user1'", "user1?", "user1 ! user2$"}
-	// usernames = append(usernames, "user1`AND") // TODO: MB-50619 - broken until Server 7.1.0
+	if gocbBucket, err := base.AsGocbV2Bucket(db.Bucket); err != nil && gocbBucket != nil {
+		if gocbBucket.IsMinimumVersion(7, 1) {
+			usernames = append(usernames, "user1`AND") // MB-50619 - was broken until Server 7.1.0
+		}
+	}
 	for _, username := range usernames {
 		results, queryErr = collection.QueryRoleAccess(base.TestCtx(t), username)
 		assert.NoError(t, queryErr, "Query error")

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -327,11 +327,7 @@ func TestRoleAccessQuery(t *testing.T) {
 	// Attempt to introduce syntax errors. Each of these should return zero rows and no error.
 	// Validates select clause protection
 	usernames := []string{"user1'", "user1?", "user1 ! user2$"}
-	if gocbBucket, err := base.AsGocbV2Bucket(db.Bucket); err != nil && gocbBucket != nil {
-		if gocbBucket.IsMinimumVersion(7, 1) {
-			usernames = append(usernames, "user1`AND") // MB-50619 - was broken until Server 7.1.0
-		}
-	}
+	usernames = append(usernames, "user1`AND") // MB-50619 - was broken until Server 7.1.0
 	for _, username := range usernames {
 		results, queryErr = collection.QueryRoleAccess(base.TestCtx(t), username)
 		assert.NoError(t, queryErr, "Query error")


### PR DESCRIPTION
Pulled out of other cleanup/refactoring.

* Uses `IsMinimumVersion` to conditionally enable now passing assertion for MB-50619

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `enterprise-7.6.7` `^TestRoleAccessQuery$` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/218/