### PR TITLE
[4.0.3 backport] CBG-4904: test-only active replicator tests to run in 4.x and 3.x

### DIFF
--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2725,47 +2725,54 @@ func TestBlipInternalPropertiesHandling(t *testing.T) {
 func TestProcessRevIncrementsStat(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	activeRT, remoteRT, remoteURLString := SetupSGRPeers(t)
-	activeCtx := activeRT.Context()
+	sgrRunner := NewSGRTestRunner(t)
 
-	remoteURL, _ := url.Parse(remoteURLString)
+	sgrRunner.Run(func(t *testing.T) {
+		activeRT, remoteRT, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		activeCtx := activeRT.Context()
+		remoteURL, err := url.Parse(remoteURLString)
+		require.NoError(t, err)
 
-	stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		replicationID := SafeDocumentName(t, t.Name())
 
-	ar, err := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
-		ID:                  t.Name(),
-		Direction:           db.ActiveReplicatorTypePull,
-		ActiveDB:            &db.Database{DatabaseContext: activeRT.GetDatabase()},
-		RemoteDBURL:         remoteURL,
-		Continuous:          true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  !activeRT.GetDatabase().OnlyDefaultCollection(),
+		stats, err := base.SyncGatewayStats.NewDBStats("test", false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := stats.DBReplicatorStats(replicationID)
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(activeCtx, &db.ActiveReplicatorConfig{
+			ID:                     replicationID,
+			Direction:              db.ActiveReplicatorTypePull,
+			ActiveDB:               &db.Database{DatabaseContext: activeRT.GetDatabase()},
+			RemoteDBURL:            remoteURL,
+			Continuous:             true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     !activeRT.GetDatabase().OnlyDefaultCollection(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+
+		// Confirm all stats starting on 0
+		require.NotNil(t, ar.Pull)
+		pullStats := ar.Pull.GetStats()
+		require.EqualValues(t, 0, pullStats.HandleRevCount.Value())
+		require.EqualValues(t, 0, pullStats.HandleRevBytes.Value())
+		require.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())
+
+		const docID = "doc"
+		version := remoteRT.CreateTestDoc(docID)
+
+		assert.NoError(t, ar.Start(activeCtx))
+		defer func() { require.NoError(t, ar.Stop()) }()
+
+		activeRT.WaitForPendingChanges()
+		sgrRunner.WaitForVersion(docID, activeRT, version)
+
+		base.RequireWaitForStat(t, pullStats.HandleRevCount.Value, 1)
+		assert.NotEqualValues(t, 0, pullStats.HandleRevBytes.Value())
+		// Confirm connected client count has not increased, which uses same processRev code
+		assert.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())
 	})
-	require.NoError(t, err)
-
-	// Confirm all stats starting on 0
-	require.NotNil(t, ar.Pull)
-	pullStats := ar.Pull.GetStats()
-	require.EqualValues(t, 0, pullStats.HandleRevCount.Value())
-	require.EqualValues(t, 0, pullStats.HandleRevBytes.Value())
-	require.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())
-
-	const docID = "doc"
-	version := remoteRT.CreateTestDoc(docID)
-
-	assert.NoError(t, ar.Start(activeCtx))
-	defer func() { require.NoError(t, ar.Stop()) }()
-
-	activeRT.WaitForPendingChanges()
-	activeRT.WaitForVersion(docID, version)
-
-	base.RequireWaitForStat(t, pullStats.HandleRevCount.Value, 1)
-	assert.NotEqualValues(t, 0, pullStats.HandleRevBytes.Value())
-	// Confirm connected client count has not increased, which uses same processRev code
-	assert.EqualValues(t, 0, pullStats.HandlePutRevCount.Value())
 }
 
 // Attempt to send rev as GUEST when read-only guest is enabled

--- a/rest/replicatortest/replicator_collection_test.go
+++ b/rest/replicatortest/replicator_collection_test.go
@@ -41,260 +41,279 @@ func TestActiveReplicatorMultiCollection(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg, base.KeyReplicate)
 
-	const (
-		rt1DbName            = "rt1_active"
-		rt2DbName            = "rt2_passive"
-		numCollections       = 3
-		numDocsPerCollection = 9 // 3 in each channel (a, b, c)
-	)
-	channels := []string{"a", "b", "c"}
-
-	base.RequireNumTestDataStores(t, numCollections)
-
-	// rt2 passive
-	rt2 := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{
-		SyncFn: `function(doc) { channel(doc.chan) }`,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: rt2DbName,
-			},
-		}}, numCollections)
-	defer rt2.Close()
-
-	rt2Collections := rt2.GetDbCollections()
-	require.Len(t, rt2Collections, 3)
-	passiveKeyspace1 := rt2Collections[0].ScopeName + "." + rt2Collections[0].Name
-	passiveKeyspace2 := rt2Collections[1].ScopeName + "." + rt2Collections[1].Name
-	passiveKeyspace3 := rt2Collections[2].ScopeName + "." + rt2Collections[2].Name
-
-	// rt1 active
-	rt1 := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{
-		SyncFn: `function(doc) { channel(doc.chan) }`,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: rt1DbName,
-			},
-		}}, numCollections)
-	defer rt1.Close()
-
-	rt1Collections := rt1.GetDbCollections()
-	require.Len(t, rt1Collections, 3)
-	activeKeyspace1 := rt1Collections[0].ScopeName + "." + rt1Collections[0].Name
-	activeKeyspace2 := rt1Collections[1].ScopeName + "." + rt1Collections[1].Name
-	activeKeyspace3 := rt1Collections[2].ScopeName + "." + rt1Collections[2].Name
-
-	t.Logf("remapping active %q to passive %q", activeKeyspace1, passiveKeyspace2)
-	t.Logf("not remapping active %q", activeKeyspace3)
-	localCollections := []string{activeKeyspace1, activeKeyspace3}
-	remoteCollections := []string{passiveKeyspace2, ""}
-	t.Logf("not replicating active %q", activeKeyspace2)
-	nonReplicatedLocalCollections := []string{activeKeyspace2}
-	t.Logf("not replicating passive %q", passiveKeyspace1)
-	nonReplicatedRemoteCollections := []string{passiveKeyspace1}
-
-	collectionsFilter := [][]string{{"b"}, {"a", "c"}}
-	t.Logf("filtering to channels: %q", collectionsFilter)
-
-	var resp *rest.TestResponse
-
-	// create docs in all collections
-	for keyspaceNum := 1; keyspaceNum <= numCollections; keyspaceNum++ {
-		for j := 1; j <= numDocsPerCollection; j++ {
-			chanName := channels[j%len(channels)]
-			resp = rt1.SendAdminRequest(http.MethodPut,
-				fmt.Sprintf("/{{.keyspace%d}}/active-doc%d", keyspaceNum, j),
-				fmt.Sprintf(`{"source":"active", "sourceKeyspace":"%s", "chan":"%s"}`,
-					rt1Collections[keyspaceNum-1].ScopeName+"."+rt1Collections[keyspaceNum-1].Name, chanName))
-			rest.RequireStatus(t, resp, http.StatusCreated)
-
-			resp = rt2.SendAdminRequest(http.MethodPut,
-				fmt.Sprintf("/{{.keyspace%d}}/passive-doc%d", keyspaceNum, j),
-				fmt.Sprintf(`{"source":"passive", "sourceKeyspace":"%s", "chan":"%s"}`,
-					rt2Collections[keyspaceNum-1].ScopeName+"."+rt2Collections[keyspaceNum-1].Name, chanName))
-			rest.RequireStatus(t, resp, http.StatusCreated)
-		}
-	}
-
-	rt1.WaitForPendingChanges()
-	rt2.WaitForPendingChanges()
-
-	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
-	srv := httptest.NewServer(rt2.TestAdminHandler())
-	defer srv.Close()
-
-	passiveDBURL, err := url.Parse(srv.URL + "/" + rt2DbName)
-	require.NoError(t, err)
-
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
-
-	// The mapping of `""` for activeKeyspace3 requires that these two collections are the same name.
-	assert.Equal(t, activeKeyspace3, passiveKeyspace3)
-
-	ctx1 := rt1.Context()
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePushAndPull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
+	testCases := []struct {
+		name            string
+		protocolVersion string
+	}{
+		{
+			name:            "v3",
+			protocolVersion: db.CBMobileReplicationV3.SubprotocolString(),
 		},
-		ChangesBatchSize:         200,
-		Continuous:               true,
-		ReplicationStatsMap:      dbstats,
-		CollectionsEnabled:       true,
-		CollectionsLocal:         localCollections,
-		CollectionsRemote:        remoteCollections,
-		Filter:                   base.ByChannelFilter,
-		CollectionsChannelFilter: collectionsFilter,
-	})
-	require.NoError(t, err)
+		{
+			name:            "v4",
+			protocolVersion: db.CBMobileReplicationV4.SubprotocolString(),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 
-	assert.Equal(t, "", ar.GetStatus(ctx1).LastSeqPull)
+			const (
+				rt1DbName            = "rt1_active"
+				rt2DbName            = "rt2_passive"
+				numCollections       = 3
+				numDocsPerCollection = 9 // 3 in each channel (a, b, c)
+			)
+			channels := []string{"a", "b", "c"}
 
-	// Start the replicator (implicit connect)
-	require.NoError(t, ar.Start(ctx1))
+			base.RequireNumTestDataStores(t, numCollections)
 
-	// check all expected docs were pushed and pulled
-	for i, localCollection := range localCollections {
-		remoteCollection := remoteCollections[i]
-		if remoteCollection == "" {
-			remoteCollection = localCollection
-		}
+			// rt2 passive
+			rt2 := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{
+				SyncFn: `function(doc) { channel(doc.chan) }`,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: rt2DbName,
+					},
+				}}, numCollections)
+			defer rt2.Close()
 
-		// local set
-		expectedNumDocs := numDocsPerCollection
-		if slices.Contains(nonReplicatedLocalCollections, localCollection) ||
-			slices.Contains(nonReplicatedRemoteCollections, remoteCollection) {
-			// only one set of docs for non-replicated collections
-		} else {
-			// plus docs for filtered channels
-			expectedNumDocs += (numDocsPerCollection / len(channels)) * len(collectionsFilter[i])
-		}
+			rt2Collections := rt2.GetDbCollections()
+			require.Len(t, rt2Collections, 3)
+			passiveKeyspace1 := rt2Collections[0].ScopeName + "." + rt2Collections[0].Name
+			passiveKeyspace2 := rt2Collections[1].ScopeName + "." + rt2Collections[1].Name
+			passiveKeyspace3 := rt2Collections[2].ScopeName + "." + rt2Collections[2].Name
 
-		localKeyspace := rt1DbName + "." + localCollection
-		rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
+			// rt1 active
+			rt1 := rest.NewRestTesterMultipleCollections(t, &rest.RestTesterConfig{
+				SyncFn: `function(doc) { channel(doc.chan) }`,
+				DatabaseConfig: &rest.DatabaseConfig{
+					DbConfig: rest.DbConfig{
+						Name: rt1DbName,
+					},
+				}}, numCollections)
+			defer rt1.Close()
 
-		remoteKeyspace := rt2DbName + "." + remoteCollection
-		rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
+			rt1Collections := rt1.GetDbCollections()
+			require.Len(t, rt1Collections, 3)
+			activeKeyspace1 := rt1Collections[0].ScopeName + "." + rt1Collections[0].Name
+			activeKeyspace2 := rt1Collections[1].ScopeName + "." + rt1Collections[1].Name
+			activeKeyspace3 := rt1Collections[2].ScopeName + "." + rt1Collections[2].Name
 
-		for j := 1; j <= numDocsPerCollection; j++ {
-			expectedStatus := http.StatusOK
-			if !slices.Contains(collectionsFilter[i], channels[j%len(channels)]) {
-				// doc doesn't match channel filter
-				expectedStatus = http.StatusNotFound
+			t.Logf("remapping active %q to passive %q", activeKeyspace1, passiveKeyspace2)
+			t.Logf("not remapping active %q", activeKeyspace3)
+			localCollections := []string{activeKeyspace1, activeKeyspace3}
+			remoteCollections := []string{passiveKeyspace2, ""}
+			t.Logf("not replicating active %q", activeKeyspace2)
+			nonReplicatedLocalCollections := []string{activeKeyspace2}
+			t.Logf("not replicating passive %q", passiveKeyspace1)
+			nonReplicatedRemoteCollections := []string{passiveKeyspace1}
+
+			collectionsFilter := [][]string{{"b"}, {"a", "c"}}
+			t.Logf("filtering to channels: %q", collectionsFilter)
+
+			var resp *rest.TestResponse
+
+			// create docs in all collections
+			for keyspaceNum := 1; keyspaceNum <= numCollections; keyspaceNum++ {
+				for j := 1; j <= numDocsPerCollection; j++ {
+					chanName := channels[j%len(channels)]
+					resp = rt1.SendAdminRequest(http.MethodPut,
+						fmt.Sprintf("/{{.keyspace%d}}/active-doc%d", keyspaceNum, j),
+						fmt.Sprintf(`{"source":"active", "sourceKeyspace":"%s", "chan":"%s"}`,
+							rt1Collections[keyspaceNum-1].ScopeName+"."+rt1Collections[keyspaceNum-1].Name, chanName))
+					rest.RequireStatus(t, resp, http.StatusCreated)
+
+					resp = rt2.SendAdminRequest(http.MethodPut,
+						fmt.Sprintf("/{{.keyspace%d}}/passive-doc%d", keyspaceNum, j),
+						fmt.Sprintf(`{"source":"passive", "sourceKeyspace":"%s", "chan":"%s"}`,
+							rt2Collections[keyspaceNum-1].ScopeName+"."+rt2Collections[keyspaceNum-1].Name, chanName))
+					rest.RequireStatus(t, resp, http.StatusCreated)
+				}
 			}
 
-			// check rt1 for passive docs (pull)
-			resp = rt1.SendAdminRequest(http.MethodGet,
-				fmt.Sprintf("/%s/passive-doc%d", localKeyspace, j), "")
-			rest.AssertStatus(t, resp, expectedStatus)
-			if resp.Code == http.StatusOK {
-				var docBody db.Body
-				require.NoError(t, docBody.Unmarshal(resp.BodyBytes()))
-				assert.Equal(t, "passive", docBody["source"])
-				assert.Equal(t, remoteCollection, docBody["sourceKeyspace"])
+			rt1.WaitForPendingChanges()
+			rt2.WaitForPendingChanges()
+
+			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+			srv := httptest.NewServer(rt2.TestAdminHandler())
+			defer srv.Close()
+
+			passiveDBURL, err := url.Parse(srv.URL + "/" + rt2DbName)
+			require.NoError(t, err)
+
+			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+			require.NoError(t, err)
+			dbstats, err := stats.DBReplicatorStats(t.Name())
+			require.NoError(t, err)
+
+			// The mapping of `""` for activeKeyspace3 requires that these two collections are the same name.
+			assert.Equal(t, activeKeyspace3, passiveKeyspace3)
+
+			ctx1 := rt1.Context()
+			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePushAndPull,
+				RemoteDBURL: passiveDBURL,
+				ActiveDB: &db.Database{
+					DatabaseContext: rt1.GetDatabase(),
+				},
+				ChangesBatchSize:         200,
+				Continuous:               true,
+				ReplicationStatsMap:      dbstats,
+				CollectionsEnabled:       true,
+				CollectionsLocal:         localCollections,
+				CollectionsRemote:        remoteCollections,
+				Filter:                   base.ByChannelFilter,
+				CollectionsChannelFilter: collectionsFilter,
+				SupportedBLIPProtocols:   []string{tc.protocolVersion},
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, "", ar.GetStatus(ctx1).LastSeqPull)
+
+			// Start the replicator (implicit connect)
+			require.NoError(t, ar.Start(ctx1))
+
+			// check all expected docs were pushed and pulled
+			for i, localCollection := range localCollections {
+				remoteCollection := remoteCollections[i]
+				if remoteCollection == "" {
+					remoteCollection = localCollection
+				}
+
+				// local set
+				expectedNumDocs := numDocsPerCollection
+				if slices.Contains(nonReplicatedLocalCollections, localCollection) ||
+					slices.Contains(nonReplicatedRemoteCollections, remoteCollection) {
+					// only one set of docs for non-replicated collections
+				} else {
+					// plus docs for filtered channels
+					expectedNumDocs += (numDocsPerCollection / len(channels)) * len(collectionsFilter[i])
+				}
+
+				localKeyspace := rt1DbName + "." + localCollection
+				rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
+
+				remoteKeyspace := rt2DbName + "." + remoteCollection
+				rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
+
+				for j := 1; j <= numDocsPerCollection; j++ {
+					expectedStatus := http.StatusOK
+					if !slices.Contains(collectionsFilter[i], channels[j%len(channels)]) {
+						// doc doesn't match channel filter
+						expectedStatus = http.StatusNotFound
+					}
+
+					// check rt1 for passive docs (pull)
+					resp = rt1.SendAdminRequest(http.MethodGet,
+						fmt.Sprintf("/%s/passive-doc%d", localKeyspace, j), "")
+					rest.AssertStatus(t, resp, expectedStatus)
+					if resp.Code == http.StatusOK {
+						var docBody db.Body
+						require.NoError(t, docBody.Unmarshal(resp.BodyBytes()))
+						assert.Equal(t, "passive", docBody["source"])
+						assert.Equal(t, remoteCollection, docBody["sourceKeyspace"])
+					}
+
+					// check rt2 for active docs (push)
+					resp = rt2.SendAdminRequest(http.MethodGet,
+						fmt.Sprintf("/%s/active-doc%d", remoteKeyspace, j), "")
+					rest.AssertStatus(t, resp, expectedStatus)
+					if resp.Code == http.StatusOK {
+						var docBody db.Body
+						require.NoError(t, docBody.Unmarshal(resp.BodyBytes()))
+						assert.Equal(t, "active", docBody["source"])
+						assert.Equal(t, localCollection, docBody["sourceKeyspace"])
+					}
+				}
 			}
 
-			// check rt2 for active docs (push)
-			resp = rt2.SendAdminRequest(http.MethodGet,
-				fmt.Sprintf("/%s/active-doc%d", remoteKeyspace, j), "")
-			rest.AssertStatus(t, resp, expectedStatus)
-			if resp.Code == http.StatusOK {
-				var docBody db.Body
-				require.NoError(t, docBody.Unmarshal(resp.BodyBytes()))
-				assert.Equal(t, "active", docBody["source"])
-				assert.Equal(t, localCollection, docBody["sourceKeyspace"])
+			// Stop the replication
+			err = ar.Stop()
+			require.NoError(t, err)
+
+			//  create one more doc on each collection and make sure we're able to resume from the checkpoint.
+			for keyspaceNum := 1; keyspaceNum <= numCollections; keyspaceNum++ {
+				resp = rt1.SendAdminRequest(http.MethodPut,
+					fmt.Sprintf("/{{.keyspace%d}}/active-doc%d", keyspaceNum, numDocsPerCollection+1),
+					fmt.Sprintf(`{"source":"active", "sourceKeyspace":"%s", "chan":["a","b","c"]}`,
+						rt1Collections[keyspaceNum-1].ScopeName+"."+rt1Collections[keyspaceNum-1].Name))
+				rest.RequireStatus(t, resp, http.StatusCreated)
+
+				resp = rt2.SendAdminRequest(http.MethodPut,
+					fmt.Sprintf("/{{.keyspace%d}}/passive-doc%d", keyspaceNum, numDocsPerCollection+1),
+					fmt.Sprintf(`{"source":"passive", "sourceKeyspace":"%s", "chan":["a","b","c"]}`,
+						rt2Collections[keyspaceNum-1].ScopeName+"."+rt2Collections[keyspaceNum-1].Name))
+				rest.RequireStatus(t, resp, http.StatusCreated)
 			}
-		}
-	}
 
-	// Stop the replication
-	err = ar.Stop()
-	require.NoError(t, err)
+			rt1.WaitForPendingChanges()
+			rt2.WaitForPendingChanges()
 
-	//  create one more doc on each collection and make sure we're able to resume from the checkpoint.
-	for keyspaceNum := 1; keyspaceNum <= numCollections; keyspaceNum++ {
-		resp = rt1.SendAdminRequest(http.MethodPut,
-			fmt.Sprintf("/{{.keyspace%d}}/active-doc%d", keyspaceNum, numDocsPerCollection+1),
-			fmt.Sprintf(`{"source":"active", "sourceKeyspace":"%s", "chan":["a","b","c"]}`,
-				rt1Collections[keyspaceNum-1].ScopeName+"."+rt1Collections[keyspaceNum-1].Name))
-		rest.RequireStatus(t, resp, http.StatusCreated)
+			err = ar.Start(ctx1)
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, ar.Stop()) }()
 
-		resp = rt2.SendAdminRequest(http.MethodPut,
-			fmt.Sprintf("/{{.keyspace%d}}/passive-doc%d", keyspaceNum, numDocsPerCollection+1),
-			fmt.Sprintf(`{"source":"passive", "sourceKeyspace":"%s", "chan":["a","b","c"]}`,
-				rt2Collections[keyspaceNum-1].ScopeName+"."+rt2Collections[keyspaceNum-1].Name))
-		rest.RequireStatus(t, resp, http.StatusCreated)
-	}
+			// check all expected docs were pushed and pulled
+			for i, localCollection := range localCollections {
+				remoteCollection := remoteCollections[i]
+				if remoteCollection == "" {
+					remoteCollection = localCollection
+				}
 
-	rt1.WaitForPendingChanges()
-	rt2.WaitForPendingChanges()
+				// local set
+				expectedNumDocs := numDocsPerCollection + 1
+				if slices.Contains(nonReplicatedLocalCollections, localCollection) ||
+					slices.Contains(nonReplicatedRemoteCollections, remoteCollection) {
+					// only one set of docs for non-replicated collections
+				} else {
+					// plus docs for filtered channels
+					expectedNumDocs += 1 + (numDocsPerCollection/len(channels))*len(collectionsFilter[i])
+				}
 
-	err = ar.Start(ctx1)
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, ar.Stop()) }()
+				localKeyspace := rt1DbName + "." + localCollection
+				rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
 
-	// check all expected docs were pushed and pulled
-	for i, localCollection := range localCollections {
-		remoteCollection := remoteCollections[i]
-		if remoteCollection == "" {
-			remoteCollection = localCollection
-		}
+				remoteKeyspace := rt2DbName + "." + remoteCollection
+				rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
 
-		// local set
-		expectedNumDocs := numDocsPerCollection + 1
-		if slices.Contains(nonReplicatedLocalCollections, localCollection) ||
-			slices.Contains(nonReplicatedRemoteCollections, remoteCollection) {
-			// only one set of docs for non-replicated collections
-		} else {
-			// plus docs for filtered channels
-			expectedNumDocs += 1 + (numDocsPerCollection/len(channels))*len(collectionsFilter[i])
-		}
+				// check rt1 for passive docs (pull)
+				resp = rt1.SendAdminRequest(http.MethodGet,
+					fmt.Sprintf("/%s/passive-doc%d", localKeyspace, numDocsPerCollection+1), "")
+				if rest.AssertStatus(t, resp, http.StatusOK) {
+					var docBody db.Body
+					require.NoError(t, docBody.Unmarshal(resp.BodyBytes()))
+					assert.Equal(t, "passive", docBody["source"])
+					assert.Equal(t, remoteCollection, docBody["sourceKeyspace"])
+				}
 
-		localKeyspace := rt1DbName + "." + localCollection
-		rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
+				// check rt2 for active docs (push)
+				resp = rt2.SendAdminRequest(http.MethodGet,
+					fmt.Sprintf("/%s/active-doc%d", remoteKeyspace, numDocsPerCollection+1), "")
+				if rest.AssertStatus(t, resp, http.StatusOK) {
+					var docBody db.Body
+					require.NoError(t, docBody.Unmarshal(resp.BodyBytes()))
+					assert.Equal(t, "active", docBody["source"])
+					assert.Equal(t, localCollection, docBody["sourceKeyspace"])
+				}
+			}
 
-		remoteKeyspace := rt2DbName + "." + remoteCollection
-		rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
+			// and check we _didn't_ replicate docs in the absent collection
+			for _, localCollection := range nonReplicatedLocalCollections {
 
-		// check rt1 for passive docs (pull)
-		resp = rt1.SendAdminRequest(http.MethodGet,
-			fmt.Sprintf("/%s/passive-doc%d", localKeyspace, numDocsPerCollection+1), "")
-		if rest.AssertStatus(t, resp, http.StatusOK) {
-			var docBody db.Body
-			require.NoError(t, docBody.Unmarshal(resp.BodyBytes()))
-			assert.Equal(t, "passive", docBody["source"])
-			assert.Equal(t, remoteCollection, docBody["sourceKeyspace"])
-		}
+				expectedNumDocs := numDocsPerCollection + 1 // we created a set of 3 docs (plus one later), but didn't replicate any in or out of here...
 
-		// check rt2 for active docs (push)
-		resp = rt2.SendAdminRequest(http.MethodGet,
-			fmt.Sprintf("/%s/active-doc%d", remoteKeyspace, numDocsPerCollection+1), "")
-		if rest.AssertStatus(t, resp, http.StatusOK) {
-			var docBody db.Body
-			require.NoError(t, docBody.Unmarshal(resp.BodyBytes()))
-			assert.Equal(t, "active", docBody["source"])
-			assert.Equal(t, localCollection, docBody["sourceKeyspace"])
-		}
-	}
+				localKeyspace := rt1DbName + "." + localCollection
+				rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
+			}
+			for _, remoteCollection := range nonReplicatedRemoteCollections {
 
-	// and check we _didn't_ replicate docs in the absent collection
-	for _, localCollection := range nonReplicatedLocalCollections {
+				expectedNumDocs := numDocsPerCollection + 1 // we created a set of 3 docs (plus one later), but didn't replicate any in or out of here...
 
-		expectedNumDocs := numDocsPerCollection + 1 // we created a set of 3 docs (plus one later), but didn't replicate any in or out of here...
-
-		localKeyspace := rt1DbName + "." + localCollection
-		rt1.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", localKeyspace), "", true)
-	}
-	for _, remoteCollection := range nonReplicatedRemoteCollections {
-
-		expectedNumDocs := numDocsPerCollection + 1 // we created a set of 3 docs (plus one later), but didn't replicate any in or out of here...
-
-		remoteKeyspace := rt2DbName + "." + remoteCollection
-		rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
+				remoteKeyspace := rt2DbName + "." + remoteCollection
+				rt2.WaitForChanges(expectedNumDocs, fmt.Sprintf("/%s/_changes", remoteKeyspace), "", true)
+			}
+		})
 	}
 }
 
@@ -305,35 +324,39 @@ func TestActiveReplicatorMultiCollectionMismatchedLocalRemote(t *testing.T) {
 
 	localCollections := []string{"ks1", "ks3"}
 	remoteCollections := []string{"ks2"}
+	sgrRunner := rest.NewSGRTestRunner(t)
 
-	activeRT, _, remoteDbURLString := rest.SetupSGRPeers(t)
+	sgrRunner.Run(func(t *testing.T) {
+		activeRT, _, remoteDbURLString := sgrRunner.SetupSGRPeers(t)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := stats.DBReplicatorStats(t.Name())
+		require.NoError(t, err)
 
-	passiveDBURL, err := url.Parse(remoteDbURLString)
-	require.NoError(t, err)
+		passiveDBURL, err := url.Parse(remoteDbURLString)
+		require.NoError(t, err)
 
-	ctx1 := activeRT.Context()
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePushAndPull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: activeRT.GetDatabase(),
-		},
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  true,
-		CollectionsLocal:    localCollections,
-		CollectionsRemote:   remoteCollections,
+		ctx1 := activeRT.Context()
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          t.Name(),
+			Direction:   db.ActiveReplicatorTypePushAndPull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: activeRT.GetDatabase(),
+			},
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     true,
+			CollectionsLocal:       localCollections,
+			CollectionsRemote:      remoteCollections,
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+
+		err = ar.Start(ctx1)
+		assert.ErrorContains(t, err, "local and remote collections must be the same length")
+		assert.NoError(t, ar.Stop())
 	})
-	require.NoError(t, err)
-
-	err = ar.Start(ctx1)
-	assert.ErrorContains(t, err, "local and remote collections must be the same length")
-	assert.NoError(t, ar.Stop())
 }
 
 // TestActiveReplicatorMultiCollectionMissingRemote attempts to map to a missing remote collection.
@@ -341,38 +364,43 @@ func TestActiveReplicatorMultiCollectionMissingRemote(t *testing.T) {
 
 	base.TestRequiresCollections(t)
 
-	activeRT, _, remoteDbURLString := rest.SetupSGRPeers(t)
+	sgrRunner := rest.NewSGRTestRunner(t)
 
-	localCollection := activeRT.GetSingleDataStore().ScopeName() + "." + activeRT.GetSingleDataStore().CollectionName()
-	localCollections := []string{localCollection}
-	remoteCollections := []string{"missing.collection"}
+	sgrRunner.Run(func(t *testing.T) {
+		activeRT, _, remoteDbURLString := sgrRunner.SetupSGRPeers(t)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		localCollection := activeRT.GetSingleDataStore().ScopeName() + "." + activeRT.GetSingleDataStore().CollectionName()
+		localCollections := []string{localCollection}
+		remoteCollections := []string{"missing.collection"}
 
-	passiveDBURL, err := url.Parse(remoteDbURLString)
-	require.NoError(t, err)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := stats.DBReplicatorStats(t.Name())
+		require.NoError(t, err)
 
-	ctx1 := activeRT.Context()
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePushAndPull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: activeRT.GetDatabase(),
-		},
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  true,
-		CollectionsLocal:    localCollections,
-		CollectionsRemote:   remoteCollections,
+		passiveDBURL, err := url.Parse(remoteDbURLString)
+		require.NoError(t, err)
+
+		ctx1 := activeRT.Context()
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          t.Name(),
+			Direction:   db.ActiveReplicatorTypePushAndPull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: activeRT.GetDatabase(),
+			},
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     true,
+			CollectionsLocal:       localCollections,
+			CollectionsRemote:      remoteCollections,
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+
+		err = ar.Start(ctx1)
+		assert.ErrorContains(t, err, "peer does not have collection")
+		assert.NoError(t, ar.Stop())
 	})
-	require.NoError(t, err)
-
-	err = ar.Start(ctx1)
-	assert.ErrorContains(t, err, "peer does not have collection")
-	assert.NoError(t, ar.Stop())
 }
 
 // TestActiveReplicatorMultiCollectionMissingLocal attempts to use a missing local collection.
@@ -380,39 +408,44 @@ func TestActiveReplicatorMultiCollectionMissingLocal(t *testing.T) {
 
 	base.TestRequiresCollections(t)
 
-	activeRT, passiveRT, remoteDbURLString := rest.SetupSGRPeers(t)
+	sgrRunner := rest.NewSGRTestRunner(t)
 
-	localCollection := activeRT.GetSingleDataStore().ScopeName() + ".invalid"
-	localCollections := []string{localCollection}
-	remoteCollection := passiveRT.GetSingleDataStore().ScopeName() + "." + passiveRT.GetSingleDataStore().CollectionName()
-	remoteCollections := []string{remoteCollection}
+	sgrRunner.Run(func(t *testing.T) {
+		activeRT, passiveRT, remoteDbURLString := sgrRunner.SetupSGRPeers(t)
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		localCollection := activeRT.GetSingleDataStore().ScopeName() + ".invalid"
+		localCollections := []string{localCollection}
+		remoteCollection := passiveRT.GetSingleDataStore().ScopeName() + "." + passiveRT.GetSingleDataStore().CollectionName()
+		remoteCollections := []string{remoteCollection}
 
-	passiveDBURL, err := url.Parse(remoteDbURLString)
-	require.NoError(t, err)
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := stats.DBReplicatorStats(t.Name())
+		require.NoError(t, err)
 
-	ctx1 := activeRT.Context()
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePushAndPull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: activeRT.GetDatabase(),
-		},
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  true,
-		CollectionsLocal:    localCollections,
-		CollectionsRemote:   remoteCollections,
+		passiveDBURL, err := url.Parse(remoteDbURLString)
+		require.NoError(t, err)
+
+		ctx1 := activeRT.Context()
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          t.Name(),
+			Direction:   db.ActiveReplicatorTypePushAndPull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: activeRT.GetDatabase(),
+			},
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     true,
+			CollectionsLocal:       localCollections,
+			CollectionsRemote:      remoteCollections,
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+
+		err = ar.Start(ctx1)
+		assert.ErrorContains(t, err, "does not exist on this database")
+		assert.NoError(t, ar.Stop())
 	})
