### PR TITLE
CBG-5181 jenkins: download go version from go.mod

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,9 @@ pipeline {
                             // bootstrap a go version from go.mod. This requires a new enough version of go to run golang.org/dl/go$ver
                             env.GO_VERSION = 'go' + sh(
                               returnStdout: true,
-                              script: 'cat go.mod | grep "^go" | cut -f2 -d " "'
+                              script: '''
+                                go list -m -f '{{.GoVersion}}'
+                              '''
                             ).trim()
                             sh '''
                               set -eux

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,10 +14,6 @@ pipeline {
         GH_ACCESS_TOKEN_CREDENTIAL = 'github_cb-robot-sg_access_token'
     }
 
-    tools {
-        go '1.25.7'
-    }
-
     stages {
         stage('SCM') {
             steps {
@@ -28,7 +24,6 @@ pipeline {
                     if (env.CHANGE_TARGET) {
                         env.BRANCH = env.CHANGE_TARGET
                     }
-                    env.GOTOOLS = sh(returnStdout: true, script: 'go env GOPATH').trim()
                 }
                 // forces go to get private modules via ssh
                 sh 'git config --global url."git@github.com:".insteadOf "https://github.com/"'
@@ -38,15 +33,40 @@ pipeline {
             stages {
                 stage('Go Modules') {
                     steps {
-                        sh 'which go'
-                        sh 'go version'
-                        sh 'go env'
-                        sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
+                        script {
+                            // bootstrap a go version from go.mod. This requires a new enough version of go to run golang.org/dl/go$ver
+                            env.GO_VERSION = 'go' + sh(
+                              returnStdout: true,
+                              script: 'cat go.mod | grep "^go" | cut -f2 -d " "'
+                            ).trim()
                             sh '''
+                              set -eux
+
+                              echo "Sync Gateway go.mod version is $GO_VERSION"
+                              go install "golang.org/dl/$GO_VERSION@latest"
+                              ~/go/bin/$GO_VERSION download
+                            '''
+                            env.GOROOT = sh(
+                              returnStdout: true,
+                              script: '~/go/bin/$GO_VERSION env GOROOT'
+                            ).trim()
+                            env.GOTOOLS = sh(
+                              returnStdout: true,
+                              script: '~/go/bin/$GO_VERSION env GOPATH'
+                            ).trim()
+                            env.PATH = "${env.GOROOT}/bin:${env.PATH}"
+                            sh '''
+                              which go
+                              go version
+                              go env
+                            '''
+                            sshagent(credentials: ['CB_SG_Robot_Github_SSH_Key']) {
+                                sh '''
                                 [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
                                 ssh-keyscan -t rsa,dsa github.com >> ~/.ssh/known_hosts
                             '''
-                            sh "go get -v -tags ${EE_BUILD_TAG} ./..."
+                                sh "go get -v -tags ${EE_BUILD_TAG} ./..."
+                            }
                         }
                     }
                 }

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -47,7 +47,7 @@ for var in "${REQUIRED_VARS[@]}"; do
     fi
 done
 # Use Git SSH and define private repos
-git config --global url.git@github.com:couchbaselabs/go-fleecedelta.insteadOf https://github.com/couchbaselabs/go-fleecedelta
+git config --global --replace-all url."git@github.com:".insteadOf "https://github.com/"
 export GOPRIVATE=github.com/couchbaselabs/go-fleecedelta
 
 # Print commit

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -47,14 +47,14 @@ for var in "${REQUIRED_VARS[@]}"; do
     fi
 done
 # Use Git SSH and define private repos
-git config --global --replace-all url."git@github.com:".insteadOf "https://github.com/"
+git config --global url.git@github.com:couchbaselabs/go-fleecedelta.insteadOf https://github.com/couchbaselabs/go-fleecedelta
 export GOPRIVATE=github.com/couchbaselabs/go-fleecedelta
 
 # Print commit
 SG_COMMIT_HASH=$(git rev-parse HEAD)
 echo "Sync Gateway git commit hash: $SG_COMMIT_HASH"
 
-GO_VERSION=go$(cat go.mod | grep "^go" | cut -f2 -d " ")
+GO_VERSION=go$(go list -m -f '{{.GoVersion}}')
 echo "Sync Gateway go.mod version is ${GO_VERSION}"
 go install "golang.org/dl/${GO_VERSION}@latest"
 ~/go/bin/"${GO_VERSION}" download

--- a/jenkins-integration-build.sh
+++ b/jenkins-integration-build.sh
@@ -54,6 +54,13 @@ export GOPRIVATE=github.com/couchbaselabs/go-fleecedelta
 SG_COMMIT_HASH=$(git rev-parse HEAD)
 echo "Sync Gateway git commit hash: $SG_COMMIT_HASH"
 
+GO_VERSION=go$(cat go.mod | grep "^go" | cut -f2 -d " ")
+echo "Sync Gateway go.mod version is ${GO_VERSION}"
+go install "golang.org/dl/${GO_VERSION}@latest"
+~/go/bin/"${GO_VERSION}" download
+GOROOT=$(~/go/bin/"${GO_VERSION}" env GOROOT)
+PATH=${GOROOT}/bin:$PATH
+
 echo "Downloading tool dependencies..."
 go install gotest.tools/gotestsum@latest
 


### PR DESCRIPTION
This would prevent us from having to update jenkins for every build. 

I changed Jenkins to install a version of go `snap install go --classic` which is new enough to bootstrap a newer version of go from (using `golang.org/dl/${GO_VERSION}`)

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/280/
