### PR TITLE
[3.3.3 backport] CBG-5077: Avoid logging at debug in pruning of cache (#7863)

### DIFF
--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -280,7 +280,10 @@ func (c *singleChannelCacheImpl) _pruneCacheLength(ctx context.Context) (pruned 
 	}
 
 	if pruned > 0 {
-		base.DebugfCtx(ctx, base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelID))
+		// Only enter trace log line if trace is enabled, to avoid the cost of UD() calls
+		if base.LogTraceEnabled(ctx, base.KeyCache) {
+			base.TracefCtx(ctx, base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelID))
+		}
 	}
 
 	return pruned
@@ -306,7 +309,10 @@ func (c *singleChannelCacheImpl) pruneCacheAge(ctx context.Context) {
 		pruned++
 	}
 	if pruned > 0 {
-		base.DebugfCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
+		// Only enter trace log line if trace is enabled, to avoid the cost of UD() calls
+		if base.LogTraceEnabled(ctx, base.KeyCache) {
+			base.TracefCtx(ctx, base.KeyCache, "Pruned %d old entries from channel %q", pruned, base.UD(c.channelID))
+		}
 	}
 
 }

--- a/tools/cache_perf_tool/dcpDataGeneration.go
+++ b/tools/cache_perf_tool/dcpDataGeneration.go
@@ -40,8 +40,8 @@ type dcpDataGen struct {
 func (dcp *dcpDataGen) vBucketCreation(ctx context.Context) {
 	delayIndex := 0
 	// vBucket creation logic
-	for i := 0; i < 1024; i++ {
-		time.Sleep(500 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
+	for i := range 1024 {
+		time.Sleep(100 * time.Millisecond) // we need a slight delay each iteration otherwise many vBuckets end up writing at the same times
 		if i == 520 {
 			go dcp.syncSeqVBucketCreation(ctx, uint16(i), 2*time.Second) // sync seq hot vBucket so high delay
 		} else {


### PR DESCRIPTION
CBG-5077
Describe your PR here...
- Backport of CBG-4968

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