-	require.NoError(t, err)
-
-	err = ar.Start(ctx1)
-	assert.ErrorContains(t, err, "does not exist on this database")
-	assert.NoError(t, ar.Stop())
 }
 
 func TestReplicatorMissingCollections(t *testing.T) {

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -11,6 +11,7 @@ package replicatortest
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"testing"
 	"time"
 
@@ -37,313 +38,286 @@ func TestActiveReplicatorHLVConflictRemoteAndLocalWins(t *testing.T) {
 			conflictResType: db.ConflictResolverLocalWins,
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "passivedb",
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
+				require.NoError(t, err)
+				ctx1 := rt1.Context()
+
+				docID := "doc1_"
+				version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+				rt2.WaitForPendingChanges()
+
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   db.ActiveReplicatorTypePull,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
 					},
-				},
+					ChangesBatchSize:           200,
+					ReplicationStatsMap:        dbReplicatorStats(t),
+					ConflictResolverFuncForHLV: resolverFunc,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:                 false,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() { assert.NoError(t, ar.Stop()) }()
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+				rt1Version, _ := rt1.GetDoc(docID)
+				rest.RequireDocVersionEqual(t, version, rt1Version)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				var expectedConflictResBody []byte
+
+				for i := 0; i < 10; i++ {
+					version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
+				}
+				rt2.WaitForPendingChanges()
+				for i := 0; i < 10; i++ {
+					rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
+				}
+				rt1.WaitForPendingChanges()
+
+				rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
+				rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
+
+				var nonWinningRevPreConflict rest.DocVersion
+				var winningRevPreConflict rest.DocVersion
+				if testCase.conflictResType == db.ConflictResolverRemoteWins {
+					docToPull, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+					require.NoError(t, err)
+					expectedConflictResBody, err = docToPull.BodyBytes(rt2ctx)
+					require.NoError(t, err)
+
+					nonWinningRevPreConflict = rt1Version
+					winningRevPreConflict = version
+				} else {
+					localDoc, err := rt1collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+					require.NoError(t, err)
+					expectedConflictResBody, err = localDoc.BodyBytes(rt2ctx)
+					require.NoError(t, err)
+
+					nonWinningRevPreConflict = version
+					winningRevPreConflict = rt1Version
+				}
+
+				since, err := rt1collection.LastSequence(rt1ctx)
+				require.NoError(t, err)
+
+				// start again for new revisions
+				require.NoError(t, ar.Start(ctx1))
+
+				changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+
+				// grab local doc body and assert it is as expected
+				actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+				require.NoError(t, err)
+				assert.Equal(t, expectedConflictResBody, actualBody)
+
+				// assert HLV/rev tree is as expected
+				if testCase.conflictResType == db.ConflictResolverRemoteWins {
+					rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
+					// PV should have the source version pair from the updates on rt1
+					require.Len(t, rt1Doc.HLV.PreviousVersions, 1)
+					assert.Equal(t, nonWinningRevPreConflict.CV.Value, rt1Doc.HLV.PreviousVersions[nonWinningRevPreConflict.CV.SourceID])
+
+					// remote wins tombstones local rev and takes remote rev tree to write as active
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, version.RevTreeID, rt1Version.RevTreeID)
+				} else {
+					localWinsVersion := rt1Version
+					// local wins will generate a new rev ID as child of remote RevID
+					remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
+					newRevID := db.CreateRevIDWithBytes(remoteGeneration+1, version.RevTreeID, expectedConflictResBody)
+					localWinsVersion.RevTreeID = newRevID
+					require.NotNil(t, rt1Doc.HLV)
+					require.Equal(t, db.HybridLogicalVector{
+						CurrentVersionCAS: rt1Doc.Cas,
+						SourceID:          winningRevPreConflict.CV.SourceID,
+						Version:           winningRevPreConflict.CV.Value,
+						PreviousVersions: db.HLVVersions{
+							nonWinningRevPreConflict.CV.SourceID: nonWinningRevPreConflict.CV.Value,
+						},
+					}, *rt1Doc.HLV)
+
+					// check tombstoned leaf previous local active rev and active rev is above generated rev ID
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, localWinsVersion.RevTreeID, rt1Version.RevTreeID)
+				}
+
 			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
-
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "activedb",
-					},
-				},
-			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-
-			docID := "doc1_"
-			version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-			rt2.WaitForPendingChanges()
-
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResType, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				ReplicationStatsMap:        dbReplicatorStats(t),
-				ConflictResolverFuncForHLV: resolverFunc,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:                 false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-			rt1Version, _ := rt1.GetDoc(docID)
-			rest.RequireDocVersionEqual(t, version, rt1Version)
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			var expectedConflictResBody []byte
-
-			for i := 0; i < 10; i++ {
-				version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
-			}
-			rt2.WaitForPendingChanges()
-			for i := 0; i < 10; i++ {
-				rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
-			}
-			rt1.WaitForPendingChanges()
-
-			rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
-			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
-
-			var nonWinningRevPreConflict rest.DocVersion
-			var winningRevPreConflict rest.DocVersion
-			if testCase.conflictResType == db.ConflictResolverRemoteWins {
-				docToPull, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
-				require.NoError(t, err)
-				expectedConflictResBody, err = docToPull.BodyBytes(rt2ctx)
-				require.NoError(t, err)
-
-				nonWinningRevPreConflict = rt1Version
-				winningRevPreConflict = version
-			} else {
-				localDoc, err := rt1collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
-				require.NoError(t, err)
-				expectedConflictResBody, err = localDoc.BodyBytes(rt2ctx)
-				require.NoError(t, err)
-
-				nonWinningRevPreConflict = version
-				winningRevPreConflict = rt1Version
-			}
-
-			since, err := rt1collection.LastSequence(rt1ctx)
-			require.NoError(t, err)
-
-			// start again for new revisions
-			require.NoError(t, ar.Start(ctx1))
-
-			changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-
-			// grab local doc body and assert it is as expected
-			actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-			require.NoError(t, err)
-			assert.Equal(t, expectedConflictResBody, actualBody)
-
-			// assert HLV/rev tree is as expected
-			if testCase.conflictResType == db.ConflictResolverRemoteWins {
-				rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
-				// PV should have the source version pair from the updates on rt1
-				require.Len(t, rt1Doc.HLV.PreviousVersions, 1)
-				assert.Equal(t, nonWinningRevPreConflict.CV.Value, rt1Doc.HLV.PreviousVersions[nonWinningRevPreConflict.CV.SourceID])
-
-				// remote wins tombstones local rev and takes remote rev tree to write as active
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, version.RevTreeID, rt1Version.RevTreeID)
-			} else {
-				localWinsVersion := rt1Version
-				// local wins will generate a new rev ID as child of remote RevID
-				remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
-				newRevID := db.CreateRevIDWithBytes(remoteGeneration+1, version.RevTreeID, expectedConflictResBody)
-				localWinsVersion.RevTreeID = newRevID
-				require.NotNil(t, rt1Doc.HLV)
-				require.Equal(t, db.HybridLogicalVector{
-					CurrentVersionCAS: rt1Doc.Cas,
-					SourceID:          winningRevPreConflict.CV.SourceID,
-					Version:           winningRevPreConflict.CV.Value,
-					PreviousVersions: db.HLVVersions{
-						nonWinningRevPreConflict.CV.SourceID: nonWinningRevPreConflict.CV.Value,
-					},
-				}, *rt1Doc.HLV)
-
-				// check tombstoned leaf previous local active rev and active rev is above generated rev ID
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, localWinsVersion.RevTreeID, rt1Version.RevTreeID)
-			}
-
-		})
-	}
+		}
+	})
 }
 
 func TestActiveReplicatorLWWDefaultResolver(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "passivedb",
+
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		remoteURL, err := url.Parse(remoteURLString)
+		require.NoError(t, err)
+		ctx1 := rt1.Context()
+
+		docID := "doc1_"
+		version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+		rt2.WaitForPendingChanges()
+
+		resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
+		require.NoError(t, err)
+
+		replicationID := rest.SafeDocumentName(t, t.Name())
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          replicationID,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: remoteURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
 			},
-		},
-	})
-	defer rt2.Close()
-	username := "alice"
-	rt2.CreateUser(username, []string{username})
+			ChangesBatchSize:           200,
+			ReplicationStatsMap:        dbReplicatorStats(t),
+			ConflictResolverFuncForHLV: resolverFunc,
+			CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+			Continuous:                 false,
+			SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, ar.Stop()) }()
 
-	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "activedb",
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
+
+		// wait for the document originally written to rt1 to arrive at rt2
+		changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+		changesResults.RequireDocIDs(t, []string{docID})
+		rt1Version, _ := rt1.GetDoc(docID)
+		rest.RequireDocVersionEqual(t, version, rt1Version)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+		}, time.Second*20, time.Millisecond*100)
+
+		var expectedConflictResBody []byte
+		var expectedWinner rest.DocVersion
+		var nonWinningRevPreConflict rest.DocVersion
+
+		for i := 0; i < 10; i++ {
+			version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
+		}
+		rt2.WaitForPendingChanges()
+		for i := 0; i < 10; i++ {
+			rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
+		}
+		rt1.WaitForPendingChanges()
+
+		rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
+		rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
+
+		// pull out expected winner and expected conflict response body
+		var localWins bool
+		if rt1Version.CV.Value > version.CV.Value {
+			localWinsCaseDoc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			expectedWinner = rt1Version
+			expectedConflictResBody, err = localWinsCaseDoc.BodyBytes(rt2ctx)
+			require.NoError(t, err)
+			nonWinningRevPreConflict = version
+			localWins = true
+		} else {
+			localDoc, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			expectedWinner = version
+			expectedConflictResBody, err = localDoc.BodyBytes(rt2ctx)
+			require.NoError(t, err)
+			nonWinningRevPreConflict = rt1Version
+			localWins = false
+		}
+
+		since, err := rt1collection.LastSequence(rt1ctx)
+		require.NoError(t, err)
+
+		// start again for new revisions
+		require.NoError(t, ar.Start(ctx1))
+
+		changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+		changesResults.RequireDocIDs(t, []string{docID})
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+		}, time.Second*20, time.Millisecond*100)
+
+		rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		if localWins {
+			// local wins will gen a new rev ID as child of remote RevID
+			remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
+			newRevID := db.CreateRevIDWithBytes(remoteGeneration+1, version.RevTreeID, expectedConflictResBody)
+			expectedWinner.RevTreeID = newRevID
+		}
+		rest.RequireDocVersionEqual(t, expectedWinner, rt1Doc.ExtractDocVersion())
+		require.Equal(t, db.HybridLogicalVector{
+			CurrentVersionCAS: rt1Doc.Cas,
+			SourceID:          expectedWinner.CV.SourceID,
+			Version:           expectedWinner.CV.Value,
+			PreviousVersions: db.HLVVersions{
+				nonWinningRevPreConflict.CV.SourceID: nonWinningRevPreConflict.CV.Value,
 			},
-		},
+		}, *rt1Doc.HLV)
+
+		// PV should have the source version pair from the updates on rt1
+		if !localWins {
+
+			// remote wins:
+			//	- tombstones local active revision
+			// 	- winning rev is incoming active rev
+			docHistoryLeaves := rt1Doc.History.GetLeaves()
+			require.Len(t, docHistoryLeaves, 2)
+			rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, expectedWinner.RevTreeID, nonWinningRevPreConflict.RevTreeID)
+		} else {
+
+			// local wins:
+			// - tombstones local active revision
+			// - winning rev is written as child of remote winning rev
+			docHistoryLeaves := rt1Doc.History.GetLeaves()
+			require.Len(t, docHistoryLeaves, 2)
+			rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, expectedWinner.RevTreeID, rt1Version.RevTreeID)
+		}
+		// grab local doc body and assert it is as expected
+		actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+		require.NoError(t, err)
+		assert.Equal(t, expectedConflictResBody, actualBody)
 	})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
-
-	docID := "doc1_"
-	version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-	rt2.WaitForPendingChanges()
-
-	resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
-	require.NoError(t, err)
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:           200,
-		ReplicationStatsMap:        dbReplicatorStats(t),
-		ConflictResolverFuncForHLV: resolverFunc,
-		CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-		Continuous:                 false,
-	})
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, ar.Stop()) }()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	changesResults.RequireDocIDs(t, []string{docID})
-	rt1Version, _ := rt1.GetDoc(docID)
-	rest.RequireDocVersionEqual(t, version, rt1Version)
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-	}, time.Second*20, time.Millisecond*100)
-
-	var expectedConflictResBody []byte
-	var expectedWinner rest.DocVersion
-	var nonWinningRevPreConflict rest.DocVersion
-
-	for i := 0; i < 10; i++ {
-		version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
-	}
-	rt2.WaitForPendingChanges()
-	for i := 0; i < 10; i++ {
-		rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
-	}
-	rt1.WaitForPendingChanges()
-
-	rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
-	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
-
-	// pull out expected winner and expected conflict response body
-	var localWins bool
-	if rt1Version.CV.Value > version.CV.Value {
-		localWinsCaseDoc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-		require.NoError(t, err)
-		expectedWinner = rt1Version
-		expectedConflictResBody, err = localWinsCaseDoc.BodyBytes(rt2ctx)
-		require.NoError(t, err)
-		nonWinningRevPreConflict = version
-		localWins = true
-	} else {
-		localDoc, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
-		require.NoError(t, err)
-		expectedWinner = version
-		expectedConflictResBody, err = localDoc.BodyBytes(rt2ctx)
-		require.NoError(t, err)
-		nonWinningRevPreConflict = rt1Version
-		localWins = false
-	}
-
-	since, err := rt1collection.LastSequence(rt1ctx)
-	require.NoError(t, err)
-
-	// start again for new revisions
-	require.NoError(t, ar.Start(ctx1))
-
-	changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-	changesResults.RequireDocIDs(t, []string{docID})
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-	}, time.Second*20, time.Millisecond*100)
-
-	rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-	require.NoError(t, err)
-	if localWins {
-		// local wins will gen a new rev ID as child of remote RevID
-		remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
-		newRevID := db.CreateRevIDWithBytes(remoteGeneration+1, version.RevTreeID, expectedConflictResBody)
-		expectedWinner.RevTreeID = newRevID
-	}
-	rest.RequireDocVersionEqual(t, expectedWinner, rt1Doc.ExtractDocVersion())
-	require.Equal(t, db.HybridLogicalVector{
-		CurrentVersionCAS: rt1Doc.Cas,
-		SourceID:          expectedWinner.CV.SourceID,
-		Version:           expectedWinner.CV.Value,
-		PreviousVersions: db.HLVVersions{
-			nonWinningRevPreConflict.CV.SourceID: nonWinningRevPreConflict.CV.Value,
-		},
-	}, *rt1Doc.HLV)
-
-	// PV should have the source version pair from the updates on rt1
-	if !localWins {
-
-		// remote wins:
-		//	- tombstones local active revision
-		// 	- winning rev is incoming active rev
-		docHistoryLeaves := rt1Doc.History.GetLeaves()
-		require.Len(t, docHistoryLeaves, 2)
-		rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, expectedWinner.RevTreeID, nonWinningRevPreConflict.RevTreeID)
-	} else {
-
-		// local wins:
-		// - tombstones local active revision
-		// - winning rev is written as child of remote winning rev
-		docHistoryLeaves := rt1Doc.History.GetLeaves()
-		require.Len(t, docHistoryLeaves, 2)
-		rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, expectedWinner.RevTreeID, rt1Version.RevTreeID)
-	}
-	// grab local doc body and assert it is as expected
-	actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-	require.NoError(t, err)
-	assert.Equal(t, expectedConflictResBody, actualBody)
 }
 
 func TestActiveReplicatorLocalWinsCases(t *testing.T) {
@@ -455,182 +429,168 @@ func TestActiveReplicatorLocalWinsCases(t *testing.T) {
 			},
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "passivedb",
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
+				require.NoError(t, err)
+				ctx1 := rt1.Context()
+				ctx2 := rt2.Context()
+
+				docID := "doc1_"
+				version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+				rt2.WaitForPendingChanges()
+
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverLocalWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   db.ActiveReplicatorTypePull,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
 					},
-				},
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
+					ChangesBatchSize:           200,
+					ReplicationStatsMap:        dbReplicatorStats(t),
+					ConflictResolverFuncForHLV: resolverFunc,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:                 false,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() { assert.NoError(t, ar.Stop()) }()
 
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "activedb",
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+				rt1Version, _ := rt1.GetDoc(docID)
+				rest.RequireDocVersionEqual(t, version, rt1Version)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				// alter remote doc HLV to have MV
+				newHLVForRemote := &db.HybridLogicalVector{
+					Version:          math.MaxUint64, // will macro expand
+					SourceID:         version.CV.SourceID,
+					PreviousVersions: testCase.pvForRemote,
+					MergeVersions:    testCase.mvForRemote,
+				}
+
+				// create local hlv for conflict (simulating an update locally)
+				newHLVForLocal := &db.HybridLogicalVector{
+					SourceID: rt1.GetDatabase().EncodedSourceID,
+					Version:  math.MaxUint64, // will macro expand
+					PreviousVersions: map[string]uint64{
+						rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
 					},
-				},
+					MergeVersions: testCase.mvForLocal,
+				}
+				for key, value := range testCase.pvForLocal {
+					newHLVForLocal.PreviousVersions[key] = value
+				}
+
+				docBody := map[string]interface{}{
+					"source":   "rt2",
+					"channels": []string{"alice"},
+					"some":     "data",
+				}
+				remoteCas := db.AlterHLVForTest(t, ctx2, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
+				remoteDocPreConflict, _ := rt2.GetDoc(docID) // ensure doc is imported
+				base.RequireWaitForStat(t, func() int64 {
+					return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+				}, 1)
+
+				// simplify local doc body to one field so we can easily generate expected revID for local wins case
+				docBody = map[string]interface{}{
+					"channels": []string{"alice"},
+				}
+				localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
+				localDocPreConflict, localDocPreConflictBody := rt1.GetDoc(docID) // ensure doc is imported
+				base.RequireWaitForStat(t, func() int64 {
+					return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+				}, 1)
+
+				expectedHLV := &db.HybridLogicalVector{
+					Version:          localCas,
+					SourceID:         rt1.GetDatabase().EncodedSourceID,
+					PreviousVersions: testCase.expectedPV,
+				}
+				if testCase.mvForLocal != nil {
+					expectedHLV.MergeVersions = testCase.mvForLocal
+				}
+				// add current CVs to expected MV
+				expectedHLV.PreviousVersions[rt2.GetDatabase().EncodedSourceID] = remoteCas
+
+				rt1.WaitForPendingChanges()
+				rt2.WaitForPendingChanges()
+
+				rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+				since, err := rt1collection.LastSequence(rt1ctx)
+				require.NoError(t, err)
+
+				// start again for new revisions
+				require.NoError(t, ar.Start(ctx1))
+
+				changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+
+				// local wins:
+				//	- tombstones local active revision
+				//  - winning rev is written as child of remote winning rev
+				remoteGeneration, _ := db.ParseRevID(ctx1, remoteDocPreConflict.RevTreeID)
+				newRevID, err := db.CreateRevID(remoteGeneration+1, remoteDocPreConflict.RevTreeID, localDocPreConflictBody)
+				require.NoError(t, err)
+				assert.Equal(t, newRevID, rt1Doc.SyncData.GetRevTreeID())
+				docHistoryLeaves := rt1Doc.History.GetLeaves()
+				require.Len(t, docHistoryLeaves, 2)
+				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, newRevID, localDocPreConflict.RevTreeID)
+
+				require.Equal(t,
+					db.HybridLogicalVector{
+						CurrentVersionCAS: rt1Doc.Cas,
+						SourceID:          expectedHLV.SourceID,
+						Version:           expectedHLV.Version,
+						PreviousVersions:  testCase.expectedPV,
+						MergeVersions:     expectedHLV.MergeVersions,
+					},
+					*rt1Doc.HLV)
+				// assert on pv
+				require.Len(t, rt1Doc.HLV.PreviousVersions, len(testCase.expectedPV))
+				for key, val := range testCase.expectedPV {
+					assert.Equal(t, val, rt1Doc.HLV.PreviousVersions[key], "Expected key or value is missing in previous versions")
+				}
+				// assert on mv
+				require.Len(t, rt1Doc.HLV.MergeVersions, len(expectedHLV.MergeVersions))
+				for key, val := range expectedHLV.MergeVersions {
+					assert.Equal(t, val, rt1Doc.HLV.MergeVersions[key], "Expected key or value is missing in merge versions")
+				}
+
+				// assert on body
+				localDocPreConflictBody, _ = db.StripInternalProperties(localDocPreConflictBody)
+				expectedBytes := base.MustJSONMarshal(t, localDocPreConflictBody)
+				actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+				require.NoError(t, err)
+				require.JSONEq(t, string(expectedBytes), string(actualBody))
 			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-			ctx2 := rt2.Context()
-
-			docID := "doc1_"
-			version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-			rt2.WaitForPendingChanges()
-
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverLocalWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				ReplicationStatsMap:        dbReplicatorStats(t),
-				ConflictResolverFuncForHLV: resolverFunc,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:                 false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-			rt1Version, _ := rt1.GetDoc(docID)
-			rest.RequireDocVersionEqual(t, version, rt1Version)
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			// alter remote doc HLV to have MV
-			newHLVForRemote := &db.HybridLogicalVector{
-				Version:          math.MaxUint64, // will macro expand
-				SourceID:         version.CV.SourceID,
-				PreviousVersions: testCase.pvForRemote,
-				MergeVersions:    testCase.mvForRemote,
-			}
-
-			// create local hlv for conflict (simulating an update locally)
-			newHLVForLocal := &db.HybridLogicalVector{
-				SourceID: rt1.GetDatabase().EncodedSourceID,
-				Version:  math.MaxUint64, // will macro expand
-				PreviousVersions: map[string]uint64{
-					rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
-				},
-				MergeVersions: testCase.mvForLocal,
-			}
-			for key, value := range testCase.pvForLocal {
-				newHLVForLocal.PreviousVersions[key] = value
-			}
-
-			docBody := map[string]interface{}{
-				"source":   "rt2",
-				"channels": []string{"alice"},
-				"some":     "data",
-			}
-			remoteCas := db.AlterHLVForTest(t, ctx2, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
-			remoteDocPreConflict, _ := rt2.GetDoc(docID) // ensure doc is imported
-			base.RequireWaitForStat(t, func() int64 {
-				return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
-			}, 1)
-
-			// simplify local doc body to one field so we can easily generate expected revID for local wins case
-			docBody = map[string]interface{}{
-				"channels": []string{"alice"},
-			}
-			localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
-			localDocPreConflict, localDocPreConflictBody := rt1.GetDoc(docID) // ensure doc is imported
-			base.RequireWaitForStat(t, func() int64 {
-				return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
-			}, 1)
-
-			expectedHLV := &db.HybridLogicalVector{
-				Version:          localCas,
-				SourceID:         rt1.GetDatabase().EncodedSourceID,
-				PreviousVersions: testCase.expectedPV,
-			}
-			if testCase.mvForLocal != nil {
-				expectedHLV.MergeVersions = testCase.mvForLocal
-			}
-			// add current CVs to expected MV
-			expectedHLV.PreviousVersions[rt2.GetDatabase().EncodedSourceID] = remoteCas
-
-			rt1.WaitForPendingChanges()
-			rt2.WaitForPendingChanges()
-
-			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-			since, err := rt1collection.LastSequence(rt1ctx)
-			require.NoError(t, err)
-
-			// start again for new revisions
-			require.NoError(t, ar.Start(ctx1))
-
-			changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-
-			// local wins:
-			//	- tombstones local active revision
-			//  - winning rev is written as child of remote winning rev
-			remoteGeneration, _ := db.ParseRevID(ctx1, remoteDocPreConflict.RevTreeID)
-			newRevID, err := db.CreateRevID(remoteGeneration+1, remoteDocPreConflict.RevTreeID, localDocPreConflictBody)
-			require.NoError(t, err)
-			assert.Equal(t, newRevID, rt1Doc.SyncData.GetRevTreeID())
-			docHistoryLeaves := rt1Doc.History.GetLeaves()
-			require.Len(t, docHistoryLeaves, 2)
-			rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, newRevID, localDocPreConflict.RevTreeID)
-
-			require.Equal(t,
-				db.HybridLogicalVector{
-					CurrentVersionCAS: rt1Doc.Cas,
-					SourceID:          expectedHLV.SourceID,
-					Version:           expectedHLV.Version,
-					PreviousVersions:  testCase.expectedPV,
-					MergeVersions:     expectedHLV.MergeVersions,
-				},
-				*rt1Doc.HLV)
-			// assert on pv
-			require.Len(t, rt1Doc.HLV.PreviousVersions, len(testCase.expectedPV))
-			for key, val := range testCase.expectedPV {
-				assert.Equal(t, val, rt1Doc.HLV.PreviousVersions[key], "Expected key or value is missing in previous versions")
-			}
-			// assert on mv
-			require.Len(t, rt1Doc.HLV.MergeVersions, len(expectedHLV.MergeVersions))
-			for key, val := range expectedHLV.MergeVersions {
-				assert.Equal(t, val, rt1Doc.HLV.MergeVersions[key], "Expected key or value is missing in merge versions")
-			}
-
-			// assert on body
-			localDocPreConflictBody, _ = db.StripInternalProperties(localDocPreConflictBody)
-			expectedBytes := base.MustJSONMarshal(t, localDocPreConflictBody)
-			actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-			require.NoError(t, err)
-			require.JSONEq(t, string(expectedBytes), string(actualBody))
-		})
-	}
+		}
+	})
 }
 
 func TestActiveReplicatorRemoteWinsCases(t *testing.T) {
@@ -768,169 +728,155 @@ func TestActiveReplicatorRemoteWinsCases(t *testing.T) {
 			},
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "passivedb",
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
+				require.NoError(t, err)
+				ctx1 := rt1.Context()
+				ctx2 := rt2.Context()
+
+				docID := "doc1_"
+				version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+				rt2.WaitForPendingChanges()
+
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverRemoteWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   db.ActiveReplicatorTypePull,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
 					},
-				},
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
+					ChangesBatchSize:           200,
+					ReplicationStatsMap:        dbReplicatorStats(t),
+					ConflictResolverFuncForHLV: resolverFunc,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:                 false,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() { assert.NoError(t, ar.Stop()) }()
 
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "activedb",
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+				rt1Version, _ := rt1.GetDoc(docID)
+				rest.RequireDocVersionEqual(t, version, rt1Version)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				// alter remote doc HLV to have MV
+				newHLVForRemote := &db.HybridLogicalVector{
+					Version:          math.MaxUint64, // will macro expand
+					SourceID:         version.CV.SourceID,
+					MergeVersions:    testCase.mvForRemote,
+					PreviousVersions: testCase.pvForRemote,
+				}
+
+				// create local hlv for conflict (simulating an update locally)
+				newHLVForLocal := &db.HybridLogicalVector{
+					SourceID: rt1.GetDatabase().EncodedSourceID,
+					Version:  math.MaxUint64, // will macro expand
+					PreviousVersions: map[string]uint64{
+						rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
 					},
-				},
+					MergeVersions: testCase.mvForLocal,
+				}
+				for key, value := range testCase.pvForLocal {
+					newHLVForLocal.PreviousVersions[key] = value
+				}
+
+				docBody := map[string]interface{}{
+					"source":   "rt2",
+					"channels": []string{"alice"},
+					"some":     "data",
+				}
+				remoteCas := db.AlterHLVForTest(t, ctx1, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
+				remoteDocVersionPreConflict, remoteDocBodyPreConflict := rt2.GetDoc(docID) // ensure doc is imported
+				base.RequireWaitForStat(t, func() int64 {
+					return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+				}, 1)
+
+				docBody = map[string]interface{}{
+					"source":   "rt1",
+					"channels": []string{"alice"},
+				}
+				localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
+				localDocVersionPreConflict, _ := rt1.GetDoc(docID) // ensure doc is imported
+				base.RequireWaitForStat(t, func() int64 {
+					return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+				}, 1)
+
+				expectedHLV := &db.HybridLogicalVector{
+					SourceID:      rt2.GetDatabase().EncodedSourceID,
+					Version:       remoteCas,
+					MergeVersions: testCase.expectedMV,
+					PreviousVersions: map[string]uint64{
+						rt1.GetDatabase().EncodedSourceID: localCas,
+					},
+				}
+				for key, value := range testCase.expectedPV {
+					expectedHLV.PreviousVersions[key] = value
+				}
+
+				rt1.WaitForPendingChanges()
+				rt2.WaitForPendingChanges()
+
+				rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+				since, err := rt1collection.LastSequence(rt1ctx)
+				require.NoError(t, err)
+
+				// start again for new revisions
+				require.NoError(t, ar.Start(ctx1))
+
+				changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+				cvSource, cvValue := rt1Doc.HLV.GetCurrentVersion()
+				assert.Equal(t, expectedHLV.SourceID, cvSource)
+				assert.Equal(t, expectedHLV.Version, cvValue)
+				// remote wins:
+				//	- tombstones local active revision
+				// 	- winning rev is incoming active rev
+				assert.Equal(t, remoteDocVersionPreConflict.RevTreeID, rt1Doc.GetRevTreeID())
+				docHistoryLeaves := rt1Doc.History.GetLeaves()
+				require.Len(t, docHistoryLeaves, 2)
+				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, remoteDocVersionPreConflict.RevTreeID, localDocVersionPreConflict.RevTreeID)
+
+				require.Equal(t, db.HybridLogicalVector{
+					CurrentVersionCAS: rt1Doc.Cas,
+					SourceID:          expectedHLV.SourceID,
+					Version:           expectedHLV.Version,
+					PreviousVersions:  expectedHLV.PreviousVersions,
+					MergeVersions:     expectedHLV.MergeVersions,
+				}, *rt1Doc.HLV)
+
+				remoteDocBodyPreConflict, _ = db.StripInternalProperties(remoteDocBodyPreConflict)
+				expectedJsonBody := base.MustJSONMarshal(t, remoteDocBodyPreConflict)
+				actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+				require.NoError(t, err)
+				require.JSONEq(t, string(expectedJsonBody), string(actualBody))
 			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-			ctx2 := rt2.Context()
-
-			docID := "doc1_"
-			version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-			rt2.WaitForPendingChanges()
-
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverRemoteWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				ReplicationStatsMap:        dbReplicatorStats(t),
-				ConflictResolverFuncForHLV: resolverFunc,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:                 false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-			rt1Version, _ := rt1.GetDoc(docID)
-			rest.RequireDocVersionEqual(t, version, rt1Version)
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			// alter remote doc HLV to have MV
-			newHLVForRemote := &db.HybridLogicalVector{
-				Version:          math.MaxUint64, // will macro expand
-				SourceID:         version.CV.SourceID,
-				MergeVersions:    testCase.mvForRemote,
-				PreviousVersions: testCase.pvForRemote,
-			}
-
-			// create local hlv for conflict (simulating an update locally)
-			newHLVForLocal := &db.HybridLogicalVector{
-				SourceID: rt1.GetDatabase().EncodedSourceID,
-				Version:  math.MaxUint64, // will macro expand
-				PreviousVersions: map[string]uint64{
-					rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
-				},
-				MergeVersions: testCase.mvForLocal,
-			}
-			for key, value := range testCase.pvForLocal {
-				newHLVForLocal.PreviousVersions[key] = value
-			}
-
-			docBody := map[string]interface{}{
-				"source":   "rt2",
-				"channels": []string{"alice"},
-				"some":     "data",
-			}
-			remoteCas := db.AlterHLVForTest(t, ctx1, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
-			remoteDocVersionPreConflict, remoteDocBodyPreConflict := rt2.GetDoc(docID) // ensure doc is imported
-			base.RequireWaitForStat(t, func() int64 {
-				return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
-			}, 1)
-
-			docBody = map[string]interface{}{
-				"source":   "rt1",
-				"channels": []string{"alice"},
-			}
-			localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
-			localDocVersionPreConflict, _ := rt1.GetDoc(docID) // ensure doc is imported
-			base.RequireWaitForStat(t, func() int64 {
-				return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
-			}, 1)
-
-			expectedHLV := &db.HybridLogicalVector{
-				SourceID:      rt2.GetDatabase().EncodedSourceID,
-				Version:       remoteCas,
-				MergeVersions: testCase.expectedMV,
-				PreviousVersions: map[string]uint64{
-					rt1.GetDatabase().EncodedSourceID: localCas,
-				},
-			}
-			for key, value := range testCase.expectedPV {
-				expectedHLV.PreviousVersions[key] = value
-			}
-
-			rt1.WaitForPendingChanges()
-			rt2.WaitForPendingChanges()
-
-			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-			since, err := rt1collection.LastSequence(rt1ctx)
-			require.NoError(t, err)
-
-			// start again for new revisions
-			require.NoError(t, ar.Start(ctx1))
-
-			changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-			cvSource, cvValue := rt1Doc.HLV.GetCurrentVersion()
-			assert.Equal(t, expectedHLV.SourceID, cvSource)
-			assert.Equal(t, expectedHLV.Version, cvValue)
-			// remote wins:
-			//	- tombstones local active revision
-			// 	- winning rev is incoming active rev
-			assert.Equal(t, remoteDocVersionPreConflict.RevTreeID, rt1Doc.GetRevTreeID())
-			docHistoryLeaves := rt1Doc.History.GetLeaves()
-			require.Len(t, docHistoryLeaves, 2)
-			rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, remoteDocVersionPreConflict.RevTreeID, localDocVersionPreConflict.RevTreeID)
-
-			require.Equal(t, db.HybridLogicalVector{
-				CurrentVersionCAS: rt1Doc.Cas,
-				SourceID:          expectedHLV.SourceID,
-				Version:           expectedHLV.Version,
-				PreviousVersions:  expectedHLV.PreviousVersions,
-				MergeVersions:     expectedHLV.MergeVersions,
-			}, *rt1Doc.HLV)
-
-			remoteDocBodyPreConflict, _ = db.StripInternalProperties(remoteDocBodyPreConflict)
-			expectedJsonBody := base.MustJSONMarshal(t, remoteDocBodyPreConflict)
-			actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-			require.NoError(t, err)
-			require.JSONEq(t, string(expectedJsonBody), string(actualBody))
-		})
-	}
+		}
+	})
 }
 
 func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
