### PR TITLE
CBG-4651: change _online/_offline endpoints to work for both persistent and non persistent config

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -263,3 +263,8 @@ func ServerIsWalrus(server string) bool {
 		strings.HasPrefix(server, "/") ||
 		strings.HasPrefix(server, ".")
 }
+
+// BucketIsRosmar Returns true of bucket is rosmar bucket
+func BucketIsRosmar(bucket string) bool {
+	return strings.HasPrefix(bucket, "rosmar")
+}

--- a/base/constants.go
+++ b/base/constants.go
@@ -263,8 +263,3 @@ func ServerIsWalrus(server string) bool {
 		strings.HasPrefix(server, "/") ||
 		strings.HasPrefix(server, ".")
 }
-
-// BucketIsRosmar Returns true of bucket is rosmar bucket
-func BucketIsRosmar(bucket string) bool {
-	return strings.HasPrefix(bucket, "rosmar")
-}

--- a/db/changes.go
+++ b/db/changes.go
@@ -1612,9 +1612,6 @@ loop:
 		case <-timeout:
 			forceClose = true
 			break loop
-		case <-database.exitChanges():
-			forceClose = true
-			break loop
 		case <-options.ChangesCtx.Done():
 			forceClose = true
 			break loop

--- a/db/database.go
+++ b/db/database.go
@@ -855,47 +855,6 @@ func (context *DatabaseContext) NotifyTerminatedChanges(ctx context.Context, use
 	context.mutationListener.NotifyCheckForTermination(ctx, base.SetOf(base.UserPrefixRoot+username))
 }
 
-func (dc *DatabaseContext) TakeDbOffline(ctx context.Context, reason string) error {
-
-	if atomic.CompareAndSwapUint32(&dc.State, DBOnline, DBStopping) {
-		// notify all active _changes feeds to close
-		close(dc.ExitChanges)
-
-		// Block until all current calls have returned, including _changes feeds
-		dc.AccessLock.Lock()
-		defer dc.AccessLock.Unlock()
-
-		dc.changeCache.Stop(ctx)
-
-		// set DB state to Offline
-		atomic.StoreUint32(&dc.State, DBOffline)
-
-		if err := dc.EventMgr.RaiseDBStateChangeEvent(ctx, dc.Name, "offline", reason, dc.Options.AdminInterface); err != nil {
-			base.InfofCtx(ctx, base.KeyCRUD, "Error raising database state change event: %v", err)
-		}
-
-		return nil
-	} else {
-		dbState := atomic.LoadUint32(&dc.State)
-		// If the DB is already transitioning to: offline or is offline silently return
-		if dbState == DBOffline || dbState == DBResyncing || dbState == DBStopping {
-			return nil
-		}
-
-		msg := "Unable to take Database offline, database must be in Online state but was " + RunStateString[dbState]
-		if dbState == DBOnline {
-			msg = "Unable to take Database offline, another operation was already in progress. Please try again."
-		}
-
-		base.InfofCtx(ctx, base.KeyCRUD, "%s", msg)
-		return base.NewHTTPError(http.StatusServiceUnavailable, msg)
-	}
-}
-
-func (db *Database) TakeDbOffline(nonContextStruct base.NonCancellableContext, reason string) error {
-	return db.DatabaseContext.TakeDbOffline(nonContextStruct.Ctx, reason)
-}
-
 func (context *DatabaseContext) Authenticator(ctx context.Context) *auth.Authenticator {
 	context.BucketLock.RLock()
 	defer context.BucketLock.RUnlock()

--- a/db/database.go
+++ b/db/database.go
@@ -129,7 +129,6 @@ type DatabaseContext struct {
 	AttachmentCompactionManager *BackgroundManager
 	AttachmentMigrationManager  *BackgroundManager
 	AsyncIndexInitManager       *BackgroundManager
-	ExitChanges                 chan struct{}        // Active _changes feeds on the DB will close when this channel is closed
 	OIDCProviders               auth.OIDCProviderMap // OIDC clients
 	LocalJWTProviders           auth.LocalJWTProviderMap
 	ServerUUID                  string // UUID of the server, if available
@@ -2415,8 +2414,6 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 	if err := base.RequireNoBucketTTL(ctx, db.Bucket); err != nil {
 		return err
 	}
-
-	db.ExitChanges = make(chan struct{})
 
 	// Start checking heartbeats for other nodes.  Must be done after caching feed starts, to ensure any removals
 	// are detected and processed by this node.

--- a/db/database_collection.go
+++ b/db/database_collection.go
@@ -206,11 +206,6 @@ func (c *DatabaseCollection) eventMgr() *EventManager {
 	return c.dbCtx.EventMgr
 }
 
-// exitChanges will close active _changes feeds on the DB. This is a database level close.
-func (c *DatabaseCollection) exitChanges() chan struct{} {
-	return c.dbCtx.ExitChanges
-}
-
 // GetCollectionID returns a collectionID. If couchbase server does not return collections, it will return base.DefaultCollectionID, like the default collection for a Couchbase Server that does support collections.
 func (c *DatabaseCollection) GetCollectionID() uint32 {
 	return c.dataStore.GetCollectionID()

--- a/docs/api/paths/admin/db-_offline.yaml
+++ b/docs/api/paths/admin/db-_offline.yaml
@@ -10,7 +10,9 @@ parameters:
 post:
   summary: Take the database offline
   description: |-
-    If using persistent config this will alter the database config in the bucket to take the database offline across all nodes. If you're not using persistent config, this will bring the database online on this node only. Actions can be taken without disrupting current operations ungracefully or having the restart the Sync Gateway instance.
+    Transition the state of the database to offline. This database will no longer accept traffic and only maintenance operations can be performed. This operation blocks until all REST traffic is idle.
+
+    If using persistent config this will affect all Sync Gateway nodes, otherwise this is operation is local to the node.
 
     This will not take the backing Couchbase Server bucket offline.
 

--- a/docs/api/paths/admin/db-_offline.yaml
+++ b/docs/api/paths/admin/db-_offline.yaml
@@ -10,9 +10,7 @@ parameters:
 post:
   summary: Take the database offline
   description: |-
-    This will take the database offline on this node only. Actions can be taken without disrupting current operations ungracefully or having the restart the Sync Gateway instance.
-
-    If using persistent config, call [POST /{db}/_config](#operation/post_db-_config) with `{"offline": true}` to set the database to offline.
+    If using persistent config this will alter the database config in the bucket to take the database offline across all nodes. If you're not using persistent config, this will bring the database online on this node only. Actions can be taken without disrupting current operations ungracefully or having the restart the Sync Gateway instance.
 
     This will not take the backing Couchbase Server bucket offline.
 

--- a/docs/api/paths/admin/db-_online.yaml
+++ b/docs/api/paths/admin/db-_online.yaml
@@ -12,7 +12,7 @@ post:
   description: |-
     Transition the state of the database to online.
 
-    If using persistent config this will affect all Sync Gateway nodes, otherwise this is operation is local to the node.
+    If using persistent config this will affect all Sync Gateway nodes, otherwise this operation is local to the node.
 
     Bringing a database online will:
     * Close the database connection to the backing Couchbase Server bucket.

--- a/docs/api/paths/admin/db-_online.yaml
+++ b/docs/api/paths/admin/db-_online.yaml
@@ -10,7 +10,9 @@ parameters:
 post:
   summary: Bring the database online
   description: |-
-    If using persistent config this will alter the database config in the bucket to take the database online across all nodes. If you're not using persistent config, this will bring the database online on this node only.
+    Transition the state of the database to online.
+
+    If using persistent config this will affect all Sync Gateway nodes, otherwise this is operation is local to the node.
 
     Bringing a database online will:
     * Close the database connection to the backing Couchbase Server bucket.

--- a/docs/api/paths/admin/db-_online.yaml
+++ b/docs/api/paths/admin/db-_online.yaml
@@ -10,9 +10,7 @@ parameters:
 post:
   summary: Bring the database online
   description: |-
-    This will bring the database online on this node only so the Public and full Admin REST API requests can be served.
-
-    If using persistent config, call [POST /{db}/_config](#operation/post_db-_config) with `{"offline": false}` to set the database to online.
+    If using persistent config this will alter the database config in the bucket to take the database online across all nodes. If you're not using persistent config, this will bring the database online on this node only.
 
     Bringing a database online will:
     * Close the database connection to the backing Couchbase Server bucket.

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -264,18 +264,24 @@ func (h *handler) handleDbOnline() error {
 				currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
 
 				dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
-				if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
+				if err := currentDatabaseCfg.setup(ctx.Ctx, h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
+					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
+					atomic.StoreUint32(&h.db.State, db.DBOffline)
 					base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
+					return
 				}
 				if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
+					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
+					atomic.StoreUint32(&h.db.State, db.DBOffline)
 					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+					return
 				}
 			} else {
 				// persistent config here
 				bucket := h.db.Bucket.GetName()
 				dbName := h.db.Name
 				var updatedDbConfig *DatabaseConfig
-				cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				cas, err := h.server.BootstrapContext.UpdateConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 					if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 						return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 					}
@@ -284,11 +290,11 @@ func (h *handler) handleDbOnline() error {
 					// set config to offline false to start online processes
 					bucketDbConfig.StartOffline = base.Ptr(false)
 
-					if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
+					if err := bucketDbConfig.validateConfigUpdate(contextNoCancel.Ctx, oldConfig, false); err != nil {
 						return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
 					}
 
-					bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(h.ctx(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+					bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(ctx.Ctx, bucketDbConfig.Version, &bucketDbConfig.DbConfig)
 					if err != nil {
 						return nil, err
 					}
@@ -299,14 +305,18 @@ func (h *handler) handleDbOnline() error {
 				})
 				if err != nil {
 					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
+					atomic.StoreUint32(&h.db.State, db.DBOffline)
 					return
 				}
 				updatedDbConfig.cfgCas = cas
 
 				dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 				bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-				if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+				if err := updatedDbConfig.setup(contextNoCancel.Ctx, dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 					base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
+					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
+					atomic.StoreUint32(&h.db.State, db.DBOffline)
 					return
 				}
 
@@ -314,8 +324,10 @@ func (h *handler) handleDbOnline() error {
 				defer h.server._databasesLock.Unlock()
 
 				// TODO: Dynamic update instead of reload
-				if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+				if err := h.server._reloadDatabaseWithConfig(contextNoCancel.Ctx, *updatedDbConfig, false, false); err != nil {
 					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
+					atomic.StoreUint32(&h.db.State, db.DBOffline)
 					return
 				}
 			}
@@ -338,79 +350,63 @@ func (h *handler) handleDbOffline() error {
 	h.db.AccessLock.Lock()
 	defer h.db.AccessLock.Unlock()
 
-	if atomic.CompareAndSwapUint32(&h.db.State, db.DBOnline, db.DBStopping) {
-		if !h.server.persistentConfig {
-			currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
-			oldConfig = currentConfig
-			currentConfig.StartOffline = base.Ptr(true)
-			currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
+	if !h.server.persistentConfig {
+		currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
+		oldConfig = currentConfig
+		currentConfig.StartOffline = base.Ptr(true)
+		currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
 
-			dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
-			if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
-				return err
-			}
-			if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
-				return err
-			}
-		} else {
-			bucket := h.db.Bucket.GetName()
-			dbName := h.db.Name
-			var updatedDbConfig *DatabaseConfig
-			cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-				if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-					return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-				}
-				oldConfig = bucketDbConfig.DbConfig
-
-				// set config to offline true
-				bucketDbConfig.StartOffline = base.Ptr(true)
-
-				if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
-					return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
-				}
-
-				bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(h.ctx(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-				if err != nil {
-					return nil, err
-				}
-
-				bucketDbConfig.SGVersion = base.ProductVersion.String()
-				updatedDbConfig = bucketDbConfig
-				return bucketDbConfig, nil
-			})
-			if err != nil {
-				return err
-			}
-			updatedDbConfig.cfgCas = cas
-
-			dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-			bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-			if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-				return err
-			}
-
-			h.server._databasesLock.Lock()
-			defer h.server._databasesLock.Unlock()
-
-			// TODO: Dynamic update instead of reload
-			if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
-				return err
-			}
+		dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
+		if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
+			return err
+		}
+		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
+			return err
 		}
 	} else {
-		dbState := atomic.LoadUint32(&h.db.State)
-		// If the DB is already transitioning to: offline or is offline silently return
-		if dbState == db.DBOffline || dbState == db.DBResyncing || dbState == db.DBStopping {
-			return nil
+		bucket := h.db.Bucket.GetName()
+		dbName := h.db.Name
+		var updatedDbConfig *DatabaseConfig
+		cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+			}
+			oldConfig = bucketDbConfig.DbConfig
+
+			// set config to offline true
+			bucketDbConfig.StartOffline = base.Ptr(true)
+
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
+				return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
+			}
+
+			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(h.ctx(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			bucketDbConfig.SGVersion = base.ProductVersion.String()
+			updatedDbConfig = bucketDbConfig
+			return bucketDbConfig, nil
+		})
+		if err != nil {
+			return err
+		}
+		updatedDbConfig.cfgCas = cas
+
+		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+		bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+		if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+			return err
 		}
 
