### PR TITLE
fix lint issue on structtag

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -125,3 +125,6 @@ formatters:
     - goimports
   exclusions:
     generated: strict
+
+run:
+  allow-parallel-runners: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,3 +61,6 @@ formatters:
     - goimports
   exclusions:
     generated: strict
+
+run:
+  allow-parallel-runners: true

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -93,7 +93,7 @@ type StartupConfig struct {
 	MaxFileDescriptors         uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 	CouchbaseKeepaliveInterval *int   `json:"couchbase_keepalive_interval,omitempty" help:"TCP keep-alive interval between SG and Couchbase server"`
 
-	DeprecatedConfig               *DeprecatedConfig `json:"-,omitempty" help:"Deprecated options that can be set from a legacy config upgrade, but cannot be set from a 3.0 config."`
+	DeprecatedConfig               *DeprecatedConfig `json:"-" help:"Deprecated options that can be set from a legacy config upgrade, but cannot be set from a 3.0 config."`
 	HeapProfileCollectionThreshold *uint64           `json:"heap_profile_collection_threshold,omitempty" help:"Threshold in bytes for collecting heap profiles automatically. If set, Sync Gateway will collect a memory profile when it exceeds this value. The default value will be set to 85% of the lesser of cgroup or system memory."`
 	HeapProfileDisableCollection   bool              `json:"heap_profile_disable_collection,omitempty" help:"Disables automatic heap profile collection"`
 }


### PR DESCRIPTION
The issue with the structtag was found with newer versions of staticcheck on the .golangci-strict.yml

- allow parallel runners by default, useful for working on multiple parts of a repo simultaneously, or one file, and then editing another 
