### PR TITLE
CBG-5134: attachment fetch is in wrong place when loading from bucket by CV

### DIFF
--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -506,9 +506,8 @@ func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Documen
 			return nil, nil, nil, err
 		}
 		channels = doc.SyncData.getCurrentChannels()
+		attachments = doc.Attachments()
 	}
-
-	attachments = doc.Attachments()
 
 	// handle backup revision inline attachments, or pre-2.5 meta
 	if inlineAtts, cleanBodyBytes, _, err := extractInlineAttachments(bodyBytes); err != nil {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3540,6 +3540,41 @@ func TestDisableAllowStarChannel(t *testing.T) {
 	base.DebugfCtx(t.Context(), base.KeySGTest, "additional logs")
 }
 
+func TestFetchBackupRevisionWithAttachmentWhenCurrentHasNone(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				// enable delta sync to ensure we have a backup revision stored for cv
+				DeltaSync: &DeltaSyncConfig{
+					Enabled:          base.Ptr(true),
+					RevMaxAgeSeconds: base.Ptr(db.DefaultDeltaSyncRevMaxAge),
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	docID := t.Name()
+	// create rev 1 with attachment
+	createVersion := rt.PutDoc(docID, `{"test":"data", "_attachments": {"att1": {"data":"SGVsbG8gd29ybGQh"}}}`)
+
+	// update to rev 2 without attachment
+	rt.UpdateDoc(docID, createVersion, `{"test":"data updated"}`)
+
+	// fetch rev 1 by its CV, which should include the attachment
+	resp := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, url.QueryEscape(createVersion.CV.String())), "")
+	RequireStatus(t, resp, http.StatusOK)
+	fmt.Println(resp.Body.String())
+	var body db.Body
+	err := base.JSONUnmarshal(resp.Body.Bytes(), &body)
+	require.NoError(t, err)
+
+	attachments, ok := body["_attachments"].(map[string]interface{})
+	require.True(t, ok, "expected _attachments in response body")
+	_, ok = attachments["att1"].(map[string]interface{})
+	require.True(t, ok, "expected att1 in _attachments")
+}
+
 // TestECCV validates if the ECCV value of the bucket is returned as a response
 // for _cluster_info endpoint. ECCV value is returned for each bucket, if the
 // bucket does not contain any SGW database, the value will be set to false

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3564,7 +3564,6 @@ func TestFetchBackupRevisionWithAttachmentWhenCurrentHasNone(t *testing.T) {
 	// fetch rev 1 by its CV, which should include the attachment
 	resp := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, url.QueryEscape(createVersion.CV.String())), "")
 	RequireStatus(t, resp, http.StatusOK)
-	fmt.Println(resp.Body.String())
 	var body db.Body
 	err := base.JSONUnmarshal(resp.Body.Bytes(), &body)
 	require.NoError(t, err)

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
@@ -2951,6 +2952,82 @@ func TestBlipPushRevWithAttachment(t *testing.T) {
 		RequireStatus(t, response, http.StatusOK)
 		require.Equal(t, attachmentData, string(response.BodyBytes()))
 	})
+}
+
+// TestGetNonWinningRevisionAttachmentLeak tests that when fetching a non-winning revision via the REST API,
+// users do not see attachment metadata from revisions they don't have access to.
+func TestGetNonWinningRevisionAttachmentLeak(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta sync (required for backup revisions in 4.x) requires EE")
+	}
+
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+		}},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	rt.CreateUser("alice", []string{"ABC"})
+
+	for _, revType := range []string{"RevTreeID", "CV"} {
+		t.Run(revType, func(t *testing.T) {
+			for _, flushCache := range []bool{false, true} {
+				cacheName := "cached"
+				if flushCache {
+					cacheName = "uncached"
+				}
+				t.Run(cacheName, func(t *testing.T) {
+					docID := fmt.Sprintf("doc_%s_%s", revType, cacheName)
+
+					// version 1 in channel A (alice has access) without attachments
+					resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID, `{"channels": ["ABC"], "value": "v1"}`)
+					RequireStatus(t, resp, http.StatusCreated)
+					version1 := DocVersionFromPutResponse(t, resp)
+
+					// version 2 moves to channel B (alice has no access) with an attachment
+					resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+docID+"?rev="+version1.RevTreeID,
+						`{"channels": ["NBC"], "value": "v2", "_attachments": {"attachment.txt": {"data": "YXR0ZGF0YQ=="}}}`)
+					RequireStatus(t, resp, http.StatusCreated)
+
+					if flushCache {
+						rt.GetDatabase().FlushRevisionCacheForTest()
+					}
+
+					revParam := version1.RevTreeID
+					if revType == "CV" {
+						revParam = version1.CV.String()
+					}
+
+					// Alice requests v1 - she has access to this revision
+					resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, revParam), "", "alice")
+					RequireStatus(t, resp, http.StatusOK)
+					t.Logf("resp body: %s", resp.BodyBytes())
+
+					var body db.Body
+					require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+
+					assert.Equal(t, "v1", body["value"], "Should get v1's body content")
+
+					// v1 should have no attachments - it was created without any
+					attachments := body["_attachments"]
+					assert.Nil(t, attachments, "v1 should have no attachments")
+
+					// Try to fetch the attachment directly - should fail since v1 has no attachments
+					resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s/attachment.txt?rev=%s", docID, revParam), "", "alice")
+
+					assert.NotEqual(t, http.StatusOK, resp.Code, "Should not be able to fetch attachment that doesn't exist on v1")
+
+					assert.NotEqual(t, "attdata", resp.Body.String(), "Should not receive attachment content from v2")
+				})
+			}
+		})
+	}
 }
 
 // attachmentMetaResponse is the response body for GET /ks/doc/att?meta=true


### PR DESCRIPTION
CBG-5134

- Was always fetch current revision attachments when loading from bucket. This is not correct when dealing with backup revision. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/244/
