### PR TITLE
CBG-4990 docs fix: admin api returns 403 if database not found

### DIFF
--- a/docs/api/components/responses.yaml
+++ b/docs/api/components/responses.yaml
@@ -21,6 +21,12 @@ Unauthorized:
     application/json:
       schema:
         $ref: ./schemas.yaml#/HTTP-Error
+Unauthorized-database:
+  description: User does not have access to the database resource, or database resource does not exist
+  content:
+    application/json:
+      schema:
+        $ref: ./schemas.yaml#/HTTP-Error
 Conflict:
   description: Resource already exists under that name
   content:

--- a/docs/api/paths/admin/db-.yaml
+++ b/docs/api/paths/admin/db-.yaml
@@ -69,8 +69,8 @@ get:
               init_in_progress:
                 description: Indicates whether database initialization is in progress.
                 type: boolean
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Management
   operationId: get_db-
@@ -92,8 +92,8 @@ delete:
           schema:
             type: object
             properties: {}
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '500':
       description: Cannot remove database from bucket
       content:
@@ -114,8 +114,8 @@ head:
   responses:
     '200':
       description: Database exists
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Management
   operationId: head_db-

--- a/docs/api/paths/admin/db-_attachment_migration.yaml
+++ b/docs/api/paths/admin/db-_attachment_migration.yaml
@@ -38,8 +38,8 @@ post:
       description: Started or stopped compact operation successfully
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '503':
       description: Cannot start attachment migration due to another migration operation still running.
       content:
@@ -66,8 +66,8 @@ get:
             $ref: ../../components/schemas.yaml#/Attachment-Migration-status
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Management
   operationId: get_db-_attachment_migration

--- a/docs/api/paths/admin/db-_blipsync.yaml
+++ b/docs/api/paths/admin/db-_blipsync.yaml
@@ -28,8 +28,8 @@ get:
   responses:
     '101':
       description: Upgraded to a web socket connection
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '426':
       description: Cannot upgrade connection to a web socket connection
       content:

--- a/docs/api/paths/admin/db-_compact.yaml
+++ b/docs/api/paths/admin/db-_compact.yaml
@@ -53,8 +53,8 @@ post:
       description: Started or stopped compact operation successfully
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '503':
       description: Cannot start compaction due to another compaction operation still running.
       content:
@@ -83,8 +83,8 @@ get:
             $ref: ../../components/schemas.yaml#/Compact-status
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Management
   operationId: get_db-_compact

--- a/docs/api/paths/admin/db-_config-audit.yaml
+++ b/docs/api/paths/admin/db-_config-audit.yaml
@@ -35,8 +35,8 @@ get:
             oneOf:
               - $ref: ../../components/schemas.yaml#/Database-audit
               - $ref: ../../components/schemas.yaml#/Database-audit-verbose
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Configuration
   operationId: get_db-_config-audit
@@ -63,8 +63,8 @@ put:
       description: Database audit configuration successfully updated
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Configuration
   operationId: put_db-_config-audit
@@ -98,8 +98,8 @@ post:
       description: Database audit configuration successfully updated
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      description: Not Found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Configuration
   operationId: post_db-_config-audit

--- a/docs/api/paths/admin/db-_config.yaml
+++ b/docs/api/paths/admin/db-_config.yaml
@@ -40,8 +40,8 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Database
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Configuration
   operationId: get_db-_config
@@ -70,8 +70,8 @@ put:
       $ref: ../../components/responses.yaml#/DB-config-updated
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
@@ -101,8 +101,8 @@ post:
       $ref: ../../components/responses.yaml#/DB-config-updated
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      description: Not Found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:

--- a/docs/api/paths/admin/db-_dump-view.yaml
+++ b/docs/api/paths/admin/db-_dump-view.yaml
@@ -26,6 +26,8 @@ get:
         text/html:
           schema:
             type: string
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '500':

--- a/docs/api/paths/admin/db-_facebook.yaml
+++ b/docs/api/paths/admin/db-_facebook.yaml
@@ -40,8 +40,8 @@ post:
                 type: string
               reason:
                 type: string
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '502':
       description: Received invalid response from the Facebook verifier
       content:

--- a/docs/api/paths/admin/db-_flush.yaml
+++ b/docs/api/paths/admin/db-_flush.yaml
@@ -22,8 +22,8 @@ post:
   responses:
     '200':
       description: Successfully flushed the bucket
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '503':
       description: The bucket does not support flush or delete
       content:

--- a/docs/api/paths/admin/db-_google.yaml
+++ b/docs/api/paths/admin/db-_google.yaml
@@ -40,8 +40,8 @@ post:
                 type: string
               reason:
                 type: string
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '502':
       description: Received invalid response from the Google token verifier
       content:

