### PR TITLE
Allow go test benchmark to compile/run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'release/') && !contains(github.ref, 'main') }}
 
+env:
+  GO_VERSION: &go_version 1.25.6
+  GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.8.0
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,7 +42,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - name: go-build
         run: go build "./..."
 
@@ -49,7 +53,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - run: go install github.com/google/addlicense@latest
       - run: addlicense -check -f licenses/addlicense.tmpl .
 
@@ -60,7 +64,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -87,7 +91,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -95,7 +99,7 @@ jobs:
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *go_test_annotations_version
         with:
           test-results: test.json
 
@@ -107,13 +111,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - name: Run Tests
         run: go test -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *go_test_annotations_version
         with:
           test-results: test.json
 
@@ -126,15 +130,33 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - name: Run Tests
         run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
         shell: bash
       - name: Annotate Failures
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
+        uses: *go_test_annotations_version
         with:
           test-results: test.json
+  test-benchmark-compile:
+    runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/couchbaselabs
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: *go_version
+      - name: Run Tests
+        run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -short -bench=. -benchtime=1x -run '!' -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        shell: bash
+      - name: Annotate Failures
+        if: always()
+        uses: *go_test_annotations_version
+        with:
+          test-results: test.json
+
 
   python-format:
     runs-on: ubuntu-latest
@@ -174,7 +196,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Run Tests
@@ -187,7 +209,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - name: Build
         run: go build "./tools/cache_perf_tool"
   govulncheck:
