### PR TITLE
Switch location of setting log context for import

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -81,9 +81,6 @@ func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string,
 		return nil, err
 	}
 
-	// Add logging info before passing ctx down
-	ctx = CorrelationIDLogCtx(ctx, DCPImportFeedID)
-
 	// Start Manager.  Registers this node in the cfg
 	err = cbgtContext.StartManager(ctx, dbName, configGroup, bucket, scope, collections, numPartitions)
 	if err != nil {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -53,6 +53,7 @@ func NewImportListener(ctx context.Context, checkpointPrefix string, dbContext *
 // StartImportFeed starts an import DCP feed.  Always starts the feed based on previous checkpoints (Backfill:FeedResume).
 // Writes DCP stats into the StatKeyImportDcpStats map
 func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error) {
+	ctx := base.CorrelationIDLogCtx(il.loggingCtx, base.DCPImportFeedID)
 
 	collectionNamesByScope := make(map[string][]string)
 	var scopeName string
@@ -88,13 +89,13 @@ func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error
 		Scopes:           collectionNamesByScope,
 	}
 
-	base.InfofCtx(il.loggingCtx, base.KeyDCP, "Attempting to start import DCP feed %v...", base.MD(il.importDestKey))
+	base.InfofCtx(ctx, base.KeyDCP, "Attempting to start import DCP feed %v...", base.MD(il.importDestKey))
 
 	importFeedStatsMap := dbContext.DbStats.Database().ImportFeedMapStats
 
 	// Store the listener in global map for dbname-based retrieval by cbgt prior to index registration
-	base.StoreDestFactory(il.loggingCtx, il.importDestKey, getImportDestFactory(
-		il.loggingCtx,
+	base.StoreDestFactory(ctx, il.importDestKey, getImportDestFactory(
+		ctx,
 		il.ProcessFeedEvent,
 		dbContext,
 		il.checkpointPrefix),


### PR DESCRIPTION
Prepare for calling StartShardedDCPFeed for more than import in prep for distributed resync. Force callers to set the correlation ID on the context if they want.

I think it is useful to have c:SGI in some places for managing `DCPDest` code, but we do not show this value in `ProcessFeedEvent`. This has very little impact on existing logging except if there are errors in `initCBGTManager` and logs `c:SGI` in:

```
base.InfofCtx(ctx, base.KeyDCP, "Attempting to start import DCP feed %v...", base.MD(il.importDestKey))
```