### PR TITLE
CBG-4286 separate feed name from checkpoint prefix

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -257,7 +257,7 @@ func makeFeedEvent(key []byte, value []byte, dataType uint8, cas uint64, expiry 
 	return event
 }
 
-// Create a prefix that will be used to create the dcp stream name, which must be globally unique
+// GenerateDcpStreamName creates a prefix that will be used to create the dcp stream name, which must be globally unique
 // in order to avoid https://issues.couchbase.com/browse/MB-24237.  It's also useful to have the Sync Gateway
 // version number / commit for debugging purposes
 func GenerateDcpStreamName(feedID string) (string, error) {
@@ -270,12 +270,15 @@ func GenerateDcpStreamName(feedID string) (string, error) {
 
 	commitTruncated := StringPrefix(GitCommit, 7)
 
-	return fmt.Sprintf(
+	feedName := fmt.Sprintf(
 		"%v-v-%v-commit-%v-uuid-%v",
 		feedID,
 		ProductAPIVersion,
 		commitTruncated,
 		u.String(),
-	), nil
-
+	)
+	if len(feedName) > 200 {
+		return "", fmt.Errorf("Generated DCP feed name is too long: %d characters.  Max length is 200 characters.  Generated name: %s", len(feedName), feedName)
+	}
+	return feedName, nil
 }

--- a/base/gocb_dcp_feed.go
+++ b/base/gocb_dcp_feed.go
@@ -102,6 +102,7 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 		CollectionIDs:     collectionIDs,
 		AgentPriority:     gocbcore.DcpAgentPriorityMed,
 		CheckpointPrefix:  args.CheckpointPrefix,
+		FeedID:            args.ID,
 	}
 
 	if args.Backfill == sgbucket.FeedNoBackfill {
@@ -114,7 +115,6 @@ func StartGocbDCPFeed(ctx context.Context, bucket *GocbV2Bucket, bucketName stri
 
 	dcpClient, err := NewDCPClient(
 		ctx,
-		feedName,
 		callback,
 		options,
 		bucket)

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -22,11 +22,13 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 )
 
+type attachmentCompactionPhase string
+
 const (
-	CompactionIDKey = "compactID"
-	MarkPhase       = "mark"
-	SweepPhase      = "sweep"
-	CleanupPhase    = "cleanup"
+	CompactionIDKey                           = "compactID"
+	MarkPhase       attachmentCompactionPhase = "mark"
+	SweepPhase      attachmentCompactionPhase = "sweep"
+	CleanupPhase    attachmentCompactionPhase = "cleanup"
 )
 
 func attachmentCompactMarkPhase(ctx context.Context, dataStore base.DataStore, collectionID uint32, db *Database, compactionID string, terminator *base.SafeTerminator, markedAttachmentCount *base.AtomicInt) (count int64, vbUUIDs []uint64, checkpointPrefix string, err error) {
@@ -131,21 +133,21 @@ func attachmentCompactMarkPhase(ctx context.Context, dataStore base.DataStore, c
 		return true
 	}
 
-	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
-	if err != nil {
-		return 0, nil, "", err
-	}
+	clientOptions := getCompactionDCPClientOptions(
+		db,
+		compactionID,
+		collectionID,
+		MarkPhase,
+	)
 
 	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed for mark phase of attachment compaction", compactionLoggingID)
-
-	dcpFeedKey := GenerateCompactionDCPStreamName(compactionID, MarkPhase)
 
 	bucket, err := base.AsGocbV2Bucket(db.Bucket)
 	if err != nil {
 		return 0, nil, "", err
 	}
 
-	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, callback, *clientOptions, bucket)
+	dcpClient, err := base.NewDCPClient(ctx, callback, *clientOptions, bucket)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return 0, nil, "", err
@@ -379,21 +381,21 @@ func attachmentCompactSweepPhase(ctx context.Context, dataStore base.DataStore, 
 		return true
 	}
 
-	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
-	if err != nil {
-		return 0, "", err
-	}
+	clientOptions := getCompactionDCPClientOptions(
+		db,
+		compactionID,
+		collectionID,
+		SweepPhase,
+	)
 	clientOptions.InitialMetadata = base.BuildDCPMetadataSliceFromVBUUIDs(vbUUIDs)
-
-	dcpFeedKey := GenerateCompactionDCPStreamName(compactionID, SweepPhase)
 
 	bucket, err := base.AsGocbV2Bucket(db.Bucket)
 	if err != nil {
 		return 0, "", err
 	}
 
-	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed %q for sweep phase of attachment compaction", compactionLoggingID, dcpFeedKey)
-	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, callback, *clientOptions, bucket)
+	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed for sweep phase of attachment compaction", compactionLoggingID)
+	dcpClient, err := base.NewDCPClient(ctx, callback, *clientOptions, bucket)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return 0, "", err
@@ -517,22 +519,22 @@ func attachmentCompactCleanupPhase(ctx context.Context, dataStore base.DataStore
 		return true
 	}
 
