### PR TITLE
[3.3.3 Backport] CBG-4933: restart db initialization if needed

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -474,7 +474,7 @@ func RetryLoop[T any](ctx context.Context, description string, worker RetryWorke
 			} else if errors.Is(ctxErr, context.DeadlineExceeded) {
 				verb = "timed out"
 			}
-			return fmt.Errorf("Retry loop for %v %s based on context: %w", description, verb, ctxErr), *new(T)
+			return fmt.Errorf("Retry loop for %v %s based on context: %w", description, verb, context.Cause(ctx)), *new(T)
 		case <-time.After(time.Millisecond * time.Duration(sleepMs)):
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -297,7 +297,7 @@ func (h *handler) handlePostIndexInit() error {
 	action := cmp.Or(h.getQuery("action"), "start")
 
 	if action == "stop" {
-		h.server.DatabaseInitManager.Cancel(h.db.Name)
+		h.server.DatabaseInitManager.Cancel(h.db.Name, fmt.Sprintf("Initialization stopped by %s", h.rq.URL))
 		if err := h.db.AsyncIndexInitManager.Stop(); err != nil {
 			return err
 		}
@@ -1411,13 +1411,13 @@ func (h *handler) handleDeleteDB() error {
 		if err != nil {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't remove database %q from bucket %q: %s", base.MD(dbName), base.MD(bucket), err.Error())
 		}
-		h.server.RemoveDatabase(h.ctx(), dbName) // unhandled 404 to allow broken config deletion (CBG-2420)
+		h.server.RemoveDatabase(h.ctx(), dbName, fmt.Sprintf("called from %s", h.rq.URL)) // unhandled 404 to allow broken config deletion (CBG-2420)
 		h.writeRawJSON([]byte("{}"))
 		base.Audit(h.ctx(), base.AuditIDDeleteDatabase, nil)
 		return nil
 	}
 
-	if !h.server.RemoveDatabase(h.ctx(), dbName) {
+	if !h.server.RemoveDatabase(h.ctx(), dbName, fmt.Sprintf("called from %s", h.rq.URL)) {
 		return base.HTTPErrorf(http.StatusNotFound, "no such database %q", dbName)
 	}
 	h.writeRawJSON([]byte("{}"))

--- a/rest/api.go
+++ b/rest/api.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	httpprof "net/http/pprof"
 	"os"
@@ -244,7 +245,7 @@ func (h *handler) handleFlush() error {
 		config := h.server.GetDatabaseConfig(name)
 
 		// This needs to first call RemoveDatabase since flushing the bucket under Sync Gateway might cause issues.
-		h.server.RemoveDatabase(h.ctx(), name)
+		h.server.RemoveDatabase(h.ctx(), name, fmt.Sprintf("called from %s", h.rq.URL))
 
 		// Create a bucket connection spec from the database config
 		spec, err := GetBucketSpec(h.ctx(), &config.DatabaseConfig, h.server.Config)
@@ -283,7 +284,7 @@ func (h *handler) handleFlush() error {
 
 		name := h.db.Name
 		config := h.server.GetDatabaseConfig(name)
-		h.server.RemoveDatabase(h.ctx(), name)
+		h.server.RemoveDatabase(h.ctx(), name, fmt.Sprintf("called from %s", h.rq.URL))
 		err := bucket.CloseAndDelete(h.ctx())
 		_, err2 := h.server.AddDatabaseFromConfig(h.ctx(), config.DatabaseConfig)
 		if err != nil {

--- a/rest/database_init_manager.go
+++ b/rest/database_init_manager.go
@@ -10,6 +10,7 @@ package rest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -62,13 +63,18 @@ func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.C
 	if ok {
 		// If worker exists for the database and the collection sets match, add watcher to the existing worker
 		if dbInitWorker.collectionsEqual(collectionSet) {
-			base.InfofCtx(ctx, base.KeyAll, "Found existing database initialization for database %s ...",
-				base.MD(dbConfig.Name))
-			doneChan := dbInitWorker.addWatcher()
-			return doneChan, nil
+			// make sure the worker isn't in the process of shutting down
+			if dbInitWorker.ctx.Err() == nil {
+				base.InfofCtx(ctx, base.KeyAll, "Found existing database initialization for database %s ...",
+					base.MD(dbConfig.Name))
+				doneChan := dbInitWorker.addWatcher()
+				return doneChan, nil
+			}
+			base.DebugfCtx(ctx, base.KeyAll, "Existing database initialization for database %s has been cancelled, starting new initialization ... ctx=%s", base.MD(dbConfig.Name), context.Cause(dbInitWorker.ctx))
+		} else {
+			// For a mismatch in collections, stop and remove the existing worker, then continue through to creation of new worker
+			dbInitWorker.Stop("Database requested to be initialized with different collections than existing initialization, canceling existing initialization.")
 		}
-		// For a mismatch in collections, stop and remove the existing worker, then continue through to creation of new worker
-		dbInitWorker.Stop()
 		delete(m.workers, dbConfig.Name)
 	}
 
@@ -133,7 +139,7 @@ func (m *DatabaseInitManager) InitializeDatabaseWithStatusCallback(ctx context.C
 	return doneChan, nil
 }
 
-// Initializes the database.  Will establish a new cluster connection using the provided server config.  Establishes a new
+// InitializeDatabase will establish a new cluster connection using the provided server config.  Establishes a new
 // cluster-only N1QLStore based on the startup config to perform initialization.
 func (m *DatabaseInitManager) InitializeDatabase(ctx context.Context, startupConfig *StartupConfig, dbConfig *DatabaseConfig, useLegacySyncDocsIndex bool) (doneChan chan error, err error) {
 	return m.InitializeDatabaseWithStatusCallback(ctx, startupConfig, dbConfig, nil, useLegacySyncDocsIndex)
@@ -165,14 +171,14 @@ func (m *DatabaseInitManager) SetTestCallbacks(collectionCallback CollectionCall
 	m.testDatabaseCompleteCallback = databaseComplete
 }
 
-func (m *DatabaseInitManager) Cancel(dbName string) {
+func (m *DatabaseInitManager) Cancel(dbName string, reason string) {
 	m.workersLock.Lock()
 	defer m.workersLock.Unlock()
 	worker, ok := m.workers[dbName]
 	if !ok {
 		return
 	}
-	worker.Stop()
+	worker.Stop(reason)
 }
 
 // buildCollectionIndexData determines the set of indexes required for each collection in the config, including
@@ -207,10 +213,10 @@ type DatabaseInitWorker struct {
 	dbName                   string
 	n1qlStore                *base.ClusterOnlyN1QLStore
 	options                  DatabaseInitOptions
-	ctx                      context.Context        // On close, terminates any goroutines associated with the worker
-	cancelFunc               context.CancelFunc     // Cancel function for context, invoked if Cancel is called
-	collections              CollectionInitData     // The set of collections associated with the worker, mapped by name to their index set
-	collectionStatusCallback CollectionCallbackFunc // Callback for status observability
+	ctx                      context.Context         // On close, terminates any goroutines associated with the worker
+	cancelFunc               context.CancelCauseFunc // Cancel function for context, invoked if Cancel is called
+	collections              CollectionInitData      // The set of collections associated with the worker, mapped by name to their index set
+	collectionStatusCallback CollectionCallbackFunc  // Callback for status observability
 
 	// Multiple goroutines (watchers) may be waiting for database initialization.  To support sending error information to
 	// every goroutine, we maintain a channel for each of these watching goroutines.  On success, all channels are
@@ -227,7 +233,7 @@ type DatabaseInitOptions struct {
 }
 
 func NewDatabaseInitWorker(ctx context.Context, dbName string, n1qlStore *base.ClusterOnlyN1QLStore, collections CollectionInitData, indexOptions db.InitializeIndexOptions, callback CollectionCallbackFunc) *DatabaseInitWorker {
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	cancelCtx, cancelFunc := context.WithCancelCause(ctx)
 	return &DatabaseInitWorker{
 		dbName:                   dbName,
 		options:                  DatabaseInitOptions{indexOptions: indexOptions},
@@ -243,7 +249,7 @@ func (w *DatabaseInitWorker) Run() {
 	// Ensure cancelFunc resources are released on normal completion
 	defer func() {
 		if w.cancelFunc != nil {
-			w.cancelFunc()
+			w.cancelFunc(errors.New("database initialization finished normally"))
 		}
 	}()
 
@@ -333,6 +339,6 @@ func (w *DatabaseInitWorker) collectionsEqual(newCollectionSet CollectionInitDat
 }
 
 // Stop cancels the context, which will terminate initialization after the current collection being processed
-func (w *DatabaseInitWorker) Stop() {
-	w.cancelFunc()
+func (w *DatabaseInitWorker) Stop(reason string) {
+	w.cancelFunc(errors.New(reason))
 }

--- a/rest/database_init_manager_test.go
+++ b/rest/database_init_manager_test.go
@@ -52,10 +52,9 @@ func TestDatabaseInitManager(t *testing.T) {
 	require.NoError(t, err)
 
 	select {
-	case <-doneChan:
-		log.Printf("done channel was closed")
-		// continue
-	case <-time.After(10 * time.Second):
+	case err := <-doneChan:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
 		require.Fail(t, "InitializeDatabase didn't complete in 10s")
 	}
 
@@ -443,12 +442,12 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	initMgr := sc.DatabaseInitManager
 
 	// Create collection callback that blocks and waits for test notification the first time a collection is initialized, does not block afterward.
-	collectionCount := int64(0)
+	var collectionCount atomic.Int64
 	initMgr.testCollectionStatusUpdateCallback = func(_ string, _ base.ScopeAndCollectionName, status db.CollectionIndexStatus) {
 		if status != db.CollectionIndexStatusReady {
 			return
 		}
-		atomic.AddInt64(&collectionCount, 1)
+		collectionCount.Add(1)
 	}
 	dbName := "dbName"
 	dbConfig := makeDbConfig(tb.GetName(), dbName, collection1and2ScopesConfig)
@@ -456,19 +455,16 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	databaseCompleteCount := int64(0)
+	var databaseCompleteCount atomic.Int64
 	initMgr.testDatabaseCompleteCallback = func(dbName string) {
 		// On first completion, invoke InitializeDatabase with the same collection set post-completion
-		currentCount := atomic.LoadInt64(&databaseCompleteCount)
-		if currentCount == 0 {
+		if databaseCompleteCount.Add(1) == 1 {
 			defer wg.Done()
 			log.Printf("invoking InitializeDatabase again during teardown")
 			doneChan2, err := initMgr.InitializeDatabase(ctx, sc.Config, dbConfig.ToDatabaseConfig(), testUseLegacySyncDocsIndex)
 			require.NoError(t, err)
 			WaitForChannel(t, doneChan2, "done chan 2")
 		}
-		atomic.AddInt64(&databaseCompleteCount, 1)
-
 	}
 
 	// Start first async index creation, should block after first collection
@@ -478,14 +474,11 @@ func TestDatabaseInitTeardownTiming(t *testing.T) {
 	WaitForChannel(t, doneChan1, "done chan 1")
 	wg.Wait()
 
-	// Verify initialization was run for 3 collections only
-	totalCollectionInitCount := atomic.LoadInt64(&collectionCount)
-	require.Equal(t, int64(3), totalCollectionInitCount)
+	// Verify initialization was run for 6 collections, since it runs on 3 collections twice
+	require.Equal(t, int64(6), collectionCount.Load())
 
-	// Expect only a single database complete callback, since init should only have been run once.
-	totalDbCompleteCount := atomic.LoadInt64(&databaseCompleteCount)
-	require.Equal(t, int64(1), totalDbCompleteCount)
-
+	// Expect two database complete callbacks, since initialization is run twice
+	require.Equal(t, int64(2), databaseCompleteCount.Load())
 }
 
 func makeScopesConfig(scopeName string, collectionNames []string) ScopesConfig {

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -321,7 +321,8 @@ func TestChangeIndexPartitionsStartStopAndRestart(t *testing.T) {
 		var body db.AsyncIndexInitManagerResponse
 		err := base.JSONUnmarshal(resp.BodyBytes(), &body)
 		require.NoError(c, err)
-		require.Equal(c, db.BackgroundProcessStateStopped, body.State)
+		assert.Equal(c, db.BackgroundProcessStateStopped, body.State, "body: %#+v", body)
+		require.Equal(c, "", body.LastErrorMessage, "expected no error when stopping, got: %s", body.LastErrorMessage)
 	}, 1*time.Minute, 1*time.Second)
 
 	// restart with new params
@@ -335,7 +336,9 @@ func TestChangeIndexPartitionsStartStopAndRestart(t *testing.T) {
 		var body db.AsyncIndexInitManagerResponse
 		err := base.JSONUnmarshal(resp.BodyBytes(), &body)
 		require.NoError(c, err)
-		require.Equal(c, db.BackgroundProcessStateCompleted, body.State)
+		// immediately exit if the state turns to error
+		require.NotEqual(t, db.BackgroundProcessStateError, body.State, "body: %#+v", body)
+		assert.Equal(c, db.BackgroundProcessStateCompleted, body.State, "body: %#+v", body)
 	}, 1*time.Minute, 1*time.Second)
 }
 

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7893,7 +7893,7 @@ func TestExistingConfigEmptyReplicationID(t *testing.T) {
 			dbName := fmt.Sprintf("db%d", i)
 			ctx := rt.Context()
 			defer func() {
-				require.True(t, rt.ServerContext().RemoveDatabase(ctx, dbName))
+				require.True(t, rt.ServerContext().RemoveDatabase(ctx, dbName, fmt.Sprintf("Removing database for %s", testCase.name)))
 			}()
 			dbConfig := rt.NewDbConfig()
 			dbConfig.Name = dbName
@@ -7936,7 +7936,7 @@ func TestNoDBInCheckpointHash(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, ar.Stop()) }()
 	// remove the db context for rt1 off the server context
-	ok := rt1.ServerContext().RemoveDatabase(base.TestCtx(t), "db")
+	ok := rt1.ServerContext().RemoveDatabase(base.TestCtx(t), "db", "Removing database context for test")
 	require.True(t, ok)
 
 	// assert that the db context has been removed

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1611,14 +1611,14 @@ func (sc *ServerContext) processEventHandlersForEvent(ctx context.Context, event
 }
 
 // RemoveDatabase is called when an external request is made to delete the database
-func (sc *ServerContext) RemoveDatabase(ctx context.Context, dbName string) bool {
+func (sc *ServerContext) RemoveDatabase(ctx context.Context, dbName string, reason string) bool {
 	sc._databasesLock.Lock()
 	defer sc._databasesLock.Unlock()
 
 	// If async init is running for the database, cancel it for an external remove.  (cannot be
 	// done in _removeDatabase, as this is called during reload)
 	if sc.DatabaseInitManager != nil && sc.DatabaseInitManager.HasActiveInitialization(dbName) {
-		sc.DatabaseInitManager.Cancel(dbName)
+		sc.DatabaseInitManager.Cancel(dbName, reason)
 	}
 
 	return sc._removeDatabase(ctx, dbName)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -152,7 +152,7 @@ func TestAllDatabaseNames(t *testing.T) {
 	assert.Contains(t, serverContext.AllDatabaseNames(), "imdb1")
 	assert.Contains(t, serverContext.AllDatabaseNames(), "imdb2")
 
-	status := serverContext.RemoveDatabase(ctx, "imdb2")
+	status := serverContext.RemoveDatabase(ctx, "imdb2", "Removing imdb2 in test")
 	assert.True(t, status, "Database should be removed from server context")
 	assert.Len(t, serverContext.AllDatabaseNames(), 1)
 	assert.Contains(t, serverContext.AllDatabaseNames(), "imdb1")


### PR DESCRIPTION
Cherry-pick of #7825 for 3.3.3

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/243/
