### PR TITLE
CBG-5201: Simplify test assertions for sequence handling

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -86,10 +86,6 @@ const (
 
 	DefaultViewQueryPageSize = 5000 // This must be greater than 1, or the code won't work due to windowing method
 
-	// Until the sporadic integration tests failures in SG #3570 are fixed, should be GTE n1ql query timeout
-	// to make it easier to identify root cause of test failures.
-	DefaultWaitForSequence = time.Second * 30
-
 	// Default the max number of idle connections per host to a relatively high number to avoid
 	// excessive socket churn caused by opening short-lived connections and closing them after, which can cause
 	// a high number of connections to end up in the TIME_WAIT state and exhaust system resources.  Since

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -49,7 +49,7 @@ func TestUserWaiter(t *testing.T) {
 	require.NoError(t, err, "Error saving user")
 
 	// Wait for notify from initial save
-	require.True(t, WaitForUserWaiterChange(userWaiter))
+	WaitForUserWaiterChange(t, userWaiter)
 
 	// Update the user to grant new channel
 	updatedUser := auth.PrincipalConfig{
@@ -60,8 +60,7 @@ func TestUserWaiter(t *testing.T) {
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notification from grant
-	require.True(t, WaitForUserWaiterChange(userWaiter))
-
+	WaitForUserWaiterChange(t, userWaiter)
 }
 
 func TestUserWaiterForRoleChange(t *testing.T) {
@@ -99,7 +98,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	require.NoError(t, err, "Error saving user")
 
 	// Wait for notify from initial save
-	require.True(t, WaitForUserWaiterChange(userWaiter))
+	WaitForUserWaiterChange(t, userWaiter)
 
 	// Update the user to grant role
 	updatedUser := auth.PrincipalConfig{
@@ -110,14 +109,14 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	require.NoError(t, err, "Error updating user")
 
 	// Wait for notify from updated user
-	require.True(t, WaitForUserWaiterChange(userWaiter))
+	WaitForUserWaiterChange(t, userWaiter)
 
 	// Retrieve the user.  This will trigger a user update to move ExplicitRoles->roles
 	userRefresh, err := authenticator.GetUser(username)
 	require.NoError(t, err, "Error retrieving user")
 
 	// Wait for notify from retrieval
-	require.True(t, WaitForUserWaiterChange(userWaiter))
+	WaitForUserWaiterChange(t, userWaiter)
 
 	// Update the waiter with the current user (adds role to waiter.UserKeys)
 	userWaiter.RefreshUserKeys(userRefresh, db.MetadataKeys)
@@ -131,5 +130,5 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	require.NoError(t, err, "Error updating role")
 
 	// Wait for user notification of updated role
-	require.True(t, WaitForUserWaiterChange(userWaiter))
+	WaitForUserWaiterChange(t, userWaiter)
 }

--- a/db/changes.go
+++ b/db/changes.go
@@ -1226,28 +1226,6 @@ func (c *DatabaseCollection) GetChangeLog(ctx context.Context, channel channels.
 	return c.changeCache().getChannelCache().GetCachedChanges(ctx, channel)
 }
 
-// WaitForSequenceNotSkipped blocks until the given sequence has been received or skipped by the change cache.
-func (c *DatabaseCollection) WaitForSequence(ctx context.Context, sequence uint64) (err error) {
-	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", sequence)
-	return c.changeCache().waitForSequence(ctx, sequence, base.DefaultWaitForSequence)
-}
-
-// WaitForSequenceNotSkipped blocks until the given sequence has been received by the change cache without being skipped.
-func (c *DatabaseCollection) WaitForSequenceNotSkipped(ctx context.Context, sequence uint64) (err error) {
-	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", sequence)
-	return c.changeCache().waitForSequenceNotSkipped(ctx, sequence, base.DefaultWaitForSequence)
-}
-
-// WaitForPendingChanges blocks until the change-cache has caught up with the latest writes to the database.
-func (c *DatabaseCollection) WaitForPendingChanges(ctx context.Context) error {
-	lastSequence, err := c.LastSequence(ctx)
-	if err != nil {
-		return err
-	}
-	base.DebugfCtx(ctx, base.KeyChanges, "Waiting for sequence: %d", lastSequence)
-	return c.changeCache().waitForSequence(ctx, lastSequence, base.DefaultWaitForSequence)
-}
-
 // Late Sequence Feed
 // Manages the changes feed interaction with a channels cache's set of late-arriving entries
 type lateSequenceFeed struct {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -68,8 +68,7 @@ func TestFilterToAvailableChannels(t *testing.T) {
 				_, _, err = collection.Put(ctx, "doc"+id, Body{"channels": []string{"ch" + id}})
 				require.NoError(t, err)
 			}
-			err = collection.WaitForPendingChanges(base.TestCtx(t))
-			require.NoError(t, err)
+			db.WaitForPendingChanges(t)
 
 			collection.user, err = auth.GetUser("test")
 			require.NoError(t, err)
@@ -121,8 +120,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	_, _, err = db.UpdatePrincipal(base.TestCtx(t), userInfo, true, true)
 	assert.NoError(t, err, "UpdatePrincipal failed")
 
-	err = collection.WaitForPendingChanges(base.TestCtx(t))
-	assert.NoError(t, err)
+	db.WaitForPendingChanges(t)
 
 	// Check the _changes feed:
 	collection.user, err = authenticator.GetUser("naomi")
@@ -308,7 +306,7 @@ func TestCVPopulationOnChangeEntry(t *testing.T) {
 	_, doc, err := collection.Put(ctx, "doc1", Body{"channels": []string{"A"}})
 	require.NoError(t, err)
 
-	require.NoError(t, collection.WaitForPendingChanges(base.TestCtx(t)))
+	db.WaitForPendingChanges(t)
 
 	changes := getChanges(t, collection, base.SetOf("A"), changesOpts)
 	require.NoError(t, err)
@@ -423,8 +421,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 		require.NoError(t, err, "Couldn't delete document")
 	}
 
-	waitErr := collection.WaitForPendingChanges(base.TestCtx(t))
-	assert.NoError(t, waitErr)
+	db.WaitForPendingChanges(t)
 
 	changesOptions := ChangesOptions{
 		Since:      SequenceID{Seq: 0},
@@ -505,8 +502,7 @@ func TestCurrentVersionPopulationOnChannelCache(t *testing.T) {
 	// Put a doc that gets assigned a CV to populate the channel cache with
 	_, _, err = collection.Put(ctx, "doc1", Body{"channels": []string{"ABC"}})
 	require.NoError(t, err)
-	err = collection.WaitForPendingChanges(base.TestCtx(t))
-	require.NoError(t, err)
+	db.WaitForPendingChanges(t)
 
 	doc, err := collection.GetDocument(ctx, "doc1", DocUnmarshalSync)
 	require.NoError(t, err)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1587,8 +1587,7 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 	require.Greaterf(t, doc.Sequence, uint64(otherClusterSequenceOffset), "Expected new doc sequence %d to be greater than other cluster's sequence %d", doc.Sequence, otherClusterSequenceOffset)
 
 	// wait for the doc to be received
-	err = db.changeCache.waitForSequence(ctx, doc.Sequence, time.Second*30)
-	require.NoError(t, err)
+	db.WaitForSequence(t, doc.Sequence)
 
 	expectedReleasedSequenceCount := otherClusterSequenceOffset
 	releasedSequenceCount := db.DbStats.Database().SequenceReleasedCount.Value() - startReleasedSequenceCount
@@ -1646,8 +1645,7 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	_, _, err := collection.Put(ctx, timeoutDoc, Body{"test": "doc"})
 	require.Error(t, err)
 
-	// wait for changes
-	require.NoError(t, collection.WaitForPendingChanges(ctx))
+	db.WaitForPendingChanges(t)
 
 	// assert that no sequences were released + a sequence was cached
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1666,8 +1664,7 @@ func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	_, _, err = collection.Put(ctx, conflictDoc, Body{"test": "doc"})
 	require.Error(t, err)
 
-	// wait for changes
-	require.NoError(t, collection.WaitForPendingChanges(ctx))
+	db.WaitForPendingChanges(t)
 
 	// assert that a sequence was released after the above write error
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/db/database.go
+++ b/db/database.go
@@ -2582,3 +2582,9 @@ func (db *DatabaseContext) usingRosmar() bool {
 	_, err := base.AsRosmarBucket(db.Bucket)
 	return err == nil
 }
+
+// WaitForSequenceNotSkipped will wait until the specified sequence is no longer in the skipped list. Returns an error
+// if the sequence remains in skipped list.
+func (db *DatabaseContext) WaitForSequenceNotSkipped(ctx context.Context, targetSequence uint64) error {
+	return db.changeCache.waitForSequenceNotSkipped(ctx, targetSequence, defaultWaitForSequence)
+}

--- a/db/dcp_sharded_upgrade_test.go
+++ b/db/dcp_sharded_upgrade_test.go
@@ -268,14 +268,14 @@ func TestShardedDCPUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	// assert that the doc we created before starting this node gets imported once all the pindexes are reassigned
-	require.NoError(t, collection.WaitForPendingChanges(ctx))
+	db.WaitForPendingChanges(t)
 	doc, err := collection.GetDocument(collectionCtx, testDoc1, DocUnmarshalAll)
 	require.NoError(t, err, "GetDocument 1")
 	require.NotNil(t, doc, "GetDocument 1")
 
 	// Write a doc to the test bucket to check that import still works
 	require.NoError(t, dataStore.SetRaw(testDoc2, 0, nil, []byte(`{}`)))
-	require.NoError(t, collection.WaitForPendingChanges(ctx))
+	db.WaitForPendingChanges(t)
 	doc, err = collection.GetDocument(collectionCtx, testDoc2, DocUnmarshalAll)
 	require.NoError(t, err, "GetDocument 2")
 	require.NotNil(t, doc, "GetDocument 2")

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -804,7 +804,7 @@ function(doc, oldDoc) {
 	RequireStatus(t, response, 200)
 
 	// Wait for notification
-	require.True(t, db.WaitForUserWaiterChange(userWaiter))
+	db.WaitForUserWaiterChange(t, userWaiter)
 
 	// Attempt to send the doc again, should succeed if the blip context also received notification
 	bt.SendRev(
@@ -1317,7 +1317,7 @@ func TestReloadUser(t *testing.T) {
 	RequireStatus(t, response, 201)
 
 	// Wait for notification
-	require.True(t, db.WaitForUserWaiterChange(userWaiter))
+	db.WaitForUserWaiterChange(t, userWaiter)
 
 	// Add a doc in the PBS channel
 	addRevResponse := bt.SendRev(

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -410,7 +410,7 @@ func TestCVPopulationOnChangesViaAPI(t *testing.T) {
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+DocID, `{"channels": ["ABC"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	require.NoError(t, collection.WaitForPendingChanges(t.Context()))
+	rt.WaitForPendingChanges()
 
 	changes := rt.WaitForChanges(1, "/{{.keyspace}}/_changes?version_type=cv", "", true)
 
@@ -439,7 +439,7 @@ func TestCVPopulationOnDocIDChanges(t *testing.T) {
 	resp := rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/"+DocID, `{"channels": ["ABC"]}`)
 	RequireStatus(t, resp, http.StatusCreated)
 
-	require.NoError(t, collection.WaitForPendingChanges(base.TestCtx(t)))
+	rt.WaitForPendingChanges()
 
 	changes := rt.WaitForChanges(1, fmt.Sprintf(`/{{.keyspace}}/_changes?version_type=cv&filter=_doc_ids&doc_ids=%s`, DocID), "", true)
 

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -953,7 +953,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	collection, _ := rt.GetSingleTestDatabaseCollection()
 
 	rt.CreateUser("bernard", []string{"PBS"})
 
@@ -961,7 +961,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	db.WriteDirect(t, collection, []string{"PBS"}, 2)
 	db.WriteDirect(t, collection, []string{"PBS"}, 5)
 	db.WriteDirect(t, collection, []string{"PBS"}, 6)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 6))
+	rt.WaitForSequenceNotSkipped(6)
 
 	// Check the _changes feed:
 	rt.WaitForPendingChanges()
@@ -991,7 +991,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
 	db.WriteDirect(t, collection, []string{"PBS"}, 7)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 7))
+	rt.WaitForSequenceNotSkipped(7)
 
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1027,7 +1027,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	collection, _ := rt.GetSingleTestDatabaseCollection()
 
 	rt.CreateUser("bernard", []string{"PBS"})
 
@@ -1036,7 +1036,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	db.WriteDirect(t, collection, []string{"PBS"}, 3)
 	db.WriteDirect(t, collection, []string{"PBS"}, 4)
 	db.WriteDirect(t, collection, []string{"PBS"}, 5)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 5))
+	rt.WaitForSequenceNotSkipped(5)
 
 	// Check the _changes feed:
 	rt.WaitForPendingChanges()
@@ -1051,7 +1051,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	db.WriteDirect(t, collection, []string{"PBS"}, 8)
 	db.WriteDirect(t, collection, []string{"PBS"}, 9)
 	db.WriteDirect(t, collection, []string{"PBS"}, 10)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 10))
+	rt.WaitForSequenceNotSkipped(10)
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1063,7 +1063,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Write a few more docs
 	db.WriteDirect(t, collection, []string{"PBS"}, 11)
 	db.WriteDirect(t, collection, []string{"PBS"}, 12)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 12))
+	rt.WaitForSequenceNotSkipped(12)
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1147,7 +1147,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 
 	const user = "alice"
 	rt.CreateUser(user, []string{"PBS"})
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	collection, _ := rt.GetSingleTestDatabaseCollection()
 
 	// Simulate 5 non-skipped writes (seq 1,2,3,4,5)
 	db.WriteDirect(t, collection, []string{"PBS"}, 1)
@@ -1155,7 +1155,8 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	db.WriteDirect(t, collection, []string{"PBS"}, 3)
 	db.WriteDirect(t, collection, []string{"PBS"}, 4)
 	db.WriteDirect(t, collection, []string{"PBS"}, 5)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 5))
+	rt.WaitForSequenceNotSkipped(5)
+
 	// Check the _changes feed:
 	rt.WaitForPendingChanges()
 	changes := rt.GetChanges("/{{.keyspace}}/_changes", user)
@@ -1169,7 +1170,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	db.WriteDirect(t, collection, []string{"PBS"}, 8)
 	db.WriteDirect(t, collection, []string{"PBS"}, 9)
 	db.WriteDirect(t, collection, []string{"PBS"}, 10)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 10))
+	rt.WaitForSequenceNotSkipped(10)
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1181,7 +1182,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Write a few more docs
 	db.WriteDirect(t, collection, []string{"PBS"}, 11)
 	db.WriteDirect(t, collection, []string{"PBS"}, 12)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 12))
+	rt.WaitForSequenceNotSkipped(12)
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1265,7 +1266,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	rt := rest.NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
+	collection, _ := rt.GetSingleTestDatabaseCollection()
 
 	rt.CreateUser("bernard", []string{"PBS"})
 
@@ -1274,7 +1275,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	db.WriteDirect(t, collection, []string{"PBS"}, 3)
 	db.WriteDirect(t, collection, []string{"PBS"}, 4)
 	db.WriteDirect(t, collection, []string{"PBS"}, 5)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 5))
+	rt.WaitForSequenceNotSkipped(5)
 
 	// Check the _changes feed:
 	rt.WaitForPendingChanges()
@@ -1289,7 +1290,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	db.WriteDirect(t, collection, []string{"PBS"}, 8)
 	db.WriteDirect(t, collection, []string{"PBS"}, 9)
 	db.WriteDirect(t, collection, []string{"PBS"}, 10)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 10))
+	rt.WaitForSequenceNotSkipped(10)
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1301,7 +1302,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Write a few more docs
 	db.WriteDirect(t, collection, []string{"PBS"}, 11)
 	db.WriteDirect(t, collection, []string{"PBS"}, 12)
-	require.NoError(t, collection.WaitForSequenceNotSkipped(ctx, 12))
+	rt.WaitForSequenceNotSkipped(12)
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -655,7 +655,7 @@ func (h *handler) handlePutDoc() error {
 	}
 
 	if doc != nil && roundTrip {
-		if err := h.collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
+		if err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
 			return err
 		}
 	}
@@ -732,7 +732,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 	}
 
 	if doc != nil && roundTrip {
-		if err := h.collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
+		if err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence); err != nil {
 			return err
 		}
 	}
@@ -767,7 +767,7 @@ func (h *handler) handlePostDoc() error {
 	}
 
 	if doc != nil && roundTrip {
-		err := h.collection.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence)
+		err := h.db.WaitForSequenceNotSkipped(h.ctx(), doc.Sequence)
 		if err != nil {
 			return err
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -619,16 +619,12 @@ func (rt *RestTester) SequenceForDoc(docid string) (seq uint64) {
 
 // WaitForSequence waits for the sequence to be buffered by the channel cache
 func (rt *RestTester) WaitForSequence(seq uint64) {
-	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	require.NoError(rt.TB(), collection.WaitForSequence(ctx, seq))
+	rt.GetDatabase().WaitForSequence(rt.TB(), seq)
 }
 
 // WaitForPendingChanges waits all outstanding changes to be buffered by the channel cache.
 func (rt *RestTester) WaitForPendingChanges() {
-	ctx := rt.Context()
-	for _, collection := range rt.GetDbCollections() {
-		require.NoError(rt.TB(), collection.WaitForPendingChanges(ctx))
-	}
+	rt.GetDatabase().WaitForPendingChanges(rt.TB())
 }
 
 // SetAdminParty toggles the guest user between disabled and enabled.  If enabled, the guest user is given access to the UserStar channel on all collections.

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -513,6 +513,12 @@ func (rt *RestTester) PutDocWithAttachment(docID string, body string, attachment
 	return rt.PutDoc(docID, string(newBody))
 }
 
+// WaitForSequenceNotSkipped will wait until the specified sequence is no longer in the skipped list. Fails the
+// test harness if the sequence remains in the skipped list after timeout.
+func (rt *RestTester) WaitForSequenceNotSkipped(sequence uint64) {
+	require.NoError(rt.TB(), rt.GetDatabase().WaitForSequenceNotSkipped(rt.Context(), sequence))
+}
+
 type RawDocResponse struct {
 	Xattrs RawDocXattrs `json:"_xattrs"`
 }


### PR DESCRIPTION
- sequences are allocated per database, not per collection. Move the functions to DatabaseContext to make this more clear
- Move the assertions into common functions to not have to require.NoError outside the test functions
- Move DefaultWaitForSequence into change cache code. This constant might be modified globally in certain test circumstances to find issues with change cache.

This is prep work for fixing CBG-5201, since `DefaultWaitForSequence` can need to get modified if the caching feed slows down.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/305/ (known failure in `TestResyncWithoutIndexes`)
