### PR TITLE
[4.0.3 backport] CBG-5142: Only fetch backup revision for fromRev for delta sync

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -134,7 +134,7 @@ func TestGetBackupRevisionWhenCurrentRevisionHasAttachments(t *testing.T) {
 	// can remove in CBG-4542
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.GetRev(ctx, "doc1", doc1.HLV.GetCurrentVersionString(), false, nil)
+	docRev, err := collection.revisionCache.GetWithCV(ctx, "doc1", doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
 	require.NoError(t, err)
 
 	// assert version is fetched and attachments is empty

--- a/db/hybrid_logical_vector_test.go
+++ b/db/hybrid_logical_vector_test.go
@@ -335,7 +335,7 @@ func TestHLVImport(t *testing.T) {
 			name: "HLV write from without mou",
 			preFunc: func(t *testing.T, collection *DatabaseCollectionWithUser, docID string) {
 				hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_vv")
-				_ = hlvHelper.InsertWithHLV(ctx, docID)
+				_ = hlvHelper.InsertWithHLV(ctx, docID, nil)
 			},
 			expectedMou: func(output *outputData) *MetadataOnlyUpdate {
 				return &MetadataOnlyUpdate{
@@ -356,7 +356,7 @@ func TestHLVImport(t *testing.T) {
 			name: "XDCR stamped with _mou",
 			preFunc: func(t *testing.T, collection *DatabaseCollectionWithUser, docID string) {
 				hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_vv")
-				cas := hlvHelper.InsertWithHLV(ctx, docID)
+				cas := hlvHelper.InsertWithHLV(ctx, docID, nil)
 
 				_, xattrs, _, err := collection.dataStore.GetWithXattrs(ctx, docID, []string{base.VirtualXattrRevSeqNo})
 				require.NoError(t, err)
@@ -387,7 +387,7 @@ func TestHLVImport(t *testing.T) {
 			name: "invalid _mou, but valid hlv",
 			preFunc: func(t *testing.T, collection *DatabaseCollectionWithUser, docID string) {
 				hlvHelper := NewHLVAgent(t, collection.dataStore, otherSource, "_vv")
-				cas := hlvHelper.InsertWithHLV(ctx, docID)
+				cas := hlvHelper.InsertWithHLV(ctx, docID, nil)
 
 				_, xattrs, _, err := collection.dataStore.GetWithXattrs(ctx, docID, []string{base.VirtualXattrRevSeqNo})
 				require.NoError(t, err)

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -58,7 +58,7 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 }
 
 // GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
 
 	docRev = DocumentRevision{
 		CV:                     cv,
@@ -71,12 +71,11 @@ func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *
 	}
 
 	var hlv *HybridLogicalVector
-	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, hlv, err = revCacheLoaderForDocumentCV(ctx, rc.backingStores[collectionID], doc, *cv)
+	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, hlv, err = revCacheLoaderForDocumentCV(ctx, rc.backingStores[collectionID], doc, *cv, loadBackup)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
 	if hlv != nil {
-		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
 		docRev.HlvHistory = hlv.ToHistoryForHLV()
 	}
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -82,7 +82,7 @@ func (t *testBackingStore) getRevision(ctx context.Context, doc *Document, revid
 	return bodyBytes, nil, ch, err
 }
 
-func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, bool, error) {
+func (t *testBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version, loadBackup bool) ([]byte, AttachmentsMeta, base.Set, bool, error) {
 	t.getRevisionCounter.Add(1)
 
 	revTreeID := doc.GetRevTreeID()
@@ -113,7 +113,7 @@ func (*noopBackingStore) getRevision(ctx context.Context, doc *Document, revid s
 	return nil, nil, nil, nil
 }
 
-func (*noopBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version) ([]byte, AttachmentsMeta, base.Set, bool, error) {
+func (*noopBackingStore) getCurrentVersion(ctx context.Context, doc *Document, cv Version, loadBackup bool) ([]byte, AttachmentsMeta, base.Set, bool, error) {
 	return nil, nil, nil, false, nil
 }
 
@@ -253,7 +253,7 @@ func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
 		id := strconv.Itoa(i + 3)
 		vrs := uint64(i + 3)
 		cv := Version{Value: vrs, SourceID: "test"}
-		docRev, err := cache.GetWithCV(ctx, id, &cv, testCollectionID, RevCacheOmitDelta)
+		docRev, err := cache.GetWithCV(ctx, id, &cv, testCollectionID, RevCacheOmitDelta, false)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -405,7 +405,7 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetWithCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
@@ -432,7 +432,7 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 
 			// test fail load event doesn't increment memory stat
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetWithCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				assertHTTPError(t, err, 404)
 			} else {
 				docRev, err = cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta)
@@ -447,7 +447,7 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			memStatBeforeThirdLoad := memoryBytesCounted.Value()
 			// test another load from bucket but doing so should trigger memory based eviction
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetWithCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = cache.GetWithRev(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta)
@@ -535,7 +535,7 @@ func TestBackingStoreCV(t *testing.T) {
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
 	cv := Version{SourceID: "test", Value: 123}
-	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta)
+	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
@@ -547,7 +547,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Perform a get on the same doc as above, check that we get cache hit
-	docRev, err = cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
@@ -559,7 +559,7 @@ func TestBackingStoreCV(t *testing.T) {
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
 	cv = Version{SourceID: "test11", Value: 100}
-	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta, false)
 
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -569,7 +569,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta, false)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -920,7 +920,7 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			// assert we can still fetch this upsert doc
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetWithCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, false)
@@ -933,7 +933,7 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			assert.Equal(t, int64(0), cacheNumItems.Value())
 
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetWithCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
@@ -1091,7 +1091,7 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetWithCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = cache.GetWithRev(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta)
@@ -1173,7 +1173,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			// Test Get with item in the cache
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.GetWithCV(ctx, "doc1", docCV, collctionID, false)
+				docRev, err = db.revisionCache.GetWithCV(ctx, "doc1", docCV, collctionID, false, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = db.revisionCache.GetWithRev(ctx, "doc1", revID, collctionID, RevCacheOmitDelta)
@@ -1189,7 +1189,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			revDoc2 := createThenRemoveFromRevCache(t, ctx, "doc2", db, collection)
 			// load from doc from bucket
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.GetWithCV(ctx, "doc2", &revDoc2.CV, collctionID, false)
+				docRev, err = db.revisionCache.GetWithCV(ctx, "doc2", &revDoc2.CV, collctionID, false, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = db.revisionCache.GetWithRev(ctx, "doc2", docRev.RevID, collctionID, RevCacheOmitDelta)
@@ -1517,7 +1517,7 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			// test not found doc, assert that the stat isn't incremented
 			if testCase.UseCVCache {
 				cv := Version{SourceID: "test", Value: 123}
-				_, err = cache.GetWithCV(ctx, "badDoc", &cv, testCollectionID, false)
+				_, err = cache.GetWithCV(ctx, "badDoc", &cv, testCollectionID, false, false)
 				require.Error(t, err)
 			} else {
 				_, err = cache.GetWithRev(ctx, "badDoc", "1-abc", testCollectionID, false)
@@ -1530,7 +1530,7 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
 				cv := Version{SourceID: "test", Value: 123}
-				docRev, err = cache.GetWithCV(ctx, "doc2", &cv, testCollectionID, false)
+				docRev, err = cache.GetWithCV(ctx, "doc2", &cv, testCollectionID, false, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, false)
@@ -1543,7 +1543,7 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			// Get on item in cache, assert num items remains the same
 			if testCase.UseCVCache {
 				cv := Version{SourceID: "test", Value: 123}
-				docRev, err = cache.GetWithCV(ctx, "doc1", &cv, testCollectionID, false)
+				docRev, err = cache.GetWithCV(ctx, "doc1", &cv, testCollectionID, false, false)
 				require.NoError(t, err)
 			} else {
 				docRev, err = cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, false)
@@ -1723,7 +1723,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	}
 	cache.Put(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta)
+	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1736,7 +1736,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 
 	cache.Upsert(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err = cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1922,7 +1922,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	// create cv with incorrect version to the one stored in backing store
 	cv := Version{SourceID: "test", Value: 1234}
 
-	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta)
+	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	require.Error(t, err)
 	require.Error(t, err, base.ErrNotFound)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -1962,7 +1962,7 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	}()
 
 	go func() {
-		_, err := cache.GetWithCV(ctx, "doc1", &cv, testCollectionID, RevCacheIncludeDelta)
+		_, err := cache.GetWithCV(ctx, "doc1", &cv, testCollectionID, RevCacheIncludeDelta, false)
 		require.NoError(t, err)
 		wg.Done()
 	}()
@@ -2279,7 +2279,7 @@ func TestFetchBackupWithDeletedFlag(t *testing.T) {
 	// flush cache
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.getRev(ctx, docID, doc1.HLV.GetCurrentVersionString(), 0, nil)
+	docRev, err := collection.revisionCache.GetWithCV(ctx, docID, doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, doc1.HLV.GetCurrentVersionString(), docRev.CV.String())
@@ -2294,12 +2294,54 @@ func TestFetchBackupWithDeletedFlag(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch deleted, will get backup rev and assert that the deleted flag is true
-	docRev, err = collection.getRev(ctx, docID, deleteDoc.HLV.GetCurrentVersionString(), 0, nil)
+	docRev, err = collection.revisionCache.GetWithCV(ctx, docID, deleteDoc.HLV.ExtractCurrentVersionFromHLV(), false, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, deleteDoc.HLV.GetCurrentVersionString(), docRev.CV.String())
 	// assert backup rev is marked as deleted
 	assert.True(t, docRev.Deleted)
+}
+
+func TestCorrectHLVWhenFetchingBackupRev(t *testing.T) {
+	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
+		// enable delta sync so CV revs are backed up
+		DeltaSyncOptions: DeltaSyncOptions{
+			Enabled:          true,
+			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
+		},
+	})
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	docID := t.Name()
+	agent := NewHLVAgent(t, collection.dataStore, "someSourceID", base.VvXattrName)
+
+	_ = agent.InsertWithHLV(ctx, docID, nil)
+
+	docRev, err := collection.getRev(ctx, docID, "", 0, nil)
+	require.NoError(t, err)
+	cv := docRev.CV.String()
+
+	_, _, err = collection.Put(ctx, docID, Body{"foo": "bar", BodyRev: docRev.RevID})
+	require.NoError(t, err)
+
+	// flush cache
+	db.FlushRevisionCacheForTest()
+
+	// fetch backup rev and assert that the HLV is correct
+	_, err = collection.getRev(ctx, docID, docRev.CV.String(), 0, nil)
+	require.ErrorContains(t, err, "missing")
+
+	// flush cache
+	db.FlushRevisionCacheForTest()
+
+	// fetch using lower level cache fetch with load from bucket bool true to get the backup rev
+	docRev, err = collection.revisionCache.GetWithCV(ctx, docID, docRev.CV, RevCacheOmitDelta, true)
+	require.NoError(t, err)
+
+	// hlv history should be empty as we are fetching from backup rev
+	assert.Empty(t, docRev.HlvHistory)
+	assert.Equal(t, cv, docRev.CV.String())
 }
 
 func TestRemoveFromRevLookup(t *testing.T) {
@@ -2632,19 +2674,19 @@ func TestEvictionOfCVKeysWhenNoItemInRevMap(t *testing.T) {
 
 	// create a few revs
 	docID := t.Name()
-	docCVs := make([]string, 0)
+	docCVs := make([]*Version, 0)
 	rev, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
 	require.NoError(t, err)
-	docCVs = append(docCVs, doc1.HLV.GetCurrentVersionString())
+	docCVs = append(docCVs, doc1.HLV.ExtractCurrentVersionFromHLV())
 	for range 2 {
 		newRev, doc, err := collection.Put(ctx, docID, Body{BodyRev: rev, "foo": "bar"})
 		require.NoError(t, err)
-		docCVs = append(docCVs, doc.HLV.GetCurrentVersionString())
+		docCVs = append(docCVs, doc.HLV.ExtractCurrentVersionFromHLV())
 		rev = newRev // OCC val
 	}
 	// simulate doc revs that are backed up to bucket pre upgrade
 	for i := range 2 {
-		revHash := base.Crc32cHashString([]byte(docCVs[i]))
+		revHash := base.Crc32cHashString([]byte(docCVs[i].String()))
 		err := collection.setOldRevisionJSONBody(ctx, docID, revHash, []byte(`{"foo":"bar"}`), collection.oldRevExpirySeconds())
 		require.NoError(t, err)
 	}
@@ -2654,27 +2696,27 @@ func TestEvictionOfCVKeysWhenNoItemInRevMap(t *testing.T) {
 
 	// fetch all three legacy revisions, first two should be loaded from old backup revisions
 	for i := range 3 {
-		docRev, err := collection.getRev(ctx, docID, docCVs[i], 0, nil)
+		docRev, err := collection.revisionCache.GetWithCV(ctx, docID, docCVs[i], false, true)
 		require.NoError(t, err)
-		assert.Equal(t, docCVs[i], docRev.CV.String())
+		assert.Equal(t, docCVs[i].String(), docRev.CV.String())
 	}
 	// at this point we have loaded 3 revs into a cache that can only hold 1 item
 	// assert that only 1 item exists in rev lookup (revID3 from above)
 	// to do so delete backup revs and fetch through rev cache assert first two have 404 errors whilst last one should succeed (resident in cache)
 	for i := range 2 {
-		revHash := base.Crc32cHashString([]byte(docCVs[i]))
+		revHash := base.Crc32cHashString([]byte(docCVs[i].String()))
 		err := collection.PurgeOldRevisionJSON(ctx, docID, revHash)
 		require.NoError(t, err)
 	}
 	for i := range 2 {
-		_, err := collection.getRev(ctx, docID, docCVs[i], 0, nil)
+		_, err := collection.getRev(ctx, docID, docCVs[i].String(), 0, nil)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "missing")
 	}
 	// last one should succeed
-	docRev, err := collection.getRev(ctx, docID, docCVs[2], 0, nil)
+	docRev, err := collection.getRev(ctx, docID, docCVs[2].String(), 0, nil)
 	require.NoError(t, err)
-	assert.Equal(t, docCVs[2], docRev.CV.String())
+	assert.Equal(t, docCVs[2].String(), docRev.CV.String())
 
 	// we should have one item in cache
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
@@ -2698,12 +2740,13 @@ func TestBasicLoadBackupRevCacheOnlyPopulateOneMap(t *testing.T) {
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	docID := SafeDocumentName(t, t.Name())
-	var firstRevisionID, firstCV string
+	var firstRevisionID, firstCVStr string
 	_, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
 	require.NoError(t, err)
 
 	firstRevisionID = doc1.GetRevTreeID()
-	firstCV = doc1.HLV.GetCurrentVersionString()
+	firstCVStr = doc1.HLV.GetCurrentVersionString()
+	firstCV := doc1.HLV.ExtractCurrentVersionFromHLV()
 
 	// make revision 2
 	_, _, err = collection.Put(ctx, docID, Body{BodyRev: firstRevisionID, "foo": "bar"})
@@ -2722,17 +2765,18 @@ func TestBasicLoadBackupRevCacheOnlyPopulateOneMap(t *testing.T) {
 
 	// now fetch by CV for backup rev, should load rev and only populate CV map and not revID map but
 	// should have essentially two items in underlying cache that are the same doc
-	_, err = collection.getRev(ctx, docID, firstCV, 0, nil)
+	// we need to use GetWithCV with load from bucket true to force load from backup rev
+	_, err = collection.revisionCache.GetWithCV(ctx, docID, firstCV, false, true)
 	require.NoError(t, err)
 	// assert on fetch by CV that we have two items in rev cache and 2 miss but 0 hits
 	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
 	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheHits.Value())
 
-	// now fetch by revID and CBV again and assert that we have hits now meaning they are loaded fine into lookup maps
+	// now fetch by revID and CV again and assert that we have hits now meaning they are loaded fine into lookup maps
 	_, err = collection.getRev(ctx, docID, firstRevisionID, 0, nil)
 	require.NoError(t, err)
-	_, err = collection.getRev(ctx, docID, firstCV, 0, nil)
+	_, err = collection.getRev(ctx, docID, firstCVStr, 0, nil)
 	require.NoError(t, err)
 
 	// assert we get two hits now
@@ -2792,12 +2836,15 @@ func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {
 			// by CV and vice versa for fetch by revID
 			if tc.useRevID {
 				_, err = collection.getRev(ctx, docID, firstRevisionID, 0, nil)
+				require.NoError(t, err)
+				assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
 			} else {
 				_, err = collection.getRev(ctx, docID, firstCV, 0, nil)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "missing")
+				assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
 			}
-			require.NoError(t, err)
-			// assert on fetch by CV that we have two items in rev cache and 2 miss but 0 hits
-			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
+			// assert on stats after fetch
 			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
 			assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheHits.Value())
 
@@ -2813,7 +2860,11 @@ func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {
 			assert.Equal(t, doc1.GetRevTreeID(), docRev.RevID)
 			assert.Equal(t, doc1.HLV.GetCurrentVersionString(), docRev.CV.String())
 			assert.JSONEq(t, `{"foo": "baz"}`, string(docRev.BodyBytes))
-			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
+			if tc.useRevID {
+				assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
+			} else {
+				assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
+			}
 			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
 			assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheHits.Value())
 		})

--- a/db/utilities_hlv_testing.go
+++ b/db/utilities_hlv_testing.go
@@ -46,7 +46,7 @@ func NewHLVAgent(t *testing.T, datastore base.DataStore, source string, xattrNam
 
 // InsertWithHLV inserts a new document into the bucket with a populated HLV (matching a write from
 // a different, non-SGW HLV-aware peer)
-func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64) {
+func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string, body Body) (casOut uint64) {
 	hlv := &HybridLogicalVector{}
 	err := hlv.AddVersion(CreateVersion(h.Source, expandMacroCASValueUint64))
 	require.NoError(h.t, err)
@@ -57,7 +57,12 @@ func (h *HLVAgent) InsertWithHLV(ctx context.Context, key string) (casOut uint64
 		MacroExpansion: hlv.computeMacroExpansions(),
 	}
 
-	docBody := base.MustJSONMarshal(h.t, defaultHelperBody)
+	var docBody []byte
+	if len(body) > 0 {
+		docBody = base.MustJSONMarshal(h.t, body)
+	} else {
+		docBody = base.MustJSONMarshal(h.t, defaultHelperBody)
+	}
 	xattrData := map[string][]byte{
 		h.xattrName: vvDataBytes,
 	}

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2999,7 +2999,7 @@ func TestGetNonWinningRevisionAttachmentLeak(t *testing.T) {
 
 					// Alice requests v1 - she has access to this revision
 					resp = rt.SendUserRequest(http.MethodGet, fmt.Sprintf("/{{.keyspace}}/%s?rev=%s", docID, revParam), "", "alice")
-					if revType == "CV" && flushCache || revType == "CV" && base.TestDisableRevCache() {
+					if revType == "CV" && flushCache {
 						// if flushed cache and fetching by cv we will return not found
 						RequireStatus(t, resp, http.StatusNotFound)
 						t.Logf("resp body: %s", resp.BodyBytes())

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -2165,7 +2165,7 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 		otherSource := "otherSource"
 		hlvHelper := db.NewHLVAgent(t, rt.GetSingleDataStore(), otherSource, "_vv")
 		existingHLVKey := "doc1"
-		cas := hlvHelper.InsertWithHLV(ctx, existingHLVKey)
+		cas := hlvHelper.InsertWithHLV(ctx, existingHLVKey, nil)
 
 		// force import of this write
 		_, _ = rt.GetDoc(docID)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1312,3 +1312,188 @@ func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
 		assert.Equal(t, int64(1), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
 	})
 }
+
+func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	const (
+		username = "alice"
+	)
+
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+			// force revs to be loaded from bucket, avoids need for flushing cache all the time
+			CacheConfig: &CacheConfig{
+				RevCacheConfig: &RevCacheConfig{
+					MaxItemCount: base.Ptr[uint32](0),
+				},
+			},
+		}},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+
+	testCases := []struct {
+		name             string
+		filteredChannels string
+	}{
+		{
+			name:             "filtered channels",
+			filteredChannels: "alice",
+		},
+		{
+			name:             "unfiltered channels",
+			filteredChannels: "",
+		},
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // not applicable to rev trees, we will look to backup bodies always for rev tree clients
+	btcRunner.Run(func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				docID := SafeDocumentName(t, t.Name())
+				rt := NewRestTester(t,
+					rtConfig)
+				defer rt.Close()
+				rt.CreateUser(username, []string{"*"})
+				var version2 db.DocVersion
+				updatedVersion := make(chan DocVersion)
+
+				// underneath the client's response to changes - we'll update the document so the requested rev is not available by the time SG receives the changes response.
+				changesEntryCallbackFn := func(changeEntryDocID, changeEntryRevID string) {
+					if changeEntryDocID == docID && changeEntryRevID == version2.RevTreeID || changeEntryRevID == version2.CV.String() {
+						updatedVersion <- rt.UpdateDoc(docID, version2, `{"foo":"buzz","channels":["alice"]}`)
+					}
+				}
+
+				opts := &BlipTesterClientOpts{
+					Username:             username,
+					ClientDeltas:         true,
+					changesEntryCallback: changesEntryCallbackFn,
+					sendReplacementRevs:  true,
+				}
+				client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+				defer client.Close()
+				ctx := t.Context()
+
+				// add doc from a different source to rest tester
+				agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "mySource", base.VvXattrName)
+				_ = agent.InsertWithHLV(ctx, docID, db.Body{"channels": "alice"})
+
+				// import doc
+				version1, _ := rt.GetDoc(docID)
+
+				if tc.filteredChannels != "" {
+					btcRunner.StartPullSince(client.id, BlipTesterPullOptions{Channels: tc.filteredChannels, Continuous: true})
+				} else {
+					btcRunner.StartPull(client.id)
+				}
+				btcRunner.WaitForVersion(client.id, docID, version1)
+
+				// create rev 2
+				version2 = rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
+				rt.WaitForPendingChanges()
+
+				// block until we've written the update and got the new version to use in assertions
+				version3 := <-updatedVersion
+
+				// we should get the new updated version through replacement rev functionality
+				btcRunner.WaitForVersion(client.id, docID, version3)
+
+				// rev message with a replacedRev property referring to the originally requested rev
+				msg2, ok := btcRunner.SingleCollection(client.id).GetPullRevMessage(docID, version3)
+				require.True(t, ok)
+				assert.Equal(t, db.MessageRev, msg2.Profile())
+				assert.Equal(t, version3.CV.String(), msg2.Properties[db.RevMessageRev])
+				assert.Equal(t, version2.CV.String(), msg2.Properties[db.RevMessageReplacedRev])
+
+				base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().ReplacementRevSendCount.Value, 1)
+				base.RequireWaitForStat(t, rt.GetDatabase().DbStats.CBLReplicationPull().NoRevSendCount.Value, 0)
+			})
+		}
+	})
+}
+
+func TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
+	if !base.IsEnterpriseEdition() {
+		t.Skip("Delta test requires EE")
+	}
+	const (
+		username = "alice"
+	)
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.Ptr(true),
+			},
+			// force revs to be loaded from bucket, avoids need for flushing cache all the time
+			CacheConfig: &CacheConfig{
+				RevCacheConfig: &RevCacheConfig{
+					MaxItemCount: base.Ptr[uint32](0),
+				},
+			},
+		}},
+		SyncFn: channels.DocChannelsSyncFunction,
+	}
+
+	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[VersionVectorSubtestName] = true // only for rev tree clients will we always load backup rev isf one is available
+	btcRunner.Run(func(t *testing.T) {
+
+		docID := SafeDocumentName(t, t.Name())
+		rt := NewRestTester(t,
+			rtConfig)
+		defer rt.Close()
+		rt.CreateUser(username, []string{"*"})
+		var version2 db.DocVersion
+		updatedVersion := make(chan DocVersion)
+
+		// underneath the client's response to changes - we'll update the document so the requested rev is not available by the time SG receives the changes response.
+		changesEntryCallbackFn := func(changeEntryDocID, changeEntryRevID string) {
+			if changeEntryDocID == docID && changeEntryRevID == version2.RevTreeID || changeEntryRevID == version2.CV.String() {
+				updatedVersion <- rt.UpdateDoc(docID, version2, `{"foo":"buzz","channels":["alice"]}`)
+			}
+		}
+
+		opts := &BlipTesterClientOpts{
+			Username:             username,
+			ClientDeltas:         true,
+			changesEntryCallback: changesEntryCallbackFn,
+		}
+		client := btcRunner.NewBlipTesterClientOptsWithRT(rt, opts)
+		defer client.Close()
+		ctx := t.Context()
+
+		// add doc from a different source to rest tester
+		agent := db.NewHLVAgent(t, rt.GetSingleDataStore(), "mySource", base.VvXattrName)
+		_ = agent.InsertWithHLV(ctx, docID, nil)
+
+		// import doc
+		version1, _ := rt.GetDoc(docID)
+
+		btcRunner.StartPull(client.id)
+		btcRunner.WaitForVersion(client.id, docID, version1)
+
+		// create rev 2
+		version2 = rt.UpdateDoc(docID, version1, `{"foo": "bar", "version": "2", "channels": ["alice"]}`)
+		rt.WaitForPendingChanges()
+
+		// block until we've written the update and got the new version to use in assertions
+		version3 := <-updatedVersion
+
+		// we should get the delta still for version 2
+		btcRunner.WaitForVersion(client.id, docID, version2)
+
+		// expect delta sent for rev 3 after
+		btcRunner.WaitForVersion(client.id, docID, version3)
+
+		// expect two deltas sent
+		assert.Equal(t, int64(2), rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value())
+	})
+}

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -2092,7 +2092,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
 		// no peek for cv so fetch by cv, which in turn loads from bucket so assert item ahs correct history on it
