### PR TITLE
3.2.7: Bump Go version

### DIFF
--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -611,7 +611,7 @@
             "trigger_blackduck": true
         },
         "manifest/3.2.xml": {
-            "go_version": "1.24.4",
+            "go_version": "1.24.11",
             "interval": 120,
             "production": true,
             "release": "3.2.7",


### PR DESCRIPTION
Unreleased SG version as of now, but ensures alignment for Go version with 3.3.3 and 4.0.3 if we revive this branch