### PR TITLE
CBG-5126: disable rev cache test env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,25 @@ jobs:
         with:
           test-results: test.json
 
+    test-disable-rev-cache:
+      runs-on: ubuntu-latest
+      env:
+        GOPRIVATE: github.com/couchbaselabs
+        SG_TEST_DISABLE_REV_CACHE: true
+      steps:
+        - uses: actions/checkout@v5
+        - uses: actions/setup-go@v5
+          with:
+            go-version: 1.25.6
+        - name: Run Tests
+          run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+          shell: bash
+        - name: Annotate Failures
+          if: always()
+          uses: guyarb/golang-test-annotations@v0.8.0
+          with:
+            test-results: test.json
+
   python-format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,24 +136,24 @@ jobs:
         with:
           test-results: test.json
 
-    test-disable-rev-cache:
-      runs-on: ubuntu-latest
-      env:
-        GOPRIVATE: github.com/couchbaselabs
-        SG_TEST_DISABLE_REV_CACHE: true
-      steps:
-        - uses: actions/checkout@v5
-        - uses: actions/setup-go@v5
-          with:
-            go-version: 1.25.6
-        - name: Run Tests
-          run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
-          shell: bash
-        - name: Annotate Failures
-          if: always()
-          uses: guyarb/golang-test-annotations@v0.8.0
-          with:
-            test-results: test.json
+  test-disable-rev-cache:
+    runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/couchbaselabs
+      SG_TEST_DISABLE_REV_CACHE: true
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.6
+      - name: Run Tests
+        run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        shell: bash
+      - name: Annotate Failures
+        if: always()
+        uses: guyarb/golang-test-annotations@v0.8.0
+        with:
+          test-results: test.json
 
   python-format:
     runs-on: ubuntu-latest

--- a/base/constants.go
+++ b/base/constants.go
@@ -47,6 +47,9 @@ const (
 	TestEnvSyncGatewayUseXattrs = "SG_TEST_USE_XATTRS"
 	TestEnvSyncGatewayTrue      = "True"
 
+	// TestEnvDisableRevCache if set to true will disable the revision cache for tests
+	TestEnvDisableRevCache = "SG_TEST_DISABLE_REV_CACHE"
+
 	// Should the tests drop the GSI indexes?
 	TestEnvSyncGatewayDropIndexes = "SG_TEST_DROP_INDEXES"
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -284,6 +284,15 @@ func TestsDisableGSI() bool {
 	return !useGSI
 }
 
+// TestDisableRevCache returns true if environment variable SG_TEST_DISABLE_REV_CACHE is set to true
+func TestDisableRevCache() bool {
+	if disableRevCache := os.Getenv(TestEnvDisableRevCache); disableRevCache != "" {
+		val, _ := strconv.ParseBool(disableRevCache)
+		return val
+	}
+	return false
+}
+
 // Check the whether tests are being run with SG_TEST_BACKING_STORE=Couchbase
 func TestUseCouchbaseServer() bool {
 	backingStore := os.Getenv(TestEnvSyncGatewayBackingStore)

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -138,7 +138,7 @@ func TestGetBackupRevisionWhenCurrentRevisionHasAttachments(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert version is fetched and attachments is empty
-	assert.Equal(t, docRev.CV.String(), doc1.HLV.GetCurrentVersionString())
+	assert.Equal(t, doc1.HLV.GetCurrentVersionString(), docRev.CV.String())
 	assert.Empty(t, docRev.Attachments)
 }
 

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -107,6 +107,9 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 }
 
 func TestGetBackupRevisionWhenCurrentRevisionHasAttachments(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("pending fix in CBG-5141")
+	}
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1154,6 +1154,9 @@ func TestDeltaSyncConcurrentClientCachePopulation(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta sync only supported in EE")
 	}
+	if base.TestDisableRevCache() {
+		t.Skip("test requires revision cache to be enabled")
+	}
 
 	tests := []struct {
 		name              string
@@ -1661,7 +1664,6 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	assert.NoError(t, err, "Put")
 
 	rev2body := Body{
-		"key1":      1234,
 		BodyDeleted: true,
 		BodyRev:     rev1id,
 	}
@@ -1683,7 +1685,6 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	rev2digest := rev2id[2:]
 	rev1digest := rev1id[2:]
 	expectedResult := Body{
-		"key1":      1234,
 		BodyDeleted: true,
 		BodyRevisions: Revisions{
 			RevisionsStart: 2,

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -106,7 +106,6 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 	if err != nil {
 		return DocumentRevision{}, err
 	}
-	docRev.DocID = docID
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
 		docRev.HlvHistory = hlv.ToHistoryForHLV()

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -40,6 +40,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 
 	docRev = DocumentRevision{
 		RevID:                  revID,
+		DocID:                  docID,
 		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
 	}
 	var hlv *HybridLogicalVector
@@ -62,6 +63,7 @@ func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *
 
 	docRev = DocumentRevision{
 		CV:                     cv,
+		DocID:                  docID,
 		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
 	}
 
@@ -95,6 +97,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 
 	docRev = DocumentRevision{
 		RevID:                  doc.GetRevTreeID(),
+		DocID:                  docID,
 		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
 	}
 
@@ -103,6 +106,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 	if err != nil {
 		return DocumentRevision{}, err
 	}
+	docRev.DocID = docID
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
 		docRev.HlvHistory = hlv.ToHistoryForHLV()

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package db
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"time"
@@ -506,7 +505,6 @@ func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Documen
 			base.WarnfCtx(ctx, "Marshal error when retrieving active current version body: %v", err)
 			return nil, nil, nil, false, err
 		}
-		cvIsRequested = true
 		channels = doc.SyncData.getCurrentChannels()
 		attachments = doc.Attachments()
 	}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -11,6 +11,7 @@ licenses/APL2.txt.
 package db
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"time"
@@ -505,6 +506,7 @@ func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Documen
 			base.WarnfCtx(ctx, "Marshal error when retrieving active current version body: %v", err)
 			return nil, nil, nil, false, err
 		}
+		cvIsRequested = true
 		channels = doc.SyncData.getCurrentChannels()
 		attachments = doc.Attachments()
 	}

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -277,6 +277,9 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 }
 
 func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("Revision cache disabled, eviction test needs revision cache enabled")
