### PR TITLE
CBG-5099: Fix missing doc id in doc body

### DIFF
--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package rest
 
 import (
+	"cmp"
 	"errors"
 	"net/http"
 
@@ -56,7 +57,7 @@ type SyncFnDryRunPayload struct {
 	UserCtx  *SyncDryRunUserCtx  `json:"userCtx,omitempty"`
 }
 
-const SYNC_FN_DIAGNOSTIC_DOCID = "diagnostic doc"
+const SYNC_FN_DIAGNOSTIC_DOCID = "diagnostic_doc"
 
 type ImportFilterDryRunPayload struct {
 	DocID    string  `json:"doc_id"`
@@ -106,8 +107,8 @@ func (h *handler) handleSyncFnDryRun() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Error reading sync function payload: %v", err)
 	}
 
-	docid := syncDryRunPayload.DocID
-	if syncDryRunPayload.Doc == nil && docid == "" {
+	bucketDocID := syncDryRunPayload.DocID
+	if syncDryRunPayload.Doc == nil && bucketDocID == "" {
 		return base.HTTPErrorf(http.StatusBadRequest, "no doc_id or document provided")
 	}
 
@@ -153,10 +154,16 @@ func (h *handler) handleSyncFnDryRun() error {
 		userCtx["roles"] = rolesMap
 	}
 
+	var docid string
+
+	id, _ := syncDryRunPayload.Doc[db.BodyId].(string)
+	docid = cmp.Or(bucketDocID, id, SYNC_FN_DIAGNOSTIC_DOCID)
+
 	oldDoc := &db.Document{ID: docid}
 	oldDoc.UpdateBody(syncDryRunPayload.Doc)
-	if docid != "" {
-		if docInbucket, err := h.collection.GetDocument(h.ctx(), docid, db.DocUnmarshalAll); err == nil {
+	// Read the document from the bucket
+	if bucketDocID != "" {
+		if docInbucket, err := h.collection.GetDocument(h.ctx(), bucketDocID, db.DocUnmarshalAll); err == nil {
 			oldDoc = docInbucket
 			if len(syncDryRunPayload.Doc) == 0 {
 				syncDryRunPayload.Doc = oldDoc.Body(h.ctx())
@@ -169,13 +176,6 @@ func (h *handler) handleSyncFnDryRun() error {
 		oldDoc.UpdateBody(nil)
 	}
 
-	if docid == "" {
-		if id, exists := syncDryRunPayload.Doc[db.BodyId]; exists {
-			oldDoc.ID = id.(string)
-		} else {
-			oldDoc.ID = SYNC_FN_DIAGNOSTIC_DOCID
-		}
-	}
 	delete(syncDryRunPayload.Doc, db.BodyId)
 
 	// Get the revision ID to match, and the new generation number:

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -56,6 +56,8 @@ type SyncFnDryRunPayload struct {
 	UserCtx  *SyncDryRunUserCtx  `json:"userCtx,omitempty"`
 }
 
+const SYNC_FN_DIAGNOSTIC_DOCID = "diagnostic doc"
+
 type ImportFilterDryRunPayload struct {
 	DocID    string  `json:"doc_id"`
 	Function string  `json:"import_filter"`
@@ -167,6 +169,13 @@ func (h *handler) handleSyncFnDryRun() error {
 		oldDoc.UpdateBody(nil)
 	}
 
+	if docid == "" {
+		if id, exists := syncDryRunPayload.Doc[db.BodyId]; exists {
+			oldDoc.ID = id.(string)
+		} else {
+			oldDoc.ID = SYNC_FN_DIAGNOSTIC_DOCID
+		}
+	}
 	delete(syncDryRunPayload.Doc, db.BodyId)
 
 	// Get the revision ID to match, and the new generation number:

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -1395,6 +1395,49 @@ func TestSyncFuncDryRun(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 		},
+		{
+			name: "missing _id in request doc",
+			dbSyncFunction: `function(doc, oldDoc, meta) {
+				console.log(JSON.stringify(doc))
+			}`,
+			request: SyncFnDryRunPayload{
+				Doc: db.Body{
+					"foo": "bar",
+				},
+			},
+			expectedOutput: SyncFnDryRun{
+				Channels: base.SetFromArray([]string{}),
+				Access:   channels.AccessMap{},
+				Roles:    channels.AccessMap{},
+				Logging: DryRunLogging{
+					Errors: []string{},
+					Info:   []string{fmt.Sprintf("{\"_id\":\"%s\",\"_rev\":\"1-cd809becc169215072fd567eebd8b8de\",\"foo\":\"bar\"}", SYNC_FN_DIAGNOSTIC_DOCID)},
+				},
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "doc id in request doc",
+			dbSyncFunction: `function(doc, oldDoc, meta) {
+				console.log(JSON.stringify(doc))
+			}`,
+			request: SyncFnDryRunPayload{
+				Doc: db.Body{
+					db.BodyId: "test",
+					"foo":     "bar",
+				},
+			},
+			expectedOutput: SyncFnDryRun{
+				Channels: base.SetFromArray([]string{}),
+				Access:   channels.AccessMap{},
+				Roles:    channels.AccessMap{},
+				Logging: DryRunLogging{
+					Errors: []string{},
+					Info:   []string{"{\"_id\":\"test\",\"_rev\":\"1-cd809becc169215072fd567eebd8b8de\",\"foo\":\"bar\"}"},
+				},
+			},
+			expectedStatus: http.StatusOK,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
CBG-5099

Describe your PR here...
- Fix missing doc id in doc body when no doc id is passed in the request body

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/231/
