### PR TITLE
[3.3.3 backport] CBG-5080: pre allocate slices on processEntry/addPendingLogs

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -766,7 +766,7 @@ func (c *changeCache) processEntry(ctx context.Context, change *LogEntry) []chan
 	}
 	c.receivedSeqs[sequence] = struct{}{}
 
-	var changedChannels []channels.ID
+	changedChannels := make([]channels.ID, 0, len(change.Channels))
 	if sequence == c.nextSequence || c.nextSequence == 0 {
 		// This is the expected next sequence so we can add it now:
 		changedChannels = c._addToCache(ctx, change)
@@ -855,7 +855,9 @@ func (c *changeCache) _addToCache(ctx context.Context, change *LogEntry) []chann
 // Returns the channels that changed. This may return the same channel more than once, channels should be deduplicated
 // before notifying the changes.
 func (c *changeCache) _addPendingLogs(ctx context.Context) []channels.ID {
-	var changedChannels []channels.ID
+	// pre allocate slice for changed channels, give size 5 to allow for some headroom so we
+	// aren't constantly growing the slice
+	changedChannels := make([]channels.ID, 0, 5)
 	var isNext bool
 
 	for len(c.pendingLogs) > 0 {


### PR DESCRIPTION
CBG-5080

Describe your PR here...
- backport of CBG-5040

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