@@ -197,5 +219,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-           go-version-input: 1.25.6
+           go-version-input: *go_version
            go-package: ./...

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"io/fs"
@@ -479,7 +480,12 @@ func SetUpGlobalTestMemoryWatermark(m *testing.M, memWatermarkThresholdMB uint64
 
 		if inuseHighWaterMarkMB > float64(memWatermarkThresholdMB) {
 			// Exit during teardown to fail the suite if they exceeded the threshold
-			log.Fatalf("FATAL - TEST: Memory high water mark %.2f MB exceeded threshold (%d MB)", inuseHighWaterMarkMB, memWatermarkThresholdMB)
+			benchmark := flag.Lookup("test.bench")
+			if benchmark != nil && benchmark.Value.String() != "" {
+				log.Printf("Would be fatal if not running benchmarks FATAL - TEST: Memory high water mark %.2f MB exceeded threshold (%d MB)", inuseHighWaterMarkMB, memWatermarkThresholdMB)
+			} else {
+				log.Fatalf("FATAL - TEST: Memory high water mark %.2f MB exceeded threshold (%d MB)", inuseHighWaterMarkMB, memWatermarkThresholdMB)
+			}
 		} else {
 			log.Printf("TEST: Memory high water mark %.2f MB", inuseHighWaterMarkMB)
 		}

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -326,7 +326,17 @@ func BenchmarkCheckpointerUpdateCheckpointLists(b *testing.B) {
 						b.ReportAllocs()
 						b.ResetTimer()
 						for b.Loop() {
-							c := &Checkpointer{expectedSeqs: expectedSeqs, processedSeqs: processedSeqs, expectedSeqCompactionThreshold: 100}
+							c := &Checkpointer{
+								expectedSeqs:                   expectedSeqs,
+								processedSeqs:                  processedSeqs,
+								expectedSeqCompactionThreshold: 100,
+								stats: CheckpointerStats{
+									ProcessedSequenceLen:            &base.SgwIntStat{},
+									ProcessedSequenceLenPostCleanup: &base.SgwIntStat{},
+									ExpectedSequenceLen:             &base.SgwIntStat{},
+									ExpectedSequenceLenPostCleanup:  &base.SgwIntStat{},
+								},
+							}
 							// run checkpointing multiple times to test pruning speedup
 							for range numCheckpoints {
 								_ = c._updateCheckpointLists()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1807,7 +1807,12 @@ func BenchmarkProcessEntry(b *testing.B) {
 	for _, bm := range processEntryBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			ctx := base.TestCtx(b)
-			context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+			bucket := base.GetTestBucket(b)
+			defer bucket.Close(ctx)
+			context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{
+				EnableXattr: true,
+				Scopes:      GetScopesOptions(b, bucket, 1),
+			})
 			require.NoError(b, err)
 			defer context.Close(ctx)
 
@@ -1967,7 +1972,11 @@ func BenchmarkDocChanged(b *testing.B) {
 	for _, bm := range processEntryBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			ctx := base.TestCtx(b)
-			context, err := NewDatabaseContext(ctx, "db", base.GetTestBucket(b), false, DatabaseContextOptions{})
+			bucket := base.GetTestBucket(b)
+			defer bucket.Close(ctx)
+			context, err := NewDatabaseContext(ctx, "db", bucket, false, DatabaseContextOptions{
+				Scopes: GetScopesOptions(b, bucket, 1),
+			})
 			require.NoError(b, err)
 			defer context.Close(ctx)
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -511,7 +511,7 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 		// Create child rev 2
 		docBody["child"] = "B"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-B", revId}, false, ExistingVersionWithUpdateToHLV)
+		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"3-B", "2-A", revId}, false, ExistingVersionWithUpdateToHLV)
 		if err != nil {
 			b.Fatalf("Error creating child2 rev: %v", err)
 		}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -9,8 +9,6 @@
 package db
 
 import (
-	"bytes"
-	"context"
 	"fmt"
 	"log"
 	"reflect"
@@ -459,91 +457,6 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 
 	postChangesQueryCount = db.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, initQueryCount+2, postChangesQueryCount)
-
-}
-
-// Benchmark to validate fix for https://github.com/couchbase/sync_gateway/issues/2428
-func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
-	base.SetUpBenchmarkLogging(b, base.LevelWarn, base.KeyHTTP)
-
-	db, ctx := setupTestDB(b)
-	defer db.Close(ctx)
-	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, b, db)
-
-	fieldVal := func(valSizeBytes int) string {
-		buffer := bytes.Buffer{}
-		for range valSizeBytes {
-			buffer.WriteString("a")
-		}
-		return buffer.String()
-	}
-
-	createDoc := func(numKeys, valSizeBytes int) Body {
-		doc := Body{}
-		for keyNum := range numKeys {
-			doc[fmt.Sprintf("%v", keyNum)] = fieldVal(valSizeBytes)
-		}
-		return doc
-	}
-
-	numDocs := 400
-	numKeys := 200
-	valSizeBytes := 1024
-
-	// Create 2k docs of size 50k, 1000 keys with branches, 1 parent + 2 child branches -- doesn't matter which API .. bucket api
-	for range numDocs {
-
-		// Create the parent rev
-		docid, err := base.GenerateRandomID()
-		require.NoError(b, err)
-		docBody := createDoc(numKeys, valSizeBytes)
-		revId, _, err := collection.Put(ctx, docid, docBody)
-		if err != nil {
-			b.Fatalf("Error creating doc: %v", err)
-		}
-
-		// Create child rev 1
-		docBody["child"] = "A"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"2-A", revId}, false, ExistingVersionWithUpdateToHLV)
-		if err != nil {
-			b.Fatalf("Error creating child1 rev: %v", err)
-		}
-
-		// Create child rev 2
-		docBody["child"] = "B"
-		_, _, err = collection.PutExistingRevWithBody(ctx, docid, docBody, []string{"3-B", "2-A", revId}, false, ExistingVersionWithUpdateToHLV)
-		if err != nil {
-			b.Fatalf("Error creating child2 rev: %v", err)
-		}
-
-	}
-
-	// Start changes feed
-	var options ChangesOptions
-	options.Conflicts = true  // style=all_docs
-	options.ActiveOnly = true // active_only=true
-	options.Since = SequenceID{Seq: 0}
-
-	for b.Loop() {
-
-		// Changes params: POST /pm/_changes?feed=normal&heartbeat=30000&style=all_docs&active_only=true
-		// Changes request of all docs (could also do GetDoc call, but misses other possible things). One shot, .. etc
-
-		changesCtx, changesCtxCancel := context.WithCancel(base.TestCtx(b))
-		options.ChangesCtx = changesCtx
-		feed, err := collection.MultiChangesFeed(ctx, base.SetOf("*"), options)
-		if err != nil {
-			b.Fatalf("Error getting changes feed: %v", err)
-		}
-		for changeEntry := range feed {
-			// log.Printf("changeEntry: %v", changeEntry)
-			if changeEntry == nil {
-				break
-			}
-		}
-		changesCtxCancel()
-
-	}
 
 }
 

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -741,7 +741,6 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	b.StartTimer()
 	for i := range docCount {
 		cache.addToCache(ctx, testLogEntry(uint64(i), docIDs[i], "1-a"), false)
 	}
