### PR TITLE
[4.0.3 backport] CBG-5118: Support request-provided oldDoc values in Sync Function Dry-Run

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1713,10 +1713,10 @@ func (db *DatabaseCollectionWithUser) PutExistingRevWithBody(ctx context.Context
 
 }
 
-// SyncFnDryrun Runs the given document body through a sync function and returns expiry, channels doc was placed in,
+// SyncFnDryRun Runs the given document body through a sync function and returns expiry, channels doc was placed in,
 // access map for users, roles, handler errors and sync fn exceptions.
 // If syncFn is provided, it will be used instead of the one configured on the database.
-func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, oldDoc *Document, userMeta, syncOptions map[string]any, syncFn string, errorLogFunc, infoLogFunc func(string)) (*channels.ChannelMapperOutput, error) {
+func (db *DatabaseCollectionWithUser) SyncFnDryRun(ctx context.Context, newDoc, oldDoc *Document, userMeta, syncOptions map[string]any, syncFn string, errorLogFunc, infoLogFunc func(string)) (*channels.ChannelMapperOutput, error) {
 	mutableBody, metaMap, _, err := db.prepareSyncFn(oldDoc, newDoc)
 	if err != nil {
 		base.InfofCtx(ctx, base.KeyDiagnostic, "Failed to prepare to run sync function: %v", err)
@@ -1751,7 +1751,11 @@ func (db *DatabaseCollectionWithUser) SyncFnDryrun(ctx context.Context, newDoc, 
 		return nil, fmt.Errorf("failed to create sync runner: %v", err)
 	}
 
-	jsOutput, err := syncRunner.Call(ctx, mutableBody, sgbucket.JSONString(oldDoc._rawBody), metaMap, syncOptions)
+	oldDocBodyBytes, err := oldDoc.BodyBytes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	jsOutput, err := syncRunner.Call(ctx, mutableBody, sgbucket.JSONString(oldDocBodyBytes), metaMap, syncOptions)
 	if err != nil {
 		return nil, &base.SyncFnDryRunError{Err: err}
 	}

--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -15,12 +15,14 @@ post:
     If no custom sync function is provided in the request, the user-defined sync function for the collection is used (or the default).
 
     The document being run through the sync function can be provided in one of the following ways:
-    | `doc` property | `doc_id` property | Behaviour                                                                                                                                                                                               |
-    | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-    | Set   | Unset    | The document body passed will be the `doc` value in the sync function, and `oldDoc` will be empty.                                                                                                                        |
-    | Unset | Set      | The document of the given id will be fetched from the bucket/collection and will be passed in as the `doc` value in the sync function. If the document is not found, an error will be returned                            |
-    | Set   | Set      | The document body passed will be the `doc` value in the sync function, and the `doc_id` will be fetched from the bucket/collection and will be the `oldDoc` value. If `doc_id` doesn't exist, then `oldDoc` will be empty |
-    | Unset | Unset    | Will throw an error (at least one of `doc` or `doc_id` is required)                                                                                                                                                       |
+    | `doc` property | `oldDoc` property | `doc_id` property | Behaviour                                                                                                                                                                                               |
+    | ----- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | Set   | Unset   | Unset    | The document body passed will be the `doc` value in the sync function, and `oldDoc` will be empty.                                                                                                                        |
+    | Set   | Set     | Unset    | The document body passed will be the `doc` value in the sync function, and the `oldDoc` value will be set to the inline `oldDoc` request body.                                                                              |
+    | Unset | Unset   | Set      | The document of the given id will be fetched from the bucket/collection and will be passed in as the `doc` value in the sync function. If the document is not found, an error will be returned                            |
+    | Set   | Unset   | Set      | The document body passed will be the `doc` value in the sync function, and the `doc_id` will be fetched from the bucket/collection and will be the `oldDoc` value. If `doc_id` doesn't exist, then `oldDoc` will be empty |
+    | Unset | -       | Unset    | Will throw an error (at least one of `doc` or `doc_id` is required)                                                                                                                                                       |
+    | -     | Set     | Set      | Will throw an error (`doc_id` and inline `oldDoc` cannot both be specified)                                                                                                                                                |
 
     * Sync Gateway Application Read Only
   requestBody:
@@ -45,11 +47,19 @@ post:
                   channel(doc.channels);
                 }
             doc:
-              description: A new document body to run the dry-run operation against.
+              description: A document body to run the sync function dry-run operation against.
+              type: object
+              additionalProperties: true
+              example:
+                foo: buzz
+                doc_num_updates: 2
+            oldDoc:
+              description: A document body to use as `oldDoc` during the dry-run. Cannot be used with `doc_id`.
               type: object
               additionalProperties: true
               example:
                 foo: bar
+                doc_num_updates: 1
             meta:
               description: Optional metadata used during evaluation.
               type: object

--- a/rest/diagnostic_doc_api.go
+++ b/rest/diagnostic_doc_api.go
@@ -53,11 +53,12 @@ type SyncFnDryRunPayload struct {
 	DocID    string              `json:"doc_id"`
 	Function string              `json:"sync_function"`
 	Doc      db.Body             `json:"doc,omitempty"`
+	OldDoc   db.Body             `json:"oldDoc,omitempty"`
 	Meta     SyncFnDryRunMetaMap `json:"meta,omitempty"`
 	UserCtx  *SyncDryRunUserCtx  `json:"userCtx,omitempty"`
 }
 
-const SYNC_FN_DIAGNOSTIC_DOCID = "diagnostic_doc"
+const defaultSyncDryRunDocID = "sync_dryrun"
 
 type ImportFilterDryRunPayload struct {
 	DocID    string  `json:"doc_id"`
@@ -95,10 +96,12 @@ func (h *handler) handleGetDocChannels() error {
 }
 
 // HTTP handler for running a document through the sync function and returning the results
-// body only provided, the sync function will run with no oldDoc provided
-// body and doc ID provided, the sync function will run using the current revision in the bucket as oldDoc
-// docid only provided, the sync function will run using the current revision in the bucket as doc
-// If docid is specified and the document does not exist in the bucket, it will return error
+//
+// The sync function can be dry-run with the following combinations of doc properties:
+//   - If 'doc' only provided, the sync function will run with the provided doc (and no oldDoc)
+//   - If 'doc' and 'oldDoc' provided, the sync function will run using the provided doc and oldDoc
+//   - If 'doc_id' only provided, the sync function will run using the current revision in the bucket as doc
+//   - If 'doc' and 'doc_id' provided, the sync function will run using the provided doc and the current revision in the bucket as oldDoc
 func (h *handler) handleSyncFnDryRun() error {
 
 	var syncDryRunPayload SyncFnDryRunPayload
@@ -109,7 +112,10 @@ func (h *handler) handleSyncFnDryRun() error {
 
 	bucketDocID := syncDryRunPayload.DocID
 	if syncDryRunPayload.Doc == nil && bucketDocID == "" {
-		return base.HTTPErrorf(http.StatusBadRequest, "no doc_id or document provided")
+		return base.HTTPErrorf(http.StatusBadRequest, "must provide either doc_id or doc")
+	}
+	if syncDryRunPayload.OldDoc != nil && bucketDocID != "" {
+		return base.HTTPErrorf(http.StatusBadRequest, "cannot specify doc_id with a provided oldDoc")
 	}
 
 	var userXattrs map[string]any
@@ -117,7 +123,7 @@ func (h *handler) handleSyncFnDryRun() error {
 	if syncDryRunPayload.Meta.Xattrs != nil {
 		xattrs := syncDryRunPayload.Meta.Xattrs
 		if len(xattrs) > 1 {
-			return base.HTTPErrorf(http.StatusBadRequest, "Only one xattr key can be specified in meta")
+			return base.HTTPErrorf(http.StatusBadRequest, "only one xattr key can be specified in meta")
 		}
 		userXattrKey := h.collection.UserXattrKey()
 		if userXattrKey == "" {
@@ -154,26 +160,29 @@ func (h *handler) handleSyncFnDryRun() error {
 		userCtx["roles"] = rolesMap
 	}
 
-	var docid string
+	inlineDocID, _ := syncDryRunPayload.Doc[db.BodyId].(string)
+	docID := cmp.Or(bucketDocID, inlineDocID, defaultSyncDryRunDocID)
 
-	id, _ := syncDryRunPayload.Doc[db.BodyId].(string)
-	docid = cmp.Or(bucketDocID, id, SYNC_FN_DIAGNOSTIC_DOCID)
-
-	oldDoc := &db.Document{ID: docid}
-	oldDoc.UpdateBody(syncDryRunPayload.Doc)
+	oldDoc := &db.Document{ID: docID}
 	// Read the document from the bucket
 	if bucketDocID != "" {
-		if docInbucket, err := h.collection.GetDocument(h.ctx(), bucketDocID, db.DocUnmarshalAll); err == nil {
-			oldDoc = docInbucket
-			if len(syncDryRunPayload.Doc) == 0 {
-				syncDryRunPayload.Doc = oldDoc.Body(h.ctx())
-				oldDoc.UpdateBody(nil)
-			}
-		} else {
-			return base.HTTPErrorf(http.StatusNotFound, "Error reading document: %v", err)
+		bucketDoc, err := h.collection.GetDocument(h.ctx(), bucketDocID, db.DocUnmarshalAll)
+		if err != nil {
+			return err
 		}
-	} else {
-		oldDoc.UpdateBody(nil)
+		if len(syncDryRunPayload.Doc) == 0 {
+			// use bucket doc as current doc value
+			syncDryRunPayload.Doc = bucketDoc.Body(h.ctx())
+			// set oldDoc for any xattrs that may be present for use in `meta`, but nil the body
+			oldDoc = bucketDoc
+			oldDoc.UpdateBody(nil)
+		} else {
+			// use bucket doc as oldDoc value
+			oldDoc = bucketDoc
+		}
+	} else if syncDryRunPayload.OldDoc != nil {
+		// use inline oldDoc value
+		oldDoc.UpdateBody(syncDryRunPayload.OldDoc)
 	}
 
 	delete(syncDryRunPayload.Doc, db.BodyId)
@@ -188,7 +197,7 @@ func (h *handler) handleSyncFnDryRun() error {
 
 	// Create newDoc which will be used to pass around Body
 	newDoc := &db.Document{
-		ID: docid,
+		ID: docID,
 	}
 	// Pull attachments
 	newDoc.SetAttachments(db.GetBodyAttachments(syncDryRunPayload.Doc))
@@ -227,7 +236,7 @@ func (h *handler) handleSyncFnDryRun() error {
 		logInfo = append(logInfo, s)
 	}
 
-	output, err := h.collection.SyncFnDryrun(h.ctx(), newDoc, oldDoc, userXattrs, userCtx, syncDryRunPayload.Function, errorLogFn, infoLogFn)
+	output, err := h.collection.SyncFnDryRun(h.ctx(), newDoc, oldDoc, userXattrs, userCtx, syncDryRunPayload.Function, errorLogFn, infoLogFn)
 	if err != nil {
 		var syncFnDryRunErr *base.SyncFnDryRunError
 		if !errors.As(err, &syncFnDryRunErr) {


### PR DESCRIPTION
Clean cherry-pick of #8019 for 4.0.3

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a