### PR TITLE
[4.0.3 backport] CBG-4949: Prevent Excessive conflict logging

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1373,10 +1373,15 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 		// 2. local doc has no hlv
 		allowConflictingTombstone := opts.ForceAllowConflictingTombstone && doc.IsDeleted()
 
+		// variables to keep track if there was rev tree conflict check and storing the status of the check
+		revTreeConflictChecked := false
+		revTreeConflictCheckStatus := false
+
 		// if local doc is a pre-upgraded mutation and the rev tree is conflicting with incoming, assign this local
 		// version an implicit hlv based on its rev tree ID + this nodes sourceID to allow HLV conflict resolution to occur
 		// between the two versions.
 		if doc.HLV == nil && doc.Cas != 0 && !allowConflictingTombstone {
+			revTreeConflictChecked = true
 			_, _, conflictErr := db.revTreeConflictCheck(ctx, opts.RevTreeHistory, doc, opts.NewDoc.Deleted)
 			if conflictErr != nil {
 				// conflict detected between incoming rev and local rev revtrees, allow hlv conflict resolvers
@@ -1385,6 +1390,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				if err != nil {
 					return nil, nil, false, nil, err
 				}
+				revTreeConflictCheckStatus = true
 				base.DebugfCtx(ctx, base.KeyVV, "No existing HLV for existing doc %s, generated implicit CV from rev tree id, updated CV %#v", base.UD(doc.ID), doc.HLV.ExtractCurrentVersionFromHLV())
 			}
 		}
@@ -1402,7 +1408,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				}
 			}
 		} else {
-			conflictStatus := doc.IsInConflict(ctx, db, opts.NewDocHLV, opts)
+			conflictStatus := doc.IsInConflict(ctx, db, opts.NewDocHLV, opts, revTreeConflictChecked, revTreeConflictCheckStatus)
 			switch conflictStatus {
 			case HLVNoConflictRevAlreadyPresent:
 				base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add.  existing: %#v  new:%#v", base.UD(opts.NewDoc.ID), doc.HLV, opts.NewDocHLV)
@@ -1427,11 +1433,17 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 			case HLVConflict:
 				// if we have been supplied a rev tree from cbl, perform conflict check on rev tree history
 				if len(opts.RevTreeHistory) > 0 && !opts.ISGRWrite {
+					if revTreeConflictChecked && revTreeConflictCheckStatus {
+						base.DebugfCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, and conflict found in rev tree history", base.UD(doc.ID))
+						return nil, nil, false, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
+					}
+
 					parent, currentRevIndex, err := db.revTreeConflictCheck(ctx, opts.RevTreeHistory, doc, opts.NewDoc.Deleted)
 					if err != nil {
 						base.DebugfCtx(ctx, base.KeyCRUD, "conflict detected between the two HLV's for doc %s, and conflict found in rev tree history", base.UD(doc.ID))
 						return nil, nil, false, nil, err
 					}
+
 					_, err = doc.addNewerRevisionsToRevTreeHistory(opts.NewDoc, currentRevIndex, parent, opts.RevTreeHistory)
 					if err != nil {
 						return nil, nil, false, nil, err

--- a/db/document.go
+++ b/db/document.go
@@ -1486,7 +1486,7 @@ func (doc *Document) ExtractDocVersion() DocVersion {
 }
 
 // IsInConflict is true if the incoming HLV is in conflict with the current document.
-func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWithUser, incomingHLV *HybridLogicalVector, putOpts PutDocOptions) HLVConflictStatus {
+func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWithUser, incomingHLV *HybridLogicalVector, putOpts PutDocOptions, revTreeConflictCheck, revTreeConflictCheckStatus bool) HLVConflictStatus {
 	// If there is no SyncData, then the document can not be in conflict.
 	if doc.SyncData.Sequence == 0 {
 		return HLVNoConflict
@@ -1494,9 +1494,17 @@ func (doc *Document) IsInConflict(ctx context.Context, db *DatabaseCollectionWit
 	}
 	// we need to check if local CV version was generated from a revID if so we need to perform conflict check on rev tree history
 	if doc.HLV.HasRevEncodedCV() {
-		_, _, isConflictErr := db.revTreeConflictCheck(ctx, putOpts.RevTreeHistory, doc, putOpts.NewDoc.Deleted)
-		if isConflictErr != nil {
-			return HLVConflict
+		if revTreeConflictCheck {
+			if revTreeConflictCheckStatus {
+				return HLVConflict
+			} else {
+				return HLVNoConflict
+			}
+		} else {
+			_, _, isConflictErr := db.revTreeConflictCheck(ctx, putOpts.RevTreeHistory, doc, putOpts.NewDoc.Deleted)
+			if isConflictErr != nil {
+				return HLVConflict
+			}
 		}
 		return HLVNoConflict
 	}


### PR DESCRIPTION
[4.0.3 backport] CBG-4949: Prevent Excessive conflict logging

cherry-pick of b8b689b