@@ -1011,203 +957,189 @@ func TestActiveReplicatorHLVConflictNoCommonMVPV(t *testing.T) {
 			conflictResolverType: db.ConflictResolverLocalWins,
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					},
-				},
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
-
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "activedb",
-					},
-				},
-			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-			ctx2 := rt2.Context()
-
-			// disable pruning window so we can avoid HLV compaction for the artificially low HLV values in this test
-			rt1.GetDatabase().Options.TestVersionPruningWindowOverride = base.Ptr(time.Duration(0))
-			rt2.GetDatabase().Options.TestVersionPruningWindowOverride = base.Ptr(time.Duration(0))
-
-			docID := "doc1_"
-			version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-			rt2.WaitForPendingChanges()
-
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				ReplicationStatsMap:        dbReplicatorStats(t),
-				ConflictResolverFuncForHLV: resolverFunc,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:                 false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-			rt1Version, _ := rt1.GetDoc(docID)
-			rest.RequireDocVersionEqual(t, version, rt1Version)
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			// alter remote doc HLV to have MV
-			newHLVForRemote := &db.HybridLogicalVector{
-				Version:          math.MaxUint64, // will macro expand
-				SourceID:         version.CV.SourceID,
-				MergeVersions:    testCase.remoteMV,
-				PreviousVersions: testCase.remotePV,
-			}
-
-			// create local hlv for conflict (simulating an update locally)
-			newHLVForLocal := &db.HybridLogicalVector{
-				SourceID: rt1.GetDatabase().EncodedSourceID,
-				Version:  math.MaxUint64, // will macro expand
-				PreviousVersions: map[string]uint64{
-					rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
-				},
-				MergeVersions: testCase.localMV,
-			}
-			for key, value := range testCase.localPV {
-				newHLVForLocal.PreviousVersions[key] = value
-			}
-
-			docBody := map[string]interface{}{
-				"some":     "data",
-				"source":   "rt2",
-				"channels": []string{"alice"},
-			}
-			remoteCas := db.AlterHLVForTest(t, ctx1, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
-			remoteDocVersionPreConflict, remoteDocBodyPreConflict := rt2.GetDoc(docID) // ensure doc is imported
-			base.RequireWaitForStat(t, func() int64 {
-				return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
-			}, 1)
-
-			// simplify local doc body to one field so we can easily generate expected revID for local wins case
-			docBody = map[string]interface{}{
-				"channels": []string{"alice"},
-			}
-			localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
-			localDocVersionPreConflict, localDocBodyPreConflict := rt1.GetDoc(docID) // ensure doc is imported
-			base.RequireWaitForStat(t, func() int64 {
-				return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
-			}, 1)
-
-			rt1.WaitForPendingChanges()
-			rt2.WaitForPendingChanges()
-
-			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-			since, err := rt1collection.LastSequence(rt1ctx)
-			require.NoError(t, err)
-
-			// start again for new revisions
-			require.NoError(t, ar.Start(ctx1))
-
-			changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			rt1Doc := rt1.GetDocument(docID)
-			var expectedWinnerPreConflict db.Body
-			var expectedHLV db.HybridLogicalVector
-			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
-				expectedHLV = db.HybridLogicalVector{
-					CurrentVersionCAS: rt1Doc.Cas,
-					SourceID:          rt2.GetDatabase().EncodedSourceID,
-					Version:           remoteCas,
-					MergeVersions:     testCase.expectedMV,
-					PreviousVersions: map[string]uint64{
-						rt1.GetDatabase().EncodedSourceID: localCas,
-					},
-				}
-				expectedWinnerPreConflict = remoteDocBodyPreConflict
-			} else {
-				expectedHLV = db.HybridLogicalVector{
-					CurrentVersionCAS: rt1Doc.Cas,
-					SourceID:          rt1.GetDatabase().EncodedSourceID,
-					Version:           localCas,
-					MergeVersions:     testCase.expectedMV,
-					PreviousVersions: db.HLVVersions{
-						rt2.GetDatabase().EncodedSourceID: remoteCas,
-					},
-				}
-				expectedWinnerPreConflict = localDocBodyPreConflict
-			}
-			// add extra pv expected
-			for key, value := range testCase.expectedPV {
-				expectedHLV.PreviousVersions[key] = value
-			}
-
-			require.Equal(t, expectedHLV, *rt1Doc.HLV)
-
-			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
-				// remote wins:
-				//	- tombstones local active revision
-				// 	- winning rev is incoming active rev
-				assert.Equal(t, remoteDocVersionPreConflict.RevTreeID, rt1Doc.GetRevTreeID())
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, remoteDocVersionPreConflict.RevTreeID, localDocVersionPreConflict.RevTreeID)
-			} else {
-				// local wins:
-				//	- tombstones local active revision
-				//  - winning rev is written as child of remote winning rev
-				remoteGeneration, _ := db.ParseRevID(ctx1, remoteDocVersionPreConflict.RevTreeID)
-				newRevID, err := db.CreateRevID(remoteGeneration+1, remoteDocVersionPreConflict.RevTreeID, localDocBodyPreConflict)
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
-				assert.Equal(t, newRevID, rt1Doc.SyncData.GetRevTreeID())
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, newRevID, localDocVersionPreConflict.RevTreeID)
-			}
+				ctx1 := rt1.Context()
+				ctx2 := rt2.Context()
 
-			assert.Len(t, rt1Doc.HLV.PreviousVersions, len(expectedHLV.PreviousVersions))
-			for key, value := range expectedHLV.PreviousVersions {
-				assert.Equal(t, value, rt1Doc.HLV.PreviousVersions[key], "Expected key %s to have value %d in previous versions", key, value)
-			}
-			assert.Len(t, rt1Doc.HLV.MergeVersions, len(expectedHLV.MergeVersions))
-			for key, value := range expectedHLV.MergeVersions {
-				assert.Equal(t, value, rt1Doc.HLV.MergeVersions[key], "Expected key %s to have value %d in merge versions", key, value)
-			}
+				// disable pruning window so we can avoid HLV compaction for the artificially low HLV values in this test
+				rt1.GetDatabase().Options.TestVersionPruningWindowOverride = base.Ptr(time.Duration(0))
+				rt2.GetDatabase().Options.TestVersionPruningWindowOverride = base.Ptr(time.Duration(0))
 
-			expectedWinnerPreConflict, _ = db.StripInternalProperties(expectedWinnerPreConflict)
-			expectedJsonBody := base.MustJSONMarshal(t, expectedWinnerPreConflict)
-			actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-			require.NoError(t, err)
-			require.JSONEq(t, string(expectedJsonBody), string(actualBody))
-		})
-	}
+				docID := "doc1_"
+				version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+				rt2.WaitForPendingChanges()
+
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   db.ActiveReplicatorTypePull,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:           200,
+					ReplicationStatsMap:        dbReplicatorStats(t),
+					ConflictResolverFuncForHLV: resolverFunc,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:                 false,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() { assert.NoError(t, ar.Stop()) }()
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+				rt1Version, _ := rt1.GetDoc(docID)
+				rest.RequireDocVersionEqual(t, version, rt1Version)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				// alter remote doc HLV to have MV
+				newHLVForRemote := &db.HybridLogicalVector{
+					Version:          math.MaxUint64, // will macro expand
+					SourceID:         version.CV.SourceID,
+					MergeVersions:    testCase.remoteMV,
+					PreviousVersions: testCase.remotePV,
+				}
+
+				// create local hlv for conflict (simulating an update locally)
+				newHLVForLocal := &db.HybridLogicalVector{
+					SourceID: rt1.GetDatabase().EncodedSourceID,
+					Version:  math.MaxUint64, // will macro expand
+					PreviousVersions: map[string]uint64{
+						rt1Version.CV.SourceID: rt1Version.CV.Value, // move current cv to pv
+					},
+					MergeVersions: testCase.localMV,
+				}
+				for key, value := range testCase.localPV {
+					newHLVForLocal.PreviousVersions[key] = value
+				}
+
+				docBody := map[string]interface{}{
+					"some":     "data",
+					"source":   "rt2",
+					"channels": []string{"alice"},
+				}
+				remoteCas := db.AlterHLVForTest(t, ctx1, rt2.GetSingleDataStore(), docID, newHLVForRemote, docBody)
+				remoteDocVersionPreConflict, remoteDocBodyPreConflict := rt2.GetDoc(docID) // ensure doc is imported
+				base.RequireWaitForStat(t, func() int64 {
+					return rt2.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+				}, 1)
+
+				// simplify local doc body to one field so we can easily generate expected revID for local wins case
+				docBody = map[string]interface{}{
+					"channels": []string{"alice"},
+				}
+				localCas := db.AlterHLVForTest(t, ctx2, rt1.GetSingleDataStore(), docID, newHLVForLocal, docBody)
+				localDocVersionPreConflict, localDocBodyPreConflict := rt1.GetDoc(docID) // ensure doc is imported
+				base.RequireWaitForStat(t, func() int64 {
+					return rt1.GetDatabase().DbStats.SharedBucketImportStats.ImportCount.Value()
+				}, 1)
+
+				rt1.WaitForPendingChanges()
+				rt2.WaitForPendingChanges()
+
+				rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+				since, err := rt1collection.LastSequence(rt1ctx)
+				require.NoError(t, err)
+
+				// start again for new revisions
+				require.NoError(t, ar.Start(ctx1))
+
+				changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				rt1Doc := rt1.GetDocument(docID)
+				var expectedWinnerPreConflict db.Body
+				var expectedHLV db.HybridLogicalVector
+				if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+					expectedHLV = db.HybridLogicalVector{
+						CurrentVersionCAS: rt1Doc.Cas,
+						SourceID:          rt2.GetDatabase().EncodedSourceID,
+						Version:           remoteCas,
+						MergeVersions:     testCase.expectedMV,
+						PreviousVersions: map[string]uint64{
+							rt1.GetDatabase().EncodedSourceID: localCas,
+						},
+					}
+					expectedWinnerPreConflict = remoteDocBodyPreConflict
+				} else {
+					expectedHLV = db.HybridLogicalVector{
+						CurrentVersionCAS: rt1Doc.Cas,
+						SourceID:          rt1.GetDatabase().EncodedSourceID,
+						Version:           localCas,
+						MergeVersions:     testCase.expectedMV,
+						PreviousVersions: db.HLVVersions{
+							rt2.GetDatabase().EncodedSourceID: remoteCas,
+						},
+					}
+					expectedWinnerPreConflict = localDocBodyPreConflict
+				}
+				// add extra pv expected
+				for key, value := range testCase.expectedPV {
+					expectedHLV.PreviousVersions[key] = value
+				}
+
+				require.Equal(t, expectedHLV, *rt1Doc.HLV)
+
+				if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+					// remote wins:
+					//	- tombstones local active revision
+					// 	- winning rev is incoming active rev
+					assert.Equal(t, remoteDocVersionPreConflict.RevTreeID, rt1Doc.GetRevTreeID())
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, remoteDocVersionPreConflict.RevTreeID, localDocVersionPreConflict.RevTreeID)
+				} else {
+					// local wins:
+					//	- tombstones local active revision
+					//  - winning rev is written as child of remote winning rev
+					remoteGeneration, _ := db.ParseRevID(ctx1, remoteDocVersionPreConflict.RevTreeID)
+					newRevID, err := db.CreateRevID(remoteGeneration+1, remoteDocVersionPreConflict.RevTreeID, localDocBodyPreConflict)
+					require.NoError(t, err)
+					assert.Equal(t, newRevID, rt1Doc.SyncData.GetRevTreeID())
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, newRevID, localDocVersionPreConflict.RevTreeID)
+				}
+
+				assert.Len(t, rt1Doc.HLV.PreviousVersions, len(expectedHLV.PreviousVersions))
+				for key, value := range expectedHLV.PreviousVersions {
+					assert.Equal(t, value, rt1Doc.HLV.PreviousVersions[key], "Expected key %s to have value %d in previous versions", key, value)
+				}
+				assert.Len(t, rt1Doc.HLV.MergeVersions, len(expectedHLV.MergeVersions))
+				for key, value := range expectedHLV.MergeVersions {
+					assert.Equal(t, value, rt1Doc.HLV.MergeVersions[key], "Expected key %s to have value %d in merge versions", key, value)
+				}
+
+				expectedWinnerPreConflict, _ = db.StripInternalProperties(expectedWinnerPreConflict)
+				expectedJsonBody := base.MustJSONMarshal(t, expectedWinnerPreConflict)
+				actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+				require.NoError(t, err)
+				require.JSONEq(t, string(expectedJsonBody), string(actualBody))
+			})
+		}
+	})
 }
 
 func TestActiveReplicatorAttachmentHandling(t *testing.T) {
@@ -1226,146 +1158,132 @@ func TestActiveReplicatorAttachmentHandling(t *testing.T) {
 			conflictResolverType: db.ConflictResolverLocalWins,
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					},
-				},
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
-
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "activedb",
-					},
-				},
-			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-
-			docID := "doc1_"
-			version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-			rt2.WaitForPendingChanges()
-
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				ReplicationStatsMap:        dbReplicatorStats(t),
-				ConflictResolverFuncForHLV: resolverFunc,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:                 false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-			rt1Version, _ := rt1.GetDoc(docID)
-			rest.RequireDocVersionEqual(t, version, rt1Version)
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			// update remote doc to have two attachments
-			version = rt2.UpdateDoc(docID, version, `{"source":"rt2", "channels": ["alice"], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}, "world.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
-			// update local to have one different attachment
-			rt1Version = rt1.UpdateDoc(docID, rt1Version, `{"source":"rt1", "channels": ["alice"], "_attachments": {"different.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
-			rt2.WaitForPendingChanges()
-			rt1.WaitForPendingChanges()
-
-			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-			since, err := rt1collection.LastSequence(rt1ctx)
-			require.NoError(t, err)
-
-			_, localDocBodyPreConflict := rt1.GetDoc(docID) // get body for later comparison + revID assertion
-			localDocBodyPreConflict, _ = db.StripInternalProperties(localDocBodyPreConflict)
-			_, remoteDocBodyPreConflict := rt2.GetDoc(docID)
-			remoteDocBodyPreConflict, _ = db.StripInternalProperties(remoteDocBodyPreConflict)
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-
-			actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-			require.NoError(t, err)
-
-			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
-				// remote wins, so we expect the remote attachments to be present
-				rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
-				// remote wins:
-				//	- tombstones local active revision
-				// 	- winning rev is incoming active rev
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, version.RevTreeID, rt1Version.RevTreeID)
-
-				attMeta := rt1Doc.Attachments()
-				require.Len(t, attMeta, 2)
-				base.RequireKeysEqual(t, []string{"hello.txt", "world.txt"}, attMeta)
-
-				// remote attachment from body
-				delete(remoteDocBodyPreConflict, db.BodyAttachments)
-				expectedBodyBytes := base.MustJSONMarshal(t, remoteDocBodyPreConflict)
-				require.JSONEq(t, string(expectedBodyBytes), string(actualBody), "Doc body does not match expected for remote wins")
-			} else {
-				// local wins, so we expect the local attachment to be present
-				// local wins:
-				//	- tombstones local active revision
-				//  - winning rev is written as child of remote winning rev
-				remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
-				// remote attachment from body
-				delete(localDocBodyPreConflict, db.BodyAttachments)
-				newRevID, err := db.CreateRevID(remoteGeneration+1, version.RevTreeID, localDocBodyPreConflict)
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, newRevID, rt1Version.RevTreeID)
+				ctx1 := rt1.Context()
 
-				rt1Version.RevTreeID = newRevID
-				rest.RequireDocVersionEqual(t, rt1Version, rt1Doc.ExtractDocVersion())
+				docID := "doc1_"
+				version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+				rt2.WaitForPendingChanges()
 
-				attMeta := rt1Doc.Attachments()
-				require.Len(t, attMeta, 1)
-				base.RequireKeysEqual(t, []string{"different.txt"}, attMeta)
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
 
-				expectedBodyBytes := base.MustJSONMarshal(t, localDocBodyPreConflict)
-				require.JSONEq(t, string(expectedBodyBytes), string(actualBody), "Doc body does not match expected for local wins")
-			}
-		})
-	}
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   db.ActiveReplicatorTypePull,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:           200,
+					ReplicationStatsMap:        dbReplicatorStats(t),
+					ConflictResolverFuncForHLV: resolverFunc,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:                 false,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() { assert.NoError(t, ar.Stop()) }()
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+				rt1Version, _ := rt1.GetDoc(docID)
+				rest.RequireDocVersionEqual(t, version, rt1Version)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				// update remote doc to have two attachments
+				version = rt2.UpdateDoc(docID, version, `{"source":"rt2", "channels": ["alice"], "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}, "world.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
+				// update local to have one different attachment
+				rt1Version = rt1.UpdateDoc(docID, rt1Version, `{"source":"rt1", "channels": ["alice"], "_attachments": {"different.txt": {"data":"aGVsbG8gd29ybGQ="}}}`)
+				rt2.WaitForPendingChanges()
+				rt1.WaitForPendingChanges()
+
+				rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+				since, err := rt1collection.LastSequence(rt1ctx)
+				require.NoError(t, err)
+
+				_, localDocBodyPreConflict := rt1.GetDoc(docID) // get body for later comparison + revID assertion
+				localDocBodyPreConflict, _ = db.StripInternalProperties(localDocBodyPreConflict)
+				_, remoteDocBodyPreConflict := rt2.GetDoc(docID)
+				remoteDocBodyPreConflict, _ = db.StripInternalProperties(remoteDocBodyPreConflict)
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+
+				actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+				require.NoError(t, err)
+
+				if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+					// remote wins, so we expect the remote attachments to be present
+					rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
+					// remote wins:
+					//	- tombstones local active revision
+					// 	- winning rev is incoming active rev
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, version.RevTreeID, rt1Version.RevTreeID)
+
+					attMeta := rt1Doc.Attachments()
+					require.Len(t, attMeta, 2)
+					base.RequireKeysEqual(t, []string{"hello.txt", "world.txt"}, attMeta)
+
+					// remote attachment from body
+					delete(remoteDocBodyPreConflict, db.BodyAttachments)
+					expectedBodyBytes := base.MustJSONMarshal(t, remoteDocBodyPreConflict)
+					require.JSONEq(t, string(expectedBodyBytes), string(actualBody), "Doc body does not match expected for remote wins")
+				} else {
+					// local wins, so we expect the local attachment to be present
+					// local wins:
+					//	- tombstones local active revision
+					//  - winning rev is written as child of remote winning rev
+					remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
+					// remote attachment from body
+					delete(localDocBodyPreConflict, db.BodyAttachments)
+					newRevID, err := db.CreateRevID(remoteGeneration+1, version.RevTreeID, localDocBodyPreConflict)
+					require.NoError(t, err)
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, newRevID, rt1Version.RevTreeID)
+
+					rt1Version.RevTreeID = newRevID
+					rest.RequireDocVersionEqual(t, rt1Version, rt1Doc.ExtractDocVersion())
+
+					attMeta := rt1Doc.Attachments()
+					require.Len(t, attMeta, 1)
+					base.RequireKeysEqual(t, []string{"different.txt"}, attMeta)
+
+					expectedBodyBytes := base.MustJSONMarshal(t, localDocBodyPreConflict)
+					require.JSONEq(t, string(expectedBodyBytes), string(actualBody), "Doc body does not match expected for local wins")
+				}
+			})
+		}
+	})
 }
 
 func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
@@ -1384,232 +1302,214 @@ func TestActiveReplicatorHLVConflictWinnerIsTombstone(t *testing.T) {
 			conflictResolverType: db.ConflictResolverLocalWins,
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					},
-				},
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
-
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "activedb",
-					},
-				},
-			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-
-			docID := "doc1_"
-			version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-			rt2.WaitForPendingChanges()
-
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				ReplicationStatsMap:        dbReplicatorStats(t),
-				ConflictResolverFuncForHLV: resolverFunc,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:                 false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-			rt1Version, _ := rt1.GetDoc(docID)
-			rest.RequireDocVersionEqual(t, version, rt1Version)
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			// update winning rev to be a tombstone
-			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
-				// remote wins, so we update the remote doc to be a tombstone
-				version = rt2.DeleteDoc(docID, version)
-
-				rt1Version = rt1.UpdateDoc(docID, rt1Version, `{"source":"rt1","channels":["alice"]}`) // create conflicting update
-			} else {
-				// need to update remote doc to have something to replicate
-				version = rt2.UpdateDoc(docID, version, `{"source":"rt2","channels":["alice"]}`)
-				// local wins, so we update the local doc to be a tombstone
-				rt1Version = rt1.DeleteDoc(docID, rt1Version)
-			}
-			rt2.WaitForPendingChanges()
-			rt1.WaitForPendingChanges()
-
-			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-			since, err := rt1collection.LastSequence(rt1ctx)
-			require.NoError(t, err)
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-
-			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
-				// here local revIDs gets promoted back to active as the local rev tree is 3-... but remote is 2-...
-				newRev := db.CreateRevIDWithBytes(3, rt1Version.RevTreeID, []byte(db.DeletedDocument))
-				version.RevTreeID = newRev
-				rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				// both branches should be tombstones
-				for _, revID := range docHistoryLeaves {
-					revItem, ok := rt1Doc.History[revID]
-					require.True(t, ok)
-					assert.True(t, revItem.Deleted)
-				}
-			} else {
-				// local wins:
-				//	- tombstones local active revision
-				//  - winning rev is written as child of remote winning rev
-				remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
-				newRevID, err := db.CreateRevID(remoteGeneration+1, version.RevTreeID, db.Body{})
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
+				ctx1 := rt1.Context()
 
-				require.Equal(t, db.HybridLogicalVector{
-					CurrentVersionCAS: rt1Doc.Cas,
-					Version:           rt1Version.CV.Value,
-					SourceID:          rt1Version.CV.SourceID,
-					PreviousVersions: db.HLVVersions{
-						rt2.GetDatabase().EncodedSourceID: version.CV.Value,
+				docID := "doc1_"
+				version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+				rt2.WaitForPendingChanges()
+
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   db.ActiveReplicatorTypePull,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
 					},
-				}, *rt1Doc.HLV)
-				rt1Version.RevTreeID = newRevID
-				rest.RequireDocVersionEqual(t, rt1Version, rt1Doc.ExtractDocVersion())
+					ChangesBatchSize:           200,
+					ReplicationStatsMap:        dbReplicatorStats(t),
+					ConflictResolverFuncForHLV: resolverFunc,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:                 false,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() { assert.NoError(t, ar.Stop()) }()
 
-				// both branches should be tombstones
-				for _, revID := range docHistoryLeaves {
-					revItem, ok := rt1Doc.History[revID]
-					require.True(t, ok)
-					assert.True(t, revItem.Deleted)
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+				rt1Version, _ := rt1.GetDoc(docID)
+				rest.RequireDocVersionEqual(t, version, rt1Version)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				// update winning rev to be a tombstone
+				if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+					// remote wins, so we update the remote doc to be a tombstone
+					version = rt2.DeleteDoc(docID, version)
+
+					rt1Version = rt1.UpdateDoc(docID, rt1Version, `{"source":"rt1","channels":["alice"]}`) // create conflicting update
+				} else {
+					// need to update remote doc to have something to replicate
+					version = rt2.UpdateDoc(docID, version, `{"source":"rt2","channels":["alice"]}`)
+					// local wins, so we update the local doc to be a tombstone
+					rt1Version = rt1.DeleteDoc(docID, rt1Version)
 				}
-			}
-			assert.True(t, rt1Doc.IsDeleted(), "Expected document to be a tombstone after remote wins conflict resolution")
-		})
-	}
+				rt2.WaitForPendingChanges()
+				rt1.WaitForPendingChanges()
+
+				rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+				since, err := rt1collection.LastSequence(rt1ctx)
+				require.NoError(t, err)
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+
+				if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+					// here local revIDs gets promoted back to active as the local rev tree is 3-... but remote is 2-...
+					newRev := db.CreateRevIDWithBytes(3, rt1Version.RevTreeID, []byte(db.DeletedDocument))
+					version.RevTreeID = newRev
+					rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					// both branches should be tombstones
+					for _, revID := range docHistoryLeaves {
+						revItem, ok := rt1Doc.History[revID]
+						require.True(t, ok)
+						assert.True(t, revItem.Deleted)
+					}
+				} else {
+					// local wins:
+					//	- tombstones local active revision
+					//  - winning rev is written as child of remote winning rev
+					remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
+					newRevID, err := db.CreateRevID(remoteGeneration+1, version.RevTreeID, db.Body{})
+					require.NoError(t, err)
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+
+					require.Equal(t, db.HybridLogicalVector{
+						CurrentVersionCAS: rt1Doc.Cas,
+						Version:           rt1Version.CV.Value,
+						SourceID:          rt1Version.CV.SourceID,
+						PreviousVersions: db.HLVVersions{
+							rt2.GetDatabase().EncodedSourceID: version.CV.Value,
+						},
+					}, *rt1Doc.HLV)
+					rt1Version.RevTreeID = newRevID
+					rest.RequireDocVersionEqual(t, rt1Version, rt1Doc.ExtractDocVersion())
+
+					// both branches should be tombstones
+					for _, revID := range docHistoryLeaves {
+						revItem, ok := rt1Doc.History[revID]
+						require.True(t, ok)
+						assert.True(t, revItem.Deleted)
+					}
+				}
+				assert.True(t, rt1Doc.IsDeleted(), "Expected document to be a tombstone after remote wins conflict resolution")
+			})
+		}
+	})
 }
 
 func TestActiveReplicatorInvalidCustomResolver(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "passivedb",
-			},
-		},
-	})
-	defer rt2.Close()
-	username := "alice"
-	rt2.CreateUser(username, []string{"*"})
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		remoteURL, err := url.Parse(remoteURLString)
+		require.NoError(t, err)
+		ctx1 := rt1.Context()
 
-	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "activedb",
-			},
-		},
-	})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		rt1Collection, rt1Ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+		rt2Collection, rt2Ctx := rt2.GetSingleTestDatabaseCollectionWithUser()
 
-	rt1Collection, rt1Ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-	rt2Collection, rt2Ctx := rt2.GetSingleTestDatabaseCollectionWithUser()
+		docID := t.Name()
+		newDoc := db.CreateTestDocument(docID, "", rest.JsonToMap(t, `{"some": "data"}`), false, 0)
+		incomingHLV := &db.HybridLogicalVector{
+			SourceID: "abc",
+			Version:  1234,
+		}
+		// add local version
+		opts := db.PutDocOptions{
+			NewDoc:    newDoc,
+			NewDocHLV: incomingHLV,
+		}
+		_, _, _, err = rt1Collection.PutExistingCurrentVersion(rt1Ctx, opts)
+		require.NoError(t, err)
 
-	docID := t.Name()
-	newDoc := db.CreateTestDocument(docID, "", rest.JsonToMap(t, `{"some": "data"}`), false, 0)
-	incomingHLV := &db.HybridLogicalVector{
-		SourceID: "abc",
-		Version:  1234,
-	}
-	// add local version
-	opts := db.PutDocOptions{
-		NewDoc:    newDoc,
-		NewDocHLV: incomingHLV,
-	}
-	_, _, _, err := rt1Collection.PutExistingCurrentVersion(rt1Ctx, opts)
-	require.NoError(t, err)
+		newDoc = db.CreateTestDocument(docID, "", rest.JsonToMap(t, `{"some": "data"}`), false, 0)
+		incomingHLV = &db.HybridLogicalVector{
+			SourceID: "def",
+			Version:  1234,
+		}
+		opts.NewDocHLV = incomingHLV
+		opts.NewDoc = newDoc
+		_, _, _, err = rt2Collection.PutExistingCurrentVersion(rt2Ctx, opts)
+		require.NoError(t, err)
 
-	newDoc = db.CreateTestDocument(docID, "", rest.JsonToMap(t, `{"some": "data"}`), false, 0)
-	incomingHLV = &db.HybridLogicalVector{
-		SourceID: "def",
-		Version:  1234,
-	}
-	opts.NewDocHLV = incomingHLV
-	opts.NewDoc = newDoc
-	_, _, _, err = rt2Collection.PutExistingCurrentVersion(rt2Ctx, opts)
-	require.NoError(t, err)
+		newDoc = db.CreateTestDocument(docID, "", rest.JsonToMap(t, `{"some": "data"}`), false, 0)
+		incomingHLV = &db.HybridLogicalVector{
+			SourceID: "def",
+			Version:  1234,
+		}
+		opts.NewDocHLV = incomingHLV
+		opts.NewDoc = newDoc
+		_, _, _, err = rt2Collection.PutExistingCurrentVersion(rt2Ctx, opts)
+		require.NoError(t, err)
 
-	resolver := `function(conflict) {var mergedDoc = new Object();
+		resolver := `function(conflict) {var mergedDoc = new Object();
 										mergedDoc._cv = "@";
 										return mergedDoc;}` // invalid - setting cv to something that doesn't match either doc
-	customConflictResolver, err := db.NewCustomConflictResolver(ctx1, resolver, rt1.GetDatabase().Options.JavascriptTimeout)
-	require.NoError(t, err)
+		customConflictResolver, err := db.NewCustomConflictResolver(ctx1, resolver, rt1.GetDatabase().Options.JavascriptTimeout)
+		require.NoError(t, err)
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:           200,
-		ReplicationStatsMap:        dbReplicatorStats(t),
-		ConflictResolverFunc:       customConflictResolver,
-		ConflictResolverFuncForHLV: customConflictResolver,
-		CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-		Continuous:                 true,
+		replicationID := rest.SafeDocumentName(t, t.Name())
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          replicationID,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: remoteURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			ChangesBatchSize:           200,
+			ReplicationStatsMap:        dbReplicatorStats(t),
+			ConflictResolverFunc:       customConflictResolver,
+			ConflictResolverFuncForHLV: customConflictResolver,
+			CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+			Continuous:                 true,
+			SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+		defer func() { require.NoError(t, ar.Stop()) }()
+
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			status := ar.GetStatus(ctx1)
+			assert.Equal(c, 1, int(status.PullReplicationStatus.RejectedLocal))
+		}, 10*time.Second, 100*time.Millisecond)
 	})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ar.Stop()) }()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		status := ar.GetStatus(ctx1)
-		assert.Equal(c, 1, int(status.PullReplicationStatus.RejectedLocal))
-	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
@@ -1687,135 +1587,121 @@ func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
 			useRemoteRevTreeID:    false,
 		},
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeySync, base.KeySyncMsg, base.KeyVV)
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					},
-				},
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{"*"})
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) // test has flaked in jenkins, need to debug
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
+				require.NoError(t, err)
+				ctx1 := rt1.Context()
 
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "activedb",
-					},
-				},
-			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
+				rt1Collection, rt1Ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+				rt2Collection, rt2Ctx := rt2.GetSingleTestDatabaseCollectionWithUser()
 
