### PR TITLE
Diagnostic API: Tweak OpenAPI spec wording for user impersonation

### DIFF
--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -92,18 +92,20 @@ post:
               description: |-
                 Optional user context used during evaluation. Can be used to impersonate a non-admin user during evaluation. Can be used to test sync function utilities `requireUser()`, `requireRole()`, `requireAccess()`, etc.
 
+                The user, channels and roles do not have to exist in the system to be declared here. The Sync Function dry-run will be evaluated as though they do exist.
+
                 If this `userCtx` is not provided, the sync function will be evaluated as an admin user (e.g. Admin API writes, Import, Resync, etc.)
               type: object
               properties:
                 name:
                   type: string
-                  description: The name of the user to impersonate. Used by `requireUser()`.
+                  description: The name of the user to impersonate. The user does not have to exist. Used by `requireUser()`.
                   example: user1
                 roles:
                   type: array
                   items:
                     type: string
-                  description: A set of roles the user being impersonated has. Used by `requireRole()`.
+                  description: A set of roles the user being impersonated has. The role does not have to exist. Used by `requireRole()`.
                   example:
                     - role1
                     - role2

--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -90,7 +90,7 @@ post:
                       foo: bar
             userCtx:
               description: |-
-                Optional user context used during evaluation. Can be used to impersonate a non-admin user during evaluation. Can be used to test sync function utilities `requireUser()`, `requireRole()`, `requireAccess()`, etc.
+                Optional user context used during evaluation. Can be used to test a document update as a non-admin user. Used by Sync Function utilities `requireUser()`, `requireRole()`, `requireAccess()`, etc.
 
                 The user, channels and roles do not have to exist in the system to be declared here. The Sync Function dry-run will be evaluated as though they do exist.
 
@@ -99,13 +99,13 @@ post:
               properties:
                 name:
                   type: string
-                  description: The name of the user to impersonate. The user does not have to exist. Used by `requireUser()`.
+                  description: The name of the user to run as. The user does not have to exist. Used by `requireUser()`.
                   example: user1
                 roles:
                   type: array
                   items:
                     type: string
-                  description: A set of roles the user being impersonated has. The role does not have to exist. Used by `requireRole()`.
+                  description: A set of roles the user has. The roles do not have to exist. Used by `requireRole()`.
                   example:
                     - role1
                     - role2
@@ -113,7 +113,7 @@ post:
                   type: array
                   items:
                     type: string
-                  description: A set of channels the user being impersonated has (*including those inherited from their roles*). Used by `requireAccess()`.
+                  description: A set of channels the user has (*including those inherited from their roles*). Used by `requireAccess()`.
                   example:
                     - channel1
                     - channel2


### PR DESCRIPTION
Tweak wording for `userCtx` to clarify that users and roles do not need to exist to be able to use them in dry-run.