### PR TITLE
Diagnostic API: Update OpenAPI Specs

### DIFF
--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -3209,3 +3209,22 @@ CORS:
         type: string
       example: ["https://example.com"]
   title: Cors Configuration
+DiagnosticFunctionException:
+  description: The exception thrown during evaluation (if any).
+  type: string
+DiagnosticFunctionLogging:
+  description: Logging emitted during evaluation.
+  type: object
+  properties:
+    errors:
+      description: Error messages logged during evaluation.
+      type: array
+      items:
+        type: string
+        example: This is an error message produced by console.error("oops").
+    info:
+      description: Info messages logged during evaluation.
+      type: array
+      items:
+        type: string
+        example: This is an info message produced by console.log("test").

--- a/docs/api/paths/diagnostic/keyspace-import_filter.yaml
+++ b/docs/api/paths/diagnostic/keyspace-import_filter.yaml
@@ -7,7 +7,6 @@
 # the file licenses/APL2.txt.
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
-  - $ref: ../../components/parameters.yaml#/doc_id
 post:
   summary: Run a doc body through the Import filter and return results.
   description: |-
@@ -16,6 +15,14 @@ post:
     provided in the request body, the default or user-defined import filter
     is used.
 
+    The document being run through the import filter can be provided in one of the following ways:
+    | `doc` property | `doc_id` property | Behaviour                                                                                                                                                             |
+    | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | Set   | Unset  | The document body passed will be the `doc` value in the function.                                                                                                                         |
+    | Unset | Set    | The document of the given id will be fetched from the bucket/collection and will be passed in as the `doc` value in the function. If the document is not found, an error will be returned |
+    | Set   | Set    | Will throw an error (only one of `doc` or `doc_id` is allowed for the import filter dry run)                                                                                              |
+    | Unset | Unset  | Will throw an error (at least one of `doc` or `doc_id` is required)                                                                                                                       |
+
     * Sync Gateway Application Read Only
   requestBody:
     content:
@@ -23,6 +30,10 @@ post:
         schema:
           type: object
           properties:
+            doc_id:
+              description: An existing document ID to run the dry-run operation against.
+              type: string
+              example: doc1
             import_filter:
               description: |-
                 A JavaScript function that all imported documents in the
@@ -31,7 +42,11 @@ post:
               type: string
               example: 'function(doc) { if (doc.type != ''mobile'') { return false; } return true; }'
             doc:
-              $ref: ../../components/schemas.yaml#/Document
+              description: A new document body to run the dry-run operation against.
+              type: object
+              additionalProperties: true
+              example:
+                foo: bar
   responses:
     '200':
       description: Document Processed by import filter successfully
@@ -43,27 +58,12 @@ post:
               shouldImport:
                 description: Whether this document would be imported after being processed by the import filter.
                 type: boolean
-              error:
-                description: Errors thrown by the Import filter.
-                type: string
+              exception:
+                $ref: ../../components/schemas.yaml#/DiagnosticFunctionException
               logging:
-                description: Logging emitted by the import filter during evaluation.
-                type: object
-                properties:
-                  errors:
-                    description: Error messages logged by the import filter.
-                    type: array
-                    items:
-                      type: string
-                  info:
-                    description: Info messages logged by the import filter.
-                    type: array
-                    items:
-                      type: string
+                $ref: ../../components/schemas.yaml#/DiagnosticFunctionLogging
     '404':
       $ref: ../../components/responses.yaml#/Not-found
-  parameters:
-    - $ref: ../../components/parameters.yaml#/doc_id
   tags:
     - Document
-  operationId: get_keyspace-import_filter-docid
+  operationId: get_keyspace-import_filter

--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -7,19 +7,19 @@
 # the file licenses/APL2.txt.
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
-  - $ref: ../../components/parameters.yaml#/doc_id
 post:
   summary: Run a doc body through the sync function and return sync data.
   description: |-
