### PR TITLE
fix wrong error and incorrect paramter

### DIFF
--- a/db/revision.go
+++ b/db/revision.go
@@ -274,7 +274,7 @@ func (c *DatabaseCollection) getOldRevisionJSON(ctx context.Context, docid strin
 		if deletedMeta, ok := meta[backupRevisionBodyDeletedMetaKey]; ok && deletedMeta != nil {
 			err = base.JSONUnmarshal(deletedMeta, &deletedDoc)
 			if err != nil {
-				return nil, nil, false, fmt.Errorf("error unmarshalling _channels xattr for old revision %q / %q: %v", base.UD(docid), revOrCV, err)
+				return nil, nil, false, fmt.Errorf("error unmarshalling _deleted xattr for old revision %q / %q: %v", base.UD(docid), revOrCV, err)
 			}
 		}
 		return jsonBody, channelSet, deletedDoc, nil
@@ -364,7 +364,7 @@ func (db *DatabaseCollectionWithUser) setOldRevisionJSON(ctx context.Context, do
 func (db *DatabaseCollectionWithUser) refreshOldRevisionJSON(ctx context.Context, docid string, revid string, body []byte, expiry uint32, channels base.Set, deleted bool) error {
 	_, err := db.dataStore.Touch(oldRevisionKey(docid, revid), expiry)
 	if base.IsDocNotFoundError(err) && len(body) > 0 {
-		return db.setOldRevisionJSON(ctx, docid, revid, body, false, expiry, channels)
+		return db.setOldRevisionJSON(ctx, docid, revid, body, deleted, expiry, channels)
 	}
 	return err
 }


### PR DESCRIPTION
CBG-0000

Co pilot caught two areas on backport that were wrong. Need _deleted property in error message and need to pass deleted boolean down from refresh json function. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
