### PR TITLE
CBG-3605 fix test flake: wait for stat

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2129,7 +2129,12 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "rt2", body["source"])
 
-		assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus(ctx1).LastSeqPull)
+		// replication status updates just after the document has been written in a blip handler callback, so the
+		// document can exist before stat is updated
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			status := ar.GetStatus(ctx1)
+			assert.Equal(c, strconv.FormatUint(remoteDoc.Sequence, 10), status.LastSeqPull, "status=%#+v", status)
+		}, 5*time.Second, 10*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
CBG-3605 fix test flake: wait for stat

This flake is reproducible with adding a sleep here https://github.com/couchbase/sync_gateway/blob/14787f7ce696a381ffbc0ddda92a2c23a2dbe76c/db/active_replicator_checkpointer.go#L197