### PR TITLE
[3.3.3 backport] CBG-4984: Ignore updating local rev if BlipTesterCollectionClient is closed

### DIFF
--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -730,6 +730,11 @@ func (btcc *BlipTesterCollectionClient) getAttachment(digest string) (attachment
 func (btcc *BlipTesterCollectionClient) updateLastReplicatedRev(docID string, version DocVersion, msg *blip.Message) {
 	btcc.seqLock.Lock()
 	defer btcc.seqLock.Unlock()
+	// If this fires after a replication is completed, ignore it since BlipTesterCollectionClient.Close will zero
+	// out all documents
+	if btcc.ctx.Err() != nil {
+		return
+	}
 	doc, ok := btcc._getClientDoc(docID)
 	require.True(btcc.TB(), ok, "docID %q not found in _seqFromDocID", docID)
 	doc._latestServerVersion = version


### PR DESCRIPTION
CBG-4985

Describe your PR here...
- Backport of CBG-4924

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