-			rt1Collection, rt1Ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-			rt2Collection, rt2Ctx := rt2.GetSingleTestDatabaseCollectionWithUser()
-
-			docID := "doc1_" + testCase.name
-			newDoc := db.CreateTestDocument(docID, "", rest.JsonToMap(t, testCase.localBody), false, 0)
-			incomingHLV := &db.HybridLogicalVector{
-				SourceID: "activeRT",
-				Version:  12234,
-			}
-			// add local version
-			opts := db.PutDocOptions{
-				NewDoc:    newDoc,
-				NewDocHLV: incomingHLV,
-			}
-			localDoc, _, _, err := rt1Collection.PutExistingCurrentVersion(rt1Ctx, opts)
-			require.NoError(t, err)
-
-			newDoc = db.CreateTestDocument(docID, "", rest.JsonToMap(t, testCase.remoteBody), false, 0)
-			incomingHLV = &db.HybridLogicalVector{
-				SourceID: "passiveRT",
-				Version:  1234,
-			}
-			opts = db.PutDocOptions{
-				NewDoc:    newDoc,
-				NewDocHLV: incomingHLV,
-			}
-			remoteDoc, _, _, err := rt2Collection.PutExistingCurrentVersion(rt2Ctx, opts)
-			require.NoError(t, err)
-
-			customConflictResolver, err := db.NewCustomConflictResolver(ctx1, testCase.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePushAndPull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				ReplicationStatsMap:        dbReplicatorStats(t),
-				ConflictResolverFunc:       customConflictResolver,
-				ConflictResolverFuncForHLV: customConflictResolver,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:                 true,
-			})
-			require.NoError(t, err)
-			defer func() { require.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				status := ar.GetStatus(ctx1)
-				assert.Equal(c, 1, int(status.PullReplicationStatus.DocsRead))
-				assert.Equal(c, 1, int(status.PushReplicationStatus.DocWriteConflict))
-				if testCase.expectedDocPushResolved {
-					assert.Equal(c, 1, int(status.PushReplicationStatus.DocsWritten))
+				docID := "doc1_" + testCase.name
+				newDoc := db.CreateTestDocument(docID, "", rest.JsonToMap(t, testCase.localBody), false, 0)
+				incomingHLV := &db.HybridLogicalVector{
+					SourceID: "activeRT",
+					Version:  12234,
 				}
-			}, 10*time.Second, 100*time.Millisecond)
-
-			changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", localDoc.Sequence), "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-
-			resolvedDoc, err := rt1Collection.GetDocument(rt1Ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-
-			expectedHLV := testCase.hlvResult
-			expectedHLV.CurrentVersionCAS = resolvedDoc.Cas
-			if testCase.newCVGenerated {
-				expectedHLV.SourceID = rt1.GetDatabase().EncodedSourceID
-				expectedHLV.Version = resolvedDoc.Cas
-			}
-			require.Equal(t, expectedHLV, *resolvedDoc.HLV)
-
-			if testCase.expectedDocPushResolved {
-				resolvedDocBodyLocal, err := resolvedDoc.BodyBytes(rt1Ctx)
-				require.NoError(t, err)
-				resolvedDocRemote, err := rt2Collection.GetDocument(rt2Ctx, docID, db.DocUnmarshalAll)
+				// add local version
+				opts := db.PutDocOptions{
+					NewDoc:    newDoc,
+					NewDocHLV: incomingHLV,
+				}
+				localDoc, _, _, err := rt1Collection.PutExistingCurrentVersion(rt1Ctx, opts)
 				require.NoError(t, err)
 
-				resolvedDocBodyRemote, err := resolvedDocRemote.BodyBytes(rt2Ctx)
+				newDoc = db.CreateTestDocument(docID, "", rest.JsonToMap(t, testCase.remoteBody), false, 0)
+				incomingHLV = &db.HybridLogicalVector{
+					SourceID: "passiveRT",
+					Version:  1234,
+				}
+				opts = db.PutDocOptions{
+					NewDoc:    newDoc,
+					NewDocHLV: incomingHLV,
+				}
+				remoteDoc, _, _, err := rt2Collection.PutExistingCurrentVersion(rt2Ctx, opts)
 				require.NoError(t, err)
-				assert.Equal(t, string(resolvedDocBodyLocal), string(resolvedDocBodyRemote))
-			}
 
-			// merge/local wins will:
-			//	- tombstones local active revision
-			//  - winning merged rev is written as child of remote winning r
-			//  remote wins will:
-			//  - tombstones local active revision
-			//  - winning rev is incoming active rev
-			newRevTreeID := remoteDoc.GetRevTreeID()
-			if !testCase.useRemoteRevTreeID {
-				newRevTreeID = getRevTreeID(t, remoteDoc.GetRevTreeID(), []byte(testCase.expectedBody))
-			}
-			docHistoryLeaves := resolvedDoc.History.GetLeaves()
-			require.Len(t, docHistoryLeaves, 2)
-			rest.AssertRevTreeAfterHLVConflictResolution(t, resolvedDoc, newRevTreeID, localDoc.GetRevTreeID())
-		})
-	}
+				customConflictResolver, err := db.NewCustomConflictResolver(ctx1, testCase.conflictResolver, rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   db.ActiveReplicatorTypePushAndPull,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:           200,
+					ReplicationStatsMap:        dbReplicatorStats(t),
+					ConflictResolverFunc:       customConflictResolver,
+					ConflictResolverFuncForHLV: customConflictResolver,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:                 true,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() { require.NoError(t, ar.Stop()) }()
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					status := ar.GetStatus(ctx1)
+					assert.Equal(c, 1, int(status.PullReplicationStatus.DocsRead))
+					assert.Equal(c, 1, int(status.PushReplicationStatus.DocWriteConflict))
+					if testCase.expectedDocPushResolved {
+						assert.Equal(c, 1, int(status.PushReplicationStatus.DocsWritten))
+					}
+				}, 10*time.Second, 100*time.Millisecond)
+
+				changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", localDoc.Sequence), "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+
+				resolvedDoc, err := rt1Collection.GetDocument(rt1Ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+
+				expectedHLV := testCase.hlvResult
+				expectedHLV.CurrentVersionCAS = resolvedDoc.Cas
+				if testCase.newCVGenerated {
+					expectedHLV.SourceID = rt1.GetDatabase().EncodedSourceID
+					expectedHLV.Version = resolvedDoc.Cas
+				}
+				require.Equal(t, expectedHLV, *resolvedDoc.HLV)
+
+				if testCase.expectedDocPushResolved {
+					resolvedDocBodyLocal, err := resolvedDoc.BodyBytes(rt1Ctx)
+					require.NoError(t, err)
+					resolvedDocRemote, err := rt2Collection.GetDocument(rt2Ctx, docID, db.DocUnmarshalAll)
+					require.NoError(t, err)
+
+					resolvedDocBodyRemote, err := resolvedDocRemote.BodyBytes(rt2Ctx)
+					require.NoError(t, err)
+					assert.Equal(t, string(resolvedDocBodyLocal), string(resolvedDocBodyRemote))
+				}
+
+				// merge/local wins will:
+				//	- tombstones local active revision
+				//  - winning merged rev is written as child of remote winning r
+				//  remote wins will:
+				//  - tombstones local active revision
+				//  - winning rev is incoming active rev
+				newRevTreeID := remoteDoc.GetRevTreeID()
+				if !testCase.useRemoteRevTreeID {
+					newRevTreeID = getRevTreeID(t, remoteDoc.GetRevTreeID(), []byte(testCase.expectedBody))
+				}
+				docHistoryLeaves := resolvedDoc.History.GetLeaves()
+				require.Len(t, docHistoryLeaves, 2)
+				rest.AssertRevTreeAfterHLVConflictResolution(t, resolvedDoc, newRevTreeID, localDoc.GetRevTreeID())
+			})
+		}
+	})
 }
 
 func TestActiveReplicatorHLVConflictWhenNonWinningRevHasMoreRevisions(t *testing.T) {
@@ -1834,446 +1720,390 @@ func TestActiveReplicatorHLVConflictWhenNonWinningRevHasMoreRevisions(t *testing
 			conflictResolverType: db.ConflictResolverLocalWins,
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					},
-				},
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
-
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-				DatabaseConfig: &rest.DatabaseConfig{
-					DbConfig: rest.DbConfig{
-						Name: "activedb",
-					},
-				},
-			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-
-			docID := "doc1_"
-			version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-			rt2.WaitForPendingChanges()
-
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				ReplicationStatsMap:        dbReplicatorStats(t),
-				ConflictResolverFuncForHLV: resolverFunc,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:                 false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-			rt1Version, _ := rt1.GetDoc(docID)
-			rest.RequireDocVersionEqual(t, version, rt1Version)
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			var expectedWinnerPreConflict db.Body
-			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
-				// update doc on remote to ensure it we have something to replicate
-				// update doc locally many times to create more revisions than remote
-				version = rt2.UpdateDoc(docID, version, `{"source":"rt2","channels":["alice"]}`)
-				for i := 0; i < 10; i++ {
-					rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
-				}
-
-				_, expectedWinnerPreConflict = rt2.GetDoc(docID) // get body for later comparison + revID assertion
-			} else {
-				// update doc on remote loads of times to cause large diff in revisions
-				for i := 0; i < 10; i++ {
-					version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
-				}
-				// update doc locally to conflict
-				rt1Version = rt1.UpdateDoc(docID, rt1Version, `{"source":"rt1","channels":["alice"]}`)
-
-				_, expectedWinnerPreConflict = rt1.GetDoc(docID) // get body for later comparison + revID assertion
-			}
-			rt2.WaitForPendingChanges()
-			rt1.WaitForPendingChanges()
-
-			// grab last seq allocated for since param
-			rt1Collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-			since, err := rt1Collection.LastSequence(rt1ctx)
-			require.NoError(t, err)
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-			changesResults.RequireDocIDs(t, []string{docID})
-			resolvedVersion, _ := rt1.GetDoc(docID)
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			rt1Doc, err := rt1Collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-
-			if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
-				rest.RequireDocVersionEqual(t, version, resolvedVersion)
-				// remote wins:
-				//	- tombstones local active revision
-				// 	- winning rev is incoming active rev
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, version.RevTreeID, rt1Version.RevTreeID)
-			} else {
-				// local wins:
-				//	- tombstones local active revision
-				//  - winning rev is written as child of remote winning rev
-				remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
-				newRevID, err := db.CreateRevID(remoteGeneration+1, version.RevTreeID, expectedWinnerPreConflict)
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
-				docHistoryLeaves := rt1Doc.History.GetLeaves()
-				require.Len(t, docHistoryLeaves, 2)
-				rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, newRevID, rt1Version.RevTreeID)
-				rt1Version.RevTreeID = newRevID
-				rest.RequireDocVersionEqual(t, rt1Version, resolvedVersion)
-			}
+				ctx1 := rt1.Context()
 
-			expectedWinnerPreConflict, _ = db.StripInternalProperties(expectedWinnerPreConflict)
-			expectedJsonBody := base.MustJSONMarshal(t, expectedWinnerPreConflict)
-			actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-			require.NoError(t, err)
-			require.JSONEq(t, string(expectedJsonBody), string(actualBody))
-		})
-	}
+				docID := "doc1_"
+				version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+				rt2.WaitForPendingChanges()
+
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, testCase.conflictResolverType, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   db.ActiveReplicatorTypePull,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:           200,
+					ReplicationStatsMap:        dbReplicatorStats(t),
+					ConflictResolverFuncForHLV: resolverFunc,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:                 false,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() { assert.NoError(t, ar.Stop()) }()
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+				rt1Version, _ := rt1.GetDoc(docID)
+				rest.RequireDocVersionEqual(t, version, rt1Version)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				var expectedWinnerPreConflict db.Body
+				if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+					// update doc on remote to ensure it we have something to replicate
+					// update doc locally many times to create more revisions than remote
+					version = rt2.UpdateDoc(docID, version, `{"source":"rt2","channels":["alice"]}`)
+					for i := 0; i < 10; i++ {
+						rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
+					}
+
+					_, expectedWinnerPreConflict = rt2.GetDoc(docID) // get body for later comparison + revID assertion
+				} else {
+					// update doc on remote loads of times to cause large diff in revisions
+					for i := 0; i < 10; i++ {
+						version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
+					}
+					// update doc locally to conflict
+					rt1Version = rt1.UpdateDoc(docID, rt1Version, `{"source":"rt1","channels":["alice"]}`)
+
+					_, expectedWinnerPreConflict = rt1.GetDoc(docID) // get body for later comparison + revID assertion
+				}
+				rt2.WaitForPendingChanges()
+				rt1.WaitForPendingChanges()
+
+				// grab last seq allocated for since param
+				rt1Collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+				since, err := rt1Collection.LastSequence(rt1ctx)
+				require.NoError(t, err)
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+				changesResults.RequireDocIDs(t, []string{docID})
+				resolvedVersion, _ := rt1.GetDoc(docID)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				rt1Doc, err := rt1Collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+
+				if testCase.conflictResolverType == db.ConflictResolverRemoteWins {
+					rest.RequireDocVersionEqual(t, version, resolvedVersion)
+					// remote wins:
+					//	- tombstones local active revision
+					// 	- winning rev is incoming active rev
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, version.RevTreeID, rt1Version.RevTreeID)
+				} else {
+					// local wins:
+					//	- tombstones local active revision
+					//  - winning rev is written as child of remote winning rev
+					remoteGeneration, _ := db.ParseRevID(ctx1, version.RevTreeID)
+					newRevID, err := db.CreateRevID(remoteGeneration+1, version.RevTreeID, expectedWinnerPreConflict)
+					require.NoError(t, err)
+					docHistoryLeaves := rt1Doc.History.GetLeaves()
+					require.Len(t, docHistoryLeaves, 2)
+					rest.AssertRevTreeAfterHLVConflictResolution(t, rt1Doc, newRevID, rt1Version.RevTreeID)
+					rt1Version.RevTreeID = newRevID
+					rest.RequireDocVersionEqual(t, rt1Version, resolvedVersion)
+				}
+
+				expectedWinnerPreConflict, _ = db.StripInternalProperties(expectedWinnerPreConflict)
+				expectedJsonBody := base.MustJSONMarshal(t, expectedWinnerPreConflict)
+				actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+				require.NoError(t, err)
+				require.JSONEq(t, string(expectedJsonBody), string(actualBody))
+			})
+		}
+	})
 }
 
 func TestActiveReplicatorHLVConflictLocalWinsWhenNonWinningRevHasLessRevisionsLocalIsTombstoned(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "passivedb",
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		remoteURL, err := url.Parse(remoteURLString)
+		require.NoError(t, err)
+		ctx1 := rt1.Context()
+
+		docID := "doc1_"
+		rt2Version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+		rt2.WaitForPendingChanges()
+
+		// create conflicting update on rt1 and create more revisions than remote
+		rt1Version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
+		rt1.WaitForPendingChanges()
+		for i := 0; i < 10; i++ {
+			rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
+		}
+		// delete local version
+		rt1Version = rt1.DeleteDoc(docID, rt1Version)
+		rt1.WaitForPendingChanges()
+
+		resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverLocalWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
+		require.NoError(t, err)
+
+		replicationID := rest.SafeDocumentName(t, t.Name())
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          replicationID,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: remoteURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
 			},
-		},
+			ChangesBatchSize:           200,
+			ReplicationStatsMap:        dbReplicatorStats(t),
+			ConflictResolverFuncForHLV: resolverFunc,
+			CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+			Continuous:                 false,
+			SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, ar.Stop()) }()
+
+		// grab last seq allocated for since param
+		rt1Collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+		since, err := rt1Collection.LastSequence(rt1ctx)
+		require.NoError(t, err)
+
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
+
+		// wait for the document originally written to rt1 to arrive at rt2
+		changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+		changesResults.RequireDocIDs(t, []string{docID})
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+		}, time.Second*20, time.Millisecond*100)
+
+		rt1Doc, err := rt1Collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+
+		// local wins:
+		//	- tombstones local active revision
+		//  - winning rev is written as child of remote winning rev
+		// 	- remote rev is behind in terms of rev tree so local wins will inject revs to catch up and then write new winning rev
+		remoteGeneration, _ := db.ParseRevID(ctx1, rt2Version.RevTreeID)
+		localGeneration, _ := db.ParseRevID(ctx1, rt1Version.RevTreeID)
+		requiredAdditionalRevs := localGeneration - remoteGeneration
+		// we will create 10 additional revs to inject into remote  doc's history to catch up with local rev tree
+		previousRevID := rt2Version.RevTreeID
+		generatedRevs := make([]string, 0)
+		for i := 0; i < requiredAdditionalRevs; i++ {
+			remoteGeneration++
+			previousRevID = db.CreateRevIDWithBytes(remoteGeneration, previousRevID, []byte("{}"))
+			generatedRevs = append(generatedRevs, previousRevID)
+		}
+		newRevID := db.CreateRevIDWithBytes(remoteGeneration+1, previousRevID, []byte("{}"))
+		require.NotEmpty(t, newRevID)
+		docHistoryLeaves := rt1Doc.History.GetLeaves()
+		require.Len(t, docHistoryLeaves, 2)
+		for _, revID := range generatedRevs {
+			_, ok := rt1Doc.History[revID]
+			require.True(t, ok, "expected to find generated rev %s in doc history", revID)
+		}
+		for _, revID := range docHistoryLeaves {
+			_, ok := rt1Doc.History[revID]
+			require.True(t, ok, "expected to find leaf rev %s in doc history", revID)
+			assert.True(t, rt1Doc.History[revID].Deleted)
+		}
+
+		rt1Version.RevTreeID = newRevID
+		rest.RequireDocVersionEqual(t, rt1Version, rt1Doc.ExtractDocVersion())
+
+		actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{}`, string(actualBody))
 	})
-	defer rt2.Close()
-	username := "alice"
-	rt2.CreateUser(username, []string{username})
-
-	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "activedb",
-			},
-		},
-	})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
-
-	docID := "doc1_"
-	rt2Version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-	rt2.WaitForPendingChanges()
-
-	// create conflicting update on rt1 and create more revisions than remote
-	rt1Version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
-	rt1.WaitForPendingChanges()
-	for i := 0; i < 10; i++ {
-		rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
-	}
-	// delete local version
-	rt1Version = rt1.DeleteDoc(docID, rt1Version)
-	rt1.WaitForPendingChanges()
-
-	resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverLocalWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
-	require.NoError(t, err)
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:           200,
-		ReplicationStatsMap:        dbReplicatorStats(t),
-		ConflictResolverFuncForHLV: resolverFunc,
-		CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-		Continuous:                 false,
-	})
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, ar.Stop()) }()
-
-	// grab last seq allocated for since param
-	rt1Collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-	since, err := rt1Collection.LastSequence(rt1ctx)
-	require.NoError(t, err)
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-	changesResults.RequireDocIDs(t, []string{docID})
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-	}, time.Second*20, time.Millisecond*100)
-
-	rt1Doc, err := rt1Collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-	require.NoError(t, err)
-
-	// local wins:
-	//	- tombstones local active revision
-	//  - winning rev is written as child of remote winning rev
-	// 	- remote rev is behind in terms of rev tree so local wins will inject revs to catch up and then write new winning rev
-	remoteGeneration, _ := db.ParseRevID(ctx1, rt2Version.RevTreeID)
-	localGeneration, _ := db.ParseRevID(ctx1, rt1Version.RevTreeID)
-	requiredAdditionalRevs := localGeneration - remoteGeneration
-	// we will create 10 additional revs to inject into remote  doc's history to catch up with local rev tree
-	previousRevID := rt2Version.RevTreeID
-	generatedRevs := make([]string, 0)
-	for i := 0; i < requiredAdditionalRevs; i++ {
-		remoteGeneration++
-		previousRevID = db.CreateRevIDWithBytes(remoteGeneration, previousRevID, []byte("{}"))
-		generatedRevs = append(generatedRevs, previousRevID)
-	}
-	newRevID := db.CreateRevIDWithBytes(remoteGeneration+1, previousRevID, []byte("{}"))
-	require.NotEmpty(t, newRevID)
-	docHistoryLeaves := rt1Doc.History.GetLeaves()
-	require.Len(t, docHistoryLeaves, 2)
-	for _, revID := range generatedRevs {
-		_, ok := rt1Doc.History[revID]
-		require.True(t, ok, "expected to find generated rev %s in doc history", revID)
-	}
-	for _, revID := range docHistoryLeaves {
-		_, ok := rt1Doc.History[revID]
-		require.True(t, ok, "expected to find leaf rev %s in doc history", revID)
-		assert.True(t, rt1Doc.History[revID].Deleted)
-	}
-
-	rt1Version.RevTreeID = newRevID
-	rest.RequireDocVersionEqual(t, rt1Version, rt1Doc.ExtractDocVersion())
-
-	actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-	require.NoError(t, err)
-	require.JSONEq(t, `{}`, string(actualBody))
 }
 
 func TestActiveReplicatorHLVConflictWithBothLocalAndRemoteTombstones(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "passivedb",
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		remoteURL, err := url.Parse(remoteURLString)
+		require.NoError(t, err)
+		ctx1 := rt1.Context()
+
+		docRevIDVersions := make(map[string]struct{})
+
+		docID := "doc1_"
+		rt2Version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+		rt2.WaitForPendingChanges()
+		docRevIDVersions[rt2Version.RevTreeID] = struct{}{}
+
+		rt1Version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
+		rt1.WaitForPendingChanges()
+		docRevIDVersions[rt1Version.RevTreeID] = struct{}{}
+
+		// delete both docs
+		rt1Version = rt1.DeleteDoc(docID, rt1Version)
+		rt2Version = rt2.DeleteDoc(docID, rt2Version)
+		rt2.WaitForPendingChanges()
+		rt1.WaitForPendingChanges()
+		docRevIDVersions[rt1Version.RevTreeID] = struct{}{}
+		docRevIDVersions[rt2Version.RevTreeID] = struct{}{}
+
+		resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
+		require.NoError(t, err)
+
+		replicationID := rest.SafeDocumentName(t, t.Name())
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          replicationID,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: remoteURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
 			},
-		},
+			ChangesBatchSize:           200,
+			ReplicationStatsMap:        dbReplicatorStats(t),
+			ConflictResolverFuncForHLV: resolverFunc,
+			CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+			Continuous:                 false,
+			SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, ar.Stop()) }()
+
+		rt1Collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+		since, err := rt1Collection.LastSequence(rt1ctx)
+		require.NoError(t, err)
+
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
+
+		// wait for the document originally written to rt1 to arrive at rt2
+		changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
+		changesResults.RequireDocIDs(t, []string{docID})
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+		}, time.Second*20, time.Millisecond*100)
+
+		// assert on local revision rev tree + CV
+		rt1Doc, err := rt1Collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		rest.RequireDocVersionEqual(t, rt2Version, rt1Doc.ExtractDocVersion())
+		assert.True(t, rt1Doc.IsDeleted())
+
+		// assert that both branches are tombstones
+		docHistoryLeaves := rt1Doc.History.GetLeaves()
+		require.Len(t, docHistoryLeaves, 2)
+		for _, revID := range docHistoryLeaves {
+			assert.True(t, rt1Doc.History[revID].Deleted)
+		}
+		// assert that all 4 revisions created above are in history
+		require.Len(t, rt1Doc.History, 4)
+		for _, revItem := range rt1Doc.History {
+			_, ok := docRevIDVersions[revItem.ID]
+			assert.True(t, ok)
+		}
+
+		actualBody, err := rt1Doc.BodyBytes(rt1ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{}`, string(actualBody))
 	})
-	defer rt2.Close()
-	username := "alice"
-	rt2.CreateUser(username, []string{username})
-
-	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "activedb",
-			},
-		},
-	})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
-
-	docRevIDVersions := make(map[string]struct{})
-
-	docID := "doc1_"
-	rt2Version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-	rt2.WaitForPendingChanges()
-	docRevIDVersions[rt2Version.RevTreeID] = struct{}{}
-
-	rt1Version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
-	rt1.WaitForPendingChanges()
-	docRevIDVersions[rt1Version.RevTreeID] = struct{}{}
-
-	// delete both docs
-	rt1Version = rt1.DeleteDoc(docID, rt1Version)
-	rt2Version = rt2.DeleteDoc(docID, rt2Version)
-	rt2.WaitForPendingChanges()
-	rt1.WaitForPendingChanges()
-	docRevIDVersions[rt1Version.RevTreeID] = struct{}{}
-	docRevIDVersions[rt2Version.RevTreeID] = struct{}{}
-
-	resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
-	require.NoError(t, err)
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:           200,
-		ReplicationStatsMap:        dbReplicatorStats(t),
-		ConflictResolverFuncForHLV: resolverFunc,
-		CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-		Continuous:                 false,
-	})
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, ar.Stop()) }()
-
-	rt1Collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
-	since, err := rt1Collection.LastSequence(rt1ctx)
-	require.NoError(t, err)
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	// wait for the document originally written to rt1 to arrive at rt2
-	changesResults := rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", since), "", true)
-	changesResults.RequireDocIDs(t, []string{docID})
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-	}, time.Second*20, time.Millisecond*100)
-
-	// assert on local revision rev tree + CV
-	rt1Doc, err := rt1Collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-	require.NoError(t, err)
-	rest.RequireDocVersionEqual(t, rt2Version, rt1Doc.ExtractDocVersion())
-	assert.True(t, rt1Doc.IsDeleted())
-
-	// assert that both branches are tombstones
-	docHistoryLeaves := rt1Doc.History.GetLeaves()
-	require.Len(t, docHistoryLeaves, 2)
-	for _, revID := range docHistoryLeaves {
-		assert.True(t, rt1Doc.History[revID].Deleted)
-	}
-	// assert that all 4 revisions created above are in history
-	require.Len(t, rt1Doc.History, 4)
-	for _, revItem := range rt1Doc.History {
-		_, ok := docRevIDVersions[revItem.ID]
-		assert.True(t, ok)
-	}
-
-	actualBody, err := rt1Doc.BodyBytes(rt1ctx)
-	require.NoError(t, err)
-	require.JSONEq(t, `{}`, string(actualBody))
 }
 
 func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "passivedb",
+	sgrRunner := rest.NewSGRTestRunner(t)
+	// v4 protocol only test
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		remoteURL, err := url.Parse(remoteURLString)
+		require.NoError(t, err)
+		ctx1 := rt1.Context()
+
+		docID := rest.SafeDocumentName(t, t.Name())
+		rt2Version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+		rt2.WaitForPendingChanges()
+		rt1Version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
+		rt1.WaitForPendingChanges()
+
+		resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverLocalWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
+		require.NoError(t, err)
+
+		// add active rt to simulate two nodes on active cluster
+		active := addActiveRT(t, rt1.GetDatabase().Name, rt1.TestBucket)
+		defer active.Close()
+
+		replicationID := rest.SafeDocumentName(t, t.Name())
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          replicationID,
+			Direction:   db.ActiveReplicatorTypePushAndPull,
+			RemoteDBURL: remoteURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
 			},
-		},
+			ChangesBatchSize:           200,
+			ReplicationStatsMap:        dbReplicatorStats(t),
+			ConflictResolverFuncForHLV: resolverFunc,
+			CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+			Continuous:                 true,
+			SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, ar.Stop()) }()
+
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
+
+		// wait for conflict res and for it to push to passive
+		docBodyBytes := []byte(`{"channels":["alice"],"source":"rt1"}`)
+		newRev := db.CreateRevIDWithBytes(2, rt2Version.RevTreeID, docBodyBytes) // generate what the new revID will be after conflict resolution
+		conflictResVersion := rt1Version
+		conflictResVersion.RevTreeID = newRev
+		rt2.WaitForVersion(docID, conflictResVersion)
+
+		// assert we cannot keep old cache entry for original wrote (before conflict resolution) on active cluster rest testers
+		collectionActive1, ctxActive1 := active.GetSingleTestDatabaseCollectionWithUser()
+		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, rt1Version.RevTreeID)
+		require.False(t, ok)
+		// no peek for cv so fetch by cv, which in turn loads from bucket so assert item ahs correct history on it
+		docRev, err := collectionActive1.GetRevisionCacheForTest().GetWithCV(ctxActive1, docID, &rt1Version.CV, false)
+		require.NoError(t, err)
+		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
+
+		// same for other active rest tester
+		collectionRT1, ctxRT1 := rt1.GetSingleTestDatabaseCollectionWithUser()
+		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, rt1Version.RevTreeID)
+		require.False(t, ok)
+		docRev, err = collectionRT1.GetRevisionCacheForTest().GetWithCV(ctxRT1, docID, &rt1Version.CV, false)
+		require.NoError(t, err)
+		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 	})
-	defer rt2.Close()
-	username := "alice"
-	rt2.CreateUser(username, []string{username})
-
-	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "activedb",
-			},
-		},
-	})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
-
-	docID := rest.SafeDocumentName(t, t.Name())
-	rt2Version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-	rt2.WaitForPendingChanges()
-	rt1Version := rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
-	rt1.WaitForPendingChanges()
-
-	resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverLocalWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
-	require.NoError(t, err)
-
-	// add active rt to simulate two nodes on active cluster
-	active := addActiveRT(t, rt1.GetDatabase().Name, rt1.TestBucket)
-	defer active.Close()
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePushAndPull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:           200,
-		ReplicationStatsMap:        dbReplicatorStats(t),
-		ConflictResolverFuncForHLV: resolverFunc,
-		CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-		Continuous:                 true,
-	})
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, ar.Stop()) }()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	// wait for conflict res and for it to push to passive
-	docBodyBytes := []byte(`{"channels":["alice"],"source":"rt1"}`)
-	newRev := db.CreateRevIDWithBytes(2, rt2Version.RevTreeID, docBodyBytes) // generate what the new revID will be after conflict resolution
-	conflictResVersion := rt1Version
-	conflictResVersion.RevTreeID = newRev
-	rt2.WaitForVersion(docID, conflictResVersion)
-
-	// assert we cannot keep old cache entry for original wrote (before conflict resolution) on active cluster rest testers
-	collectionActive1, ctxActive1 := active.GetSingleTestDatabaseCollectionWithUser()
-	_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, rt1Version.RevTreeID)
-	require.False(t, ok)
-	// no peek for cv so fetch by cv, which in turn loads from bucket so assert item ahs correct history on it
-	docRev, err := collectionActive1.GetRevisionCacheForTest().GetWithCV(ctxActive1, docID, &rt1Version.CV, false)
-	require.NoError(t, err)
-	assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
-
-	// same for other active rest tester
-	collectionRT1, ctxRT1 := rt1.GetSingleTestDatabaseCollectionWithUser()
-	_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, rt1Version.RevTreeID)
-	require.False(t, ok)
-	docRev, err = collectionRT1.GetRevisionCacheForTest().GetWithCV(ctxRT1, docID, &rt1Version.CV, false)
-	require.NoError(t, err)
-	assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 }
 
 func TestActiveReplicatorV4DefaultResolverWithTombstoneLocal(t *testing.T) {

--- a/rest/replicatortest/replicator_revtree_test.go
+++ b/rest/replicatortest/replicator_revtree_test.go
@@ -11,12 +11,12 @@ package replicatortest
 import (
 	"fmt"
 	"maps"
+	"net/url"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/assert"
@@ -38,248 +38,226 @@ func TestActiveReplicatorRevTreeReconciliation(t *testing.T) {
 			replicationType: db.ActiveReplicatorTypePush,
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
-
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-
-			docHistoryList := make([]string, 0, 11)
-			docID := "doc1_" + tc.name
-			var version rest.DocVersion
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				version = rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-				docHistoryList = append(docHistoryList, version.RevTreeID)
-				rt2.WaitForPendingChanges()
-			} else {
-				version = rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
-				docHistoryList = append(docHistoryList, version.RevTreeID)
-				rt1.WaitForPendingChanges()
-			}
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   tc.replicationType,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:    200,
-				ReplicationStatsMap: dbReplicatorStats(t),
-				CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:          false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			var changesResults rest.ChangesResults
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-				changesResults.RequireDocIDs(t, []string{docID})
-
-				rt1Version, _ := rt1.GetDoc(docID)
-				rest.RequireDocVersionEqual(t, version, rt1Version)
-			} else {
-				changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-				changesResults.RequireDocIDs(t, []string{docID})
-
-				rt2Version, _ := rt2.GetDoc(docID)
-				rest.RequireDocVersionEqual(t, version, rt2Version)
-			}
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				for i := 0; i < 10; i++ {
-					version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
-					docHistoryList = append(docHistoryList, version.RevTreeID)
-				}
-				rt2.WaitForPendingChanges()
-			} else {
-				for i := 0; i < 10; i++ {
-					version = rt1.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
-					docHistoryList = append(docHistoryList, version.RevTreeID)
-				}
-				rt1.WaitForPendingChanges()
-			}
-
-			// start again for new revisions
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document originally written to rt1 to arrive at rt2
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
-				changesResults.RequireDocIDs(t, []string{docID})
-
-				rt1Version, _ := rt1.GetDoc(docID)
-				rest.RequireDocVersionEqual(t, version, rt1Version)
-			} else {
-				changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
-				changesResults.RequireDocIDs(t, []string{docID})
-
-				rt2Version, _ := rt2.GetDoc(docID)
-				rest.RequireDocVersionEqual(t, version, rt2Version)
-			}
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
-				rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
 				require.NoError(t, err)
-				assert.Equal(t, version.RevTreeID, rt1Doc.GetRevTreeID())
-				assert.Len(t, rt1Doc.History.GetLeaves(), 1)
-				assert.Len(t, rt1Doc.History, 11) // 1 base + 10 updates
-				rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
-				base.RequireKeysEqual(t, docHistoryList, rt1Doc.History)
-			} else {
-				rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
-				rt2Doc, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+				ctx1 := rt1.Context()
+
+				docHistoryList := make([]string, 0, 11)
+				docID := "doc1_" + tc.name
+				var version rest.DocVersion
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					version = rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+					docHistoryList = append(docHistoryList, version.RevTreeID)
+					rt2.WaitForPendingChanges()
+				} else {
+					version = rt1.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
+					docHistoryList = append(docHistoryList, version.RevTreeID)
+					rt1.WaitForPendingChanges()
+				}
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   tc.replicationType,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:    200,
+					ReplicationStatsMap: dbReplicatorStats(t),
+					CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:          false,
+				})
 				require.NoError(t, err)
-				assert.Equal(t, version.RevTreeID, rt2Doc.GetRevTreeID())
-				assert.Len(t, rt2Doc.History.GetLeaves(), 1)
-				assert.Len(t, rt2Doc.History, 11) // 1 base + 10 updates
-				rest.RequireDocVersionEqual(t, version, rt2Doc.ExtractDocVersion())
-				base.RequireKeysEqual(t, docHistoryList, rt2Doc.History)
-			}
-		})
-	}
+				defer func() { assert.NoError(t, ar.Stop()) }()
+
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				var changesResults rest.ChangesResults
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+					changesResults.RequireDocIDs(t, []string{docID})
+
+					rt1Version, _ := rt1.GetDoc(docID)
+					rest.RequireDocVersionEqual(t, version, rt1Version)
+				} else {
+					changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+					changesResults.RequireDocIDs(t, []string{docID})
+
+					rt2Version, _ := rt2.GetDoc(docID)
+					rest.RequireDocVersionEqual(t, version, rt2Version)
+				}
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					for i := 0; i < 10; i++ {
+						version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
+						docHistoryList = append(docHistoryList, version.RevTreeID)
+					}
+					rt2.WaitForPendingChanges()
+				} else {
+					for i := 0; i < 10; i++ {
+						version = rt1.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
+						docHistoryList = append(docHistoryList, version.RevTreeID)
+					}
+					rt1.WaitForPendingChanges()
+				}
+
+				// start again for new revisions
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document originally written to rt1 to arrive at rt2
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+					changesResults.RequireDocIDs(t, []string{docID})
+
+					rt1Version, _ := rt1.GetDoc(docID)
+					rest.RequireDocVersionEqual(t, version, rt1Version)
+				} else {
+					changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+					changesResults.RequireDocIDs(t, []string{docID})
+
+					rt2Version, _ := rt2.GetDoc(docID)
+					rest.RequireDocVersionEqual(t, version, rt2Version)
+				}
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
+					rt1Doc, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+					require.NoError(t, err)
+					assert.Equal(t, version.RevTreeID, rt1Doc.GetRevTreeID())
+					assert.Len(t, rt1Doc.History.GetLeaves(), 1)
+					assert.Len(t, rt1Doc.History, 11) // 1 base + 10 updates
+					rest.RequireDocVersionEqual(t, version, rt1Doc.ExtractDocVersion())
+					base.RequireKeysEqual(t, docHistoryList, rt1Doc.History)
+				} else {
+					rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
+					rt2Doc, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+					require.NoError(t, err)
+					assert.Equal(t, version.RevTreeID, rt2Doc.GetRevTreeID())
+					assert.Len(t, rt2Doc.History.GetLeaves(), 1)
+					assert.Len(t, rt2Doc.History, 11) // 1 base + 10 updates
+					rest.RequireDocVersionEqual(t, version, rt2Doc.ExtractDocVersion())
+					base.RequireKeysEqual(t, docHistoryList, rt2Doc.History)
+				}
+			})
+		}
+	})
 }
 
 func TestActiveReplicatorNoHLVConflictConflictInRevTree(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	// Passive
-	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "passivedb",
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+		remoteURL, err := url.Parse(remoteURLString)
+		require.NoError(t, err)
+		ctx1 := rt1.Context()
+		docID := rest.SafeDocumentName(t, t.Name())
+
+		rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+
+		rt2Version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+		rt2.WaitForPendingChanges()
+
+		resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverRemoteWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
+		require.NoError(t, err)
+
+		replicationID := rest.SafeDocumentName(t, t.Name())
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          replicationID,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: remoteURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
 			},