-	clientOptions, err := getCompactionDCPClientOptions(collectionID, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
-	if err != nil {
-		return "", err
-	}
+	clientOptions := getCompactionDCPClientOptions(
+		db,
+		compactionID,
+		collectionID,
+		CleanupPhase,
+	)
 	clientOptions.InitialMetadata = base.BuildDCPMetadataSliceFromVBUUIDs(vbUUIDs)
 
 	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed for cleanup phase of attachment compaction", compactionLoggingID)
-
-	dcpFeedKey := GenerateCompactionDCPStreamName(compactionID, CleanupPhase)
 
 	bucket, err := base.AsGocbV2Bucket(db.Bucket)
 	if err != nil {
 		return "", err
 	}
 
-	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, callback, *clientOptions, bucket)
+	dcpClient, err := base.NewDCPClient(ctx, callback, *clientOptions, bucket)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create attachment compaction DCP client! %v", compactionLoggingID, err)
 		return "", err
@@ -578,25 +580,26 @@ func getCompactionIDSubDocPath(compactionID string) string {
 }
 
 // getCompactionDCPClientOptions returns the default set of DCPClientOptions suitable for attachment compaction
-func getCompactionDCPClientOptions(collectionID uint32, groupID string, prefix string) (*base.DCPClientOptions, error) {
-	clientOptions := &base.DCPClientOptions{
+func getCompactionDCPClientOptions(db *Database, compactionID string, collectionID uint32, phase attachmentCompactionPhase) *base.DCPClientOptions {
+	return &base.DCPClientOptions{
 		OneShot:           true,
 		FailOnRollback:    true,
 		MetadataStoreType: base.DCPMetadataStoreCS,
-		GroupID:           groupID,
 		CollectionIDs:     []uint32{collectionID},
-		CheckpointPrefix:  prefix,
+		FeedID:            fmt.Sprintf("att_compaction:%v_%v", compactionID, phase),
+		CheckpointPrefix:  GetAttachmentCompactionDCPCheckpointPrefix(db.DatabaseContext, compactionID, phase),
 	}
-	return clientOptions, nil
-
 }
 
-func GenerateCompactionDCPStreamName(compactionID, compactionAction string) string {
+// GetAttachmentCompactionDCPCheckpointPrefix returns the prefix of the DCP checkpoint documents for attachment
+// compaction.
+func GetAttachmentCompactionDCPCheckpointPrefix(db *DatabaseContext, compactionID string, phase attachmentCompactionPhase) string {
 	return fmt.Sprintf(
-		"sg-%v:att_compaction:%v_%v",
+		"%s:sg-%v:att_compaction:%v_%v",
+		db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID),
 		base.ProductAPIVersion,
 		compactionID,
-		compactionAction,
+		phase,
 	)
 }
 

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -286,10 +286,13 @@ func TestAttachmentCleanupRollback(t *testing.T) {
 
 	bucket, err := base.AsGocbV2Bucket(testDb.Bucket)
 	require.NoError(t, err)
-	dcpFeedKey := GenerateCompactionDCPStreamName(t.Name(), CleanupPhase)
-	clientOptions, err := getCompactionDCPClientOptions(collectionID, testDb.Options.GroupID, testDb.MetadataKeys.DCPCheckpointPrefix(testDb.Options.GroupID))
-	require.NoError(t, err)
-	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, nil, *clientOptions, bucket)
+	clientOptions := getCompactionDCPClientOptions(
+		testDb,
+		t.Name(),
+		collectionID,
+		CleanupPhase,
+	)
+	dcpClient, err := base.NewDCPClient(ctx, nil, *clientOptions, bucket)
 	require.NoError(t, err)
 
 	// alter dcp metadata to feed into the compaction manager
@@ -298,7 +301,7 @@ func TestAttachmentCleanupRollback(t *testing.T) {
 
 	metadataKeys := base.NewMetadataKeys(testDb.Options.MetadataID)
 	testDb.AttachmentCompactionManager = NewAttachmentCompactionManager(dataStore, metadataKeys)
-	manager := AttachmentCompactionManager{CompactID: t.Name(), Phase: CleanupPhase, VBUUIDs: vbUUID}
+	manager := AttachmentCompactionManager{CompactID: t.Name(), Phase: string(CleanupPhase), VBUUIDs: vbUUID}
 	testDb.AttachmentCompactionManager.Process = &manager
 
 	terminator := base.NewSafeTerminator()

--- a/db/background_mgr_attachment_compaction.go
+++ b/db/background_mgr_attachment_compaction.go
@@ -182,7 +182,7 @@ func (a *AttachmentCompactionManager) Run(ctx context.Context, options map[strin
 	return nil
 }
 
-func (a *AttachmentCompactionManager) handleAttachmentCompactionRollbackError(ctx context.Context, options map[string]any, dataStore base.DataStore, database *Database, err error, phase, keyPrefix string) (bool, error) {
+func (a *AttachmentCompactionManager) handleAttachmentCompactionRollbackError(ctx context.Context, options map[string]any, dataStore base.DataStore, database *Database, err error, phase attachmentCompactionPhase, keyPrefix string) (bool, error) {
 	var rollbackErr gocbcore.DCPRollbackError
 	if errors.As(err, &rollbackErr) || errors.Is(err, base.ErrVbUUIDMismatch) {
 		base.InfofCtx(ctx, base.KeyDCP, "rollback indicated on %s phase of attachment compaction, resetting the task", phase)

--- a/db/background_mgr_attachment_migration_test.go
+++ b/db/background_mgr_attachment_migration_test.go
@@ -310,17 +310,15 @@ func TestAttachmentMigrationCheckpointPrefix(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close(ctx)
 			clientOptions := getMigrationDCPClientOptions(
+				db,
+				migrationID,
 				test.collectionIDs,
-				db.Options.GroupID,
-				db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID),
 			)
 
-			dcpFeedKey := GenerateAttachmentMigrationDCPStreamName(migrationID)
 			b, err := base.AsGocbV2Bucket(bucket)
 			require.NoError(t, err)
 			dcpClient, err := base.NewDCPClient(
 				ctx,
-				dcpFeedKey,
 				nil,
 				*clientOptions,
 				b,

--- a/db/background_mgr_resync_dcp.go
+++ b/db/background_mgr_resync_dcp.go
@@ -178,16 +178,15 @@ func (r *ResyncManagerDCP) Run(ctx context.Context, options map[string]any, pers
 		base.InfofCtx(ctx, base.KeyAll, "[%s] running resync against specified collections", resyncLoggingID)
 	}
 
-	clientOptions := getResyncDCPClientOptions(r.collectionIDs, db.Options.GroupID, db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID))
+	clientOptions := getResyncDCPClientOptions(db.DatabaseContext, r.ResyncID, r.collectionIDs)
 
-	dcpFeedKey := GenerateResyncDCPStreamName(r.ResyncID)
-	dcpClient, err := base.NewDCPClient(ctx, dcpFeedKey, callback, *clientOptions, bucket)
+	dcpClient, err := base.NewDCPClient(ctx, callback, *clientOptions, bucket)
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to create resync DCP client! %v", resyncLoggingID, err)
 		return err
 	}
 
-	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed %q for resync", resyncLoggingID, dcpFeedKey)
+	base.InfofCtx(ctx, base.KeyAll, "[%s] Starting DCP feed for resync", resyncLoggingID)
 	doneChan, err := dcpClient.Start()
 	if err != nil {
 		base.WarnfCtx(ctx, "[%s] Failed to start resync DCP feed! %v", resyncLoggingID, err)
@@ -411,21 +410,23 @@ func initializePrincipalDocsIndex(ctx context.Context, db *Database) error {
 }
 
 // getResyncDCPClientOptions returns the default set of DCPClientOptions suitable for resync
-func getResyncDCPClientOptions(collectionIDs []uint32, groupID string, prefix string) *base.DCPClientOptions {
+func getResyncDCPClientOptions(db *DatabaseContext, resyncID string, collectionIDs []uint32) *base.DCPClientOptions {
 	return &base.DCPClientOptions{
+		FeedID:            fmt.Sprintf("resync:%v", resyncID),
 		OneShot:           true,
 		FailOnRollback:    false,
 		MetadataStoreType: base.DCPMetadataStoreCS,
-		GroupID:           groupID,
 		CollectionIDs:     collectionIDs,
-		CheckpointPrefix:  prefix,
+		CheckpointPrefix:  GetResyncDCPCheckpointPrefix(db, resyncID),
 	}
 }
 
-// GenerateResyncDCPStreamName returns the DCP stream name for a resync.
-func GenerateResyncDCPStreamName(resyncID string) string {
+// GetResyncDCPCheckpointPrefix returns the prefix of the DCP checkpoint documents for resync.
+func GetResyncDCPCheckpointPrefix(db *DatabaseContext, resyncID string) string {
 	return fmt.Sprintf(
-		"sg-%v:resync:%v",
+		"%s:sg-%v:resync:%v",
+		db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID),
 		base.ProductAPIVersion,
-		resyncID)
+		resyncID,
+	)
 }

--- a/db/background_mgr_resync_dcp_test.go
+++ b/db/background_mgr_resync_dcp_test.go
@@ -691,17 +691,15 @@ func TestResyncCheckpointPrefix(t *testing.T) {
 			require.NoError(t, err)
 			defer db.Close(ctx)
 			clientOptions := getResyncDCPClientOptions(
+				db,
+				resyncID,
 				test.collectionIDs,
-				db.Options.GroupID,
-				db.MetadataKeys.DCPCheckpointPrefix(db.Options.GroupID),
 			)
 
-			dcpFeedKey := GenerateResyncDCPStreamName(resyncID)
 			b, err := base.AsGocbV2Bucket(bucket)
 			require.NoError(t, err)
 			dcpClient, err := base.NewDCPClient(
 				ctx,
-				dcpFeedKey,
 				nil,
 				*clientOptions,
 				b,

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -203,6 +203,7 @@ func purgeWithDCPFeed(ctx context.Context, bucket base.Bucket, tbp *base.TestBuc
 	}
 
 	dcpClientOpts := base.DCPClientOptions{
+		FeedID:            "purgeFeed-" + bucket.GetName(),
 		OneShot:           true,
 		FailOnRollback:    false,
 		CollectionIDs:     slices.Collect(maps.Keys(collections)),
@@ -273,12 +274,11 @@ func purgeWithDCPFeed(ctx context.Context, bucket base.Bucket, tbp *base.TestBuc
 		}
 		return false
 	}
-	feedID := "purgeFeed-" + bucket.GetName()
 	gocbBucket, err := base.AsGocbV2Bucket(bucket)
 	if err != nil {
 		return err
 	}
-	dcpClient, err := base.NewDCPClient(ctx, feedID, purgeCallback, dcpClientOpts, gocbBucket)
+	dcpClient, err := base.NewDCPClient(ctx, purgeCallback, dcpClientOpts, gocbBucket)
 	if err != nil {
 		return err
 	}

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -56,8 +56,7 @@ func TestResyncRollback(t *testing.T) {
 	require.Equal(t, db.BackgroundProcessStateStopped, status.State)
 
 	// alter persisted dcp metadata from the first run to force a rollback
-	name := db.GenerateResyncDCPStreamName(status.ResyncID)
-	checkpointPrefix := fmt.Sprintf("%s:%v", rt.GetDatabase().MetadataKeys.DCPCheckpointPrefix(rt.GetDatabase().Options.GroupID), name)
+	checkpointPrefix := db.GetResyncDCPCheckpointPrefix(rt.GetDatabase(), status.ResyncID)
 	meta := base.NewDCPMetadataCS(rt.Context(), rt.Bucket().DefaultDataStore(), 1024, 8, checkpointPrefix)
 	vbMeta := meta.GetMeta(0)
 	var garbageVBUUID gocbcore.VbUUID = 1234

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -409,11 +409,10 @@ func TestAttachmentCompactionMarkPhaseRollback(t *testing.T) {
 	resp = rt.SendAdminRequest("POST", "/{{.db}}/_compact?type=attachment&action=stop", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
 	stat := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateStopped)
-	require.Equal(t, db.MarkPhase, stat.Phase)
+	require.Equal(t, string(db.MarkPhase), stat.Phase)
 
 	// alter persisted dcp metadata from the first run to force a rollback
-	name := db.GenerateCompactionDCPStreamName(stat.CompactID, "mark")
-	checkpointPrefix := fmt.Sprintf("%s:%v", "_sync:dcp_ck:", name)
+	checkpointPrefix := db.GetAttachmentCompactionDCPCheckpointPrefix(rt.GetDatabase(), stat.CompactID, "mark")
 
 	meta := base.NewDCPMetadataCS(rt.Context(), dataStore, 1024, 8, checkpointPrefix)
 	vbMeta := meta.GetMeta(0)

--- a/tools/cache_perf_tool/dcpDataGeneration.go
+++ b/tools/cache_perf_tool/dcpDataGeneration.go
@@ -331,6 +331,7 @@ func createDCPClient(t *testing.T, ctx context.Context, bucket *base.GocbV2Bucke
 	options := base.DCPClientOptions{
 		MetadataStoreType: base.DCPMetadataStoreInMemory,
 		GroupID:           "",
+		FeedID:            "test",
 		DbStats:           dbStats,
 		CollectionIDs:     []uint32{0},
 		AgentPriority:     gocbcore.DcpAgentPriorityMed,
@@ -338,7 +339,7 @@ func createDCPClient(t *testing.T, ctx context.Context, bucket *base.GocbV2Bucke
 		NumWorkers:        numWorkers,
 	}
 	// fake client that we want to hook into
-	client, err := base.NewDCPClientForTest(ctx, t, "test", callback, options, bucket, uint16(numVBuckets))
+	client, err := base.NewDCPClientForTest(ctx, t, callback, options, bucket, uint16(numVBuckets))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CBG-4286 separate feed name from checkpoint prefix

The only behavior change is that https://github.com/couchbase/sync_gateway/blob/main/base/dcp_client_worker.go#L149 will ignore the given DCP client's checkpoint prefix rather than something that is closer to `_sync:dcp_ck`. I can restore this behavior but I'm not super worried about it in practice since we only persist metadata periodically anyway.

Please do a careful review to see if I've accidentally changed the checkpoint prefixes, but this is why I wrote https://github.com/couchbase/sync_gateway/commit/4717efbaeefb6bbfc4606ae5c180e839304db7a6

The feed name is only visible via cbcollect. It needs to be:

- unique for each `DCPAgent` that opens, or else kv will drop the connection. Hence appending UUID
- less than 200 characters
- should have a meaningful matching prefix to find SG feeds in a cbcollect

| DCP User                | DCP Client type | Use checkpoints                                      | Affected by Code Pathway | Checkpoint Frequency |
|-------------------------|-----------------|------------------------------------------------------|---------------------------|----------------------|
| EE import               | cbgt            | ✅                                                   | ❌                        | 1m                   |
| CE import               | GoCBDCPClient   | does not effectively use checkpoints due to CBG-5144 | ❌                        | 1m                   |
| resync                  | GoCBDCPClient   | ✅                                                   | ✅                        | 30s                  |
| attachment migration    | GoCBDCPClient   | ✅                                                   | ✅                        | 30s                  |
| attachment compaction   | GoCBDCPClient   | ✅                                                   | ✅                        | 30s                  |
| caching feed            | GoCBDCPClient   | ❌                                                   | ✅                        |                      |


Only the code that uses `GoCBDCPClient` with meaningful checkpoints has a very small behavioral change with the code. In this case, if you were running a feed with checkpoints at the same time as another feed, it would previously ignore the other feed's checkpoint documents and a callback. In practice, the callbacks return immediately for `_sync` documents so this is pretty much a no-op.

The concern in the code is making sure that the `GoCBDCPClient` did not change checkpoint names since we wish to resume a DCP feed across a version update.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/279/