--- a/docs/api/paths/admin/db-_index_init.yaml
+++ b/docs/api/paths/admin/db-_index_init.yaml
@@ -72,8 +72,8 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/IndexInitStatus
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Management
   operationId: get_db-_index_init

--- a/docs/api/paths/admin/db-_offline.yaml
+++ b/docs/api/paths/admin/db-_offline.yaml
@@ -30,8 +30,8 @@ post:
   responses:
     '200':
       description: Database has been taken offline successfully
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '503':
       description: An error occurred while trying to take the database offline
       content:

--- a/docs/api/paths/admin/db-_oidc.yaml
+++ b/docs/api/paths/admin/db-_oidc.yaml
@@ -23,6 +23,8 @@ get:
           description: The link to redirect to so the client can authenticate.
     '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-provider
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '500':

--- a/docs/api/paths/admin/db-_oidc_callback.yaml
+++ b/docs/api/paths/admin/db-_oidc_callback.yaml
@@ -26,6 +26,8 @@ get:
       description: A problem occurred when reading the callback request body
     '401':
       description: An error was received from the OpenID Connect provider. This means the error query parameter was filled.
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '500':

--- a/docs/api/paths/admin/db-_oidc_challenge.yaml
+++ b/docs/api/paths/admin/db-_oidc_challenge.yaml
@@ -23,6 +23,8 @@ get:
           schema:
             type: string
           description: The OpenID Connect authentication URL.
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '500':

--- a/docs/api/paths/admin/db-_oidc_refresh.yaml
+++ b/docs/api/paths/admin/db-_oidc_refresh.yaml
@@ -23,6 +23,8 @@ get:
       $ref: ../../components/responses.yaml#/OIDC-callback
     '400':
       $ref: ../../components/responses.yaml#/OIDC-invalid-provider
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '500':

--- a/docs/api/paths/admin/db-_online.yaml
+++ b/docs/api/paths/admin/db-_online.yaml
@@ -40,8 +40,8 @@ post:
   responses:
     '200':
       description: Database will be brought online immediately or with the specified delay
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '503':
       description: An error occurred
       content:

--- a/docs/api/paths/admin/db-_replication-.yaml
+++ b/docs/api/paths/admin/db-_replication-.yaml
@@ -24,8 +24,8 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/All-replications
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Replication
   operationId: get_db-_replication-
@@ -48,8 +48,8 @@ post:
       $ref: ../../components/responses.yaml#/Replicator-created
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Replication
   operationId: post_db-_replication-

--- a/docs/api/paths/admin/db-_replication-replicationid.yaml
+++ b/docs/api/paths/admin/db-_replication-replicationid.yaml
@@ -23,6 +23,8 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Retrieved-replication
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -49,6 +51,8 @@ put:
       $ref: ../../components/responses.yaml#/Replicator-created
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -67,6 +71,8 @@ delete:
       description: Replication successfully deleted
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -76,6 +82,8 @@ head:
   responses:
     '200':
       description: Replication exists
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       description: Replication does not exist
   tags:

--- a/docs/api/paths/admin/db-_replicationStatus-.yaml
+++ b/docs/api/paths/admin/db-_replicationStatus-.yaml
@@ -31,6 +31,8 @@ get:
               $ref: ../../components/schemas.yaml#/Replication-status
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Replication
   operationId: get_db-_replicationStatus-

--- a/docs/api/paths/admin/db-_resync.yaml
+++ b/docs/api/paths/admin/db-_resync.yaml
@@ -22,8 +22,8 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Resync-status
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Management
   operationId: get_db-_resync
@@ -87,6 +87,8 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/Resync-status
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '503':
       description: Service Unavailable
       content:

--- a/docs/api/paths/admin/db-_role-.yaml
+++ b/docs/api/paths/admin/db-_role-.yaml
@@ -42,6 +42,8 @@ get:
           example:
             - Administrator
             - Moderator
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -61,8 +63,8 @@ post:
   responses:
     '201':
       description: New role created successfully
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '409':
       $ref: ../../components/responses.yaml#/Conflict
   tags:

--- a/docs/api/paths/admin/db-_role-name.yaml
+++ b/docs/api/paths/admin/db-_role-name.yaml
@@ -21,6 +21,8 @@ get:
   responses:
     '200':
       $ref: ../../components/responses.yaml#/Role
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -42,8 +44,8 @@ put:
       description: OK
     '201':
       description: Created
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Security
   operationId: put_db-_role-name