-		},
-		SyncFn: channels.DocChannelsSyncFunction,
-	})
-	defer rt2.Close()
-	username := "alice"
-	rt2.CreateUser(username, []string{username})
+			ChangesBatchSize:           200,
+			ConflictResolverFuncForHLV: resolverFunc,
+			ReplicationStatsMap:        dbReplicatorStats(t),
+			CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+			Continuous:                 false,
+		})
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, ar.Stop()) }()
 
-	// Active
-	rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
-		DatabaseConfig: &rest.DatabaseConfig{
-			DbConfig: rest.DbConfig{
-				Name: "active",
-			},
-		},
-	})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
-	docID := t.Name()
+		require.NoError(t, ar.Start(ctx1))
 
-	rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollectionWithUser()
+		changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+		changesResults.RequireDocIDs(t, []string{docID})
 
-	rt2Version := rt2.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-	rt2.WaitForPendingChanges()
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+		}, time.Second*20, time.Millisecond*100)
 
-	resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverRemoteWins, "", rt1.GetDatabase().Options.JavascriptTimeout)
-	require.NoError(t, err)
+		// verify doc arrives as expected
+		rt1InitDocVersion, _ := rt1.GetDoc(docID)
+		rest.RequireDocVersionEqual(t, rt2Version, rt1InitDocVersion)
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:           200,
-		ConflictResolverFuncForHLV: resolverFunc,
-		ReplicationStatsMap:        dbReplicatorStats(t),
-		CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-		Continuous:                 false,
-	})
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, ar.Stop()) }()
-
-	require.NoError(t, ar.Start(ctx1))
-
-	changesResults := rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-	changesResults.RequireDocIDs(t, []string{docID})
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-	}, time.Second*20, time.Millisecond*100)
-
-	// verify doc arrives as expected
-	rt1InitDocVersion, _ := rt1.GetDoc(docID)
-	rest.RequireDocVersionEqual(t, rt2Version, rt1InitDocVersion)
-
-	// update doc on rt2 + rt1 to create diff in rev tree history
-	for i := 0; i < 2; i++ {
-		rt2Version = rt2.UpdateDoc(docID, rt2Version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
-	}
-	rt2.WaitForPendingChanges()
-	rt1Version := rt1InitDocVersion
-	lastUpdateNum := 0
-	for i := 0; i < 2; i++ {
-		rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
-		lastUpdateNum = i
-	}
-	alterBody := rest.JsonToMap(t, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, lastUpdateNum))
-	// alter HLV on local to not conflict with remote
-	db.AlterHLVForTest(t, rt1ctx, rt1.GetSingleDataStore(), docID, &db.HybridLogicalVector{SourceID: rt1InitDocVersion.CV.SourceID, Version: rt1InitDocVersion.CV.Value}, alterBody)
-	preRevTreeAlignmentCurrRev, _ := rt1.GetDoc(docID) // ensure imported
-	rt1.WaitForPendingChanges()
-
-	lastSequence, err := rt1collection.LastSequence(rt1ctx)
-	require.NoError(t, err)
-
-	// start pull again
-	require.NoError(t, ar.Start(ctx1))
-
-	changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", lastSequence), "", true)
-	changesResults.RequireDocIDs(t, []string{docID})
-
-	docRT1, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-	require.NoError(t, err)
-
-	rest.RequireDocVersionEqual(t, rt2Version, docRT1.ExtractDocVersion())
-	// assert that local doc has tombstones branch
-	docHistoryLeaves := docRT1.History.GetLeaves()
-	require.Len(t, docHistoryLeaves, 2)
-
-	for _, v := range docHistoryLeaves {
-		if revItem := docRT1.History[v]; revItem.Deleted {
-			assert.Equal(t, preRevTreeAlignmentCurrRev.RevTreeID, revItem.Parent)
-		} else {
-			assert.Equal(t, rt2Version.RevTreeID, v)
+		// update doc on rt2 + rt1 to create diff in rev tree history
+		for i := 0; i < 2; i++ {
+			rt2Version = rt2.UpdateDoc(docID, rt2Version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
 		}
-	}
+		rt2.WaitForPendingChanges()
+		rt1Version := rt1InitDocVersion
+		lastUpdateNum := 0
+		for i := 0; i < 2; i++ {
+			rt1Version = rt1.UpdateDoc(docID, rt1Version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
+			lastUpdateNum = i
+		}
+		alterBody := rest.JsonToMap(t, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, lastUpdateNum))
+		// alter HLV on local to not conflict with remote
+		db.AlterHLVForTest(t, rt1ctx, rt1.GetSingleDataStore(), docID, &db.HybridLogicalVector{SourceID: rt1InitDocVersion.CV.SourceID, Version: rt1InitDocVersion.CV.Value}, alterBody)
+		preRevTreeAlignmentCurrRev, _ := rt1.GetDoc(docID) // ensure imported
+		rt1.WaitForPendingChanges()
 
-	// add new rev and assert rev tree is updated correctly, i.e. non tombstoned branch is written to
-	rt1Version = rt1.UpdateDoc(docID, rt2Version, `{"source":"rt1","channels":["alice"], "version": "last"}`)
-	rt1.WaitForPendingChanges()
-	docRT1, err = rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-	require.NoError(t, err)
-	docHistoryLeaves = docRT1.History.GetLeaves()
-	require.Len(t, docHistoryLeaves, 2)
-	rest.AssertRevTreeAfterHLVConflictResolution(t, docRT1, rt1Version.RevTreeID, preRevTreeAlignmentCurrRev.RevTreeID)
+		lastSequence, err := rt1collection.LastSequence(rt1ctx)
+		require.NoError(t, err)
+
+		// start pull again
+		require.NoError(t, ar.Start(ctx1))
+
+		changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%d", lastSequence), "", true)
+		changesResults.RequireDocIDs(t, []string{docID})
+
+		docRT1, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+
+		rest.RequireDocVersionEqual(t, rt2Version, docRT1.ExtractDocVersion())
+		// assert that local doc has tombstones branch
+		docHistoryLeaves := docRT1.History.GetLeaves()
+		require.Len(t, docHistoryLeaves, 2)
+
+		for _, v := range docHistoryLeaves {
+			if revItem := docRT1.History[v]; revItem.Deleted {
+				assert.Equal(t, preRevTreeAlignmentCurrRev.RevTreeID, revItem.Parent)
+			} else {
+				assert.Equal(t, rt2Version.RevTreeID, v)
+			}
+		}
+
+		// add new rev and assert rev tree is updated correctly, i.e. non tombstoned branch is written to
+		rt1Version = rt1.UpdateDoc(docID, rt2Version, `{"source":"rt1","channels":["alice"], "version": "last"}`)
+		rt1.WaitForPendingChanges()
+		docRT1, err = rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+		require.NoError(t, err)
+		docHistoryLeaves = docRT1.History.GetLeaves()
+		require.Len(t, docHistoryLeaves, 2)
+		rest.AssertRevTreeAfterHLVConflictResolution(t, docRT1, rt1Version.RevTreeID, preRevTreeAlignmentCurrRev.RevTreeID)
+	})
 }
 
 func TestActiveReplicatorRevtreeLargeDiffInSize(t *testing.T) {
@@ -298,113 +276,107 @@ func TestActiveReplicatorRevtreeLargeDiffInSize(t *testing.T) {
 			replicationType: db.ActiveReplicatorTypePush,
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Passive
-			rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-			})
-			defer rt2.Close()
-			username := "alice"
-			rt2.CreateUser(username, []string{username})
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				rt1, rt2, remoteURLString := sgrRunner.SetupSGRPeers(t)
+				remoteURL, err := url.Parse(remoteURLString)
+				require.NoError(t, err)
+				ctx1 := rt1.Context()
 
-			// Active
-			rt1 := rest.NewRestTester(t, &rest.RestTesterConfig{
-				SyncFn: channels.DocChannelsSyncFunction,
-			})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
-
-			docID := "doc1"
-			var version rest.DocVersion
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				version = rt2.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
-				rt2.WaitForPendingChanges()
-			} else {
-				version = rt1.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
-				rt1.WaitForPendingChanges()
-			}
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   tc.replicationType,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:    200,
-				ReplicationStatsMap: dbReplicatorStats(t),
-				CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
-				Continuous:          false,
-			})
-			require.NoError(t, err)
-			defer func() { assert.NoError(t, ar.Stop()) }()
-
-			require.NoError(t, ar.Start(ctx1))
-
-			// wait for the document to arrive
-			var changesResults rest.ChangesResults
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-				changesResults.RequireDocIDs(t, []string{docID})
-
-				rt1Doc, _ := rt1.GetDoc(docID)
-				rest.RequireDocVersionEqual(t, version, rt1Doc)
-			} else {
-				changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-				changesResults.RequireDocIDs(t, []string{docID})
-
-				docRt2, _ := rt2.GetDoc(docID)
-				rest.RequireDocVersionEqual(t, version, docRt2)
-			}
-
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
-
-			rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
-			rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
-
-			// update doc hundreds of times to create a large diff in rev tree versions
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				for i := 0; i < 200; i++ {
-					version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
+				docID := "doc1"
+				var version rest.DocVersion
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					version = rt2.PutDoc(docID, `{"source":"rt1","channels":["alice"]}`)
+					rt2.WaitForPendingChanges()
+				} else {
+					version = rt1.PutDoc(docID, `{"source":"rt2","channels":["alice"]}`)
+					rt1.WaitForPendingChanges()
 				}
-				rt2.WaitForPendingChanges()
-			} else {
-				for i := 0; i < 200; i++ {
-					version = rt1.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
+
+				replicationID := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          replicationID,
+					Direction:   tc.replicationType,
+					RemoteDBURL: remoteURL,
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:    200,
+					ReplicationStatsMap: dbReplicatorStats(t),
+					CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+					Continuous:          false,
+				})
+				require.NoError(t, err)
+				defer func() { assert.NoError(t, ar.Stop()) }()
+
+				require.NoError(t, ar.Start(ctx1))
+
+				// wait for the document to arrive
+				var changesResults rest.ChangesResults
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+					changesResults.RequireDocIDs(t, []string{docID})
+
+					rt1Doc, _ := rt1.GetDoc(docID)
+					rest.RequireDocVersionEqual(t, version, rt1Doc)
+				} else {
+					changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+					changesResults.RequireDocIDs(t, []string{docID})
+
+					docRt2, _ := rt2.GetDoc(docID)
+					rest.RequireDocVersionEqual(t, version, docRt2)
 				}
-				rt1.WaitForPendingChanges()
-			}
 
-			// start replicator again for new revisions
-			require.NoError(t, ar.Start(ctx1))
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
 
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
-				changesResults.RequireDocIDs(t, []string{docID})
-			} else {
-				changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
-				changesResults.RequireDocIDs(t, []string{docID})
-			}
+				rt1collection, rt1ctx := rt1.GetSingleTestDatabaseCollection()
+				rt2collection, rt2ctx := rt2.GetSingleTestDatabaseCollection()
 
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
-			}, time.Second*20, time.Millisecond*100)
+				// update doc hundreds of times to create a large diff in rev tree versions
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					for i := 0; i < 200; i++ {
+						version = rt2.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt2","channels":["alice"], "version": "%d"}`, i))
+					}
+					rt2.WaitForPendingChanges()
+				} else {
+					for i := 0; i < 200; i++ {
+						version = rt1.UpdateDoc(docID, version, fmt.Sprintf(`{"source":"rt1","channels":["alice"], "version": "%d"}`, i))
+					}
+					rt1.WaitForPendingChanges()
+				}
 
-			docRT1, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-			docRT2, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
-			require.NoError(t, err)
-			if tc.replicationType == db.ActiveReplicatorTypePull {
-				rest.RequireDocVersionEqual(t, version, docRT1.ExtractDocVersion())
-			} else {
-				rest.RequireDocVersionEqual(t, version, docRT2.ExtractDocVersion())
-			}
-			assert.Equal(t, len(docRT1.History), len(docRT2.History))
-			assert.Equal(t, docRT1.HLV.GetCurrentVersionString(), docRT2.HLV.GetCurrentVersionString())
-			assert.ElementsMatch(t, slices.Collect(maps.Keys(docRT1.History)), slices.Collect(maps.Keys(docRT2.History)))
-		})
-	}
+				// start replicator again for new revisions
+				require.NoError(t, ar.Start(ctx1))
+
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					changesResults = rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+					changesResults.RequireDocIDs(t, []string{docID})
+				} else {
+					changesResults = rt2.WaitForChanges(1, "/{{.keyspace}}/_changes?since="+changesResults.Last_Seq.String(), "", true)
+					changesResults.RequireDocIDs(t, []string{docID})
+				}
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Equal(c, db.ReplicationStateStopped, ar.GetStatus(ctx1).Status)
+				}, time.Second*20, time.Millisecond*100)
+
+				docRT1, err := rt1collection.GetDocument(rt1ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+				docRT2, err := rt2collection.GetDocument(rt2ctx, docID, db.DocUnmarshalAll)
+				require.NoError(t, err)
+				if tc.replicationType == db.ActiveReplicatorTypePull {
+					rest.RequireDocVersionEqual(t, version, docRT1.ExtractDocVersion())
+				} else {
+					rest.RequireDocVersionEqual(t, version, docRT2.ExtractDocVersion())
+				}
+				assert.Equal(t, len(docRT1.History), len(docRT2.History))
+				assert.Equal(t, docRT1.HLV.GetCurrentVersionString(), docRT2.HLV.GetCurrentVersionString())
+				assert.ElementsMatch(t, slices.Collect(maps.Keys(docRT1.History)), slices.Collect(maps.Keys(docRT2.History)))
+			})
+		}
+	})
 }

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -26,59 +26,46 @@ func TestActiveReplicatorPushPullLegacyRev(t *testing.T) {
 
 	const username = "alice"
 
-	// Passive
-	rt2 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "passivedb",
-			}},
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UserChannelAccess: []string{username},
 		})
-	defer rt2.Close()
 
-	rt2.CreateUser(username, []string{username})
+		docIDRT2 := rest.SafeDocumentName(t, t.Name()+"rt2doc1")
+		rt2InitDoc := rt2.CreateDocNoHLV(docIDRT2, db.Body{"source": "rt2", "channels": []string{username}})
+		legacyRevRt2 := rt2InitDoc.GetRevTreeID()
+		ctx1 := rt1.Context()
 
-	docIDRT2 := t.Name() + "rt2doc1"
-	rt2InitDoc := rt2.CreateDocNoHLV(docIDRT2, db.Body{"source": "rt2", "channels": []string{username}})
-	legacyRevRt2 := rt2InitDoc.GetRevTreeID()
+		id := rest.SafeDocumentName(t, t.Name())
+		docIDRT1 := id + "rt1doc1"
+		rt1InitDoc := rt1.CreateDocNoHLV(docIDRT1, db.Body{"source": "rt1", "channels": []string{username}})
+		legacyRevRt1 := rt1InitDoc.GetRevTreeID()
 
-	// Active
-	rt1 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "activedb",
-			}},
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePushAndPull,
+			RemoteDBURL: userDBURL(rt2, username),
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    dbReplicatorStats(t),
+			CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, ar.Stop())
+		}()
 
-	docIDRT1 := t.Name() + "rt1doc1"
-	rt1InitDoc := rt1.CreateDocNoHLV(docIDRT1, db.Body{"source": "rt1", "channels": []string{username}})
-	legacyRevRt1 := rt1InitDoc.GetRevTreeID()
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePushAndPull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:    200,
-		Continuous:          true,
-		ReplicationStatsMap: dbReplicatorStats(t),
-		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+		rt1.WaitForLegacyRev(docIDRT2, legacyRevRt2, []byte(`{"source":"rt2","channels":["alice"]}`))
+		rt2.WaitForLegacyRev(docIDRT1, legacyRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
 	})
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, ar.Stop())
-	}()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	rt1.WaitForLegacyRev(docIDRT2, legacyRevRt2, []byte(`{"source":"rt2","channels":["alice"]}`))
-	rt2.WaitForLegacyRev(docIDRT1, legacyRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
 }
 
 func TestActiveReplicatorBiDirectionalPreUpgradedDocOnPeer(t *testing.T) {
@@ -116,117 +103,106 @@ func TestActiveReplicatorBiDirectionalPreUpgradedDocOnPeer(t *testing.T) {
 			newRevOnActivePeer: false,
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Passive (SGW2 in diagram above)
-			rt2 := rest.NewRestTester(t,
-				&rest.RestTesterConfig{
-					SyncFn: channels.DocChannelsSyncFunction,
-					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					}},
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Active is SGW1 in diagram above
+				// Passive is SGW2 in diagram above
+				rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+					UserChannelAccess: []string{username},
 				})
-			defer rt2.Close()
+				ctx1 := rt1.Context()
 
-			rt2.CreateUser(username, []string{username})
+				docID := rest.SafeDocumentName(t, t.Name())
 
-			// Active (SGW1 in diagram above)
-			rt1 := rest.NewRestTester(t,
-				&rest.RestTesterConfig{
-					SyncFn: channels.DocChannelsSyncFunction,
-					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-						Name: "activedb",
-					}},
+				var legacyRevRT1, legacyRevRT2, initLegacyRevRT1, initLegacyRevRT2 string
+
+				if tc.newRevOnActivePeer {
+					// create doc on rt1 with two revisions
+					bodyRT1 := db.Body{"channels": []string{username}}
+					rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+					initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "source": "rt1", "channels": []string{username}}
+					rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
+					legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+
+					// create doc on rt2 with same body to keep revID generation the same as rev1 of the document above
+					bodyRT2 := db.Body{"channels": []string{username}}
+					rt2DocInit := rt2.CreateDocNoHLV(docID, bodyRT2)
+					legacyRevRT2 = rt2DocInit.GetRevTreeID()
+				} else {
+					// create doc on rt1 with one revision
+					bodyRT1 := db.Body{"channels": []string{username}}
+					rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+					legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+
+					// create docs on rt2 with same body for rev 1 to keep revID generation the same as rev1 of the document above
+					bodyRT2 := db.Body{"channels": []string{username}}
+					rt2DocInit := rt2.CreateDocNoHLV(docID, bodyRT2)
+					initLegacyRevRT2 = rt2DocInit.GetRevTreeID()
+					bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "source": "rt2", "channels": []string{username}}
+					rt2DocInit = rt2.CreateDocNoHLV(docID, bodyRT2)
+					legacyRevRT2 = rt2DocInit.GetRevTreeID()
+				}
+
+				id := rest.SafeDocumentName(t, t.Name())
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          id,
+					Direction:   db.ActiveReplicatorTypePushAndPull,
+					RemoteDBURL: userDBURL(rt2, username),
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:       200,
+					Continuous:             true,
+					ReplicationStatsMap:    dbReplicatorStats(t),
+					CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+					SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 				})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
+				require.NoError(t, err)
+				defer func() {
+					require.NoError(t, ar.Stop())
+				}()
 
-			docID := rest.SafeDocumentName(t, t.Name())
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
 
-			var legacyRevRT1, legacyRevRT2, initLegacyRevRT1, initLegacyRevRT2 string
+				if tc.newRevOnActivePeer {
+					rt2.WaitForLegacyRev(docID, legacyRevRT1, []byte(`{"source":"rt1","channels":["alice"]}`))
+					rt2Doc := rt2.GetDocument(docID)
+					rest.RequireHistoryContains(t, rt2Doc.History, []string{legacyRevRT1, initLegacyRevRT1})
 
-			if tc.newRevOnActivePeer {
-				// create doc on rt1 with two revisions
-				bodyRT1 := db.Body{"channels": []string{username}}
-				rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-				initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
-				bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "source": "rt1", "channels": []string{username}}
-				rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
-				legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					// add new doc for some replication activity on pull side to allow us to assert that legacy rev 2-abc added
+					// isn't pulled back to rt1 now it has a legacy revID encoded CV
+					newDocVersion := rt2.PutDoc("newdoc", `{"channels": ["alice"]}`)
+					rt1.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt2
 
-				// create doc on rt2 with same body to keep revID generation the same as rev1 of the document above
-				bodyRT2 := db.Body{"channels": []string{username}}
-				rt2DocInit := rt2.CreateDocNoHLV(docID, bodyRT2)
-				legacyRevRT2 = rt2DocInit.GetRevTreeID()
-			} else {
-				// create doc on rt1 with one revision
-				bodyRT1 := db.Body{"channels": []string{username}}
-				rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-				legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					// assert that the document isn't replicated back to rt1 after legacy rev CV is written on rt2
+					rt1Doc := rt1.GetDocument(docID)
+					assert.Equal(t, legacyRevRT1, rt1Doc.GetRevTreeID())
+					assert.Nil(t, rt1Doc.HLV)
+					rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1})
+				} else {
+					rt1.WaitForLegacyRev(docID, legacyRevRT2, []byte(`{"source":"rt2","channels":["alice"]}`))
+					rt1Doc := rt1.GetDocument(docID)
+					rest.RequireHistoryContains(t, rt1Doc.History, []string{initLegacyRevRT2, legacyRevRT2})
 
-				// create docs on rt2 with same body for rev 1 to keep revID generation the same as rev1 of the document above
-				bodyRT2 := db.Body{"channels": []string{username}}
-				rt2DocInit := rt2.CreateDocNoHLV(docID, bodyRT2)
-				initLegacyRevRT2 = rt2DocInit.GetRevTreeID()
-				bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "source": "rt2", "channels": []string{username}}
-				rt2DocInit = rt2.CreateDocNoHLV(docID, bodyRT2)
-				legacyRevRT2 = rt2DocInit.GetRevTreeID()
-			}
+					// add new doc for some replication activity on push side to allow us to assert that legacy rev 2-abc added
+					// isn't pushed back to rt2 now it has a legacy revID encoded CV
+					newDocVersion := rt1.PutDoc("newdoc", `{"channels": ["alice"]}`)
+					rt2.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt2
 
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePushAndPull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:    200,
-				Continuous:          true,
-				ReplicationStatsMap: dbReplicatorStats(t),
-				CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+					// assert that the document isn't replicated back to rt2 after legacy rev CV is written on rt1
+					rt2Doc := rt2.GetDocument(docID)
+					assert.Equal(t, legacyRevRT2, rt2Doc.GetRevTreeID())
+					assert.Nil(t, rt2Doc.HLV)
+					rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2})
+				}
+
 			})
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, ar.Stop())
-			}()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			if tc.newRevOnActivePeer {
-				rt2.WaitForLegacyRev(docID, legacyRevRT1, []byte(`{"source":"rt1","channels":["alice"]}`))
-				rt2Doc := rt2.GetDocument(docID)
-				rest.RequireHistoryContains(t, rt2Doc.History, []string{legacyRevRT1, initLegacyRevRT1})
-
-				// add new doc for some replication activity on pull side to allow us to assert that legacy rev 2-abc added
-				// isn't pulled back to rt1 now it has a legacy revID encoded CV
-				newDocVersion := rt2.PutDoc("newdoc", `{"channels": ["alice"]}`)
-				rt1.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt2
-
-				// assert that the document isn't replicated back to rt1 after legacy rev CV is written on rt2
-				rt1Doc := rt1.GetDocument(docID)
-				assert.Equal(t, legacyRevRT1, rt1Doc.GetRevTreeID())
-				assert.Nil(t, rt1Doc.HLV)
-				rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1})
-			} else {
-				rt1.WaitForLegacyRev(docID, legacyRevRT2, []byte(`{"source":"rt2","channels":["alice"]}`))
-				rt1Doc := rt1.GetDocument(docID)
-				rest.RequireHistoryContains(t, rt1Doc.History, []string{initLegacyRevRT2, legacyRevRT2})
-
-				// add new doc for some replication activity on push side to allow us to assert that legacy rev 2-abc added
-				// isn't pushed back to rt2 now it has a legacy revID encoded CV
-				newDocVersion := rt1.PutDoc("newdoc", `{"channels": ["alice"]}`)
-				rt2.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt2
-
-				// assert that the document isn't replicated back to rt2 after legacy rev CV is written on rt1
-				rt2Doc := rt2.GetDocument(docID)
-				assert.Equal(t, legacyRevRT2, rt2Doc.GetRevTreeID())
-				assert.Nil(t, rt2Doc.HLV)
-				rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2})
-			}
-
-		})
-	}
+		}
+	})
 }
 
 // +-----------------+-------------+------+-------------+------+--+--+--+--+--+
@@ -242,93 +218,80 @@ func TestActiveReplicatorBiDirectionalPreUpgradedDocOnBothSidesAlreadyKnownRev(t
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
-
-	// Passive (SGW2 in diagram above)
-	rt2 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "passivedb",
-			}},
+	// Passive is SGW2 in diagram above
+	// Active is SGW1 in diagram above
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UserChannelAccess: []string{username},
 		})
-	defer rt2.Close()
+		ctx1 := rt1.Context()
 
-	rt2.CreateUser(username, []string{username})
+		docID := rest.SafeDocumentName(t, t.Name())
 
-	// Active (SGW1 in diagram above)
-	rt1 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "activedb",
-			}},
+		// create doc on rt2 with two revisions
+		bodyRT2 := db.Body{"channels": []string{username}}
+		rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
+		initLegacyRevRT2 := rt2InitDoc.GetRevTreeID()
+		bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}}
+		rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
+		legacyRevRT2 := rt2InitDoc.GetRevTreeID()
+
+		// create doc on rt1 with same body to keep revID generation the same as rev1 of the document above
+		bodyRT1 := db.Body{"channels": []string{username}}
+		rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+		initLegacyRevRT1 := rt1InitDoc.GetRevTreeID()
+		bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}}
+		rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
+		legacyRevRT1 := rt1InitDoc.GetRevTreeID()
+
+		// need revIDs to match so the peers know the revs are known to each other
+		require.Equal(t, legacyRevRT1, legacyRevRT2)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          t.Name(),
+			Direction:   db.ActiveReplicatorTypePushAndPull,
+			RemoteDBURL: userDBURL(rt2, username),
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    dbReplicatorStats(t),
+			CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, ar.Stop())
+		}()
 
-	docID := rest.SafeDocumentName(t, t.Name())
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
 
-	// create doc on rt2 with two revisions
-	bodyRT2 := db.Body{"channels": []string{username}}
-	rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
-	initLegacyRevRT2 := rt2InitDoc.GetRevTreeID()
-	bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}}
-	rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
-	legacyRevRT2 := rt2InitDoc.GetRevTreeID()
+		// wait for doc checked on each side of replication
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			stats := ar.GetStatus(ctx1)
+			assert.Equal(c, int64(1), stats.PushReplicationStatus.DocsCheckedPush)
+			assert.Equal(c, int64(1), stats.PullReplicationStatus.DocsCheckedPull)
+		}, time.Second*10, time.Millisecond*100)
 
-	// create doc on rt1 with same body to keep revID generation the same as rev1 of the document above
-	bodyRT1 := db.Body{"channels": []string{username}}
-	rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-	initLegacyRevRT1 := rt1InitDoc.GetRevTreeID()
-	bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}}
-	rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
-	legacyRevRT1 := rt1InitDoc.GetRevTreeID()
+		rt1Doc := rt1.GetDocument(docID)
+		expVersion := rest.DocVersion{
+			RevTreeID: legacyRevRT1,
+		}
+		rest.RequireDocRevTreeEqual(t, expVersion, rest.DocVersion{RevTreeID: rt1Doc.GetRevTreeID()})
+		assert.Nil(t, rt1Doc.HLV)
+		rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1})
 
-	// need revIDs to match so the peers know the revs are known to each other
-	require.Equal(t, legacyRevRT1, legacyRevRT2)
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePushAndPull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:    200,
-		Continuous:          true,
-		ReplicationStatsMap: dbReplicatorStats(t),
-		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+		rt2Doc := rt2.GetDocument(docID)
+		expVersion = rest.DocVersion{
+			RevTreeID: legacyRevRT2,
+		}
+		rest.RequireDocRevTreeEqual(t, expVersion, rest.DocVersion{RevTreeID: rt2Doc.GetRevTreeID()})
+		assert.Nil(t, rt2Doc.HLV)
+		rest.RequireHistoryContains(t, rt2Doc.History, []string{legacyRevRT2, initLegacyRevRT2})
 	})
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, ar.Stop())
-	}()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	// wait for doc checked on each side of replication
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		stats := ar.GetStatus(ctx1)
-		assert.Equal(c, int64(1), stats.PushReplicationStatus.DocsCheckedPush)
-		assert.Equal(c, int64(1), stats.PullReplicationStatus.DocsCheckedPull)
-	}, time.Second*10, time.Millisecond*100)
-
-	rt1Doc := rt1.GetDocument(docID)
-	expVersion := rest.DocVersion{
-		RevTreeID: legacyRevRT1,
-	}
-	rest.RequireDocRevTreeEqual(t, expVersion, rest.DocVersion{RevTreeID: rt1Doc.GetRevTreeID()})
-	assert.Nil(t, rt1Doc.HLV)
-	rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1})
-
-	rt2Doc := rt2.GetDocument(docID)
-	expVersion = rest.DocVersion{
-		RevTreeID: legacyRevRT2,
-	}
-	rest.RequireDocRevTreeEqual(t, expVersion, rest.DocVersion{RevTreeID: rt2Doc.GetRevTreeID()})
-	assert.Nil(t, rt2Doc.HLV)
-	rest.RequireHistoryContains(t, rt2Doc.History, []string{legacyRevRT2, initLegacyRevRT2})
 }
 
 func TestActiveReplicatorBiDirectionalPreUpgradedRevInHistory(t *testing.T) {
@@ -367,140 +330,128 @@ func TestActiveReplicatorBiDirectionalPreUpgradedRevInHistory(t *testing.T) {
 			activePeerHasUpgradedRev: true,
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Passive (SGW2 in diagram above)
-			rt2 := rest.NewRestTester(t,
-				&rest.RestTesterConfig{
-					SyncFn: channels.DocChannelsSyncFunction,
-					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					}},
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Active is SGW1 in diagram above
+				// Passive is SGW2 in diagram above
+				rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+					UserChannelAccess: []string{username},
 				})
-			defer rt2.Close()
+				ctx1 := rt1.Context()
 
-			rt2.CreateUser(username, []string{username})
+				docID := rest.SafeDocumentName(t, t.Name())
 
-			// Active (SGW1 in diagram above)
-			rt1 := rest.NewRestTester(t,
-				&rest.RestTesterConfig{
-					SyncFn: channels.DocChannelsSyncFunction,
-					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-						Name: "activedb",
-					}},
+				var initLegacyRevRT2, legacyRevRT2, upgradedRevID, legacyRevRT1, initLegacyRevRT1 string
+				var upgradedDocVersion rest.DocVersion
+				var expectedBody string
+
+				if !tc.activePeerHasUpgradedRev {
+					// create doc on rt2 with two revisions + a third upgraded rev to give it a HLV
+					bodyRT2 := db.Body{"channels": []string{username}}
+					rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
+					initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
+					bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}}
+					rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
+					legacyRevRT2 = rt2InitDoc.GetRevTreeID()
+					// now give passive a third revision to RT2 (non legacy update to give it a HLV)
+					inputBody := fmt.Sprintf(`{"%s": "%s", "source": "rt2", "channels": ["%s"]}`, db.BodyRev, legacyRevRT2, username)
+					upgradedDocVersion = rt2.PutDoc(docID, inputBody)
+					upgradedRevID = upgradedDocVersion.RevTreeID
+					expectedBody = fmt.Sprintf(`{"source": "rt2", "channels": ["%s"]}`, username)
+
+					// create doc on rt1 with same body to keep revID generation the same as rev1 of the document above
+					bodyRT1 := db.Body{"channels": []string{username}}
+					rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+					initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}}
+					rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
+					legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+				} else {
+					// create doc on rt1 with two revisions + a third upgraded rev to give it a HLV
+					bodyRT1 := db.Body{"channels": []string{username}}
+					rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+					initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}}
+					rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
+					legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					// now give passive a third revision to RT1 (non legacy update to give it a HLV)
+					inputBody := fmt.Sprintf(`{"%s": "%s", "source": "rt1", "channels": ["%s"]}`, db.BodyRev, legacyRevRT1, username)
+					upgradedDocVersion = rt1.PutDoc(docID, inputBody)
+					upgradedRevID = upgradedDocVersion.RevTreeID
+					expectedBody = fmt.Sprintf(`{"source": "rt1", "channels": ["%s"]}`, username)
+
+					// create doc on rt2 with same body to keep revID generation the same as rev1 of the document above
+					bodyRT2 := db.Body{"channels": []string{username}}
+					rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
+					initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
+					bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}}
+					rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
+					legacyRevRT2 = rt2InitDoc.GetRevTreeID()
+				}
+
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          t.Name(),
+					Direction:   db.ActiveReplicatorTypePushAndPull,
+					RemoteDBURL: userDBURL(rt2, username),
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:       200,
+					Continuous:             true,
+					ReplicationStatsMap:    dbReplicatorStats(t),
+					CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+					SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 				})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
+				require.NoError(t, err)
+				defer func() {
+					require.NoError(t, ar.Stop())
+				}()
 