+	}
 	testCases := []struct {
 		name       string
 		UseCVCache bool
@@ -691,6 +694,9 @@ func TestBypassRevisionCache(t *testing.T) {
 // Ensure attachment properties aren't being incorrectly stored in revision cache body when inserted via Put
 func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 
+	if base.TestDisableRevCache() {
+		t.Skip("Revision cache expected to be used for this test")
+	}
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
@@ -959,6 +965,9 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 //   - Add new doc that will take over the shard memory capacity and assert that that eviction takes place and
 //     all stats are as expected
 func TestShardedMemoryEviction(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("Test is sharded revision cache specific")
+	}
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
 			MaxBytes:     160,
@@ -1009,6 +1018,9 @@ func TestShardedMemoryEviction(t *testing.T) {
 //   - Test adding a doc to sharded revision cache that will immediately be evicted due to size
 //   - Assert that stats look as expected
 func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test is sharded revision cache specific")
+	}
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
 			MaxBytes:     100,
@@ -1112,6 +1124,9 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 }
 
 func TestResetRevCache(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("Revision cache expected to be used for this test")
+	}
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
 			MaxBytes:     100,
@@ -1137,6 +1152,9 @@ func TestResetRevCache(t *testing.T) {
 }
 
 func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("Revision cache expected to be used for this test")
+	}
 	testCases := []struct {
 		name       string
 		UseCVCache bool
@@ -1333,6 +1351,9 @@ func TestConcurrentLoad(t *testing.T) {
 }
 
 func TestRevisionCacheRemove(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test requires revision cache to be enabled")
+	}
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
@@ -1375,6 +1396,9 @@ func TestRevisionCacheRemove(t *testing.T) {
 //   - Assert each doc returned is the correct one (correct rev ID etc)
 //   - Assert that each doc is found at the rev cache and no misses are reported
 func TestRevCacheHitMultiCollection(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test requires revision cache to be enabled")
+	}
 	base.TestRequiresCollections(t)
 
 	tb := base.GetTestBucket(t)
@@ -2226,6 +2250,9 @@ func TestPutRevHighRevCacheChurn(t *testing.T) {
 }
 
 func TestRevCacheOnDemandImportNoCache(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test requires rev cache enabled")
+	}
 	base.SkipImportTestsIfNotEnabled(t)
 
 	db, ctx := setupTestDB(t)
@@ -2354,6 +2381,9 @@ func TestRemoveFromRevLookup(t *testing.T) {
 }
 
 func TestLoadFromBucketLegacyRevsThatAreBackedUpPreUpgrade(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test requires rev cache enabled")
+	}
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		OldRevExpirySeconds: base.DefaultOldRevExpirySeconds,
 		RevisionCacheOptions: &RevisionCacheOptions{
@@ -2561,6 +2591,9 @@ func TestUpdateDeltaRevCacheMemoryStatPanicMultipleEntries(t *testing.T) {
 }
 
 func TestEvictionOfRevIDKeysWhenNoItemInCVMap(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test requires rev cache enabled for eviction to run")
+	}
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		OldRevExpirySeconds: base.DefaultOldRevExpirySeconds,
 		RevisionCacheOptions: &RevisionCacheOptions{
@@ -2614,6 +2647,9 @@ func TestEvictionOfRevIDKeysWhenNoItemInCVMap(t *testing.T) {
 }
 
 func TestEvictionOfCVKeysWhenNoItemInRevMap(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test requires rev cache enabled for eviction to run")
+	}
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		OldRevExpirySeconds: base.DefaultOldRevExpirySeconds,
 		RevisionCacheOptions: &RevisionCacheOptions{
@@ -2681,6 +2717,9 @@ func TestEvictionOfCVKeysWhenNoItemInRevMap(t *testing.T) {
 
 func TestBasicLoadBackupRevCacheOnlyPopulateOneMap(t *testing.T) {
 
+	if base.TestDisableRevCache() {
+		t.Skip("test requires rev cache enabled")
+	}
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		OldRevExpirySeconds: base.DefaultOldRevExpirySeconds,
 		RevisionCacheOptions: &RevisionCacheOptions{
@@ -2741,6 +2780,9 @@ func TestBasicLoadBackupRevCacheOnlyPopulateOneMap(t *testing.T) {
 }
 
 func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test requires rev cache enabled")
+	}
 	testCases := []struct {
 		name     string
 		useRevID bool

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2282,6 +2282,9 @@ func TestRevCacheOnDemandImportNoCache(t *testing.T) {
 }
 
 func TestFetchBackupWithDeletedFlag(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("pending fix in CBG-5141")
+	}
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		// enable delta sync so CV revs are backed up
 		DeltaSyncOptions: DeltaSyncOptions{

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -573,6 +573,13 @@ func AddOptionsFromEnvironmentVariables(dbcOptions *DatabaseContextOptions) {
 	if base.TestsDisableGSI() {
 		dbcOptions.UseViews = true
 	}
+
+	if base.TestDisableRevCache() {
+		if dbcOptions.RevisionCacheOptions == nil {
+			dbcOptions.RevisionCacheOptions = DefaultRevisionCacheOptions()
+		}
+		dbcOptions.RevisionCacheOptions.MaxItemCount = 0
+	}
 }
 
 // SetupTestDBWithOptions creates an online test db with the specified database context options. Note that environment variables will override values (SG_TEST_USE_XATTRS, SG_TEST_USE_DEFAULT_COLLECTION).

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -74,6 +74,10 @@ if [ "${TEST_DEBUG:-}" == "true" ]; then
     export SG_TEST_BUCKET_POOL_DEBUG="true"
 fi
 
+if [ "${DISABLE_REV_CACHE:-}" == "true" ]; then
+    export SG_TEST_DISABLE_REV_CACHE="true"
+fi
+
 if [ "${TARGET_TEST}" != "ALL" ]; then
     GO_TEST_FLAGS+=(-run "${TARGET_TEST}")
 fi

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3401,6 +3401,9 @@ func TestHLVUpdateOnRevReplicatorPut(t *testing.T) {
 }
 
 func TestDocCRUDWithCV(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("Test requires revision cache to be enabled, fetches older revisions expecting to be resident in cache")
+	}
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -12,10 +12,8 @@ package rest
 
 import (
 	"encoding/base64"
-	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
@@ -706,26 +704,6 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 	})
 }
 
-func TestDeltaBackupDelete(t *testing.T) {
-	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}
-
-	rt := NewRestTester(t, rtConfig)
-	defer rt.Close()
-
-	const docID = "doc1"
-
-	// create doc1 rev 1
-	version := rt.PutDoc(docID, `{"greetings": [{"hello": "world!"}]}`)
-
-	// delete doc1 at rev 2
-	version = rt.DeleteDoc(docID, version)
-
-	time.Sleep(5 * time.Second)
-
-	fmt.Println("stop")
-}
-
 // TestBlipDeltaSyncPullTombstonedStarChan tests two clients can perform a simple pull replication that deletes a document when the user has access to the star channel.
 //
 // Sync Gateway: creates rev-1 and then tombstones it in rev-2
@@ -743,7 +721,7 @@ func TestDeltaBackupDelete(t *testing.T) {
 func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) //base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := &RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}}

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -1757,6 +1757,7 @@ func updateTestDoc(rt *rest.RestTester, docid string, revid string, body string)
 // Validate retrieval of various document body types using include_docs.
 func TestChangesIncludeDocs(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
+	t.Skip("pending CBG-4542")
 
 	rtConfig := rest.RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
 	rt := rest.NewRestTester(t, &rtConfig)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3070,6 +3070,9 @@ func TestNotFoundOnInvalidDatabase(t *testing.T) {
 
 func TestRevCacheMemoryLimitConfig(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	if base.TestDisableRevCache() {
+		t.Skip("test is rev cache config related test, should not override the test")
+	}
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1582,6 +1582,9 @@ func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 func TestImportRevisionCopy(t *testing.T) {
 
 	base.SkipImportTestsIfNotEnabled(t)
+	if base.TestDisableRevCache() {
+		t.Skip("Backup import revs requires previous rev to be in revision cache")
+	}
 
 	rtConfig := rest.RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -6873,6 +6873,9 @@ func TestUnprocessableDeltas(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("Requires EE for some delta sync")
 	}
+	if base.TestDisableRevCache() {
+		t.Skipf("Test requires altering of rev cache values")
+	}
 
 	// need Sync debugging due to AssertLogContains below
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeySync)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -379,6 +379,14 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		rt.DatabaseConfig.SGReplicateEnabled = base.Ptr(rt.RestTesterConfig.SgReplicateEnabled)
 
+		if base.TestDisableRevCache() {
+			rt.DatabaseConfig.CacheConfig = &CacheConfig{
+				RevCacheConfig: &RevCacheConfig{
+					MaxItemCount: base.Ptr[uint32](0),
+				},
+			}
+		}
+
 		// Check for override of AutoImport in the rt config
 		if rt.AutoImport != nil {
 			rt.DatabaseConfig.AutoImport = *rt.AutoImport
@@ -2572,6 +2580,14 @@ func (rt *RestTester) NewDbConfig() DbConfig {
 	} else {
 		config.Index = &IndexConfig{
 			NumReplicas: base.Ptr(uint(0)),
+		}
+	}
+
+	if base.TestDisableRevCache() {
+		config.CacheConfig = &CacheConfig{
+			RevCacheConfig: &RevCacheConfig{
+				MaxItemCount: base.Ptr[uint32](0),
+			},
 		}
 	}
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -380,11 +380,13 @@ func (rt *RestTester) Bucket() base.Bucket {
 		rt.DatabaseConfig.SGReplicateEnabled = base.Ptr(rt.RestTesterConfig.SgReplicateEnabled)
 
 		if base.TestDisableRevCache() {
-			rt.DatabaseConfig.CacheConfig = &CacheConfig{
-				RevCacheConfig: &RevCacheConfig{
-					MaxItemCount: base.Ptr[uint32](0),
-				},
+			if rt.DatabaseConfig.CacheConfig == nil {
+				rt.DatabaseConfig.CacheConfig = &CacheConfig{}
 			}
+			if rt.DatabaseConfig.CacheConfig.RevCacheConfig == nil {
+				rt.DatabaseConfig.CacheConfig.RevCacheConfig = &RevCacheConfig{}
+			}
+			rt.DatabaseConfig.CacheConfig.RevCacheConfig.MaxItemCount = base.Ptr[uint32](0)
 		}
 
 		// Check for override of AutoImport in the rt config


### PR DESCRIPTION
CBG-5126

Have the option to run test suite with bypass revision cache interface.

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/248/ (cache disabled)
- [x] - [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/249/ (flake that will be fixed in CBG-5141)
