### PR TITLE
[4.0.3 backport] CBG-5092: Replace websocket with fork for extended control frame timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.3
 require (
 	dario.cat/mergo v1.0.0
 	github.com/KimMachineGun/automemlimit v0.7.2
+	github.com/coder/websocket v1.8.12
 	github.com/coreos/go-oidc/v3 v3.15.0
 	github.com/couchbase/cbgt v1.4.10
 	github.com/couchbase/clog v0.1.0
@@ -45,7 +46,6 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/coder/websocket v1.8.12 // indirect
 	github.com/couchbase/blance v0.1.6 // indirect
 	github.com/couchbase/cbauth v0.1.13 // indirect
 	github.com/couchbase/go-couchbase v0.1.1 // indirect
@@ -98,3 +98,5 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/coder/websocket => github.com/couchbasedeps/websocket v1.8.13-0.20260116135942-21bb2da15e3d

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
-github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coreos/go-oidc/v3 v3.15.0 h1:R6Oz8Z4bqWR7VFQ+sPSvZPQv4x8M+sJkDO5ojgwlyAg=
 github.com/coreos/go-oidc/v3 v3.15.0/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/couchbase/blance v0.1.6 h1:zyNew/SN2AheIoJxQ2LqqA1u3bMp03eGCer6hSDMUDs=
@@ -66,6 +64,8 @@ github.com/couchbase/tools-common/types v1.1.4 h1:YAZn9VOkkmn05YC24/TEm7eXa/j8k/
 github.com/couchbase/tools-common/types v1.1.4/go.mod h1:089L74+qhIDvDLEZzWk7PoQKAxij9j7KwUnw2aMYUv4=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac h1:6ekMSvH+AJkT30hMfZtto+M7viRNHCSbJgMwCvO4p64=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac/go.mod h1:ssmbsFABKtkHCeT2fN/xeRUnvmsOihRL9CAh3BDzfhU=
+github.com/couchbasedeps/websocket v1.8.13-0.20260116135942-21bb2da15e3d h1:WItpflTk5XRmXcvO5KBoar6xArWoCyFK9xmGiZ7pXgw=
+github.com/couchbasedeps/websocket v1.8.13-0.20260116135942-21bb2da15e3d/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
 github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8 h1:MQfvw4BiLTuyR69FuA5Kex+tXUeLkH+/ucJfVL1/hkM=


### PR DESCRIPTION
CBG-5092

Replace websocket library with forked branch to increase hardcoded timeouts:
https://github.com/couchbasedeps/websocket/tree/CBG-5092 (v1.8.12 based)

Upstream issue https://github.com/coder/websocket/issues/555

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a