### PR TITLE
[4.0.3 Backport] CBG-5128: Restore warnings when the import filter function for a document fails

### DIFF
--- a/db/import.go
+++ b/db/import.go
@@ -528,9 +528,14 @@ func (i *ImportFilterFunction) EvaluateFunction(ctx context.Context, doc Body) (
 
 	result, err := i.Call(ctx, doc)
 	if err != nil {
+		base.WarnfCtx(ctx, "Unexpected error invoking import filter for document %s - processing aborted, document will not be imported.  Error: %v", base.UD(doc), err)
 		return false, err
 	}
-	return parseImportFilterOutput(result)
+	ok, err := parseImportFilterOutput(result)
+	if err != nil {
+		base.WarnfCtx(ctx, "Unexpected error parsing output from import filter for document %s - processing aborted, document will not be imported.  Error: %v", base.UD(doc), err)
+	}
+	return ok, err
 }
 
 // ImportFilterDryRun Runs a document through the import filter and returns a boolean and error


### PR DESCRIPTION
CBG-5128

Clean-cherry pick of #8017 for 4.0.3

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a