### PR TITLE
CBG-5096: Stamp channel information into backup revision documents

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -54,19 +54,19 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 	// current revision backups depend on delta sync (to support deltas to SDK updates)
 	if deltasEnabled {
-		rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		rev1OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 
-		rev1OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		rev1OldBody, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	} else {
-		_, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		_, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 
-		_, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		_, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}
@@ -80,26 +80,26 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 	// rev 1 should be backed up even without delta sync now (by revTree ID - but not CV)
 	if !deltasEnabled {
-		rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		rev1OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	}
 
 	// again, only backup current winning revision if delta sync
 	if deltasEnabled {
-		rev2OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid2)
+		rev2OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid2)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 
-		rev2OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+		rev2OldBody, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 	} else {
-		_, err := collection.getOldRevisionJSON(ctx, docID, revid2)
+		_, _, err := collection.getOldRevisionJSON(ctx, docID, revid2)
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 
-		_, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+		_, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -941,9 +941,7 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 		}
 	}
 
-	// TODO: Why doc.getCurrentChannels() - is ancestor rev *always* the oldDoc version?
-	//ch, _ := doc.channelsForRevTreeID(ancestorRevId)
-	ch := doc.getCurrentChannels()
+	ch, _ := doc.channelsForRevTreeID(ancestorRevId)
 
 	// Back up the revision JSON as a separate doc in the bucket:
 	db.backupRevisionJSON(ctx, doc.ID, ancestorRevId, json, ch)

--- a/db/crud.go
+++ b/db/crud.go
@@ -703,7 +703,7 @@ func (c *DatabaseCollection) getRevision(ctx context.Context, doc *Document, rev
 	}
 
 	if channels == nil {
-		// ignore ok value - we don't care if this is a leaf or not if we have the metadata to get channels
+		// ignore ok value - we don't care if this is a leaf or not, if we have the data to get channels we'll use it
 		channels, _ = doc.channelsForRevTreeID(revid)
 	}
 

--- a/db/import.go
+++ b/db/import.go
@@ -478,7 +478,7 @@ func (db *DatabaseCollectionWithUser) backupPreImportRevision(ctx context.Contex
 		return err
 	}
 
-	setOldRevErr := db.setOldRevisionJSONBody(ctx, docid, revid, oldRevJSON, db.oldRevExpirySeconds())
+	setOldRevErr := db.setOldRevisionJSON(ctx, docid, revid, oldRevJSON, db.oldRevExpirySeconds(), previousRev.Channels)
 	if setOldRevErr != nil {
 		return fmt.Errorf("Persistence error: %v", setOldRevErr)
 	}

--- a/db/revision.go
+++ b/db/revision.go
@@ -43,7 +43,7 @@ const (
 	BodyInternalPrefix = "_sync_" // New internal properties prefix (CBG-1995)
 )
 
-const backupRevisionCannelsMetaKey = "_channels"
+const backupRevisionChannelsMetaKey = "_channels"
 
 // A revisions property found within a Body.  Expected to be of the form:
 //
@@ -261,7 +261,7 @@ func (c *DatabaseCollection) getOldRevisionJSON(ctx context.Context, docid strin
 		}
 		base.DebugfCtx(ctx, base.KeyCRUD, "Got old revision (with %d meta properties) %q / %q --> %d bytes", len(meta), base.UD(docid), revOrCV, len(jsonBody))
 		var channelSet base.Set
