### PR TITLE
CBG-5170 change listener: don't process docs without xattr

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -374,12 +374,6 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 		return
 	}
 
-	// If this is a delete and there are no xattrs (no existing SG revision), we can ignore
-	if event.Opcode == sgbucket.FeedOpDeletion && len(docJSON) == 0 {
-		base.DebugfCtx(ctx, base.KeyCache, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(docID))
-		return
-	}
-
 	// First unmarshal the doc (just its metadata, to save time/memory):
 	doc, syncData, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.UserXattrKey(), false)
 	if err != nil {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -385,6 +385,8 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 	if err != nil {
 		if errors.Is(err, sgbucket.ErrEmptyMetadata) {
 			base.WarnfCtx(ctx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
+		} else {
+			base.DebugfCtx(ctx, base.KeyCache, "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", base.UD(docID), err)
 		}
 		return
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -364,25 +364,25 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 
 	ctx = collection.AddCollectionContext(ctx)
 
+	// If the document has no xattrs, it can not have a _sync xattr
+	if event.DataType&base.MemcachedDataTypeXattr == 0 {
+		return
+	}
+
+	// If this is a binary document, we can ignore.
+	if event.DataType == base.MemcachedDataTypeRaw {
+		return
+	}
+
 	// If this is a delete and there are no xattrs (no existing SG revision), we can ignore
 	if event.Opcode == sgbucket.FeedOpDeletion && len(docJSON) == 0 {
 		base.DebugfCtx(ctx, base.KeyCache, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(docID))
 		return
 	}
 
-	// If this is a binary document (and not one of the above types), we can ignore.  Currently only performing this check when xattrs
-	// are enabled, because walrus doesn't support DataType on feed.
-	if collection.UseXattrs() && event.DataType == base.MemcachedDataTypeRaw {
-		return
-	}
-
 	// First unmarshal the doc (just its metadata, to save time/memory):
 	doc, syncData, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, collection.UserXattrKey(), false)
 	if err != nil {
-		// Avoid log noise related to failed unmarshaling of binary documents.
-		if event.DataType != base.MemcachedDataTypeRaw {
-			base.DebugfCtx(ctx, base.KeyCache, "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", base.UD(docID), err)
-		}
 		if errors.Is(err, sgbucket.ErrEmptyMetadata) {
 			base.WarnfCtx(ctx, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
 		}


### PR DESCRIPTION
CBG-5170 change listener: don't process docs without xattr

This avoids unmarshalling documents without _sync xattr, which was necessarily in pre-xattr mode. The change cache could see documents without _sync xattrs if they were not yet imported, or they got rejected by the import filter.

If this were to get backported to 3.3, you would add a check for db.UseXattrs() around this section. 

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/289/ (known flakes)
