### PR TITLE
CBG-5203: Silently handle PING BLIP messages for cbl-js

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -43,6 +43,7 @@ var handlersByProfile = map[string]blipHandlerFunc{
 	MessageProposeChanges:  collectionBlipHandler((*blipHandler).handleProposeChanges),
 	MessageGetRev:          userBlipHandler(collectionBlipHandler((*blipHandler).handleGetRev)),
 	MessagePutRev:          userBlipHandler(collectionBlipHandler((*blipHandler).handlePutRev)),
+	MessagePing:            (*blipHandler).handlePing,
 
 	MessageGetCollections: userBlipHandler((*blipHandler).handleGetCollections),
 }
@@ -982,6 +983,11 @@ func (bsc *BlipSyncContext) sendRevAsDelta(ctx context.Context, sender *blip.Sen
 	handleChangesResponseCollection.collectionStats.DocReadsBytes.Add(int64(len(revDelta.DeltaBytes)))
 
 	bsc.replicationStats.SendRevDeltaSentCount.Add(1)
+	return nil
+}
+
+// handlePing handles a PING request from cbl-js.
+func (bh *blipHandler) handlePing(rq *blip.Message) error {
 	return nil
 }
 

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -41,6 +41,8 @@ const (
 	MessagePutRev       = "putRev"       // Connected Client API
 	MessageUnsubChanges = "unsubChanges" // Connected Client API
 	MessageFunction     = "function"     // Connected Client API
+
+	MessagePing = "PING" // PING request (cbl-js heartbeat)
 )
 
 // Message properties

--- a/rest/blip_message_test.go
+++ b/rest/blip_message_test.go
@@ -77,6 +77,6 @@ func TestBlipUnknownProfileMessage(t *testing.T) {
 		resp := unknownRequest.Response()
 		require.NotNil(t, resp)
 		assert.Equal(t, blip.ErrorType, resp.Type())
-		assert.Equal(t, "404", resp.Properties["Error-Code"])
+		assert.Equal(t, "404", resp.Properties[db.BlipErrorCode])
 	})
 }