-		if ch, ok := meta[backupRevisionCannelsMetaKey]; ok && ch != nil {
+		if ch, ok := meta[backupRevisionChannelsMetaKey]; ok && ch != nil {
 			err = base.JSONUnmarshal(ch, &channelSet)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error unmarshalling _channels xattr for old revision %q / %q: %v", base.UD(docid), revOrCV, err)
@@ -328,7 +328,7 @@ func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, do
 		return fmt.Errorf("error marshalling channels for old revision %q / %q: %v", base.UD(docid), rev, err)
 	}
 	meta := []sgbucket.Xattr{
-		{Name: backupRevisionCannelsMetaKey, Value: channelsJSON},
+		{Name: backupRevisionChannelsMetaKey, Value: channelsJSON},
 	}
 	bodyWithMeta := sgbucket.EncodeValueWithXattrs(body, meta...)
 	nonJSONBytes := withNonJSONPrefix(nonJSONPrefixKindRevWithMeta, bodyWithMeta)

--- a/db/revision.go
+++ b/db/revision.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -41,6 +42,8 @@ const (
 	BodyRemoved        = "_removed"
 	BodyInternalPrefix = "_sync_" // New internal properties prefix (CBG-1995)
 )
+
+const backupRevisionCannelsMetaKey = "_channels"
 
 // A revisions property found within a Body.  Expected to be of the form:
 //
@@ -151,7 +154,7 @@ func (revisions Revisions) ParseRevisions() []string {
 // Returns revisions as a slice of ancestor revids, from the parent to the target ancestor.
 func (revisions Revisions) parseAncestorRevisions(toAncestorRevID string) []string {
 	start, ids := splitRevisionList(revisions)
-	if ids == nil || len(ids) < 2 {
+	if len(ids) < 2 {
 		return nil
 	}
 	result := make([]string, 0)
@@ -234,30 +237,52 @@ func (body Body) getExpiry() (uint32, bool, error) {
 
 // getOldRevisionJSON looks up the raw JSON data of a revision that's been archived to a separate doc.
 // If the revision isn't found (e.g. has been deleted by compaction) returns 404 error.
-func (c *DatabaseCollection) getOldRevisionJSON(ctx context.Context, docid string, revOrCV string) ([]byte, error) {
+func (c *DatabaseCollection) getOldRevisionJSON(ctx context.Context, docid string, revOrCV string) ([]byte, base.Set, error) {
 	data, _, err := c.dataStore.GetRaw(oldRevisionKey(docid, revOrCV))
 	if base.IsDocNotFoundError(err) {
 		base.DebugfCtx(ctx, base.KeyCRUD, "No old revision %q / %q", base.UD(docid), revOrCV)
-		return nil, ErrMissing
+		return nil, nil, ErrMissing
 	} else if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	kind, revData := stripNonJSONPrefix(data)
 	switch kind {
 	case nonJSONPrefixKindRevBody:
 		base.DebugfCtx(ctx, base.KeyCRUD, "Got old revision %q / %q --> %d bytes", base.UD(docid), revOrCV, len(revData))
-		return revData, nil
+		return revData, nil, nil
 	case nonJSONPrefixKindRevPtr:
 		// pointer to a CV-keyed backup revision - do another fetch by CV for the body
 		base.DebugfCtx(ctx, base.KeyCRUD, "Found old revision pointer %q -> %q / %q", revOrCV, base.UD(docid), string(revData))
 		return c.getOldRevisionJSON(ctx, docid, string(revData))
+	case nonJSONPrefixKindRevWithMeta:
+		jsonBody, meta, err := getOldRevisionJSONAndMeta(revData)
+		if err != nil {
+			return nil, nil, err
+		}
+		base.DebugfCtx(ctx, base.KeyCRUD, "Got old revision (with %d meta properties) %q / %q --> %d bytes", len(meta), base.UD(docid), revOrCV, len(jsonBody))
+		var channelSet base.Set
+		if ch, ok := meta[backupRevisionCannelsMetaKey]; ok && ch != nil {
+			err = base.JSONUnmarshal(ch, &channelSet)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error unmarshalling _channels xattr for old revision %q / %q: %v", base.UD(docid), revOrCV, err)
+			}
+		}
+		return jsonBody, channelSet, nil
 	default:
-		return nil, fmt.Errorf("unexpected prefix %b for old revision doc %q / %q", kind, base.UD(docid).String(), revOrCV)
+		return nil, nil, fmt.Errorf("unexpected prefix %b for old revision doc %q / %q", kind, base.UD(docid).String(), revOrCV)
 	}
 }
 
+func getOldRevisionJSONAndMeta(payload []byte) (jsonBody []byte, kvPairs map[string][]byte, err error) {
+	body, meta, err := sgbucket.DecodeValueWithAllXattrs(payload)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, meta, nil
+}
+
 // Makes a backup of revision body for use by in-flight replications requesting an old revision (for clients not supporting replacementRevs)
-func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, docId, oldRev string, oldBody []byte) {
+func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, docId, oldRev string, oldBody []byte, channels base.Set) {
 	if db.deltaSyncEnabled() && db.deltaSyncRevMaxAgeSeconds() > 0 {
 		// See postWriteUpdateHLV - we're writing a CV and RevTreeID backup there to support delta sync
 		return
@@ -274,8 +299,7 @@ func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, do
 	}
 
 	// store or refresh the old document revision by revtree ID for in-flight replications
-	_ = db.refreshOldRevisionJSON(ctx, docId, oldRev, oldBody, db.oldRevExpirySeconds())
-	return
+	_ = db.refreshOldRevisionJSON(ctx, docId, oldRev, oldBody, db.oldRevExpirySeconds(), channels)
 }
 
 // setOldRevisionJSONBody stores the raw JSON body of a revision that has been archived to a separate doc.
@@ -292,12 +316,38 @@ func (db *DatabaseCollectionWithUser) setOldRevisionJSONBody(ctx context.Context
 	return err
 }
 
-// Extends the expiry on a revision backup.  If this fails w/ key not found, will attempt to
-// recreate the revision backup when body is non-empty.
-func (db *DatabaseCollectionWithUser) refreshOldRevisionJSON(ctx context.Context, docid string, revid string, body []byte, expiry uint32) error {
+func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, docid string, rev string, body []byte, expiry uint32, channels base.Set) error {
+	if channels == nil {
+		return db.setOldRevisionJSONBody(ctx, docid, rev, body, expiry)
+	}
+
+	// store channels as optional metadata in the backup
+	// not stored as a real Couchbase Server xattr since we need to write this as a binary document
+	channelsJSON, err := channels.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("error marshalling channels for old revision %q / %q: %v", base.UD(docid), rev, err)
+	}
+	meta := []sgbucket.Xattr{
+		{Name: backupRevisionCannelsMetaKey, Value: channelsJSON},
+	}
+	bodyWithMeta := sgbucket.EncodeValueWithXattrs(body, meta...)
+	nonJSONBytes := withNonJSONPrefix(nonJSONPrefixKindRevWithMeta, bodyWithMeta)
+
+	err = db.dataStore.SetRaw(oldRevisionKey(docid, rev), expiry, nil, nonJSONBytes)
+	if err != nil {
+		base.WarnfCtx(ctx, "setOldRevisionJSONBodyWithMeta failed: doc=%q rev=%q err=%v", base.UD(docid), rev, err)
+		return err
+	}
+
+	base.DebugfCtx(ctx, base.KeyCRUD, "Backed up revision body (with meta) %q/%q (%d bytes, ttl:%d)", base.UD(docid), rev, len(body), expiry)
+	return nil
+}
+
+// Extends the expiry on a revision backup.  If this fails w/ key not found, will attempt to recreate the revision backup when body is non-empty.
+func (db *DatabaseCollectionWithUser) refreshOldRevisionJSON(ctx context.Context, docid string, revid string, body []byte, expiry uint32, channels base.Set) error {
 	_, err := db.dataStore.Touch(oldRevisionKey(docid, revid), expiry)
 	if base.IsDocNotFoundError(err) && len(body) > 0 {
-		return db.setOldRevisionJSONBody(ctx, docid, revid, body, expiry)
+		return db.setOldRevisionJSON(ctx, docid, revid, body, expiry, channels)
 	}
 	return err
 }

--- a/db/revision.go
+++ b/db/revision.go
@@ -154,7 +154,7 @@ func (revisions Revisions) ParseRevisions() []string {
 // Returns revisions as a slice of ancestor revids, from the parent to the target ancestor.
 func (revisions Revisions) parseAncestorRevisions(toAncestorRevID string) []string {
 	start, ids := splitRevisionList(revisions)
-	if len(ids) < 2 {
+	if ids == nil || len(ids) < 2 {
 		return nil
 	}
 	result := make([]string, 0)

--- a/db/revision.go
+++ b/db/revision.go
@@ -317,7 +317,9 @@ func (db *DatabaseCollectionWithUser) setOldRevisionJSONBody(ctx context.Context
 }
 
 func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, docid string, rev string, body []byte, expiry uint32, channels base.Set) error {
+	// no channel information available (Note: this is different than an empty set of channels)
 	if channels == nil {
+		base.WarnfCtx(ctx, "setOldRevisionJSON called with nil channels for old revision %q / %q", base.UD(docid), rev)
 		return db.setOldRevisionJSONBody(ctx, docid, rev, body, expiry)
 	}
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -459,9 +459,6 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 		return bodyBytes, history, channels, removed, nil, deleted, nil, hlv, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
-	if channels == nil {
-		channels = doc.getCurrentChannels()
-	}
 	// only add doc hlv if the revision we have fetched is current revision, otherwise we don't know whether hlv applies to that revision
 	if doc.GetRevTreeID() == revid {
 		if doc.HLV != nil {
@@ -486,9 +483,6 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	}
 
 	deleted = doc.Deleted
-	if channels == nil {
-		channels = doc.getCurrentChannels()
-	}
 	hlv = doc.HLV
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -126,8 +126,8 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 // RevisionCacheBackingStore is the interface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.
 type RevisionCacheBackingStore interface {
 	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
-	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error)
-	getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, error)
+	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, base.Set, error)
+	getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, error)
 }
 
 // collectionRevisionCache is a view of a revision cache for a collection.
@@ -437,7 +437,7 @@ func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingS
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
 
 func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, hlv *HybridLogicalVector, err error) {
-	if bodyBytes, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
+	if bodyBytes, attachments, channels, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
@@ -459,8 +459,8 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 		return bodyBytes, history, channels, removed, nil, deleted, nil, hlv, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
-	if revChannels, ok := doc.channelsForRevTreeID(revid); ok {
-		channels = revChannels
+	if channels == nil {
+		channels = doc.getCurrentChannels()
 	}
 	// only add doc hlv if the revision we have fetched is current revision, otherwise we don't know whether hlv applies to that revision
 	if doc.GetRevTreeID() == revid {
@@ -475,7 +475,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
 // nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
-	if bodyBytes, attachments, err = backingStore.getCurrentVersion(ctx, doc, cv); err != nil {
+	if bodyBytes, attachments, channels, err = backingStore.getCurrentVersion(ctx, doc, cv); err != nil {
 		return nil, nil, nil, false, nil, false, nil, "", nil, err
 	}
 
@@ -486,7 +486,9 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	}
 
 	deleted = doc.Deleted
-	channels = doc.SyncData.getCurrentChannels()
+	if channels == nil {
+		channels = doc.getCurrentChannels()
+	}
 	hlv = doc.HLV
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
@@ -497,29 +499,30 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	return bodyBytes, history, channels, removed, attachments, deleted, doc.Expiry, revid, hlv, err
 }
 
-func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document, cv Version) (bodyBytes []byte, attachments AttachmentsMeta, err error) {
+func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document, cv Version) (bodyBytes []byte, attachments AttachmentsMeta, channels base.Set, err error) {
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {
-		bodyBytes, err = c.getOldRevisionJSON(ctx, doc.ID, base.Crc32cHashString([]byte(cv.String())))
+		bodyBytes, channels, err = c.getOldRevisionJSON(ctx, doc.ID, base.Crc32cHashString([]byte(cv.String())))
 		if err != nil || bodyBytes == nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	} else {
 		bodyBytes, err = doc.BodyBytes(ctx)
 		if err != nil {
 			base.WarnfCtx(ctx, "Marshal error when retrieving active current version body: %v", err)
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
+		channels = doc.SyncData.getCurrentChannels()
 	}
 
 	attachments = doc.Attachments()
 
 	// handle backup revision inline attachments, or pre-2.5 meta
 	if inlineAtts, cleanBodyBytes, _, err := extractInlineAttachments(bodyBytes); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	} else if len(inlineAtts) > 0 {
 		// we found some inline attachments, so merge them with attachments, and update the bodies
 		attachments = mergeAttachments(inlineAtts, attachments)
 		bodyBytes = cleanBodyBytes
 	}
-	return bodyBytes, attachments, err
+	return bodyBytes, attachments, channels, err
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -63,7 +63,7 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 	return doc, nil
 }
 
-func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error) {
+func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, base.Set, error) {
 	t.getRevisionCounter.Add(1)
 
 	b := Body{
@@ -76,10 +76,10 @@ func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid
 		b[BodyCV] = doc.HLV.GetCurrentVersionString()
 	}
 	bodyBytes, err := base.JSONMarshal(b)
-	return bodyBytes, nil, err
+	return bodyBytes, nil, nil, err
 }
 
-func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, error) {
+func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, error) {
 	t.getRevisionCounter.Add(1)
 
 	b := Body{
@@ -92,10 +92,10 @@ func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document,
 		b[BodyCV] = doc.HLV.GetCurrentVersionString()
 	}
 	if err := doc.HasCurrentVersion(ctx, cv); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	bodyBytes, err := base.JSONMarshal(b)
-	return bodyBytes, nil, err
+	return bodyBytes, nil, nil, err
 }
 
 type noopBackingStore struct{}
@@ -104,12 +104,12 @@ func (*noopBackingStore) GetDocument(ctx context.Context, docid string, unmarsha
 	return nil, nil
 }
 
-func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error) {
-	return nil, nil, nil
+func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, base.Set, error) {
+	return nil, nil, nil, nil
 }
 
