### PR TITLE
Fix openapi example mistakes

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -6,6 +6,8 @@
 # will be governed by the Apache License, Version 2.0, included in the file
 # licenses/APL2.txt.
 
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
 name: openapi
 permissions:
   contents: read
@@ -50,7 +52,7 @@ jobs:
       - uses: r7kamura/redocly-problem-matchers@v1
       - name: redocly lint
         run: |-
-          npx --yes @redocly/cli@1 lint --format=stylish
+          npx --yes @redocly/cli@2 lint --config=.redocly.yaml --format=stylish
 
   yamllint:
     name: 'yamllint'

--- a/docs/api/components/schemas.yaml
+++ b/docs/api/components/schemas.yaml
@@ -1443,7 +1443,7 @@ Database:
               type: array
               items:
                 type: number
-                example: [1234, 5678]
+              example: [1234, 5678]
         console:
           description: Console logging configuration.
           type: object
@@ -2808,7 +2808,7 @@ Console-logging-keys-level:
           "WS": "Websocket replication log messages."
           "WSFrame": "Additional logging on top of `WS` key."
           "gocb": "All logging emitted by the gocb SDK"
-        example: ["CRUD", "HTTP", "Query"]
+      example: ["CRUD", "HTTP", "Query"]
 Console-logging-config:
   title: Configuration for console logging.
   allOf:
@@ -2892,7 +2892,7 @@ Vendor:
         API version.
         Omitted if `api.hide_product_version=true`
       type: string
-      example: 3.1
+      example: "3.1"
   required:
     - name
   title: Vendor
@@ -3001,7 +3001,7 @@ CollectionNames:
   type: array
   items:
     type: string
-    example: ["collection1", "collection2"]
+  example: ["collection1", "collection2"]
 "All DBs":
   title: Simple
   description: "The names of all databases."

--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -65,14 +65,14 @@ post:
               type: object
               properties:
                 xattrs:
+                  maximum: 1
                   description: |-
                     Optional XATTR values to include during evaluation.
 
                     To provide the user XATTR, include a property whose name exactly matches the configured `user_xattr_key`.
                   type: object
                   properties:
-                    additionalProperties:
-                      x-additionalPropertiesName: user_xattr_key
+                    user_xattr_key:
                       description: The user XATTR JSON value. The property name must exactly match the configured `user_xattr_key`. The value can be any valid JSON type (Object, String, Number, etc.)
                       oneOf:
                         - type: object
@@ -95,10 +95,6 @@ post:
                               - foo
                               - bar
                             description: An array of values to be used as the user XATTR.
-
-                  example:
-                    my_user_xattr_key:
-                      foo: bar
             userCtx:
               description: |-
                 Optional user context used during evaluation. Can be used to test a document update as a non-admin user. Used by Sync Function utilities `requireUser()`, `requireRole()`, `requireAccess()`, etc.

--- a/docs/api/paths/diagnostic/keyspace-sync.yaml
+++ b/docs/api/paths/diagnostic/keyspace-sync.yaml
@@ -65,36 +65,39 @@ post:
               type: object
               properties:
                 xattrs:
-                  maximum: 1
                   description: |-
                     Optional XATTR values to include during evaluation.
 
                     To provide the user XATTR, include a property whose name exactly matches the configured `user_xattr_key`.
                   type: object
-                  properties:
+                  example:
                     user_xattr_key:
-                      description: The user XATTR JSON value. The property name must exactly match the configured `user_xattr_key`. The value can be any valid JSON type (Object, String, Number, etc.)
-                      oneOf:
-                        - type: object
-                          additionalProperties: true
+                      foo: bar
+                  additionalProperties:
+                    x-additionalPropertiesName: user_xattr_key
+                    description: The user XATTR JSON value. The property name must exactly match the configured `user_xattr_key`. The value can be any valid JSON type (Object, String, Number, etc.)
+                    maxProperties: 1
+                    oneOf:
+                      - type: object
+                        additionalProperties: true
+                        example:
+                          foo: bar
+                        description: An object value to be used as the user XATTR.
+                      - type: string
+                        example: foo
+                        description: A string value to be used as the user XATTR.
+                      - type: integer
+                        example: 100
+                        description: A number value to be used as the user XATTR.
+                      - type: boolean
+                        example: true
+                        description: A boolean value to be used as the user XATTR.
+                      - type: array
+                        items:
                           example:
-                            foo: bar
-                          description: An object value to be used as the user XATTR.
-                        - type: string
-                          example: foo
-                          description: A string value to be used as the user XATTR.
-                        - type: integer
-                          example: 100
-                          description: A number value to be used as the user XATTR.
-                        - type: boolean
-                          example: true
-                          description: A boolean value to be used as the user XATTR.
-                        - type: array
-                          items:
-                            example:
-                              - foo
-                              - bar
-                            description: An array of values to be used as the user XATTR.
+                            - foo
+                            - bar
+                          description: An array of values to be used as the user XATTR.
             userCtx:
               description: |-
                 Optional user context used during evaluation. Can be used to test a document update as a non-admin user. Used by Sync Function utilities `requireUser()`, `requireRole()`, `requireAccess()`, etc.


### PR DESCRIPTION
Using redocly v2 for linting showed some schema mistakes in trying to match the examples.