### PR TITLE
Decouple BucketSpec from DatabaseContext

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -106,7 +106,7 @@ type DatabaseContext struct {
 	UUID                        string             // UUID for this database instance. Used by cbgt and sgr
 	MetadataStore               base.DataStore     // Storage for database metadata (anything that isn't an end-user's/customer's documents)
 	Bucket                      base.Bucket        // Storage
-	BucketSpec                  base.BucketSpec    // The BucketSpec
+	bucketUsername              string             // name of the connecting user for audit logging
 	BucketUUID                  string             // The bucket UUID for the bucket the database is created against
 	EncodedSourceID             string             // The md5 hash of bucket UUID + cluster UUID for the bucket/cluster the database is created against but encoded in base64
 	BucketLock                  sync.RWMutex       // Control Access to the underlying bucket object
@@ -417,6 +417,12 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		return nil, err
 	}
 
+	bucketUsername := "rosmar_noauth"
+	b, err := base.AsGocbV2Bucket(bucket)
+	if err == nil {
+		bucketUsername, _, _ = b.GetSpec().Auth.GetCredentials()
+	}
+
 	// Register the cbgt pindex type for the configGroup
 	RegisterImportPindexImpl(ctx, options.GroupID)
 
@@ -425,6 +431,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 		UUID:                 cbgt.NewUUID(),
 		MetadataStore:        metadataStore,
 		Bucket:               bucket,
+		bucketUsername:       bucketUsername,
 		BucketUUID:           bucketUUID,
 		EncodedSourceID:      sourceID,
 		StartTime:            time.Now(),
@@ -2135,14 +2142,7 @@ func (dbCtx *DatabaseContext) AddDatabaseLogContext(ctx context.Context) context
 
 // AddBucketUserLogContext adds bucket user to the parent context for logging. This is used to mark actions not caused by a user.
 func (dbCtx *DatabaseContext) AddBucketUserLogContext(ctx context.Context) context.Context {
-	spec := dbCtx.BucketSpec
-	// Server is empty in testing only
-	if spec.Server == "" || spec.IsWalrusBucket() {
-		return base.UserLogCtx(ctx, "rosmar_noauth", base.UserDomainBuiltin, nil)
-	}
-	username, _, _ := dbCtx.BucketSpec.Auth.GetCredentials()
-	return base.UserLogCtx(ctx, username, base.UserDomainBuiltin, nil)
-
+	return base.UserLogCtx(ctx, dbCtx.bucketUsername, base.UserDomainBuiltin, nil)
 }
 
 // onlyDefaultCollection is true if the database is only configured with default collection.
@@ -2431,7 +2431,7 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	db.AttachmentMigrationManager = NewAttachmentMigrationManager(db)
 	// if we have collections requiring migration, run the job