-		msg := "Unable to take Database offline, database must be in Online state but was " + db.RunStateString[dbState]
-		if dbState == db.DBOnline {
-			msg = "Unable to take Database offline, another operation was already in progress. Please try again."
-		}
+		h.server._databasesLock.Lock()
+		defer h.server._databasesLock.Unlock()
 
-		base.InfofCtx(h.ctx(), base.KeyCRUD, "%s", msg)
-		return base.NewHTTPError(http.StatusServiceUnavailable, msg)
+		// TODO: Dynamic update instead of reload
+		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+			return err
+		}
 	}
 	base.Audit(h.ctx(), base.AuditIDDatabaseOffline, nil)
 	return nil

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -247,11 +247,76 @@ func (h *handler) handleDbOnline() error {
 
 	_ = base.JSONUnmarshal(body, &input)
 
+	contextNoCancel := base.NewNonCancelCtx()
+
 	base.InfofCtx(h.ctx(), base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
-	go func() {
+	// allow db to come online in background in its own goroutine
+	go func(ctx base.NonCancellableContext) {
 		time.Sleep(time.Duration(input.Delay) * time.Second)
-		h.server.TakeDbOnline(base.NewNonCancelCtx(), h.db.DatabaseContext)
-	}()
+		var oldConfig DbConfig
+		if !h.server.persistentConfig {
+			currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
+			oldConfig = currentConfig
+			currentConfig.StartOffline = base.Ptr(false)
+			currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
+
+			dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
+			if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
+				base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
+			}
+			if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
+				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+			}
+		} else {
+			// persistent config here
+			bucket := h.db.Bucket.GetName()
+			dbName := h.db.Name
+			var updatedDbConfig *DatabaseConfig
+			cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+					return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+				}
+				oldConfig = bucketDbConfig.DbConfig
+
+				// set config to offline false to start online processes
+				bucketDbConfig.StartOffline = base.Ptr(false)
+
+				if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
+					return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
+				}
+
+				bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(h.ctx(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+				if err != nil {
+					return nil, err
+				}
+
+				bucketDbConfig.SGVersion = base.ProductVersion.String()
+				updatedDbConfig = bucketDbConfig
+				return bucketDbConfig, nil
+			})
+			if err != nil {
+				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+				return
+			}
+			updatedDbConfig.cfgCas = cas
+
+			dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+			bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+			if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+				base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
+				return
+			}
+
+			h.server._databasesLock.Lock()
+			defer h.server._databasesLock.Unlock()
+
+			// TODO: Dynamic update instead of reload
+			if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+				return
+			}
+		}
+	}(contextNoCancel)
 	base.Audit(h.ctx(), base.AuditIDDatabaseOnline, nil)
 
 	return nil
@@ -260,9 +325,66 @@ func (h *handler) handleDbOnline() error {
 // Take a DB offline
 func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
-	if err := h.db.TakeDbOffline(base.NewNonCancelCtx(), "ADMIN Request"); err != nil {
-		base.InfofCtx(h.ctx(), base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
-		return err
+
+	var oldConfig DbConfig
+	contextNoCancel := base.NewNonCancelCtx()
+	if !h.server.persistentConfig {
+		currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
+		oldConfig = currentConfig
+		currentConfig.StartOffline = base.Ptr(true)
+		currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
+
+		dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
+		if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
+			return err
+		}
+		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
+			return err
+		}
+	} else {
+		bucket := h.db.Bucket.GetName()
+		dbName := h.db.Name
+		var updatedDbConfig *DatabaseConfig
+		cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+			}
+			oldConfig = bucketDbConfig.DbConfig
+
+			// set config to offline true
+			bucketDbConfig.StartOffline = base.Ptr(true)
+
+			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
+				return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
+			}
+
+			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(h.ctx(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			bucketDbConfig.SGVersion = base.ProductVersion.String()
+			updatedDbConfig = bucketDbConfig
+			return bucketDbConfig, nil
+		})
+		if err != nil {
+			return err
+		}
+		updatedDbConfig.cfgCas = cas
+
+		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+		bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+		if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+			return err
+		}
+
+		h.server._databasesLock.Lock()
+		defer h.server._databasesLock.Unlock()
+
+		// TODO: Dynamic update instead of reload
+		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+			return err
+		}
 	}
 	base.Audit(h.ctx(), base.AuditIDDatabaseOffline, nil)
 	return nil

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -268,18 +268,18 @@ func (h *handler) handleDbOnline() error {
 		h.db.AccessLock.Lock()
 		defer h.db.AccessLock.Unlock()
 		if !atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBStarting) {
-			base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(h.db.Name))
+			base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.MD(h.db.Name))
 			return
 		}
