### PR TITLE
[3.3.3 backport] CBG-5093: Replace websocket with fork for extended control frame timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,3 +99,5 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/coder/websocket => github.com/couchbasedeps/websocket v1.8.13-0.20260116135942-21bb2da15e3d

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
-github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coreos/go-oidc/v3 v3.13.0 h1:M66zd0pcc5VxvBNM4pB331Wrsanby+QomQYjN8HamW8=
 github.com/coreos/go-oidc/v3 v3.13.0/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/couchbase/blance v0.1.5 h1:kNSAwhb8FXSJpicJ8R8Kk7+0V1+MyTcY1MOHIDbU79w=
@@ -70,6 +68,8 @@ github.com/couchbase/tools-common/utils v1.0.0 h1:6mWXqWWj7aM0Kp2LWpSKEu9pLAYm7i
 github.com/couchbase/tools-common/utils v1.0.0/go.mod h1:i6cN5Z5hB9vQRLxe2j1v6Nu8bv+pKl9BFXjbQUHSah8=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac h1:6ekMSvH+AJkT30hMfZtto+M7viRNHCSbJgMwCvO4p64=
 github.com/couchbasedeps/fast-skiplist v0.0.0-20250722125747-e0dd031fe2ac/go.mod h1:ssmbsFABKtkHCeT2fN/xeRUnvmsOihRL9CAh3BDzfhU=
+github.com/couchbasedeps/websocket v1.8.13-0.20260116135942-21bb2da15e3d h1:WItpflTk5XRmXcvO5KBoar6xArWoCyFK9xmGiZ7pXgw=
+github.com/couchbasedeps/websocket v1.8.13-0.20260116135942-21bb2da15e3d/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338 h1:xMeDnMiapTiq8n8J83Mo2tPjQNIU7GssSsbQsP1CLOY=
 github.com/couchbaselabs/go-fleecedelta v0.0.0-20220909152808-6d09efa7a338/go.mod h1:0f+dmhfcTKK+4quAe6rwqQUVVWtHX/eztNB8cmBUniQ=
 github.com/couchbaselabs/gocaves/client v0.0.0-20250107114554-f96479220ae8 h1:MQfvw4BiLTuyR69FuA5Kex+tXUeLkH+/ucJfVL1/hkM=


### PR DESCRIPTION
CBG-5093

Replace websocket library with forked branch to increase hardcoded timeouts:
https://github.com/couchbasedeps/websocket/tree/CBG-5092 (v1.8.12 based)

Upstream issue https://github.com/coder/websocket/issues/555

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a