-			docID := rest.SafeDocumentName(t, t.Name())
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
 
-			var initLegacyRevRT2, legacyRevRT2, upgradedRevID, legacyRevRT1, initLegacyRevRT1 string
-			var upgradedDocVersion rest.DocVersion
-			var expectedBody string
+				if !tc.activePeerHasUpgradedRev {
+					rt1.WaitForVersion(docID, upgradedDocVersion)
 
-			if !tc.activePeerHasUpgradedRev {
-				// create doc on rt2 with two revisions + a third upgraded rev to give it a HLV
-				bodyRT2 := db.Body{"channels": []string{username}}
-				rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
-				initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
-				bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}}
-				rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
-				legacyRevRT2 = rt2InitDoc.GetRevTreeID()
-				// now give passive a third revision to RT2 (non legacy update to give it a HLV)
-				inputBody := fmt.Sprintf(`{"%s": "%s", "source": "rt2", "channels": ["%s"]}`, db.BodyRev, legacyRevRT2, username)
-				upgradedDocVersion = rt2.PutDoc(docID, inputBody)
-				upgradedRevID = upgradedDocVersion.RevTreeID
-				expectedBody = fmt.Sprintf(`{"source": "rt2", "channels": ["%s"]}`, username)
+					rt1Doc := rt1.GetDocument(docID)
+					rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1, upgradedRevID})
+					actualBodyRT1, err := rt1Doc.BodyBytes(rt1.Context())
+					require.NoError(t, err)
 
-				// create doc on rt1 with same body to keep revID generation the same as rev1 of the document above
-				bodyRT1 := db.Body{"channels": []string{username}}
-				rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-				initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
-				bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}}
-				rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
-				legacyRevRT1 = rt1InitDoc.GetRevTreeID()
-			} else {
-				// create doc on rt1 with two revisions + a third upgraded rev to give it a HLV
-				bodyRT1 := db.Body{"channels": []string{username}}
-				rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-				initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
-				bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}}
-				rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
-				legacyRevRT1 = rt1InitDoc.GetRevTreeID()
-				// now give passive a third revision to RT1 (non legacy update to give it a HLV)
-				inputBody := fmt.Sprintf(`{"%s": "%s", "source": "rt1", "channels": ["%s"]}`, db.BodyRev, legacyRevRT1, username)
-				upgradedDocVersion = rt1.PutDoc(docID, inputBody)
-				upgradedRevID = upgradedDocVersion.RevTreeID
-				expectedBody = fmt.Sprintf(`{"source": "rt1", "channels": ["%s"]}`, username)
+					// assert passive side doc hasn't changed
+					rt2Doc := rt2.GetDocument(docID)
+					rest.RequireDocVersionEqual(t, upgradedDocVersion, rt2Doc.ExtractDocVersion())
+					rest.RequireHistoryContains(t, rt2Doc.History, []string{legacyRevRT2, initLegacyRevRT2, upgradedRevID})
+					actualBodyRT2, err := rt2Doc.BodyBytes(rt2.Context())
+					require.NoError(t, err)
 
-				// create doc on rt2 with same body to keep revID generation the same as rev1 of the document above
-				bodyRT2 := db.Body{"channels": []string{username}}
-				rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
-				initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
-				bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}}
-				rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
-				legacyRevRT2 = rt2InitDoc.GetRevTreeID()
-			}
+					// Assert body matches expected
+					require.JSONEq(t, expectedBody, string(actualBodyRT2))
+					require.JSONEq(t, expectedBody, string(actualBodyRT1))
+				} else {
+					rt2.WaitForVersion(docID, upgradedDocVersion)
 
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePushAndPull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:    200,
-				Continuous:          true,
-				ReplicationStatsMap: dbReplicatorStats(t),
-				CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+					rt2Doc := rt2.GetDocument(docID)
+					rest.RequireHistoryContains(t, rt2Doc.History, []string{legacyRevRT2, initLegacyRevRT2, upgradedRevID})
+					actualBodyRT2, err := rt2Doc.BodyBytes(rt2.Context())
+					require.NoError(t, err)
+
+					// assert active side doc hasn't changed
+					rt1Doc := rt1.GetDocument(docID)
+					rest.RequireDocVersionEqual(t, upgradedDocVersion, rt1Doc.ExtractDocVersion())
+					rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1, upgradedRevID})
+					actualBodyRT1, err := rt1Doc.BodyBytes(rt1.Context())
+					require.NoError(t, err)
+
+					// Assert body matches expected
+					require.JSONEq(t, expectedBody, string(actualBodyRT2))
+					require.JSONEq(t, expectedBody, string(actualBodyRT1))
+				}
 			})
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, ar.Stop())
-			}()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			if !tc.activePeerHasUpgradedRev {
-				rt1.WaitForVersion(docID, upgradedDocVersion)
-
-				rt1Doc := rt1.GetDocument(docID)
-				rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1, upgradedRevID})
-				actualBodyRT1, err := rt1Doc.BodyBytes(rt1.Context())
-				require.NoError(t, err)
-
-				// assert passive side doc hasn't changed
-				rt2Doc := rt2.GetDocument(docID)
-				rest.RequireDocVersionEqual(t, upgradedDocVersion, rt2Doc.ExtractDocVersion())
-				rest.RequireHistoryContains(t, rt2Doc.History, []string{legacyRevRT2, initLegacyRevRT2, upgradedRevID})
-				actualBodyRT2, err := rt2Doc.BodyBytes(rt2.Context())
-				require.NoError(t, err)
-
-				// Assert body matches expected
-				require.JSONEq(t, expectedBody, string(actualBodyRT2))
-				require.JSONEq(t, expectedBody, string(actualBodyRT1))
-			} else {
-				rt2.WaitForVersion(docID, upgradedDocVersion)
-
-				rt2Doc := rt2.GetDocument(docID)
-				rest.RequireHistoryContains(t, rt2Doc.History, []string{legacyRevRT2, initLegacyRevRT2, upgradedRevID})
-				actualBodyRT2, err := rt2Doc.BodyBytes(rt2.Context())
-				require.NoError(t, err)
-
-				// assert active side doc hasn't changed
-				rt1Doc := rt1.GetDocument(docID)
-				rest.RequireDocVersionEqual(t, upgradedDocVersion, rt1Doc.ExtractDocVersion())
-				rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1, upgradedRevID})
-				actualBodyRT1, err := rt1Doc.BodyBytes(rt1.Context())
-				require.NoError(t, err)
-
-				// Assert body matches expected
-				require.JSONEq(t, expectedBody, string(actualBodyRT2))
-				require.JSONEq(t, expectedBody, string(actualBodyRT1))
-			}
-		})
-	}
+		}
+	})
 }
 
 // Test Case:
@@ -521,96 +472,82 @@ func TestActiveReplicatorPushPullNewDocLegacyRevAndAllowUpdateAfter(t *testing.T
 	base.RequireNumTestBuckets(t, 2)
 
 	const username = "alice"
-
-	// Passive (SGW2 in diagram above)
-	rt2 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "passivedb",
-			}},
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UserChannelAccess: []string{username},
 		})
-	defer rt2.Close()
+		ctx1 := rt1.Context()
 
-	rt2.CreateUser(username, []string{username})
+		docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
+		docIDToPull := rest.SafeDocumentName(t, t.Name()+"_pull")
 
-	// Active (SGW1 in diagram above)
-	rt1 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "activedb",
-			}},
+		// create doc on rt1 with one revision
+		bodyRT1 := db.Body{"channels": []string{username}, "source": "rt1"}
+		rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
+		legacyRevRt1 := rt1InitDoc.GetRevTreeID()
+
+		// create doc on rt2 to pull with one revision
+		bodyRT2 := db.Body{"channels": []string{username}, "source": "rt2"}
+		rt2InitDoc := rt2.CreateDocNoHLV(docIDToPull, bodyRT2)
+		legacyRevRt2 := rt2InitDoc.GetRevTreeID()
+
+		id := rest.SafeDocumentName(t, t.Name())
+		stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		replicationStats, err := stats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePushAndPull,
+			RemoteDBURL: userDBURL(rt2, username),
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    replicationStats,
+			CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, ar.Stop())
+		}()
 
-	docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
-	docIDToPull := rest.SafeDocumentName(t, t.Name()+"_pull")
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
 
-	// create doc on rt1 with one revision
-	bodyRT1 := db.Body{"channels": []string{username}, "source": "rt1"}
-	rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
-	legacyRevRt1 := rt1InitDoc.GetRevTreeID()
+		rt1.WaitForLegacyRev(docIDToPull, legacyRevRt2, []byte(`{"source":"rt2","channels":["alice"]}`))
+		rt2.WaitForLegacyRev(docIDToPush, legacyRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
 
-	// create doc on rt2 to pull with one revision
-	bodyRT2 := db.Body{"channels": []string{username}, "source": "rt2"}
-	rt2InitDoc := rt2.CreateDocNoHLV(docIDToPull, bodyRT2)
-	legacyRevRt2 := rt2InitDoc.GetRevTreeID()
+		// now update both docs to create a new revision on each side giving them each hlv based off their nodes source
+		cvVersion, err := db.LegacyRevToRevTreeEncodedVersion(legacyRevRt1)
+		require.NoError(t, err)
+		rt1DocVersion := rest.DocVersion{
+			RevTreeID: legacyRevRt1,
+		}
+		updateVer := rt1.UpdateDoc(docIDToPush, rt1DocVersion, `{"channels": ["alice"], "source": "rt1-updated"}`)
+		rt2.WaitForVersion(docIDToPush, updateVer)
+		// check rev tree encoded version is in pv
+		finalRT2Doc := rt2.GetDocument(docIDToPush)
+		assert.Equal(t, cvVersion.Value, finalRT2Doc.HLV.PreviousVersions[cvVersion.SourceID])
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	replicationStats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		cvVersion, err = db.LegacyRevToRevTreeEncodedVersion(legacyRevRt2)
+		require.NoError(t, err)
+		rt2DocVersion := rest.DocVersion{
+			RevTreeID: legacyRevRt2,
+		}
+		updateVer = rt2.UpdateDoc(docIDToPull, rt2DocVersion, `{"channels": ["alice"], "source": "rt2-updated"}`)
+		rt1.WaitForVersion(docIDToPull, updateVer)
+		finalRT1Doc := rt1.GetDocument(docIDToPull)
+		assert.Equal(t, cvVersion.Value, finalRT1Doc.HLV.PreviousVersions[cvVersion.SourceID])
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePushAndPull,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:    200,
-		Continuous:          true,
-		ReplicationStatsMap: replicationStats,
-		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+		// assert no conflicts on either side
+		assert.Equal(t, int64(0), replicationStats.PushConflictCount.Value())
+		assert.Equal(t, int64(2), replicationStats.PulledCount.Value())
 	})
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, ar.Stop())
-	}()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	rt1.WaitForLegacyRev(docIDToPull, legacyRevRt2, []byte(`{"source":"rt2","channels":["alice"]}`))
-	rt2.WaitForLegacyRev(docIDToPush, legacyRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
-
-	// now update both docs to create a new revision on each side giving them each hlv based off their nodes source
-	cvVersion, err := db.LegacyRevToRevTreeEncodedVersion(legacyRevRt1)
-	require.NoError(t, err)
-	rt1DocVersion := rest.DocVersion{
-		RevTreeID: legacyRevRt1,
-	}
-	updateVer := rt1.UpdateDoc(docIDToPush, rt1DocVersion, `{"channels": ["alice"], "source": "rt1-updated"}`)
-	rt2.WaitForVersion(docIDToPush, updateVer)
-	// check rev tree encoded version is in pv
-	finalRT2Doc := rt2.GetDocument(docIDToPush)
-	assert.Equal(t, cvVersion.Value, finalRT2Doc.HLV.PreviousVersions[cvVersion.SourceID])
-
-	cvVersion, err = db.LegacyRevToRevTreeEncodedVersion(legacyRevRt2)
-	require.NoError(t, err)
-	rt2DocVersion := rest.DocVersion{
-		RevTreeID: legacyRevRt2,
-	}
-	updateVer = rt2.UpdateDoc(docIDToPull, rt2DocVersion, `{"channels": ["alice"], "source": "rt2-updated"}`)
-	rt1.WaitForVersion(docIDToPull, updateVer)
-	finalRT1Doc := rt1.GetDocument(docIDToPull)
-	assert.Equal(t, cvVersion.Value, finalRT1Doc.HLV.PreviousVersions[cvVersion.SourceID])
-
-	// assert no conflicts on either side
-	assert.Equal(t, int64(0), replicationStats.PushConflictCount.Value())
-	assert.Equal(t, int64(2), replicationStats.PulledCount.Value())
 }
 
 /// conflict test cases
@@ -629,85 +566,73 @@ func TestActiveReplicatorPushConflictingPreUpgradedVersion(t *testing.T) {
 
 	const username = "alice"
 
-	// Passive (SGW2 in diagram above)
-	rt2 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "passivedb",
-			}},
+	// Active is SGW1 in diagram above
+	// Passive is SGW2 in diagram above
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UserChannelAccess: []string{username},
 		})
-	defer rt2.Close()
+		ctx1 := rt1.Context()
 
-	rt2.CreateUser(username, []string{username})
+		docID := rest.SafeDocumentName(t, t.Name())
 
-	// Active (SGW1 in diagram above)
-	rt1 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "activedb",
-			}},
+		// create doc on rt1 with two revisions
+		bodyRT1 := db.Body{"channels": []string{username}}
+		rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+		initLegacyRevRT1 := rt1InitDoc.GetRevTreeID()
+		bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "source": "rt1", "channels": []string{username}}
+		rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
+		legacyRevRT1 := rt1InitDoc.GetRevTreeID()
+
+		// create doc on rt2 with same body to keep revID generation the same as rev1 of the document above
+		bodyRT2 := db.Body{"channels": []string{username}}
+		rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
+		initLegacyRevRT2 := rt2InitDoc.GetRevTreeID()
+		bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "source": "rt2", "channels": []string{username}}
+		rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
+		legacyRevRT2 := rt2InitDoc.GetRevTreeID()
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          rest.SafeDocumentName(t, t.Name()),
+			Direction:   db.ActiveReplicatorTypePush,
+			RemoteDBURL: userDBURL(rt2, username),
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    dbReplicatorStats(t),
+			CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, ar.Stop())
+		}()
 
-	docID := rest.SafeDocumentName(t, t.Name())
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
 
-	// create doc on rt1 with two revisions
-	bodyRT1 := db.Body{"channels": []string{username}}
-	rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-	initLegacyRevRT1 := rt1InitDoc.GetRevTreeID()
-	bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "source": "rt1", "channels": []string{username}}
-	rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
-	legacyRevRT1 := rt1InitDoc.GetRevTreeID()
+		// wait for doc conflict rejection on push
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			stats := ar.GetStatus(ctx1)
+			assert.Equal(c, int64(1), stats.PushReplicationStatus.DocWriteConflict)
+		}, time.Second*10, time.Millisecond*100)
 
-	// create doc on rt2 with same body to keep revID generation the same as rev1 of the document above
-	bodyRT2 := db.Body{"channels": []string{username}}
-	rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
-	initLegacyRevRT2 := rt2InitDoc.GetRevTreeID()
-	bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "source": "rt2", "channels": []string{username}}
-	rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
-	legacyRevRT2 := rt2InitDoc.GetRevTreeID()
+		// assert versions each side are not changed (can only assert on rev tree ids given legacy documents on both sides)
+		rt1Doc := rt1.GetDocument(docID)
+		expVersionRT1 := rest.DocVersion{
+			RevTreeID: legacyRevRT1,
+		}
+		rest.RequireDocRevTreeEqual(t, expVersionRT1, rest.DocVersion{RevTreeID: rt1Doc.GetRevTreeID()})
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePush,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:    200,
-		Continuous:          true,
-		ReplicationStatsMap: dbReplicatorStats(t),
-		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
+		rt2Doc := rt2.GetDocument(docID)
+		expVersionRT2 := rest.DocVersion{
+			RevTreeID: legacyRevRT2,
+		}
+		rest.RequireDocRevTreeEqual(t, expVersionRT2, rest.DocVersion{RevTreeID: rt2Doc.GetRevTreeID()})
 	})
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, ar.Stop())
-	}()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	// wait for doc conflict rejection on push
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		stats := ar.GetStatus(ctx1)
-		assert.Equal(c, int64(1), stats.PushReplicationStatus.DocWriteConflict)
-	}, time.Second*10, time.Millisecond*100)
-
-	// assert versions each side are not changed (can only assert on rev tree ids given legacy documents on both sides)
-	rt1Doc := rt1.GetDocument(docID)
-	expVersionRT1 := rest.DocVersion{
-		RevTreeID: legacyRevRT1,
-	}
-	rest.RequireDocRevTreeEqual(t, expVersionRT1, rest.DocVersion{RevTreeID: rt1Doc.GetRevTreeID()})
-
-	rt2Doc := rt2.GetDocument(docID)
-	expVersionRT2 := rest.DocVersion{
-		RevTreeID: legacyRevRT2,
-	}
-	rest.RequireDocRevTreeEqual(t, expVersionRT2, rest.DocVersion{RevTreeID: rt2Doc.GetRevTreeID()})
 }
 
 func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
@@ -746,148 +671,136 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 			activeWins: false,
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Passive (SGW2 in diagram above)
-			rt2 := rest.NewRestTester(t,
-				&rest.RestTesterConfig{
-					SyncFn: channels.DocChannelsSyncFunction,
-					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					}},
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Passive is SGW2 in diagram above
+				// Active is SGW1 in diagram above
+				rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+					UserChannelAccess: []string{username},
 				})
-			defer rt2.Close()
+				ctx1 := rt1.Context()
 
-			rt2.CreateUser(username, []string{username})
+				docID := rest.SafeDocumentName(t, t.Name())
 
-			// Active (SGW1 in diagram above)
-			rt1 := rest.NewRestTester(t,
-				&rest.RestTesterConfig{
-					SyncFn: channels.DocChannelsSyncFunction,
-					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-						Name: "activedb",
-					}},
-				})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
+				var legacyRevRT1, initLegacyRevRT1, legacyRevRT2, initLegacyRevRT2 string
+				if tc.activeWins {
+					// create doc on rt1 with two revisions
+					bodyRT1 := db.Body{"channels": []string{username}}
+					rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+					initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}, "source": "rt1"}
+					rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
+					legacyRevRT1 = rt1InitDoc.GetRevTreeID()
 
-			docID := rest.SafeDocumentName(t, t.Name())
+					// create doc on rt2 with same body to keep revID generation the same as rev1 of the document above
+					bodyRT2 := db.Body{"channels": []string{username}}
+					rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
+					initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
+					bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}}
+					rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
+					legacyRevRT2 = rt2InitDoc.GetRevTreeID()
+				} else {
+					// create doc on rt2 with two revisions
+					bodyRT2 := db.Body{"channels": []string{username}}
+					rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
+					initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
+					bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}, "source": "rt2"}
+					rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
+					legacyRevRT2 = rt2InitDoc.GetRevTreeID()
 
-			var legacyRevRT1, initLegacyRevRT1, legacyRevRT2, initLegacyRevRT2 string
-			if tc.activeWins {
-				// create doc on rt1 with two revisions
-				bodyRT1 := db.Body{"channels": []string{username}}
-				rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-				initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
-				bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}, "source": "rt1"}
-				rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
-				legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					// create doc on rt1 with same body to keep revID generation the same as rev1 of the document above
+					bodyRT1 := db.Body{"channels": []string{username}}
+					rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+					initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}}
+					rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
+					legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+				}
 
-				// create doc on rt2 with same body to keep revID generation the same as rev1 of the document above
-				bodyRT2 := db.Body{"channels": []string{username}}
-				rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
-				initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
-				bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}}
-				rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
-				legacyRevRT2 = rt2InitDoc.GetRevTreeID()
-			} else {
-				// create doc on rt2 with two revisions
-				bodyRT2 := db.Body{"channels": []string{username}}
-				rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
-				initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
-				bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}, "source": "rt2"}
-				rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
-				legacyRevRT2 = rt2InitDoc.GetRevTreeID()
-
-				// create doc on rt1 with same body to keep revID generation the same as rev1 of the document above
-				bodyRT1 := db.Body{"channels": []string{username}}
-				rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-				initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
-				bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}}
-				rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
-				legacyRevRT1 = rt1InitDoc.GetRevTreeID()
-			}
-
-			// build conflict resolver functions
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-			resolverFuncRevID, err := db.NewConflictResolverFunc(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-			require.NoError(t, err)
-			replicationStats, err := stats.DBReplicatorStats(t.Name())
-			require.NoError(t, err)
-
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePushAndPull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				Continuous:                 true,
-				ReplicationStatsMap:        replicationStats,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				ConflictResolverFuncForHLV: resolverFunc,
-				ConflictResolverFunc:       resolverFuncRevID,
-			})
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, ar.Stop())
-			}()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			if tc.activeWins {
-				base.RequireWaitForStat(t, func() int64 {
-					return replicationStats.ConflictResolvedLocalCount.Value()
-				}, 1)
-				verPostConflictRes, _ := rt1.GetDoc(docID)
-				rt2.WaitForLegacyRev(docID, verPostConflictRes.RevTreeID, []byte(`{"channels":["alice"],"source":"rt1"}`))
-				rt2Doc := rt2.GetDocument(docID)
-				rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2, verPostConflictRes.RevTreeID})
-
-				// add doc for some replication activity on pull to assert that local doesn't change after remote is written with legacy CV
-				newDocVersion := rt2.PutDoc("newdoc", `{"channels": ["alice"]}`)
-				rt1.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt1
-
-				// assert active side doc hasn't changed
-				rt1Doc := rt1.GetDocument(docID)
-				rest.RequireDocRevTreeEqual(t, rest.DocVersion{RevTreeID: verPostConflictRes.RevTreeID}, rest.DocVersion{RevTreeID: rt1Doc.GetRevTreeID()})
-				tombstonedID := db.CreateRevIDWithBytes(3, legacyRevRT1, []byte(db.DeletedDocument)) // create what would be the tombstone rev id for local branch
-				rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1, verPostConflictRes.RevTreeID, legacyRevRT2, tombstonedID})
-				// we should have legacy encoded rev tree locally now given the resolved conflict above writes a new
-				// revision of the doc locally
-				cvVer, err := db.LegacyRevToRevTreeEncodedVersion(rt1Doc.GetRevTreeID())
+				// build conflict resolver functions
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
 				require.NoError(t, err)
-				assert.Equal(t, cvVer.String(), rt1Doc.HLV.GetCurrentVersionString())
-			} else {
-				base.RequireWaitForStat(t, func() int64 {
-					return replicationStats.ConflictResolvedRemoteCount.Value()
-				}, 1)
+				resolverFuncRevID, err := db.NewConflictResolverFunc(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
 
-				rt1.WaitForLegacyRev(docID, legacyRevRT2, []byte(`{"channels":["alice"],"source":"rt2"}`))
-				rt1Doc := rt1.GetDocument(docID)
-				tombstonedID := db.CreateRevIDWithBytes(3, legacyRevRT1, []byte(db.DeletedDocument)) // create what would be the tombstone rev id for local branch
-				rest.RequireHistoryContains(t, rt1Doc.History, []string{initLegacyRevRT1, legacyRevRT1, legacyRevRT2, tombstonedID})
+				id := rest.SafeDocumentName(t, t.Name())
+				stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+				require.NoError(t, err)
+				replicationStats, err := stats.DBReplicatorStats(id)
+				require.NoError(t, err)
 
-				// add doc for some replication activity on push to assert that local doesn't change after remote is written with legacy CV
-				newDocVersion := rt1.PutDoc("newdoc", `{"channels": ["alice"]}`)
-				rt2.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt2
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          id,
+					Direction:   db.ActiveReplicatorTypePushAndPull,
+					RemoteDBURL: userDBURL(rt2, username),
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:           200,
+					Continuous:                 true,
+					ReplicationStatsMap:        replicationStats,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					ConflictResolverFuncForHLV: resolverFunc,
+					ConflictResolverFunc:       resolverFuncRevID,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
+				})
+				require.NoError(t, err)
+				defer func() {
+					require.NoError(t, ar.Stop())
+				}()
 
-				// assert passive side doc hasn't changed
-				rt2Doc := rt2.GetDocument(docID)
-				rest.RequireDocRevTreeEqual(t, rest.DocVersion{RevTreeID: legacyRevRT2}, rest.DocVersion{RevTreeID: rt2Doc.GetRevTreeID()})
-				rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2})
-				// legacy cv written to rt1 will correspond to local rev tree ID thus no HLV should be written yet
-				assert.Nil(t, rt2Doc.HLV)
-			}
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
 
-		})
-	}
+				if tc.activeWins {
+					base.RequireWaitForStat(t, func() int64 {
+						return replicationStats.ConflictResolvedLocalCount.Value()
+					}, 1)
+					verPostConflictRes, _ := rt1.GetDoc(docID)
+					rt2.WaitForLegacyRev(docID, verPostConflictRes.RevTreeID, []byte(`{"channels":["alice"],"source":"rt1"}`))
+					rt2Doc := rt2.GetDocument(docID)
+					rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2, verPostConflictRes.RevTreeID})
+
+					// add doc for some replication activity on pull to assert that local doesn't change after remote is written with legacy CV
+					newDocVersion := rt2.PutDoc("newdoc", `{"channels": ["alice"]}`)
+					rt1.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt1
+
+					// assert active side doc hasn't changed
+					rt1Doc := rt1.GetDocument(docID)
+					rest.RequireDocRevTreeEqual(t, rest.DocVersion{RevTreeID: verPostConflictRes.RevTreeID}, rest.DocVersion{RevTreeID: rt1Doc.GetRevTreeID()})
+					tombstonedID := db.CreateRevIDWithBytes(3, legacyRevRT1, []byte(db.DeletedDocument)) // create what would be the tombstone rev id for local branch
+					rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1, verPostConflictRes.RevTreeID, legacyRevRT2, tombstonedID})
+					// we should have legacy encoded rev tree locally now given the resolved conflict above writes a new
+					// revision of the doc locally
+					cvVer, err := db.LegacyRevToRevTreeEncodedVersion(rt1Doc.GetRevTreeID())
+					require.NoError(t, err)
+					assert.Equal(t, cvVer.String(), rt1Doc.HLV.GetCurrentVersionString())
+				} else {
+					base.RequireWaitForStat(t, func() int64 {
+						return replicationStats.ConflictResolvedRemoteCount.Value()
+					}, 1)
+
+					rt1.WaitForLegacyRev(docID, legacyRevRT2, []byte(`{"channels":["alice"],"source":"rt2"}`))
+					rt1Doc := rt1.GetDocument(docID)
+					tombstonedID := db.CreateRevIDWithBytes(3, legacyRevRT1, []byte(db.DeletedDocument)) // create what would be the tombstone rev id for local branch
+					rest.RequireHistoryContains(t, rt1Doc.History, []string{initLegacyRevRT1, legacyRevRT1, legacyRevRT2, tombstonedID})
+
+					// add doc for some replication activity on push to assert that local doesn't change after remote is written with legacy CV
+					newDocVersion := rt1.PutDoc("newdoc", `{"channels": ["alice"]}`)
+					rt2.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt2
+
+					// assert passive side doc hasn't changed
+					rt2Doc := rt2.GetDocument(docID)
+					rest.RequireDocRevTreeEqual(t, rest.DocVersion{RevTreeID: legacyRevRT2}, rest.DocVersion{RevTreeID: rt2Doc.GetRevTreeID()})
+					rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2})
+					// legacy cv written to rt1 will correspond to local rev tree ID thus no HLV should be written yet
+					assert.Nil(t, rt2Doc.HLV)
+				}
+			})
+		}
+	})
 }
 
 func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
@@ -926,173 +839,161 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 			activePeerHasPostUpgradeVersion: false,
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Passive (SGW2 in diagram above)
-			rt2 := rest.NewRestTester(t,
-				&rest.RestTesterConfig{
-					SyncFn: channels.DocChannelsSyncFunction,
-					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-						Name: "passivedb",
-					}},
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Passive (SGW2 in diagram above)
+				rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+					UserChannelAccess: []string{username},
 				})
-			defer rt2.Close()
+				ctx1 := rt1.Context()
 
-			rt2.CreateUser(username, []string{username})
+				docID := rest.SafeDocumentName(t, t.Name())
 
-			// Active (SGW1 in diagram above)
-			rt1 := rest.NewRestTester(t,
-				&rest.RestTesterConfig{
-					SyncFn: channels.DocChannelsSyncFunction,
-					DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-						Name: "activedb",
-					}},
+				var legacyRevRT1, initLegacyRevRT1, legacyRevRT2, initLegacyRevRT2, expectedBody string
+				var upgradedDocVersion rest.DocVersion
+
+				if tc.activePeerHasPostUpgradeVersion {
+					// create doc rt1 with two revisions and second revision has HLV
+					bodyRT1 := db.Body{"channels": []string{username}}
+					rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+					initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					upgradedDocVersion = rt1.PutDoc(docID, fmt.Sprintf(`{"%s":"%s", "channels": ["alice"], "source": "rt1"}`, db.BodyRev, initLegacyRevRT1))
+					expectedBody = fmt.Sprintf(`{"channels": ["alice"], "source": "rt1"}`)
+					legacyRevRT1 = upgradedDocVersion.RevTreeID
+
+					// create doc on rt2 with same body for rev1 to keep revID generation the same as rev1 of the document above
+					// but have both revisions be pre upgraded versions
+					bodyRT2 := db.Body{"channels": []string{username}}
+					rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
+					initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
+					bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}, "source": "rt2"}
+					rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
+					legacyRevRT2 = rt2InitDoc.GetRevTreeID()
+				} else {
+					// create doc rt2 with two revisions and second revision has HLV
+					bodyRT2 := db.Body{"channels": []string{username}}
+					rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
+					initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
+					upgradedDocVersion = rt2.PutDoc(docID, fmt.Sprintf(`{"%s":"%s", "channels": ["alice"], "source": "rt2"}`, db.BodyRev, initLegacyRevRT2))
+					expectedBody = fmt.Sprintf(`{"channels": ["alice"], "source": "rt2"}`)
+
+					// create doc on rt1 with same body for rev1 to keep revID generation the same as rev1 of the document above
+					// but have both revisions be pre upgraded versions
+					bodyRT1 := db.Body{"channels": []string{username}}
+					rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
+					initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
+					bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}, "source": "rt1"}
+					rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
+					legacyRevRT1 = rt1InitDoc.GetRevTreeID()
+				}
+
+				// build conflict resolver functions
+				resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+				resolverFuncRevID, err := db.NewConflictResolverFunc(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
+				require.NoError(t, err)
+
+				id := rest.SafeDocumentName(t, t.Name())
+				stats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+				require.NoError(t, err)
+				replicationStats, err := stats.DBReplicatorStats(id)
+				require.NoError(t, err)
+
+				ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+					ID:          id,
+					Direction:   db.ActiveReplicatorTypePushAndPull,
+					RemoteDBURL: userDBURL(rt2, username),
+					ActiveDB: &db.Database{
+						DatabaseContext: rt1.GetDatabase(),
+					},
+					ChangesBatchSize:           200,
+					Continuous:                 true,
+					ReplicationStatsMap:        replicationStats,
+					CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
+					ConflictResolverFuncForHLV: resolverFunc,
+					ConflictResolverFunc:       resolverFuncRevID,
+					SupportedBLIPProtocols:     sgrRunner.SupportedSubprotocols,
 				})
-			defer rt1.Close()
-			ctx1 := rt1.Context()
+				require.NoError(t, err)
+				defer func() {
+					require.NoError(t, ar.Stop())
+				}()
 
-			docID := rest.SafeDocumentName(t, t.Name())
+				// Start the replicator
+				require.NoError(t, ar.Start(ctx1))
 
