### PR TITLE
[4.0.3 backport] CBG-4929 test fix topologytests

### DIFF
--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1525,7 +1525,10 @@ func (btcc *BlipTesterCollectionClient) StopPush() {
 	// wait for push replication to stop running
 	assert.EventuallyWithT(btcc.TB(), func(c *assert.CollectT) {
 		assert.False(c, btcc.pushRunning.IsTrue(), "push replication still running %t", btcc.pushRunning.IsTrue())
-	}, 20*time.Second, 1*time.Millisecond)
+		// reawaken any waiting push loops to check for cancellation,
+		// This is a workaround for a race between ctx.Err() != nil check and btcc._seqCond.Wait()
+		btcc._seqCond.Broadcast()
+	}, 20*time.Second, 10*time.Millisecond)
 
 }
 

--- a/topologytest/couchbase_lite_mock_peer_test.go
+++ b/topologytest/couchbase_lite_mock_peer_test.go
@@ -262,7 +262,9 @@ func (p *CouchbaseLiteMockPeer) CreateReplication(peer Peer, config PeerReplicat
 	default:
 		require.Fail(p.TB(), fmt.Sprintf("unsupported peer type %v for pull replication", p.Type()))
 	}
-	ctx := base.CorrelationIDLogCtx(sg.rt.TB().Context(), p.name)
+	// separate TestCtx out of context to shorten the length of log message
+	// do not inherit testing.Context()'s cancellation since it can cancel t.Cleanup() calls out of order
+	ctx := base.CorrelationIDLogCtx(context.WithoutCancel(sg.rt.TB().Context()), p.name)
 	replication.btc = replication.btcRunner.NewBlipTesterClientOptsWithRTAndContext(ctx, sg.rt, &rest.BlipTesterClientOpts{
 		Username: "user",
 		AllowCreationWithoutBlipTesterClientRunner: true,


### PR DESCRIPTION
[4.0.3 backport] CBG-4929 test fix topologytests

cherry-pick of d22c9589bea59a94e780f3fb4e9b0b7ca963418e

This is a test only change.