-    Runs a document body through the sync function and returns document sync
-    data. If no custom sync function is provided in the request body, the
+    Runs a document body through the sync function and returns resulting sync function data. If no custom sync function is provided in the request body, the
     default or user-defined sync function for the collection is used.
-    | Document | DocID | Behaviour                                                                                                                                                                            |
-    | -------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-    | Yes      | No    | The document passed will be considered as newDoc and oldDoc will be empty                                                                                                            |
-    | Yes      | Yes   | The document passed in the body will be newDoc and DocID will be read from the bucket/collection and will be passed as the oldDoc. If DocID doesn't exist, then oldDoc will be empty |
-    | No       | No    | Will throw an error                                                                                                                                                                  |
-    | No       | Yes   | The docID will be passed in as the newDoc and oldDoc will be empty. If the document is not found, an error will be returned                                                          |
+
+    The document being run through the sync function can be provided in one of the following ways:
+    | `doc` property | `doc_id` property | Behaviour                                                                                                                                                                                               |
+    | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | Set   | Unset       | The document body passed will be the `doc` value in the sync function, and `oldDoc` will be empty.                                                                                                                        |
+    | Unset | Set      | The document of the given id will be fetched from the bucket/collection and will be passed in as the `doc` value in the sync function. If the document is not found, an error will be returned                            |
+    | Set   | Set      | The document body passed will be the `doc` value in the sync function, and the `doc_id` will be fetched from the bucket/collection and will be the `oldDoc` value. If `doc_id` doesn't exist, then `oldDoc` will be empty |
+    | Unset | Unset       | Will throw an error (at least one of `doc` or `doc_id` is required)                                                                                                                                                       |
 
     * Sync Gateway Application Read Only
   requestBody:
@@ -28,6 +28,10 @@ post:
         schema:
           type: object
           properties:
+            doc_id:
+              description: An existing document ID to run the dry-run operation against.
+              type: string
+              example: doc1
             sync_function:
               description: |-
                 A JavaScript function that defines custom access, channel, and
@@ -36,11 +40,81 @@ post:
                 grants, and validation outcomes during synchronization.
               type: string
               example: |-