-			var legacyRevRT1, initLegacyRevRT1, legacyRevRT2, initLegacyRevRT2, expectedBody string
-			var upgradedDocVersion rest.DocVersion
+				if tc.activePeerHasPostUpgradeVersion {
+					base.RequireWaitForStat(t, func() int64 {
+						return replicationStats.ConflictResolvedLocalCount.Value()
+					}, 1)
+					replicatedDoc := rt1.GetDocument(docID)
+					verPostConflictRes := replicatedDoc.ExtractDocVersion()
+					// wait for this resolution to be pushed back to passive peer
+					rt2.WaitForVersion(docID, verPostConflictRes)
 
-			if tc.activePeerHasPostUpgradeVersion {
-				// create doc rt1 with two revisions and second revision has HLV
-				bodyRT1 := db.Body{"channels": []string{username}}
-				rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-				initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
-				upgradedDocVersion = rt1.PutDoc(docID, fmt.Sprintf(`{"%s":"%s", "channels": ["alice"], "source": "rt1"}`, db.BodyRev, initLegacyRevRT1))
-				expectedBody = fmt.Sprintf(`{"channels": ["alice"], "source": "rt1"}`)
-				legacyRevRT1 = upgradedDocVersion.RevTreeID
+					// assert original upgraded version in PV history
+					assert.Equal(t, upgradedDocVersion.CV.Value, replicatedDoc.HLV.PreviousVersions[upgradedDocVersion.CV.SourceID])
 
-				// create doc on rt2 with same body for rev1 to keep revID generation the same as rev1 of the document above
-				// but have both revisions be pre upgraded versions
-				bodyRT2 := db.Body{"channels": []string{username}}
-				rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
-				initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
-				bodyRT2 = db.Body{db.BodyRev: initLegacyRevRT2, "channels": []string{username}, "source": "rt2"}
-				rt2InitDoc = rt2.CreateDocNoHLV(docID, bodyRT2)
-				legacyRevRT2 = rt2InitDoc.GetRevTreeID()
-			} else {
-				// create doc rt2 with two revisions and second revision has HLV
-				bodyRT2 := db.Body{"channels": []string{username}}
-				rt2InitDoc := rt2.CreateDocNoHLV(docID, bodyRT2)
-				initLegacyRevRT2 = rt2InitDoc.GetRevTreeID()
-				upgradedDocVersion = rt2.PutDoc(docID, fmt.Sprintf(`{"%s":"%s", "channels": ["alice"], "source": "rt2"}`, db.BodyRev, initLegacyRevRT2))
-				expectedBody = fmt.Sprintf(`{"channels": ["alice"], "source": "rt2"}`)
+					rt2Doc := rt2.GetDocument(docID)
+					rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2, verPostConflictRes.RevTreeID})
+					// assert that original upgraded version is in HLV pv on passive too
+					assert.Equal(t, upgradedDocVersion.CV.Value, rt2Doc.HLV.PreviousVersions[upgradedDocVersion.CV.SourceID])
 
-				// create doc on rt1 with same body for rev1 to keep revID generation the same as rev1 of the document above
-				// but have both revisions be pre upgraded versions
-				bodyRT1 := db.Body{"channels": []string{username}}
-				rt1InitDoc := rt1.CreateDocNoHLV(docID, bodyRT1)
-				initLegacyRevRT1 = rt1InitDoc.GetRevTreeID()
-				bodyRT1 = db.Body{db.BodyRev: initLegacyRevRT1, "channels": []string{username}, "source": "rt1"}
-				rt1InitDoc = rt1.CreateDocNoHLV(docID, bodyRT1)
-				legacyRevRT1 = rt1InitDoc.GetRevTreeID()
-			}
+					rt2BodyBytes, err := rt2Doc.BodyBytes(rt2.Context())
+					require.NoError(t, err)
 
-			// build conflict resolver functions
-			resolverFunc, err := db.NewConflictResolverFuncForHLV(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
-			resolverFuncRevID, err := db.NewConflictResolverFunc(ctx1, db.ConflictResolverDefault, "", rt1.GetDatabase().Options.JavascriptTimeout)
-			require.NoError(t, err)
+					// add doc for some replication activity on pull to assert that local doesn't change after remote is written with legacy CV
+					newDocVersion := rt2.PutDoc("newdoc", `{"channels": ["alice"]}`)
+					rt1.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt1
 
-			stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-			require.NoError(t, err)
-			replicationStats, err := stats.DBReplicatorStats(t.Name())
-			require.NoError(t, err)
+					// assert active side doc hasn't changed
+					rt1Doc := rt1.GetDocument(docID)
+					rest.RequireDocVersionEqual(t, verPostConflictRes, rt1Doc.ExtractDocVersion())
+					tombstonedID := db.CreateRevIDWithBytes(3, legacyRevRT1, []byte(db.DeletedDocument)) // create what would be the tombstone rev id for local branch
+					rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1, verPostConflictRes.RevTreeID, legacyRevRT2, tombstonedID})
 
-			ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-				ID:          t.Name(),
-				Direction:   db.ActiveReplicatorTypePushAndPull,
-				RemoteDBURL: userDBURL(rt2, username),
-				ActiveDB: &db.Database{
-					DatabaseContext: rt1.GetDatabase(),
-				},
-				ChangesBatchSize:           200,
-				Continuous:                 true,
-				ReplicationStatsMap:        replicationStats,
-				CollectionsEnabled:         !rt1.GetDatabase().OnlyDefaultCollection(),
-				ConflictResolverFuncForHLV: resolverFunc,
-				ConflictResolverFunc:       resolverFuncRevID,
+					// assert that the body is as expected each side
+					rt1BodyBytes, err := rt1Doc.BodyBytes(rt1.Context())
+					require.NoError(t, err)
+					require.JSONEq(t, expectedBody, string(rt1BodyBytes))
+					require.JSONEq(t, expectedBody, string(rt2BodyBytes))
+				} else {
+					base.RequireWaitForStat(t, func() int64 {
+						return replicationStats.ConflictResolvedRemoteCount.Value()
+					}, 1)
+					rt1.WaitForVersion(docID, upgradedDocVersion)
+
+					rt1Doc := rt1.GetDocument(docID)
+					tombstonedID := db.CreateRevIDWithBytes(3, legacyRevRT1, []byte(db.DeletedDocument)) // create what would be the tombstone rev id for local branch
+					rest.RequireHistoryContains(t, rt1Doc.History, []string{initLegacyRevRT1, legacyRevRT1, upgradedDocVersion.RevTreeID, tombstonedID})
+
+					rt1BodyBytes, err := rt1Doc.BodyBytes(rt1.Context())
+					require.NoError(t, err)
+
+					// add doc for some replication activity on push to assert that remote doesn't change after remote wins conflict res is done
+					newDocVersion := rt1.PutDoc("newdoc", `{"channels": ["alice"]}`)
+					rt2.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt2
+
+					// assert passive side doc hasn't changed
+					rt2Doc := rt2.GetDocument(docID)
+					rest.RequireDocVersionEqual(t, upgradedDocVersion, rt2Doc.ExtractDocVersion())
+					rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, upgradedDocVersion.RevTreeID})
+
+					// assert that the body is as expected each side
+					rt2BodyBytes, err := rt2Doc.BodyBytes(rt2.Context())
+					require.NoError(t, err)
+					require.JSONEq(t, expectedBody, string(rt1BodyBytes))
+					require.JSONEq(t, expectedBody, string(rt2BodyBytes))
+
+					// update doc on active side to ensure we can push with no conflict
+					updateVer := rt1.UpdateDoc(docID, upgradedDocVersion, `{"channels": ["alice"], "source": "rt1-updated"}`)
+					rt2.WaitForVersion(docID, updateVer)
+				}
 			})
-			require.NoError(t, err)
-			defer func() {
-				require.NoError(t, ar.Stop())
-			}()
-
-			// Start the replicator
-			require.NoError(t, ar.Start(ctx1))
-
-			if tc.activePeerHasPostUpgradeVersion {
-				base.RequireWaitForStat(t, func() int64 {
-					return replicationStats.ConflictResolvedLocalCount.Value()
-				}, 1)
-				replicatedDoc := rt1.GetDocument(docID)
-				verPostConflictRes := replicatedDoc.ExtractDocVersion()
-				// wait for this resolution to be pushed back to passive peer
-				rt2.WaitForVersion(docID, verPostConflictRes)
-
-				// assert original upgraded version in PV history
-				assert.Equal(t, upgradedDocVersion.CV.Value, replicatedDoc.HLV.PreviousVersions[upgradedDocVersion.CV.SourceID])
-
-				rt2Doc := rt2.GetDocument(docID)
-				rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, legacyRevRT2, verPostConflictRes.RevTreeID})
-				// assert that original upgraded version is in HLV pv on passive too
-				assert.Equal(t, upgradedDocVersion.CV.Value, rt2Doc.HLV.PreviousVersions[upgradedDocVersion.CV.SourceID])
-
-				rt2BodyBytes, err := rt2Doc.BodyBytes(rt2.Context())
-				require.NoError(t, err)
-
-				// add doc for some replication activity on pull to assert that local doesn't change after remote is written with legacy CV
-				newDocVersion := rt2.PutDoc("newdoc", `{"channels": ["alice"]}`)
-				rt1.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt1
-
-				// assert active side doc hasn't changed
-				rt1Doc := rt1.GetDocument(docID)
-				rest.RequireDocVersionEqual(t, verPostConflictRes, rt1Doc.ExtractDocVersion())
-				tombstonedID := db.CreateRevIDWithBytes(3, legacyRevRT1, []byte(db.DeletedDocument)) // create what would be the tombstone rev id for local branch
-				rest.RequireHistoryContains(t, rt1Doc.History, []string{legacyRevRT1, initLegacyRevRT1, verPostConflictRes.RevTreeID, legacyRevRT2, tombstonedID})
-
-				// assert that the body is as expected each side
-				rt1BodyBytes, err := rt1Doc.BodyBytes(rt1.Context())
-				require.NoError(t, err)
-				require.JSONEq(t, expectedBody, string(rt1BodyBytes))
-				require.JSONEq(t, expectedBody, string(rt2BodyBytes))
-			} else {
-				base.RequireWaitForStat(t, func() int64 {
-					return replicationStats.ConflictResolvedRemoteCount.Value()
-				}, 1)
-				rt1.WaitForVersion(docID, upgradedDocVersion)
-
-				rt1Doc := rt1.GetDocument(docID)
-				tombstonedID := db.CreateRevIDWithBytes(3, legacyRevRT1, []byte(db.DeletedDocument)) // create what would be the tombstone rev id for local branch
-				rest.RequireHistoryContains(t, rt1Doc.History, []string{initLegacyRevRT1, legacyRevRT1, upgradedDocVersion.RevTreeID, tombstonedID})
-
-				rt1BodyBytes, err := rt1Doc.BodyBytes(rt1.Context())
-				require.NoError(t, err)
-
-				// add doc for some replication activity on push to assert that remote doesn't change after remote wins conflict res is done
-				newDocVersion := rt1.PutDoc("newdoc", `{"channels": ["alice"]}`)
-				rt2.WaitForVersion("newdoc", newDocVersion) // wait for it to arrive at rt2
-
-				// assert passive side doc hasn't changed
-				rt2Doc := rt2.GetDocument(docID)
-				rest.RequireDocVersionEqual(t, upgradedDocVersion, rt2Doc.ExtractDocVersion())
-				rest.RequireHistoryContains(t, rt2Doc.History, []string{initLegacyRevRT2, upgradedDocVersion.RevTreeID})
-
-				// assert that the body is as expected each side
-				rt2BodyBytes, err := rt2Doc.BodyBytes(rt2.Context())
-				require.NoError(t, err)
-				require.JSONEq(t, expectedBody, string(rt1BodyBytes))
-				require.JSONEq(t, expectedBody, string(rt2BodyBytes))
-
-				// update doc on active side to ensure we can push with no conflict
-				updateVer := rt1.UpdateDoc(docID, upgradedDocVersion, `{"channels": ["alice"], "source": "rt1-updated"}`)
-				rt2.WaitForVersion(docID, updateVer)
-			}
-		})
-	}
+		}
+	})
 }
 
 func TestActiveReplicatorDeltaSyncWhenBothSidesLegacy(t *testing.T) {
@@ -1104,88 +1005,85 @@ func TestActiveReplicatorDeltaSyncWhenBothSidesLegacy(t *testing.T) {
 	}
 
 	const username = "alice"
-
-	// Passive (SGW2 in diagram above)
-	rt2 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "passivedb",
-				DeltaSync: &rest.DeltaSyncConfig{
-					Enabled: base.Ptr(true),
-				},
-			}},
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UserChannelAccess: []string{username},
+			ActiveRestTesterConfig: &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					Name: "activedb",
+					DeltaSync: &rest.DeltaSyncConfig{
+						Enabled: base.Ptr(true),
+					},
+				}},
+			},
+			PassiveRestTesterConfig: &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					Name: "passivedb",
+					DeltaSync: &rest.DeltaSyncConfig{
+						Enabled: base.Ptr(true),
+					},
+				}},
+			},
 		})
-	defer rt2.Close()
+		ctx1 := rt1.Context()
 
-	rt2.CreateUser(username, []string{username})
+		docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
 
-	// Active (SGW1 in diagram above)
-	rt1 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "activedb",
-				DeltaSync: &rest.DeltaSyncConfig{
-					Enabled: base.Ptr(true),
-				},
-			}},
+		// create doc on rt1 with one revision
+		bodyRT1 := db.Body{"channels": []string{username}, "source": "rt1"}
+		rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
+		legacyInitRevRt1 := rt1InitDoc.GetRevTreeID()
+		// create another rev to ensure we have a rev to delta from
+		bodyRT1 = db.Body{db.BodyRev: legacyInitRevRt1, "channels": []string{username}, "source": "rt1"}
+		rt1InitDoc = rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
+		legacyRevRt1 := rt1InitDoc.GetRevTreeID()
+
+		// create rev on rt2 that will resolve to same revID as rev one above simulating the following:
+		// 1. doc created on rt1, pushed to rt2
+		// 2. doc updated on rt1 to create rev2, but upgrade happens before being pushed to rt2
+		// 3. doc is pushed post upgrade to rt2 and the delta from rev1 to rev2 is sent
+		bodyRT2 := db.Body{"channels": []string{username}, "source": "rt1"}
+		rt2InitDoc := rt2.CreateDocNoHLV(docIDToPush, bodyRT2)
+		legacyRevRt2 := rt2InitDoc.GetRevTreeID()
+
+		require.Equal(t, legacyInitRevRt1, legacyRevRt2)
+
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		require.NoError(t, err)
+		replicationStats, err := stats.DBReplicatorStats(t.Name())
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          t.Name(),
+			Direction:   db.ActiveReplicatorTypePush,
+			RemoteDBURL: userDBURL(rt2, username),
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    replicationStats,
+			CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+			DeltasEnabled:          true,
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, ar.Stop())
+		}()
 
-	docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
 
-	// create doc on rt1 with one revision
-	bodyRT1 := db.Body{"channels": []string{username}, "source": "rt1"}
-	rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
-	legacyInitRevRt1 := rt1InitDoc.GetRevTreeID()
-	// create another rev to ensure we have a rev to delta from
-	bodyRT1 = db.Body{db.BodyRev: legacyInitRevRt1, "channels": []string{username}, "source": "rt1"}
-	rt1InitDoc = rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
-	legacyRevRt1 := rt1InitDoc.GetRevTreeID()
+		rt2.WaitForLegacyRev(docIDToPush, legacyRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
 
-	// create rev on rt2 that will resolve to same revID as rev one above simulating the following:
-	// 1. doc created on rt1, pushed to rt2
-	// 2. doc updated on rt1 to create rev2, but upgrade happens before being pushed to rt2
-	// 3. doc is pushed post upgrade to rt2 and the delta from rev1 to rev2 is sent
-	bodyRT2 := db.Body{"channels": []string{username}, "source": "rt1"}
-	rt2InitDoc := rt2.CreateDocNoHLV(docIDToPush, bodyRT2)
-	legacyRevRt2 := rt2InitDoc.GetRevTreeID()
-
-	require.Equal(t, legacyInitRevRt1, legacyRevRt2)
-
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	replicationStats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePush,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:    200,
-		Continuous:          true,
-		ReplicationStatsMap: replicationStats,
-		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
-		DeltasEnabled:       true,
+		base.RequireWaitForStat(t, func() int64 {
+			return replicationStats.PushDeltaSentCount.Value()
+		}, 1)
 	})
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, ar.Stop())
-	}()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	rt2.WaitForLegacyRev(docIDToPush, legacyRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
-
-	base.RequireWaitForStat(t, func() int64 {
-		return replicationStats.PushDeltaSentCount.Value()
-	}, 1)
 }
 
 func TestDeltaSyncWhenOneSideHasEncodedCV(t *testing.T) {
@@ -1196,82 +1094,79 @@ func TestDeltaSyncWhenOneSideHasEncodedCV(t *testing.T) {
 	}
 
 	const username = "alice"
-
-	// Passive (SGW2 in diagram above)
-	rt2 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "passivedb",
-				DeltaSync: &rest.DeltaSyncConfig{
-					Enabled: base.Ptr(true),
-				},
-			}},
+	sgrRunner := rest.NewSGRTestRunner(t)
+	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
+		rt1, rt2, _ := sgrRunner.SetupSGRPeersWithOptions(t, rest.TestISGRPeerOpts{
+			UserChannelAccess: []string{username},
+			ActiveRestTesterConfig: &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					Name: "activedb",
+					DeltaSync: &rest.DeltaSyncConfig{
+						Enabled: base.Ptr(true),
+					},
+				}},
+			},
+			PassiveRestTesterConfig: &rest.RestTesterConfig{
+				SyncFn: channels.DocChannelsSyncFunction,
+				DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
+					Name: "passivedb",
+					DeltaSync: &rest.DeltaSyncConfig{
+						Enabled: base.Ptr(true),
+					},
+				}},
+			},
 		})
-	defer rt2.Close()
+		ctx1 := rt1.Context()
 
-	rt2.CreateUser(username, []string{username})
+		docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
 
-	// Active (SGW1 in diagram above)
-	rt1 := rest.NewRestTester(t,
-		&rest.RestTesterConfig{
-			SyncFn: channels.DocChannelsSyncFunction,
-			DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
-				Name: "activedb",
-				DeltaSync: &rest.DeltaSyncConfig{
-					Enabled: base.Ptr(true),
-				},
-			}},
+		// create doc on rt1 with one revision
+		bodyRT1 := db.Body{"channels": []string{username}, "source": "rt1"}
+		rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
+		legacyInitRevRt1 := rt1InitDoc.GetRevTreeID()
+
+		stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
+		require.NoError(t, err)
+		replicationStats, err := stats.DBReplicatorStats(t.Name())
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          t.Name(),
+			Direction:   db.ActiveReplicatorTypePush,
+			RemoteDBURL: userDBURL(rt2, username),
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			ChangesBatchSize:       200,
+			Continuous:             true,
+			ReplicationStatsMap:    replicationStats,
+			CollectionsEnabled:     !rt1.GetDatabase().OnlyDefaultCollection(),
+			DeltasEnabled:          true,
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, ar.Stop())
+		}()
 
-	docIDToPush := rest.SafeDocumentName(t, t.Name()+"_push")
+		// Start the replicator
+		require.NoError(t, ar.Start(ctx1))
 
-	// create doc on rt1 with one revision
-	bodyRT1 := db.Body{"channels": []string{username}, "source": "rt1"}
-	rt1InitDoc := rt1.CreateDocNoHLV(docIDToPush, bodyRT1)
-	legacyInitRevRt1 := rt1InitDoc.GetRevTreeID()
+		rt2.WaitForLegacyRev(docIDToPush, legacyInitRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
 
-	stats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	replicationStats, err := stats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		// flush revision cache to remove old reference to rev 1 in rev cache
+		rt1.GetDatabase().FlushRevisionCacheForTest()
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePush,
-		RemoteDBURL: userDBURL(rt2, username),
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize:    200,
-		Continuous:          true,
-		ReplicationStatsMap: replicationStats,
-		CollectionsEnabled:  !rt1.GetDatabase().OnlyDefaultCollection(),
-		DeltasEnabled:       true,
+		// update doc on rt1 to create a second revision with HLV
+		// This should:
+		// 1. update doc on rt1 to give HLV based of rt1 sourceID
+		// 2. push doc to rt2 with delta from rev1 to rev2
+		upgradeVersion := rt1.UpdateDoc(docIDToPush, db.DocVersion{RevTreeID: legacyInitRevRt1}, `{"channels": ["alice"], "source": "rt1-updated"}`)
+		rt1.WaitForVersion(docIDToPush, upgradeVersion)
+
+		base.RequireWaitForStat(t, func() int64 {
+			return replicationStats.PushDeltaSentCount.Value()
+		}, 1)
 	})
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, ar.Stop())
-	}()
-
-	// Start the replicator
-	require.NoError(t, ar.Start(ctx1))
-
-	rt2.WaitForLegacyRev(docIDToPush, legacyInitRevRt1, []byte(`{"source":"rt1","channels":["alice"]}`))
-
-	// flush revision cache to remove old reference to rev 1 in rev cache
-	rt1.GetDatabase().FlushRevisionCacheForTest()
-
-	// update doc on rt1 to create a second revision with HLV
-	// This should:
-	// 1. update doc on rt1 to give HLV based of rt1 sourceID
-	// 2. push doc to rt2 with delta from rev1 to rev2
-	upgradeVersion := rt1.UpdateDoc(docIDToPush, db.DocVersion{RevTreeID: legacyInitRevRt1}, `{"channels": ["alice"], "source": "rt1-updated"}`)
-	rt1.WaitForVersion(docIDToPush, upgradeVersion)
-
-	base.RequireWaitForStat(t, func() int64 {
-		return replicationStats.PushDeltaSentCount.Value()
-	}, 1)
 }

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1502,326 +1501,345 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 func TestReplicatorRevocations(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	// Passive
-	revocationTester, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		revocationTester, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
 
-	// Active
-	rt1 := NewRestTester(t,
-		&RestTesterConfig{
-			CustomTestBucket: base.GetTestBucket(t),
-			SyncFn:           channels.DocChannelsSyncFunction,
+		// Active
+		rt1 := NewRestTester(t,
+			&RestTesterConfig{
+				CustomTestBucket: base.GetTestBucket(t),
+				SyncFn:           channels.DocChannelsSyncFunction,
+			})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		revocationTester.addRole("user", "foo")
+		revocationTester.addRoleChannel("foo", "chanA")
+
+		resp := rt2.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "chanA"}`)
+		RequireStatus(t, resp, http.StatusCreated)
+
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/db")
+		require.NoError(t, err)
+
+		passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
+		id := SafeDocumentName(t, t.Name())
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             false,
+			PurgeOnRemoval:         true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
 
-	revocationTester.addRole("user", "foo")
-	revocationTester.addRoleChannel("foo", "chanA")
+		require.NoError(t, ar.Start(ctx1))
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	resp := rt2.SendAdminRequest("PUT", "/{{.keyspace}}/doc1", `{"channels": "chanA"}`)
-	RequireStatus(t, resp, http.StatusCreated)
+		resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
+		RequireStatus(t, resp, http.StatusOK)
 
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+		revocationTester.removeRole("user", "foo")
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
+		require.NoError(t, ar.Start(ctx1))
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          false,
-		PurgeOnRemoval:      true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
+		resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
+		RequireStatus(t, resp, http.StatusNotFound)
 	})
-	require.NoError(t, err)
-
-	require.NoError(t, ar.Start(ctx1))
-	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
-
-	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
-	RequireStatus(t, resp, http.StatusOK)
-
-	revocationTester.removeRole("user", "foo")
-
-	require.NoError(t, ar.Start(ctx1))
-	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
-
-	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
-	RequireStatus(t, resp, http.StatusNotFound)
 }
 
 func TestReplicatorRevocationsNoRev(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	// Passive
-	revocationTester, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		revocationTester, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
 
-	// Active
-	rt1 := NewRestTester(t,
-		&RestTesterConfig{
-			CustomTestBucket: base.GetTestBucket(t),
-			SyncFn:           channels.DocChannelsSyncFunction,
+		// Active
+		rt1 := NewRestTester(t,
+			&RestTesterConfig{
+				CustomTestBucket: base.GetTestBucket(t),
+				SyncFn:           channels.DocChannelsSyncFunction,
+			})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		revocationTester.addRole("user", "foo")
+		revocationTester.addRoleChannel("foo", "chanA")
+
+		const doc1ID = "doc1"
+		doc1Version := rt2.PutDoc(doc1ID, `{"channels": "chanA"}`)
+		rt2.WaitForPendingChanges()
+
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/db")
+		require.NoError(t, err)
+
+		passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
+		id := SafeDocumentName(t, t.Name())
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             false,
+			PurgeOnRemoval:         true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
 
-	revocationTester.addRole("user", "foo")
-	revocationTester.addRoleChannel("foo", "chanA")
+		require.NoError(t, ar.Start(ctx1))
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	const doc1ID = "doc1"
-	doc1Version := rt2.PutDoc(doc1ID, `{"channels": "chanA"}`)
-	rt2.WaitForPendingChanges()
+		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
+		RequireStatus(t, resp, http.StatusOK)
 
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+		revocationTester.removeRole("user", "foo")
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
+		_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": "chanA", "mutate": "val"}`)
+		rt2.WaitForPendingChanges()
 
-	passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		require.NoError(t, ar.Start(ctx1))
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          false,
-		PurgeOnRemoval:      true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
+		resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
+		RequireStatus(t, resp, http.StatusNotFound)
 	})
-	require.NoError(t, err)
-
-	require.NoError(t, ar.Start(ctx1))
-	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
-
-	resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
-	RequireStatus(t, resp, http.StatusOK)
-
-	revocationTester.removeRole("user", "foo")
-
-	_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": "chanA", "mutate": "val"}`)
-	rt2.WaitForPendingChanges()
-
-	require.NoError(t, ar.Start(ctx1))
-	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
-
-	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
-	RequireStatus(t, resp, http.StatusNotFound)
 }
 
 func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	// Passive
-	revocationTester, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		revocationTester, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
 
-	// Active
-	rt1 := NewRestTester(t,
-		&RestTesterConfig{
-			CustomTestBucket: base.GetTestBucket(t),
-			SyncFn:           channels.DocChannelsSyncFunction,
+		// Active
+		rt1 := NewRestTester(t,
+			&RestTesterConfig{
+				CustomTestBucket: base.GetTestBucket(t),
+				SyncFn:           channels.DocChannelsSyncFunction,
+			})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		revocationTester.addRole("user", "foo")
+		revocationTester.addRoleChannel("foo", "chanA")
+
+		resp := rt2.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
+		RequireStatus(t, resp, http.StatusCreated)
+
+		revocationTester.addRole("user", "foo2")
+		revocationTester.addRoleChannel("foo2", "chanB")
+
+		const doc1ID = "doc1"
+		doc1Version := rt2.PutDoc(doc1ID, `{"channels": ["chanA", "chanB"]}`)
+		rt2.WaitForPendingChanges()
+
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/db")
+		require.NoError(t, err)
+
+		passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
+		id := SafeDocumentName(t, t.Name())
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             false,
+			PurgeOnRemoval:         true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
 
-	revocationTester.addRole("user", "foo")
-	revocationTester.addRoleChannel("foo", "chanA")
+		require.NoError(t, ar.Start(ctx1))
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	resp := rt2.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
-	RequireStatus(t, resp, http.StatusCreated)
+		resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
+		RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.addRole("user", "foo2")
-	revocationTester.addRoleChannel("foo2", "chanB")
+		revocationTester.removeRole("user", "foo")
 
-	const doc1ID = "doc1"
-	doc1Version := rt2.PutDoc(doc1ID, `{"channels": ["chanA", "chanB"]}`)
-	rt2.WaitForPendingChanges()
+		_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": ["chanA", "chanB"], "mutate": "val"}`)
+		rt2.WaitForPendingChanges()
 
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+		require.NoError(t, ar.Start(ctx1))
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
-
-	passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          false,
-		PurgeOnRemoval:      true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
+		resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
+		RequireStatus(t, resp, http.StatusOK)
 	})
-	require.NoError(t, err)
-
-	require.NoError(t, ar.Start(ctx1))
-	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
-
-	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
-	RequireStatus(t, resp, http.StatusOK)
-
-	revocationTester.removeRole("user", "foo")
-
-	_ = rt2.UpdateDoc(doc1ID, doc1Version, `{"channels": ["chanA", "chanB"], "mutate": "val"}`)
-	rt2.WaitForPendingChanges()
-
-	require.NoError(t, ar.Start(ctx1))
-	rt1.WaitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
-
-	resp = rt1.SendAdminRequest("GET", "/{{.keyspace}}/doc1", "")
-	RequireStatus(t, resp, http.StatusOK)
 }
 
 func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) // CBG-1981
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
-	// Passive
-	revocationTester, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
-	rt2ds := rt2.GetSingleDataStore()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		revocationTester, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
+		rt2ds := rt2.GetSingleDataStore()
 
-	// Active
-	rt1 := NewRestTester(t,
-		&RestTesterConfig{
-			DatabaseConfig: &DatabaseConfig{
-				DbConfig: DbConfig{
-					Name: "active",
+		// Active
+		rt1 := NewRestTester(t,
+			&RestTesterConfig{
+				DatabaseConfig: &DatabaseConfig{
+					DbConfig: DbConfig{
+						Name: "active",
+					},
 				},
+				CustomTestBucket: base.GetTestBucket(t),
+				SyncFn:           channels.DocChannelsSyncFunction,
+				GuestEnabled:     true,
+			})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		// Setup replicator
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/" + rt2.GetDatabase().Name)
+		require.NoError(t, err)
+
+		passiveDBURL.User = url.UserPassword(revocationTestUser, RestTesterDefaultUserPassword)
+		id := SafeDocumentName(t, t.Name())
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		revocationTester.addRole(revocationTestUser, revocationTestRole)
+		rt2.WaitForPendingChanges()
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
 			},
-			CustomTestBucket: base.GetTestBucket(t),
-			SyncFn:           channels.DocChannelsSyncFunction,
-			GuestEnabled:     true,
+			Continuous:             true,
+			PurgeOnRemoval:         true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
+		require.NoError(t, ar.Start(ctx1))
 
-	// Setup replicator
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+		defer func() {
+			require.NoError(t, ar.Stop())
+		}()
 
-	passiveDBURL, err := url.Parse(srv.URL + "/" + rt2.GetDatabase().Name)
-	require.NoError(t, err)
+		// perform role grant to allow for all channels
+		resp := rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A", "B", "C"}))
 
-	passiveDBURL.User = url.UserPassword(revocationTestUser, RestTesterDefaultUserPassword)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
+		RequireStatus(t, resp, http.StatusOK)
+		_ = rt2.PutDoc("docAB", `{"channels": ["A", "B"]}`)
+		RequireStatus(t, resp, http.StatusOK)
+		_ = rt2.PutDoc("docB", `{"channels": ["B"]}`)
+		RequireStatus(t, resp, http.StatusOK)
+		_ = rt2.PutDoc("docABC", `{"channels": ["A", "B", "C"]}`)
+		RequireStatus(t, resp, http.StatusOK)
+		_ = rt2.PutDoc("docC", `{"channels": ["C"]}`)
+		RequireStatus(t, resp, http.StatusOK)
 
-	revocationTester.addRole(revocationTestUser, revocationTestRole)
-	rt2.WaitForPendingChanges()
+		// Wait for docs to turn up on local / rt1
+		rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          true,
-		PurgeOnRemoval:      true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
+		// Revoke C and ensure docC gets purged from local
+		resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A", "B"}))
+		RequireStatus(t, resp, http.StatusOK)
+		rt2.WaitForPendingChanges()
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docC", "")
+			return resp.Code == http.StatusNotFound
+		})
+		require.NoError(t, err)
+
+		// Revoke B and ensure docB gets purged from local
+		resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A"}))
+		RequireStatus(t, resp, http.StatusOK)
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docB", "")
+			return resp.Code == http.StatusNotFound
+		})
+		require.NoError(t, err)
+
+		// Revoke A and ensure docA, docAB, docABC gets purged from local
+		resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{}))
+		RequireStatus(t, resp, http.StatusOK)
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
+			return resp.Code == http.StatusNotFound
+		})
+		require.NoError(t, err)
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docAB", "")
+			return resp.Code == http.StatusNotFound
+		})
+		require.NoError(t, err)
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docABC", "")
+			return resp.Code == http.StatusNotFound
+		})
+		require.NoError(t, err)
 	})
-	require.NoError(t, err)
-	require.NoError(t, ar.Start(ctx1))
-
-	defer func() {
-		assert.NoError(t, ar.Stop())
-	}()
-
-	// perform role grant to allow for all channels
-	resp := rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A", "B", "C"}))
-
-	_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
-	RequireStatus(t, resp, http.StatusOK)
-	_ = rt2.PutDoc("docAB", `{"channels": ["A", "B"]}`)
-	RequireStatus(t, resp, http.StatusOK)
-	_ = rt2.PutDoc("docB", `{"channels": ["B"]}`)
-	RequireStatus(t, resp, http.StatusOK)
-	_ = rt2.PutDoc("docABC", `{"channels": ["A", "B", "C"]}`)
-	RequireStatus(t, resp, http.StatusOK)
-	_ = rt2.PutDoc("docC", `{"channels": ["C"]}`)
-	RequireStatus(t, resp, http.StatusOK)
-
-	// Wait for docs to turn up on local / rt1
-	rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
-
-	// Revoke C and ensure docC gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A", "B"}))
-	RequireStatus(t, resp, http.StatusOK)
-	rt2.WaitForPendingChanges()
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docC", "")
-		return resp.Code == http.StatusNotFound
-	})
-	require.NoError(t, err)
-
-	// Revoke B and ensure docB gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{"A"}))
-	RequireStatus(t, resp, http.StatusOK)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docB", "")
-		return resp.Code == http.StatusNotFound
-	})
-	require.NoError(t, err)
-
-	// Revoke A and ensure docA, docAB, docABC gets purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_role/"+revocationTestRole, GetRolePayload(t, "", rt2ds, []string{}))
-	RequireStatus(t, resp, http.StatusOK)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-		return resp.Code == http.StatusNotFound
-	})
-	require.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docAB", "")
-		return resp.Code == http.StatusNotFound
-	})
-	require.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docABC", "")
-		return resp.Code == http.StatusNotFound
-	})
-	require.NoError(t, err)
-
 }
 
 func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
