### PR TITLE
[4.0.3 backport] CBG-5081: pre allocate slices on processEntry

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -787,7 +787,7 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) []chan
 	}
 	c.receivedSeqs[sequence] = struct{}{}
 
-	var changedChannels []channels.ID
+	changedChannels := make([]channels.ID, 0, len(change.Channels))
 	if sequence == c.nextSequence || c.nextSequence == 0 {
 		// This is the expected next sequence so we can add it now:
 		changedChannels = c._addToCache(ctx, change)
@@ -876,7 +876,9 @@ func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) []chann
 // Returns the channels that changed. This may return the same channel more than once, channels should be deduplicated
 // before notifying the changes.
 func (c *changeCache) _addPendingLogs(ctx context.Context) []channels.ID {
-	var changedChannels []channels.ID
+	// pre allocate slice for changed channels, give size 5 to allow for some headroom so we
+	// aren't constantly growing the slice
+	changedChannels := make([]channels.ID, 0, 5)
 	var isNext bool
 
 	for len(c.pendingLogs) > 0 {


### PR DESCRIPTION
[4.0.3 backport] CBG-5081: pre allocate slices on processEntry

cherry-pick of c98864d