### PR TITLE
CBG-5141: Only fetch backup revision for fromRev for delta sync

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -137,7 +137,7 @@ func TestGetBackupRevisionWhenCurrentRevisionHasAttachments(t *testing.T) {
 	// can remove in CBG-4542
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.GetRev(ctx, "doc1", doc1.HLV.GetCurrentVersionString(), false, nil)
+	docRev, err := collection.revisionCache.GetWithCV(ctx, "doc1", doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
 	require.NoError(t, err)
 
 	// assert version is fetched and attachments is empty

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -335,7 +335,7 @@ func TestHLVImport(t *testing.T) {
 			name: "HLV write from without mou",
 			preFunc: func(t *testing.T, collection *DatabaseCollectionWithUser, docID string) {
 				hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_vv")
-				_ = hlvHelper.InsertWithHLV(ctx, docID)
+				_ = hlvHelper.InsertWithHLV(ctx, docID, nil)
 			},
 			expectedMou: func(output *outputData) *MetadataOnlyUpdate {
 				return &MetadataOnlyUpdate{
@@ -356,7 +356,7 @@ func TestHLVImport(t *testing.T) {
 			name: "XDCR stamped with _mou",
 			preFunc: func(t *testing.T, collection *DatabaseCollectionWithUser, docID string) {
 				hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_vv")
-				cas := hlvHelper.InsertWithHLV(ctx, docID)
+				cas := hlvHelper.InsertWithHLV(ctx, docID, nil)
 
 				_, xattrs, _, err := collection.dataStore.GetWithXattrs(ctx, docID, []string{base.VirtualXattrRevSeqNo})
 				require.NoError(t, err)
@@ -387,7 +387,7 @@ func TestHLVImport(t *testing.T) {
 			name: "invalid _mou, but valid hlv",
 			preFunc: func(t *testing.T, collection *DatabaseCollectionWithUser, docID string) {
 				hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_vv")
-				cas := hlvHelper.InsertWithHLV(ctx, docID)
+				cas := hlvHelper.InsertWithHLV(ctx, docID, nil)
 
 				_, xattrs, _, err := collection.dataStore.GetWithXattrs(ctx, docID, []string{base.VirtualXattrRevSeqNo})
 				require.NoError(t, err)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -59,7 +59,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 }
 
 // GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
 
 	docRev = DocumentRevision{
 		CV:                     cv,
@@ -73,7 +73,7 @@ func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *
 	}
 
 	var hlv *HybridLogicalVector
-	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, hlv, err = revCacheLoaderForDocumentCV(ctx, rc.backingStores[collectionID], doc, *cv)
+	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, hlv, err = revCacheLoaderForDocumentCV(ctx, rc.backingStores[collectionID], doc, *cv, loadBackup)
 	if err != nil {
 		return DocumentRevision{}, err
 	}

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -78,7 +78,6 @@ func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *
 		return DocumentRevision{}, err
 	}
 	if hlv != nil {
-		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
 		docRev.HlvHistory = hlv.ToHistoryForHLV()
 	}
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -481,9 +481,9 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	if doc.HLV.ExtractCurrentVersionFromHLV().Equal(cv) {
 		revid = doc.GetRevTreeID()
 		deleted = doc.Deleted
+		hlv = doc.HLV
 	}
 
-	hlv = doc.HLV
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
 		return bodyBytes, history, channels, removed, attachments, deleted, doc.Expiry, revid, hlv, err

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -34,9 +34,9 @@ type RevisionCache interface {
 	GetWithRev(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
 
 	// GetWithCV returns the given revision by CV, and stores if not already cached.
-	// When includeBody=true, the returned DocumentRevision will include a mutable shallow copy of the marshaled body.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool) (DocumentRevision, error)
+	// When loadBackup=true, will load from backup revisions if requested version is not active document
+	GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
@@ -127,7 +127,7 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 type RevisionCacheBackingStore interface {
 	GetDocument(ctx context.Context, docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
 	getRevision(ctx context.Context, doc *Document, revid string) ([]byte, AttachmentsMeta, base.Set, error)
-	getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, bool, error)
+	getCurrentVersion(ctx context.Context, doc *Document, cv Version, loadBackup bool) ([]byte, AttachmentsMeta, base.Set, bool, error)
 }
 
 // collectionRevisionCache is a view of a revision cache for a collection.
@@ -150,8 +150,8 @@ func (c *collectionRevisionCache) GetWithRev(ctx context.Context, docID, revID s
 }
 
 // Get is for per collection access to Get method
-func (c *collectionRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, includeDelta bool) (DocumentRevision, error) {
-	return (*c.revCache).GetWithCV(ctx, docID, cv, c.collectionID, includeDelta)
+func (c *collectionRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
+	return (*c.revCache).GetWithCV(ctx, docID, cv, c.collectionID, includeDelta, loadBackup)
 }
 
 // GetActive is for per collection access to GetActive method
@@ -421,7 +421,7 @@ func revCacheLoader(ctx context.Context, backingStore RevisionCacheBackingStore,
 
 // revCacheLoaderForCv will load a document from the bucket using the CV, compare the fetched doc and the CV specified in the function,
 // and will still return revid for purpose of populating the Rev ID lookup map on the cache
-func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
+func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingStore, id IDandCV, loadBackup bool) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
 	cv := Version{
 		Value:    id.Version,
 		SourceID: id.Source,
@@ -431,7 +431,7 @@ func revCacheLoaderForCv(ctx context.Context, backingStore RevisionCacheBackingS
 		return bodyBytes, history, channels, removed, attachments, deleted, expiry, revid, hlv, err
 	}
 
-	return revCacheLoaderForDocumentCV(ctx, backingStore, doc, cv)
+	return revCacheLoaderForDocumentCV(ctx, backingStore, doc, cv, loadBackup)
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
@@ -471,8 +471,8 @@ func revCacheLoaderForDocument(ctx context.Context, backingStore RevisionCacheBa
 
 // revCacheLoaderForDocumentCV used either during cache miss (from revCacheLoaderForCv), or used directly when getting current active CV from cache
 // nolint:staticcheck
-func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
-	if bodyBytes, attachments, channels, deleted, err = backingStore.getCurrentVersion(ctx, doc, cv); err != nil {
+func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCacheBackingStore, doc *Document, cv Version, loadBackup bool) (bodyBytes []byte, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, revid string, hlv *HybridLogicalVector, err error) {
+	if bodyBytes, attachments, channels, deleted, err = backingStore.getCurrentVersion(ctx, doc, cv, loadBackup); err != nil {
 		return nil, nil, nil, false, nil, false, nil, "", nil, err
 	}
 
@@ -493,8 +493,12 @@ func revCacheLoaderForDocumentCV(ctx context.Context, backingStore RevisionCache
 	return bodyBytes, history, channels, removed, attachments, deleted, doc.Expiry, revid, hlv, err
 }
 
-func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document, cv Version) (bodyBytes []byte, attachments AttachmentsMeta, channels base.Set, deleted bool, err error) {
+func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Document, cv Version, loadBackup bool) (bodyBytes []byte, attachments AttachmentsMeta, channels base.Set, deleted bool, err error) {
 	if err = doc.HasCurrentVersion(ctx, cv); err != nil {
+		if !loadBackup {
+			// do not attempt to fetch backup revision by CV unless specified
+			return nil, nil, nil, false, ErrMissing
+		}
 		bodyBytes, channels, deleted, err = c.getOldRevisionJSON(ctx, doc.ID, base.Crc32cHashString([]byte(cv.String())))
 		if err != nil || bodyBytes == nil {
 			return nil, nil, nil, false, err

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -57,8 +57,8 @@ func (sc *ShardedLRURevisionCache) GetWithRev(ctx context.Context, docID, revID 
 	return sc.getShard(docID).GetWithRev(ctx, docID, revID, collectionID, includeDelta)
 }
 
-func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).GetWithCV(ctx, docID, cv, collectionID, includeDelta)
+func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetWithCV(ctx, docID, cv, collectionID, includeDelta, loadBackup)
 }
 
 func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool) {
@@ -164,8 +164,8 @@ func (rc *LRURevisionCache) GetWithRev(ctx context.Context, docID, revID string,
 	return rc.getFromCacheByRev(ctx, docID, revID, collectionID, true, includeDelta)
 }
 
-func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool) (DocumentRevision, error) {
-	return rc.getFromCacheByCV(ctx, docID, cv, collectionID, true, includeDelta)
+func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
+	return rc.getFromCacheByCV(ctx, docID, cv, collectionID, true, includeDelta, loadBackup)
 }
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
@@ -212,7 +212,8 @@ func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID 
 		return DocumentRevision{}, nil
 	}
 
-	docRev, statEvent, err := value.load(ctx, rc.backingStores[collectionID], includeDelta)
+	// for revID pathway we should always load from backup if required
+	docRev, statEvent, err := value.load(ctx, rc.backingStores[collectionID], includeDelta, true)
 	rc.statsRecorderFunc(statEvent)
 
 	if !statEvent && err == nil {
@@ -233,13 +234,14 @@ func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID 
 	return docRev, err
 }
 
-func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *Version, collectionID uint32, loadCacheOnMiss bool, includeDelta bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *Version, collectionID uint32, loadCacheOnMiss bool, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
 	value := rc.getValueByCV(ctx, docID, cv, collectionID, loadCacheOnMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
 	}
 
-	docRev, cacheHit, err := value.load(ctx, rc.backingStores[collectionID], includeDelta)
+	// for CV pathway we respect the loadBackup flag passed in
+	docRev, cacheHit, err := value.load(ctx, rc.backingStores[collectionID], includeDelta, loadBackup)
 	rc.statsRecorderFunc(cacheHit)
 
 	if err != nil {
@@ -655,7 +657,7 @@ func (rc *LRURevisionCache) _numberCapacityEviction() (numItemsEvicted int64, nu
 // Gets the body etc. out of a revCacheValue. If they aren't present already, the loader func
 // will be called. This is synchronized so that the loader will only be called once even if
 // multiple goroutines try to load at the same time.
-func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCacheBackingStore, includeDelta bool) (docRev DocumentRevision, cacheHit bool, err error) {
+func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCacheBackingStore, includeDelta bool, loadBackup bool) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	// Reading the delta from the revCacheValue requires holding the read lock, so it's managed outside asDocumentRevision,
 	// to reduce locking when includeDelta=false
@@ -692,7 +694,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 		hlv := &HybridLogicalVector{}
 		if value.revID == "" {
 			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Value}
-			value.bodyBytes, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, hlv, value.err = revCacheLoaderForCv(ctx, backingStore, hlvKey)
+			value.bodyBytes, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, hlv, value.err = revCacheLoaderForCv(ctx, backingStore, hlvKey, loadBackup)
 			// based off the current value load we need to populate the revid key with what has been fetched from the bucket (for use of populating the opposite lookup map)
 			if revid != "" {
 				value.revID = revid
@@ -780,7 +782,7 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 		cacheHit = false
 		hlv := &HybridLogicalVector{}
 		if value.revID == "" {
-			value.bodyBytes, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, hlv, value.err = revCacheLoaderForDocumentCV(ctx, backingStore, doc, value.cv)
+			value.bodyBytes, value.history, value.channels, value.removed, value.attachments, value.deleted, value.expiry, revid, hlv, value.err = revCacheLoaderForDocumentCV(ctx, backingStore, doc, value.cv, false)
 			if revid != "" {
 				value.revID = revid
 			}

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2881,13 +2881,14 @@ func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {
 			if tc.useRevID {
 				_, err = collection.getRev(ctx, docID, firstRevisionID, 0, nil)
 				require.NoError(t, err)
+				assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
 			} else {
 				_, err = collection.getRev(ctx, docID, firstCV, 0, nil)
 				require.Error(t, err)
 				require.ErrorContains(t, err, "missing")
+				assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
 			}
 			// assert on stats after fetch
-			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
 			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
 			assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheHits.Value())
 
@@ -2903,7 +2904,11 @@ func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {
 			assert.Equal(t, doc1.GetRevTreeID(), docRev.RevID)
 			assert.Equal(t, doc1.HLV.GetCurrentVersionString(), docRev.CV.String())
 			assert.JSONEq(t, `{"foo": "baz"}`, string(docRev.BodyBytes))
-			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
+			if tc.useRevID {
+				assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
+			} else {
+				assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
+			}
 			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
 			assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheHits.Value())
 		})

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -46,7 +46,7 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 
 // InsertWithHLV inserts a new document into the bucket with a populated HLV (matching a write from
 // a different, non-SGW HLV-aware peer)
-func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64) {
+func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string, body Body) (casOut uint64) {
 	hlv := &HybridLogicalVector{}
 	err := hlv.AddVersion(CreateVersion(h.Source, expandMacroCASValueUint64))
 	require.NoError(h.t, err)
@@ -57,7 +57,12 @@ func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64
 		MacroExpansion: hlv.computeMacroExpansions(),
 	}
 
-	docBody := base.MustJSONMarshal(h.t, defaultHelperBody)
+	var docBody []byte
+	if len(body) > 0 {
+		docBody = base.MustJSONMarshal(h.t, body)
+	} else {
+		docBody = base.MustJSONMarshal(h.t, defaultHelperBody)
+	}
 	xattrData := map[string][]byte{
 		h.xattrName: vvDataBytes,
 	}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3015,7 +3015,7 @@ func TestPvDeltaReadAndWrite(t *testing.T) {
 	otherSource := "otherSource"
 	hlvHelper := db.NewHLVAgent(t, rt.GetSingleDataStore(), otherSource, "_vv")
 	existingHLVKey := docID
-	cas := hlvHelper.InsertWithHLV(ctx, existingHLVKey)
+	cas := hlvHelper.InsertWithHLV(ctx, existingHLVKey, nil)
 	casV1 := cas
 	encodedSourceV1 := db.EncodeSource(otherSource)
 
@@ -3462,6 +3462,8 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	})
 	defer rt.Close()
 
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
 	const docID = "doc1"
 
 	createVersion := rt.PutDoc(docID, `{"test":"doc"}`)
@@ -3471,15 +3473,11 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	// flush cache to ensure we're reading from the bucket
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
-	resp := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, url.QueryEscape(createVersion.CV.String())), "")
-	RequireStatus(t, resp, http.StatusOK)
-
-	var body db.Body
-	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
-	assert.Equal(t, "doc", body["test"].(string))
-	// assert that the _deleted property is not present rev 1
-	_, ok := body["_deleted"]
-	assert.False(t, ok)
+	docRev, err := collection.GetRevisionCacheForTest().GetWithCV(ctx, docID, &createVersion.CV, false, true)
+	require.NoError(t, err)
+	// assert doc is not deleted
+	assert.False(t, docRev.Deleted)
+	assert.False(t, bytes.Contains(docRev.BodyBytes, []byte("{}")))
 
 	// resurrect the document
 	rt.UpdateDoc(docID, deleteVrs, `{"test":"doc resurrected"}`)
@@ -3488,12 +3486,11 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// fetch rev 2 which is deleted
-	resp = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, url.QueryEscape(deleteVrs.CV.String())), "")
-	RequireStatus(t, resp, http.StatusOK)
-	body = db.Body{}
-	require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+	docRev, err = collection.GetRevisionCacheForTest().GetWithCV(ctx, docID, &deleteVrs.CV, false, true)
+	require.NoError(t, err)
+	assert.True(t, docRev.Deleted)
 	// assert deleted property is there
-	assert.True(t, body["_deleted"].(bool))
+	assert.True(t, bytes.Contains(docRev.BodyBytes, []byte("{}")))
 }
 
 // TestAllowConflictsConfig verifies that the database configuration does not allow
@@ -3837,4 +3834,48 @@ func TestGetConfigAfterFailToStartOnlineProcess(t *testing.T) {
 	// Original bug will trigger panic here on this endpoint
 	resp = rt.SendAdminRequest(http.MethodGet, "/_config?include_runtime=true", "")
 	RequireStatus(t, resp, http.StatusOK)
+}
+
+func TestFetchBackupRevisionByCVThroughAPI(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				// enable delta sync to ensure we have a backup revision stored for cv
+				DeltaSync: &DeltaSyncConfig{
+					Enabled:          base.Ptr(true),
+					RevMaxAgeSeconds: base.Ptr(db.DefaultDeltaSyncRevMaxAge),
+				},
+			},
+		},
+	})
+	defer rt.Close()
+
+	docID := t.Name()
+	// create rev 1
+	createVersion := rt.PutDoc(docID, `{"test":"data"}`)
+
+	// update to rev 2
+	rt.UpdateDoc(docID, createVersion, `{"test":"data updated"}`)
+
+	// flush cache
+	rt.GetDatabase().FlushRevisionCacheForTest()
+
+	// fetch rev 1 by its CV
+	resp := rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, url.QueryEscape(createVersion.CV.String())), "")
+	RequireStatus(t, resp, http.StatusNotFound)
+	assert.Contains(t, string(resp.BodyBytes()), "missing")
+
+	// flush cache
+	rt.GetDatabase().FlushRevisionCacheForTest()
+
+	// fetch rev 1 by revID
+	resp = rt.SendAdminRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, createVersion.RevTreeID), "")
+	RequireStatus(t, resp, http.StatusOK)
+	var body db.Body
+	err := base.JSONUnmarshal(resp.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "data", body["test"].(string))
+	assert.Equal(t, docID, body[db.BodyId])
+	assert.Equal(t, createVersion.RevTreeID, body[db.BodyRev])
+	assert.Nil(t, body[db.BodyCV])
 }

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -3007,7 +3007,7 @@ func TestGetNonWinningRevisionAttachmentLeak(t *testing.T) {
 
 					// Alice requests v1 - she has access to this revision
 					resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, revParam), "", "alice")
