### PR TITLE
[3.3.3 Backport] CBG-5124: assign Update call back to allChangedChannels

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -619,7 +619,7 @@ func (c *changeCache) releaseUnusedSequenceRange(ctx context.Context, fromSequen
 
 	// push unused range to either pending or skipped lists based on current state of the change cache
 	changedChannels := c.processUnusedRange(ctx, fromSequence, toSequence, timeReceived)
-	allChangedChannels.Update(channels.SetFromArrayNoValidate(changedChannels))
+	allChangedChannels = allChangedChannels.Update(channels.SetFromArrayNoValidate(changedChannels))
 
 	if c.notifyChangeFunc != nil {
 		c.notifyChangeFunc(ctx, allChangedChannels)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -3123,6 +3123,64 @@ func TestChangeInBroadcastForSkipped(t *testing.T) {
 
 }
 
+func TestUnblockPendingWithUnusedRange(t *testing.T) {
+	base.LongRunningTest(t)
+
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	opts := DefaultCacheOptions()
+	opts.CachePendingSeqMaxWait = 20 * time.Minute
+	opts.CacheSkippedSeqMaxWait = 20 * time.Minute
+	opts.CachePendingSeqMaxNum = DefaultCachePendingSeqMaxNum
+	db, ctx := setupTestDBWithCacheOptions(t, opts)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	// init change cache
+	_, err := db.changeCache.GetChanges(ctx, channels.NewID("channelA", collection.GetCollectionID()), getChangesOptionsWithZeroSeq(t))
+	require.NoError(t, err)
+
+	docID := fmt.Sprintf("doc_%d", 1)
+	highEntry := &LogEntry{
+		Channels: channels.ChannelMap{
+			"channelA": nil,
+		},
+		Sequence:     20,
+		DocID:        docID,
+		RevID:        "1-abcdefabcdefabcdef",
+		CollectionID: collection.GetCollectionID(),
+		Version:      123,
+		SourceID:     "sourceA",
+		TimeReceived: channels.NewFeedTimestampFromNow(),
+	}
+	_ = db.changeCache.processEntry(ctx, highEntry)
+
+	// assert that pending list is populated with above entry
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		db.changeCache.updateStats(ctx)
+		assert.Equal(c, int64(1), db.DbStats.CacheStats.PendingSeqLen.Value())
+		assert.Equal(c, uint64(1), db.changeCache.nextSequence)
+	}, time.Second*10, time.Millisecond*100)
+
+	// process unused sequence range
+	db.changeCache.releaseUnusedSequenceRange(ctx, 1, 19, channels.NewFeedTimestampFromNow())
+
+	// assert on cache stats after range processed
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		db.changeCache.updateStats(ctx)
+		db.UpdateCalculatedStats(ctx)
+		assert.Equal(c, uint64(20), db.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, uint64(21), db.changeCache.nextSequence)
+	}, time.Second*10, time.Millisecond*100)
+
+	entries, err := db.changeCache.GetChanges(ctx, channels.NewID("channelA", collection.GetCollectionID()), getChangesOptionsWithZeroSeq(t))
+	require.NoError(t, err)
+
+	assert.Len(t, entries, 1)
+	assert.Equal(t, docID, entries[0].DocID)
+	assert.Equal(t, uint64(20), entries[0].Sequence)
+}
+
 type sequenceRange struct {
 	start uint64
 	end   uint64

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -3149,8 +3149,6 @@ func TestUnblockPendingWithUnusedRange(t *testing.T) {
 		DocID:        docID,
 		RevID:        "1-abcdefabcdefabcdef",
 		CollectionID: collection.GetCollectionID(),
-		Version:      123,
-		SourceID:     "sourceA",
 		TimeReceived: channels.NewFeedTimestampFromNow(),
 	}
 	_ = db.changeCache.processEntry(ctx, highEntry)
@@ -3169,7 +3167,7 @@ func TestUnblockPendingWithUnusedRange(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		db.changeCache.updateStats(ctx)
 		db.UpdateCalculatedStats(ctx)
-		assert.Equal(c, uint64(20), db.DbStats.CacheStats.HighSeqCached.Value())
+		assert.Equal(c, int64(20), db.DbStats.CacheStats.HighSeqCached.Value())
 		assert.Equal(c, uint64(21), db.changeCache.nextSequence)
 	}, time.Second*10, time.Millisecond*100)
 


### PR DESCRIPTION
CBG-5124

Backports cf231ba

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