-	if len(db.RequireAttachmentMigration) > 0 && !db.BucketSpec.IsWalrusBucket() {
+	if len(db.RequireAttachmentMigration) > 0 && !db.usingRosmar() {
 		err := db.AttachmentMigrationManager.Start(ctx, nil)
 		if err != nil {
 			base.WarnfCtx(ctx, "Error trying to migrate attachments for %s with error: %v", db.Name, err)
@@ -2575,4 +2575,10 @@ func (o *UnsupportedOptions) GetSameSiteCookieMode() (http.SameSite, error) {
 	default:
 		return http.SameSiteDefaultMode, fmt.Errorf("unsupported_options.same_site_cookie option %q is not valid, choices are \"Lax\", \"Strict\", and \"None", *o.SameSiteCookie)
 	}
+}
+
+// usingRosmar returns true if the database is configured to use Rosmar.
+func (db *DatabaseContext) usingRosmar() bool {
+	_, err := base.AsRosmarBucket(db.Bucket)
+	return err == nil
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -944,7 +944,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(ctx context.Context, config
 		}
 		return nil, err
 	}
-	dbcontext.BucketSpec = spec
 	dbcontext.ServerContextHasStarted = sc.hasStarted
 	dbcontext.NoX509HTTPClient = sc.NoX509HTTPClient
 	dbcontext.RequireResync = collectionsRequiringResync
@@ -2403,7 +2402,7 @@ func (sc *ServerContext) removeBucketAndRecreateDatabase(ctx context.Context, db
 func (sc *ServerContext) getBucketCCVSettings() map[string]bool {
 	bucketCCVSettings := make(map[string]bool)
 	for _, _db := range sc._databases {
-		bucketName := _db.BucketSpec.BucketName
+		bucketName := _db.Bucket.GetName()
 		bucketCCVSettings[bucketName] = _db.CachedCCVEnabled.Load()
 	}
 	return bucketCCVSettings

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/rosmar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -210,8 +209,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	dbContext, err = serverContext.AddDatabaseFromConfig(ctx, DatabaseConfig{DbConfig: dbConfig})
 
 	assert.NoError(t, err, "Unexpected error while adding database to server context")
-	assert.Equal(t, rosmar.InMemoryURL, dbContext.BucketSpec.Server)
-	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
+	assert.Equal(t, bucketName, dbContext.Bucket.GetName())
 
 	dbConfig = DbConfig{
 		Name:                databaseName,
@@ -237,8 +235,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 		})
 
 	assert.NoError(t, err, "No error while trying to get the existing database name")
-	assert.Equal(t, rosmar.InMemoryURL, dbContext.BucketSpec.Server)
-	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
+	assert.Equal(t, bucketName, dbContext.Bucket.GetName())
 
 	// config with disallowed allow_conflicts=true
 	dbConfig = DbConfig{

--- a/rest/serverless_test.go
+++ b/rest/serverless_test.go
@@ -198,7 +198,6 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Skip("here")
 			ctx := base.TestCtx(t)
 			tb := base.GetTestBucket(t)
 			defer tb.Close(ctx)
@@ -218,7 +217,9 @@ func TestServerlessGoCBConnectionString(t *testing.T) {
 				tb.GetName(), base.TestsDisableGSI()))
 			RequireStatus(t, resp, http.StatusCreated)
 
-			assert.Equal(t, expectedServer, sc.getBucketSpec("db").Server)
+			bucket, ok := base.AsCouchbaseBucketStore(rt.GetDatabase().Bucket)
+			require.True(t, ok)
+			assert.Equal(t, expectedServer, bucket.GetSpec().Server)
 		})
 	}
 
@@ -265,7 +266,10 @@ func TestServerlessUnsupportedOptions(t *testing.T) {
 					tb.GetName(), base.TestsDisableGSI()))
 				RequireStatus(t, resp, http.StatusCreated)
 			}
-			assert.Equal(t, test.expectedConnStr, sc.getBucketSpec("db").Server)
+			bucket, ok := base.AsCouchbaseBucketStore(rt.GetDatabase().Bucket)
+			require.True(t, ok)
+			assert.Equal(t, test.expectedConnStr, bucket.GetSpec().Server)
+
 		})
 	}
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2406,12 +2406,6 @@ func (sc *ServerContext) isDatabaseSuspended(t *testing.T, dbName string) bool {
 	return sc._isDatabaseSuspended(dbName)
 }
 
-func (sc *ServerContext) getBucketSpec(dbName string) base.BucketSpec {
-	sc._databasesLock.RLock()
-	defer sc._databasesLock.RUnlock()
-	return sc._databases[dbName].BucketSpec
-}
-
 func (sc *ServerContext) suspendDatabase(t *testing.T, ctx context.Context, dbName string) error {
 	sc._databasesLock.Lock()
 	defer sc._databasesLock.Unlock()


### PR DESCRIPTION
Decouple BucketSpec from DatabaseContext

This fixes an issue where `DatabaseContext.BucketSpec` was only set by the initialization of `NewDatabaseContext` in `server_context.go`. This meant that a call like `db.BucketSpec.IsWalrusBucket()` would only be valid if called via `server_context.go` and not in the db package. This addresses problems running unit tests, but does not affect production code.

I am planning to add a check for using rosmar bucket to avoid sharded DCP code, and it was adding this code where I realized there was a problem.

I considered alternate approaches, and I'm open to these or others:

1. Requiring `BucketSpec` as a parameter to `DatabaseContextOptions`. This would work but I would have had to modify more test code.
2. Constructing a bucket spec inside `NewDatabaseContext` by either finding bucketSpec after type assertion to `GocbV2Bucket` or reconstructing the value from rosmar. The problem is that once a rosmar bucket has been opened, I would have to modify `rosmar.Bucket` to be able to find `BucketSpec.Server` https://github.com/couchbase/sync_gateway/blob/61cf3ebcca647463e4cc2e116cd5c127f2a8c27e/base/bucket.go#L287
3. Move `BucketSpec` code into sgbucket and add `BucketStore.GetSpec` interface. However, the `BucketSpec` is pretty much only gocb options, with the exception of Server (typically rosmar in memory URL, but can be an on disk URL). This felt overkill.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/281/
