### PR TITLE
CBG-5070: Fix _mou not being cleared when tombstoning document 

### DIFF
--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -88,7 +88,7 @@ func (c *Collection) WriteTombstoneWithXattrs(ctx context.Context, k string, exp
 
 		// If deleteBody == true, remove the body and update xattr
 		if deleteBody {
-			casOut, tombstoneErr = c.updateXattrsDeleteBody(ctx, k, exp, cas, xattrs, nil, opts)
+			casOut, tombstoneErr = c.updateXattrsDeleteBody(ctx, k, exp, cas, xattrs, xattrsToDelete, opts)
 		} else {
 			if len(xattrs) == 0 && len(xattrsToDelete) == 0 {
 				return false, sgbucket.ErrNeedXattrs, 0

--- a/base/collection_xattr_test.go
+++ b/base/collection_xattr_test.go
@@ -798,6 +798,7 @@ func TestWriteTombstoneWithXattrs(t *testing.T) {
 				finalXattrs: map[string][]byte{
 					"_xattr1": []byte(`{"c": "d"}`),
 				},
+				writeErrorFunc: RequireXattrDeleteOnDocumentInsertError,
 			},
 			{
 				name:        "previousDoc=nil,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=0,deleteBody=true",
@@ -811,7 +812,7 @@ func TestWriteTombstoneWithXattrs(t *testing.T) {
 					"_xattr1": []byte(`{"c": "d"}`),
 				},
 				deleteBody:     true,
-				writeErrorFunc: RequireDocNotFoundError,
+				writeErrorFunc: RequireXattrDeleteOnDocumentInsertError,
 			},
 			{
 				name: "previousDoc=body+_xattr1,_xattr2,xattrsToUpdate=_xattr1,xattrsToDelete=_xattr2,cas=correct,deleteBody=false",
@@ -819,6 +820,7 @@ func TestWriteTombstoneWithXattrs(t *testing.T) {
 					Body: []byte(`{"foo": "bar"}`),
 					Xattrs: map[string][]byte{
 						"_xattr1": []byte(`{"a" : "b"}`),
+						"_xattr2": []byte(`{"c": "d"}`),
 					},
 				},
 				updatedXattrs: map[string][]byte{
@@ -838,6 +840,7 @@ func TestWriteTombstoneWithXattrs(t *testing.T) {
 					Body: []byte(`{"foo": "bar"}`),
 					Xattrs: map[string][]byte{
 						"_xattr1": []byte(`{"a" : "b"}`),
+						"_xattr2": []byte(`{"c": "d"}`),
 					},
 				},
 				updatedXattrs: map[string][]byte{
@@ -874,7 +877,7 @@ func TestWriteTombstoneWithXattrs(t *testing.T) {
 					cas = casOut
 				}
 			}
-			_, err := col.WriteTombstoneWithXattrs(ctx, docID, exp, cas, test.updatedXattrs, nil, test.deleteBody, nil)
+			_, err := col.WriteTombstoneWithXattrs(ctx, docID, exp, cas, test.updatedXattrs, test.xattrsToDelete, test.deleteBody, nil)
 			if test.writeErrorFunc != nil {
 				test.writeErrorFunc(t, err)
 				if test.finalBody != nil {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -783,6 +783,11 @@ func RequireDocNotFoundError(t testing.TB, e error) {
 	require.True(t, IsDocNotFoundError(e), fmt.Sprintf("Expected error to be a doc not found error, but was: %v", e))
 }
 
+// RequireXattrDeleteOnDocumentInsertError asserts that the given error represents error deleting xattrs during document delete
+func RequireXattrDeleteOnDocumentInsertError(t testing.TB, e error) {
+	require.True(t, errors.Is(e, sgbucket.ErrDeleteXattrOnDocumentInsert))
+}
+
 // RequireXattrNotFoundError asserts that the given error represents an xattr not found error.
 func RequireXattrNotFoundError(t testing.TB, e error) {
 	require.True(t, IsXattrNotFoundError(e), fmt.Sprintf("Expected error to be an xattr not found error, but was: %v", e))

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3794,7 +3794,8 @@ func TestMOUDeletedOnTombstone(t *testing.T) {
 		rt.WaitForTombstone(docID, tombStoneVersion)
 
 		rawDoc := rt.GetRawDoc(docID)
-		assert.NotContains(t, rawDoc.Xattrs.RawDocXattrsOthers, base.MouXattrName)
+		mou, _ := rawDoc.Xattrs.RawDocXattrsOthers[base.MouXattrName]
+		assert.Nil(t, mou)
 
 	})
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -3752,4 +3753,48 @@ func TestGetConfigAfterFailToStartOnlineProcess(t *testing.T) {
 	// Original bug will trigger panic here on this endpoint
 	resp = rt.SendAdminRequest(http.MethodGet, "/_config?include_runtime=true", "")
 	RequireStatus(t, resp, http.StatusOK)
+}
+
+func TestMOUDeletedOnTombstone(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	col := bucket.GetSingleDataStore()
+
+	docID := t.Name()
+	docBody := map[string]any{"foo": "bar"}
+
+	rtConfig := RestTesterConfig{
+		CustomTestBucket: bucket,
+		GuestEnabled:     true,
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true
+
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer client.Close()
+
+		btcRunner.StartPull(client.ID())
+		btcRunner.StartPush(client.ID())
+
+		err := col.Set(docID, 0, &sgbucket.UpsertOptions{}, docBody)
+		require.NoError(t, err)
+
+		rt.WaitForDoc(docID)
+		version, _ := rt.GetDoc(docID)
+
+		btcRunner.WaitForVersion(client.ID(), docID, version)
+
+		tombStoneVersion := btcRunner.DeleteDoc(client.ID(), docID, &version)
+		rt.WaitForTombstone(docID, tombStoneVersion)
+
+		rawDoc := rt.GetRawDoc(docID)
+		assert.NotContains(t, rawDoc.Xattrs.RawDocXattrsOthers, base.MouXattrName)
+
+	})
 }

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/gocb/v2"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
@@ -3728,5 +3729,50 @@ func TestBlipNoRevOnCorruptHistoryDelta(t *testing.T) {
 		btcRunner.StartOneshotPull(btc.id)
 		msg := btcRunner.WaitForPullRevMessage(btc.id, docID, expectedVersion)
 		require.Equal(t, db.MessageNoRev, msg.Profile())
+	})
+}
+
+func TestMOUDeletedOnTombstone(t *testing.T) {
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+	col := bucket.GetSingleDataStore()
+
+	docID := t.Name()
+	docBody := map[string]any{"foo": "bar"}
+
+	rtConfig := RestTesterConfig{
+		CustomTestBucket: bucket,
+		GuestEnabled:     true,
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true
+
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &rtConfig)
+		defer rt.Close()
+
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer client.Close()
+
+		btcRunner.StartPull(client.ID())
+		btcRunner.StartPush(client.ID())
+
+		err := col.Set(docID, 0, &sgbucket.UpsertOptions{}, docBody)
+		require.NoError(t, err)
+
+		rt.WaitForDoc(docID)
+		version, _ := rt.GetDoc(docID)
+
+		btcRunner.WaitForVersion(client.ID(), docID, version)
+
+		tombStoneVersion := btcRunner.DeleteDoc(client.ID(), docID, &version)
+		rt.WaitForTombstone(docID, tombStoneVersion)
+
+		rawDoc := rt.GetRawDoc(docID)
+		mou, _ := rawDoc.Xattrs.RawDocXattrsOthers[base.MouXattrName]
+		assert.Nil(t, mou)
+
 	})
 }


### PR DESCRIPTION
CBG-5070

Describe your PR here...
- Fixed the scenario where the _mou is not being cleared when a document is tombstoned
- Added test coverage for the same

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/251/
