### PR TITLE
Fix logging panic

### DIFF
--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -238,6 +238,7 @@ func TestLogSyncGatewayVersion(t *testing.T) {
 	SetUpTestLogging(t, LevelInfo, KeyAll) // force logging to be set
 	for i := range levelCount {
 		t.Run("level="+i.String(), func(t *testing.T) {
+			consoleLogger.Load().LogLevel.Set(i)
 			AssertLogContains(t, LongVersionString, func() { LogSyncGatewayVersion(TestCtx(t)) })
 		})
 	}

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -9,7 +9,6 @@
 package base
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,10 +23,6 @@ import (
 )
 
 func TestRedactedLogFuncs(t *testing.T) {
-	if GlobalTestLoggingSet.IsTrue() {
-		t.Skip("Test does not work when a global test log level is set")
-	}
-
 	username := UD("alice")
 	ctx := TestCtx(t)
 
@@ -239,26 +234,13 @@ func TestLastComponent(t *testing.T) {
 }
 
 func TestLogSyncGatewayVersion(t *testing.T) {
-	if GlobalTestLoggingSet.IsTrue() {
-		t.Skip("Test does not work when a global test log level is set")
-	}
-
+	ResetGlobalTestLogging(t)
+	SetUpTestLogging(t, LevelInfo, KeyAll) // force logging to be set
 	for i := range levelCount {
-		t.Run(i.String(), func(t *testing.T) {
-			consoleLogger.Load().LogLevel.Set(i)
-			out := CaptureConsolefLogOutput(func() { LogSyncGatewayVersion(TestCtx(t)) })
-			assert.Contains(t, out, LongVersionString)
+		t.Run("level="+i.String(), func(t *testing.T) {
+			AssertLogContains(t, LongVersionString, func() { LogSyncGatewayVersion(TestCtx(t)) })
 		})
 	}
-	consoleLogger.Load().LogLevel.Set(LevelInfo)
-}
-
-func CaptureConsolefLogOutput(f func()) string {
-	buf := bytes.Buffer{}
-	consoleFOutput = &buf
-	f()
-	consoleFOutput = os.Stderr
-	return buf.String()
 }
 
 func BenchmarkGetCallersName(b *testing.B) {

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -164,11 +164,7 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 
 func TestLoggingKeys(t *testing.T) {
 	base.ResetGlobalTestLogging(t)
-	if base.GlobalTestLoggingSet.IsTrue() {
-		t.Skip("Test does not work when a global test log level is set")
-	}
-
-	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
+	// Force explicit logging via SetUpTestLogging
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rt := rest.NewRestTester(t, nil)
@@ -176,41 +172,36 @@ func TestLoggingKeys(t *testing.T) {
 
 	// Assert default log channels are enabled
 	response := rt.SendAdminRequest("GET", "/_logging", "")
-	var logKeys map[string]any
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
-	assert.Equal(t, map[string]any{}, logKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{}`, response.BodyString())
 
 	// Set logKeys, Changes+ should enable Changes (PUT replaces any existing log keys)
 	rest.RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Cache":true, "HTTP":true}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	var updatedLogKeys map[string]any
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &updatedLogKeys))
-	assert.Equal(t, map[string]any{"Changes": true, "Cache": true, "HTTP": true}, updatedLogKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{"Cache": true, "Changes": true, "HTTP": true}`, response.BodyString())
 
 	// Disable Changes logKey which should also disable Changes+
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	var deletedLogKeys map[string]any
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &deletedLogKeys))
-	assert.Equal(t, map[string]any{"Cache": true, "HTTP": true}, deletedLogKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{"Cache": true, "HTTP": true}`, response.BodyString())
 
 	// Enable Changes++, which should enable Changes (POST append logKeys)
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	var appendedLogKeys map[string]any
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &appendedLogKeys))
-	assert.Equal(t, map[string]any{"Changes": true, "Cache": true, "HTTP": true}, appendedLogKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{"Cache": true, "Changes": true, "HTTP": true}`, response.BodyString())
 
 	// Disable Changes++ (POST modifies logKeys)
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	var disabledLogKeys map[string]any
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &disabledLogKeys))
-	assert.Equal(t, map[string]any{"Cache": true, "HTTP": true}, disabledLogKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{"Cache": true, "HTTP": true}`, response.BodyString())
 
 	// Re-Enable Changes++, which should enable Changes (POST append logKeys)
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
@@ -219,9 +210,8 @@ func TestLoggingKeys(t *testing.T) {
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes+":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	var disabled2LogKeys map[string]any
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &disabled2LogKeys))
-	assert.Equal(t, map[string]any{"Cache": true, "HTTP": true}, disabled2LogKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{"Cache": true, "HTTP": true}`, response.BodyString())
 
 	// Re-Enable Changes++, which should enable Changes (POST append logKeys)
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
@@ -230,17 +220,15 @@ func TestLoggingKeys(t *testing.T) {
 	rest.RequireStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	var disabled3LogKeys map[string]any
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &disabled3LogKeys))
-	assert.Equal(t, map[string]any{"Cache": true, "HTTP": true}, disabled3LogKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{"Cache": true, "HTTP": true}`, response.BodyString())
 
 	// Disable all logKeys by using PUT with an empty channel list
 	rest.RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	var noLogKeys map[string]any
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &noLogKeys))
-	assert.Equal(t, map[string]any{}, noLogKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{}`, response.BodyString())
 }
 
 func TestServerlessChangesEndpointLimit(t *testing.T) {
@@ -299,11 +287,8 @@ func TestServerlessChangesEndpointLimit(t *testing.T) {
 }
 
 func TestLoggingLevels(t *testing.T) {
-	if base.GlobalTestLoggingSet.IsTrue() {
-		t.Skip("Test does not work when a global test log level is set")
-	}
-
-	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
+	base.ResetGlobalTestLogging(t)
+	// Force explicit logging via SetUpTestLogging
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rt := rest.NewRestTester(t, nil)
@@ -311,9 +296,8 @@ func TestLoggingLevels(t *testing.T) {
 
 	// Log keys should be blank
 	response := rt.SendAdminRequest("GET", "/_logging", "")
-	var logKeys map[string]bool
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
-	assert.Equal(t, map[string]bool{}, logKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{}`, response.BodyString())
 
 	// Set log level via logLevel query parameter
 	rest.RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=error", ``), http.StatusOK)
@@ -337,11 +321,8 @@ func TestLoggingLevels(t *testing.T) {
 }
 
 func TestLoggingCombined(t *testing.T) {
-	if base.GlobalTestLoggingSet.IsTrue() {
-		t.Skip("Test does not work when a global test log level is set")
-	}
-
-	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
+	base.ResetGlobalTestLogging(t)
+	// Force explicit logging via SetUpTestLogging
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyNone)
 
 	rt := rest.NewRestTester(t, nil)
@@ -349,16 +330,15 @@ func TestLoggingCombined(t *testing.T) {
 
 	// Log keys should be blank
 	response := rt.SendAdminRequest("GET", "/_logging", "")
-	var logKeys map[string]bool
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
-	assert.Equal(t, map[string]bool{}, logKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{}`, response.BodyString())
 
 	// Set log keys and log level in a single request
 	rest.RequireStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=trace", `{"Changes":true, "Cache":true, "HTTP":true}`), http.StatusOK)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
-	assert.Equal(t, map[string]bool{"Changes": true, "Cache": true, "HTTP": true}, logKeys)
+	rest.RequireStatus(t, response, http.StatusOK)
+	require.JSONEq(t, `{"Cache": true, "Changes": true, "HTTP": true}`, response.BodyString())
 }
 
 func TestGetStatus(t *testing.T) {
@@ -2497,6 +2477,7 @@ func TestChannelNameSizeWarningDeleteChannel(t *testing.T) {
 }
 
 func TestConfigEndpoint(t *testing.T) {
+	rest.ClearServerContextLoggingGlobals(t)
 	testCases := []struct {
 		Name              string
 		Config            string
@@ -2697,6 +2678,7 @@ func TestLoggingDeprecationWarning(t *testing.T) {
 }
 
 func TestInitialStartupConfig(t *testing.T) {
+	rest.ClearServerContextLoggingGlobals(t)
 
 	rt := rest.NewRestTester(t, nil)
 	defer rt.Close()
@@ -2731,7 +2713,7 @@ func TestInitialStartupConfig(t *testing.T) {
 }
 
 func TestIncludeRuntimeStartupConfig(t *testing.T) {
-	base.ResetGlobalTestLogging(t)
+	rest.ClearServerContextLoggingGlobals(t)
 
 	base.InitializeMemoryLoggers()
 	tempDir := os.TempDir()
@@ -2983,7 +2965,7 @@ func TestNotExistentDBRequest(t *testing.T) {
 }
 
 func TestConfigsIncludeDefaults(t *testing.T) {
-	base.ResetGlobalTestLogging(t)
+	rest.ClearServerContextLoggingGlobals(t)
 	base.RequireNumTestBuckets(t, 2)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -138,6 +138,8 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 }
 
 func TestSetupAndValidate(t *testing.T) {
+	ClearServerContextLoggingGlobals(t)
+
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("Skipping this test; it only works on Walrus bucket")
 	}

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -203,7 +203,7 @@ func TestBootstrapPingAPI(t *testing.T) {
 
 // Development-time test, expects locally running Couchbase Server and designed for long-running memory profiling
 func DevTestFetchConfigManual(t *testing.T) {
-
+	base.ResetGlobalTestLogging(t)
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyHTTP)
 
 	serverErr := make(chan error)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -758,7 +758,8 @@ func TestSetupAndValidateDatabases(t *testing.T) {
 }
 
 func TestParseCommandLine(t *testing.T) {
-	base.ResetGlobalTestLogging(t)
+	ClearServerContextLoggingGlobals(t)
+
 	var (
 		adminInterface     = "127.0.0.1:4985"
 		bucket             = "sync_gateway"
@@ -875,7 +876,8 @@ func TestParseCommandLineWithBadConfigContent(t *testing.T) {
 }
 
 func TestParseCommandLineWithConfigContent(t *testing.T) {
-	base.ResetGlobalTestLogging(t)
+	ClearServerContextLoggingGlobals(t)
+
 	content := `{"logging":{"log_file_path":"/var/tmp/sglogs","console":{"log_level":"debug","log_keys":["*"]},
 		"error":{"enabled":true,"rotation":{"max_size":20,"max_age":180}},"warn":{"enabled":true,"rotation":{
         "max_size":20,"max_age":90}},"info":{"enabled":false},"debug":{"enabled":false}},"databases":{"db1":{

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -758,6 +758,7 @@ func TestSetupAndValidateDatabases(t *testing.T) {
 }
 
 func TestParseCommandLine(t *testing.T) {
+	base.ResetGlobalTestLogging(t)
 	var (
 		adminInterface     = "127.0.0.1:4985"
 		bucket             = "sync_gateway"
@@ -874,6 +875,7 @@ func TestParseCommandLineWithBadConfigContent(t *testing.T) {
 }
 
 func TestParseCommandLineWithConfigContent(t *testing.T) {
+	base.ResetGlobalTestLogging(t)
 	content := `{"logging":{"log_file_path":"/var/tmp/sglogs","console":{"log_level":"debug","log_keys":["*"]},
 		"error":{"enabled":true,"rotation":{"max_size":20,"max_age":180}},"warn":{"enabled":true,"rotation":{
         "max_size":20,"max_age":90}},"info":{"enabled":false},"debug":{"enabled":false}},"databases":{"db1":{

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -614,6 +614,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 func TestLogFlush(t *testing.T) {
 	// FIXME: CBG-1869 flaky test
 	t.Skip("CBG-1869: Flaky test")
+	base.ResetGlobalTestLogging(t)
 
 	testCases := []struct {
 		Name                 string

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -614,7 +614,7 @@ func TestServerContextSetupCollectionsSupport(t *testing.T) {
 func TestLogFlush(t *testing.T) {
 	// FIXME: CBG-1869 flaky test
 	t.Skip("CBG-1869: Flaky test")
-	base.ResetGlobalTestLogging(t)
+	ClearServerContextLoggingGlobals(t)
 
 	testCases := []struct {
 		Name                 string

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2767,6 +2767,7 @@ func TestBucketPoolRestWithIndexes(ctx context.Context, m *testing.M, tbpOptions
 			panic(fmt.Sprintf("%v active blip tester clients should be 0 at end of tests", globalBlipTesterClients.m))
 		}
 	})
+	serverContextGlobalsInitialized.Store(true)
 	db.TestBucketPoolWithIndexes(ctx, m, tbpOptions)
 }
 
@@ -2802,4 +2803,11 @@ func AssertRevTreeAfterHLVConflictResolution(t *testing.T, doc *db.Document, exp
 	}
 	// should only have one active leaf
 	require.Equal(t, 1, activeLeafCount)
+}
+
+// ClearServerContextLoggingGlobals clears the global variables related to logging in ServerContext and allows testing initialization of a server context's logging parameters.
+func ClearServerContextLoggingGlobals(t *testing.T) {
+	// the end of the test must clean up global logging
+	base.ResetGlobalTestLogging(t)
+	serverContextGlobalsInitialized.Store(false)
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2810,4 +2810,7 @@ func ClearServerContextLoggingGlobals(t *testing.T) {
 	// the end of the test must clean up global logging
 	base.ResetGlobalTestLogging(t)
 	serverContextGlobalsInitialized.Store(false)
+	t.Cleanup(func() {
+		serverContextGlobalsInitialized.Store(true)
+	})
 }


### PR DESCRIPTION
After https://github.com/couchbase/sync_gateway/commit/814c3439aef0f564155e5e84788ec86820a3f726, calling a test like `TestSetupServerContext` before running any test that calls `SetUpTestLogging` would cause a panic https://github.com/couchbase/sync_gateway/blob/39636bd83a0b3c135bf5b965249f1e71f968031e/base/util_testing.go#L671

In SetupServerContext, loggers get forced to be initialized, once. If on that occasion SetUpTestLogging was not called,
then future tests would panic in setTestLogging

- avoid ever having a test incidentally set serverContextGlobalsInitialized, only clear this
when a test is trying to assertion on having set this value using ClearServerContextLoggingGlobals. Calling the code protected by `serverContextGlobalsInitialized` is OK if `RestGlobalTestLogging` is called first.
- incidentally fix some tests that didn't work if SG_TEST_LOG_LEVEL was set, by forcing ResetGlobalTestLogging and
  calling SetUpTestLogging in the test

Tested with and without `SG_TEST_LOG_LEVEL` set.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/324/
