### PR TITLE
Simplify sharded dcp API

### DIFF
--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -86,7 +86,7 @@ func TestDCPIsMetadataDocument(t *testing.T) {
 					metadataDocument: true,
 				},
 				{
-					docName:          m.metaKeys.UserKey("role2"),
+					docName:          m.metaKeys.RoleKey("role2"),
 					metadataDocument: true,
 				},
 				{

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -57,9 +57,9 @@ func TestTransformBucketCredentials(t *testing.T) {
 
 }
 
-func TestDCPKeyFilter(t *testing.T) {
+func TestDCPIsMetadataDocument(t *testing.T) {
 
-	testCases := []struct {
+	metadataCases := []struct {
 		name     string
 		metaKeys *MetadataKeys
 	}{
@@ -67,26 +67,76 @@ func TestDCPKeyFilter(t *testing.T) {
 		{"default meta keys from empty metaID", NewMetadataKeys("")},
 		{"db specific meta keys", NewMetadataKeys("dbname")},
 	}
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("%s", tc.name), func(t *testing.T) {
-
-			assert.True(t, dcpKeyFilter([]byte("doc123"), tc.metaKeys))
-			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.UnusedSeqKey(1234)), tc.metaKeys))
-			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.UserKey("user1")), tc.metaKeys))
-			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.UserKey("role2")), tc.metaKeys))
-			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.SGCfgPrefix("")+"123"), tc.metaKeys))
-			assert.True(t, dcpKeyFilter([]byte(tc.metaKeys.SGCfgPrefix("group")+"123"), tc.metaKeys))
-
-			assert.False(t, dcpKeyFilter([]byte(SyncDocPrefix+"unusualSeq"), tc.metaKeys))
-			assert.False(t, dcpKeyFilter([]byte(SyncFunctionKeyWithoutGroupID), tc.metaKeys))
-			assert.False(t, dcpKeyFilter([]byte(DCPCheckpointRootPrefix+"12"), tc.metaKeys))
-			assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData"), tc.metaKeys))
-			assert.False(t, dcpKeyFilter([]byte(tc.metaKeys.DCPCheckpointPrefix("")+"12"), tc.metaKeys))
-			assert.False(t, dcpKeyFilter([]byte(tc.metaKeys.DCPCheckpointPrefix("group")+"12"), tc.metaKeys))
-			assert.False(t, dcpKeyFilter([]byte(tc.metaKeys.SyncSeqKey()), tc.metaKeys))
+	for _, m := range metadataCases {
+		t.Run(m.name, func(t *testing.T) {
+			testCases := []struct {
+				docName          string
+				metadataDocument bool
+			}{
+				{
+					docName:          "doc123",
+					metadataDocument: false,
+				},
+				{
+					docName:          m.metaKeys.UnusedSeqKey(1234),
+					metadataDocument: true,
+				},
+				{
+					docName:          m.metaKeys.UserKey("user1"),
+					metadataDocument: true,
+				},
+				{
+					docName:          m.metaKeys.UserKey("role2"),
+					metadataDocument: true,
+				},
+				{
+					docName:          m.metaKeys.SGCfgPrefix("") + "123",
+					metadataDocument: true,
+				},
+				{
+					docName:          m.metaKeys.SGCfgPrefix("group") + "123",
+					metadataDocument: true,
+				},
+				{
+					docName:          SyncDocPrefix + "unusualSeq",
+					metadataDocument: true,
+				},
+				{
+					docName:          SyncFunctionKeyWithoutGroupID,
+					metadataDocument: true,
+				},
+				{
+					docName:          DCPCheckpointRootPrefix + "12",
+					metadataDocument: true,
+				},
+				{
+					docName:          TxnPrefix + "atrData",
+					metadataDocument: true,
+				},
+				{
+					docName:          m.metaKeys.DCPCheckpointPrefix("") + "12",
+					metadataDocument: true,
+				},
+				{
+					docName:          m.metaKeys.DCPCheckpointPrefix("group") + "12",
+					metadataDocument: true,
+				},
+				{
+					docName:          m.metaKeys.SyncSeqKey(),
+					metadataDocument: true,
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.docName, func(t *testing.T) {
+					if tc.metadataDocument {
+						assert.True(t, isMetadataDocumentName([]byte(tc.docName)))
+					} else {
+						assert.False(t, isMetadataDocumentName([]byte(tc.docName)))
+					}
+				})
+			}
 		})
 	}
-
 }
 
 func TestCBGTIndexCreation(t *testing.T) {

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -98,23 +98,3 @@ func getOpenImportPIndexImplUsing(ctx context.Context) func(indexType, indexPara
 	}
 	return openImportPIndexImplUsing
 }
-
-// NewImportDest returns a cbgt.Dest targeting the importListener's ProcessFeedEvent
-func (il *importListener) NewImportDest(janitorRollback func()) (cbgt.Dest, error) {
-	callback := il.ProcessFeedEvent
-
-	maxVbNo, err := il.bucket.GetMaxVbno() // can safely assume that all collections on the same bucket will have the same vbNo
-	if err != nil {
-		return nil, err
-	}
-
-	importFeedStatsMap := il.dbStats.ImportFeedMapStats
-	importPartitionStat := il.importStats.ImportPartitions
-
-	importDest, _, err := base.NewDCPDest(il.loggingCtx, callback, il.bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix, il.metadataKeys)
-	if err != nil {
-		return nil, err
-	}
-
-	return importDest, nil
-}


### PR DESCRIPTION
Simplify sharded dcp API

This might help the work in https://github.com/couchbase/sync_gateway/pull/8057 but we do not have to do this.

This drops some of the arguments from `DCPDest`, `DCPCommon`:

- replaces `Bucket` with `sgbucket.DataStore` for the location where checkpoints are supposed to be
- replace `dcpKeyFilter` with `isMetadataDocumentName`. `dcpKeyFilter` was written for the caching feed where we needed to pay attention to some _sync documents. It's not used for that anymore. This allows us to avoid passing `MetadataKeys`

- Replace setting correlation ID inside the `DCPDest` with setting it in the caller. This should simplify the usage.
- Drop unused members of `importListener` struct

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/274/ (unrelated failure)