--- a/rest/blip_message_test.go
+++ b/rest/blip_message_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBlipMessageProfiles verifies that BLIP profiles are handled correctly.
-func TestBlipMessageProfiles(t *testing.T) {
+// TestBlipMessagePingProfiles verifies that BLIP profiles used for heartbeats are handled correctly.
+func TestBlipMessagePingProfiles(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
 
 	rtConfig := &RestTesterConfig{
@@ -34,15 +34,29 @@ func TestBlipMessageProfiles(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
-		t.Run("PING reply", func(t *testing.T) {
+		// CBL-js 1.0.1 heartbeat message type
+		t.Run("PING noreply", func(t *testing.T) {
+			pingRequest := blip.NewRequest()
+			pingRequest.SetProfile(db.MessagePing)
+			pingRequest.SetNoReply(true)
+
+			// can't AssertLogNotContains since Response() returns immediately for noreply
+			btc.pullReplication.sendMsg(pingRequest)
+			resp := pingRequest.Response()
+			assert.Nil(t, resp)
+		})
+
+		// with reply variant for testing
+		t.Run("PING", func(t *testing.T) {
 			pingRequest := blip.NewRequest()
 			pingRequest.SetProfile(db.MessagePing)
 
+			var resp *blip.Message
 			base.AssertLogNotContains(t, "404 Unknown profile", func() {
 				btc.pullReplication.sendMsg(pingRequest)
+				resp = pingRequest.Response()
 			})
 
-			resp := pingRequest.Response()
 			require.NotNil(t, resp)
 			assert.Equal(t, blip.ResponseType, resp.Type())
 
@@ -51,41 +65,31 @@ func TestBlipMessageProfiles(t *testing.T) {
 			assert.Empty(t, body)
 		})
 
-		t.Run("PING noreply", func(t *testing.T) {
-			pingRequest := blip.NewRequest()
-			pingRequest.SetProfile(db.MessagePing)
-			pingRequest.SetNoReply(true)
+		// test behavior of an unknown profile with noreply (i.e. CBL-js 1.0.1 on an older SG pre-PING support)
+		t.Run("unknown profile noreply", func(t *testing.T) {
+			unknownRequest := blip.NewRequest()
+			unknownRequest.SetProfile("not_a_ping")
+			unknownRequest.SetNoReply(true)
 
-			base.AssertLogNotContains(t, "404 Unknown profile", func() {
-				btc.pullReplication.sendMsg(pingRequest)
-			})
-
-			// With noreply=true, Response() should return nil
-			resp := pingRequest.Response()
+			// can't AssertLogContains since Response() returns immediately for noreply
+			btc.pullReplication.sendMsg(unknownRequest)
+			resp := unknownRequest.Response()
 			assert.Nil(t, resp)
 		})
 
 		t.Run("unknown profile", func(t *testing.T) {
 			unknownRequest := blip.NewRequest()
-			unknownRequest.SetProfile("foo")
+			unknownRequest.SetProfile("not_a_ping")
 
-			btc.pullReplication.sendMsg(unknownRequest)
-			resp := unknownRequest.Response()
+			var resp *blip.Message
+			base.AssertLogContains(t, "404 Unknown profile", func() {
+				btc.pullReplication.sendMsg(unknownRequest)
+				resp = unknownRequest.Response()
+			})
+
 			require.NotNil(t, resp)
 			assert.Equal(t, blip.ErrorType, resp.Type())
 			assert.Equal(t, "404", resp.Properties[db.BlipErrorCode])
-		})
-
-		t.Run("unknown profile noreply", func(t *testing.T) {
-			unknownRequest := blip.NewRequest()
-			unknownRequest.SetProfile("foo")
-			unknownRequest.SetNoReply(true)
-
-			// Even with noreply, the server should handle the message
-			// but won't send a response back
-			btc.pullReplication.sendMsg(unknownRequest)
-			resp := unknownRequest.Response()
-			assert.Nil(t, resp)
 		})
 	})
 }

--- a/rest/blip_message_test.go
+++ b/rest/blip_message_test.go
@@ -18,10 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBlipPingMessage verifies that PING BLIP messages are handled successfully
-// without logging "404 Unknown profile". This is the heartbeat mechanism from
-// Couchbase Lite JS.
-func TestBlipPingMessage(t *testing.T) {
+// TestBlipMessageProfiles verifies that BLIP profiles are handled correctly.
+func TestBlipMessageProfiles(t *testing.T) {
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
 
 	rtConfig := &RestTesterConfig{
@@ -36,47 +34,58 @@ func TestBlipPingMessage(t *testing.T) {
 		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
 		defer btc.Close()
 
-		pingRequest := blip.NewRequest()
-		pingRequest.SetProfile(db.MessagePing)
+		t.Run("PING reply", func(t *testing.T) {
+			pingRequest := blip.NewRequest()
+			pingRequest.SetProfile(db.MessagePing)
 
-		base.AssertLogNotContains(t, "404 Unknown profile", func() {
-			btc.pullReplication.sendMsg(pingRequest)
+			base.AssertLogNotContains(t, "404 Unknown profile", func() {
+				btc.pullReplication.sendMsg(pingRequest)
+			})
+
+			resp := pingRequest.Response()
+			require.NotNil(t, resp)
+			assert.Equal(t, blip.ResponseType, resp.Type())
+
+			body, err := resp.Body()
+			require.NoError(t, err)
+			assert.Empty(t, body)
 		})
 
-		resp := pingRequest.Response()
-		require.NotNil(t, resp)
-		assert.Equal(t, blip.ResponseType, resp.Type())
+		t.Run("PING noreply", func(t *testing.T) {
+			pingRequest := blip.NewRequest()
+			pingRequest.SetProfile(db.MessagePing)
+			pingRequest.SetNoReply(true)
 
-		body, err := resp.Body()
-		require.NoError(t, err)
-		assert.Empty(t, body)
-	})
-}
+			base.AssertLogNotContains(t, "404 Unknown profile", func() {
+				btc.pullReplication.sendMsg(pingRequest)
+			})
 
-// TestBlipUnknownProfileMessage verifies that unknown BLIP profiles still hit
-// the NotFoundHandler and return a 404 error.
-func TestBlipUnknownProfileMessage(t *testing.T) {
-	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
+			// With noreply=true, Response() should return nil
+			resp := pingRequest.Response()
+			assert.Nil(t, resp)
+		})
 
-	rtConfig := &RestTesterConfig{
-		GuestEnabled: true,
-	}
-	btcRunner := NewBlipTesterClientRunner(t)
+		t.Run("unknown profile", func(t *testing.T) {
+			unknownRequest := blip.NewRequest()
+			unknownRequest.SetProfile("foo")
 
-	btcRunner.Run(func(t *testing.T) {
-		rt := NewRestTester(t, rtConfig)
-		defer rt.Close()
+			btc.pullReplication.sendMsg(unknownRequest)
+			resp := unknownRequest.Response()
+			require.NotNil(t, resp)
+			assert.Equal(t, blip.ErrorType, resp.Type())
+			assert.Equal(t, "404", resp.Properties[db.BlipErrorCode])
+		})
 
-		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
-		defer btc.Close()
+		t.Run("unknown profile noreply", func(t *testing.T) {
+			unknownRequest := blip.NewRequest()
+			unknownRequest.SetProfile("foo")
+			unknownRequest.SetNoReply(true)
 
-		unknownRequest := blip.NewRequest()
-		unknownRequest.SetProfile("foo")
-
-		btc.pullReplication.sendMsg(unknownRequest)
-		resp := unknownRequest.Response()
-		require.NotNil(t, resp)
-		assert.Equal(t, blip.ErrorType, resp.Type())
-		assert.Equal(t, "404", resp.Properties[db.BlipErrorCode])
+			// Even with noreply, the server should handle the message
+			// but won't send a response back
+			btc.pullReplication.sendMsg(unknownRequest)
+			resp := unknownRequest.Response()
+			assert.Nil(t, resp)
+		})
 	})
 }

--- a/rest/blip_message_test.go
+++ b/rest/blip_message_test.go
@@ -1,0 +1,82 @@
+// Copyright 2020-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+
+package rest
+
+import (
+	"testing"
+
+	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlipPingMessage verifies that PING BLIP messages are handled successfully
+// without logging "404 Unknown profile". This is the heartbeat mechanism from
+// Couchbase Lite JS.
+func TestBlipPingMessage(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
+
+	rtConfig := &RestTesterConfig{
+		GuestEnabled: true,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer btc.Close()
+
+		pingRequest := blip.NewRequest()
+		pingRequest.SetProfile(db.MessagePing)
+
+		base.AssertLogNotContains(t, "404 Unknown profile", func() {
+			btc.pullReplication.sendMsg(pingRequest)
+		})
+
+		resp := pingRequest.Response()
+		require.NotNil(t, resp)
+		assert.Equal(t, blip.ResponseType, resp.Type())
+
+		body, err := resp.Body()
+		require.NoError(t, err)
+		assert.Empty(t, body)
+	})
+}
+
+// TestBlipUnknownProfileMessage verifies that unknown BLIP profiles still hit
+// the NotFoundHandler and return a 404 error.
+func TestBlipUnknownProfileMessage(t *testing.T) {
+	base.SetUpTestLogging(t, base.LevelInfo, base.KeySync)
+
+	rtConfig := &RestTesterConfig{
+		GuestEnabled: true,
+	}
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, rtConfig)
+		defer rt.Close()
+
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer btc.Close()
+
+		unknownRequest := blip.NewRequest()
+		unknownRequest.SetProfile("foo")
+
+		btc.pullReplication.sendMsg(unknownRequest)
+		resp := unknownRequest.Response()
+		require.NotNil(t, resp)
+		assert.Equal(t, blip.ErrorType, resp.Type())
+		assert.Equal(t, "404", resp.Properties["Error-Code"])
+	})
+}


### PR DESCRIPTION
CBG-5203

Adds a no-op BLIP handler for `PING` messages.

See: https://github.com/couchbase/couchbase-lite-js/pull/101 

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a