### PR TITLE
CBG-4812: Use base.IsRevTreeID in BLIP when determining CV/RevTreeID values

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -3677,8 +3677,7 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 	// previousRev may be revTreeID or version
 	var previousVersion Version
 	previousRevFormat := "version"
-	// TODO: CBG-4812 Use base.IsRevTreeID
-	if !strings.Contains(previousRev, "@") {
+	if base.IsRevTreeID(previousRev) {
 		previousRevFormat = "revTreeID"
 	}
 	if previousRev != "" && previousRevFormat == "version" {


### PR DESCRIPTION
CBG-4812

Replace `strings.Contains(rev, "@")` with `base.IsRevTreeID` in BLIP handler and CRUD code for determining whether a version value is a CV or RevTreeID

- **Note:** Semi-automated refactoring/cleanup (using an Opus 4.6 agent)
  - Manually reviewed and cleaned up (still required cleanup to simplify the diff/readability)

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/288/