### PR TITLE
CBG-5133: fix backup revs being marked as deleted when current rev is deleted

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -54,19 +54,19 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 	// current revision backups depend on delta sync (to support deltas to SDK updates)
 	if deltasEnabled {
-		rev1OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		rev1OldBody, _, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 
-		rev1OldBody, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		rev1OldBody, _, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	} else {
-		_, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		_, _, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 
-		_, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		_, _, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}
@@ -80,26 +80,26 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 	// rev 1 should be backed up even without delta sync now (by revTree ID - but not CV)
 	if !deltasEnabled {
-		rev1OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
+		rev1OldBody, _, _, err := collection.getOldRevisionJSON(ctx, docID, revid1)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev1OldBody), "hello.txt")
 	}
 
 	// again, only backup current winning revision if delta sync
 	if deltasEnabled {
-		rev2OldBody, _, err := collection.getOldRevisionJSON(ctx, docID, revid2)
+		rev2OldBody, _, _, err := collection.getOldRevisionJSON(ctx, docID, revid2)
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 
-		rev2OldBody, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+		rev2OldBody, _, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 		require.NoError(t, err)
 		assert.Contains(t, string(rev2OldBody), "hello.txt")
 	} else {
-		_, _, err := collection.getOldRevisionJSON(ctx, docID, revid2)
+		_, _, _, err := collection.getOldRevisionJSON(ctx, docID, revid2)
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 
-		_, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+		_, _, _, err = collection.getOldRevisionJSON(ctx, docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 		require.Error(t, err)
 		assert.Equal(t, "404 missing", err.Error())
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -942,7 +942,11 @@ func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, do
 	}
 
 	// Back up the revision JSON as a separate doc in the bucket:
-	db.backupRevisionJSON(ctx, doc.ID, ancestorRevId, json, ch, docDeleted)
+	revInfo, ok := doc.History[ancestorRevId]
+	if !ok {
+		return
+	}
+	db.backupRevisionJSON(ctx, doc.ID, ancestorRevId, json, ch, revInfo.Deleted)
 
 	// Nil out the ancestor rev's body in the document struct:
 	if ancestorRevId == doc.GetRevTreeID() {
@@ -2159,7 +2163,7 @@ func (db *DatabaseCollectionWithUser) tombstoneActiveRevision(ctx context.Contex
 	// Backup previous revision body, then remove the current body from the doc
 	bodyBytes, err := doc.BodyBytes(ctx)
 	if err == nil {
-		_ = db.setOldRevisionJSON(ctx, doc.ID, revID, bodyBytes, doc.Deleted, db.oldRevExpirySeconds(), doc.getCurrentChannels())
+		_ = db.setOldRevisionJSON(ctx, doc.ID, revID, bodyBytes, doc.IsDeleted(), db.oldRevExpirySeconds(), doc.getCurrentChannels())
 	}
 	doc.RemoveBody()
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -927,7 +927,7 @@ func (db *DatabaseCollectionWithUser) getAvailableRevAttachments(ctx context.Con
 }
 
 // Moves a revision's ancestor's body out of the document object and into a separate db doc.
-func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, doc *Document, newDocRevID string, ch base.Set, docDeleted bool) {
+func (db *DatabaseCollectionWithUser) backupAncestorRevs(ctx context.Context, doc *Document, newDocRevID string, ch base.Set) {
 
 	// Find an ancestor that still has JSON in the document:
 	var json []byte
@@ -2537,7 +2537,6 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 	// grab the current channels so that we're able to use them when stamping the backup revision later
 	// we lose channel information for non-leaf revisions in the RevTree when updated, so we take a copy now.
 	oldChannels := doc.getCurrentChannels()
-	docDeleted := doc.Deleted
 
 	// compute mouMatch before the callback modifies doc.MetadataOnlyUpdate
 	mouMatch := false
@@ -2597,7 +2596,7 @@ func (col *DatabaseCollectionWithUser) documentUpdateFunc(
 		}
 	}
 
-	col.backupAncestorRevs(ctx, doc, newDoc.RevID, oldChannels, docDeleted)
+	col.backupAncestorRevs(ctx, doc, newDoc.RevID, oldChannels)
 
 	unusedSequences, err = col.assignSequence(ctx, previousDocSequenceIn, doc, unusedSequences)
 	if err != nil {

--- a/db/import.go
+++ b/db/import.go
@@ -478,7 +478,7 @@ func (db *DatabaseCollectionWithUser) backupPreImportRevision(ctx context.Contex
 		return err
 	}
 
-	setOldRevErr := db.setOldRevisionJSON(ctx, docid, revid, oldRevJSON, db.oldRevExpirySeconds(), previousRev.Channels)
+	setOldRevErr := db.setOldRevisionJSON(ctx, docid, revid, oldRevJSON, previousRev.Deleted, db.oldRevExpirySeconds(), previousRev.Channels)
 	if setOldRevErr != nil {
 		return fmt.Errorf("Persistence error: %v", setOldRevErr)
 	}

--- a/db/revision.go
+++ b/db/revision.go
@@ -43,7 +43,10 @@ const (
 	BodyInternalPrefix = "_sync_" // New internal properties prefix (CBG-1995)
 )
 
-const backupRevisionChannelsMetaKey = "_channels"
+const (
+	backupRevisionChannelsMetaKey    = "_channels"
+	backupRevisionBodyDeletedMetaKey = "_deleted"
+)
 
 // A revisions property found within a Body.  Expected to be of the form:
 //
@@ -237,19 +240,19 @@ func (body Body) getExpiry() (uint32, bool, error) {
 
 // getOldRevisionJSON looks up the raw JSON data of a revision that's been archived to a separate doc.
 // If the revision isn't found (e.g. has been deleted by compaction) returns 404 error.
-func (c *DatabaseCollection) getOldRevisionJSON(ctx context.Context, docid string, revOrCV string) ([]byte, base.Set, error) {
+func (c *DatabaseCollection) getOldRevisionJSON(ctx context.Context, docid string, revOrCV string) ([]byte, base.Set, bool, error) {
 	data, _, err := c.dataStore.GetRaw(oldRevisionKey(docid, revOrCV))
 	if base.IsDocNotFoundError(err) {
 		base.DebugfCtx(ctx, base.KeyCRUD, "No old revision %q / %q", base.UD(docid), revOrCV)
-		return nil, nil, ErrMissing
+		return nil, nil, false, ErrMissing
 	} else if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 	kind, revData := stripNonJSONPrefix(data)
 	switch kind {
 	case nonJSONPrefixKindRevBody:
 		base.DebugfCtx(ctx, base.KeyCRUD, "Got old revision %q / %q --> %d bytes", base.UD(docid), revOrCV, len(revData))
-		return revData, nil, nil
+		return revData, nil, false, nil
 	case nonJSONPrefixKindRevPtr:
 		// pointer to a CV-keyed backup revision - do another fetch by CV for the body
 		base.DebugfCtx(ctx, base.KeyCRUD, "Found old revision pointer %q -> %q / %q", revOrCV, base.UD(docid), string(revData))
@@ -257,19 +260,26 @@ func (c *DatabaseCollection) getOldRevisionJSON(ctx context.Context, docid strin
 	case nonJSONPrefixKindRevWithMeta:
 		jsonBody, meta, err := getOldRevisionJSONAndMeta(revData)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		base.DebugfCtx(ctx, base.KeyCRUD, "Got old revision (with %d meta properties) %q / %q --> %d bytes", len(meta), base.UD(docid), revOrCV, len(jsonBody))
 		var channelSet base.Set
 		if ch, ok := meta[backupRevisionChannelsMetaKey]; ok && ch != nil {
 			err = base.JSONUnmarshal(ch, &channelSet)
 			if err != nil {
-				return nil, nil, fmt.Errorf("error unmarshalling _channels xattr for old revision %q / %q: %v", base.UD(docid), revOrCV, err)
+				return nil, nil, false, fmt.Errorf("error unmarshalling _channels xattr for old revision %q / %q: %v", base.UD(docid), revOrCV, err)
 			}
 		}
-		return jsonBody, channelSet, nil
+		var deletedDoc bool
+		if deletedMeta, ok := meta[backupRevisionBodyDeletedMetaKey]; ok && deletedMeta != nil {
+			err = base.JSONUnmarshal(deletedMeta, &deletedDoc)
+			if err != nil {
+				return nil, nil, false, fmt.Errorf("error unmarshalling _channels xattr for old revision %q / %q: %v", base.UD(docid), revOrCV, err)
+			}
+		}
+		return jsonBody, channelSet, deletedDoc, nil
 	default:
-		return nil, nil, fmt.Errorf("unexpected prefix %b for old revision doc %q / %q", kind, base.UD(docid).String(), revOrCV)
+		return nil, nil, false, fmt.Errorf("unexpected prefix %b for old revision doc %q / %q", kind, base.UD(docid).String(), revOrCV)
 	}
 }
 
@@ -282,7 +292,7 @@ func getOldRevisionJSONAndMeta(payload []byte) (jsonBody []byte, kvPairs map[str
 }
 
 // Makes a backup of revision body for use by in-flight replications requesting an old revision (for clients not supporting replacementRevs)
-func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, docId, oldRev string, oldBody []byte, channels base.Set) {
+func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, docId, oldRev string, oldBody []byte, channels base.Set, deleted bool) {
 	if db.deltaSyncEnabled() && db.deltaSyncRevMaxAgeSeconds() > 0 {
 		// See postWriteUpdateHLV - we're writing a CV and RevTreeID backup there to support delta sync
 		return
@@ -299,7 +309,7 @@ func (db *DatabaseCollectionWithUser) backupRevisionJSON(ctx context.Context, do
 	}
 
 	// store or refresh the old document revision by revtree ID for in-flight replications
-	_ = db.refreshOldRevisionJSON(ctx, docId, oldRev, oldBody, db.oldRevExpirySeconds(), channels)
+	_ = db.refreshOldRevisionJSON(ctx, docId, oldRev, oldBody, db.oldRevExpirySeconds(), channels, deleted)
 }
 
 // setOldRevisionJSONBody stores the raw JSON body of a revision that has been archived to a separate doc.
@@ -316,7 +326,7 @@ func (db *DatabaseCollectionWithUser) setOldRevisionJSONBody(ctx context.Context
 	return err
 }
 
-func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, docid string, rev string, body []byte, expiry uint32, channels base.Set) error {
+func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, docid string, rev string, body []byte, deletedDoc bool, expiry uint32, channels base.Set) error {
 	// no channel information available (Note: this is different than an empty set of channels)
 	if channels == nil {
 		base.WarnfCtx(ctx, "setOldRevisionJSON called with nil channels for old revision %q / %q", base.UD(docid), rev)
@@ -329,8 +339,13 @@ func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, do
 	if err != nil {
 		return fmt.Errorf("error marshalling channels for old revision %q / %q: %v", base.UD(docid), rev, err)
 	}
+	deletedJSON, err := base.JSONMarshal(deletedDoc)
+	if err != nil {
+		return fmt.Errorf("error marshalling deleted flag for old revision %q / %q: %v", base.UD(docid), rev, err)
+	}
 	meta := []sgbucket.Xattr{
 		{Name: backupRevisionChannelsMetaKey, Value: channelsJSON},
+		{Name: backupRevisionBodyDeletedMetaKey, Value: deletedJSON},
 	}
 	bodyWithMeta := sgbucket.EncodeValueWithXattrs(body, meta...)
 	nonJSONBytes := withNonJSONPrefix(nonJSONPrefixKindRevWithMeta, bodyWithMeta)
@@ -346,10 +361,10 @@ func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, do
 }
 
 // Extends the expiry on a revision backup.  If this fails w/ key not found, will attempt to recreate the revision backup when body is non-empty.
-func (db *DatabaseCollectionWithUser) refreshOldRevisionJSON(ctx context.Context, docid string, revid string, body []byte, expiry uint32, channels base.Set) error {
+func (db *DatabaseCollectionWithUser) refreshOldRevisionJSON(ctx context.Context, docid string, revid string, body []byte, expiry uint32, channels base.Set, deleted bool) error {
 	_, err := db.dataStore.Touch(oldRevisionKey(docid, revid), expiry)
 	if base.IsDocNotFoundError(err) && len(body) > 0 {
-		return db.setOldRevisionJSON(ctx, docid, revid, body, expiry, channels)
+		return db.setOldRevisionJSON(ctx, docid, revid, body, false, expiry, channels)
 	}
 	return err
 }

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -116,12 +116,12 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// make sure we didn't accidentally store an empty old revision
-	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, "")
+	_, _, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, "")
 	assert.Error(t, err)
 	assert.Equal(t, "404 missing", err.Error())
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+	_, _, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {
@@ -135,15 +135,15 @@ func TestBackupOldRevision(t *testing.T) {
 	require.NoError(t, err)
 
 	// now in all cases we'll have revtree ID 1 backed up (for at least 5 minutes)
-	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
+	_, _, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, rev1ID)
 	if deltasEnabled && xattrsEnabled {
 		// and optionally keyed by CV
-		_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
+		_, _, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev1.HLV.GetCurrentVersionString())))
 	}
 	require.NoError(t, err)
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
-	_, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
+	_, _, _, err = collection.getOldRevisionJSON(base.TestCtx(t), docID, base.Crc32cHashString([]byte(docRev2.HLV.GetCurrentVersionString())))
 	if deltasEnabled && xattrsEnabled {
 		require.NoError(t, err)
 	} else {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3445,6 +3445,54 @@ func TestDocCRUDWithCV(t *testing.T) {
 	assert.Greaterf(t, revIDGen(deleteVersion), revIDGen(updateVersion), "Expected revision generation to be bumped on delete")
 }
 
+func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				// enable delta sync to ensure we have a backup revision stored for cv
+				DeltaSync: &DeltaSyncConfig{
+					Enabled:          base.Ptr(true),
+					RevMaxAgeSeconds: base.Ptr(db.DefaultDeltaSyncRevMaxAge),
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	const docID = "doc1"
+
+	createVersion := rt.PutDoc(docID, `{"test":"doc"}`)
+
+	deleteVrs := rt.DeleteDoc(docID, createVersion)
+
+	// flush cache to ensure we're reading from the bucket
+	rt.GetDatabase().FlushRevisionCacheForTest()
+
+	resp := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, url.QueryEscape(createVersion.CV.String())), "")
+	RequireStatus(t, resp, http.StatusOK)
+
+	var body db.Body
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+	assert.Equal(t, "doc", body["test"].(string))
+	// assert that the _deleted property is not present rev 1
+	_, ok := body["_deleted"]
+	assert.False(t, ok)
+
+	// resurrect the document
+	rt.UpdateDoc(docID, deleteVrs, `{"test":"doc resurrected"}`)
+
+	// flush cache to ensure we're reading from the bucket
+	rt.GetDatabase().FlushRevisionCacheForTest()
+
+	// fetch rev 2 which is deleted
+	resp = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, url.QueryEscape(deleteVrs.CV.String())), "")
+	RequireStatus(t, resp, http.StatusOK)
+	body = db.Body{}
+	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+	// assert deleted property is there
+	assert.True(t, body["_deleted"].(bool))
+}
+
 // TestAllowConflictsConfig verifies that the database configuration does not allow
 // the `allow_conflicts` property to be set to true. `allow_conflicts` is no longer
 // supported in SGW 4.0. This test ensures that a config loaded will add the


### PR DESCRIPTION
CBG-5133

- correctly mark backup revs as deleted
- Given we have no mapping between CV and rev ID we cannot use history to do this like in the revID pathway, so must use body to determine this. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/245/
