### PR TITLE
add test for existing DCP checkpoint prefixes

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -306,7 +306,9 @@ func handleAttachments(attachmentKeyMap map[string]string, docKey string, attach
 	}
 }
 
-func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, terminator *base.SafeTerminator, purgedAttachmentCount *base.AtomicInt) (int64, error) {
+// attachmentCompactSweepPhase will process all v1 attachments and purge any which are marked with the supplied xattr.
+// Returns the number of purged documents, the dcp checkpoint prefix, and any error.
+func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, terminator *base.SafeTerminator, purgedAttachmentCount *base.AtomicInt) (int64, string, error) {
 	base.InfofCtx(ctx, base.KeyAll, "Starting second phase of attachment compaction (sweep phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Sweep: " + compactionID
 
@@ -379,7 +381,7 @@ func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, 
 
 	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 	clientOptions.InitialMetadata = base.BuildDCPMetadataSliceFromVBUUIDs(vbUUIDs)
 
@@ -387,21 +389,21 @@ func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, 
 
 	bucket, err := base.AsGocbV2Bucket(db.Bucket)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 
 	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed %q for sweep phase of attachment compaction", compactionLoggingID, dcpFeedKey)
 	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, callback, *clientOptions, bucket)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
-		return 0, err
+		return 0, "", err
 	}
 
 	doneChan, err := dcpClient.Start()
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to start attachment compaction DCP feed! %v", compactionLoggingID, err)
 		_ = dcpClient.Close()
-		return 0, err
+		return 0, dcpClient.GetMetadataKeyPrefix(), err
 	}
 	base.DebugfCtx(ctx, base.KeyAll, "[%s] DCP client started.", compactionLoggingID)
 
@@ -414,20 +416,22 @@ func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, 
 		err = dcpClient.Close()
 		if err != nil {
 			base.WarnfCtx(ctx, "[%s] Failed to close attachment compaction DCP client! %v", compactionLoggingID, err)
-			return purgedAttachmentCount.Value(), err
+			return purgedAttachmentCount.Value(), dcpClient.GetMetadataKeyPrefix(), err
 		}
 
 		err = <-doneChan
 		if err != nil {
-			return purgedAttachmentCount.Value(), err
+			return purgedAttachmentCount.Value(), dcpClient.GetMetadataKeyPrefix(), err
 		}
 
 		base.InfofCtx(ctx, base.KeyAll, "[%s] Sweep phase of attachment compaction was terminated. Deleted %d attachments", compactionLoggingID, purgedAttachmentCount.Value())
 	}
 
-	return purgedAttachmentCount.Value(), err
+	return purgedAttachmentCount.Value(), dcpClient.GetMetadataKeyPrefix(), err
 }
 
