### PR TITLE
CBG-5130: fix panic when using bypass revision cache with delta sync

### DIFF
--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"sync"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -45,6 +46,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 	if err != nil {
 		return DocumentRevision{}, err
 	}
+	docRev.RevCacheValueDeltaLock = &sync.Mutex{} // initialize the mutex for delta updates
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
 		docRev.HlvHistory = hlv.ToHistoryForHLV()
@@ -72,6 +74,7 @@ func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *
 	if err != nil {
 		return DocumentRevision{}, err
 	}
+	docRev.RevCacheValueDeltaLock = &sync.Mutex{} // initialize the mutex for delta updates
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
 		docRev.HlvHistory = hlv.ToHistoryForHLV()
@@ -99,6 +102,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 	if err != nil {
 		return DocumentRevision{}, err
 	}
+	docRev.RevCacheValueDeltaLock = &sync.Mutex{} // initialize the mutex for delta updates
 	if hlv != nil {
 		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
 		docRev.HlvHistory = hlv.ToHistoryForHLV()

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1272,3 +1272,54 @@ func TestBlipDeltaComputationFromBackupRev(t *testing.T) {
 		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
 	})
 }
+
+// TestDeltaGenerationWithBypassRevCache tests that delta generation works when the rev cache is bypassed.
+func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	const (
+		username = "alice"
+		docID    = "doc1"
+	)
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+			CacheConfig: &CacheConfig{
+				RevCacheConfig: &RevCacheConfig{
+					MaxItemCount: base.Ptr[uint32](0),
+				},
+			},
+		}},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
+		rt.CreateUser(username, []string{"alice"})
+		opts := &BlipTesterClientOpts{Username: username, ClientDeltas: true}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		// create doc1
+		version1 := rt.PutDoc(docID, `{"foo": "bar", "version": "1", "channels": ["alice"]}`)
+		rt.WaitForPendingChanges()
+
+		btcRunner.StartPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version1)
+
+		// create rev 2
+		version2 := rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
+		rt.WaitForPendingChanges()
+
+		// Bypass rev cache to force delta computation from backup rev and go through bypass revision cache interface
+		btcRunner.WaitForVersion(client.id, docID, version2)
+		// assert rev sent as delta
+		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+	})
+}

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1317,7 +1317,7 @@ func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
 		version2 := rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
 		rt.WaitForPendingChanges()
 
-		// Bypass rev cache to force delta computation from backup rev and go through bypass revision cache interface
+		// code will go though bypass revision cache interface, delta will be generated from backup rev
 		btcRunner.WaitForVersion(client.id, docID, version2)
 		// assert rev sent as delta
 		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())


### PR DESCRIPTION
CBG-5130

- Fix for panic when running delta sync with bypass rev cache 
- We were missing initialisation of mutex on doc rev in the bypass code pathway 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