-		docRev, err := collectionActive1.GetRevisionCacheForTest().GetWithCV(ctxActive1, docID, &rt1Version.CV, false)
+		docRev, err := collectionActive1.GetRevisionCacheForTest().GetWithCV(ctxActive1, docID, &rt1Version.CV, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 
@@ -2100,7 +2100,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		collectionRT1, ctxRT1 := rt1.GetSingleTestDatabaseCollectionWithUser()
 		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
-		docRev, err = collectionRT1.GetRevisionCacheForTest().GetWithCV(ctxRT1, docID, &rt1Version.CV, false)
+		docRev, err = collectionRT1.GetRevisionCacheForTest().GetWithCV(ctxRT1, docID, &rt1Version.CV, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 	})

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -233,7 +233,7 @@ func TestReplicateVV(t *testing.T) {
 			hasHLV: true,
 			preXDCRFunc: func(t *testing.T, docID string) uint64 {
 				ctx := base.TestCtx(t)
-				return hlvAgent.InsertWithHLV(ctx, docID)
+				return hlvAgent.InsertWithHLV(ctx, docID, nil)
 			},
 		},
 	}
@@ -316,7 +316,7 @@ func TestVVObeyMou(t *testing.T) {
 
 	docID := "doc1"
 	hlvAgent := db.NewHLVAgent(t, fromDs, fromBucketSourceID, base.VvXattrName)
-	fromCas1 := hlvAgent.InsertWithHLV(ctx, "doc1")
+	fromCas1 := hlvAgent.InsertWithHLV(ctx, "doc1", nil)
 
 	xdcr := startXDCR(t, fromBucket, toBucket, XDCROptions{Mobile: MobileOn})
 	defer func() {


### PR DESCRIPTION
CBG-5142

Backports 14787f7

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/261/
