### PR TITLE
CBG-5205 test speed up: avoid sleep on db start

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -2430,8 +2430,6 @@ func TestReleasedSequenceRangeHandlingEverythingPendingAndProcessPending(t *test
 //   - Then add another pending entry to take over pending capacity and assert that the range is processed correctly
 //   - Then add another range to completely unblock pending
 func TestReleasedSequenceRangeHandlingEverythingPendingLowPendingCapacity(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	ctx := base.TestCtx(t)
@@ -2530,8 +2528,6 @@ func TestReleasedSequenceRangeHandlingEverythingPendingLowPendingCapacity(t *tes
 //   - Assert this single range is processed off pending after new entry is added taking pending over the limit
 //   - Test release of another single range that is now skipped and assert that skipped is emptied
 func TestReleasedSequenceRangeHandlingSingleSequence(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	ctx := base.TestCtx(t)
@@ -2755,8 +2751,6 @@ func TestReleasedSequenceRangeHandlingEdgeCase2(t *testing.T) {
 //   - Empty skipped through unused sequence release
 //   - Add new contiguous sequence and assert it is processed correctly
 func TestReleasedSequenceRangeHandlingDuplicateSequencesInSkipped(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCache)
 
 	ctx := base.TestCtx(t)
@@ -3170,8 +3164,6 @@ func TestChangeInBroadcastForSkipped(t *testing.T) {
 }
 
 func TestUnblockPendingWithUnusedRange(t *testing.T) {
-	base.LongRunningTest(t)
-
 	opts := DefaultCacheOptions()
 	opts.CachePendingSeqMaxWait = 20 * time.Minute
 	opts.CacheSkippedSeqMaxWait = 20 * time.Minute

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -1006,8 +1006,6 @@ func TestImportFeedInvalidSyncMetadata(t *testing.T) {
 }
 
 func TestOnDemandImportPanicInvalidSyncData(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.SetUpTestLogging(t, base.LevelDebug, base.KeyCRUD, base.KeyImport, base.KeyMigrate)
 	base.SkipImportTestsIfNotEnabled(t)
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -716,16 +716,6 @@ func RawDocWithInlineSyncData(_ testing.TB) string {
 `
 }
 
-// DisableSequenceWaitOnDbStart disables the release sequence wait on db start.  Appropriate for tests
-// that make changes to database config after first startup, and don't assert/require on sequence correctness
-func DisableSequenceWaitOnDbRestart(tb testing.TB) {
-	//
-	BypassReleasedSequenceWait.Store(true)
-	tb.Cleanup(func() {
-		BypassReleasedSequenceWait.Store(false)
-	})
-}
-
 // WriteDirect will write a document named doc-{sequence} with a given set of channels. This is used to simulate out of order sequence writes by bypassing typical Sync Gateway CRUD functions.
 func WriteDirect(t *testing.T, collection *DatabaseCollection, channelArray []string, sequence uint64) {
 	key := fmt.Sprintf("doc-%v", sequence)

--- a/rest/access_test.go
+++ b/rest/access_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestPublicChanGuestAccess(t *testing.T) {
-	base.LongRunningTest(t)
-
 	rt := NewRestTester(t,
 		&RestTesterConfig{
 			SyncFn: channels.DocChannelsSyncFunction,

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -547,8 +547,6 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 // Tests that the users returned in the config endpoint have the correct names
 // Reproduces #2223
 func TestDBGetConfigNamesAndDefaultLogging(t *testing.T) {
-	base.LongRunningTest(t)
-
 	p := "password"
 	rt := rest.NewRestTester(t,
 		&rest.RestTesterConfig{
@@ -2287,8 +2285,6 @@ func TestHandleGetStackTrace(t *testing.T) {
 }
 
 func TestConfigRedaction(t *testing.T) {
-	base.LongRunningTest(t)
-
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{Users: map[string]*auth.PrincipalConfig{"alice": {Password: base.Ptr("password")}}}}})
 	defer rt.Close()
 

--- a/rest/api_collections_test.go
+++ b/rest/api_collections_test.go
@@ -27,8 +27,6 @@ import (
 // TestCollectionsPutDocInKeyspace creates a collection and starts up a RestTester instance on it.
 // Ensures that various keyspaces can or can't be used to insert a doc in the collection.
 func TestCollectionsPutDocInKeyspace(t *testing.T) {
-	base.LongRunningTest(t)
-
 	const (
 		username = "alice"
 		password = "pass"
@@ -967,8 +965,6 @@ func TestRuntimeConfigUpdateAfterConfigUpdateConflict(t *testing.T) {
 //   - Fetch runtime config and assert the scope config matches what we expect
 //   - Assert we can perform crud operations against each collection 1 and 2
 func TestRaceBetweenConfigPollAndDbConfigUpdate(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.TestRequiresCollections(t)
 
 	ctx := base.TestCtx(t)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -81,8 +81,6 @@ func TestRoot(t *testing.T) {
 }
 
 func TestPublicRESTStatCount(t *testing.T) {
-	base.LongRunningTest(t)
-
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -781,8 +781,6 @@ func TestRedactConfigAsStr(t *testing.T) {
 }
 
 func TestEffectiveUserID(t *testing.T) {
-	base.LongRunningTest(t)
-
 	tempdir := t.TempDir()
 	base.ResetGlobalTestLogging(t)
 	base.InitializeMemoryLoggers()
@@ -1808,8 +1806,6 @@ func TestDatabaseAuditChanges(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Audit logging only works in EE")
 	}
-
-	db.DisableSequenceWaitOnDbRestart(t)
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestBytesReadDocOperations(t *testing.T) {
-	base.LongRunningTest(t)
-
 	rt := NewRestTester(t, &RestTesterConfig{SyncFn: channels.DocChannelsSyncFunction})
 	defer rt.Close()
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -2933,8 +2933,6 @@ func makeScopesConfigWithDefault(scopeName string, collections []string) *Scopes
 //   - Delete the invalid db config form the bucket
 //   - Force config poll reload and assert the invalid db is cleared
 func TestInvalidDbConfigNoLongerPresentInBucket(t *testing.T) {
-	base.LongRunningTest(t)
-
 	rt := NewRestTester(t, &RestTesterConfig{
 		CustomTestBucket: base.GetTestBucket(t),
 		PersistentConfig: true,

--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -25,8 +25,6 @@ import (
 const accessControlAllowOrigin = "Access-Control-Allow-Origin"
 
 func TestCORSDynamicSet(t *testing.T) {
-	base.LongRunningTest(t)
-
 	rt := NewRestTester(t, &RestTesterConfig{
 		PersistentConfig: true,
 	})

--- a/rest/diagnostic_api_test.go
+++ b/rest/diagnostic_api_test.go
@@ -724,8 +724,6 @@ func TestGetAllChannelsByUserWithSingleNamedCollection(t *testing.T) {
 }
 
 func TestGetAllChannelsByUserWithMultiCollections(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.TestRequiresCollections(t)
 
 	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true}, 2)

--- a/rest/diagnostic_doc_api_test.go
+++ b/rest/diagnostic_doc_api_test.go
@@ -562,8 +562,6 @@ func TestGetUserDocAccessSpanWithSingleNamedCollection(t *testing.T) {
 }
 
 func TestGetUserDocAccessSpanWithMultiCollections(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.TestRequiresCollections(t)
 
 	rt := NewRestTesterMultipleCollections(t, &RestTesterConfig{PersistentConfig: true, SyncFn: `function(doc) {channel(doc.channel);}`}, 2)

--- a/rest/functionsapitest/user_functions_queries_test.go
+++ b/rest/functionsapitest/user_functions_queries_test.go
@@ -74,8 +74,6 @@ func TestUserFunctions(t *testing.T) {
 }
 
 func TestJSFunctionAsGuest(t *testing.T) {
-	base.LongRunningTest(t)
-
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		GuestEnabled:      true,
 		EnableUserQueries: true,

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -338,8 +338,6 @@ func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 }
 
 func TestImportFilterEndpoint(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.SkipImportTestsIfNotEnabled(t) // import tests don't work without xattrs
 
 	rt := NewRestTesterPersistentConfig(t)
@@ -1375,8 +1373,6 @@ func makeDbConfig(bucketName string, dbName string, scopesConfig ScopesConfig) D
 }
 
 func TestPersistentConfigNoBucketField(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.RequireNumTestBuckets(t, 2)
 
 	base.SetUpTestLogging(t, base.LevelTrace, base.KeyConfig)

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -7176,8 +7176,6 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 }
 
 func TestBlipSyncNonUpgradableConnection(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)
 	rt := rest.NewRestTester(t, &rest.RestTesterConfig{
 		DatabaseConfig: &rest.DatabaseConfig{DbConfig: rest.DbConfig{

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -808,8 +808,6 @@ func TestDisableScopesInLegacyConfig(t *testing.T) {
 
 // TestOfflineDatabaseStartup ensures that background processes are not actually running when starting up a database in offline mode.
 func TestOfflineDatabaseStartup(t *testing.T) {
-	base.LongRunningTest(t)
-
 	if !base.TestUseXattrs() {
 		t.Skip("TestOfflineDatabaseStartup requires xattrs for document import")
 	}

--- a/rest/sync_fn_test.go
+++ b/rest/sync_fn_test.go
@@ -658,8 +658,6 @@ func TestResyncPersistence(t *testing.T) {
 }
 
 func TestExpiryUpdateSyncFunction(t *testing.T) {
-	base.LongRunningTest(t)
-
 	rt := NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 

--- a/rest/upgradetest/upgrade_registry_test.go
+++ b/rest/upgradetest/upgrade_registry_test.go
@@ -185,8 +185,6 @@ func getDbConfigFromLegacyConfig(rt *rest.RestTester) string {
 
 }
 func TestLegacyMetadataID(t *testing.T) {
-	base.LongRunningTest(t)
-
 	tb1 := base.GetTestBucket(t)
 	// Create a non-persistent rest tester.  Standard RestTester
 	// creates a database 'db' targeting the default collection (when !TestUseNamedCollections)
@@ -221,8 +219,6 @@ func TestLegacyMetadataID(t *testing.T) {
 // TestMetadataIDRenameDatabase verifies that resync is not required when deleting and recreating a database (with a
 // different name) targeting only the default collection.
 func TestMetadataIDRenameDatabase(t *testing.T) {
-	base.LongRunningTest(t)
-
 	// Create a persistent rest tester with default collection.
 	rt := rest.NewRestTesterDefaultCollection(t, &rest.RestTesterConfig{
 		PersistentConfig: true,

--- a/rest/user_api_test.go
+++ b/rest/user_api_test.go
@@ -29,8 +29,6 @@ import (
 
 // TestUsersAPI tests pagination of QueryPrincipals
 func TestUsersAPI(t *testing.T) {
-	base.LongRunningTest(t)
-
 	// Create rest tester with low pagination limit
 	rtConfig := &RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{
@@ -80,8 +78,6 @@ func TestUsersAPI(t *testing.T) {
 
 // TestUsersAPIDetails tests users endpoint with name_only=false when using views (unsupported combination, should return 400)
 func TestUsersAPIDetailsViews(t *testing.T) {
-	base.LongRunningTest(t)
-
 	if !base.TestsDisableGSI() {
 		t.Skip("This test only works with UseViews=true")
 	}
@@ -1195,8 +1191,6 @@ func TestRemovingUserXattr(t *testing.T) {
 }
 
 func TestGetUserCollectionAccess(t *testing.T) {
-	base.LongRunningTest(t)
-
 	numCollections := 2
 	base.RequireNumTestDataStores(t, numCollections)
 
@@ -1368,8 +1362,6 @@ func requireJWTChannels(t *testing.T, expectedChannels base.Set, principalConfig
 }
 
 func TestPutUserCollectionAccess(t *testing.T) {
-	base.LongRunningTest(t)
-
 	base.RequireNumTestDataStores(t, 2)
 	testBucket := base.GetTestBucket(t)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2767,6 +2767,7 @@ func TestBucketPoolRestWithIndexes(ctx context.Context, m *testing.M, tbpOptions
 			panic(fmt.Sprintf("%v active blip tester clients should be 0 at end of tests", globalBlipTesterClients.m))
 		}
 	})
+	db.BypassReleasedSequenceWait.Store(true)
 	serverContextGlobalsInitialized.Store(true)
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -923,7 +923,7 @@ func (rt *RestTester) WaitForChanges(numChangesExpected int, changesURL, usernam
 			response = rt.Send(RequestByUser("GET", url, "", username))
 		}
 		assert.NoError(c, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-		assert.Len(c, changes.Results, numChangesExpected, "Expected %d changes, got %d changes", numChangesExpected, len(changes.Results))
+		assert.Len(c, changes.Results, numChangesExpected, "Expected %d changes, got %s changes", numChangesExpected, changes.Summary())
 	}, waitTime, 10*time.Millisecond)
 	return *changes
 }

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -57,6 +57,8 @@ type SGRTestRunner struct {
 func NewSGRTestRunner(t *testing.T) *SGRTestRunner {
 	// If BypassReleasedSequenceWait is true, tests like TestReplicationRebalancePush can miss sequences due to a
 	// race between SGReplicateMgr assigning nodes and the sequenceAllocator/changeListener starting.
+	//
+	// See CBG-5267.
 	previousBypassReleasedSequenceWait := db.BypassReleasedSequenceWait.Load()
 	t.Cleanup(func() {
 		db.BypassReleasedSequenceWait.Store(previousBypassReleasedSequenceWait)

--- a/rest/utilities_testing_isgr.go
+++ b/rest/utilities_testing_isgr.go
@@ -55,6 +55,14 @@ type SGRTestRunner struct {
 
 // NewSGRTestRunner returns a new SGRTestRunner instance.
 func NewSGRTestRunner(t *testing.T) *SGRTestRunner {
+	// If BypassReleasedSequenceWait is true, tests like TestReplicationRebalancePush can miss sequences due to a
+	// race between SGReplicateMgr assigning nodes and the sequenceAllocator/changeListener starting.
+	previousBypassReleasedSequenceWait := db.BypassReleasedSequenceWait.Load()
+	t.Cleanup(func() {
+		db.BypassReleasedSequenceWait.Store(previousBypassReleasedSequenceWait)
+	})
+	db.BypassReleasedSequenceWait.Store(false)
+
 	return &SGRTestRunner{
 		t:           t,
 		SkipSubtest: make(map[string]bool),


### PR DESCRIPTION
CBG-5205 test speed up: avoid sleep on db start

When starting a database that has a non zero _sync:seq, the database will sleep 1.5 to wait for released sequences.
In a test environment, this occurs often when there is a single RestTester running an a database configuration
occurs.

Fixes a bug where if users or roles are specified on database configuration, they would allocate a sequence
before the initial sequence was computed, so this would always result in waiting.

Set DisableSequenceWaitOnDbRestart anywhere there was a single RestTester. Keep this value for ISGR tests that
actually use multiple RestTesters.

Remove LongRunningTest for any test that runs faster than 50ms. This affects 37 tests.

I think it might be worthwhile to drop the comments around the usage of DisableSequenceWaitOnDbRestart?

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/436/