-					if revType == "CV" && flushCache {
+					if revType == "CV" && flushCache || revType == "CV" && base.TestDisableRevCache() {
 						// if flushed cache and fetching by cv we will return not found
 						RequireStatus(t, resp, http.StatusNotFound)
 						t.Logf("resp body: %s", resp.BodyBytes())

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -3006,18 +3006,23 @@ func TestGetNonWinningRevisionAttachmentLeak(t *testing.T) {
 
 					// Alice requests v1 - she has access to this revision
 					resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, revParam), "", "alice")
-					RequireStatus(t, resp, http.StatusOK)
-					t.Logf("resp body: %s", resp.BodyBytes())
+					if revType == "CV" && flushCache {
+						// if flushed cache and fetching by cv we will return not found
+						RequireStatus(t, resp, http.StatusNotFound)
+						t.Logf("resp body: %s", resp.BodyBytes())
+					} else {
+						RequireStatus(t, resp, http.StatusOK)
+						t.Logf("resp body: %s", resp.BodyBytes())
 
-					var body db.Body
-					require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
+						var body db.Body
+						require.NoError(t, base.JSONUnmarshal(resp.BodyBytes(), &body))
 
-					assert.Equal(t, "v1", body["value"], "Should get v1's body content")
+						assert.Equal(t, "v1", body["value"], "Should get v1's body content")
 
-					// v1 should have no attachments - it was created without any
-					attachments := body["_attachments"]
-					assert.Nil(t, attachments, "v1 should have no attachments")
-
+						// v1 should have no attachments - it was created without any
+						attachments := body["_attachments"]
+						assert.Nil(t, attachments, "v1 should have no attachments")
+					}
 					// Try to fetch the attachment directly - should fail since v1 has no attachments
 					resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s/attachment.txt?rev=%s", docID, revParam), "", "alice")
 

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -16,6 +16,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -3001,7 +3002,7 @@ func TestGetNonWinningRevisionAttachmentLeak(t *testing.T) {
 
 					revParam := version1.RevTreeID
 					if revType == "CV" {
-						revParam = version1.CV.String()
+						revParam = url.QueryEscape(version1.CV.String())
 					}
 
 					// Alice requests v1 - she has access to this revision

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2038,7 +2038,7 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 		otherSource := "otherSource"
 		hlvHelper := db.NewHLVAgent(t, rt.GetSingleDataStore(), otherSource, "_vv")
 		existingHLVKey := "doc1"
-		cas := hlvHelper.InsertWithHLV(ctx, existingHLVKey)
+		cas := hlvHelper.InsertWithHLV(ctx, existingHLVKey, nil)
 
 		// force import of this write
 		_, _ = rt.GetDoc(docID)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1363,10 +1363,10 @@ func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
 			name:             "filtered channels",
 			filteredChannels: "alice",
 		},
-		//{
-		//	name:             "unfiltered channels",
-		//	filteredChannels: "",
-		//},
+		{
+			name:             "unfiltered channels",
+			filteredChannels: "",
+		},
 	}
 
 	btcRunner := NewBlipTesterClientRunner(t)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1330,3 +1330,194 @@ func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
 		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
 	})
 }
