### PR TITLE
[3.3.3 Backport] CBG-5015: fix panic in _config?include_runtime=true endpoint

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -511,15 +511,17 @@ func (h *handler) handleGetConfig() error {
 				return err
 			}
 
-			replications, err := database.SGReplicateMgr.GetReplications()
-			if err != nil {
-				return err
-			}
+			if database.SGReplicateMgr != nil {
+				replications, err := database.SGReplicateMgr.GetReplications()
+				if err != nil {
+					return err
+				}
 
-			dbConfig.Replications = make(map[string]*db.ReplicationConfig, len(replications))
+				dbConfig.Replications = make(map[string]*db.ReplicationConfig, len(replications))
 
-			for replicationName, replicationConfig := range replications {
-				dbConfig.Replications[replicationName] = replicationConfig.ReplicationConfig.Redacted(h.ctx())
+				for replicationName, replicationConfig := range replications {
+					dbConfig.Replications[replicationName] = replicationConfig.ReplicationConfig.Redacted(h.ctx())
+				}
 			}
 		}
 


### PR DESCRIPTION
Cherry-pick of #7887 for 3.3.3