### PR TITLE
CBG-5168 don't panic when db is offline initializing indexes

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -596,6 +596,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, dbContext.UseXattrs(), metaKeys)
+	dbContext.AsyncIndexInitManager = NewAsyncIndexInitManager(dbContext.MetadataStore, dbContext.MetadataKeys)
 
 	return dbContext, nil
 }
@@ -2455,7 +2456,6 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	db.TombstoneCompactionManager = NewTombstoneCompactionManager()
 	db.AttachmentCompactionManager = NewAttachmentCompactionManager(db.MetadataStore, db.MetadataKeys)
-	db.AsyncIndexInitManager = NewAsyncIndexInitManager(db.MetadataStore, db.MetadataKeys)
 
 	db.startReplications(ctx)
 

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -274,12 +274,12 @@ func TestChangeIndexPartitionsDbOffline(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server with GSI enabled")
 	}
 
-	// requires index init
-
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
 	defer rt.Close()
 
-	rt.TakeDbOffline()
+	dbConfig := rt.NewDbConfig()
+	dbConfig.StartOffline = base.Ptr(true)
+	rest.RequireStatus(t, rt.CreateDatabase("db", dbConfig), http.StatusCreated)
 
 	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_index_init", `{"num_partitions":2}`)
 	rest.RequireStatus(t, resp, http.StatusOK)


### PR DESCRIPTION
CBG-5168 don't panic when db is offline initializing indexes

This didn't panic before because the _index_init call was done via non persistent config which starts the database in offline mode, vs the non ideal way to put a db offline using `DatabaseContext.TakeDbOffline` which only takes the database offline in local mode. See https://github.com/couchbase/sync_gateway/blob/b111d34ed63cfaaa044e5a0c64b721b381f0e739/rest/utilities_testing_resttester.go#L468

We recommend in docs to start the database with offline: true.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/269/