-		var oldConfig DbConfig
 		if !h.server.persistentConfig {
 			newDbConfig := &DbConfig{StartOffline: base.Ptr(false)}
-			err := h.updateNonPersistentDbConfig(contextNoCancel, h.db.Name, false, false, true, newDbConfig)
+			err = h.updateNonPersistentDbConfig(contextNoCancel, h.db.Name, false, false, true, newDbConfig)
 			if err != nil {
 				base.WarnfCtx(contextNoCancel.Ctx, "database reload failed during db online, Err: %v", err)
 				return
 			}
 		} else {
+			var oldConfig DbConfig
 			// persistent config here
 			bucket := h.db.Bucket.GetName()
 			dbName := h.db.Name
@@ -308,7 +308,7 @@ func (h *handler) handleDbOnline() error {
 				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
 				return
 			}
-			if err = h.updateConfigAndReloadDatabase(contextNoCancel.Ctx, dbName, bucket, cas, updatedDbConfig); err != nil {
+			if err = h.updateConfigAndReloadDatabase(contextNoCancel, dbName, bucket, cas, updatedDbConfig); err != nil {
 				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
 				return
 			}
@@ -326,46 +326,62 @@ func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 
 	var oldConfig DbConfig
-	contextNoCancel := base.NewNonCancelCtx()
+	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
 	// Block until all current calls have returned, including _changes feeds
 	h.db.AccessLock.Lock()
 	defer h.db.AccessLock.Unlock()
 
-	if !h.server.persistentConfig {
-		newDbConfig := &DbConfig{StartOffline: base.Ptr(true)}
-		err := h.updateNonPersistentDbConfig(contextNoCancel, h.db.Name, false, false, true, newDbConfig)
-		if err != nil {
-			return err
+	if atomic.CompareAndSwapUint32(&h.db.State, db.DBOnline, db.DBStopping) {
+		if !h.server.persistentConfig {
+			newDbConfig := &DbConfig{StartOffline: base.Ptr(true)}
+			err := h.updateNonPersistentDbConfig(contextNoCancel, h.db.Name, false, false, true, newDbConfig)
+			if err != nil {
+				return err
+			}
+		} else {
+			bucket := h.db.Bucket.GetName()
+			dbName := h.db.Name
+			var updatedDbConfig *DatabaseConfig
+			cas, err := h.server.BootstrapContext.UpdateConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				oldConfig = bucketDbConfig.DbConfig
+
+				// set config to offline true
+				bucketDbConfig.StartOffline = base.Ptr(true)
+
+				if err := bucketDbConfig.validateConfigUpdate(contextNoCancel.Ctx, oldConfig, false); err != nil {
+					return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
+				}
+
+				bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(contextNoCancel.Ctx, bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+				if err != nil {
+					return nil, err
+				}
+
+				bucketDbConfig.SGVersion = base.ProductVersion.String()
+				updatedDbConfig = bucketDbConfig
+				return bucketDbConfig, nil
+			})
+			if err != nil {
+				return err
+			}
+			if err := h.updateConfigAndReloadDatabase(contextNoCancel, dbName, bucket, cas, updatedDbConfig); err != nil {
+				return err
+			}
 		}
 	} else {
-		bucket := h.db.Bucket.GetName()
-		dbName := h.db.Name
-		var updatedDbConfig *DatabaseConfig
-		cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-			oldConfig = bucketDbConfig.DbConfig
-
-			// set config to offline true
-			bucketDbConfig.StartOffline = base.Ptr(true)
-
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
-				return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
-			}
-
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(h.ctx(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-			if err != nil {
-				return nil, err
-			}
-
-			bucketDbConfig.SGVersion = base.ProductVersion.String()
-			updatedDbConfig = bucketDbConfig
-			return bucketDbConfig, nil
-		})
-		if err != nil {
-			return err
+		dbState := atomic.LoadUint32(&h.db.State)
+		// If the DB is already transitioning to: offline or is offline silently return
+		if dbState == db.DBOffline || dbState == db.DBResyncing || dbState == db.DBStopping {
+			return nil
 		}
-		if err := h.updateConfigAndReloadDatabase(h.ctx(), dbName, bucket, cas, updatedDbConfig); err != nil {
-			return err
+
+		msg := "Unable to take Database offline, database must be in Online state but was " + db.RunStateString[dbState]
+		if dbState == db.DBOnline {
+			msg = "Unable to take Database offline, another operation was already in progress. Please try again."
 		}
+
+		base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "%s", msg)
+		return base.NewHTTPError(http.StatusServiceUnavailable, msg)
 	}
 	base.Audit(h.ctx(), base.AuditIDUpdateDatabaseConfig, base.AuditFields{base.AuditFieldPayload: `{"offline": true}`})
 	base.Audit(h.ctx(), base.AuditIDDatabaseOffline, nil)
@@ -749,12 +765,12 @@ func (h *handler) handlePutConfig() error {
 // the CAS on the config, runs setup (credential injection etc.), acquires _databasesLock and reloads
 // the database. ctx must be non-cancellable because it is used inside a goroutine or across long-lived
 // operations.
-func (h *handler) updateConfigAndReloadDatabase(ctx context.Context, dbName, bucket string, cas uint64, updatedDbConfig *DatabaseConfig) error {
+func (h *handler) updateConfigAndReloadDatabase(ctx base.NonCancellableContext, dbName, bucket string, cas uint64, updatedDbConfig *DatabaseConfig) error {
 	updatedDbConfig.cfgCas = cas
 
 	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(ctx, dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+	if err := updatedDbConfig.setup(ctx.Ctx, dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 		return err
 	}
 
@@ -762,7 +778,7 @@ func (h *handler) updateConfigAndReloadDatabase(ctx context.Context, dbName, buc
 	defer h.server._databasesLock.Unlock()
 
 	// TODO: Dynamic update instead of reload
-	return h.server._reloadDatabaseWithConfig(ctx, *updatedDbConfig, false, false)
+	return h.server._reloadDatabaseWithConfig(ctx.Ctx, *updatedDbConfig, false, false)
 }
 
 func (h *handler) updateNonPersistentDbConfig(ctx base.NonCancellableContext, dbName string, validateOIDC, validateConfigUpdate, mergeConfig bool, dbConfig *DbConfig) error {
@@ -770,17 +786,17 @@ func (h *handler) updateNonPersistentDbConfig(ctx base.NonCancellableContext, db
 	oldDBConfig := h.server.GetDatabaseConfig(dbName).DatabaseConfig.DbConfig
 	updatedDbConfig.DbConfig = oldDBConfig
 	if mergeConfig {
-		base.TracefCtx(h.ctx(), base.KeyConfig, "merging upserted config into bucket config")
+		base.TracefCtx(ctx.Ctx, base.KeyConfig, "merging upserted config into bucket config")
 		if err := base.ConfigMerge(&updatedDbConfig.DbConfig, dbConfig); err != nil {
 			return err
 		}
 	} else {
-		base.TracefCtx(h.ctx(), base.KeyConfig, "using config as-is without merge")
+		base.TracefCtx(ctx.Ctx, base.KeyConfig, "using config as-is without merge")
 		updatedDbConfig.DbConfig = *dbConfig
 	}
 	// only validate config update if we need to.
 	if validateConfigUpdate {
-		err := updatedDbConfig.validateConfigUpdate(h.ctx(), oldDBConfig,
+		err := updatedDbConfig.validateConfigUpdate(ctx.Ctx, oldDBConfig,
 			validateOIDC)
 		if err != nil {
 			return base.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -788,7 +804,7 @@ func (h *handler) updateNonPersistentDbConfig(ctx base.NonCancellableContext, db
 	}
 
 	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-	if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
+	if err := updatedDbConfig.setup(ctx.Ctx, dbName, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
 		return err
 	}
 	if err := h.server.ReloadDatabaseWithConfig(ctx, *updatedDbConfig); err != nil {
@@ -1256,6 +1272,7 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 	bucket := h.db.Bucket.GetName()
 	var updatedConfigStr string
 	var updatedDbConfig *DatabaseConfig
+	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
 	cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, h.db.Name, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 		if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
 			return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
@@ -1283,7 +1300,7 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 	if err != nil {
 		return err
 	}
-	if err := h.updateConfigAndReloadDatabase(h.ctx(), h.db.Name, bucket, cas, updatedDbConfig); err != nil {
+	if err := h.updateConfigAndReloadDatabase(contextNoCancel, h.db.Name, bucket, cas, updatedDbConfig); err != nil {
 		return err
 	}
 
@@ -1302,6 +1319,8 @@ func (h *handler) handlePutCollectionConfigSync() error {
 	if err != nil {
 		return err
 	}
+
+	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
 
 	bucket := h.db.Bucket.GetName()
 	dbName := h.db.Name
@@ -1340,7 +1359,7 @@ func (h *handler) handlePutCollectionConfigSync() error {
 	if err != nil {
 		return err
 	}
-	if err := h.updateConfigAndReloadDatabase(h.ctx(), dbName, bucket, cas, updatedDbConfig); err != nil {
+	if err := h.updateConfigAndReloadDatabase(contextNoCancel, dbName, bucket, cas, updatedDbConfig); err != nil {
 		return err
 	}
 
@@ -1395,6 +1414,8 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "endpoint only supports persistent config mode")
 	}
 
+	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
+
 	bucket := h.db.Bucket.GetName()
 	dbName := h.db.Name
 
@@ -1428,7 +1449,7 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 	if err != nil {
 		return err
 	}
-	if err := h.updateConfigAndReloadDatabase(h.ctx(), dbName, bucket, cas, updatedDbConfig); err != nil {
+	if err := h.updateConfigAndReloadDatabase(contextNoCancel, dbName, bucket, cas, updatedDbConfig); err != nil {
 		return err
 	}
 
@@ -1450,6 +1471,8 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 	}
 	bucket := h.db.Bucket.GetName()
 	dbName := h.db.Name
+
+	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
 
 	var updatedConfigStr string
 	var updatedDbConfig *DatabaseConfig
@@ -1486,7 +1509,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 	if err != nil {
 		return err
 	}
-	if err := h.updateConfigAndReloadDatabase(h.ctx(), dbName, bucket, cas, updatedDbConfig); err != nil {
+	if err := h.updateConfigAndReloadDatabase(contextNoCancel, dbName, bucket, cas, updatedDbConfig); err != nil {
 		return err
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -252,27 +252,22 @@ func (h *handler) handleDbOnline() error {
 	base.InfofCtx(h.ctx(), base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
 	// allow db to come online in background in its own goroutine
 	go func(ctx base.NonCancellableContext) {
+		var err error
+		defer func() {
+			if err != nil {
+				// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
+				atomic.StoreUint32(&h.db.State, db.DBOffline)
+			}
+		}()
 		time.Sleep(time.Duration(input.Delay) * time.Second)
 		h.db.AccessLock.Lock()
 		defer h.db.AccessLock.Unlock()
 		if atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBStarting) {
 			var oldConfig DbConfig
 			if !h.server.persistentConfig {
-				currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
-				oldConfig = currentConfig
-				currentConfig.StartOffline = base.Ptr(false)
-				currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
-
-				dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
-				if err := currentDatabaseCfg.setup(ctx.Ctx, h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
-					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
-					atomic.StoreUint32(&h.db.State, db.DBOffline)
-					base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
-					return
-				}
-				if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
-					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
-					atomic.StoreUint32(&h.db.State, db.DBOffline)
+				newDbConfig := &DbConfig{StartOffline: base.Ptr(false)}
+				err := h.updateNonPersistentDbConfig(contextNoCancel, h.db.Name, false, false, true, newDbConfig)
+				if err != nil {
 					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
 					return
 				}
@@ -280,11 +275,9 @@ func (h *handler) handleDbOnline() error {
 				// persistent config here
 				bucket := h.db.Bucket.GetName()
 				dbName := h.db.Name
+				var cas uint64
 				var updatedDbConfig *DatabaseConfig
-				cas, err := h.server.BootstrapContext.UpdateConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-					if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-						return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-					}
+				cas, err = h.server.BootstrapContext.UpdateConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
 					oldConfig = bucketDbConfig.DbConfig
 
 					// set config to offline false to start online processes
@@ -305,18 +298,14 @@ func (h *handler) handleDbOnline() error {
 				})
 				if err != nil {
 					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
-					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
-					atomic.StoreUint32(&h.db.State, db.DBOffline)
 					return
 				}
 				updatedDbConfig.cfgCas = cas
 
 				dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 				bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-				if err := updatedDbConfig.setup(contextNoCancel.Ctx, dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+				if err = updatedDbConfig.setup(contextNoCancel.Ctx, dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
 					base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
-					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
-					atomic.StoreUint32(&h.db.State, db.DBOffline)
 					return
 				}
 
@@ -324,10 +313,8 @@ func (h *handler) handleDbOnline() error {
 				defer h.server._databasesLock.Unlock()
 
 				// TODO: Dynamic update instead of reload
-				if err := h.server._reloadDatabaseWithConfig(contextNoCancel.Ctx, *updatedDbConfig, false, false); err != nil {
+				if err = h.server._reloadDatabaseWithConfig(contextNoCancel.Ctx, *updatedDbConfig, false, false); err != nil {
 					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
-					// Reset DB state back to Offline on setup failure to avoid being stuck in DBStarting.
-					atomic.StoreUint32(&h.db.State, db.DBOffline)
 					return
 				}
 			}
@@ -335,6 +322,8 @@ func (h *handler) handleDbOnline() error {
 			base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(h.db.Name))
 		}
 	}(contextNoCancel)
+
+	base.Audit(h.ctx(), base.AuditIDUpdateDatabaseConfig, base.AuditFields{base.AuditFieldPayload: `{"offline": false}`})
 	base.Audit(h.ctx(), base.AuditIDDatabaseOnline, nil)
 
 	return nil
@@ -351,16 +340,9 @@ func (h *handler) handleDbOffline() error {
 	defer h.db.AccessLock.Unlock()
 
 	if !h.server.persistentConfig {
-		currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
-		oldConfig = currentConfig
-		currentConfig.StartOffline = base.Ptr(true)
-		currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
-
-		dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
-		if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
-			return err
-		}
-		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
+		newDbConfig := &DbConfig{StartOffline: base.Ptr(true)}
+		err := h.updateNonPersistentDbConfig(contextNoCancel, h.db.Name, false, false, true, newDbConfig)
+		if err != nil {
 			return err
 		}
 	} else {
@@ -408,6 +390,7 @@ func (h *handler) handleDbOffline() error {
 			return err
 		}
 	}
+	base.Audit(h.ctx(), base.AuditIDUpdateDatabaseConfig, base.AuditFields{base.AuditFieldPayload: `{"offline": true}`})
 	base.Audit(h.ctx(), base.AuditIDDatabaseOffline, nil)
 	return nil
 }
@@ -785,6 +768,40 @@ func (h *handler) handlePutConfig() error {
 	return base.HTTPErrorf(http.StatusOK, "Updated")
 }
 
+func (h *handler) updateNonPersistentDbConfig(ctx base.NonCancellableContext, dbName string, validateOIDC, validateConfigUpdate, mergeConfig bool, dbConfig *DbConfig) error {
+	updatedDbConfig := &DatabaseConfig{}
+	oldDBConfig := h.server.GetDatabaseConfig(dbName).DatabaseConfig.DbConfig
+	updatedDbConfig.DbConfig = oldDBConfig
+	// We have a long-standing behaviour where POST to dbconfig for non-persistent config acts a PUT.
+	// This is behaviour we cannot change at this time, see CBG-4618 for more info
+	if mergeConfig {
+		base.TracefCtx(h.ctx(), base.KeyConfig, "merging upserted config into bucket config")
+		if err := base.ConfigMerge(&updatedDbConfig.DbConfig, dbConfig); err != nil {
+			return err
+		}
+	} else {
+		base.TracefCtx(h.ctx(), base.KeyConfig, "using config as-is without merge")
+		updatedDbConfig.DbConfig = *dbConfig
+	}
+	// only validate config update if we need to.
+	if validateConfigUpdate {
+		err := updatedDbConfig.validateConfigUpdate(h.ctx(), oldDBConfig,
+			validateOIDC)
+		if err != nil {
+			return base.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+	}
+
+	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+	if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
+		return err
+	}
+	if err := h.server.ReloadDatabaseWithConfig(ctx, *updatedDbConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
 // handlePutDbConfig Upserts a new database config
 func (h *handler) handlePutDbConfig() (err error) {
 	h.assertAdminOnly()
@@ -869,19 +886,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 	}
 
 	if !h.server.persistentConfig {
-		updatedDbConfig := &DatabaseConfig{DbConfig: *dbConfig}
-		oldDBConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
-		err = updatedDbConfig.validateConfigUpdate(h.ctx(), oldDBConfig,
-			validateOIDC)
+		err = h.updateNonPersistentDbConfig(contextNoCancel, dbName, validateOIDC, true, false, dbConfig)
 		if err != nil {
-			return base.NewHTTPError(http.StatusBadRequest, err.Error())
-		}
-
-		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-		if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
-			return err
-		}
-		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *updatedDbConfig); err != nil {
 			return err
 		}
 		base.Audit(h.ctx(), base.AuditIDUpdateDatabaseConfig, auditFields)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -253,22 +253,106 @@ func (h *handler) handleDbOnline() error {
 	// allow db to come online in background in its own goroutine
 	go func(ctx base.NonCancellableContext) {
 		time.Sleep(time.Duration(input.Delay) * time.Second)
-		var oldConfig DbConfig
+		h.db.AccessLock.Lock()
+		defer h.db.AccessLock.Unlock()
+		if atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBStarting) {
+			var oldConfig DbConfig
+			if !h.server.persistentConfig {
+				currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
+				oldConfig = currentConfig
+				currentConfig.StartOffline = base.Ptr(false)
+				currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
+
+				dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
+				if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
+					base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
+				}
+				if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
+					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+				}
+			} else {
+				// persistent config here
+				bucket := h.db.Bucket.GetName()
+				dbName := h.db.Name
+				var updatedDbConfig *DatabaseConfig
+				cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+					if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
+						return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+					}
+					oldConfig = bucketDbConfig.DbConfig
+
+					// set config to offline false to start online processes
+					bucketDbConfig.StartOffline = base.Ptr(false)
+
+					if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
+						return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
+					}
+
+					bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(h.ctx(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+					if err != nil {
+						return nil, err
+					}
+
+					bucketDbConfig.SGVersion = base.ProductVersion.String()
+					updatedDbConfig = bucketDbConfig
+					return bucketDbConfig, nil
+				})
+				if err != nil {
+					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+					return
+				}
+				updatedDbConfig.cfgCas = cas
+
+				dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+				bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+				if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+					base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
+					return
+				}
+
+				h.server._databasesLock.Lock()
+				defer h.server._databasesLock.Unlock()
+
+				// TODO: Dynamic update instead of reload
+				if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+					return
+				}
+			}
+		} else {
+			base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(h.db.Name))
+		}
+	}(contextNoCancel)
+	base.Audit(h.ctx(), base.AuditIDDatabaseOnline, nil)
+
+	return nil
+}
+
+// Take a DB offline
+func (h *handler) handleDbOffline() error {
+	h.assertAdminOnly()
+
+	var oldConfig DbConfig
+	contextNoCancel := base.NewNonCancelCtx()
+	// Block until all current calls have returned, including _changes feeds
+	h.db.AccessLock.Lock()
+	defer h.db.AccessLock.Unlock()
+
+	if atomic.CompareAndSwapUint32(&h.db.State, db.DBOnline, db.DBStopping) {
 		if !h.server.persistentConfig {
 			currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
 			oldConfig = currentConfig
-			currentConfig.StartOffline = base.Ptr(false)
+			currentConfig.StartOffline = base.Ptr(true)
 			currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
 
 			dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
 			if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
-				base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
+				return err
 			}
 			if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
-				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+				return err
 			}
 		} else {
-			// persistent config here
 			bucket := h.db.Bucket.GetName()
 			dbName := h.db.Name
 			var updatedDbConfig *DatabaseConfig
@@ -278,8 +362,8 @@ func (h *handler) handleDbOnline() error {
 				}
 				oldConfig = bucketDbConfig.DbConfig
 
-				// set config to offline false to start online processes
-				bucketDbConfig.StartOffline = base.Ptr(false)
+				// set config to offline true
+				bucketDbConfig.StartOffline = base.Ptr(true)
 
 				if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
 					return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -295,16 +379,14 @@ func (h *handler) handleDbOnline() error {
 				return bucketDbConfig, nil
 			})
 			if err != nil {
-				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
-				return
+				return err
 			}
 			updatedDbConfig.cfgCas = cas
 
 			dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
 			bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
 			if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-				base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
-				return
+				return err
 			}
 
 			h.server._databasesLock.Lock()
@@ -312,79 +394,23 @@ func (h *handler) handleDbOnline() error {
 
 			// TODO: Dynamic update instead of reload
 			if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
-				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
-				return
+				return err
 			}
-		}
-	}(contextNoCancel)
-	base.Audit(h.ctx(), base.AuditIDDatabaseOnline, nil)
-
-	return nil
-}
-
-// Take a DB offline
-func (h *handler) handleDbOffline() error {
-	h.assertAdminOnly()
-
-	var oldConfig DbConfig
-	contextNoCancel := base.NewNonCancelCtx()
-	if !h.server.persistentConfig {
-		currentConfig := h.server.GetDatabaseConfig(h.db.Name).DatabaseConfig.DbConfig
-		oldConfig = currentConfig
-		currentConfig.StartOffline = base.Ptr(true)
-		currentDatabaseCfg := &DatabaseConfig{DbConfig: currentConfig}
-
-		dbCreds, _ := h.server.Config.DatabaseCredentials[h.db.Name]
-		if err := currentDatabaseCfg.setup(h.ctx(), h.db.Name, h.server.Config.Bootstrap, dbCreds, nil, false); err != nil {
-			return err
-		}
-		if err := h.server.ReloadDatabaseWithConfig(contextNoCancel, *currentDatabaseCfg); err != nil {
-			return err
 		}
 	} else {
-		bucket := h.db.Bucket.GetName()
-		dbName := h.db.Name
-		var updatedDbConfig *DatabaseConfig
-		cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-			}
-			oldConfig = bucketDbConfig.DbConfig
-
-			// set config to offline true
-			bucketDbConfig.StartOffline = base.Ptr(true)
-
-			if err := bucketDbConfig.validateConfigUpdate(h.ctx(), oldConfig, false); err != nil {
-				return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
-			}
-
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(h.ctx(), bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-			if err != nil {
-				return nil, err
-			}
-
-			bucketDbConfig.SGVersion = base.ProductVersion.String()
-			updatedDbConfig = bucketDbConfig
-			return bucketDbConfig, nil
-		})
-		if err != nil {
-			return err
-		}
-		updatedDbConfig.cfgCas = cas
-
-		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-		bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-		if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-			return err
+		dbState := atomic.LoadUint32(&h.db.State)
+		// If the DB is already transitioning to: offline or is offline silently return
+		if dbState == db.DBOffline || dbState == db.DBResyncing || dbState == db.DBStopping {
+			return nil
 		}
 
-		h.server._databasesLock.Lock()
-		defer h.server._databasesLock.Unlock()
-
-		// TODO: Dynamic update instead of reload
-		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
-			return err
+		msg := "Unable to take Database offline, database must be in Online state but was " + db.RunStateString[dbState]
+		if dbState == db.DBOnline {
+			msg = "Unable to take Database offline, another operation was already in progress. Please try again."
 		}
+
+		base.InfofCtx(h.ctx(), base.KeyCRUD, "%s", msg)
+		return base.NewHTTPError(http.StatusServiceUnavailable, msg)
 	}
 	base.Audit(h.ctx(), base.AuditIDDatabaseOffline, nil)
 	return nil

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -772,8 +772,6 @@ func (h *handler) updateNonPersistentDbConfig(ctx base.NonCancellableContext, db
 	updatedDbConfig := &DatabaseConfig{}
 	oldDBConfig := h.server.GetDatabaseConfig(dbName).DatabaseConfig.DbConfig
 	updatedDbConfig.DbConfig = oldDBConfig
-	// We have a long-standing behaviour where POST to dbconfig for non-persistent config acts a PUT.
-	// This is behaviour we cannot change at this time, see CBG-4618 for more info
 	if mergeConfig {
 		base.TracefCtx(h.ctx(), base.KeyConfig, "merging upserted config into bucket config")
 		if err := base.ConfigMerge(&updatedDbConfig.DbConfig, dbConfig); err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -245,9 +245,14 @@ func (h *handler) handleDbOnline() error {
 
 	input.Delay = kDefaultDBOnlineDelay
 
-	_ = base.JSONUnmarshal(body, &input)
+	if len(body) > 0 {
+		err = base.JSONUnmarshal(body, &input)
+		if err != nil {
+			return err
+		}
+	}
 
-	contextNoCancel := base.NewNonCancelCtx()
+	contextNoCancel := base.NewNonCancelCtxForDatabase(h.ctx())
 
 	base.InfofCtx(h.ctx(), base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
 	// allow db to come online in background in its own goroutine
@@ -262,64 +267,51 @@ func (h *handler) handleDbOnline() error {
 		time.Sleep(time.Duration(input.Delay) * time.Second)
 		h.db.AccessLock.Lock()
 		defer h.db.AccessLock.Unlock()
-		if atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBStarting) {
-			var oldConfig DbConfig
-			if !h.server.persistentConfig {
-				newDbConfig := &DbConfig{StartOffline: base.Ptr(false)}
-				err := h.updateNonPersistentDbConfig(contextNoCancel, h.db.Name, false, false, true, newDbConfig)
-				if err != nil {
-					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
-					return
-				}
-			} else {
-				// persistent config here
-				bucket := h.db.Bucket.GetName()
-				dbName := h.db.Name
-				var cas uint64
-				var updatedDbConfig *DatabaseConfig
-				cas, err = h.server.BootstrapContext.UpdateConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-					oldConfig = bucketDbConfig.DbConfig
-
-					// set config to offline false to start online processes
-					bucketDbConfig.StartOffline = base.Ptr(false)
-
-					if err := bucketDbConfig.validateConfigUpdate(contextNoCancel.Ctx, oldConfig, false); err != nil {
-						return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
-					}
-
-					bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(ctx.Ctx, bucketDbConfig.Version, &bucketDbConfig.DbConfig)
-					if err != nil {
-						return nil, err
-					}
-
-					bucketDbConfig.SGVersion = base.ProductVersion.String()
-					updatedDbConfig = bucketDbConfig
-					return bucketDbConfig, nil
-				})
-				if err != nil {
-					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
-					return
-				}
-				updatedDbConfig.cfgCas = cas
-
-				dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-				bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-				if err = updatedDbConfig.setup(contextNoCancel.Ctx, dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-					base.WarnfCtx(ctx.Ctx, "config setup failed taking db online, Err: %v", err)
-					return
-				}
-
-				h.server._databasesLock.Lock()
-				defer h.server._databasesLock.Unlock()
-
-				// TODO: Dynamic update instead of reload
-				if err = h.server._reloadDatabaseWithConfig(contextNoCancel.Ctx, *updatedDbConfig, false, false); err != nil {
-					base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
-					return
-				}
+		if !atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBStarting) {
+			base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(h.db.Name))
+			return
+		}
+		var oldConfig DbConfig
+		if !h.server.persistentConfig {
+			newDbConfig := &DbConfig{StartOffline: base.Ptr(false)}
+			err := h.updateNonPersistentDbConfig(contextNoCancel, h.db.Name, false, false, true, newDbConfig)
+			if err != nil {
+				base.WarnfCtx(contextNoCancel.Ctx, "database reload failed during db online, Err: %v", err)
+				return
 			}
 		} else {
-			base.InfofCtx(contextNoCancel.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(h.db.Name))
+			// persistent config here
+			bucket := h.db.Bucket.GetName()
+			dbName := h.db.Name
+			var cas uint64
+			var updatedDbConfig *DatabaseConfig
+			cas, err = h.server.BootstrapContext.UpdateConfig(contextNoCancel.Ctx, bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
+				oldConfig = bucketDbConfig.DbConfig
+
+				// set config to offline false to start online processes
+				bucketDbConfig.StartOffline = base.Ptr(false)
+
+				if err := bucketDbConfig.validateConfigUpdate(contextNoCancel.Ctx, oldConfig, false); err != nil {
+					return nil, base.NewHTTPError(http.StatusBadRequest, err.Error())
+				}
+
+				bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(ctx.Ctx, bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+				if err != nil {
+					return nil, err
+				}
+
+				bucketDbConfig.SGVersion = base.ProductVersion.String()
+				updatedDbConfig = bucketDbConfig
+				return bucketDbConfig, nil
+			})
+			if err != nil {
+				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+				return
+			}
+			if err = h.updateConfigAndReloadDatabase(contextNoCancel.Ctx, dbName, bucket, cas, updatedDbConfig); err != nil {
+				base.WarnfCtx(ctx.Ctx, "database reload failed during db online, Err: %v", err)
+				return
+			}
 		}
 	}(contextNoCancel)
 
@@ -350,9 +342,6 @@ func (h *handler) handleDbOffline() error {
 		dbName := h.db.Name
 		var updatedDbConfig *DatabaseConfig
 		cas, err := h.server.BootstrapContext.UpdateConfig(h.ctx(), bucket, h.server.Config.Bootstrap.ConfigGroupID, dbName, func(bucketDbConfig *DatabaseConfig) (updatedConfig *DatabaseConfig, err error) {
-			if h.headerDoesNotMatchEtag(bucketDbConfig.Version) {
-				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
-			}
 			oldConfig = bucketDbConfig.DbConfig
 
 			// set config to offline true
@@ -374,19 +363,7 @@ func (h *handler) handleDbOffline() error {
 		if err != nil {
 			return err
 		}
-		updatedDbConfig.cfgCas = cas
-
-		dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-		bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-		if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-			return err
-		}
-
-		h.server._databasesLock.Lock()
-		defer h.server._databasesLock.Unlock()
-
-		// TODO: Dynamic update instead of reload
-		if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+		if err := h.updateConfigAndReloadDatabase(h.ctx(), dbName, bucket, cas, updatedDbConfig); err != nil {
 			return err
 		}
 	}
@@ -766,6 +743,26 @@ func (h *handler) handlePutConfig() error {
 	}
 
 	return base.HTTPErrorf(http.StatusOK, "Updated")
+}
+
+// updateConfigAndReloadDatabase applies the post-UpdateConfig steps shared by several handlers: it stamps
+// the CAS on the config, runs setup (credential injection etc.), acquires _databasesLock and reloads
+// the database. ctx must be non-cancellable because it is used inside a goroutine or across long-lived
+// operations.
+func (h *handler) updateConfigAndReloadDatabase(ctx context.Context, dbName, bucket string, cas uint64, updatedDbConfig *DatabaseConfig) error {
+	updatedDbConfig.cfgCas = cas
+
+	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
+	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
+	if err := updatedDbConfig.setup(ctx, dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
+		return err
+	}
+
+	h.server._databasesLock.Lock()
+	defer h.server._databasesLock.Unlock()
+
+	// TODO: Dynamic update instead of reload
+	return h.server._reloadDatabaseWithConfig(ctx, *updatedDbConfig, false, false)
 }
 
 func (h *handler) updateNonPersistentDbConfig(ctx base.NonCancellableContext, dbName string, validateOIDC, validateConfigUpdate, mergeConfig bool, dbConfig *DbConfig) error {
@@ -1286,20 +1283,7 @@ func (h *handler) handleDeleteCollectionConfigSync() error {
 	if err != nil {
 		return err
 	}
-	updatedDbConfig.cfgCas = cas
-
-	dbName := h.db.Name
-	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-		return err
-	}
-
-	h.server._databasesLock.Lock()
-	defer h.server._databasesLock.Unlock()
-
-	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+	if err := h.updateConfigAndReloadDatabase(h.ctx(), h.db.Name, bucket, cas, updatedDbConfig); err != nil {
 		return err
 	}
 
@@ -1356,19 +1340,7 @@ func (h *handler) handlePutCollectionConfigSync() error {
 	if err != nil {
 		return err
 	}
-	updatedDbConfig.cfgCas = cas
-
-	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-		return err
-	}
-
-	h.server._databasesLock.Lock()
-	defer h.server._databasesLock.Unlock()
-
-	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+	if err := h.updateConfigAndReloadDatabase(h.ctx(), dbName, bucket, cas, updatedDbConfig); err != nil {
 		return err
 	}
 
@@ -1456,19 +1428,7 @@ func (h *handler) handleDeleteCollectionConfigImportFilter() error {
 	if err != nil {
 		return err
 	}
-	updatedDbConfig.cfgCas = cas
-
-	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-		return err
-	}
-
-	h.server._databasesLock.Lock()
-	defer h.server._databasesLock.Unlock()
-
-	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+	if err := h.updateConfigAndReloadDatabase(h.ctx(), dbName, bucket, cas, updatedDbConfig); err != nil {
 		return err
 	}
 
@@ -1526,19 +1486,7 @@ func (h *handler) handlePutCollectionConfigImportFilter() error {
 	if err != nil {
 		return err
 	}
-	updatedDbConfig.cfgCas = cas
-
-	dbCreds, _ := h.server.Config.DatabaseCredentials[dbName]
-	bucketCreds, _ := h.server.Config.BucketCredentials[bucket]
-	if err := updatedDbConfig.setup(h.ctx(), dbName, h.server.Config.Bootstrap, dbCreds, bucketCreds, h.server.Config.IsServerless()); err != nil {
-		return err
-	}
-
-	h.server._databasesLock.Lock()
-	defer h.server._databasesLock.Unlock()
-
-	// TODO: Dynamic update instead of reload
-	if err := h.server._reloadDatabaseWithConfig(h.ctx(), *updatedDbConfig, false, false); err != nil {
+	if err := h.updateConfigAndReloadDatabase(h.ctx(), dbName, bucket, cas, updatedDbConfig); err != nil {
 		return err
 	}
 

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3439,7 +3439,7 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 	rest.RequireStatus(t, resp, http.StatusCreated)
 }
 
-func TestTakeDbOfflineUsingOfflineEndpoint(t *testing.T) {
+func TestTakeDbOfflineOnlineUsingOfflineEndpoint(t *testing.T) {
 	testCases := []struct {
 		name             string
 		persistentConfig bool

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3469,7 +3469,7 @@ func TestTakeDbOfflineUsingOfflineEndpoint(t *testing.T) {
 			rest.RequireStatus(t, resp, http.StatusOK)
 			require.NoError(t, json.Unmarshal(resp.BodyBytes(), &preOfflineDBConfig))
 
-			preOfflineDBConfig.UpdatedAt = nil // nill this for comparison later in test
+			preOfflineDBConfig.UpdatedAt = nil // nil this for comparison later in test
 
 			// Take DB offline
 			resp = rt.SendAdminRequest(http.MethodPost, "/db/_offline", "")

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -627,7 +627,8 @@ func TestDBOfflineSingleResyncUsingDCPStream(t *testing.T) {
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/db/_resync?action=start", ""), 503)
 
 	rt.WaitForResyncDCPStatus(db.BackgroundProcessStateCompleted)
-	assert.Equal(t, int64(2000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
+	// offline call above resets stats to 0, so sync function count will only include resync run started above
+	assert.Equal(t, int64(1000), rt.GetDatabase().DbStats.Database().SyncFunctionCount.Value())
 }
 
 func TestDCPResyncCollectionsStatus(t *testing.T) {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3141,7 +3141,8 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 	// Get config values before taking db offline, locally only
 	resp := rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_config", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	dbConfigBeforeOffline := resp.Body.String()
+	var dbConfigBeforeOffline rest.DbConfig
+	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &dbConfigBeforeOffline))
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_config/import_filter", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -3159,7 +3160,12 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 	// Check offline config matches online config
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.db}}/_config", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
-	require.Equal(t, dbConfigBeforeOffline, resp.Body.String())
+	var dbConfigAfterOffline rest.DbConfig
+	require.NoError(t, json.Unmarshal(resp.BodyBytes(), &dbConfigAfterOffline))
+	dbConfigAfterOffline.StartOffline = nil // _offline now alters config, remove this to compare before and after config to ensure nothing else is changed
+	dbConfigAfterOffline.UpdatedAt = nil
+	dbConfigBeforeOffline.UpdatedAt = nil
+	require.Equal(t, dbConfigBeforeOffline, dbConfigAfterOffline)
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_config/import_filter", "")
 	rest.RequireStatus(t, resp, http.StatusOK)
@@ -3430,6 +3436,80 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 		),
 	)
 	rest.RequireStatus(t, resp, http.StatusCreated)
+}
+
+func TestTakeDbOfflineUsingOfflineEndpoint(t *testing.T) {
+	testCases := []struct {
+		name             string
+		persistentConfig bool
+	}{
+		{
+			name:             "non persistent config",
+			persistentConfig: false,
+		},
+		{
+			name:             "persistent config",
+			persistentConfig: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{PersistentConfig: testCase.persistentConfig})
+			defer rt.Close()
+
+			if testCase.persistentConfig {
+				dbCfg := rt.NewDbConfig()
+				rest.RequireStatus(t, rt.CreateDatabase("db", dbCfg), http.StatusCreated)
+			}
+
+			// Grab db config before offline operation
+			var preOfflineDBConfig rest.DbConfig
+			resp := rt.SendAdminRequest(http.MethodGet, "/db/_config", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+			require.NoError(t, json.Unmarshal(resp.BodyBytes(), &preOfflineDBConfig))
+
+			preOfflineDBConfig.UpdatedAt = nil // nill this for comparison later in test
+
+			// Take DB offline
+			resp = rt.SendAdminRequest(http.MethodPost, "/db/_offline", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+
+			// Verify DB state
+			resp = rt.SendAdminRequest(http.MethodGet, "/db/", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+			var dbStatus map[string]any
+			err := json.Unmarshal(resp.BodyBytes(), &dbStatus)
+			require.NoError(t, err)
+			assert.Equal(t, "Offline", dbStatus["state"])
+
+			// Try to put a doc - should fail
+			resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar"}`)
+			rest.RequireStatus(t, resp, http.StatusServiceUnavailable)
+
+			// Bring DB online
+			resp = rt.SendAdminRequest(http.MethodPost, "/db/_online", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+
+			// Wait for online process to complete
+			rt.WaitForDBOnline()
+
+			// Try to put a doc - should succeed
+			resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc1", `{"foo":"bar"}`)
+			rest.RequireStatus(t, resp, http.StatusCreated)
+
+			// Grab post online config
+			var postOnlineDbConfig rest.DbConfig
+			resp = rt.SendAdminRequest(http.MethodGet, "/db/_config", "")
+			rest.RequireStatus(t, resp, http.StatusOK)
+			require.NoError(t, json.Unmarshal(resp.BodyBytes(), &postOnlineDbConfig))
+
+			// remove field that didn't exist in original db config
+			postOnlineDbConfig.StartOffline = nil
+			postOnlineDbConfig.Server = nil
+			postOnlineDbConfig.UpdatedAt = nil
+			assert.Equal(t, preOfflineDBConfig, postOnlineDbConfig)
+		})
+	}
 }
 
 // Regression test for CBG-2119 - ensure that the disable_password_auth bool field is handled correctly both when set as true and as false

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3284,7 +3284,7 @@ func TestBufferFlush(t *testing.T) {
 	assert.True(t, resp.Flushed)
 }
 
-func TestContinuousChangesDoesNotBlockIOffline(t *testing.T) {
+func TestContinuousChangesDoesNotBlockOffline(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3284,6 +3284,25 @@ func TestBufferFlush(t *testing.T) {
 	assert.True(t, resp.Flushed)
 }
 
+func TestContinuousChangesDoesNotBlockIOffline(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	_ = rt.GetDatabase()
+
+	go func() {
+		resp := rt.SendAdminRequest(http.MethodGet, "/{{.keyspace}}/_changes?feed=continuous&since=0&timeout=50000&include_docs=true", "")
+		RequireStatus(t, resp, http.StatusOK)
+	}()
+
+	base.RequireWaitForStat(t, func() int64 {
+		return rt.GetDatabase().DbStats.Database().NumReplicationsActive.Value()
+	}, 1)
+
+	// assert that we can take db offline still
+	rt.TakeDbOffline()
+}
+
 func TestPublicAllDocsApiStats(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: channels.DocChannelsSyncFunction,

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3301,6 +3301,11 @@ func TestContinuousChangesDoesNotBlockIOffline(t *testing.T) {
 
 	// assert that we can take db offline still
 	rt.TakeDbOffline()
+
+	// expect changes to be closed after offline
+	base.RequireWaitForStat(t, func() int64 {
+		return rt.GetDatabase().DbStats.Database().NumReplicationsActive.Value()
+	}, 0)
 }
 
 func TestPublicAllDocsApiStats(t *testing.T) {

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3288,7 +3288,6 @@ func TestBlipDisconnectOnDbOffline(t *testing.T) {
 
 				var blipPullContextClosed atomic.Bool
 				btcRunner.clients[btc.id].pullReplication.bt.blipContext.OnExitCallback = func() {
-					log.Printf("on exit callback invoked")
 					blipPullContextClosed.Store(true)
 				}
 				// add some replication activity

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3247,17 +3247,6 @@ func TestBlipDatabaseClose(t *testing.T) {
 	})
 }
 
-func TestLol(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
-
-	_ = rt.GetDatabase()
-
-	dbCfg := rt.NewDbConfig()
-	resp := rt.UpsertDbConfig("db", dbCfg)
-	fmt.Println(resp)
-}
-
 func TestBlipDisconnectOnDbOffline(t *testing.T) {
 	base.LongRunningTest(t)
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -3247,6 +3247,77 @@ func TestBlipDatabaseClose(t *testing.T) {
 	})
 }
 
+func TestLol(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	_ = rt.GetDatabase()
+
+	dbCfg := rt.NewDbConfig()
+	resp := rt.UpsertDbConfig("db", dbCfg)
+	fmt.Println(resp)
+}
+
+func TestBlipDisconnectOnDbOffline(t *testing.T) {
+	base.LongRunningTest(t)
+
+	testCases := []struct {
+		name             string
+		persistentConfig bool
+	}{
+		{
+			name:             "non persistent config",
+			persistentConfig: false,
+		},
+		{
+			name:             "persistent config",
+			persistentConfig: true,
+		},
+	}
+
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeyAll)
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				var rt *RestTester
+				if testCase.persistentConfig {
+					rt = NewRestTesterPersistentConfig(t)
+					defer rt.Close()
+				} else {
+					rt = NewRestTester(t, nil)
+					defer rt.Close()
+				}
+				const alice = "alice"
+				rt.CreateUser(alice, []string{"*"})
+				btc := btcRunner.NewBlipTesterClientOptsWithRT(rt,
+					&BlipTesterClientOpts{
+						Username: alice,
+					})
+				defer btc.Close()
+
+				var blipPullContextClosed atomic.Bool
+				btcRunner.clients[btc.id].pullReplication.bt.blipContext.OnExitCallback = func() {
+					log.Printf("on exit callback invoked")
+					blipPullContextClosed.Store(true)
+				}
+				// add some replication activity
+				markerDoc := "markerDoc"
+				markerDocVersion := rt.PutDoc(markerDoc, `{"mark": "doc"}`)
+				rt.WaitForPendingChanges()
+				btcRunner.StartPull(btc.id)
+				btcRunner.WaitForVersion(btc.id, markerDoc, markerDocVersion)
+
+				rt.TakeDbOffline()
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.True(c, blipPullContextClosed.Load())
+				}, time.Second*10, time.Millisecond*100)
+			})
+		}
+	})
+}
+
 func TestPutRevBlip(t *testing.T) {
 	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{GuestEnabled: true, blipProtocols: []string{db.CBMobileReplicationV4.SubprotocolString()}})
 	defer bt.Close()

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -443,10 +443,6 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 				base.InfofCtx(h.ctx(), base.KeyChanges, "Connection lost from client")
 				forceClose = true
 				break loop
-			case <-h.db.ExitChanges:
-				message = "OK DB has gone offline"
-				forceClose = true
-				break loop
 			}
 			if err != nil {
 				logStatus(599, fmt.Sprintf("Write error: %v", err))

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1483,35 +1483,6 @@ func dbcOptionsFromConfig(ctx context.Context, sc *ServerContext, config *DbConf
 	return contextOptions, nil
 }
 
-func (sc *ServerContext) TakeDbOnline(nonContextStruct base.NonCancellableContext, database *db.DatabaseContext) {
-
-	// Take a write lock on the Database context, so that we can cycle the underlying Database
-	// without any other call running concurrently
-	database.AccessLock.Lock()
-	defer database.AccessLock.Unlock()
-
-	// We can only transition to Online from Offline state
-	if atomic.CompareAndSwapUint32(&database.State, db.DBOffline, db.DBStarting) {
-		reloadedDb, err := sc.ReloadDatabase(nonContextStruct.Ctx, database.Name, true)
-		if err != nil {
-			base.ErrorfCtx(nonContextStruct.Ctx, "Error reloading database from config: %v", err)
-			return
-		}
-
-		if len(reloadedDb.RequireResync) > 0 {
-			base.ErrorfCtx(nonContextStruct.Ctx, "Database has collections that require regenerate_sequences resync before it can go online: %v", reloadedDb.RequireResync)
-			return
-		}
-		// Reloaded DB should already be online in most cases, but force state to online to handle cases
-		// where config specifies offline startup
-		atomic.StoreUint32(&reloadedDb.State, db.DBOnline)
-
-	} else {
-		base.InfofCtx(nonContextStruct.Ctx, base.KeyCRUD, "Unable to take Database : %v online , database must be in Offline state", base.UD(database.Name))
-	}
-
-}
-
 // validateMetadataStore will
 func validateMetadataStore(ctx context.Context, metadataStore base.DataStore) error {
 	// Check if scope/collection specified exists. Will enter retry loop if connection unsuccessful

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -942,25 +942,9 @@ func TestHeapProfileValuesPopulated(t *testing.T) {
 }
 
 func TestDatabaseStartupFailure(t *testing.T) {
-	if !base.IsEnterpriseEdition() {
-		t.Skip("EE only test, requires heartbeater error")
-	}
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("LeakyBucketConfig not supported on CBS")
-	}
-
-	tb := base.GetTestBucket(t)
-	defer tb.Close(t.Context())
-
-	rt := NewRestTester(t, &RestTesterConfig{
-		CustomTestBucket: tb.NoCloseClone(),
-		PersistentConfig: true,
-	})
+	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 	ctx := rt.Context()
-
-	dbCfg := rt.NewDbConfig()
-	RequireStatus(t, rt.CreateDatabase("db", dbCfg), http.StatusCreated)
 
 	// alter in memory db config to invalid config that will fail online process
 	rt.ServerContext()._dbConfigs["db"].Users = map[string]*auth.PrincipalConfig{
@@ -971,7 +955,7 @@ func TestDatabaseStartupFailure(t *testing.T) {
 
 	// reload db with invalid config, should fail online process and put db in offline state
 	dbContext, err := rt.ServerContext().ReloadDatabase(ctx, "db", false)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "must either specify all OIDC properties or none")
 	require.Nil(t, dbContext)
 	require.Equal(t, "Offline", rt.GetDBState())
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -10,7 +10,6 @@ package rest
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,7 +17,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -845,7 +843,7 @@ func TestOfflineDatabaseStartup(t *testing.T) {
 	// ensure doc1 is not imported - since we started the database offline
 	assert.Equal(t, int64(0), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
-	rt.ServerContext().TakeDbOnline(base.NewNonCancelCtx(), rt.GetDatabase())
+	rt.TakeDbOnline()
 	require.NotNil(t, rt.GetDatabase().ImportListener)
 
 	resp = rt.SendAdminRequest(http.MethodPut, "/{{.keyspace}}/doc3", `{"type":"doc3"}`)
@@ -951,27 +949,29 @@ func TestDatabaseStartupFailure(t *testing.T) {
 		t.Skip("LeakyBucketConfig not supported on CBS")
 	}
 
-	touchErr := errors.New("touch error")
+	tb := base.GetTestBucket(t)
+	defer tb.Close(t.Context())
+
 	rt := NewRestTester(t, &RestTesterConfig{
-		LeakyBucketConfig: &base.LeakyBucketConfig{
-			TouchCallback: func(key string) error {
-				if strings.Contains(key, "heartbeat_timeout") {
-					return touchErr
-				}
-				return nil
-			},
-		},
+		CustomTestBucket: tb.NoCloseClone(),
 		PersistentConfig: true,
 	})
 	defer rt.Close()
+	ctx := rt.Context()
 
-	dbConfig := DatabaseConfig{
-		DbConfig: rt.NewDbConfig(),
+	dbCfg := rt.NewDbConfig()
+	RequireStatus(t, rt.CreateDatabase("db", dbCfg), http.StatusCreated)
+
+	// alter in memory db config to invalid config that will fail online process
+	rt.ServerContext()._dbConfigs["db"].Users = map[string]*auth.PrincipalConfig{
+		"alice": {
+			JWTChannels: base.SetOf("asdf"),
+		},
 	}
 
-	// this call does use the leaky bucket
-	dbContext, err := rt.ServerContext().AddDatabaseFromConfigWithBucket(rt.Context(), t, dbConfig, rt.Bucket())
-	require.ErrorIs(t, err, touchErr)
+	// roald db with invalid config, should fail online process and put db in offline state
+	dbContext, err := rt.ServerContext().ReloadDatabase(ctx, "db", false)
+	require.Error(t, err)
 	require.Nil(t, dbContext)
 	require.Equal(t, "Offline", rt.GetDBState())
 
@@ -986,7 +986,7 @@ func TestDatabaseStartupFailure(t *testing.T) {
 	assert.Equal(t, invalDb.DatabaseError.ErrMsg, db.DatabaseErrorMap[db.DatabaseOnlineProcessError])
 
 	// assert that you can attempt again to bring db back online again after failure
-	resp := rt.SendAdminRequest(http.MethodPost, "/"+invalDb.Bucket+"/_online", "")
+	resp := rt.SendAdminRequest(http.MethodPost, "/db/_online", "")
 	RequireStatus(t, resp, http.StatusOK)
 	rt.WaitForDBOnline()
 }

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -969,7 +969,7 @@ func TestDatabaseStartupFailure(t *testing.T) {
 		},
 	}
 
-	// roald db with invalid config, should fail online process and put db in offline state
+	// reload db with invalid config, should fail online process and put db in offline state
 	dbContext, err := rt.ServerContext().ReloadDatabase(ctx, "db", false)
 	require.Error(t, err)
 	require.Nil(t, dbContext)

--- a/rest/utilities_testing_resttester.go
+++ b/rest/utilities_testing_resttester.go
@@ -466,26 +466,15 @@ func (rt *RestTester) PersistDbConfigToBucket(dbConfig DbConfig, bucketName stri
 
 // TakeDbOffline takes the database offline.
 func (rt *RestTester) TakeDbOffline() {
-	if rt.PersistentConfig {
-		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", `{"offline":true}`)
-		RequireStatus(rt.TB(), resp, http.StatusCreated)
-		rt.WaitForDBState(db.RunStateString[db.DBOffline])
-	} else {
-		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_offline", "")
-		RequireStatus(rt.TB(), resp, http.StatusOK)
-	}
+	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_offline", "")
+	RequireStatus(rt.TB(), resp, http.StatusOK)
 	require.Equal(rt.TB(), db.DBOffline, atomic.LoadUint32(&rt.GetDatabase().State))
 }
 
 // TakeDbOnline takes the database online and waits for online status.
 func (rt *RestTester) TakeDbOnline() {
-	if rt.PersistentConfig {
-		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_config", `{"offline":false}`)
-		RequireStatus(rt.TB(), resp, http.StatusCreated)
-	} else {
-		resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_online", "")
-		RequireStatus(rt.TB(), resp, http.StatusOK)
-	}
+	resp := rt.SendAdminRequest(http.MethodPost, "/{{.db}}/_online", "")
+	RequireStatus(rt.TB(), resp, http.StatusOK)
 	rt.WaitForDBOnline()
 }
 


### PR DESCRIPTION
CBG-4651

- Change for online/offline endpoints to be aligned between persistent and non persistent config 
- Each endpoint will alter the db config to set offline true/false. Persistent config will persist this change to be picked up by other nodes, non persistent config will not 
- Both modes will disconnect clients as the db is reloaded for each mode

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/318/
