### PR TITLE
Correct diagnostic API routes leading underscore

### DIFF
--- a/docs/api/diagnostic.yaml
+++ b/docs/api/diagnostic.yaml
@@ -32,11 +32,11 @@ paths:
     $ref: ./paths/common/_ping.yaml
   '/{keyspace}/{docid}/_all_channels':
     $ref: './paths/diagnostic/keyspace-docid-_all_channels.yaml'
-  '/{keyspace}/sync':
+  '/{keyspace}/_sync':
     $ref: './paths/diagnostic/keyspace-sync.yaml'
-  '/{keyspace}/import_filter':
+  '/{keyspace}/_import_filter':
     $ref: './paths/diagnostic/keyspace-import_filter.yaml'
-  '/{db}/_user/{name}/all_channels':
+  '/{db}/_user/{name}/_all_channels':
     $ref: './paths/diagnostic/db-_user-name-_all_channels.yaml'
   '/{keyspace}/_user/{name}':
     $ref: './paths/diagnostic/keyspace-_user-name.yaml'

--- a/docs/api/paths/diagnostic/keyspace-import_filter.yaml
+++ b/docs/api/paths/diagnostic/keyspace-import_filter.yaml
@@ -8,20 +8,19 @@
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
-  summary: Run a doc body through the Import filter and return results.
+  summary: Dry-run Import filter for testing
   description: |-
-    Runs a document body through the import filter and return whether its
-    imported or not, and any error messages. If no custom import filter is
-    provided in the request body, the default or user-defined import filter
-    is used.
+    Runs a document through the import filter and return whether its imported or not, and any error messages.
+
+    If no custom import filter is provided in the request body, the default or user-defined import filter is used.
 
     The document being run through the import filter can be provided in one of the following ways:
-    | `doc` property | `doc_id` property | Behaviour                                                                                                                                                             |
-    | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-    | Set   | Unset  | The document body passed will be the `doc` value in the function.                                                                                                                         |
-    | Unset | Set    | The document of the given id will be fetched from the bucket/collection and will be passed in as the `doc` value in the function. If the document is not found, an error will be returned |
-    | Set   | Set    | Will throw an error (only one of `doc` or `doc_id` is allowed for the import filter dry run)                                                                                              |
-    | Unset | Unset  | Will throw an error (at least one of `doc` or `doc_id` is required)                                                                                                                       |
+    | `doc` property | `doc_id` property | Behaviour                                                                                                                                                            |
+    | ------ |----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | Set   | Unset | The document body passed will be the `doc` value in the function.                                                                                                                         |
+    | Unset | Set   | The document of the given id will be fetched from the bucket/collection and will be passed in as the `doc` value in the function. If the document is not found, an error will be returned |
+    | Set   | Set   | Will throw an error (only one of `doc` or `doc_id` is allowed for the import filter dry run)                                                                                              |
+    | Unset | Unset | Will throw an error (at least one of `doc` or `doc_id` is required)                                                                                                                       |
 
     * Sync Gateway Application Read Only
   requestBody:

--- a/docs/api/paths/diagnostic/keyspace-import_filter.yaml
+++ b/docs/api/paths/diagnostic/keyspace-import_filter.yaml
@@ -10,7 +10,7 @@ parameters:
 post:
   summary: Dry-run Import filter for testing
   description: |-
-    Runs a document through the import filter and return whether its imported or not, and any error messages.
+    Runs a document through the import filter and return whether it is imported or not, and any error messages.
 
     If no custom import filter is provided in the request body, the default or user-defined import filter is used.
 

--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -8,18 +8,19 @@
 parameters:
   - $ref: ../../components/parameters.yaml#/keyspace
 post:
-  summary: Run a doc body through the sync function and return sync data.
+  summary: Dry-run Sync Function for testing
   description: |-
-    Runs a document body through the sync function and returns resulting sync function data. If no custom sync function is provided in the request body, the
-    default or user-defined sync function for the collection is used.
+    Runs a document through the Sync Function and returns the result.
+
+    If no custom sync function is provided in the request, the user-defined sync function for the collection is used (or the default).
 
     The document being run through the sync function can be provided in one of the following ways:
     | `doc` property | `doc_id` property | Behaviour                                                                                                                                                                                               |
     | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-    | Set   | Unset       | The document body passed will be the `doc` value in the sync function, and `oldDoc` will be empty.                                                                                                                        |
+    | Set   | Unset    | The document body passed will be the `doc` value in the sync function, and `oldDoc` will be empty.                                                                                                                        |
     | Unset | Set      | The document of the given id will be fetched from the bucket/collection and will be passed in as the `doc` value in the sync function. If the document is not found, an error will be returned                            |
     | Set   | Set      | The document body passed will be the `doc` value in the sync function, and the `doc_id` will be fetched from the bucket/collection and will be the `oldDoc` value. If `doc_id` doesn't exist, then `oldDoc` will be empty |
-    | Unset | Unset       | Will throw an error (at least one of `doc` or `doc_id` is required)                                                                                                                                                       |
+    | Unset | Unset    | Will throw an error (at least one of `doc` or `doc_id` is required)                                                                                                                                                       |
 
     * Sync Gateway Application Read Only
   requestBody:


### PR DESCRIPTION
Ensures the diagnostic paths have a leading underscore (matching the implementation and general SG API design)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a