### PR TITLE
[4.0.3 backport] CBG-5055 make sure to marshal sequence on norev

### DIFF
--- a/db/blip.go
+++ b/db/blip.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -84,11 +85,13 @@ func defaultBlipLogger(ctx context.Context) blip.LogFn {
 }
 
 // blipRevMessageProperties returns a set of BLIP message properties for the given parameters.
-func blipRevMessageProperties(revisionHistory []string, deleted bool, seq SequenceID, replacedRevID string, revTreeProperty []string) blip.Properties {
+func blipRevMessageProperties(revisionHistory []string, deleted bool, seq SequenceID, replacedRevID string, revTreeProperty []string) (blip.Properties, error) {
 	properties := make(blip.Properties)
 
-	// TODO: Assert? db.SequenceID.MarshalJSON can never error
-	seqJSON, _ := base.JSONMarshal(seq)
+	seqJSON, err := base.JSONMarshal(seq)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal sequence %v: %v", seq, err)
+	}
 	properties[RevMessageSequence] = string(seqJSON)
 
 	if len(revisionHistory) > 0 {
@@ -107,7 +110,7 @@ func blipRevMessageProperties(revisionHistory []string, deleted bool, seq Sequen
 		properties[RevMessageReplacedRev] = replacedRevID
 	}
 
-	return properties
+	return properties, nil
 }
 
 // Returns true if this attachment is worth trying to compress.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -934,7 +934,10 @@ func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sen
 			revTreeProperty = append(revTreeProperty, toHistory(redactedRev.History, knownRevs, maxHistory)...)
 		}
 
-		properties := blipRevMessageProperties(history, redactedRev.Deleted, seq, "", revTreeProperty)
+		properties, err := blipRevMessageProperties(history, redactedRev.Deleted, seq, "", revTreeProperty)
+		if err != nil {
+			return err
+		}
 		return bsc.sendRevisionWithProperties(ctx, sender, docID, revID, collectionIdx, redactedRev.BodyBytes, nil, properties, seq, nil)
 	}
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -594,7 +594,10 @@ func (bsc *BlipSyncContext) sendDelta(ctx context.Context, sender *blip.Sender, 
 		revTreeProperty = append(revTreeProperty, revDelta.ToRevID)
 		revTreeProperty = append(revTreeProperty, revDelta.RevisionHistory...)
 	}
-	properties := blipRevMessageProperties(history, revDelta.ToDeleted, seq, "", revTreeProperty)
+	properties, err := blipRevMessageProperties(history, revDelta.ToDeleted, seq, "", revTreeProperty)
+	if err != nil {
+		return err
+	}
 	properties[RevMessageDeltaSrc] = deltaSrcRevID
 
 	if bsc.useHLV() {
@@ -626,7 +629,10 @@ func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, 
 	if bsc.activeCBMobileSubprotocol <= CBMobileReplicationV2 && bsc.clientType == BLIPClientTypeSGR2 {
 		noRevRq.SetSeq(seq)
 	} else {
-		noRevRq.SetSequence(seq)
+		err := noRevRq.SetSequence(seq)
+		if err != nil {
+			return err
+		}
 	}
 
 	status, reason := base.ErrorAsHTTPStatus(err)
@@ -782,7 +788,10 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 		revTreeHistoryProperty = append(revTreeHistoryProperty, toHistory(docRev.History, knownRevs, maxHistory)...)
 	}
 
