### PR TITLE
[4.0.3 backport] CBG-5107: Stamp channel information into backup revision documents

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -54,19 +54,19 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 	// current revision backups depend on delta sync (to support deltas to SDK updates)
 	if deltasEnabled {
-		rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		rev1OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 
-		rev1OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		rev1OldBody, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	} else {
-		_, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		_, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 
-		_, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		_, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}
@@ -80,26 +80,26 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 	// rev 1 should be backed up even without delta sync now (by revTree ID - but not CV)
 	if !deltasEnabled {
-		rev1OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		rev1OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	}
 
 	// again, only backup current winning revision if delta sync
 	if deltasEnabled {
-		rev2OldBody, err := collection.getOldRevisionJSON(ctx, docID, revid2)
+		rev2OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid2)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 
-		rev2OldBody, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+		rev2OldBody, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 	} else {
-		_, err := collection.getOldRevisionJSON(ctx, docID, revid2)
+		_, _, err := collection.getOldRevisionJSON(ctx, docID, revid2)
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 
-		_, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+		_, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -687,19 +687,24 @@ func (col *DatabaseCollectionWithUser) authorizeDoc(doc *Document, revid string)
 
 // Gets a revision of a document. If it's obsolete it will be loaded from the database if possible.
 // inline "_attachments" properties in the body will be extracted and returned separately if present (pre-2.5 metadata, or backup revisions)
-func (c *DatabaseCollection) getRevision(ctx context.Context, doc *Document, revid string) (bodyBytes []byte, attachments AttachmentsMeta, err error) {
+func (c *DatabaseCollection) getRevision(ctx context.Context, doc *Document, revid string) (bodyBytes []byte, attachments AttachmentsMeta, channels base.Set, err error) {
 	bodyBytes = doc.getRevisionBodyJSON(ctx, revid, c.RevisionBodyLoader)
 
 	// No inline body, so look for separate doc:
 	if bodyBytes == nil {
 		if !doc.History.contains(revid) {
-			return nil, nil, ErrMissing
+			return nil, nil, nil, ErrMissing
 		}
 
-		bodyBytes, err = c.getOldRevisionJSON(ctx, doc.ID, revid)
+		bodyBytes, channels, err = c.getOldRevisionJSON(ctx, doc.ID, revid)
 		if err != nil || bodyBytes == nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
+	}
+
+	if channels == nil {
+		// ignore ok value - we don't care if this is a leaf or not, if we have the data to get channels we'll use it
+		channels, _ = doc.channelsForRevTreeID(revid)
 	}
 
 	// optimistically grab the doc body and to store as a pre-unmarshalled version, as well as anticipating no inline attachments.
@@ -709,14 +714,14 @@ func (c *DatabaseCollection) getRevision(ctx context.Context, doc *Document, rev
 
 	// handle backup revision inline attachments, or pre-2.5 meta
 	if inlineAtts, cleanBodyBytes, _, err := extractInlineAttachments(bodyBytes); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	} else if len(inlineAtts) > 0 {
 		// we found some inline attachments, so merge them with attachments, and update the bodies
 		attachments = mergeAttachments(inlineAtts, attachments)
 		bodyBytes = cleanBodyBytes
 	}
 
-	return bodyBytes, attachments, nil
+	return bodyBytes, attachments, channels, nil
 }
 
 // mergeAttachments copies the attachmentsB map, and merges attachmentsA into it. If both maps are nil, return nil.
@@ -838,7 +843,7 @@ func (db *DatabaseCollectionWithUser) get1xRevFromDoc(ctx context.Context, doc *
 				return nil, false, ErrDeleted
 			}
 		}
-		if bodyBytes, attachments, err = db.getRevision(ctx, doc, revid); err != nil {
+		if bodyBytes, attachments, _, err = db.getRevision(ctx, doc, revid); err != nil {
 			return nil, false, err
 		}
 	}
@@ -875,7 +880,7 @@ func (db *DatabaseCollectionWithUser) get1xRevFromDoc(ctx context.Context, doc *
 // Returns the body and rev ID of the asked-for revision or the most recent available ancestor.
 func (db *DatabaseCollectionWithUser) getAvailableRev(ctx context.Context, doc *Document, revid string) ([]byte, string, AttachmentsMeta, error) {
 	for ; revid != ""; revid = doc.History[revid].Parent {
-		if bodyBytes, attachments, _ := db.getRevision(ctx, doc, revid); bodyBytes != nil {
+		if bodyBytes, attachments, _, _ := db.getRevision(ctx, doc, revid); bodyBytes != nil {
 			return bodyBytes, revid, attachments, nil
 		}
 	}
@@ -922,11 +927,11 @@ func (db *DatabaseCollectionWithUser) getAvailableRevAttachments(ctx context.Con
 }
 
 // Moves a revision's ancestor's body out of the document object and into a separate db doc.
-func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, doc *Document, newDoc *Document) {
+func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, doc *Document, newDocRevID string, ch base.Set) {
 
 	// Find an ancestor that still has JSON in the document:
 	var json []byte
-	ancestorRevId := newDoc.RevID
+	ancestorRevId := newDocRevID
 	for {
 		if ancestorRevId = doc.History.getParent(ancestorRevId); ancestorRevId == "" {
 			// No ancestors with JSON found. Return early
@@ -937,7 +942,7 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 	}
 
 	// Back up the revision JSON as a separate doc in the bucket:
-	db.backupRevisionJSON(ctx, doc.ID, ancestorRevId, json)
+	db.backupRevisionJSON(ctx, doc.ID, ancestorRevId, json, ch)
 
 	// Nil out the ancestor rev's body in the document struct:
 	if ancestorRevId == doc.GetRevTreeID() {
@@ -2164,7 +2169,7 @@ func (db *DatabaseCollectionWithUser) tombstoneActiveRevision(ctx context.Contex
 	// Backup previous revision body, then remove the current body from the doc
 	bodyBytes, err := doc.BodyBytes(ctx)
 	if err == nil {
-		_ = db.setOldRevisionJSONBody(ctx, doc.ID, revID, bodyBytes, db.oldRevExpirySeconds())
+		_ = db.setOldRevisionJSON(ctx, doc.ID, revID, bodyBytes, db.oldRevExpirySeconds(), doc.getCurrentChannels())
 	}
 	doc.RemoveBody()
 
@@ -2535,6 +2540,10 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 		return
 	}
 
+	// grab the current channels so that we're able to use them when stamping the backup revision later
+	// we lose channel information for non-leaf revisions in the RevTree when updated, so we take a copy now.
+	oldChannels := doc.getCurrentChannels()
+
 	// compute mouMatch before the callback modifies doc.MetadataOnlyUpdate
 	mouMatch := false
 	if doc.MetadataOnlyUpdate != nil && doc.MetadataOnlyUpdate.CAS() == doc.Cas {
@@ -2593,7 +2602,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 		}
 	}
 
-	col.backupAncestorRevs(ctx, doc, newDoc)
+	col.backupAncestorRevs(ctx, doc, newDoc.RevID, oldChannels)
 
 	unusedSequences, err = col.assignSequence(ctx, previousDocSequenceIn, doc, unusedSequences)
 	if err != nil {
@@ -3008,7 +3017,7 @@ func (db *DatabaseCollectionWithUser) postWriteUpdateHLV(ctx context.Context, do
 			}
 		}
 		revHash := base.Crc32cHashString([]byte(doc.HLV.GetCurrentVersionString()))
-		_ = db.setOldRevisionJSONBody(ctx, doc.ID, revHash, newBodyWithAtts, db.deltaSyncRevMaxAgeSeconds())
+		_ = db.setOldRevisionJSON(ctx, doc.ID, revHash, newBodyWithAtts, db.deltaSyncRevMaxAgeSeconds(), doc.getCurrentChannels())
 		// Optionally store a lookup document to find the CV-based revHash by legacy RevTree ID
 		if db.storeLegacyRevTreeData() {
 			_ = db.setOldRevisionJSONPtr(ctx, doc, db.deltaSyncRevMaxAgeSeconds())
@@ -3040,7 +3049,7 @@ func getAttachmentIDsForLeafRevisions(ctx context.Context, db *DatabaseCollectio
 	})
 
 	for _, leafRevision := range documentLeafRevisions {
-		_, attachmentMeta, err := db.getRevision(ctx, doc, leafRevision)
+		_, attachmentMeta, _, err := db.getRevision(ctx, doc, leafRevision)
 		if err != nil {
 			return nil, err
 		}

--- a/db/import.go
+++ b/db/import.go
@@ -478,7 +478,7 @@ func (db *DatabaseCollectionWithUser) backupPreImportRevision(ctx context.Contex
 		return err
 	}
 
-	setOldRevErr := db.setOldRevisionJSONBody(ctx, docid, revid, oldRevJSON, db.oldRevExpirySeconds())
+	setOldRevErr := db.setOldRevisionJSON(ctx, docid, revid, oldRevJSON, db.oldRevExpirySeconds(), previousRev.Channels)
 	if setOldRevErr != nil {
 		return fmt.Errorf("Persistence error: %v", setOldRevErr)
 	}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -126,8 +126,8 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 // RevisionCacheBackingStore is the interface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.
 type RevisionCacheBackingStore interface {
 	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
-	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error)
-	getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, error)
+	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, base.Set, error)
+	getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, error)
 }
 
 // collectionRevisionCache is a view of a revision cache for a collection.
@@ -437,7 +437,7 @@ func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingS
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
 
 func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, hlv *HybridLogicalVector, err error) {
-	if bodyBytes, attachments, err = backingStore.getRevision(ctx, doc, revid); err != nil {
+	if bodyBytes, attachments, channels, err = backingStore.getRevision(ctx, doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(ctx, revid)
@@ -459,9 +459,6 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 		return bodyBytes, history, channels, removed, nil, deleted, nil, hlv, getHistoryErr
 	}
 	history = encodeRevisions(ctx, doc.ID, validatedHistory)
-	if revChannels, ok := doc.channelsForRevTreeID(revid); ok {
-		channels = revChannels
-	}
 	// only add doc hlv if the revision we have fetched is current revision, otherwise we don't know whether hlv applies to that revision
 	if doc.GetRevTreeID() == revid {
 		if doc.HLV != nil {
@@ -475,7 +472,7 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
 // nolint:staticcheck
 func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
-	if bodyBytes, attachments, err = backingStore.getCurrentVersion(ctx, doc, cv); err != nil {
+	if bodyBytes, attachments, channels, err = backingStore.getCurrentVersion(ctx, doc, cv); err != nil {
 		return nil, nil, nil, false, nil, false, nil, "", nil, err
 	}
 
@@ -486,7 +483,6 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	}
 
 	deleted = doc.Deleted
-	channels = doc.SyncData.getCurrentChannels()
 	hlv = doc.HLV
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
@@ -497,29 +493,30 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	return bodyBytes, history, channels, removed, attachments, deleted, doc.Expiry, revid, hlv, err
 }
 
-func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document, cv Version) (bodyBytes []byte, attachments AttachmentsMeta, err error) {
+func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document, cv Version) (bodyBytes []byte, attachments AttachmentsMeta, channels base.Set, err error) {
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {
-		bodyBytes, err = c.getOldRevisionJSON(ctx, doc.ID, base.Crc32cHashString([]byte(cv.String())))
+		bodyBytes, channels, err = c.getOldRevisionJSON(ctx, doc.ID, base.Crc32cHashString([]byte(cv.String())))
 		if err != nil || bodyBytes == nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	} else {
 		bodyBytes, err = doc.BodyBytes(ctx)
 		if err != nil {
 			base.WarnfCtx(ctx, "Marshal error when retrieving active current version body: %v", err)
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
+		channels = doc.SyncData.getCurrentChannels()
 	}
 
 	attachments = doc.Attachments()
 
 	// handle backup revision inline attachments, or pre-2.5 meta
 	if inlineAtts, cleanBodyBytes, _, err := extractInlineAttachments(bodyBytes); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	} else if len(inlineAtts) > 0 {
 		// we found some inline attachments, so merge them with attachments, and update the bodies
 		attachments = mergeAttachments(inlineAtts, attachments)
 		bodyBytes = cleanBodyBytes
 	}
-	return bodyBytes, attachments, err
+	return bodyBytes, attachments, channels, err
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -64,39 +64,43 @@ func (t *testBackingStore) GetDocument(ctx context.Context, docid string, unmars
 	return doc, nil
 }
 
-func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error) {
+func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, base.Set, error) {
 	t.getRevisionCounter.Add(1)
 
+	revTreeID := doc.GetRevTreeID()
+	ch, _ := doc.channelsForRevTreeID(revTreeID)
 	b := Body{
 		"testing":     true,
 		BodyId:        doc.ID,
-		BodyRev:       doc.GetRevTreeID(),
+		BodyRev:       revTreeID,
 		BodyRevisions: Revisions{RevisionsStart: 1},
 	}
 	if doc.HLV != nil {
 		b[BodyCV] = doc.HLV.GetCurrentVersionString()
 	}
 	bodyBytes, err := base.JSONMarshal(b)
-	return bodyBytes, nil, err
+	return bodyBytes, nil, ch, err
 }
 
-func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, error) {
+func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, error) {
 	t.getRevisionCounter.Add(1)
 
+	revTreeID := doc.GetRevTreeID()
+	ch, _ := doc.channelsForRevTreeID(revTreeID)
 	b := Body{
 		"testing":     true,
 		BodyId:        doc.ID,
-		BodyRev:       doc.GetRevTreeID(),
+		BodyRev:       revTreeID,
 		BodyRevisions: Revisions{RevisionsStart: 1},
 	}
 	if doc.HLV != nil {
 		b[BodyCV] = doc.HLV.GetCurrentVersionString()
 	}
 	if err := doc.HasCurrentVersion(ctx, cv); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	bodyBytes, err := base.JSONMarshal(b)
-	return bodyBytes, nil, err
+	return bodyBytes, nil, ch, err
 }
 
 type noopBackingStore struct{}
@@ -105,12 +109,12 @@ func (*noopBackingStore) GetDocument(ctx context.Context, docid string, unmarsha
 	return nil, nil
 }
 
-func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, error) {
-	return nil, nil, nil
+func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, base.Set, error) {
+	return nil, nil, nil, nil
 }
 
-func (*noopBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, error) {
-	return nil, nil, nil
+func (*noopBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, error) {
+	return nil, nil, nil, nil
 }
 
 // testCollectionID is a test collection ID to use for a key in the backing store map to point to a tests backing store.

--- a/db/revision_old.go
+++ b/db/revision_old.go
@@ -20,10 +20,12 @@ type nonJSONPrefix byte
 const (
 	// nonJSONPrefixKindUnknown is an unused byte value but here for clarity between the zero value
 	nonJSONPrefixKindUnknown nonJSONPrefix = iota
-	// nonJSONPrefixKindRevBody is used for old revision bodies and denotes that everything following is a standard JSON document.
+	// nonJSONPrefixKindRevBody is used for old revision bodies and denotes that everything following is a standard JSON document. (This matches the byte value used by SG < 4.0)
 	nonJSONPrefixKindRevBody
-	// nonJSONPrefixKindRevPtr is used for old revision RevTreeID->CV pointers. The bytes following this are the CV string to be used to fetch the actual body.
+	// nonJSONPrefixKindRevPtr is used for old revision RevTreeID->CV pointers. The bytes following this are the CV string to be used to fetch the actual body. (SG >= 4.0)
 	nonJSONPrefixKindRevPtr
+	// nonJSONPrefixKindRevWithMeta is used for old revision bodies that also have a set of XATTRs. (SG >= 4.0.3)
+	nonJSONPrefixKindRevWithMeta
 )
 
 // withNonJSONPrefix returns a new byte slice prefixed with a non-JSON byte. The input slice is not modified.

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -116,12 +116,12 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// make sure we didn't accidentally store an empty old revision
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, "")
+	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, "")
 	assert.Error(t, err)
 	assert.Equal(t, "404 missing", err.Error())
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {
@@ -135,15 +135,15 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// now in all cases we'll have revtree ID 1 backed up (for at least 5 minutes)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
+	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
 	if deltasEnabled && xattrsEnabled {
 		// and optionally keyed by CV
-		_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	}
 	require.NoError(t, err)
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1214,3 +1214,47 @@ func TestBlipDeltaNoAccessPush(t *testing.T) {
 
 	})
 }
