### PR TITLE
CBG-5039 use wait for stat to avoid test flake

### DIFF
--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -326,7 +326,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, int64(docCount))
 
 	// update config to add second collection
 	twoCollectionConfig := rest.GetCollectionsConfig(t, testBucket, 2)
@@ -348,7 +348,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, int64(docCount))
 
 	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoCollectionConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)


### PR DESCRIPTION
CBG-5039 use wait for stat to avoid test flake

This stat is incremented after the document & metadata are written to the bucket as part of import https://github.com/couchbase/sync_gateway/blob/14787f7ce696a381ffbc0ddda92a2c23a2dbe76c/db/import.go#L352 so it is possible but unlikely that this is not incremented yet.

Reproduced the flake by adding a sleep in the above code.