### PR TITLE
CBG-5112: add comment to explain why GetActive fetches by revID still

### DIFF
--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -100,6 +100,8 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
 	}
 
+	// We need to use revisionID loader pathway as not every document in the bucket is yet guaranteed to
+	// have a HLV assigned to it.
 	var hlv *HybridLogicalVector
 	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, hlv, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, doc.SyncData.GetRevTreeID())
 	if err != nil {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -277,6 +277,8 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 	}
 
 	// Retrieve from or add to rev cache
+	// We need to use revisionID here as not every document in the bucket is yet guaranteed to
+	// have a HLV assigned to it.
 	value := rc.getValue(ctx, docID, bucketDoc.GetRevTreeID(), collectionID, true)
 
 	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStores[collectionID], bucketDoc)


### PR DESCRIPTION
CBG-5112

- Add comment to `GetActive` functions to explain why revision ID pathway is still being used

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