+
+func TestBlipDeltaComputationFromBackupRev(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	const (
+		username = "alice"
+		docID    = "doc1"
+	)
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+		}},
+		SyncFn:       channels.DocChannelsSyncFunction,
+		GuestEnabled: true,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
+		rt.CreateUser(username, []string{"alice"})
+		opts := &BlipTesterClientOpts{Username: username, ClientDeltas: true}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		// create doc1
+		version1 := rt.PutDoc(docID, `{"foo": "bar", "version": "1", "channels": ["alice"]}`)
+
+		btcRunner.StartOneshotPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version1)
+
+		// create rev 2
+		version2 := rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
+		rt.GetDatabase().FlushRevisionCacheForTest() // force delta computation from backup rev
+		btcRunner.StartOneshotPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version2)
+
+		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+	})
+}

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1651,6 +1651,11 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 		t.Skipf("Skipping TestImportRevisionCopyUnavailable when delta sync enabled, delta revision backup handling invalidates test")
 	}
 
+	// Create user with access to ABC channel
+	rt.CreateUser("alice", []string{"ABC"})
+	// Create user with access to DEF channel
+	rt.CreateUser("bob", []string{"DEF"})
+
 	dataStore := rt.GetSingleDataStore()
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyImport)
 
@@ -1681,9 +1686,18 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 	// 5. Trigger import of update via SG retrieval
 	rt.TriggerOnDemandImport(key)
 
-	// 6. Attempt to retrieve previous revision body.  Should return missing, as rev wasn't in rev cache when import occurred.
-	response := rt.SendAdminRequest("GET", fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", key, rev1id), "")
-	assert.Equal(t, 404, response.Code)
+	// 6. Attempt to retrieve previous revision body.
+	// Should return missing, as rev wasn't in rev cache when import occurred - impossible to recover this old document body.
+	response := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", key, rev1id), "")
+	rest.AssertStatus(t, response, http.StatusNotFound)
+
+	// Even if user had access previously, we can't get this information back
+	response = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", key, rev1id), "", "alice")
+	rest.AssertStatus(t, response, http.StatusNotFound)
+
+	// Likewise for users who only have access to the current version attempting to access the older rev
+	response = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", key, rev1id), "", "bob")
+	rest.AssertStatus(t, response, http.StatusNotFound)
 }
 
 // Verify config flag for import creation of backup revision on import


### PR DESCRIPTION
CBG-5107

Clean cherry-pick of #7997 for 4.0.3

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/240/