-func (*noopBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, error) {
-	return nil, nil, nil
+func (*noopBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, error) {
+	return nil, nil, nil, nil
 }
 
 // testCollectionID is a test collection ID to use for a key in the backing store map to point to a tests backing store.

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -66,26 +66,30 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, base.Set, error) {
 	t.getRevisionCounter.Add(1)
 
+	revTreeID := doc.GetRevTreeID()
+	ch, _ := doc.channelsForRevTreeID(revTreeID)
 	b := Body{
 		"testing":     true,
 		BodyId:        doc.ID,
-		BodyRev:       doc.GetRevTreeID(),
+		BodyRev:       revTreeID,
 		BodyRevisions: Revisions{RevisionsStart: 1},
 	}
 	if doc.HLV != nil {
 		b[BodyCV] = doc.HLV.GetCurrentVersionString()
 	}
 	bodyBytes, err := base.JSONMarshal(b)
-	return bodyBytes, nil, nil, err
+	return bodyBytes, nil, ch, err
 }
 
 func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, error) {
 	t.getRevisionCounter.Add(1)
 
+	revTreeID := doc.GetRevTreeID()
+	ch, _ := doc.channelsForRevTreeID(revTreeID)
 	b := Body{
 		"testing":     true,
 		BodyId:        doc.ID,
-		BodyRev:       doc.GetRevTreeID(),
+		BodyRev:       revTreeID,
 		BodyRevisions: Revisions{RevisionsStart: 1},
 	}
 	if doc.HLV != nil {
@@ -95,7 +99,7 @@ func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document,
 		return nil, nil, nil, err
 	}
 	bodyBytes, err := base.JSONMarshal(b)
-	return bodyBytes, nil, nil, err
+	return bodyBytes, nil, ch, err
 }
 
 type noopBackingStore struct{}