-                function (doc, oldDoc) {
+                function (doc, oldDoc, meta) {
                   channel(doc.channels);
                 }
             doc:
-              $ref: ../../components/schemas.yaml#/Document
+              description: A new document body to run the dry-run operation against.
+              type: object
+              additionalProperties: true
+              example:
+                foo: bar
+            meta:
+              description: Optional metadata used during evaluation.
+              type: object
+              properties:
+                xattrs:
+                  description: |-
+                    Optional XATTR values to include during evaluation.
+
+                    To provide the user XATTR, include a property whose name exactly matches the configured `user_xattr_key`.
+                  type: object
+                  properties:
+                    additionalProperties:
+                      x-additionalPropertiesName: user_xattr_key
+                      description: The user XATTR JSON value. The property name must exactly match the configured `user_xattr_key`. The value can be any valid JSON type (Object, String, Number, etc.)
+                      oneOf:
+                        - type: object
+                          additionalProperties: true
+                          example:
+                            foo: bar
+                          description: An object value to be used as the user XATTR.
+                        - type: string
+                          example: foo
+                          description: A string value to be used as the user XATTR.
+                        - type: integer
+                          example: 100
+                          description: A number value to be used as the user XATTR.
+                        - type: boolean
+                          example: true
+                          description: A boolean value to be used as the user XATTR.
+                        - type: array
+                          items:
+                            example:
+                              - foo
+                              - bar
+                            description: An array of values to be used as the user XATTR.
+
+                  example:
+                    my_user_xattr_key:
+                      foo: bar
+            userCtx:
+              description: |-
+                Optional user context used during evaluation. Can be used to impersonate a non-admin user during evaluation. Can be used to test sync function utilities `requireUser()`, `requireRole()`, `requireAccess()`, etc.
+
+                If this `userCtx` is not provided, the sync function will be evaluated as an admin user (e.g. Admin API writes, Import, Resync, etc.)
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the user to impersonate. Used by `requireUser()`.
+                  example: user1
+                roles:
+                  type: array
+                  items:
+                    type: string
+                  description: A set of roles the user being impersonated has. Used by `requireRole()`.
+                  example:
+                    - role1
+                    - role2
+                channels:
+                  type: array
+                  items:
+                    type: string
+                  description: A set of channels the user being impersonated has (*including those inherited from their roles*). Used by `requireAccess()`.
+                  example:
+                    - channel1
+                    - channel2
   responses:
     '200':
       description: Document Processed by sync function successfully
@@ -50,47 +124,41 @@ post:
             type: object
             properties:
               channels:
-                description: The channels the document was placed in by the sync function.
+                description: A list of channels the document was placed in by the sync function.
                 type: array
+                example:
+                  - channel1
+                  - channel2
               roles:
-                description: An access map of roles granted by the sync function.
+                description: An access map of dynamic roles granted by the sync function. The properties are the usernames and the values are an array of roles.
                 type: object
-                properties:
-                  username:
-                    type: object
-                    additionalProperties:
-                      x-additionalPropertiesName: role
-                      type: string
+                additionalProperties:
+                  x-additionalPropertiesName: username
+                  example: ["role1", "role2"]
+                  type: array
+                  items:
+                    type: string
+                    example: role1
               access:
-                description: An access map of dynamic channels granted by the sync function.
+                description: An access map of dynamic channels granted by the sync function. The properties are the usernames and the values are an array of channels.
                 type: object
-                properties:
-                  username:
-                    type: object
-                    additionalProperties:
-                      x-additionalPropertiesName: channel
-                      type: string
+                additionalProperties:
+                  x-additionalPropertiesName: username
+                  example: ["channel1", "channel2"]
+                  type: array
+                  items:
+                    type: string
+                    example: channel1
+              expiry:
+                description: The document expiry (TTL in seconds) as determined by the sync function.
+                type: number
+                example: 300
               exception:
-                description: Errors thrown by the sync function.
-                type: string
+                $ref: ../../components/schemas.yaml#/DiagnosticFunctionException
               logging:
-                description: Logging emitted by the sync function during evaluation.
-                type: object
-                properties:
-                  errors:
-                    description: Error messages logged by the sync function.
-                    type: array
-                    items:
-                      type: string
-                  info:
-                    description: Info messages logged by the sync function.
-                    type: array
-                    items:
-                      type: string
+                $ref: ../../components/schemas.yaml#/DiagnosticFunctionLogging
     '404':
       $ref: ../../components/responses.yaml#/Not-found
-  parameters:
-    - $ref: ../../components/parameters.yaml#/doc_id
   tags:
     - Document
   operationId: get_keyspace-sync


### PR DESCRIPTION
Updates to Diagnostic API OpenAPI Specs to align with desired implementation and cleanup.

- Import Filter Dry-run API:
  - Added `doc` / `doc_id` table to description similar to Sync Function API
- Sync Function Dry-run API:
  - Added `meta` request property for upcoming user xattrs support
  - Added `userCtx` request property for upcoming user/channel/role impersonation support
  - Added `expiry` response property to document current implementation
- Both APIs:
  - Simplified `doc` schema to make it obvious it's a user-defined doc body, no metadata required.
  - Switch `GET` to `POST` and move `doc_id` query param to request body param
  - Share schemas for common diagnostic api dry-run response fields (exception, logging)
  - Added better/more example values for preview

<img width="1894" height="1803" alt="Screenshot 2026-01-14 at 12 02 26" src="https://github.com/user-attachments/assets/70020747-142c-4a8a-86ed-3eb6f907b6dc" />
<img width="1908" height="2012" alt="Screenshot 2026-01-14 at 12 02 08" src="https://github.com/user-attachments/assets/a75328bc-647f-4c54-885e-e845e0bbd6ac" />

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a