### PR TITLE
Update to go 1.25.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'release/') && !contains(github.ref, 'main') }}
 
 env:
-  GO_VERSION: &go_version 1.25.6
+  GO_VERSION: &go_version 1.25.7
   GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.8.0
 
 jobs:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     }
 
     tools {
-        go '1.25.6'
+        go '1.25.7'
     }
 
     stages {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.25.6
+go 1.25.7
 
 require (
 	dario.cat/mergo v1.0.0

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -867,7 +867,7 @@
             "trigger_blackduck": true
         },
         "manifest/default.xml": {
-            "go_version": "1.25.6",
+            "go_version": "1.25.7",
             "interval": 30,
             "production": true,
             "release": "4.1.0",


### PR DESCRIPTION
Update to go 1.25.7

Addresses https://pkg.go.dev/vuln/GO-2026-4337