--- a/db/revision_old.go
+++ b/db/revision_old.go
@@ -20,10 +20,12 @@ type nonJSONPrefix byte
 const (
 	// nonJSONPrefixKindUnknown is an unused byte value but here for clarity between the zero value
 	nonJSONPrefixKindUnknown nonJSONPrefix = iota
-	// nonJSONPrefixKindRevBody is used for old revision bodies and denotes that everything following is a standard JSON document.
+	// nonJSONPrefixKindRevBody is used for old revision bodies and denotes that everything following is a standard JSON document. (This matches the byte value used by SG < 4.0)
 	nonJSONPrefixKindRevBody
-	// nonJSONPrefixKindRevPtr is used for old revision RevTreeID->CV pointers. The bytes following this are the CV string to be used to fetch the actual body.
+	// nonJSONPrefixKindRevPtr is used for old revision RevTreeID->CV pointers. The bytes following this are the CV string to be used to fetch the actual body. (SG >= 4.0)
 	nonJSONPrefixKindRevPtr
+	// nonJSONPrefixKindRevWithMeta is used for old revision bodies that also have a set of XATTRs. (SG => 4.0.3+)
+	nonJSONPrefixKindRevWithMeta
 )
 
 // withNonJSONPrefix returns a new byte slice prefixed with a non-JSON byte. The input slice is not modified.