+
+func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	const (
+		username = "alice"
+	)
+
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+			// force revs to be loaded from bucket, avoids need for flushing cache all the time
+			CacheConfig: &CacheConfig{
+				RevCacheConfig: &RevCacheConfig{
+					MaxItemCount: base.Ptr[uint32](0),
+				},
+			},
+		}},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+
+	testCases := []struct {
+		name             string
+		filteredChannels string
+	}{
+		{
+			name:             "filtered channels",
+			filteredChannels: "alice",
+		},
+		//{
+		//	name:             "unfiltered channels",
+		//	filteredChannels: "",
+		//},
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // not applicable to rev trees, we will look to backup bodies always for rev tree clients
+	btcRunner.Run(func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				docID := SafeDocumentName(t, t.Name())
+				rt := NewRestTester(t,
+					rtConfig)
+				defer rt.Close()
+				rt.CreateUser(username, []string{"*"})
+				var version2 db.DocVersion
+				updatedVersion := make(chan DocVersion)
+
+				// underneath the client's response to changes - we'll update the document so the requested rev is not available by the time SG receives the changes response.
+				changesEntryCallbackFn := func(changeEntryDocID, changeEntryRevID string) {
+					if changeEntryDocID == docID && changeEntryRevID == version2.RevTreeID || changeEntryRevID == version2.CV.String() {
+						updatedVersion <- rt.UpdateDoc(docID, version2, `{"foo":"buzz","channels":["alice"]}`)
+					}
+				}
+
+				opts := &BlipTesterClientOpts{
+					Username:             username,
+					ClientDeltas:         true,
+					changesEntryCallback: changesEntryCallbackFn,
+					sendReplacementRevs:  true,
+				}
+				client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+				defer client.Close()
+				ctx := t.Context()
+
+				// add doc from a different source to rest tester
+				agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "mySource", base.VvXattrName)
+				_ = agent.InsertWithHLV(ctx, docID, db.Body{"channels": "alice"})
+
+				// wai for import to be processed
+				base.RequireWaitForStat(t, func() int64 {
+					return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value()
+				}, 1)
+				version1, _ := rt.GetDoc(docID)
+
+				if tc.filteredChannels != "" {
+					btcRunner.StartPullSince(client.id, BlipTesterPullOptions{Channels: tc.filteredChannels, Continuous: true})
+				} else {
+					btcRunner.StartPull(client.id)
+				}
+				btcRunner.WaitForVersion(client.id, docID, version1)
+
+				// create rev 2
+				version2 = rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
+				rt.WaitForPendingChanges()
+
+				// block until we've written the update and got the new version to use in assertions
+				version3 := <-updatedVersion
+
+				// we should get the new updated version through replacement rev functionality
+				btcRunner.WaitForVersion(client.id, docID, version3)
+
+				// rev message with a replacedRev property referring to the originally requested rev
+				msg2, ok := btcRunner.SingleCollection(client.id).GetPullRevMessage(docID, version3)
+				require.True(t, ok)
+				assert.Equal(t, db.MessageRev, msg2.Profile())
+				assert.Equal(t, version3.CV.String(), msg2.Properties[db.RevMessageRev])
+				assert.Equal(t, version2.CV.String(), msg2.Properties[db.RevMessageReplacedRev])
+
+				base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 1)
+				base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 0)
+			})
+		}
+	})
+}
+
+func TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	const (
+		username = "alice"
+	)
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+			// force revs to be loaded from bucket, avoids need for flushing cache all the time
+			CacheConfig: &CacheConfig{
+				RevCacheConfig: &RevCacheConfig{
+					MaxItemCount: base.Ptr[uint32](0),
+				},
+			},
+		}},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // only for rev tree clients will we always load backup rev isf one is available
+	btcRunner.Run(func(t *testing.T) {
+
+		docID := SafeDocumentName(t, t.Name())
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
+		rt.CreateUser(username, []string{"*"})
+		var version2 db.DocVersion
+		updatedVersion := make(chan DocVersion)
+
+		// underneath the client's response to changes - we'll update the document so the requested rev is not available by the time SG receives the changes response.
+		changesEntryCallbackFn := func(changeEntryDocID, changeEntryRevID string) {
+			if changeEntryDocID == docID && changeEntryRevID == version2.RevTreeID || changeEntryRevID == version2.CV.String() {
+				updatedVersion <- rt.UpdateDoc(docID, version2, `{"foo":"buzz","channels":["alice"]}`)
+			}
+		}
+
+		opts := &BlipTesterClientOpts{
+			Username:             username,
+			ClientDeltas:         true,
+			changesEntryCallback: changesEntryCallbackFn,
+		}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+		ctx := t.Context()
+
+		// add doc from a different source to rest tester
+		agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "mySource", base.VvXattrName)
+		_ = agent.InsertWithHLV(ctx, docID, nil)
+
+		// wai for import to be processed
+		base.RequireWaitForStat(t, func() int64 {
+			return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value()
+		}, 1)
+		version1, _ := rt.GetDoc(docID)
+
+		btcRunner.StartPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version1)
+
+		// create rev 2
+		version2 = rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
+		rt.WaitForPendingChanges()
+
+		// block until we've written the update and got the new version to use in assertions
+		version3 := <-updatedVersion
+
+		// we should get the delta still for version 2
+		btcRunner.WaitForVersion(client.id, docID, version2)
+
+		// expect delta sent for rev 3 after
+		btcRunner.WaitForVersion(client.id, docID, version3)
+
+		// expect two deltas sent
+		assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+	})
+}

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1403,10 +1403,7 @@ func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
 				agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "mySource", base.VvXattrName)
 				_ = agent.InsertWithHLV(ctx, docID, db.Body{"channels": "alice"})
 
