### PR TITLE
[4.0.3 backport] CBG-4998 don't panic if no _vv but _sync.rev.ver

### DIFF
--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -202,7 +202,7 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 			il.importStats.ImportErrorCount.Add(1)
 			return
 		}
-		var cv cvExtractor
+		var cv *rawHLV
 		vv := rawDoc.Xattrs[base.VvXattrName]
 		if len(vv) > 0 {
 			cv = base.Ptr(rawHLV(vv))

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -1470,3 +1470,20 @@ func TestImportCancelOnDocWithCorruptSequenceOndemand(t *testing.T) {
 	}, 1)
 
 }
+
+func TestImportWithSyncCVAndNoVV(t *testing.T) {
+	db, ctx := setupTestDBWithOptionsAndImport(t, nil, DatabaseContextOptions{})
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+	docID := SafeDocumentName(t, t.Name())
+
+	_, doc, err := collection.Put(ctx, docID, Body{"foo": "baz"})
+	require.NoError(t, err)
+
+	err = collection.dataStore.RemoveXattrs(ctx, docID, []string{base.VvXattrName}, doc.Cas)
+	require.NoError(t, err)
+
+	base.RequireWaitForStat(t, db.DbStats.Database().Crc32MatchCount.Value, 1)
+
+}


### PR DESCRIPTION
[4.0.3 backport] CBG-4998 don't panic if no _vv but _sync.rev.ver on import

cherry-pick of 00e10ab

