### PR TITLE
Unskip old now working TestGetUserDocAccessSpanDeletedRole

### DIFF
--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -607,9 +607,6 @@ func TestGetUserDocAccessSpanWithMultiCollections(t *testing.T) {
 }
 
 func TestGetUserDocAccessSpanDeletedRole(t *testing.T) {
-	if base.TestsUseNamedCollections() {
-		t.Skip("Only works with default collection until CBG-4003 is fixed")
-	}
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: `function(doc) {channel(doc.channel); access(doc.user, doc.channel); role(doc.user, doc.role);}`,
 	})


### PR DESCRIPTION
This was fixed a while ago via #6938 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a