@@ -59,6 +61,8 @@ delete:
   responses:
     '200':
       description: OK
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -68,6 +72,8 @@ head:
   responses:
     '200':
       description: Role exists
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/db-_session-sessionid.yaml
+++ b/docs/api/paths/admin/db-_session-sessionid.yaml
@@ -21,6 +21,8 @@ get:
   responses:
     '200':
       $ref: ../../components/responses.yaml#/User-session-information
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -38,6 +40,8 @@ delete:
   responses:
     '200':
       description: Successfully removed the user session
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/db-_session.yaml
+++ b/docs/api/paths/admin/db-_session.yaml
@@ -13,6 +13,8 @@ get:
   responses:
     '200':
       $ref: ../../components/responses.yaml#/User-session-information
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -67,15 +69,8 @@ post:
                 cookie_name: SyncGatewaySession
     "401":
       $ref: ../../components/responses.yaml#/Unauthorized
-    '404':
-      description: Return if database does not exist
-      content:
-        application/json:
-          schema:
-            $ref: ../../components/schemas.yaml#/HTTP-Error
-          example:
-            error: not_found
-            reason: no such database "invalid-db"
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Session
   operationId: post_db-_session

--- a/docs/api/paths/admin/db-_user-.yaml
+++ b/docs/api/paths/admin/db-_user-.yaml
@@ -33,6 +33,8 @@ get:
           example:
             - Alice
             - Bob
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -52,8 +54,8 @@ post:
   responses:
     '201':
       description: New user created successfully
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '409':
       $ref: ../../components/responses.yaml#/Conflict
   tags:

--- a/docs/api/paths/admin/db-_user-name-_session-sessionid.yaml
+++ b/docs/api/paths/admin/db-_user-name-_session-sessionid.yaml
@@ -21,6 +21,8 @@ delete:
   responses:
     '200':
       description: Session has been successfully removed as the user was associated with the session
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/db-_user-name-_session.yaml
+++ b/docs/api/paths/admin/db-_user-name-_session.yaml
@@ -22,6 +22,8 @@ delete:
   responses:
     '200':
       description: User now has no sessions
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/db-_user-name.yaml
+++ b/docs/api/paths/admin/db-_user-name.yaml
@@ -21,6 +21,8 @@ get:
   responses:
     '200':
       $ref: ../../components/responses.yaml#/User
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -42,8 +44,8 @@ put:
       description: Existing user modified successfully
     '201':
       description: New user created
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Security
   operationId: put_db-_user-name
@@ -59,6 +61,8 @@ delete:
   responses:
     '200':
       description: User deleted successfully
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -68,6 +72,8 @@ head:
   responses:
     '200':
       description: User exists
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       description: Not Found
   tags:

--- a/docs/api/paths/admin/keyspace-.yaml
+++ b/docs/api/paths/admin/keyspace-.yaml
@@ -40,8 +40,8 @@ post:
             $ref: ../../components/schemas.yaml#/New-revision
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '409':
       $ref: ../../components/responses.yaml#/Conflict
     '415':

--- a/docs/api/paths/admin/keyspace-_all_docs.yaml
+++ b/docs/api/paths/admin/keyspace-_all_docs.yaml
@@ -34,8 +34,8 @@ get:
       $ref: ../../components/responses.yaml#/all-docs
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Document
   operationId: get_keyspace-_all_docs
@@ -78,8 +78,8 @@ post:
       $ref: ../../components/responses.yaml#/all-docs
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Document
   operationId: post_keyspace-_all_docs

--- a/docs/api/paths/admin/keyspace-_bulk_docs.yaml
+++ b/docs/api/paths/admin/keyspace-_bulk_docs.yaml
@@ -103,8 +103,8 @@ post:
                   status: 409
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Document
   operationId: post_keyspace-_bulk_docs

--- a/docs/api/paths/admin/keyspace-_bulk_get.yaml
+++ b/docs/api/paths/admin/keyspace-_bulk_get.yaml
@@ -73,8 +73,8 @@ post:
       description: Returned the requested docs as `multipart/mixed` response type
     '400':
       description: Bad Request
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Document
   operationId: post_keyspace-_bulk_get

--- a/docs/api/paths/admin/keyspace-_changes.yaml
+++ b/docs/api/paths/admin/keyspace-_changes.yaml
@@ -119,6 +119,8 @@ get:
       $ref: ../../components/responses.yaml#/changes-feed
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -193,8 +195,8 @@ post:
       $ref: ../../components/responses.yaml#/changes-feed
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Document
   operationId: post_keyspace-_changes

--- a/docs/api/paths/admin/keyspace-_config-import_filter.yaml
+++ b/docs/api/paths/admin/keyspace-_config-import_filter.yaml
@@ -29,8 +29,8 @@ get:
         application/javascript:
           schema:
             type: string
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Configuration
   operationId: get_keyspace-_config-import_filter
@@ -56,8 +56,8 @@ put:
       description: Updated import filter successfully
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
@@ -76,8 +76,8 @@ delete:
   responses:
     '200':
       description: Successfully deleted the import filter
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:

--- a/docs/api/paths/admin/keyspace-_config-sync.yaml
+++ b/docs/api/paths/admin/keyspace-_config-sync.yaml
@@ -33,8 +33,8 @@ get:
             function (doc, oldDoc) {
               channel(doc.channels);
             }
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Database Configuration
   operationId: get_keyspace-_config-sync
@@ -64,8 +64,8 @@ put:
       description: Updated sync function successfully
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:
@@ -91,8 +91,8 @@ delete:
   responses:
     '200':
       description: Successfully reset the sync function
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '412':
       $ref: ../../components/responses.yaml#/DB-config-precondition-failed
   tags:

--- a/docs/api/paths/admin/keyspace-_dumpchannel-channel.yaml
+++ b/docs/api/paths/admin/keyspace-_dumpchannel-channel.yaml
@@ -37,6 +37,8 @@ get:
         text/html:
           schema:
             type: string
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/keyspace-_local-docid.yaml
+++ b/docs/api/paths/admin/keyspace-_local-docid.yaml
@@ -29,6 +29,8 @@ get:
       description: Successfully found local document
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -64,8 +66,8 @@ put:
             $ref: ../../components/schemas.yaml#/New-revision
     '400':
       $ref: ../../components/responses.yaml#/request-problem
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '409':
       description: A conflict would result from updating this document revision.
   tags:
@@ -93,6 +95,8 @@ delete:
       description: Successfully removed the local document.
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '409':
@@ -106,6 +110,8 @@ head:
       description: Document exists
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/keyspace-_purge.yaml
+++ b/docs/api/paths/admin/keyspace-_purge.yaml
@@ -89,8 +89,8 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/HTTP-Error
-    '404':
-      $ref: ../../components/responses.yaml#/Not-found
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
   tags:
     - Document
   operationId: post_keyspace-_purge

--- a/docs/api/paths/admin/keyspace-_raw-docid.yaml
+++ b/docs/api/paths/admin/keyspace-_raw-docid.yaml
@@ -73,6 +73,8 @@ get:
                     additionalProperties: true
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/keyspace-_revs_diff.yaml
+++ b/docs/api/paths/admin/keyspace-_revs_diff.yaml
@@ -48,6 +48,8 @@ post:
                     type: array
                     items:
                       type: string
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/keyspace-_revtree-docid.yaml
+++ b/docs/api/paths/admin/keyspace-_revtree-docid.yaml
@@ -32,6 +32,8 @@ get:
           schema:
             type: string
           example: 'digraph graphname{"1-d4d949b7feafc8c31215684baa45b6cd" -> "2-4f3f24143ea43d85a9a340ac016fdfc4"; }'
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:

--- a/docs/api/paths/admin/keyspace-docid-attach.yaml
+++ b/docs/api/paths/admin/keyspace-docid-attach.yaml
@@ -61,6 +61,8 @@ get:
           description: 'The attachment digest. Does not get set when request `meta=true`. '
     '206':
       description: Partial attachment content returned
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '416':
@@ -116,6 +118,8 @@ put:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '409':
@@ -136,6 +140,8 @@ head:
           schema:
             type: string
           description: The attachment digest.
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -180,6 +186,8 @@ delete:
         application/json:
           schema:
             $ref: ../../components/schemas.yaml#/New-revision
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '409':

--- a/docs/api/paths/admin/keyspace-docid.yaml
+++ b/docs/api/paths/admin/keyspace-docid.yaml
@@ -55,6 +55,8 @@ get:
             _cv: 1@src
     '400':
       $ref: ../../components/responses.yaml#/invalid-doc-id
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '501':
@@ -105,6 +107,8 @@ put:
             $ref: ../../components/schemas.yaml#/New-revision
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
     '409':
@@ -132,6 +136,8 @@ delete:
       $ref: ../../components/responses.yaml#/New-revision
     '400':
       $ref: ../../components/responses.yaml#/request-problem
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:
@@ -143,6 +149,8 @@ head:
       description: Document exists
     '400':
       $ref: ../../components/responses.yaml#/invalid-doc-id
+    '403':
+      $ref: ../../components/responses.yaml#/Unauthorized-database
     '404':
       $ref: ../../components/responses.yaml#/Not-found
   tags:


### PR DESCRIPTION
CBG-4990 docs fix: admin api returns 403 if database not found

It is extremely hard to return a 404 from a database, in my reading and practice any db/keyspace call on admin port returns https://github.com/couchbase/sync_gateway/blob/2cb6c5925c5a8da2f07046c68fd7a4b268087809/rest/handler.go#L603

For reviewer:

- validate that this returns 403 for some of these APIs
- scan via grep if there are any files I've missed