-	properties := blipRevMessageProperties(history, docRev.Deleted, seq, replacedRevID, revTreeHistoryProperty)
+	properties, err := blipRevMessageProperties(history, docRev.Deleted, seq, replacedRevID, revTreeHistoryProperty)
+	if err != nil {
+		return err
+	}
 	if base.LogDebugEnabled(ctx, base.KeySync) {
 		replacedRevMsg := ""
 		if replacedRevID != "" {

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -508,8 +508,13 @@ func (nrm *noRevMessage) SetSeq(seq SequenceID) {
 	nrm.Properties[NorevMessageSeq] = seq.String()
 }
 
-func (nrm *noRevMessage) SetSequence(sequence SequenceID) {
-	nrm.Properties[NorevMessageSequence] = sequence.String()
+func (nrm *noRevMessage) SetSequence(sequence SequenceID) error {
+	s, err := base.JSONMarshal(sequence)
+	if err != nil {
+		return err
+	}
+	nrm.Properties[NorevMessageSequence] = string(s)
+	return nil
 }
 
 func (nrm *noRevMessage) SetReason(reason string) {

--- a/db/blip_sync_messages_test.go
+++ b/db/blip_sync_messages_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlipSequenceProperty(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		seq                  SequenceID
+		expectedString       string
+		expectedISGRV2String string
+	}{
+		{
+			name:                 "Simple SequenceID",
+			seq:                  SequenceID{Seq: 1},
+			expectedString:       `1`,
+			expectedISGRV2String: `1`,
+		},
+		{
+			name:                 "compound sequenceID",
+			seq:                  SequenceID{LowSeq: 5, TriggeredBy: 10, Seq: 15},
+			expectedString:       `"5:10:15"`,
+			expectedISGRV2String: `5:10:15`,
+		},
+		{
+			name:                 "TriggeredBy only",
+			seq:                  SequenceID{TriggeredBy: 20, Seq: 25},
+			expectedString:       `"20:25"`,
+			expectedISGRV2String: `20:25`,
+		},
+		{
+			name:                 "LowSeq and Seq",
+			seq:                  SequenceID{LowSeq: 30, Seq: 35},
+			expectedString:       `"30::35"`,
+			expectedISGRV2String: `30::35`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// test norev sequence property
+			norevMessage := NewNoRevMessage()
+			require.NoError(t, norevMessage.SetSequence(tc.seq))
+			require.Equal(t, tc.expectedString, norevMessage.Properties[NorevMessageSequence])
+			// this string is only used by ISGR when CB_Mobile < 3
+			norevMessage.SetSeq(tc.seq)
+			require.Equal(t, tc.expectedISGRV2String, norevMessage.Properties[NorevMessageSeq])
+
+			// test rev sequence property
+			properties, err := blipRevMessageProperties(nil, false, tc.seq, "", nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedString, properties[RevMessageSequence])
+			changeEntry := &ChangeEntry{
+				Seq: tc.seq,
+				ID:  "docID",
+			}
+			// changes message format
+			ctx := base.TestCtx(t)
+			bh := &blipHandler{
+				loggingCtx:      ctx,
+				BlipSyncContext: &BlipSyncContext{},
+			}
+			changeRow := bh.buildChangesRow(changeEntry, ChangeByVersionType{"rev": "1-abc"})
+			rowString, err := base.JSONMarshal(changeRow)
+			require.NoError(t, err)
+			require.Equal(t, fmt.Sprintf(`[%s,"docID","1-abc"]`, tc.expectedString), string(rowString))
+		})
+	}
+
+}

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2258,7 +2258,7 @@ func TestBlipNorev(t *testing.T) {
 		norevMsg := db.NewNoRevMessage()
 		norevMsg.SetId("docid")
 		norevMsg.SetRev("1-a")
-		norevMsg.SetSequence(db.SequenceID{Seq: 50})
+		require.NoError(t, norevMsg.SetSequence(db.SequenceID{Seq: 50}))
 		norevMsg.SetError("404")
 		norevMsg.SetReason("couldn't send xyz")
 		btc.addCollectionProperty(norevMsg.Message)
@@ -2285,7 +2285,7 @@ func TestNoRevSetSeq(t *testing.T) {
 	assert.Equal(t, "", norevMsg.Properties[db.NorevMessageSeq])
 	assert.Equal(t, "", norevMsg.Properties[db.NorevMessageSequence])
 
-	norevMsg.SetSequence(db.SequenceID{Seq: 50})
+	require.NoError(t, norevMsg.SetSequence(db.SequenceID{Seq: 50}))
 	assert.Equal(t, "50", norevMsg.Properties[db.NorevMessageSequence])
 
 	norevMsg.SetSeq(db.SequenceID{Seq: 60})


### PR DESCRIPTION
[4.0.3 backport] CBG-5055 make sure to marshal sequence on norev

cherry-pick of ca16d26e05d201182dbc5a2546fc67f33ca78830