@@ -899,7 +898,6 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	b.StartTimer()
 	for i := range docCount {
 		cache.addToCache(ctx, docs[i], false)
 	}

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -160,7 +160,7 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 	for _, bm := range unmarshalBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			ctx := base.TestCtx(b)
-			for b.Loop() {
+			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 				doc := NewDocument("testDocID")
 				docReader := bytes.NewReader(doc1k_body)

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -112,7 +112,10 @@ func TestPushSkippedSequenceRange(t *testing.T) {
 
 func BenchmarkPushSkippedSequenceEntryLargeList(b *testing.B) {
 	skippedList := setupBenchmark(true, false)
-	i := uint64(240000005)
+	i := uint64(240_000_005)
+	if testing.Short() {
+		i = uint64(240)
+	}
 	for b.Loop() {
 		_ = skippedList.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntryAt(i*2, 0))
 		i++
@@ -122,6 +125,9 @@ func BenchmarkPushSkippedSequenceEntryLargeList(b *testing.B) {
 func BenchmarkPushSkippedSequenceEntryLargeListContiguous(b *testing.B) {
 	skippedList := setupBenchmark(true, false)
 	i := uint64(240000005)
+	if testing.Short() {
+		i = uint64(240)
+	}
 	for b.Loop() {
 		_ = skippedList.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntryAt(i, 0))
 		i++
@@ -660,6 +666,7 @@ func TestCompactSkippedList(t *testing.T) {
 }
 
 func BenchmarkCompactSkippedList(b *testing.B) {
+	base.SetUpTestLogging(b, base.LevelError, base.KeyAll)
 	benchmarks := []struct {
 		name         string
 		rangeEntries bool
@@ -960,7 +967,11 @@ func setupBenchmark(largeSlice bool, rangeEntries bool) *SkippedSequenceSkiplist
 	skippedList := NewSkippedSequenceSkiplist()
 	_ = skippedList.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntryAt(1, 0))
 	if largeSlice {
-		for i := uint64(1); i < 30000000; i++ {
+		size := uint64(30_000_000)
+		if testing.Short() {
+			size = 300
+		}
+		for i := uint64(1); i < size; i++ {
 			if rangeEntries {
 				_ = skippedList.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(i*multiplier, (i*multiplier)+2))
 			} else {
@@ -985,7 +996,11 @@ func setupBenchmarkForInsert(largeSlice bool, rangeEntries bool) *SkippedSequenc
 	_ = skippedList.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntryAt(1, 0))
 	_ = skippedList.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntryAt(200000000, 0))
 	if largeSlice {
-		for range 30000000 {
+		size := 30_000_000
+		if testing.Short() {
+			size = 300
+		}
+		for range size {
 			startSeq := skippedList.list.GetLastElement().Key().End
 			if rangeEntries {
 				_ = skippedList.PushSkippedSequenceEntry(NewSkippedSequenceRangeEntry(startSeq+2, startSeq+5))
@@ -1012,7 +1027,11 @@ func setupBenchmarkToCompact(largeSlice bool, rangeEntries bool) *SkippedSequenc
 	inputTime := time.Now().Unix() - 1000
 	_ = skippedList.PushSkippedSequenceEntry(NewSingleSkippedSequenceEntryAt(1, inputTime))
 	if largeSlice {
-		for range 30000000 {
+		size := 30_000_000
+		if testing.Short() {
+			size = 100_000
+		}
+		for range size {
 			startSeq := skippedList.list.GetLastElement().Key().End
 			if rangeEntries {
 				// add range entries with old timestamps for compaction

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -90,10 +90,10 @@ func BenchmarkReadOps_Get(b *testing.B) {
 	}{
 		{"Admin_Simple", "/{{.keyspace}}/doc1k", ""},
 		{"Admin_WithRev", "/{{.keyspace}}/doc1k?rev=" + revid, ""},
-		{"Admin_OpenRevsAll", "/{{.keyspace}}/doc1k?open_revs=all&rev=" + revid, ""},
+		{"Admin_OpenRevsAll", "/{{.keyspace}}/doc1k?open_revs=all", ""},
 		{"User_Simple", "/{{.keyspace}}/doc1k", username},
 		{"User_WithRev", "/{{.keyspace}}/doc1k?rev=" + revid, username},
-		{"User_OpenRevsAll", "/{{.keyspace}}/doc1k?open_revs=all&rev=" + revid, username},
+		{"User_OpenRevsAll", "/{{.keyspace}}/doc1k?open_revs=all", username},
 	}
 
 	for _, bm := range getBenchmarks {
@@ -105,12 +105,9 @@ func BenchmarkReadOps_Get(b *testing.B) {
 				} else {
 					getResponse = rt.SendUserRequest("GET", bm.URI, "", bm.asUser)
 				}
-				b.StopTimer()
 				if getResponse.Code != 200 {
-					log.Printf("Unexpected response status code: %d", getResponse.Code)
-					panic("here")
+					b.Fatalf("Unexpected response status code: %d, output: %s", getResponse.Code, getResponse.BodyString())
 				}
-				b.StartTimer()
 			}
 		})
 	}
@@ -153,10 +150,10 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 	}{
 		{"Admin_Simple", "/{{.keyspace}}/doc1k", ""},
 		{"Admin_WithRev", fmt.Sprintf("/{{.keyspace}}/doc1k?rev=%s", revid), ""},
-		{"Admin_OpenRevsAll", fmt.Sprintf("/{{.keyspace}}/doc1k?open_revs=all&rev=%s", revid), ""},
+		{"Admin_OpenRevsAll", "/{{.keyspace}}/doc1k?open_revs=all", ""},
 		{"User_Simple", "/{{.keyspace}}/doc1k", username},
 		{"User_WithRev", fmt.Sprintf("/{{.keyspace}}/doc1k?rev=%s", revid), username},
-		{"User_OpenRevsAll", fmt.Sprintf("/{{.keyspace}}/doc1k?open_revs=all&rev=%s", revid), username},
+		{"User_OpenRevsAll", "/{{.keyspace}}/doc1k?open_revs=all", username},
 	}
 
 	for _, bm := range getBenchmarks {
@@ -174,12 +171,9 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 				} else {
 					getResponse = rt.SendUserRequest("GET", docURI, "", bm.asUser)
 				}
-				b.StopTimer()
 				if getResponse.Code != 200 {
-					log.Printf("Unexpected response status code: %d", getResponse.Code)
-					panic("here")
+					b.Fatalf("Unexpected response status code: %d, output %s", getResponse.Code, getResponse.BodyString())
 				}
-				b.StartTimer()
 			}
 		})
 	}


### PR DESCRIPTION
Run go benchmarks 1x with short.

- shorten the test time to make this quick by shortening long tests with `-short`
- add to github ci
- use yaml anchors to deduplicate some CI work
- fix benchmark tests so they pass and don't panic
     - open_revs=all is incompatible with rev=
     - databases need to have `Scopes` flag
     - `b.Loop()` can't be called twice, and `b.N` only gets incremented once, so make sure to stop and start timer (benchmark will fail)