--- a/db/revision_old.go
+++ b/db/revision_old.go
@@ -24,7 +24,7 @@ const (
 	nonJSONPrefixKindRevBody
 	// nonJSONPrefixKindRevPtr is used for old revision RevTreeID->CV pointers. The bytes following this are the CV string to be used to fetch the actual body. (SG >= 4.0)
 	nonJSONPrefixKindRevPtr
-	// nonJSONPrefixKindRevWithMeta is used for old revision bodies that also have a set of XATTRs. (SG => 4.0.3+)
+	// nonJSONPrefixKindRevWithMeta is used for old revision bodies that also have a set of XATTRs. (SG >= 4.0.3)
 	nonJSONPrefixKindRevWithMeta
 )
 

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -116,12 +116,12 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// make sure we didn't accidentally store an empty old revision
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, "")
+	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, "")
 	assert.Error(t, err)
 	assert.Equal(t, "404 missing", err.Error())
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {
@@ -135,15 +135,15 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// now in all cases we'll have revtree ID 1 backed up (for at least 5 minutes)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
+	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
 	if deltasEnabled && xattrsEnabled {
 		// and optionally keyed by CV
-		_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	}
 	require.NoError(t, err)
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1225,3 +1225,47 @@ func TestBlipDeltaNoAccessPush(t *testing.T) {
 
 	})
 }
+
+func TestBlipDeltaComputationFromBackupRev(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	const (
+		username = "alice"
+		docID    = "doc1"
+	)
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+		}},
+		SyncFn:       channels.DocChannelsSyncFunction,
+		GuestEnabled: true,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
+		rt.CreateUser(username, []string{"alice"})
+		opts := &BlipTesterClientOpts{Username: username, ClientDeltas: true}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		// create doc1
+		version1 := rt.PutDoc(docID, `{"foo": "bar", "version": "1", "channels": ["alice"]}`)
+
+		btcRunner.StartOneshotPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version1)
+
+		// create rev 2
+		version2 := rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
+		rt.GetDatabase().FlushRevisionCacheForTest() // force delta computation from backup rev
+		btcRunner.StartOneshotPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version2)
+
+		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+	})
+}


### PR DESCRIPTION
CBG-5096

- Stamp channel information into backup revision documents and use on retrieval
- Still requires self-review and analysis of the remaining TODO around ancestor rev backup.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/236/
