### PR TITLE
Remove verbose logging from tests

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1614,8 +1614,6 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 func TestGetXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 
-	SetUpTestLogging(t, LevelDebug, KeyAll)
-
 	ctx := TestCtx(t)
 	bucket := GetTestBucket(t)
 	defer bucket.Close(ctx)
@@ -1699,8 +1697,6 @@ func TestGetXattr(t *testing.T) {
 
 func TestGetXattrAndBody(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
-
-	SetUpTestLogging(t, LevelDebug, KeyAll)
 
 	ctx := TestCtx(t)
 	bucket := GetTestBucket(t)
@@ -2395,7 +2391,6 @@ func TestUpsertOptionPreserveExpiry(t *testing.T) {
 	if !bucket.IsSupported(sgbucket.BucketStoreFeaturePreserveExpiry) {
 		t.Skip("Preserve expiry is not supported with this CBS version. Skipping test...")
 	}
-	SetUpTestLogging(t, LevelInfo, KeyAll)
 
 	testCases := []struct {
 		name          string

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -443,8 +443,6 @@ func TestResumeStoppedFeed(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	SetUpTestLogging(t, LevelDebug, KeyAll)
-
 	ctx := TestCtx(t)
 	bucket := GetTestBucket(t)
 	defer bucket.Close(ctx)

--- a/base/rlimit_test.go
+++ b/base/rlimit_test.go
@@ -51,7 +51,6 @@ func TestGetSoftFDLimitWithCurrent(t *testing.T) {
 }
 
 func TestSetMaxFileDescriptors(t *testing.T) {
-	SetUpTestLogging(t, LevelDebug, KeyAll)
 
 	// grab current limits
 	var startLimits syscall.Rlimit

--- a/base/util_logging_mutex_test.go
+++ b/base/util_logging_mutex_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestLoggingMutex(t *testing.T) {
-	SetUpTestLogging(t, LevelTrace, KeyAll)
 
 	tests := []struct {
 		name     string
@@ -50,7 +49,6 @@ func TestLoggingMutex(t *testing.T) {
 }
 
 func TestLoggingRWMutex(t *testing.T) {
-	SetUpTestLogging(t, LevelTrace, KeyAll)
 
 	tests := []struct {
 		name     string

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -582,7 +582,6 @@ func TestMetaMap(t *testing.T) {
 }
 
 func TestNilMetaMap(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	ctx := base.TestCtx(t)
 	mapper := NewChannelMapper(ctx, `function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.val);}`, 0)
 

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -249,7 +249,6 @@ func TestAttachmentCleanupRollback(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server since it requires DCP")
 	}
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	dbcOptions := DatabaseContextOptions{
 		Scopes: GetScopesOptionsDefaultCollectionOnly(t),
 	}
@@ -961,8 +960,6 @@ func TestAttachmentCompactIncorrectStat(t *testing.T) {
 	testDb, ctx := setupTestDBDefaultCollection(t)
 	defer testDb.Close(ctx)
 	dataStore := testDb.Bucket.DefaultDataStore()
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, testDb)
 	collectionID := collection.GetCollectionID()

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -33,7 +33,6 @@ func unmarshalBody(t *testing.T, j string) Body {
 }
 
 func TestBackupOldRevisionWithAttachments(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	deltasEnabled := base.IsEnterpriseEdition()
 
@@ -110,7 +109,6 @@ func TestGetBackupRevisionWhenCurrentRevisionHasAttachments(t *testing.T) {
 	if base.TestDisableRevCache() {
 		t.Skip("pending fix in CBG-5141")
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		// enable delta sync so CV revs are backed up
@@ -529,7 +527,6 @@ func TestForEachStubAttachmentErrors(t *testing.T) {
 }
 
 func TestGenerateProofOfAttachment(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	attData := []byte(`hello world`)
 	ctx := base.TestCtx(t)
@@ -773,7 +770,6 @@ func TestStoreAttachments(t *testing.T) {
 
 // TestMigrateBodyAttachments will set up a document with an attachment in pre-2.5 metadata format, and test various upgrade scenarios.
 func TestMigrateBodyAttachments(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	const docKey = "TestMigrateBodyAttachments"
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2034,7 +2034,6 @@ func BenchmarkDocChanged(b *testing.B) {
 //   - Assert that the length of slice stat is equal to the length of the skipped sequence slice + assert that number of
 //     sequences skipped overall stat is correct
 func TestProcessSkippedEntry(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
@@ -2110,7 +2109,6 @@ func TestProcessSkippedEntry(t *testing.T) {
 //   - Push some sequences that are skipped onto the cache and assert that the stats: number of current skipped sequences,
 //     length of slice, cumulative number of skipped sequences and capacity of slice are all updated as expected
 func TestProcessSkippedEntryStats(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
@@ -2187,8 +2185,6 @@ func TestProcessSkippedEntryStats(t *testing.T) {
 //   - Assert that the skipped slice eventually ends up with 0 length and the number of abandoned sequences are as expected
 func TestSkippedSequenceCompact(t *testing.T) {
 	base.LongRunningTest(t)
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
@@ -3177,8 +3173,6 @@ func TestChangeInBroadcastForSkipped(t *testing.T) {
 
 func TestUnblockPendingWithUnusedRange(t *testing.T) {
 	base.LongRunningTest(t)
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	opts := DefaultCacheOptions()
 	opts.CachePendingSeqMaxWait = 20 * time.Minute

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -202,8 +202,6 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  See https://gist.github.com/tleyden/a41632355fadde54f19e84ba68015512")
 	}
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -69,8 +69,6 @@ func getRevTreeList(ctx context.Context, dataStore sgbucket.DataStore, key strin
 // Tests simple retrieval of rev not resident in the cache
 func TestRevisionCacheLoad(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	db, ctx := setupTestDBWithViewsEnabled(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
@@ -110,7 +108,6 @@ func TestRevisionCacheLoad(t *testing.T) {
 }
 
 func TestHasAttachmentsFlag(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
@@ -188,8 +185,6 @@ func TestHasAttachmentsFlag(t *testing.T) {
 // TestRevisionStorageConflictAndTombstones
 // Tests permutations of inline and external storage of conflicts and tombstones
 func TestRevisionStorageConflictAndTombstones(t *testing.T) {
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db, ctx := setupTestDBAllowConflicts(t)
 	defer db.Close(ctx)
@@ -1606,7 +1601,6 @@ func TestAssignSequenceReleaseLoop(t *testing.T) {
 //   - Assert we release a sequence for this
 func TestReleaseSequenceOnDocWriteFailure(t *testing.T) {
 	defer SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	var ctx context.Context
 	var db *Database
@@ -1720,7 +1714,6 @@ func TestDocUpdateCorruptSequence(t *testing.T) {
 }
 
 func TestPutResurrection(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -174,8 +174,6 @@ func assertHTTPError(t *testing.T, err error, status int) bool {
 
 func TestDatabase(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
@@ -302,7 +300,6 @@ func TestDatabase(t *testing.T) {
 
 // TestCheckProposedVersion ensures that a given CV will return the appropriate status based on the information present in the HLV.
 func TestCheckProposedVersion(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -429,7 +426,6 @@ func TestCheckProposedVersion(t *testing.T) {
 }
 
 func TestUpsertTestDocVersion(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -447,7 +443,6 @@ func TestUpsertTestDocVersion(t *testing.T) {
 
 // TestCheckProposedVersionWithHLVRev tests CheckProposedVersion when the full HLV is provided in the rev element of the proposeChanges message
 func TestCheckProposedVersionWithHLVRev(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -846,7 +841,6 @@ func TestGetRemovedAsUser(t *testing.T) {
 }
 
 func TestFetchRevisionBackupWithCollectionAccess(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -1031,7 +1025,6 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 }
 
 func TestDeltaSyncWhenFromRevIsLegacyRevTreeID(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta sync only supported in EE")
@@ -1066,7 +1059,6 @@ func TestDeltaSyncWhenFromRevIsLegacyRevTreeID(t *testing.T) {
 }
 
 func TestFetchCurrentRevAfterFetchBackupRevByCV(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		// enable delta sync other wise CV keyed backup revs won't be stored
 		DeltaSyncOptions: DeltaSyncOptions{
@@ -1111,7 +1103,6 @@ func TestFetchCurrentRevAfterFetchBackupRevByCV(t *testing.T) {
 }
 
 func TestFetchCurrentRevAfterFetchBackupRevByRevID(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
 
@@ -3952,7 +3943,6 @@ func Test_updateAllPrincipalsSequences(t *testing.T) {
 func Test_invalidateAllPrincipalsCache(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{AllowConflicts: base.Ptr(true)})
 	defer db.Close(ctx)
 

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -769,7 +769,6 @@ func TestWebhookTimeout(t *testing.T) {
 	terminator := make(chan bool)
 	defer close(terminator)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	ts, wr := InitWebhookTest()
 	defer ts.Close()
 	url := ts.URL

--- a/db/functions/function_test.go
+++ b/db/functions/function_test.go
@@ -175,7 +175,6 @@ func addUserAlice(t *testing.T, db *db.Database) auth.User {
 func TestUserFunctions(t *testing.T) {
 	base.LongRunningTest(t)
 
-	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, &kUserFunctionConfig)
 	defer db.Close(ctx)
 
@@ -332,7 +331,6 @@ func testUserFunctionsAsUser(t *testing.T, ctx context.Context, db *db.Database)
 
 // Test CRUD operations
 func TestUserFunctionsCRUD(t *testing.T) {
-	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	dbCtx, ctx := setupTestDBWithFunctions(t, &kUserFunctionConfig)
 	defer dbCtx.Close(ctx)
 
@@ -477,7 +475,6 @@ func TestUserFunctionsMaxCodeSize(t *testing.T) {
 
 // Low-level test of channel-name parameter expansion for user query/function auth
 func TestUserFunctionAllow(t *testing.T) {
-	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, &kUserFunctionConfig)
 	defer db.Close(ctx)
 

--- a/db/functions/n1ql_function_test.go
+++ b/db/functions/n1ql_function_test.go
@@ -102,7 +102,6 @@ func TestUserN1QLQueries(t *testing.T) {
 		t.Skip("Requires collection-aware function security (CBG-2597)")
 	}
 
-	// base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	db, ctx := setupTestDBWithFunctions(t, &kUserN1QLFunctionsConfig)
 	defer db.Close(ctx)
 

--- a/db/indextest/indextest_test.go
+++ b/db/indextest/indextest_test.go
@@ -424,8 +424,6 @@ func testGetIndexesMeta(t *testing.T, database *db.Database, indexInitOptions db
 // TestInitializeIndexesConcurrentMultiNode simulates a large multi-node SG cluster starting up and racing to create indexes.
 func TestInitializeIndexesConcurrentMultiNode(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
 	// Pick a high enough number that it's likely to trigger the concurrent/race conditions we're testing for.
 	//
 	// This number doesn't significantly increase test time since, since there's still the same number of indexes being created.

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -698,7 +698,6 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 	if base.TestDisableRevCache() {
 		t.Skip("Revision cache expected to be used for this test")
 	}
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
@@ -743,8 +742,6 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 
 // Ensure attachment properties aren't being incorrectly stored in revision cache body when inserted via PutExistingRev
 func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -98,7 +98,6 @@ func TestParseRevisionsToAncestor(t *testing.T) {
 
 // TestBackupOldRevision ensures that old revisions are kept around temporarily for in-flight requests and delta sync purposes.
 func TestBackupOldRevision(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	deltasEnabled := base.IsEnterpriseEdition()
 	xattrsEnabled := base.TestUseXattrs()

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -490,7 +490,6 @@ func TestSingleNodeNextSeqGreaterThanRollbackHandling(t *testing.T) {
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	sgw, err := base.NewSyncGatewayStats()
 	require.NoError(t, err)
@@ -659,7 +658,6 @@ func TestSyncSeqRollbackMultiNode(t *testing.T) {
 //   - Trigger new allocation of batch on that node, and assert the _sync:seq document is corrected
 //   - Trigger new batch allocation on node a and assert that batch is unique
 func TestFiveNodeRollbackMiddleNodesDetects(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	ctx := base.TestCtx(t)
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close(ctx)

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -670,7 +670,6 @@ func TestIsCfgChanged(t *testing.T) {
 
 // Test replicators assigned nodes with different group IDs
 func TestReplicateGroupIDAssignedNodes(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
 	defer tb.Close(ctx)

--- a/db/skipped_sequence_test.go
+++ b/db/skipped_sequence_test.go
@@ -595,7 +595,6 @@ func BenchmarkInsertSkippedItem(b *testing.B) {
 //   - Run compact and assert that each item is compacted apart from the last added item
 //   - Assert on number sequences removed
 func TestCompactSkippedList(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	testCases := []struct {
 		name       string
@@ -666,7 +665,6 @@ func TestCompactSkippedList(t *testing.T) {
 }
 
 func BenchmarkCompactSkippedList(b *testing.B) {
-	base.SetUpTestLogging(b, base.LevelError, base.KeyAll)
 	benchmarks := []struct {
 		name         string
 		rangeEntries bool

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -1589,8 +1589,6 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
-
 	// CBG-1513: This test is prone to panicing when the walrus bucket was closed and still used
 	assert.NotPanicsf(t, func() {
 		rt := rest.NewRestTester(t, nil)
@@ -2634,7 +2632,6 @@ func TestConfigEndpoint(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
 			base.ResetGlobalTestLogging(t)
-			base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 			base.InitializeMemoryLoggers()
 			tempDir := os.TempDir()
@@ -2674,7 +2671,7 @@ func TestConfigEndpoint(t *testing.T) {
 }
 
 func TestLoggingDeprecationWarning(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	base.ResetGlobalTestLogging(t)
 
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
@@ -2700,7 +2697,6 @@ func TestLoggingDeprecationWarning(t *testing.T) {
 }
 
 func TestInitialStartupConfig(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
@@ -2736,7 +2732,6 @@ func TestInitialStartupConfig(t *testing.T) {
 
 func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	base.ResetGlobalTestLogging(t)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	base.InitializeMemoryLoggers()
 	tempDir := os.TempDir()

--- a/rest/adminapitest/collections_admin_api_test.go
+++ b/rest/adminapitest/collections_admin_api_test.go
@@ -173,7 +173,6 @@ func TestRequireResync(t *testing.T) {
 	}
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &rest.RestTesterConfig{
 		PersistentConfig: true,
 	}

--- a/rest/adminapitest/resync_test.go
+++ b/rest/adminapitest/resync_test.go
@@ -321,7 +321,6 @@ func TestResyncDoesNotWriteDocBody(t *testing.T) {
 	}
 	base.SkipImportTestsIfNotEnabled(t) // test requires import
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		PersistentConfig: true,
 	})

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -282,7 +282,6 @@ func TestMultiCollectionChannelAccess(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.TestRequiresCollections(t)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	tb := base.GetTestBucket(t)
@@ -972,7 +971,6 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 func TestRaceBetweenConfigPollAndDbConfigUpdate(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	base.TestRequiresCollections(t)
 
 	ctx := base.TestCtx(t)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1959,8 +1959,6 @@ func TestDocIDFilterResurrection(t *testing.T) {
 
 func TestChanCacheActiveRevsStat(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,
 	})
@@ -2532,7 +2530,6 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 		t.Skip("Test requires xattrs to be enabled")
 	}
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: `function(doc,oldDoc){
 			console.log("doc:"+JSON.stringify(doc))
@@ -2572,7 +2569,6 @@ func TestTombstonedBulkDocsWithExistingTombstone(t *testing.T) {
 		t.Skip("Test requires xattrs to be enabled")
 	}
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: `function(doc,oldDoc){
 			console.log("doc:"+JSON.stringify(doc))

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -141,7 +141,6 @@ func TestSetupAndValidate(t *testing.T) {
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("Skipping this test; it only works on Walrus bucket")
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	t.Run("Run setupAndValidate with valid config", func(t *testing.T) {
 		configFile := createTempFile(t, []byte(`{
           "databases": {

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -36,7 +36,6 @@ import (
 
 // Validate that Etag header value is surrounded with double quotes, see issue #808
 func TestDocEtag(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{GuestEnabled: true})
 	defer rt.Close()
@@ -2130,7 +2129,6 @@ func TestAttachmentRemovalWithConflicts(t *testing.T) {
 }
 
 func TestAttachmentsMissing(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
@@ -2156,7 +2154,6 @@ func TestAttachmentsMissing(t *testing.T) {
 }
 
 func TestAttachmentsMissingNoBody(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
@@ -2217,7 +2214,6 @@ func TestAttachmentDeleteOnPurge(t *testing.T) {
 func TestAttachmentDeleteOnExpiry(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{PersistentConfig: true})
 	defer rt.Close()
 
@@ -2500,7 +2496,6 @@ func TestProveAttachmentNotFound(t *testing.T) {
 
 	// Should log:
 	// "Peer sent prove attachment error 404 attachment not found, falling back to getAttachment for proof in doc <ud>doc1</ud> (digest sha1-wzp8ZyykdEuZ9GuqmxQ7XDrY7Co=)"
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// Use different attachment name to bypass digest check in ForEachStubAttachment() which skips prove attachment code
 	// Set attachment to V2 so it can be retrieved by RT successfully

--- a/rest/attachmentcompactiontest/attachment_compaction_api_test.go
+++ b/rest/attachmentcompactiontest/attachment_compaction_api_test.go
@@ -383,7 +383,6 @@ func TestAttachmentCompactionMarkPhaseRollback(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 	var garbageVBUUID gocbcore.VbUUID = 1234
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := rest.NewRestTesterDefaultCollection(t, nil)
 	defer rt.Close()

--- a/rest/attachmentmigrationtest/attachment_migration_test.go
+++ b/rest/attachmentmigrationtest/attachment_migration_test.go
@@ -50,7 +50,6 @@ func TestChangeDbCollectionsRestartMigrationJob(t *testing.T) {
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	tb := base.GetTestBucket(t)
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket: tb,
@@ -146,7 +145,6 @@ func TestMigrationNewCollectionToDbNoRestart(t *testing.T) {
 	base.TestRequiresOneShotDCPClient(t)
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	tb := base.GetTestBucket(t)
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket: tb,
@@ -245,7 +243,6 @@ func TestMigrationNoReRunStartStopDb(t *testing.T) {
 	base.TestRequiresOneShotDCPClient(t)
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 2)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	tb := base.GetTestBucket(t)
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket: tb,
@@ -324,7 +321,6 @@ func TestStartMigrationAlreadyRunningProcess(t *testing.T) {
 	base.TestRequiresOneShotDCPClient(t)
 	base.TestRequiresCollections(t)
 	base.RequireNumTestDataStores(t, 1)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	tb := base.GetTestBucket(t)
 	rtConfig := &rest.RestTesterConfig{
 		CustomTestBucket: tb,

--- a/rest/blip_api_attachment_test.go
+++ b/rest/blip_api_attachment_test.go
@@ -34,7 +34,6 @@ import (
 func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
@@ -103,7 +102,6 @@ func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
 func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
 			DbConfig: DbConfig{
@@ -169,7 +167,6 @@ func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 func TestBlipProveAttachmentV2(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -227,7 +224,6 @@ func TestBlipProveAttachmentV2(t *testing.T) {
 func TestBlipProveAttachmentV2Push(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -613,7 +609,6 @@ func TestBlipLegacyAttachNameChange(t *testing.T) {
 func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -686,7 +681,6 @@ func TestBlipLegacyAttachDocUpdate(t *testing.T) {
 func TestPushDocWithNonRootAttachmentProperty(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &RestTesterConfig{
 		GuestEnabled: true,
 	}

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1709,7 +1709,6 @@ func TestPutRevV4(t *testing.T) {
 // Actual:
 // - Same as Expected (this test is unable to repro SG #3281, but is being left in as a regression test)
 func TestGetRemovedDoc(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
@@ -2018,7 +2017,6 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -2073,7 +2071,6 @@ func TestPullReplicationUpdateOnOtherHLVAwarePeer(t *testing.T) {
 func TestBlipClientSendDelete(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}
@@ -2133,8 +2130,6 @@ func TestActiveOnlyContinuous(t *testing.T) {
 // Test that exercises Sync Gateway's norev handler
 func TestBlipNorev(t *testing.T) {
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 	btcRunner := NewBlipTesterClientRunner(t)
 
@@ -2187,7 +2182,6 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	base.LongRunningTest(t)
 
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
@@ -2270,7 +2264,6 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 	base.LongRunningTest(t)
 
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	btcRunner := NewBlipTesterClientRunner(t)
 
@@ -2342,8 +2335,6 @@ func TestRemovedMessageWithAlternateAccessAndChannelFilteredReplication(t *testi
 // sub changes request has completed
 func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	base.LongRunningTest(t)
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	// TODO: CBG-2653: change this to use NewBlipTester
 	bt := NewBlipTesterDefaultCollection(t)
@@ -2811,7 +2802,6 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 func TestUnsubChanges(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rtConfig := &RestTesterConfig{GuestEnabled: true}
 
 	btcRunner := NewBlipTesterClientRunner(t)
@@ -3533,7 +3523,6 @@ func TestPushHLVOntoLegacyRev(t *testing.T) {
 func TestTombstoneCount(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		GuestEnabled: true,
 	}

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -25,7 +25,6 @@ import (
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.
 func TestBlipDeltaSyncPushAttachment(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -108,7 +107,6 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 
 // TestDeltaWithAttachmentJsonProperty tests pushing a delta when _attachments is present in either delta or existing doc
 func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
@@ -215,7 +213,6 @@ func TestDeltaWithAttachmentJsonProperty(t *testing.T) {
 // 5. Update doc in the test client by adding another attachment
 // 6. Have that update pushed using delta sync via the continuous replication started in step 2
 func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -282,8 +279,6 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 // to the temporary "allowedAttachments" map.
 func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 	base.LongRunningTest(t)
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -372,8 +367,6 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 func TestBlipDeltaSyncPull(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -447,8 +440,6 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Enterprise-only test for delta sync")
 	}
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -549,8 +540,6 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
@@ -614,8 +603,6 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 // └──────────────┘ └───────────────────────────────────┘
 func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 	base.LongRunningTest(t)
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := &RestTesterConfig{
@@ -864,8 +851,6 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		t.Skip("rev cache specific test")
 	}
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1099,7 +1084,6 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 func TestBlipNonDeltaSyncPush(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
@@ -1156,7 +1140,6 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 func TestSendDeltaWhenDeltaCalculatedFromBackup(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skipf("Skipping enterprise-only delta sync test.")
 	}
@@ -1234,7 +1217,6 @@ func TestBlipDeltaNoAccessPush(t *testing.T) {
 }
 
 func TestBlipDeltaComputationFromBackupRev(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -1282,7 +1264,6 @@ func TestBlipDeltaComputationFromBackupRev(t *testing.T) {
 
 // TestDeltaGenerationWithBypassRevCache tests that delta generation works when the rev cache is bypassed.
 func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -1332,7 +1313,6 @@ func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
 }
 
 func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
@@ -1438,7 +1418,6 @@ func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
 }
 
 func TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}

--- a/rest/blip_api_replication_test.go
+++ b/rest/blip_api_replication_test.go
@@ -23,7 +23,6 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("Skipping test that requires xattrs")
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			CacheConfig: &CacheConfig{
@@ -96,8 +95,6 @@ func TestReplicationBroadcastTickerChange(t *testing.T) {
 // TestBlipClientPushAndPullReplication sets up a bidi replication for a BlipTesterClient, writes documents on SG and the client and ensures they replicate.
 func TestBlipClientPushAndPullReplication(t *testing.T) {
 	base.LongRunningTest(t)
-
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{}},

--- a/rest/changes_test.go
+++ b/rest/changes_test.go
@@ -268,8 +268,6 @@ func TestJumpInSequencesAtAllocatorSkippedSequenceFill(t *testing.T) {
 		t.Skip("This test requires xattrs because it writes directly to the xattr")
 	}
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			AutoImport: false,
@@ -337,8 +335,6 @@ func TestJumpInSequencesAtAllocatorRangeInPending(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test requires xattrs because it writes directly to the xattr")
 	}
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{

--- a/rest/changestest/changes_api_test.go
+++ b/rest/changestest/changes_api_test.go
@@ -35,8 +35,6 @@ func TestReproduce2383(t *testing.T) {
 		t.Skip("Skip LeakyBucket test when running in integration")
 	}
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 
@@ -291,8 +289,6 @@ func TestPostChangesUserTiming(t *testing.T) {
 }
 
 func TestPostChangesSinceInteger(t *testing.T) {
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{
@@ -887,7 +883,6 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 	for _, test := range tests {
 		testName := fmt.Sprintf("%v user:%v manualNotify:%t", test.feedType, test.username, test.manualNotify)
 		t.Run(testName, func(t *testing.T) {
-			base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 			rt := rest.NewRestTester(t, nil)
 			defer rt.Close()
@@ -3289,8 +3284,6 @@ func TestChangesLargeSequences(t *testing.T) {
 }
 
 func TestIncludeDocsWithPrincipals(t *testing.T) {
-
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -610,7 +610,6 @@ func TestAutoImportEnabled(t *testing.T) {
 }
 
 func TestMergeWith(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	defaultInterface := "4984"
 	adminInterface := "127.0.0.1:4985"
 	profileInterface := "127.0.0.1:4985"
@@ -681,7 +680,6 @@ func TestMergeWith(t *testing.T) {
 
 func TestSetupAndValidateLogging(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLogging")
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	sc := &StartupConfig{}
 	err := sc.SetupAndValidateLogging(base.TestCtx(t))
 	assert.NoError(t, err, "Setup and validate logging should be successful")
@@ -690,7 +688,6 @@ func TestSetupAndValidateLogging(t *testing.T) {
 
 func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLoggingWithLoggingConfig")
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	logFilePath := "/var/log/sync_gateway"
 	sc := &StartupConfig{Logging: base.LoggingConfig{LogFilePath: logFilePath, RedactionLevel: base.RedactFull}}
 	err := sc.SetupAndValidateLogging(base.TestCtx(t))
@@ -717,7 +714,6 @@ func TestAuditLogConfigDatabaseEventInGlobal(t *testing.T) {
 }
 
 func TestServerConfigValidate(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	// unsupported.stats_log_freq_secs
 	statsLogFrequencySecs := uint(9)
 	unsupported := &UnsupportedServerConfigLegacy{StatsLogFrequencySecs: &statsLogFrequencySecs}
@@ -962,7 +958,6 @@ func TestValidateServerContextSharedBuckets(t *testing.T) {
 		t.Skip("Skipping this test; requires Couchbase Bucket")
 	}
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	ctx := base.TestCtx(t)
 
 	tb1 := base.GetTestBucket(t)
@@ -1425,7 +1420,6 @@ func deleteTempFile(t *testing.T, file *os.File) {
 
 func TestDefaultLogging(t *testing.T) {
 	base.ResetGlobalTestLogging(t)
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	config := DefaultStartupConfig("")
 	assert.Equal(t, base.RedactPartial, config.Logging.RedactionLevel)
 	assert.Equal(t, true, base.RedactUserData)
@@ -1442,7 +1436,6 @@ func TestDefaultLogging(t *testing.T) {
 }
 
 func TestSetupServerContext(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	t.Run("Create server context with a valid configuration", func(t *testing.T) {
 		config := DefaultStartupConfig("")
 		config.Bootstrap.Server = base.UnitTestUrl() // Valid config requires server to be explicitly defined
@@ -1529,7 +1522,6 @@ func TestConfigGroupIDValidation(t *testing.T) {
 
 // CBG-1599
 func TestClientTLSMissing(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	errorTLSOneMissing := "both TLS Key Path and TLS Cert Path must be provided when using client TLS. Disable client TLS by not providing either of these options"
 	testCases := []struct {
 		name        string
@@ -3069,7 +3061,6 @@ func TestNotFoundOnInvalidDatabase(t *testing.T) {
 }
 
 func TestRevCacheMemoryLimitConfig(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	if base.TestDisableRevCache() {
 		t.Skip("test is rev cache config related test, should not override the test")
 	}

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -27,7 +27,6 @@ const accessControlAllowOrigin = "Access-Control-Allow-Origin"
 func TestCORSDynamicSet(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,
 	})

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -929,7 +929,6 @@ func TestGetUserDocAccessDuplicates(t *testing.T) {
 // Tests the Diagnostic Endpoint to dry run Sync Function
 func TestSyncFuncDryRun(t *testing.T) {
 	base.SkipImportTestsIfNotEnabled(t)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,
@@ -1698,7 +1697,6 @@ func TestSyncFuncDryRunUserXattrErrors(t *testing.T) {
 func TestImportFilterDryRun(t *testing.T) {
 
 	base.SkipImportTestsIfNotEnabled(t)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -107,8 +107,6 @@ func TestDocumentNumbers(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	for _, test := range tests {
 		rt.Run(test.name, func(ts *testing.T) {
 			// Create document

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -226,7 +226,6 @@ func TestShouldCheckAdminRBAC(t *testing.T) {
 }
 
 func TestHandlerRecoverLog(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 	testCases := []struct {
 		name       string
 		panicArg   any

--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -264,7 +264,6 @@ const collectionsDbConfigUpsertScopes = `{
 func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	base.SkipImportTestsIfNotEnabled(t)
 	base.RequireNumTestDataStores(t, 2)
 
@@ -360,7 +359,6 @@ func TestMultiCollectionImportRemoveCollection(t *testing.T) {
 
 	defer db.SuspendSequenceBatching()()
 	base.SkipImportTestsIfNotEnabled(t)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
 

--- a/rest/importtest/import_test.go
+++ b/rest/importtest/import_test.go
@@ -1901,7 +1901,6 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 // CBG-1995: Test the support for using an underscore prefix in the top-level body of a document
 // CBG-2023: Test preventing underscore attachments
 func TestImportInternalPropertiesHandling(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	testCases := []struct {
 		name               string
@@ -2109,7 +2108,6 @@ func TestNonImportedDuplicateID(t *testing.T) {
 }
 
 func TestImportOnWriteMigration(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	if !base.TestUseXattrs() {
 		t.Skip("Test requires xattrs to be enabled")
 	}

--- a/rest/importuserxattrtest/import_test.go
+++ b/rest/importuserxattrtest/import_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestUserXattrAutoImport(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	docKey := t.Name()
 	xattrKey := "myXattr"
@@ -139,7 +138,6 @@ func TestUserXattrAutoImport(t *testing.T) {
 }
 
 func TestUserXattrOnDemandImportGET(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	docKey := t.Name()
 	xattrKey := "myXattr"
@@ -232,7 +230,6 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 }
 
 func TestUserXattrOnDemandImportWrite(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	docKey := t.Name()
 	xattrKey := "myXattr"

--- a/rest/importuserxattrtest/revcache_test.go
+++ b/rest/importuserxattrtest/revcache_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestUserXattrRevCache(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	// need to disable sequence batching given two rest testers allocating sequence batches
 	// can mean that the changes feed has to wait for sequences from another to be released to
@@ -112,7 +111,6 @@ func TestUserXattrRevCache(t *testing.T) {
 
 func TestUserXattrDeleteWithRevCache(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	// Sync function to set channel access to a channels UserXattrKey

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	docKey := t.Name()
 	xattrKey := "myXattr"

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1124,7 +1124,6 @@ func TestOpenIDConnectImplicitFlowInitWithKeyspace(t *testing.T) {
 
 // TestOpenIDConnectImplicitFlowReuseToken ensures that requests that use the same token containing channel grants don't end up recomputing or updating the user for each use.
 func TestOpenIDConnectImplicitFlowReuseToken(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelTrace, base.KeyAll)
 	defer db.SuspendSequenceBatching()() // allows assertions on last sequence of the database to hold true when request plus is used
 
 	testProviders := auth.OIDCProviderMap{
@@ -1285,7 +1284,6 @@ func TestUserAPIReadOnlyFields(t *testing.T) {
 // TestAdminAndJWTChannels validates interaction between admin channels and JWT channels, to ensure each are preserved when
 // the other is changed
 func TestAdminAndJWTChannels(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	testProviders := auth.OIDCProviderMap{
 		"foo": mockProviderWith("foo", mockProviderUserPrefix{"foo"}, mockProviderChannelsClaim{"channels"}),
@@ -2371,7 +2369,6 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 	base.LongRunningTest(t)
 
 	// Modified copy of TestOpenIDConnectImplicitFlow
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	unreachableAddr := "http://0.0.0.0"
 	tests := []struct {
 		name                string

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -1583,7 +1583,6 @@ func TestActiveReplicatorHLVConflictCustom(t *testing.T) {
 			useRemoteRevTreeID:    false,
 		},
 	}
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) // test has flaked in jenkins, need to debug
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test
 	sgrRunner.RunSubprotocolV4(func(t *testing.T) {
@@ -2040,7 +2039,6 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	// v4 protocol only test

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -6786,7 +6786,6 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	}
 
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	sgrRunner := rest.NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {

--- a/rest/replicatortest/replicator_test_legacy_rev_test.go
+++ b/rest/replicatortest/replicator_test_legacy_rev_test.go
@@ -1015,7 +1015,6 @@ func TestActiveReplicatorConflictPreUpgradedVersionOneSide(t *testing.T) {
 
 func TestActiveReplicatorDeltaSyncWhenBothSidesLegacy(t *testing.T) {
 	base.RequireNumTestBuckets(t, 2)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	t.Skip("pending fix from CBG-5106")
 

--- a/rest/rest_tester_cluster_test.go
+++ b/rest/rest_tester_cluster_test.go
@@ -223,7 +223,6 @@ func TestPersistentDbConfigWithInvalidUpsert(t *testing.T) {
 
 // Ensures that a database remains offline when using async online with an invalid config that causes StartOnlineProcesses to fail.
 func TestPersistentDbConfigAsyncOnlineWithInvalidConfig(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,

--- a/rest/revocation_test.go
+++ b/rest/revocation_test.go
@@ -1121,7 +1121,6 @@ func TestRevocationsWithQueryLimit(t *testing.T) {
 
 func TestRevocationsWithQueryLimit2Channels(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	revocationTester, rt := InitScenario(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			AutoImport:           false,
@@ -1448,8 +1447,6 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 		t.Skipf("test is EE only - user xattrs")
 	}
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	xattrKey := "channelInfo"
 
 	revocationTester, rt := InitScenario(t, &RestTesterConfig{
@@ -1726,8 +1723,6 @@ func TestReplicatorRevocationsMultipleAlternateAccess(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestBuckets(t, 2)
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	sgrRunner := NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
@@ -2042,8 +2037,6 @@ func TestReplicatorRevocationsWithStarChannel(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll) // CBG-1981
-
 	sgrRunner := NewSGRTestRunner(t)
 	sgrRunner.Run(func(t *testing.T) {
 		// Passive
@@ -2257,8 +2250,6 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 func TestRevocationMessage(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	btcRunner := NewBlipTesterClientRunner(t)
 
 	btcRunner.Run(func(t *testing.T) {
@@ -2429,7 +2420,6 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 	base.LongRunningTest(t)
 
 	defer db.SuspendSequenceBatching()()
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	btcRunner := NewBlipTesterClientRunner(t)
 	const docID = "doc"
 	const waitMarkerID = "docmarker"
@@ -2513,8 +2503,6 @@ func TestRevocationGetSyncDataError(t *testing.T) {
 func TestBlipRevokeNonExistentRole(t *testing.T) {
 	base.LongRunningTest(t)
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
 	btcRunner := NewBlipTesterClientRunner(t)
 
 	btcRunner.Run(func(t *testing.T) {
@@ -2557,8 +2545,6 @@ func TestBlipRevokeNonExistentRole(t *testing.T) {
 
 func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	base.LongRunningTest(t)
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	defer db.SuspendSequenceBatching()()
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -249,7 +249,6 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 }
 
 func TestStatsLoggerStopped(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	sc := DefaultStartupConfig("")
 
@@ -361,7 +360,6 @@ outerLoop:
 }
 
 func TestStartAndStopHTTPServers(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	sc, closeFn := StartBootstrapServer(t)
 	defer closeFn()
@@ -486,7 +484,6 @@ func TestTLSSkipVerifyGetBucketSpec(t *testing.T) {
 
 // CBG-1535 - test Bootstrap.UseTLSServer option
 func TestUseTLSServer(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 	errorMustBeSecure := "Must use secure scheme in Couchbase Server URL, or opt out by setting bootstrap.use_tls_server to false. Current URL: %v"
 	errorAllowInsecureAndBeSecure := "Couchbase server URL cannot use secure protocol when bootstrap.use_tls_server is false. Current URL: %v"
 	testCases := []struct {
@@ -667,7 +664,6 @@ func TestLogFlush(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 			// Setup memory logging
 			base.InitializeMemoryLoggers()
@@ -818,8 +814,6 @@ func TestOfflineDatabaseStartup(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("TestOfflineDatabaseStartup requires xattrs for document import")
 	}
-
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
@@ -1062,7 +1056,6 @@ func TestDatabaseCollectionDeletedErrorState(t *testing.T) {
 }
 
 func TestCollectStackTraceFile(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
 
 	tempPath := t.TempDir()
 	serverConfig := DefaultStartupConfig(tempPath)

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -506,8 +506,6 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		}
 	}`
 
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
-
 	rt := NewRestTester(t,
 		&RestTesterConfig{
 			SyncFn: syncFn,

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -1089,8 +1089,6 @@ func TestRemovingUserXattr(t *testing.T) {
 
 	defer db.SuspendSequenceBatching()()
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	testCases := []struct {
 		name          string
 		autoImport    bool
@@ -1201,7 +1199,6 @@ func TestGetUserCollectionAccess(t *testing.T) {
 
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	testBucket := base.GetTestBucket(t)
@@ -1374,7 +1371,6 @@ func TestPutUserCollectionAccess(t *testing.T) {
 	base.LongRunningTest(t)
 
 	base.RequireNumTestDataStores(t, 2)
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 	testBucket := base.GetTestBucket(t)
 
 	scopesConfig := GetCollectionsConfig(t, testBucket, 2)

--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -29,7 +29,6 @@ import (
 // TestX509RoundtripUsingIP is a happy-path roundtrip write test for SG connecting to CBS using valid X.509 certs for authentication.
 // The test enforces SG connects using an IP address which is also present in the node cert.
 func TestX509RoundtripUsingIP(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	tb, _, _, _ := setupX509Tests(t, true)
@@ -49,7 +48,6 @@ func TestX509RoundtripUsingIP(t *testing.T) {
 // TestX509RoundtripUsingDomain is a happy-path roundtrip write test for SG connecting to CBS using valid X.509 certs for authentication.
 // The test enforces SG connects using a domain name which is also present in the node cert.
 func TestX509RoundtripUsingDomain(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	tb, _, _, _ := setupX509Tests(t, false)
@@ -67,7 +65,6 @@ func TestX509RoundtripUsingDomain(t *testing.T) {
 }
 
 func TestX509UnknownAuthorityWrap(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	ctx := base.TestCtx(t)
 	tb, _, _, _ := setupX509Tests(t, true)

--- a/xdcr/attachment_test.go
+++ b/xdcr/attachment_test.go
@@ -35,8 +35,6 @@ func TestMultiActorLosingConflictUpdateRemovingAttachments(t *testing.T) {
 
 	base.RequireNumTestBuckets(t, 2)
 
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
-
 	// turn off auto import - since we want reliable XDCR stats and don't want MOU/import echos to interfere
 	rtA := rest.NewRestTester(t, &rest.RestTesterConfig{AutoImport: base.Ptr(false)})
 	defer rtA.Close()

--- a/xdcr/xdcr_test.go
+++ b/xdcr/xdcr_test.go
@@ -636,7 +636,6 @@ func TestReplicateXattrs(t *testing.T) {
 // target without attachment links, and after migration the update is replicated and attachments
 // become available on the target.
 func TestXDCRBeforeAttachmentMigration(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelDebug, base.KeyAll)
 
 	srcBucket, srcDs, dstBucket, _ := getTwoBucketDataStores(t)
 	ctx := base.TestCtx(t)


### PR DESCRIPTION
Drop the output for when KeyDebug and KeyAll is set, since it will log rosmar/gocb and fill up logs

Things that still cause a lot of output:

- `WaitForChanges` makes http requests frequently and these log at info level.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/306/
