### PR TITLE
CBG-5056 close blip connection on panic

### DIFF
--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"errors"
+	"runtime/debug"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -228,6 +229,10 @@ func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since Seq
 
 	apr.activeSendChanges.Add(1)
 	go func(s *blip.Sender) {
+		if panicked := recover(); panicked != nil {
+			base.WarnfCtx(apr.ctx, "PANIC sending ISGR changes: %v\n%s. Canceling the replication.", panicked, debug.Stack())
+			bh.Close()
+		}
 		defer apr.activeSendChanges.Add(-1)
 		isComplete, err := bh.sendChanges(s, &sendChangesOptions{
 			docIDs:            apr.config.DocIDs,

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -335,6 +335,13 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 
 	// Start asynchronous changes goroutine
 	go func() {
+		defer func() {
+			if panicked := recover(); panicked != nil {
+				base.WarnfCtx(bh.loggingCtx, "PANIC sending changes: %v\n%s. Canceling the replication.", panicked, debug.Stack())
+				bh.Close()
+			}
+		}()
+
 		// Pull replication stats by type
 		if continuous {
 			bh.replicationStats.SubChangesContinuousActive.Add(1)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -296,7 +296,8 @@ func (bsc *BlipSyncContext) handleChangesResponse(ctx context.Context, sender *b
 	defer func() {
 		if panicked := recover(); panicked != nil {
 			bsc.replicationStats.NumHandlersPanicked.Add(1)
-			base.WarnfCtx(ctx, "PANIC handling 'changes' response: %v\n%s", panicked, debug.Stack())
+			base.WarnfCtx(ctx, "PANIC handling 'changes' response: %v\n%s. Canceling the replication.", panicked, debug.Stack())
+			bsc.Close()
 		}
 	}()
 
@@ -481,7 +482,7 @@ func (bsc *BlipSyncContext) sendRevisionWithProperties(ctx context.Context, send
 			defer func() {
 				if panicked := recover(); panicked != nil {
 					bsc.replicationStats.NumHandlersPanicked.Add(1)
-					base.WarnfCtx(ctx, "PANIC handling 'sendRevision' response: %v\n%s", panicked, debug.Stack())
+					base.WarnfCtx(ctx, "PANIC handling 'sendRevision' response: %v\n%s. Canceling the replication.", panicked, debug.Stack())
 					bsc.Close()
 				}
 			}()


### PR DESCRIPTION
CBG-5056 close blip connection on panic

If there is a panic sending changes, the couchbase lite pull replications effectively hang, since couchbase lite will wait for all expected revids and stop sending new messages. It is not expected to ever panic, but having an open pull replication seems not ideal. In some places, we already close the connection, but this was not done for all replication go routines:

https://github.com/couchbase/sync_gateway/blob/9a22b95ff4b62fa72b51649907298f5f70abff80/db/blip_sync_context.go#L485
https://github.com/couchbase/sync_gateway/blob/9a22b95ff4b62fa72b51649907298f5f70abff80/db/blip_sync_context.go#L199 implicitly closes the connection since this gets caught by the `recover` in go-blip

Closing this connection with `BlipSyncContext.Close` will result in the connection being closed with 1000 status code. In order to close with a specific error code modifying go-blip would be required https://github.com/couchbase/go-blip/pull/78

Couchbase Lite has untested code from the perspective of Sync Gateway that handles 4001 specially https://github.com/couchbase/couchbase-lite-core/blob/610fb32033c69da2aa8590374432a7a62de44502/Replicator/Replicator.cc#L519  but I am not sure how it behaves, but it also seems to reconnect on a 1000.

I tested this with and Android client introducing a panic like https://github.com/couchbase/sync_gateway/commit/1673d8177b0ee227974d4388f951ed8944cf0c73 and the behavior of closing the connection is:

- If continuous replication, the connection will reconnect automatically.
- If a non continuous replication, the connection will not reconnect automatically.

Defensively added recover and close to all replication goroutines I could find.

There isn't test code that exercises this because I could not determine how to instrument a panic into the code. I'm open to suggestions.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
