### PR TITLE
[4.0.3 backport] CBG-4935 test fix: TestChangesFeedExitDisconnect 

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3468,6 +3468,11 @@ func TestChangesFeedExitDisconnect(t *testing.T) {
 		defer rt.Close()
 		const alice = "alice"
 		rt.CreateUser(alice, []string{"*"})
+		rt.CreateTestDoc("doc1")
+		rt.WaitForPendingChanges()
+		collection, ctx := rt.GetSingleTestDatabaseCollection()
+		err := collection.FlushChannelCache(ctx)
+		require.NoError(t, err)
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt,
 			&BlipTesterClientOpts{Username: alice},
 		)


### PR DESCRIPTION
[4.0.3 backport] CBG-4935 test fix: TestChangesFeedExitDisconnect 

cherry-pick of da7f299