@@ -1829,172 +1847,182 @@ func TestReplicatorRevocationsWithTombstoneResurrection(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	// Passive
-	_, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
-	rt2ds := rt2.GetSingleDataStore()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		_, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
+		rt2ds := rt2.GetSingleDataStore()
 
-	// Active
-	rt1 := NewRestTester(t,
-		&RestTesterConfig{
-			CustomTestBucket: base.GetTestBucket(t),
-			SyncFn:           channels.DocChannelsSyncFunction,
+		// Active
+		rt1 := NewRestTester(t,
+			&RestTesterConfig{
+				CustomTestBucket: base.GetTestBucket(t),
+				SyncFn:           channels.DocChannelsSyncFunction,
+			})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"A", "B"}, nil))
+		RequireStatus(t, resp, http.StatusOK)
+
+		// Setup replicator
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/db")
+		require.NoError(t, err)
+
+		passiveDBURL.User = url.UserPassword("user", "letmein")
+		id := SafeDocumentName(t, t.Name())
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             true,
+			PurgeOnRemoval:         true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
 
-	resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"A", "B"}, nil))
-	RequireStatus(t, resp, http.StatusOK)
+		const docAID = "docA"
+		const docA1ID = "docA1"
+		docAVersion := rt2.PutDoc(docAID, `{"channels": ["A"]}`)
+		docA1Version := rt2.PutDoc(docA1ID, `{"channels": ["A"]}`)
+		_ = rt2.PutDoc("docA2", `{"channels": ["A"]}`)
 
-	// Setup replicator
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+		_ = rt2.PutDoc("docB", `{"channels": ["B"]}`)
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
+		require.NoError(t, ar.Start(ctx1))
 
-	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		rt1.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          true,
-		PurgeOnRemoval:      true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
+		require.NoError(t, ar.Stop())
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
+
+		rt2.DeleteDoc(docAID, docAVersion)
+		rt2.DeleteDoc(docA1ID, docA1Version)
+
+		resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"B"}, nil))
+		RequireStatus(t, resp, http.StatusOK)
+
+		require.NoError(t, ar.Start(ctx1))
+
+		defer func() {
+			assert.NoError(t, ar.Stop())
+		}()
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
 	})
-	require.NoError(t, err)
-
-	const docAID = "docA"
-	const docA1ID = "docA1"
-	docAVersion := rt2.PutDoc(docAID, `{"channels": ["A"]}`)
-	docA1Version := rt2.PutDoc(docA1ID, `{"channels": ["A"]}`)
-	_ = rt2.PutDoc("docA2", `{"channels": ["A"]}`)
-
-	_ = rt2.PutDoc("docB", `{"channels": ["B"]}`)
-
-	require.NoError(t, ar.Start(ctx1))
-
-	rt1.WaitForChanges(4, "/{{.keyspace}}/_changes?since=0", "", true)
-
-	require.NoError(t, ar.Stop())
-	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-
-	rt2.DeleteDoc(docAID, docAVersion)
-	rt2.DeleteDoc(docA1ID, docA1Version)
-
-	resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"B"}, nil))
-	RequireStatus(t, resp, http.StatusOK)
-
-	require.NoError(t, ar.Start(ctx1))
-
-	defer func() {
-		assert.NoError(t, ar.Stop())
-	}()
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
 }
 
 func TestReplicatorRevocationsWithChannelFilter(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
 
-	// Passive
-	_, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
-	rt2ds := rt2.GetSingleDataStore()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		_, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
+		rt2ds := rt2.GetSingleDataStore()
 
-	// Active
-	rt1 := NewRestTester(t, &RestTesterConfig{
-		SyncFn: channels.DocChannelsSyncFunction,
+		// Active
+		rt1 := NewRestTester(t, &RestTesterConfig{
+			SyncFn: channels.DocChannelsSyncFunction,
+		})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		// Setup replicator
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/db")
+		require.NoError(t, err)
+		const (
+			username = "user"
+			password = RestTesterDefaultUserPassword
+		)
+
+		id := SafeDocumentName(t, t.Name())
+		passiveDBURL.User = url.UserPassword(username, password)
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		_ = rt2.PutDoc("docA", `{"channels": ["ABC"]}`)
+		rt2.WaitForPendingChanges()
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             false,
+			PurgeOnRemoval:         true,
+			FilterChannels:         []string{"ABC"},
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+
+		resp := rt2.SendAdminRequest("PUT", "/{{.db}}/_user/user", GetUserPayload(t, username, password, "", rt2ds, []string{"ABC"}, nil))
+		RequireStatus(t, resp, http.StatusOK)
+
+		rt2.WaitForPendingChanges()
+		require.NoError(t, ar.Start(ctx1))
+
+		defer func() {
+			assert.NoError(t, ar.Stop())
+		}()
+
+		// Wait for docs to turn up on local / rt1
+		rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
+
+		// Revoke A and ensure ABC chanel access and ensure DocA is purged from local
+		resp = rt2.SendAdminRequest("PUT", "/{{.db}}/_user/user", GetUserPayload(t, username, password, "", rt2ds, []string{}, nil))
+		RequireStatus(t, resp, http.StatusOK)
+
+		require.NoError(t, ar.Stop())
+
+		require.NoError(t, ar.Start(ctx1))
+
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
 	})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
-
-	// Setup replicator
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
-
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
-	const (
-		username = "user"
-		password = RestTesterDefaultUserPassword
-	)
-
-	passiveDBURL.User = url.UserPassword(username, password)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
-
-	_ = rt2.PutDoc("docA", `{"channels": ["ABC"]}`)
-	rt2.WaitForPendingChanges()
-
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          false,
-		PurgeOnRemoval:      true,
-		FilterChannels:      []string{"ABC"},
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
-	})
-	require.NoError(t, err)
-
-	resp := rt2.SendAdminRequest("PUT", "/{{.db}}/_user/user", GetUserPayload(t, username, password, "", rt2ds, []string{"ABC"}, nil))
-	RequireStatus(t, resp, http.StatusOK)
-
-	rt2.WaitForPendingChanges()
-	require.NoError(t, ar.Start(ctx1))
-
-	defer func() {
-		assert.NoError(t, ar.Stop())
-	}()
-
-	// Wait for docs to turn up on local / rt1
-	rt1.WaitForChanges(1, "/{{.keyspace}}/_changes?since=0", "", true)
-
-	// Revoke A and ensure ABC chanel access and ensure DocA is purged from local
-	resp = rt2.SendAdminRequest("PUT", "/{{.db}}/_user/user", GetUserPayload(t, username, password, "", rt2ds, []string{}, nil))
-	RequireStatus(t, resp, http.StatusOK)
-
-	require.NoError(t, ar.Stop())
-
-	require.NoError(t, ar.Start(ctx1))
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
 }
 
 func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
@@ -2002,92 +2030,97 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) // CBG-1981
 
-	// Passive
-	_, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
-	rt2ds := rt2.GetSingleDataStore()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		_, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
+		rt2ds := rt2.GetSingleDataStore()
 
-	// Active
-	rt1 := NewRestTester(t,
-		&RestTesterConfig{
-			CustomTestBucket: base.GetTestBucket(t),
-			SyncFn:           channels.DocChannelsSyncFunction,
+		// Active
+		rt1 := NewRestTester(t,
+			&RestTesterConfig{
+				CustomTestBucket: base.GetTestBucket(t),
+				SyncFn:           channels.DocChannelsSyncFunction,
+			})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		// Setup replicator
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/db")
+		require.NoError(t, err)
+
+		passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
+		id := SafeDocumentName(t, t.Name())
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
+		_ = rt2.PutDoc("docAB", `{"channels": ["A","B"]}`)
+		_ = rt2.PutDoc("docB", `{"channels": ["B"]}`)
+		_ = rt2.PutDoc("docABC", `{"channels": ["A","B", "C"]}`)
+		_ = rt2.PutDoc("docC", `{"channels": ["C"]}`)
+		rt2.WaitForPendingChanges()
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             false,
+			PurgeOnRemoval:         true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
 
-	// Setup replicator
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+		resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", RestTesterDefaultUserPassword, "", rt2ds, []string{"*"}, nil))
+		RequireStatus(t, resp, http.StatusOK)
+		rt2.WaitForPendingChanges()
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
+		require.NoError(t, ar.Start(ctx1))
 
-	passiveDBURL.User = url.UserPassword("user", RestTesterDefaultUserPassword)
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, ar.Stop())
+		}()
 
-	_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
-	_ = rt2.PutDoc("docAB", `{"channels": ["A","B"]}`)
-	_ = rt2.PutDoc("docB", `{"channels": ["B"]}`)
-	_ = rt2.PutDoc("docABC", `{"channels": ["A","B", "C"]}`)
-	_ = rt2.PutDoc("docC", `{"channels": ["C"]}`)
-	rt2.WaitForPendingChanges()
+		// Wait for docs to turn up on local / rt1
+		rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          false,
-		PurgeOnRemoval:      true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
-	})
-	require.NoError(t, err)
+		// Revoke A and ensure docA, docAB, docABC get purged from local
+		resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", RestTesterDefaultUserPassword, "", rt2ds, []string{}, nil))
+		RequireStatus(t, resp, http.StatusOK)
 
-	resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", RestTesterDefaultUserPassword, "", rt2ds, []string{"*"}, nil))
-	RequireStatus(t, resp, http.StatusOK)
-	rt2.WaitForPendingChanges()
-
-	require.NoError(t, ar.Start(ctx1))
-
-	defer func() {
 		assert.NoError(t, ar.Stop())
-	}()
 
-	// Wait for docs to turn up on local / rt1
-	rt1.WaitForChanges(5, "/{{.keyspace}}/_changes?since=0", "", true)
+		require.NoError(t, ar.Start(ctx1))
 
-	// Revoke A and ensure docA, docAB, docABC get purged from local
-	resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", RestTesterDefaultUserPassword, "", rt2ds, []string{}, nil))
-	RequireStatus(t, resp, http.StatusOK)
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
 
-	assert.NoError(t, ar.Stop())
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docAB", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
 
-	require.NoError(t, ar.Start(ctx1))
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-		return resp.Code == http.StatusNotFound
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docABC", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
 	})
-	assert.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docAB", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docABC", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
 }
 
 func TestReplicatorRevocationsFromZero(t *testing.T) {
@@ -2095,109 +2128,114 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	// Passive
-	_, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
-	rt2ds := rt2.GetSingleDataStore()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		_, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
+		rt2ds := rt2.GetSingleDataStore()
 
-	// Active
-	rt1 := NewRestTester(t,
-		&RestTesterConfig{
-			CustomTestBucket: base.GetTestBucket(t),
-			SyncFn:           channels.DocChannelsSyncFunction,
+		// Active
+		rt1 := NewRestTester(t,
+			&RestTesterConfig{
+				CustomTestBucket: base.GetTestBucket(t),
+				SyncFn:           channels.DocChannelsSyncFunction,
+			})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"A", "B"}, nil))
+		RequireStatus(t, resp, http.StatusOK)
+
+		// Setup replicator
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/db")
+		require.NoError(t, err)
+
+		passiveDBURL.User = url.UserPassword("user", "letmein")
+		id := SafeDocumentName(t, t.Name())
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		activeReplCfg := &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             false,
+			PurgeOnRemoval:         true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		}
+
+		ar, err := db.NewActiveReplicator(ctx1, activeReplCfg)
+		require.NoError(t, err)
+
+		_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
+		_ = rt2.PutDoc("docA1", `{"channels": ["A"]}`)
+		_ = rt2.PutDoc("docA2", `{"channels": ["A"]}`)
+		rt2.WaitForPendingChanges()
+
+		require.NoError(t, ar.Start(ctx1))
+
+		rt1.WaitForChanges(3, "/{{.keyspace}}/_changes?since=0", "", true)
+
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
+
+		// Be sure docs have arrived
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
+			return resp.Code == http.StatusOK
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		assert.NoError(t, err)
 
-	resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"A", "B"}, nil))
-	RequireStatus(t, resp, http.StatusOK)
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
+			return resp.Code == http.StatusOK
+		})
+		assert.NoError(t, err)
 
-	// Setup replicator
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
+			return resp.Code == http.StatusOK
+		})
+		assert.NoError(t, err)
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
+		// Reset checkpoint (since 0)
+		require.NoError(t, ar.Reset())
 
-	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"B"}, nil))
+		RequireStatus(t, resp, http.StatusOK)
 
-	activeReplCfg := &db.ActiveReplicatorConfig{
-		ID:          strings.ReplaceAll(t.Name(), "/", ""),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          false,
-		PurgeOnRemoval:      true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
-	}
+		require.NoError(t, ar.Start(ctx1))
 
-	ar, err := db.NewActiveReplicator(ctx1, activeReplCfg)
-	require.NoError(t, err)
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	_ = rt2.PutDoc("docA", `{"channels": ["A"]}`)
-	_ = rt2.PutDoc("docA1", `{"channels": ["A"]}`)
-	_ = rt2.PutDoc("docA2", `{"channels": ["A"]}`)
-	rt2.WaitForPendingChanges()
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
 
-	require.NoError(t, ar.Start(ctx1))
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
 
-	rt1.WaitForChanges(3, "/{{.keyspace}}/_changes?since=0", "", true)
-
-	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-
-	// Be sure docs have arrived
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-		return resp.Code == http.StatusOK
+		err = rt1.WaitForCondition(func() bool {
+			resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
+			return resp.Code == http.StatusNotFound
+		})
+		assert.NoError(t, err)
 	})
-	assert.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
-		return resp.Code == http.StatusOK
-	})
-	assert.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
-		return resp.Code == http.StatusOK
-	})
-	assert.NoError(t, err)
-
-	// Reset checkpoint (since 0)
-	require.NoError(t, ar.Reset())
-
-	resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"B"}, nil))
-	RequireStatus(t, resp, http.StatusOK)
-
-	require.NoError(t, ar.Start(ctx1))
-
-	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA1", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
-
-	err = rt1.WaitForCondition(func() bool {
-		resp := rt1.SendAdminRequest("GET", "/{{.keyspace}}/docA2", "")
-		return resp.Code == http.StatusNotFound
-	})
-	assert.NoError(t, err)
 }
 
 func TestRevocationMessage(t *testing.T) {
@@ -2488,129 +2526,135 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	// Passive
-	_, rt2 := InitScenario(t, nil)
-	defer rt2.Close()
-	rt2ds := rt2.GetSingleDataStore()
+	sgrRunner := NewSGRTestRunner(t)
+	sgrRunner.Run(func(t *testing.T) {
+		// Passive
+		_, rt2 := InitScenario(t, nil)
+		defer rt2.Close()
+		rt2ds := rt2.GetSingleDataStore()
 
-	// Active
-	rt1 := NewRestTester(t,
-		&RestTesterConfig{
-			CustomTestBucket: base.GetTestBucket(t),
-			SyncFn:           channels.DocChannelsSyncFunction,
+		// Active
+		rt1 := NewRestTester(t,
+			&RestTesterConfig{
+				CustomTestBucket: base.GetTestBucket(t),
+				SyncFn:           channels.DocChannelsSyncFunction,
+			})
+		defer rt1.Close()
+		ctx1 := rt1.Context()
+
+		resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"A", "B"}, nil))
+		RequireStatus(t, resp, http.StatusOK)
+
+		// Setup replicator
+		srv := httptest.NewServer(rt2.TestPublicHandler())
+		defer srv.Close()
+
+		passiveDBURL, err := url.Parse(srv.URL + "/db")
+		require.NoError(t, err)
+
+		passiveDBURL.User = url.UserPassword("user", "letmein")
+		id := SafeDocumentName(t, t.Name())
+		sgwStats, err := base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err := sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
 		})
-	defer rt1.Close()
-	ctx1 := rt1.Context()
+		require.NoError(t, err)
 
-	resp := rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"A", "B"}, nil))
-	RequireStatus(t, resp, http.StatusOK)
+		for i := 0; i < 10; i++ {
+			_ = rt2.PutDoc(fmt.Sprintf("docA%d", i), `{"channels": ["A"]}`)
+		}
 
-	// Setup replicator
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+		for i := 0; i < 7; i++ {
+			_ = rt2.PutDoc(fmt.Sprintf("docB%d", i), `{"channels": ["B"]}`)
+		}
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
+		rt2.WaitForPendingChanges()
 
-	passiveDBURL.User = url.UserPassword("user", "letmein")
-	sgwStats, err := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err := sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
+		require.NoError(t, ar.Start(ctx1))
 
-	ar, err := db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
-	})
-	require.NoError(t, err)
+		changesResults := rt1.WaitForChanges(17, "/{{.keyspace}}/_changes?since=0", "", true)
 
-	for i := 0; i < 10; i++ {
-		_ = rt2.PutDoc(fmt.Sprintf("docA%d", i), `{"channels": ["A"]}`)
-	}
+		// Going to stop & start replication between these actions to make out of order seq no's more likely. More likely
+		// to hit CBG-1591
+		require.NoError(t, ar.Stop())
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 
-	for i := 0; i < 7; i++ {
-		_ = rt2.PutDoc(fmt.Sprintf("docB%d", i), `{"channels": ["B"]}`)
-	}
-
-	rt2.WaitForPendingChanges()
-
-	require.NoError(t, ar.Start(ctx1))
-
-	changesResults := rt1.WaitForChanges(17, "/{{.keyspace}}/_changes?since=0", "", true)
-
-	// Going to stop & start replication between these actions to make out of order seq no's more likely. More likely
-	// to hit CBG-1591
-	require.NoError(t, ar.Stop())
-	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-
-	resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"B"}, nil))
-	RequireStatus(t, resp, http.StatusOK)
-
-	// Add another few docs to 'bump' rt1's seq no. Otherwise it'll end up revoking next time as the above user PUT is
-	// not processed by the rt1 receiver.
-	for i := 7; i < 15; i++ {
-		_ = rt2.PutDoc(fmt.Sprintf("docB%d", i), `{"channels": ["B"]}`)
-	}
-
-	rt2.WaitForPendingChanges()
-
-	require.NoError(t, ar.Start(ctx1))
-	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
-
-	changesResults = rt1.WaitForChanges(8, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
-
-	require.NoError(t, ar.Stop())
-	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
-	sgwStats, err = base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false, nil, nil)
-	require.NoError(t, err)
-	dbstats, err = sgwStats.DBReplicatorStats(t.Name())
-	require.NoError(t, err)
-
-	ar, err = db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
-		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePull,
-		RemoteDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		Continuous:          true,
-		PurgeOnRemoval:      true,
-		ReplicationStatsMap: dbstats,
-		CollectionsEnabled:  base.TestsUseNamedCollections(),
-	})
-	require.NoError(t, err)
-
-	// Send a doc to act as a 'marker' so we know when replication has completed
-	_ = rt2.PutDoc("docMarker", `{"channels": ["B"]}`)
-
-	require.NoError(t, ar.Start(ctx1))
-	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
-
-	// Validate none of the documents are purged after flipping option
-	rt2.WaitForPendingChanges()
-
-	changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
-
-	for i := 0; i < 10; i++ {
-		resp = rt1.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/docA%d", i), "")
+		resp = rt2.SendAdminRequest("PUT", "/db/_user/user", GetUserPayload(t, "user", "letmein", "", rt2ds, []string{"B"}, nil))
 		RequireStatus(t, resp, http.StatusOK)
-	}
 
-	for i := 0; i < 7; i++ {
-		resp = rt1.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/docB%d", i), "")
-		RequireStatus(t, resp, http.StatusOK)
-	}
+		// Add another few docs to 'bump' rt1's seq no. Otherwise it'll end up revoking next time as the above user PUT is
+		// not processed by the rt1 receiver.
+		for i := 7; i < 15; i++ {
+			_ = rt2.PutDoc(fmt.Sprintf("docB%d", i), `{"channels": ["B"]}`)
+		}
 
-	// Shutdown replicator to close out
-	require.NoError(t, ar.Stop())
-	rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
+		rt2.WaitForPendingChanges()
+
+		require.NoError(t, ar.Start(ctx1))
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
+
+		changesResults = rt1.WaitForChanges(8, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
+
+		require.NoError(t, ar.Stop())
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
+		sgwStats, err = base.SyncGatewayStats.NewDBStats(id, false, false, false, nil, nil)
+		require.NoError(t, err)
+		dbstats, err = sgwStats.DBReplicatorStats(id)
+		require.NoError(t, err)
+
+		ar, err = db.NewActiveReplicator(ctx1, &db.ActiveReplicatorConfig{
+			ID:          id,
+			Direction:   db.ActiveReplicatorTypePull,
+			RemoteDBURL: passiveDBURL,
+			ActiveDB: &db.Database{
+				DatabaseContext: rt1.GetDatabase(),
+			},
+			Continuous:             true,
+			PurgeOnRemoval:         true,
+			ReplicationStatsMap:    dbstats,
+			CollectionsEnabled:     base.TestsUseNamedCollections(),
+			SupportedBLIPProtocols: sgrRunner.SupportedSubprotocols,
+		})
+		require.NoError(t, err)
+
+		// Send a doc to act as a 'marker' so we know when replication has completed
+		_ = rt2.PutDoc("docMarker", `{"channels": ["B"]}`)
+
+		require.NoError(t, ar.Start(ctx1))
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateRunning)
+
+		// Validate none of the documents are purged after flipping option
+		rt2.WaitForPendingChanges()
+
+		changesResults = rt1.WaitForChanges(1, fmt.Sprintf("/{{.keyspace}}/_changes?since=%v", changesResults.Last_Seq), "", true)
+
+		for i := 0; i < 10; i++ {
+			resp = rt1.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/docA%d", i), "")
+			RequireStatus(t, resp, http.StatusOK)
+		}
+
+		for i := 0; i < 7; i++ {
+			resp = rt1.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/docB%d", i), "")
+			RequireStatus(t, resp, http.StatusOK)
+		}
+
+		// Shutdown replicator to close out
+		require.NoError(t, ar.Stop())
+		rt1.WaitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
+	})
 }
 
 func TestRevocationDeletedRole(t *testing.T) {

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -11,16 +11,29 @@ package rest
 import (
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
 )
 
 // TestISGRPeerOpts has configuration for ISGR peers in a test setup.
 type TestISGRPeerOpts struct {
 	// supported protocols for the active peer for ISGR only. Empty means the default protocols.
 	ActivePeerSupportedBLIPSubProtocols []string
+	// UseDeltas indicates whether to enable delta sync on the ISGR replication
+	UseDeltas bool
+	// ActiveRestTesterConfig allows passing a custom RestTesterConfig for the active peer.
+	ActiveRestTesterConfig *RestTesterConfig
+	// PassiveRestTesterConfig allows passing a custom RestTesterConfig for the passive peer.
+	PassiveRestTesterConfig *RestTesterConfig
+	// UserChannelAccess is list of channels the passive side user needs access to
+	UserChannelAccess []string
+	// AvoidUserCreation if true, don't create the user on the passive peer
+	AvoidUserCreation bool
 }
 
 // TestISGRPeers contains two RestTesters to be used for ISGR testing.
@@ -31,6 +44,108 @@ type TestISGRPeers struct {
 	PassiveRT *RestTester
 	// PassiveDBURL is used to create replications from ActiveRT to PassiveRT and contains a username+addr.
 	PassiveDBURL string
+}
+
+type SGRTestRunner struct {
+	t                           *testing.T
+	initialisedInsideRunnerCode bool
+	SkipSubtest                 map[string]bool
+	SupportedSubprotocols       []string
+}
+
+// NewSGRTestRunner returns a new SGRTestRunner instance.
+func NewSGRTestRunner(t *testing.T) *SGRTestRunner {
+	return &SGRTestRunner{
+		t:           t,
+		SkipSubtest: make(map[string]bool),
+	}
+}
+
+func (runner *SGRTestRunner) TB() testing.TB {
+	return runner.t
+}
+
+func (runner *SGRTestRunner) Run(test func(t *testing.T)) {
+	if runner.initialisedInsideRunnerCode {
+		require.FailNow(runner.TB(), "must not initialise SGRPeers outside Run() method")
+	}
+
+	runner.initialisedInsideRunnerCode = true
+	defer func() {
+		// reset bool post test run to ensure no one can setup SetupSGRPeers outside run method upon completion of Run()
+		runner.initialisedInsideRunnerCode = false
+	}()
+
+	if !runner.SkipSubtest[RevtreeSubtestName] {
+		runner.t.Run(RevtreeSubtestName, func(t *testing.T) {
+			runner.SupportedSubprotocols = []string{db.CBMobileReplicationV3.SubprotocolString()}
+			test(t)
+		})
+	}
+	if !runner.SkipSubtest[VersionVectorSubtestName] {
+		runner.t.Run(VersionVectorSubtestName, func(t *testing.T) {
+			runner.SupportedSubprotocols = []string{db.CBMobileReplicationV4.SubprotocolString()}
+			test(t)
+		})
+	}
+}
+
+func (runner *SGRTestRunner) RunSubprotocolV3(test func(t *testing.T)) {
+	if runner.initialisedInsideRunnerCode {
+		require.FailNow(runner.TB(), "must not initialise SGRPeers outside Run() method")
+	}
+	runner.initialisedInsideRunnerCode = true
+	defer func() {
+		// reset bool post test run to ensure no one can setup SetupSGRPeers outside
+		runner.initialisedInsideRunnerCode = false
+	}()
+	if !runner.SkipSubtest[RevtreeSubtestName] {
+		runner.t.Run(RevtreeSubtestName, func(t *testing.T) {
+			runner.SupportedSubprotocols = []string{db.CBMobileReplicationV3.SubprotocolString()}
+			test(t)
+		})
+	}
+}
+
+func (runner *SGRTestRunner) RunSubprotocolV4(test func(t *testing.T)) {
+	if runner.initialisedInsideRunnerCode {
+		require.FailNow(runner.TB(), "must not initialise SGRPeers outside Run() method")
+	}
+
+	runner.initialisedInsideRunnerCode = true
+	defer func() {
+		// reset bool post test run to ensure no one can setup SetupSGRPeers outside run method upon completion of Run()
+		runner.initialisedInsideRunnerCode = false
+	}()
+
+	if !runner.SkipSubtest[VersionVectorSubtestName] {
+		runner.t.Run(VersionVectorSubtestName, func(t *testing.T) {
+			runner.SupportedSubprotocols = []string{db.CBMobileReplicationV4.SubprotocolString()}
+			test(t)
+		})
+	}
+}
+
+func (runner *SGRTestRunner) IsV4Protocol() bool {
+	return slices.Contains(runner.SupportedSubprotocols, db.CBMobileReplicationV4.SubprotocolString())
+}
+
+func (runner *SGRTestRunner) WaitForVersion(docID string, rt *RestTester, version DocVersion) {
+	if !slices.Contains(runner.SupportedSubprotocols, db.CBMobileReplicationV4.SubprotocolString()) {
+		// only assert on rev tree IDs when we're not replicating using v4 protocol
+		rt.WaitForVersionRevIDOnly(docID, version)
+		return
+	}
+	rt.WaitForVersion(docID, version)
+}
+
+func (runner *SGRTestRunner) WaitForTombstone(docID string, rt *RestTester, version DocVersion) {
+	if !slices.Contains(runner.SupportedSubprotocols, db.CBMobileReplicationV4.SubprotocolString()) {
+		// only assert on rev tree IDs when we're not replicating using v4 protocol
+		rt.WaitForTombstoneRevIDOnly(docID, version)
+		return
+	}
+	rt.WaitForTombstone(docID, version)
 }
 
 // Run is equivalent to testing.T.Run() but updates underlying the RestTesters' TB to the new testing.T.
@@ -52,8 +167,24 @@ func (p *TestISGRPeers) Run(t *testing.T, name string, test func(*testing.T)) {
 //	  - backed by different test bucket
 //	  - user 'alice' created with star channel access
 //	  - http server wrapping the public API, remoteDBURLString targets the rt2 database as user alice (e.g. http://alice:pass@host/db)
-func SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, remoteDBURLString string) {
-	peers := SetupISGRPeersWithOpts(t, TestISGRPeerOpts{})
+func (runner *SGRTestRunner) SetupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, remoteDBURLString string) {
+	if !runner.initialisedInsideRunnerCode {
+		require.FailNow(runner.TB(), "must initialise ISGRPeers inside Run() method")
+	}
+	peers := SetupISGRPeersWithOpts(t, TestISGRPeerOpts{
+		ActivePeerSupportedBLIPSubProtocols: runner.SupportedSubprotocols,
+	})
+	return peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
+}
+
+func (runner *SGRTestRunner) SetupSGRPeersWithOptions(t *testing.T, opts TestISGRPeerOpts) (activeRT *RestTester, passiveRT *RestTester, remoteDBURLString string) {
+	if !runner.initialisedInsideRunnerCode {
+		require.FailNow(runner.TB(), "must initialise ISGRPeers inside Run() method")
+	}
+	if len(opts.ActivePeerSupportedBLIPSubProtocols) == 0 {
+		opts.ActivePeerSupportedBLIPSubProtocols = runner.SupportedSubprotocols
+	}
+	peers := SetupISGRPeersWithOpts(t, opts)
 	return peers.ActiveRT, peers.PassiveRT, peers.PassiveDBURL
 }
 
@@ -65,16 +196,29 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 	passiveTestBucket := base.GetTestBucket(t)
 	t.Cleanup(func() { passiveTestBucket.Close(ctx) })
 
-	passiveRTConfig := &RestTesterConfig{
-		CustomTestBucket: passiveTestBucket.NoCloseClone(),
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Name: "passivedb",
-		}},
-		SyncFn: channels.DocChannelsSyncFunction,
+	var passiveRTConfig *RestTesterConfig
+	if opts.PassiveRestTesterConfig != nil {
+		passiveRTConfig = opts.PassiveRestTesterConfig
+	} else {
+		passiveRTConfig = &RestTesterConfig{
+			CustomTestBucket: passiveTestBucket.NoCloseClone(),
+			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+				Name: "passivedb",
+			}},
+			SyncFn: channels.DocChannelsSyncFunction,
+		}
 	}
 	passiveRT := NewRestTester(t, passiveRTConfig)
 	t.Cleanup(passiveRT.Close)
-	passiveRT.CreateUser("alice", []string{"*"})
+
+	if !opts.AvoidUserCreation {
+		if len(opts.UserChannelAccess) > 0 {
+			// Create user with access to specified channels
+			passiveRT.CreateUser("alice", opts.UserChannelAccess)
+		} else {
+			passiveRT.CreateUser("alice", []string{"*"})
+		}
+	}
 
 	// Make passiveRT listen on an actual HTTP port, so it can receive the blipsync request from activeRT
 	srv := httptest.NewServer(passiveRT.TestPublicHandler())
@@ -86,13 +230,19 @@ func SetupISGRPeersWithOpts(t *testing.T, opts TestISGRPeerOpts) TestISGRPeers {
 
 	activeTestBucket := base.GetTestBucket(t)
 	t.Cleanup(func() { activeTestBucket.Close(ctx) })
-	activeRTConfig := &RestTesterConfig{
-		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-			Name: "activedb",
-		}},
-		CustomTestBucket:   activeTestBucket.NoCloseClone(),
-		SgReplicateEnabled: true,
-		SyncFn:             channels.DocChannelsSyncFunction,
+
+	var activeRTConfig *RestTesterConfig
+	if opts.ActiveRestTesterConfig != nil {
+		activeRTConfig = opts.ActiveRestTesterConfig
+	} else {
+		activeRTConfig = &RestTesterConfig{
+			DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+				Name: "activedb",
+			}},
+			CustomTestBucket:   activeTestBucket.NoCloseClone(),
+			SgReplicateEnabled: true,
+			SyncFn:             channels.DocChannelsSyncFunction,
+		}
 	}
 	activeRT := NewRestTester(t, activeRTConfig)
 	t.Cleanup(activeRT.Close)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -299,8 +299,8 @@ func (rt *RestTester) WaitForPullBlipSenderInitialisation(name string) {
 }
 
 // CreateReplication creates a replication via the REST API with the specified ID, remoteURL, direction and channel filter
-func (rt *RestTester) CreateReplication(replicationID string, remoteURLString string, direction db.ActiveReplicatorDirection, channels []string, continuous bool, conflictResolver db.ConflictResolverType) {
-	rt.CreateReplicationForDB("{{.db}}", replicationID, remoteURLString, direction, channels, continuous, conflictResolver)
+func (rt *RestTester) CreateReplication(replicationID string, remoteURLString string, direction db.ActiveReplicatorDirection, channels []string, continuous bool, conflictResolver db.ConflictResolverType, conflictResolverFunc string) {
+	rt.CreateReplicationForDB("{{.db}}", replicationID, remoteURLString, direction, channels, continuous, conflictResolver, conflictResolverFunc)
 }
 
 // DeleteReplication deletes a replication via the REST API with the specified ID
@@ -309,7 +309,7 @@ func (rt *RestTester) DeleteReplication(replicationID string) {
 	RequireStatus(rt.TB(), resp, http.StatusOK)
 }
 
-func (rt *RestTester) CreateReplicationForDB(dbName string, replicationID string, remoteURLString string, direction db.ActiveReplicatorDirection, channels []string, continuous bool, conflictResolver db.ConflictResolverType) {
+func (rt *RestTester) CreateReplicationForDB(dbName string, replicationID string, remoteURLString string, direction db.ActiveReplicatorDirection, channels []string, continuous bool, conflictResolver db.ConflictResolverType, conflictResolverFunc string) {
 	replicationConfig := &db.ReplicationConfig{
 		ID:                     replicationID,
 		Direction:              direction,
@@ -317,6 +317,9 @@ func (rt *RestTester) CreateReplicationForDB(dbName string, replicationID string
 		Continuous:             continuous,
 		ConflictResolutionType: conflictResolver,
 		CollectionsEnabled:     base.TestsUseNamedCollections(),
+	}
+	if conflictResolver == db.ConflictResolverCustom && conflictResolverFunc != "" {
+		replicationConfig.ConflictResolutionFn = conflictResolverFunc
 	}
 
 	if len(channels) > 0 {


### PR DESCRIPTION
[4.0.3 backport] CBG-4904: test-only active replicator tests to run in 4.x and 3.x

cherry-pick of 7ef118b