### PR TITLE
CBG-5149: Stamp more default values into DefaultDbConfig() for visibility in `include_runtime`

### DIFF
--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -11,6 +11,7 @@ package rest
 import (
 	"context"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
@@ -160,7 +161,7 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		LocalDocExpirySecs:    base.Ptr(base.DefaultLocalDocExpirySecs),
 		EnableXattrs:          base.Ptr(base.DefaultUseXattrs),
 		SecureCookieOverride:  base.Ptr(sc.API.HTTPS.TLSCertPath != ""),
-		SessionCookieName:     "",
+		SessionCookieName:     auth.DefaultCookieName,
 		SessionCookieHTTPOnly: base.Ptr(false),
 		AllowConflicts:        base.Ptr(base.DefaultAllowConflicts),
 		Index: &IndexConfig{
@@ -169,7 +170,7 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		UseViews:                    base.Ptr(false),
 		SendWWWAuthenticateHeader:   base.Ptr(true),
 		DisablePasswordAuth:         base.Ptr(false),
-		BucketOpTimeoutMs:           nil,
+		BucketOpTimeoutMs:           base.Ptr(uint32(base.DefaultGocbV2OperationTimeout.Milliseconds())),
 		SlowQueryWarningThresholdMs: base.Ptr(kDefaultSlowQueryWarningThreshold),
 		DeltaSync: &DeltaSyncConfig{
 			Enabled:          base.Ptr(db.DefaultDeltaSyncEnabled),
@@ -184,6 +185,7 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		QueryPaginationLimit:             base.Ptr(db.DefaultQueryPaginationLimit),
 		UserXattrKey:                     nil,
 		ClientPartitionWindowSecs:        base.Ptr(int(base.DefaultClientPartitionWindow.Seconds())),
+		Guest:                            &auth.PrincipalConfig{Disabled: base.Ptr(true)},
 		JavascriptTimeoutSecs:            base.Ptr(base.DefaultJavascriptTimeoutSecs),
 		Suspendable:                      base.Ptr(sc.IsServerless()),
 		ChangesRequestPlus:               base.Ptr(false),
@@ -195,6 +197,8 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		dbConfig.AutoImport = base.Ptr(base.DefaultAutoImport)
 		if base.IsEnterpriseEdition() {
 			dbConfig.ImportPartitions = base.Ptr(base.GetDefaultImportPartitions(sc.IsServerless()))
+		} else {
+			dbConfig.ImportPartitions = base.Ptr(uint16(0))
 		}
 		dbConfig.Index.NumPartitions = base.Ptr(db.DefaultNumIndexPartitions)
 	} else {

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -168,6 +168,7 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		},
 		UseViews:                    base.Ptr(false),
 		SendWWWAuthenticateHeader:   base.Ptr(true),
+		DisablePasswordAuth:         base.Ptr(false),
 		BucketOpTimeoutMs:           nil,
 		SlowQueryWarningThresholdMs: base.Ptr(kDefaultSlowQueryWarningThreshold),
 		DeltaSync: &DeltaSyncConfig{
@@ -185,6 +186,7 @@ func DefaultDbConfig(sc *StartupConfig, useXattrs bool) *DbConfig {
 		ClientPartitionWindowSecs:        base.Ptr(int(base.DefaultClientPartitionWindow.Seconds())),
 		JavascriptTimeoutSecs:            base.Ptr(base.DefaultJavascriptTimeoutSecs),
 		Suspendable:                      base.Ptr(sc.IsServerless()),
+		ChangesRequestPlus:               base.Ptr(false),
 		Logging:                          DefaultPerDBLogging(sc.Logging),
 		DisablePublicAllDocs:             base.Ptr(false),
 	}


### PR DESCRIPTION
CBG-5149

Stamp several default values into `DefaultDbConfig()` for visibility in config requests specifying `include_runtime`
- Add test to catch future missed fields

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/283/
