### PR TITLE
CBG-5101: Add support for User context in Diagnostic API

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1697,7 +1697,7 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context
 // SyncFnDryrun Runs the given document body through a sync function and returns expiry, channels doc was placed in,
 // access map for users, roles, handler errors and sync fn exceptions.
 // If syncFn is provided, it will be used instead of the one configured on the database.
-func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, oldDoc *Document, userMeta, userCtx map[string]any, syncFn string, errorLogFunc, infoLogFunc func(string)) (*channels.ChannelMapperOutput, error) {
+func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, oldDoc *Document, userMeta, syncOptions map[string]any, syncFn string, errorLogFunc, infoLogFunc func(string)) (*channels.ChannelMapperOutput, error) {
 	mutableBody, metaMap, _, err := db.prepareSyncFn(oldDoc, newDoc)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyDiagnostic, "Failed to prepare to run sync function: %v", err)
@@ -1708,8 +1708,8 @@ func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, 
 		metaMap = userMeta
 	}
 
-	if userCtx == nil {
-		userCtx, err = MakeUserCtx(db.user, db.ScopeName, db.Name)
+	if syncOptions == nil {
+		syncOptions, err = MakeUserCtx(db.user, db.ScopeName, db.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -1732,7 +1732,7 @@ func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, 
 		return nil, fmt.Errorf("failed to create sync runner: %v", err)
 	}
 
-	jsOutput, err := syncRunner.Call(ctx, mutableBody, sgbucket.JSONString(oldDoc._rawBody), metaMap, userCtx)
+	jsOutput, err := syncRunner.Call(ctx, mutableBody, sgbucket.JSONString(oldDoc._rawBody), metaMap, syncOptions)
 	if err != nil {
 		return nil, &base.SyncFnDryRunError{Err: err}
 	}

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -136,6 +136,14 @@ func (h *handler) handleSyncFnDryRun() error {
 		}
 		userCtx["name"] = syncDryRunPayload.UserCtx.Name
 		userCtx["channels"] = syncDryRunPayload.UserCtx.Channels
+		/*
+			The user role defined in the User interface is of type ch.TimedSet .
+			TimedSet is basically a map of string and the sequence of when the
+			role was added to the DB. The sequence is never really used in
+			the definition of requireRole. requireRole however needs roles to be
+			of the same structure. The below code assigns a default sequence of 1
+			to all the roles passed by the user in the userCtx object.
+		*/
 		rolesMap := make(map[string]int)
 		for _, role := range syncDryRunPayload.UserCtx.Roles {
 			rolesMap[role] = 1

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -43,11 +43,17 @@ type ImportFilterDryRun struct {
 type SyncFnDryRunMetaMap struct {
 	Xattrs map[string]any `json:"xattrs"`
 }
+type SyncDryRunUserCtx struct {
+	Name     string   `json:"name"`
+	Roles    []string `json:"roles,omitempty"`
+	Channels []string `json:"channels,omitempty"`
+}
 type SyncFnDryRunPayload struct {
 	DocID    string              `json:"doc_id"`
 	Function string              `json:"sync_function"`
 	Doc      db.Body             `json:"doc,omitempty"`
 	Meta     SyncFnDryRunMetaMap `json:"meta,omitempty"`
+	UserCtx  *SyncDryRunUserCtx  `json:"userCtx,omitempty"`
 }
 
 type ImportFilterDryRunPayload struct {
@@ -122,6 +128,21 @@ func (h *handler) handleSyncFnDryRun() error {
 		userXattrs["xattrs"] = xattrs
 	}
 
+	var userCtx map[string]any
+	if syncDryRunPayload.UserCtx != nil {
+		userCtx = make(map[string]any)
+		if syncDryRunPayload.UserCtx.Name == "" {
+			return base.HTTPErrorf(http.StatusBadRequest, "no user name provided")
+		}
+		userCtx["name"] = syncDryRunPayload.UserCtx.Name
+		userCtx["channels"] = syncDryRunPayload.UserCtx.Channels
+		rolesMap := make(map[string]int)
+		for _, role := range syncDryRunPayload.UserCtx.Roles {
+			rolesMap[role] = 1
+		}
+		userCtx["roles"] = rolesMap
+	}
+
 	oldDoc := &db.Document{ID: docid}
 	oldDoc.UpdateBody(syncDryRunPayload.Doc)
 	if docid != "" {
@@ -189,7 +210,7 @@ func (h *handler) handleSyncFnDryRun() error {
 		logInfo = append(logInfo, s)
 	}
 
-	output, err := h.collection.SyncFnDryrun(h.ctx(), newDoc, oldDoc, userXattrs, syncDryRunPayload.Function, errorLogFn, infoLogFn)
+	output, err := h.collection.SyncFnDryrun(h.ctx(), newDoc, oldDoc, userXattrs, userCtx, syncDryRunPayload.Function, errorLogFn, infoLogFn)
 	if err != nil {
 		var syncFnDryRunErr *base.SyncFnDryRunError
 		if !errors.As(err, &syncFnDryRunErr) {

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -965,7 +965,6 @@ func TestSyncFuncDryRun(t *testing.T) {
 		requestDocID    bool
 		expectedOutput  SyncFnDryRun
 		expectedStatus  int
-		userCtx         SyncDryRunUserCtx
 	}{
 		{
 			name: "request sync function and doc body",


### PR DESCRIPTION
CBG-5101

Describe your PR here...
- Add support for passing user contexts via the request body in Diagnostic API
- Add test coverage for the same

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/227/
