### PR TITLE
CBG-5192: add ability to identify if pushed encoded CV is derived from our local revID

### DIFF
--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -1087,7 +1087,6 @@ func TestLegacyRevBlipTesterClient(t *testing.T) {
 }
 
 func TestCBLPushEncodedCVDerivedFromSGWLocalRevID(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeySyncMsg, base.KeyCRUD)
 	btcRunner := NewBlipTesterClientRunner(t)
 
 	btcRunner.SkipSubtest[RevtreeSubtestName] = true // vv specific test

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -1029,7 +1029,7 @@ func TestLegacyRevBlipTesterClient(t *testing.T) {
 			defer btcRunner.StopPush(client.id)
 
 			docID := SafeDocumentName(t, t.Name())
-			cblDocVersion1 := btcRunner.AddRevTreeRev(client.id, docID, "abc", EmptyDocVersion(), []byte(`{"action": "create"}`))
+			cblDocVersion1 := btcRunner.AddRevTreeRev(client.id, docID, "1-abc", EmptyDocVersion(), []byte(`{"action": "create"}`))
 			rt.WaitForVersion(docID, cblDocVersion1)
 
 			cblDocVersion2 := btcRunner.AddRev(client.id, docID, &cblDocVersion1, []byte(`{"action": "update"}`))
@@ -1061,9 +1061,7 @@ func TestLegacyRevBlipTesterClient(t *testing.T) {
 			docID := SafeDocumentName(t, t.Name())
 			dbc, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 			sgVersion1, _ := dbc.CreateDocNoHLV(t, ctx, docID, db.Body{"action": "create"})
-			generation, digest := db.ParseRevID(ctx, sgVersion1)
-			require.Equal(t, 1, generation)
-			cblVersion1 := btcRunner.AddRevTreeRev(client.id, docID, digest, EmptyDocVersion(), []byte(`{"action": "create"}`))
+			cblVersion1 := btcRunner.AddRevTreeRev(client.id, docID, sgVersion1, EmptyDocVersion(), []byte(`{"action": "create"}`))
 			require.Equal(t, sgVersion1, cblVersion1.RevTreeID)
 			sgVersion2, _ := dbc.CreateDocNoHLV(t, ctx, docID, db.Body{"_rev": sgVersion1, "action": "update"})
 			btcRunner.StartPull(client.id)
@@ -1073,12 +1071,10 @@ func TestLegacyRevBlipTesterClient(t *testing.T) {
 			docID := SafeDocumentName(t, t.Name())
 			dbc, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 			sgVersion1, _ := dbc.CreateDocNoHLV(t, ctx, docID, db.Body{"action": "create"})
-			generation, digest := db.ParseRevID(ctx, sgVersion1)
-			require.Equal(t, 1, generation)
-			cblVersion1 := btcRunner.AddRevTreeRev(client.id, docID, digest, EmptyDocVersion(), []byte(`{"action": "create"}`))
+			cblVersion1 := btcRunner.AddRevTreeRev(client.id, docID, sgVersion1, EmptyDocVersion(), []byte(`{"action": "create"}`))
 			require.Equal(t, sgVersion1, cblVersion1.RevTreeID)
 
-			cblVersion2 := btcRunner.AddRevTreeRev(client.id, docID, "bcd", &cblVersion1, []byte(`{"action": "update"}`))
+			cblVersion2 := btcRunner.AddRevTreeRev(client.id, docID, "2-bcd", &cblVersion1, []byte(`{"action": "update"}`))
 
 			btcRunner.StartPush(client.id)
 			rt.WaitForVersion(docID, cblVersion2)
@@ -1105,10 +1101,7 @@ func TestCBLPushEncodedCVDerivedFromSGWLocalRevID(t *testing.T) {
 		doc := rt.CreateDocNoHLV(docID, db.Body{"key": "val"})
 		originalSGWVersion := doc.ExtractDocVersion()
 
-		// extract digest
-		_, digest := db.ParseRevID(t.Context(), originalSGWVersion.RevTreeID)
-
-		cblVersion := btcRunner.AddEncodedCVRev(btc.id, docID, digest, EmptyDocVersion(), []byte(`{"key":"val"}`))
+		cblVersion := btcRunner.AddEncodedCVRev(btc.id, docID, originalSGWVersion.RevTreeID, EmptyDocVersion(), []byte(`{"key":"val"}`))
 		require.Equal(t, "Revision+Tree+Encoding", cblVersion.CV.SourceID) // we must be saving this rev as legacy encoded cv on client
 
 		btcRunner.StartPush(btc.id)

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -649,7 +649,6 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	const username = "alice"
 	// NOTE: below diagrams only show active rev tree branches not tombstones branches from the conflict resolution

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -649,6 +649,7 @@ func TestActiveReplicatorConflictPreUpgradedVersionEachSide(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
+	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	const username = "alice"
 	// NOTE: below diagrams only show active rev tree branches not tombstones branches from the conflict resolution

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1603,7 +1603,7 @@ type blipTesterUpsertOptions struct {
 	isDelete         bool
 	legacyRev        bool   // if true, create a legacy revtree revision even if client is using HLV
 	specificDigest   string // if specified, use this digest for the revision
-	writeAsEncodedCV bool
+	writeAsEncodedCV bool   // if specified, legacy revID will be saved as encoded CV
 }
 
 // upsertDoc will create or update the doc based on whether parentVersion is passed or not. Enforces MVCC update.
@@ -2097,6 +2097,7 @@ func (btcRunner *BlipTestClientRunner) AddRev(clientID uint32, docID string, ver
 	return btcRunner.SingleCollection(clientID).AddRev(docID, version, body)
 }
 
+// AddEncodedCVRev create a rev on client with CV generated form revID supplied.
 func (btcRunner *BlipTestClientRunner) AddEncodedCVRev(clientID uint32, docID, digest string, version *DocVersion, body []byte) DocVersion {
 	return btcRunner.SingleCollection(clientID).AddRevEncodedCVRevision(docID, digest, version, body)
 }


### PR DESCRIPTION
CBG-5192

- CBL were actually replying on some buggy behaviour form the rev cache ion version 4.0.0 - 4.0.2. With the old behaviour the documnet was being added to CBS with 3-abc@RTE as CV and 4-abc as revID. But due to bug in rev cache we were linking the rev cache value as 3-abc@RTE  and revID 3-abc. So the rest api fetch of the doc post replication was returning stale revID. So the overall replication behaviour hasn’t changes between versions just a bug being fixed at the rev cache. 
- This doesn’t take away from the fact that a resolved conflict on CBL for remote wins should not result in new mutation being pushed top SGW. The issue we have is CBL is resolving conflict and saving the remote revID as rev tree encoded CV. We currently have no handling on SGW to see that this proposed change is equal to our local revID. 
- We end up with the following being pushed in proposed changes after resolved conflict [3-abc@RTE, 3-abc, docID]
- SGW currently just sees the server revID CBL sends matches our revID and accepts this as new mutation. We should eb comparing encoded CV being sent against our revID before accepting change. 

Sheets doc explains the state of each step above:
https://docs.google.com/spreadsheets/d/12cHAi8xR7huqUYVfDflXKxejQnVVwH8glTGsdAiX4nM/edit?usp=sharing

Ran this against the test this was found in and passes. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/292/
