### PR TITLE
[4.0.3 backport] CBG-5079: Avoid logging at debug in pruning of cache

### DIFF
--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -280,7 +280,10 @@ func (c *singleChannelCacheImpl) _pruneCacheLength(ctx context.Context) (pruned 
 	}
 
 	if pruned > 0 {
-		base.DebugfCtx(ctx, base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelID))
+		// Only enter trace log line if trace is enabled, to avoid the cost of UD() calls
+		if base.LogTraceEnabled(ctx, base.KeyCache) {
+			base.TracefCtx(ctx, base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelID))
+		}
 	}
 
 	return pruned
@@ -306,7 +309,10 @@ func (c *singleChannelCacheImpl) pruneCacheAge(ctx context.Context) {
 		pruned++
 	}
 	if pruned > 0 {
-		base.DebugfCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
+		// Only enter trace log line if trace is enabled, to avoid the cost of UD() calls
+		if base.LogTraceEnabled(ctx, base.KeyCache) {
+			base.TracefCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
+		}
 	}
 
 }

--- a/tools/cache_perf_tool/dcpDataGeneration.go
+++ b/tools/cache_perf_tool/dcpDataGeneration.go
@@ -40,8 +40,8 @@ type dcpDataGen struct {
 func (dcp *dcpDataGen) vBucketCreation(ctx context.Context) {
 	delayIndex := 0
 	// vBucket creation logic
-	for i := 0; i < 1024; i++ {
-		time.Sleep(500 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
+	for i := range 1024 {
+		time.Sleep(100 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
 		if i == 520 {
 			go dcp.syncSeqVBucketCreation(ctx, uint16(i), 2*time.Second) // sync seq hot vBucket so high delay
 		} else {


### PR DESCRIPTION
[4.0.3 backport] CBG-5079: Avoid logging at debug in pruning of cache

cherry-pick of 7691406