### PR TITLE
CBG-5156 check db state after checking permissions

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -526,6 +526,9 @@ func TestDBOffline503Response(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.True(t, body["state"].(string) == "Online")
 
+	rest.RequireStatus(t, rt.SendRequest("GET", "/{{.keyspace}}/doc1", ""), http.StatusUnauthorized)
+	rest.RequireStatus(t, rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1", ""), http.StatusOK)
+
 	response = rt.SendAdminRequest("POST", "/{{.db}}/_offline", "")
 	rest.RequireStatus(t, response, 200)
 
@@ -534,7 +537,8 @@ func TestDBOffline503Response(t *testing.T) {
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.True(t, body["state"].(string) == "Offline")
 
-	rest.RequireStatus(t, rt.SendRequest("GET", "/{{.keyspace}}/doc1", ""), 503)
+	rest.RequireStatus(t, rt.SendRequest("GET", "/{{.keyspace}}/doc1", ""), http.StatusUnauthorized)
+	rest.RequireStatus(t, rt.SendAdminRequest("GET", "/{{.keyspace}}/doc1", ""), http.StatusServiceUnavailable)
 }
 
 // Take DB offline and ensure can put db config


### PR DESCRIPTION
CBG-5156 check db state after checking permissions

This fixes the `TestNewlyCreateSGWPermissions` test flake. `TestNewlyCreateSGWPermissions` would call:

1. `/db/_offline`
2. `/db/_online`
3. `/db/_dump/view`

Since `/db/_online` is asynchronously, if `/db/_dump/view` was called before online finished, it could return a 503 instead of a 403 for an unauthorized user.

For `TestNewlyCreateSGWPermissions`, we typically don't care about the success or failure of an operation, but just whether you get a 401/403 or a different error code.
 
## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/266/ (unrelated flake)
