### PR TITLE
Upgrade to go-1.25.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ concurrency:
   cancel-in-progress: ${{ !contains(github.ref, 'release/') && !contains(github.ref, 'main') }}
 
 env:
-  GO_VERSION: &go_version 1.25.7
+  GO_VERSION: &go_version 1.25.8
   GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.8.0
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/couchbase/sync_gateway
 
-go 1.25.7
+go 1.25.8
 
 require (
 	dario.cat/mergo v1.0.0

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -867,7 +867,7 @@
             "trigger_blackduck": true
         },
         "manifest/default.xml": {
-            "go_version": "1.25.7",
+            "go_version": "1.25.8",
             "interval": 30,
             "production": true,
             "release": "4.1.0",


### PR DESCRIPTION
Fixes for CVEs to silence govulncheck. These don't really affect Sync Gateway meaningfully.

Covers Sync Gateway tests only:

- GO-2026-4603 URLs in meta content attribute actions are not escaped in html/template

No impact:

- GO-2026-4602 FileInfo can escape from a Root in os Doesn't affect Sync Gateway since Sync Gateway doesn't collect metadata.

Low impact:

- GO-2026-4601 Incorrect parsing of IPv6 host literals in net/url This is used by oidc code but it is very unlikely to configure a IPv6 literal and not DNS.
