### PR TITLE
CBG-5091: Replace websocket with fork for extended control frame timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,3 +97,5 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/coder/websocket => github.com/couchbasedeps/websocket v1.8.15-0.20260116134543-30951104b23a

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
-github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/couchbase/blance v0.1.6 h1:zyNew/SN2AheIoJxQ2LqqA1u3bMp03eGCer6hSDMUDs=
@@ -66,6 +64,8 @@ github.com/couchbase/tools-common/types v1.1.4 h1:YAZn9VOkkmn05YC24/TEm7eXa/j8k/
 github.com/couchbase/tools-common/types v1.1.4/go.mod h1:089L74+qhIDvDLEZzWk7PoQKAxij9j7KwUnw2aMYUv4=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac h1:6ekMSvH+AJkT30hMfZtto+M7viRNHCSbJgMwCvO4p64=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac/go.mod h1:ssmbsFABKtkHCeT2fN/xeRUnvmsOihRL9CAh3BDzfhU=
+github.com/couchbasedeps/websocket v1.8.15-0.20260116134543-30951104b23a h1:tpjRS69oZSXaLEwQZNkv9eoK0SPFw6/n0mW2DqCUHIg=
+github.com/couchbasedeps/websocket v1.8.15-0.20260116134543-30951104b23a/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
 github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8 h1:MQfvw4BiLTuyR69FuA5Kex+tXUeLkH+/ucJfVL1/hkM=


### PR DESCRIPTION
CBG-5091

Replace websocket library with forked branch to increase hardcoded timeouts:
https://github.com/couchbasedeps/websocket/tree/CBG-5091 (v1.8.14 based)

Upstream issue https://github.com/coder/websocket/issues/555

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a