### PR TITLE
[3.3.3 backport] CBG-4952: TestUserXattrRevCache flake fix

### DIFF
--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,11 @@ import (
 
 func TestUserXattrRevCache(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+
+	// need to disable sequence batching given two rest testers allocating sequence batches
+	// can mean that the changes feed has to wait for sequences from another to be released to
+	// maintain ordering
+	defer db.SuspendSequenceBatching()()
 
 	ctx := base.TestCtx(t)
 	docKey := t.Name()
@@ -49,7 +55,6 @@ func TestUserXattrRevCache(t *testing.T) {
 
 	rt2 := rest.NewRestTester(t, &rest.RestTesterConfig{
 		CustomTestBucket: tb.NoCloseClone(),
-
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{
 			AutoImport:       true,
 			UserXattrKey:     &xattrKey,


### PR DESCRIPTION
CBG-4952

Describe your PR here...
- Backport of CBG-4921 (#7838)

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