+// attachmentCompactCleanupPhase runs a DCP feed to clean up all documents with	an attachment compaction xattr. Returns
+// the DCP checkpoint prefix and any error encountered.
 func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, vbUUIDs []uint64, terminator *base.SafeTerminator) (string, error) {
 	base.InfofCtx(ctx, base.KeyAll, "Starting third phase of attachment compaction (cleanup phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Cleanup: " + compactionID

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -430,7 +430,7 @@ func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, 
 	return purgedAttachmentCount.Value(), dcpClient.GetMetadataKeyPrefix(), err
 }
 
-// attachmentCompactCleanupPhase runs a DCP feed to clean up all documents with	an attachment compaction xattr. Returns
+// attachmentCompactCleanupPhase runs a DCP feed to clean up all documents with an attachment compaction xattr. Returns
 // the DCP checkpoint prefix and any error encountered.
 func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, vbUUIDs []uint64, terminator *base.SafeTerminator) (string, error) {
 	base.InfofCtx(ctx, base.KeyAll, "Starting third phase of attachment compaction (cleanup phase) with compactionID: %q", compactionID)

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -152,7 +152,7 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 	case "sweep":
 		a.SetPhase("sweep")
 		persistClusterStatus()
-		_, err := attachmentCompactSweepPhase(ctx, dataStore, collectionID, database, a.CompactID, a.VBUUIDs, a.dryRun, terminator, &a.PurgedAttachments)
+		_, _, err := attachmentCompactSweepPhase(ctx, dataStore, collectionID, database, a.CompactID, a.VBUUIDs, a.dryRun, terminator, &a.PurgedAttachments)
 		if err != nil || terminator.IsClosed() {
 			return err
 		}

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -84,8 +84,6 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
-	// create some docs with attachments defined, a large number is needed to allow us to stop the migration midway
-	// through without it completing first
 	for i := range 4000 {
 		docBody := Body{
 			"value":         1234,
@@ -254,4 +252,79 @@ func TestMigrationManagerDocWithSyncAndGlobalAttachmentMetadata(t *testing.T) {
 		},
 	}, GetRawGlobalSyncAttachments(t, collection.dataStore, key))
 	require.Empty(t, GetRawSyncXattr(t, collection.dataStore, key).AttachmentsPre4dot0)
+}
+
+func TestAttachmentMigrationCheckpointPrefix(t *testing.T) {
+	base.TestRequiresDCPResync(t)
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	migrationID := "1234"
+	testCases := []struct {
+		name          string
+		collectionIDs []uint32
+		groupID       string
+		expected      string
+	}{
+		{
+			name:          "default collection, no metadata id",
+			collectionIDs: []uint32{base.DefaultCollectionID},
+			groupID:       "",
+			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:att_migration:1234", base.ProductAPIVersion),
+		},
+		{
+			name:          "default collection, metadata id",
+			collectionIDs: []uint32{base.DefaultCollectionID},
+			groupID:       "foo",
+			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:att_migration:1234", base.ProductAPIVersion),
+		},
+		{
+			name:          "default collection + collection 1, no metadata id",
+			collectionIDs: []uint32{base.DefaultCollectionID, 1},
+			groupID:       "",
+			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:att_migration:1234", base.ProductAPIVersion),
+		},
+		{
+			name:          "default collection + collection 1, metadata id",
+			collectionIDs: []uint32{base.DefaultCollectionID, 1},
+			groupID:       "foo",
+			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:att_migration:1234", base.ProductAPIVersion),
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			autoImport := false
+			db, err := NewDatabaseContext(
+				ctx,
+				"db",
+				bucket.NoCloseClone(),
+				autoImport,
+				DatabaseContextOptions{
+					Scopes:  GetScopesOptions(t, bucket, 1),
+					GroupID: test.groupID,
+				},
+			)
+			require.NoError(t, err)
+			defer db.Close(ctx)
+			clientOptions := getMigrationDCPClientOptions(
+				test.collectionIDs,
+				db.Options.GroupID,
+				db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID),
+			)
+
+			dcpFeedKey := GenerateAttachmentMigrationDCPStreamName(migrationID)
+			b, err := base.AsGocbV2Bucket(bucket)
+			require.NoError(t, err)
+			dcpClient, err := base.NewDCPClient(
+				ctx,
+				dcpFeedKey,
+				nil,
+				*clientOptions,
+				b,
+			)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, dcpClient.GetMetadataKeyPrefix())
+		})
+	}
 }

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -84,6 +84,8 @@ func TestAttachmentMigrationManagerResumeStoppedMigration(t *testing.T) {
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
+	// create some docs with attachments defined, a large number is needed to allow us to stop the migration midway
+	// through without it completing first
 	for i := range 4000 {
 		docBody := Body{
 			"value":         1234,
@@ -268,25 +270,25 @@ func TestAttachmentMigrationCheckpointPrefix(t *testing.T) {
 		expected      string
 	}{
 		{
-			name:          "default collection, no metadata id",
+			name:          "default collection, no group id",
 			collectionIDs: []uint32{base.DefaultCollectionID},
 			groupID:       "",
 			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:att_migration:1234", base.ProductAPIVersion),
 		},
 		{
-			name:          "default collection, metadata id",
+			name:          "default collection, group ID=foo",
 			collectionIDs: []uint32{base.DefaultCollectionID},
 			groupID:       "foo",
 			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:att_migration:1234", base.ProductAPIVersion),
 		},
 		{
-			name:          "default collection + collection 1, no metadata id",
+			name:          "default collection + collection 1, no group id",
 			collectionIDs: []uint32{base.DefaultCollectionID, 1},
 			groupID:       "",
 			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:att_migration:1234", base.ProductAPIVersion),
 		},
 		{
-			name:          "default collection + collection 1, metadata id",
+			name:          "default collection + collection 1, group ID=foo",
 			collectionIDs: []uint32{base.DefaultCollectionID, 1},
 			groupID:       "foo",
 			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:att_migration:1234", base.ProductAPIVersion),

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -651,25 +651,25 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 		expected      string
 	}{
 		{
-			name:          "default collection, no metadata id",
+			name:          "default collection, no group id",
 			collectionIDs: []uint32{base.DefaultCollectionID},
 			groupID:       "",
 			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:resync:1234", base.ProductAPIVersion),
 		},
 		{
-			name:          "default collection, metadata id",
+			name:          "default collection, group id= foo",
 			collectionIDs: []uint32{base.DefaultCollectionID},
 			groupID:       "foo",
 			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:resync:1234", base.ProductAPIVersion),
 		},
 		{
-			name:          "default collection + collection 1, no metadata id",
+			name:          "default collection + collection 1, no group id",
 			collectionIDs: []uint32{base.DefaultCollectionID, 1},
 			groupID:       "",
 			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:resync:1234", base.ProductAPIVersion),
 		},
 		{
-			name:          "default collection + collection 1, metadata id",
+			name:          "default collection + collection 1, group id=foo",
 			collectionIDs: []uint32{base.DefaultCollectionID, 1},
 			groupID:       "foo",
 			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:resync:1234", base.ProductAPIVersion),

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -636,3 +636,78 @@ func waitForResyncDocsProcessed(t testing.TB, db *Database, count int64) {
 		assert.Greater(c, stats.DocsProcessed, count)
 	}, 10*time.Second, 1*time.Millisecond)
 }
+
+func TestResyncCheckpointPrefix(t *testing.T) {
+	base.TestRequiresDCPResync(t)
+	ctx := base.TestCtx(t)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close(ctx)
+
+	resyncID := "1234"
+	testCases := []struct {
+		name          string
+		collectionIDs []uint32
+		groupID       string
+		expected      string
+	}{
+		{
+			name:          "default collection, no metadata id",
+			collectionIDs: []uint32{base.DefaultCollectionID},
+			groupID:       "",
+			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:resync:1234", base.ProductAPIVersion),
+		},
+		{
+			name:          "default collection, metadata id",
+			collectionIDs: []uint32{base.DefaultCollectionID},
+			groupID:       "foo",
+			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:resync:1234", base.ProductAPIVersion),
+		},
+		{
+			name:          "default collection + collection 1, no metadata id",
+			collectionIDs: []uint32{base.DefaultCollectionID, 1},
+			groupID:       "",
+			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:resync:1234", base.ProductAPIVersion),
+		},
+		{
+			name:          "default collection + collection 1, metadata id",
+			collectionIDs: []uint32{base.DefaultCollectionID, 1},
+			groupID:       "foo",
+			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:resync:1234", base.ProductAPIVersion),
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			autoImport := false
+			db, err := NewDatabaseContext(
+				ctx,
+				"db",
+				bucket.NoCloseClone(),
+				autoImport,
+				DatabaseContextOptions{
+					Scopes:  GetScopesOptions(t, bucket, 1),
+					GroupID: test.groupID,
+				},
+			)
+			require.NoError(t, err)
+			defer db.Close(ctx)
+			clientOptions := getResyncDCPClientOptions(
+				test.collectionIDs,
+				db.Options.GroupID,
+				db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID),
+			)
+
+			dcpFeedKey := GenerateResyncDCPStreamName(resyncID)
+			b, err := base.AsGocbV2Bucket(bucket)
+			require.NoError(t, err)
+			dcpClient, err := base.NewDCPClient(
+				ctx,
+				dcpFeedKey,
+				nil,
+				*clientOptions,
+				b,
+			)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, dcpClient.GetMetadataKeyPrefix())
+		})
+	}
+}

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -657,7 +657,7 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 			expected:      fmt.Sprintf("_sync:dcp_ck::sg-%v:resync:1234", base.ProductAPIVersion),
 		},
 		{
-			name:          "default collection, group id= foo",
+			name:          "default collection, group id=foo",
 			collectionIDs: []uint32{base.DefaultCollectionID},
 			groupID:       "foo",
 			expected:      fmt.Sprintf("_sync:dcp_ck:foo::sg-%v:resync:1234", base.ProductAPIVersion),


### PR DESCRIPTION
CBG-5144 add test for existing DCP checkpoint prefixes

Add a test to make sure any future DCP refactoring doesn't break checkpoint names.

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/247/