-				// wai for import to be processed
-				base.RequireWaitForStat(t, func() int64 {
-					return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value()
-				}, 1)
+				// import doc
 				version1, _ := rt.GetDoc(docID)
 
 				if tc.filteredChannels != "" {
@@ -1495,10 +1492,7 @@ func TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged(t *te
 		agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "mySource", base.VvXattrName)
 		_ = agent.InsertWithHLV(ctx, docID, nil)
 
-		// wai for import to be processed
-		base.RequireWaitForStat(t, func() int64 {
-			return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value()
-		}, 1)
+		// import doc
 		version1, _ := rt.GetDoc(docID)
 
 		btcRunner.StartPull(client.id)

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -2096,7 +2096,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
 		// no peek for cv so fetch by cv, which in turn loads from bucket so assert item ahs correct history on it
-		docRev, err := collectionActive1.GetRevisionCacheForTest().GetWithCV(ctxActive1, docID, &rt1Version.CV, false)
+		docRev, err := collectionActive1.GetRevisionCacheForTest().GetWithCV(ctxActive1, docID, &rt1Version.CV, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 
@@ -2104,7 +2104,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		collectionRT1, ctxRT1 := rt1.GetSingleTestDatabaseCollectionWithUser()
 		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
-		docRev, err = collectionRT1.GetRevisionCacheForTest().GetWithCV(ctxRT1, docID, &rt1Version.CV, false)
+		docRev, err = collectionRT1.GetRevisionCacheForTest().GetWithCV(ctxRT1, docID, &rt1Version.CV, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 	})

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -237,7 +237,7 @@ func TestReplicateVV(t *testing.T) {
 			hasHLV: true,
 			preXDCRFunc: func(t *testing.T, docID string) uint64 {
 				ctx := base.TestCtx(t)
-				return hlvAgent.InsertWithHLV(ctx, docID)
+				return hlvAgent.InsertWithHLV(ctx, docID, nil)
 			},
 		},
 	}
@@ -320,7 +320,7 @@ func TestVVObeyMou(t *testing.T) {
 
 	docID := "doc1"
 	hlvAgent := db.NewHLVAgent(t, fromDs, fromBucketSourceID, base.VvXattrName)
-	fromCas1 := hlvAgent.InsertWithHLV(ctx, "doc1")
+	fromCas1 := hlvAgent.InsertWithHLV(ctx, "doc1", nil)
 
 	xdcr := startXDCR(t, fromBucket, toBucket, XDCROptions{Mobile: MobileOn})
 	defer func() {


### PR DESCRIPTION
CBG-5141

- Exposed by running new added tests with bypass rev cache
- Fetch backup revision when fetching by Cv only for delta source cases. Return not found otherwise

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/257/ (flaky test)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/258/ (disable rev cache)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/259/ (rest only package to prove test failures fixed)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/260/ (rest only package with disable rev cache to prove test issues fixed) 
