### PR TITLE
Fix openapi lint gh action

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -48,11 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: r7kamura/redocly-problem-matchers@v1
-      - uses: mhiew/redoc-lint-github-action@v4
-        with:
-          args: '--format stylish'
-        env:
-          NO_COLOR: '1'
+      - name: redocly lint
+        run: |-
+          npx --yes @redocly/cli@1 lint --format=stylish
 
   yamllint:
     name: 'yamllint'


### PR DESCRIPTION
mhiew/redoc-lint-github-action@v4 was pinned to a version of redocly on npm https://github.com/mhiew/redoc-lint-github-action/blob/1b3526395495e5c1346ebb81a67813aee757e86b/Dockerfile#L8 that stopped functioning with:

```
ReferenceError: React is not defined
    at Object.<anonymous> (/usr/local/lib/node_modules/@redocly/cli/node_modules/styled-components/dist/styled-components.cjs.js:1:860)
    at Module._compile (node:internal/modules/cjs/loader:1368:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1426:10)
    at Module.load (node:internal/modules/cjs/loader:1205:32)
    at Module._load (node:internal/modules/cjs/loader:1021:12)
    at Module.require (node:internal/modules/cjs/loader:1230:19)
    at require (node:internal/modules/helpers:179:18)
    at /usr/local/lib/node_modules/@redocly/cli/node_modules/redoc/bundles/redoc.lib.js:2:109570
    at /usr/local/lib/node_modules/@redocly/cli/node_modules/redoc/bundles/redoc.lib.js:1825:3806
    at /usr/local/lib/node_modules/@redocly/cli/node_modules/redoc/bundles/redoc.lib.js:1825:3811

Node.js v21.7.3
```

Pin to version 1, since v2 of redocly doesn't have the same API and maybe doesn't work without a paid subscription.

Fix for https://github.com/couchbase/sync_gateway/actions/runs/22143583325/job/64035998777