### PR TITLE
[4.0.3 backport] CBG-5016: fix panic in _config?include_runtime=true

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -512,15 +512,17 @@ func (h *handler) handleGetConfig() error {
 				return err
 			}
 
-			replications, err := database.SGReplicateMgr.GetReplications()
-			if err != nil {
-				return err
-			}
+			if database.SGReplicateMgr != nil {
+				replications, err := database.SGReplicateMgr.GetReplications()
+				if err != nil {
+					return err
+				}
 
-			dbConfig.Replications = make(map[string]*db.ReplicationConfig, len(replications))
+				dbConfig.Replications = make(map[string]*db.ReplicationConfig, len(replications))
 
-			for replicationName, replicationConfig := range replications {
-				dbConfig.Replications[replicationName] = replicationConfig.ReplicationConfig.Redacted(h.ctx())
+				for replicationName, replicationConfig := range replications {
+					dbConfig.Replications[replicationName] = replicationConfig.ReplicationConfig.Redacted(h.ctx())
+				}
 			}
 		}
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3586,4 +3587,40 @@ func TestECCV(t *testing.T) {
 			assert.True(t, clusterInfo.Buckets[bucketName].EnableCrossClusterVersioning)
 		})
 	}
+}
+
+func TestGetConfigAfterFailToStartOnlineProcess(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+	})
+	defer rt.Close()
+
+	dbConfig := rt.NewDbConfig()
+	dbConfig.StartOffline = base.Ptr(true)
+	resp := rt.CreateDatabase("db", dbConfig)
+	RequireStatus(t, resp, http.StatusCreated)
+
+	// create invalid user to cause StartOnlineProcesses error
+	rt.GetDatabase().Options.ConfigPrincipals.Users = map[string]*auth.PrincipalConfig{
+		"alice": {
+			JWTChannels: base.SetOf("asdf"),
+		},
+	}
+
+	// Directly set the database state to DBStarting to simulate regular startup.
+	// This direct atomic manipulation is required in this test to simulate a state transition.
+	// This is safe in the context of this test.
+	atomic.StoreUint32(&rt.GetDatabase().State, db.DBStarting)
+	rt.WaitForDBState(db.RunStateString[db.DBStarting])
+
+	// Can't trigger error case from REST API - call directly
+	rt.ServerContext().asyncDatabaseOnline(base.NewNonCancelCtx(), rt.GetDatabase(), nil, rt.ServerContext().GetDbVersion("db"))
+
+	// Error should cause db to stay offline.
+	rt.WaitForDBState(db.RunStateString[db.DBOffline])
+	require.Equal(t, int64(1), rt.GetDatabase().DbStats.Database().TotalOnlineFatalErrors.Value())
+
+	// Original bug will trigger panic here on this endpoint
+	resp = rt.SendAdminRequest(http.MethodGet, "/_config?include_runtime=true", "")
+	RequireStatus(t, resp, http.StatusOK)
 }


### PR DESCRIPTION
[4.0.3 backport] CBG-5016: fix panic in _config?include_runtime=true

cherry-pick of 27f3016f83e5097879e44496e5b1dcf57523fc5d
