### PR TITLE
CBG-5089: Add support for user defined metadata in diagnostic api

### DIFF
--- a/db/background_mgr_attachment_migration.go
+++ b/db/background_mgr_attachment_migration.go
@@ -131,7 +131,7 @@ func (a *AttachmentMigrationManager) Run(ctx context.Context, options map[string
 		}
 
 		a.docsProcessed.Add(1)
-		_, syncData, err := UnmarshalDocumentSyncDataFromFeed(event.Value, event.DataType, collection.userXattrKey(), false)
+		_, syncData, err := UnmarshalDocumentSyncDataFromFeed(event.Value, event.DataType, collection.UserXattrKey(), false)
 		if err != nil {
 			base.WarnfCtx(ctx, "[%s] error unmarshaling document %s: %v, stopping attachment migration.", migrationLoggingID, base.UD(docID), err)
 			a.docsFailed.Add(1)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -376,7 +376,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 	}
 
 	// First unmarshal the doc (just its metadata, to save time/memory):
-	doc, syncData, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.userXattrKey(), false)
+	doc, syncData, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.UserXattrKey(), false)
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
@@ -389,7 +389,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 	}
 
 	// If using xattrs and this isn't an SG write, we shouldn't attempt to cache.
-	rawUserXattr := doc.Xattrs[collection.userXattrKey()]
+	rawUserXattr := doc.Xattrs[collection.UserXattrKey()]
 	if collection.UseXattrs() {
 		if syncData == nil {
 			return

--- a/db/crud.go
+++ b/db/crud.go
@@ -1704,7 +1704,7 @@ func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, 
 		return nil, err
 	}
 
-	if len(userMeta) > 0 {
+	if userMeta != nil {
 		metaMap = userMeta
 	}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -218,7 +218,7 @@ func (c *DatabaseCollection) GetDocSyncData(ctx context.Context, docid string) (
 
 // unmarshalDocumentWithXattrs populates individual xattrs on unmarshalDocumentWithXattrs from a provided xattrs map
 func (db *DatabaseCollection) unmarshalDocumentWithXattrs(ctx context.Context, docid string, data []byte, xattrs map[string][]byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
-	return unmarshalDocumentWithXattrs(ctx, docid, data, xattrs[base.SyncXattrName], xattrs[base.VvXattrName], xattrs[base.MouXattrName], xattrs[db.userXattrKey()], xattrs[base.VirtualXattrRevSeqNo], xattrs[base.GlobalXattrName], cas, unmarshalLevel)
+	return unmarshalDocumentWithXattrs(ctx, docid, data, xattrs[base.SyncXattrName], xattrs[base.VvXattrName], xattrs[base.MouXattrName], xattrs[db.UserXattrKey()], xattrs[base.VirtualXattrRevSeqNo], xattrs[base.GlobalXattrName], cas, unmarshalLevel)
 
 }
 
@@ -1697,11 +1697,15 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context
 // SyncFnDryrun Runs the given document body through a sync function and returns expiry, channels doc was placed in,
 // access map for users, roles, handler errors and sync fn exceptions.
 // If syncFn is provided, it will be used instead of the one configured on the database.
-func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, oldDoc *Document, syncFn string, errorLogFunc, infoLogFunc func(string)) (*channels.ChannelMapperOutput, error) {
+func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, oldDoc *Document, userMeta map[string]any, syncFn string, errorLogFunc, infoLogFunc func(string)) (*channels.ChannelMapperOutput, error) {
 	mutableBody, metaMap, _, err := db.prepareSyncFn(oldDoc, newDoc)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyDiagnostic, "Failed to prepare to run sync function: %v", err)
 		return nil, err
+	}
+
+	if len(userMeta) > 0 {
+		metaMap = userMeta
 	}
 
 	syncOptions, err := MakeUserCtx(db.user, db.ScopeName, db.Name)
@@ -2236,7 +2240,7 @@ func (db *DatabaseCollectionWithUser) storeOldBodyInRevTreeAndUpdateCurrent(ctx 
 
 func (db *DatabaseCollectionWithUser) prepareSyncFn(doc *Document, newDoc *Document) (mutableBody Body, metaMap map[string]any, newRevID string, err error) {
 	// Marshal raw user xattrs for use in Sync Fn. If this fails we can bail out so we should do early as possible.
-	metaMap, err = doc.GetMetaMap(db.userXattrKey())
+	metaMap, err = doc.GetMetaMap(db.UserXattrKey())
 	if err != nil {
 		return
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -1783,7 +1783,7 @@ func (db *DatabaseCollectionWithUser) getResyncedDocument(ctx context.Context, d
 			base.WarnfCtx(ctx, "Error unmarshalling body %s/%s for sync function %s", base.UD(docid), rev.ID, err)
 			return
 		}
-		metaMap, err := doc.GetMetaMap(db.userXattrKey())
+		metaMap, err := doc.GetMetaMap(db.UserXattrKey())
 		if err != nil {
 			return
 		}

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -316,7 +316,7 @@ func (c *DatabaseCollection) unsupportedOptions() *UnsupportedOptions {
 // syncGlobalSyncAndUserXattrKeys returns the xattr keys for the user and sync xattrs.
 func (c *DatabaseCollection) syncGlobalSyncAndUserXattrKeys() []string {
 	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.GlobalXattrName}
-	userXattrKey := c.userXattrKey()
+	userXattrKey := c.UserXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)
 	}
@@ -327,7 +327,7 @@ func (c *DatabaseCollection) syncGlobalSyncAndUserXattrKeys() []string {
 func (c *DatabaseCollection) syncGlobalSyncMouAndUserXattrKeys() []string {
 	xattrKeys := []string{base.SyncXattrName, base.VvXattrName,
 		base.MouXattrName, base.GlobalXattrName}
-	userXattrKey := c.userXattrKey()
+	userXattrKey := c.UserXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)
 	}
@@ -337,7 +337,7 @@ func (c *DatabaseCollection) syncGlobalSyncMouAndUserXattrKeys() []string {
 // syncGlobalSyncMouRevSeqNoAndUserXattrKeys returns the xattr keys for the user, mou, revSeqNo and sync xattrs.
 func (c *DatabaseCollection) syncGlobalSyncMouRevSeqNoAndUserXattrKeys() []string {
 	xattrKeys := []string{base.SyncXattrName, base.VvXattrName, base.VirtualXattrRevSeqNo, base.MouXattrName, base.GlobalXattrName}
-	userXattrKey := c.userXattrKey()
+	userXattrKey := c.UserXattrKey()
 	if userXattrKey != "" {
 		xattrKeys = append(xattrKeys, userXattrKey)
 	}
@@ -345,7 +345,7 @@ func (c *DatabaseCollection) syncGlobalSyncMouRevSeqNoAndUserXattrKeys() []strin
 }
 
 // Returns the xattr key that will be accessible from the sync function. This is controlled at a database level.
-func (c *DatabaseCollection) userXattrKey() string {
+func (c *DatabaseCollection) UserXattrKey() string {
 	return c.dbCtx.Options.UserXattrKey
 }
 

--- a/db/import.go
+++ b/db/import.go
@@ -81,8 +81,8 @@ func (db *DatabaseCollectionWithUser) ImportDoc(ctx context.Context, docid strin
 		Cas:    existingDoc.Cas,
 		Xattrs: make(map[string][]byte),
 	}
-	if db.userXattrKey() != "" {
-		existingBucketDoc.Xattrs[db.userXattrKey()] = existingDoc.rawUserXattr
+	if db.UserXattrKey() != "" {
+		existingBucketDoc.Xattrs[db.UserXattrKey()] = existingDoc.rawUserXattr
 	}
 
 	// If we marked this as having inline Sync Data ensure that the existingBucketDoc we pass to importDoc has syncData
@@ -286,7 +286,7 @@ func (db *DatabaseCollectionWithUser) importDoc(ctx context.Context, docid strin
 			}
 		}
 
-		shouldGenerateNewRev := bodyChanged || len(existingDoc.Xattrs[db.userXattrKey()]) == 0
+		shouldGenerateNewRev := bodyChanged || len(existingDoc.Xattrs[db.UserXattrKey()]) == 0
 
 		// If the body has changed then the document has been updated and we should generate a new revision. Otherwise
 		// the import was triggered by a user xattr mutation and therefore should not generate a new revision.

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -179,7 +179,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool {
 }
 
 func (il *importListener) ImportFeedEvent(ctx context.Context, collection *DatabaseCollectionWithUser, event sgbucket.FeedEvent) {
-	rawDoc, syncData, err := UnmarshalDocumentSyncDataFromFeed(event.Value, event.DataType, collection.userXattrKey(), false)
+	rawDoc, syncData, err := UnmarshalDocumentSyncDataFromFeed(event.Value, event.DataType, collection.UserXattrKey(), false)
 	if err != nil {
 		if errors.Is(err, sgbucket.ErrEmptyMetadata) {
 			base.WarnfCtx(ctx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
@@ -208,7 +208,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 			cv = base.Ptr(rawHLV(vv))
 		}
 
-		isSGWrite, crc32Match, _ = syncData.IsSGWrite(ctx, event.Cas, rawDoc.Body, rawDoc.Xattrs[collection.userXattrKey()], cv)
+		isSGWrite, crc32Match, _ = syncData.IsSGWrite(ctx, event.Cas, rawDoc.Body, rawDoc.Xattrs[collection.UserXattrKey()], cv)
 		if crc32Match {
 			il.dbStats.Crc32MatchCount.Add(1)
 		}

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -104,9 +104,13 @@ func (h *handler) handleSyncFnDryRun() error {
 		if !exists {
 			return base.HTTPErrorf(http.StatusBadRequest, "Missing xattrs in meta")
 		}
-		_, exists = xattrs[h.collection.UserXattrKey()]
+		userXattrKey := h.collection.UserXattrKey()
+		if userXattrKey == "" {
+			return base.HTTPErrorf(http.StatusBadRequest, "no user xattr key configured for this database")
+		}
+		_, exists = xattrs[userXattrKey]
 		if !exists {
-			return base.HTTPErrorf(http.StatusBadRequest, "xattr key passed does not match db defined xattr key")
+			return base.HTTPErrorf(http.StatusBadRequest, "configured user xattr key %q not found in provided xattrs", userXattrKey)
 		}
 	}
 

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -40,10 +40,13 @@ type ImportFilterDryRun struct {
 	Logging      DryRunLogging `json:"logging"`
 }
 
+type SyncFnDryRunMetaMap struct {
+	Xatrrs map[string]any `json:"xatrrs"`
+}
 type SyncFnDryRunPayload struct {
-	Function string         `json:"sync_function"`
-	Doc      db.Body        `json:"doc,omitempty"`
-	Meta     map[string]any `json:"meta,omitempty"`
+	Function string              `json:"sync_function"`
+	Doc      db.Body             `json:"doc,omitempty"`
+	Meta     SyncFnDryRunMetaMap `json:"meta,omitempty"`
 }
 
 type ImportFilterDryRunPayload struct {
@@ -98,20 +101,20 @@ func (h *handler) handleSyncFnDryRun() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "no doc_id or document provided")
 	}
 
+	var userXattrs map[string]any
 	// checking user defined metadata
-	if syncDryRunPayload.Meta != nil {
-		xattrs, exists := syncDryRunPayload.Meta["xattrs"].(map[string]any)
-		if !exists {
-			return base.HTTPErrorf(http.StatusBadRequest, "Missing xattrs in meta")
-		}
+	if syncDryRunPayload.Meta.Xatrrs != nil {
+		xattrs := syncDryRunPayload.Meta.Xatrrs
 		userXattrKey := h.collection.UserXattrKey()
 		if userXattrKey == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "no user xattr key configured for this database")
 		}
-		_, exists = xattrs[userXattrKey]
+		_, exists := xattrs[userXattrKey]
 		if !exists {
 			return base.HTTPErrorf(http.StatusBadRequest, "configured user xattr key %q not found in provided xattrs", userXattrKey)
 		}
+		userXattrs = make(map[string]any)
+		userXattrs["xattrs"] = syncDryRunPayload.Meta.Xatrrs
 	}
 
 	oldDoc := &db.Document{ID: docid}
@@ -181,7 +184,7 @@ func (h *handler) handleSyncFnDryRun() error {
 		logInfo = append(logInfo, s)
 	}
 
-	output, err := h.collection.SyncFnDryrun(h.ctx(), newDoc, oldDoc, syncDryRunPayload.Meta, syncDryRunPayload.Function, errorLogFn, infoLogFn)
+	output, err := h.collection.SyncFnDryrun(h.ctx(), newDoc, oldDoc, userXattrs, syncDryRunPayload.Function, errorLogFn, infoLogFn)
 	if err != nil {
 		var syncFnDryRunErr *base.SyncFnDryRunError
 		if !errors.As(err, &syncFnDryRunErr) {

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -41,7 +41,7 @@ type ImportFilterDryRun struct {
 }
 
 type SyncFnDryRunMetaMap struct {
-	Xatrrs map[string]any `json:"xatrrs"`
+	Xattrs map[string]any `json:"xattrs"`
 }
 type SyncFnDryRunPayload struct {
 	Function string              `json:"sync_function"`
@@ -103,8 +103,8 @@ func (h *handler) handleSyncFnDryRun() error {
 
 	var userXattrs map[string]any
 	// checking user defined metadata
-	if syncDryRunPayload.Meta.Xatrrs != nil {
-		xattrs := syncDryRunPayload.Meta.Xatrrs
+	if syncDryRunPayload.Meta.Xattrs != nil {
+		xattrs := syncDryRunPayload.Meta.Xattrs
 		userXattrKey := h.collection.UserXattrKey()
 		if userXattrKey == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "no user xattr key configured for this database")
@@ -114,7 +114,7 @@ func (h *handler) handleSyncFnDryRun() error {
 			return base.HTTPErrorf(http.StatusBadRequest, "configured user xattr key %q not found in provided xattrs", userXattrKey)
 		}
 		userXattrs = make(map[string]any)
-		userXattrs["xattrs"] = syncDryRunPayload.Meta.Xatrrs
+		userXattrs["xattrs"] = syncDryRunPayload.Meta.Xattrs
 	}
 
 	oldDoc := &db.Document{ID: docid}

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -105,6 +105,9 @@ func (h *handler) handleSyncFnDryRun() error {
 	// checking user defined metadata
 	if syncDryRunPayload.Meta.Xattrs != nil {
 		xattrs := syncDryRunPayload.Meta.Xattrs
+		if len(xattrs) > 1 {
+			return base.HTTPErrorf(http.StatusBadRequest, "Only one xattr key can be specified in meta")
+		}
 		userXattrKey := h.collection.UserXattrKey()
 		if userXattrKey == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "no user xattr key configured for this database")
@@ -114,7 +117,7 @@ func (h *handler) handleSyncFnDryRun() error {
 			return base.HTTPErrorf(http.StatusBadRequest, "configured user xattr key %q not found in provided xattrs", userXattrKey)
 		}
 		userXattrs = make(map[string]any)
-		userXattrs["xattrs"] = syncDryRunPayload.Meta.Xattrs
+		userXattrs["xattrs"] = xattrs
 	}
 
 	oldDoc := &db.Document{ID: docid}

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -1467,7 +1467,9 @@ func TestSyncFuncDryRunUserXattrErrors(t *testing.T) {
 	// Invalid meta body
 	RequireStatus(t, rt.SendDiagnosticRequest(http.MethodPost, "/{{.keyspace}}/_sync", `{"meta":{"foo": "bar"}}`), http.StatusBadRequest)
 	// Invalid meta body
-	RequireStatus(t, rt.SendDiagnosticRequest(http.MethodPost, "/{{.keyspace}}/_sync", `{"meta":{"xattrs": {"foo": "bar"}}}`), http.StatusBadRequest)
+	RequireStatus(t, rt.SendDiagnosticRequest(http.MethodPost, "/{{.keyspace}}/_sync", `{"doc": {"foo":"bar"}, "meta":{"xattrs": {"foo": "bar"}}}`), http.StatusBadRequest)
+	// Multiple xattr keys
+	RequireStatus(t, rt.SendDiagnosticRequest(http.MethodPost, "/{{.keyspace}}/_sync", `{"doc": {"foo":"bar"}, "meta":{"xattrs": {"channelXattrs": "channel1", "channelXattrs2": "channel2"}}}`), http.StatusBadRequest)
 }
 
 func TestImportFilterDryRun(t *testing.T) {

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -931,6 +931,9 @@ func TestGetUserDocAccessDuplicates(t *testing.T) {
 
 // Tests the Diagnostic Endpoint to dry run Sync Function
 func TestSyncFuncDryRun(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("Requires EE for some config properties")
+	}
 	base.SkipImportTestsIfNotEnabled(t)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
@@ -1377,6 +1380,10 @@ func TestSyncFuncDryRun(t *testing.T) {
 }
 
 func TestSyncFuncDryRunErrors(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("Requires EE for some config properties")
+	}
+
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,
 	})

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -1271,7 +1271,7 @@ func TestSyncFuncDryRun(t *testing.T) {
 				},
 				Meta: map[string]any{"xattrs": map[string]any{"channelXattr": []string{"channel1", "channel3", "useradmin"}}},
 			},
-			xattrKey: `"channelXattr"`,
+			xattrKey: "channelXattr",
 			expectedOutput: SyncFnDryRun{
 				Channels: base.SetFromArray([]string{"channel1", "channel3", "useradmin"}),
 				Access:   channels.AccessMap{},
@@ -1299,7 +1299,7 @@ func TestSyncFuncDryRun(t *testing.T) {
 				},
 			},
 			existingDocBody: `{"docVersion": 1}`,
-			xattrKey:        `"channelXattr"`,
+			xattrKey:        "channelXattr",
 			xattrVal:        []string{"channel1", "channel3", "useradmin"},
 			expectedOutput: SyncFnDryRun{
 				Channels: base.SetFromArray([]string{"channel1", "channel3", "useradmin"}),
@@ -1324,7 +1324,7 @@ func TestSyncFuncDryRun(t *testing.T) {
 					}
 				}`,
 			existingDocBody: `{"docVersion": 1}`,
-			xattrKey:        `"channelXattr"`,
+			xattrKey:        "channelXattr",
 			xattrVal:        []string{"channel1", "channel3", "useradmin"},
 			expectedOutput: SyncFnDryRun{
 				Channels: base.SetFromArray([]string{"channel1", "channel3", "useradmin"}),
@@ -1350,13 +1350,13 @@ func TestSyncFuncDryRun(t *testing.T) {
 			}
 
 			if test.xattrKey != "" {
-				RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", fmt.Sprintf(`{"user_xattr_key": %s}`, test.xattrKey)), http.StatusCreated)
+				RequireStatus(t, rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", fmt.Sprintf(`{"user_xattr_key": "%s"}`, test.xattrKey)), http.StatusCreated)
 			}
 
 			if test.existingDocBody != "" {
 				rt.PutDoc(test.name, test.existingDocBody)
 				if test.xattrKey != "" {
-					_, err := dataStore.SetXattrs(ctx, test.name, map[string][]byte{"channelXattr": base.MustJSONMarshal(t, test.xattrVal)})
+					_, err := dataStore.SetXattrs(ctx, test.name, map[string][]byte{test.xattrKey: base.MustJSONMarshal(t, test.xattrVal)})
 					require.NoError(t, err)
 				}
 			}

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -1324,7 +1324,7 @@ func TestSyncFuncDryRunUserXattrs(t *testing.T) {
 				Doc: db.Body{
 					"foo": "bar",
 				},
-				Meta: SyncFnDryRunMetaMap{Xatrrs: map[string]any{"channelXattr": []string{"channel1", "channel3", "useradmin"}}},
+				Meta: SyncFnDryRunMetaMap{Xattrs: map[string]any{"channelXattr": []string{"channel1", "channel3", "useradmin"}}},
 			},
 			xattrKey: "channelXattr",
 			expectedOutput: SyncFnDryRun{


### PR DESCRIPTION
CBG-5089

Describe your PR here...
- Added ability for user to pass the user defined xattrs into Sync Function Diagnostic API
- Added test coverage for the same

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/221/
