### PR TITLE
[3.3.3 backport] CBG-5131: fix panic when using bypass revision cache with delta sync

### DIFF
--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"sync"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -39,7 +40,8 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, revID string, col
 	}
 
 	docRev = DocumentRevision{
-		RevID: revID,
+		RevID:                  revID,
+		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
 	}
 	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, revID)
 	if err != nil {
@@ -61,6 +63,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 
 	docRev = DocumentRevision{
 		RevID: doc.CurrentRev,
+		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
 	}
 
 	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.CurrentRev)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -62,7 +62,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 	}
 
 	docRev = DocumentRevision{
-		RevID: doc.CurrentRev,
+		RevID:                  doc.CurrentRev,
 		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
 	}
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1111,12 +1111,12 @@ func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.Run(func(t *testing.T) {
+	btcRunner.Run(func(t *testing.T, SupportedBLIPProtocols []string) {
 		rt := NewRestTester(t,
 			rtConfig)
 		defer rt.Close()
 		rt.CreateUser(username, []string{"alice"})
-		opts := &BlipTesterClientOpts{Username: username, ClientDeltas: true}
+		opts := &BlipTesterClientOpts{Username: username, ClientDeltas: true, SupportedBLIPProtocols: SupportedBLIPProtocols}
 		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
 		defer client.Close()
 

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1086,3 +1086,54 @@ func TestBlipDeltaNoAccessPush(t *testing.T) {
 
 	})
 }
+
+// TestDeltaGenerationWithBypassRevCache tests that delta generation works when the rev cache is bypassed.
+func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	const (
+		username = "alice"
+		docID    = "doc1"
+	)
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+			CacheConfig: &CacheConfig{
+				RevCacheConfig: &RevCacheConfig{
+					MaxItemCount: base.Ptr[uint32](0),
+				},
+			},
+		}},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
+		rt.CreateUser(username, []string{"alice"})
+		opts := &BlipTesterClientOpts{Username: username, ClientDeltas: true}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+
+		// create doc1
+		version1 := rt.PutDoc(docID, `{"foo": "bar", "version": "1", "channels": ["alice"]}`)
+		rt.WaitForPendingChanges()
+
+		btcRunner.StartPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version1)
+
+		// create rev 2
+		version2 := rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
+		rt.WaitForPendingChanges()
+
+		// code will go though bypass revision cache interface, delta will be generated from backup rev
+		btcRunner.WaitForVersion(client.id, docID, version2)
+		// assert rev sent as delta
+		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+	})
+}


### PR DESCRIPTION
CBG-5131

Backports fd3fada

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
