### PR TITLE
Test: Add a timeout in ...Delta...BypassRevCache...WhenInFlightRevChanged

### DIFF
--- a/base/util_test.go
+++ b/base/util_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1904,4 +1905,47 @@ func TestIsRevTreeID(t *testing.T) {
 			assert.Equalf(t, tt.expected, IsRevTreeID(tt.value), "IsRevTreeID(%v)", tt.value)
 		})
 	}
+}
+
+func TestRequireChan(t *testing.T) {
+	t.Run("send to buffered channel with space", func(t *testing.T) {
+		ch := make(chan int, 10)
+		RequireChanSend(t, ch, 1)
+		RequireChanSend(t, ch, 2)
+	})
+
+	t.Run("receive from buffered channel with value", func(t *testing.T) {
+		ch := make(chan int, 1)
+		ch <- 42
+		val := RequireChanRecv(t, ch)
+		assert.Equal(t, 42, val)
+	})
+
+	t.Run("receive from buffered channel with string", func(t *testing.T) {
+		ch := make(chan string, 1)
+		ch <- "hello"
+		val := RequireChanRecv(t, ch)
+		assert.Equal(t, "hello", val)
+	})
+
+	t.Run("send and recv unbuffered channel", func(t *testing.T) {
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		ch := make(chan string)
+		var val string
+
+		go func() {
+			defer wg.Done()
+			RequireChanSend(t, ch, "hello?")
+		}()
+		go func() {
+			defer wg.Done()
+			val = RequireChanRecv(t, ch)
+		}()
+
+		wg.Wait()
+		assert.Equal(t, "hello?", val)
+	})
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1010,9 +1010,11 @@ func RequireChanSend[T any](t testing.TB, ch chan<- T, val T) {
 // RequireChanSendWithTimeout performs a blocking send on a channel with a timeout. Fails the test if the send cannot complete in time.
 func RequireChanSendWithTimeout[T any](t testing.TB, ch chan<- T, val T, timeout time.Duration) {
 	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case ch <- val:
-	case <-time.After(timeout):
+	case <-timer.C:
 		require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel send", timeout))
 	}
 }
@@ -1026,11 +1028,13 @@ func RequireChanRecv[T any](t testing.TB, ch <-chan T) T {
 // RequireChanRecvWithTimeout reads from a channel with a timeout. Fails the test if no value arrives in time.
 func RequireChanRecvWithTimeout[T any](t testing.TB, ch <-chan T, timeout time.Duration) T {
 	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
 	case val, ok := <-ch:
 		require.True(t, ok, "channel closed without sending a value")
 		return val
-	case <-time.After(timeout):
+	case <-timer.C:
 		require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel read", timeout))
 		return *new(T) // unreachable
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -996,3 +996,36 @@ func TestRequiresDeltaSync(t testing.TB) {
 		t.Skipf("Skipping test - Delta Sync requires EE")
 	}
 }
+
+const (
+	TestChanTimeout = 30 * time.Second
+)
+
+// RequireChanSend performs a non-blocking send on a channel, but fails the test if the channel is full.
+func RequireChanSend[T any](t testing.TB, ch chan<- T, val T) {
+	t.Helper()
+	select {
+	case ch <- val:
+	default:
+		require.FailNow(t, "send on channel blocked")
+	}
+}
+
+// RequireChanRecv reads from a channel with a TestChanTimeout timeout. Fails the test if no value arrives in time.
+func RequireChanRecv[T any](t testing.TB, ch <-chan T) T {
+	t.Helper()
+	return RequireChanRecvWithTimeout(t, ch, TestChanTimeout)
+}
+
+// RequireChanRecvWithTimeout reads from a channel with a timeout. Fails the test if no value arrives in time.
+func RequireChanRecvWithTimeout[T any](t testing.TB, ch <-chan T, timeout time.Duration) T {
+	t.Helper()
+	select {
+	case val, ok := <-ch:
+		require.True(t, ok, "channel closed without sending a value")
+		return val
+	case <-time.After(timeout):
+		require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel read", timeout))
+		return *new(T) // unreachable
+	}
+}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1001,13 +1001,19 @@ const (
 	TestChanTimeout = 30 * time.Second
 )
 
-// RequireChanSend performs a non-blocking send on a channel, but fails the test if the channel is full.
+// RequireChanSend performs a blocking send on a channel with a TestChanTimeout timeout. Fails the test if the send cannot complete in time.
 func RequireChanSend[T any](t testing.TB, ch chan<- T, val T) {
+	t.Helper()
+	RequireChanSendWithTimeout(t, ch, val, TestChanTimeout)
+}
+
+// RequireChanSendWithTimeout performs a blocking send on a channel with a timeout. Fails the test if the send cannot complete in time.
+func RequireChanSendWithTimeout[T any](t testing.TB, ch chan<- T, val T, timeout time.Duration) {
 	t.Helper()
 	select {
 	case ch <- val:
-	default:
-		require.FailNow(t, "send on channel blocked")
+	case <-time.After(timeout):
+		require.FailNow(t, fmt.Sprintf("timed out after %v waiting for channel send", timeout))
 	}
 }
 

--- a/rest/blip_api_crud_test.go
+++ b/rest/blip_api_crud_test.go
@@ -1897,7 +1897,7 @@ func TestSendReplacementRevision(t *testing.T) {
 				// underneath the client's response to changes - we'll update the document so the requested rev is not available by the time SG receives the changes response.
 				changesEntryCallbackFn := func(changeEntryDocID, changeEntryRevID string) {
 					if changeEntryDocID == docID && changeEntryRevID == version1.RevTreeID || changeEntryRevID == version1.CV.String() {
-						updatedVersion <- rt.UpdateDoc(docID, version1, fmt.Sprintf(`{"foo":"buzz","channels":["%s"]}`, test.replacementRevChannel))
+						base.RequireChanSend(t, updatedVersion, rt.UpdateDoc(docID, version1, fmt.Sprintf(`{"foo":"buzz","channels":["%s"]}`, test.replacementRevChannel)))
 
 						// also purge revision backup and flush cache to ensure request for rev 1-... cannot be fulfilled
 						err := collection.PurgeOldRevisionJSON(ctx, docID, version1.RevTreeID)
@@ -1919,7 +1919,7 @@ func TestSendReplacementRevision(t *testing.T) {
 				btcRunner.StartPullSince(btc.id, BlipTesterPullOptions{Channels: test.replicationChannels, Continuous: false})
 
 				// block until we've written the update and got the new version to use in assertions
-				version2 := <-updatedVersion
+				version2 := base.RequireChanRecv(t, updatedVersion)
 
 				if test.expectReplacementRev {
 					// version 2 was sent instead
@@ -2760,7 +2760,7 @@ func TestSendRevisionNoRevHandling(t *testing.T) {
 				receivedNoRevs := make(chan *blip.Message)
 				btc.pullReplication.bt.blipContext.HandlerForProfile[db.MessageNoRev] = func(msg *blip.Message) {
 					fmt.Println("Received noRev", msg.Properties)
-					receivedNoRevs <- msg
+					base.RequireChanSend(t, receivedNoRevs, msg)
 				}
 
 				version := rt.PutDoc(docName, `{"foo": "bar"}`)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -12,10 +12,8 @@ package rest
 
 import (
 	"encoding/base64"
-	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
@@ -1367,7 +1365,7 @@ func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
 				// underneath the client's response to changes - we'll update the document so the requested rev is not available by the time SG receives the changes response.
 				changesEntryCallbackFn := func(changeEntryDocID, changeEntryRevID string) {
 					if changeEntryDocID == docID && changeEntryRevID == version2.RevTreeID || changeEntryRevID == version2.CV.String() {
-						updatedVersion <- rt.UpdateDoc(docID, version2, `{"foo":"buzz","channels":["alice"]}`)
+						base.RequireChanSend(t, updatedVersion, rt.UpdateDoc(docID, version2, `{"foo":"buzz","channels":["alice"]}`))
 					}
 				}
 
@@ -1400,7 +1398,7 @@ func TestDeltaReplicationWithBypassRevCacheAndInflightRevChanged(t *testing.T) {
 				rt.WaitForPendingChanges()
 
 				// block until we've written the update and got the new version to use in assertions
-				version3 := <-updatedVersion
+				version3 := base.RequireChanRecv(t, updatedVersion)
 
 				// we should get the new updated version through replacement rev functionality
 				btcRunner.WaitForVersion(client.id, docID, version3)
@@ -1456,7 +1454,7 @@ func TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged(t *te
 		// underneath the client's response to changes - we'll update the document so the requested rev is not available by the time SG receives the changes response.
 		changesEntryCallbackFn := func(changeEntryDocID, changeEntryRevID string) {
 			if changeEntryDocID == docID && changeEntryRevID == version2.RevTreeID || changeEntryRevID == version2.CV.String() {
-				updatedVersion <- rt.UpdateDoc(docID, version2, `{"foo":"buzz","channels":["alice"]}`)
+				base.RequireChanSend(t, updatedVersion, rt.UpdateDoc(docID, version2, `{"foo":"buzz","channels":["alice"]}`))
 			}
 		}
 
@@ -1484,12 +1482,7 @@ func TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged(t *te
 		rt.WaitForPendingChanges()
 
 		// block until we've written the update and got the new version to use in assertions
-		var version3 DocVersion
-		select {
-		case version3 = <-updatedVersion:
-		case <-time.After(TestChannelTimeout):
-			require.Fail(t, fmt.Sprintf("expected version did not arrive in %v", TestChannelTimeout))
-		}
+		version3 := base.RequireChanRecv(t, updatedVersion)
 
 		// we should get the delta still for version 2
 		btcRunner.WaitForVersion(client.id, docID, version2)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -12,8 +12,10 @@ package rest
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
@@ -1482,7 +1484,12 @@ func TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged(t *te
 		rt.WaitForPendingChanges()
 
 		// block until we've written the update and got the new version to use in assertions
-		version3 := <-updatedVersion
+		var version3 DocVersion
+		select {
+		case version3 = <-updatedVersion:
+		case <-time.After(TestChannelTimeout):
+			require.Fail(t, fmt.Sprintf("expected version did not arrive in %v", TestChannelTimeout))
+		}
 
 		// we should get the delta still for version 2
 		btcRunner.WaitForVersion(client.id, docID, version2)


### PR DESCRIPTION
Avoids this test locking up indefinitely if the callback is never invoked because of some other error.

Adds new test utils `RequireChanSend` `RequireChanRecv` to do "safe" channel sends/receives inside tests.

```
=== Failed
=== FAIL: rest  (0.00s)
panic: test timed out after 45m0s
	running tests:
		TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged (34m11s)
		TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged/revTree (34m11s)

...

goroutine 659941 [chan receive, 34 minutes]:
github.com/couchbase/sync_gateway/rest.TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged.func1(0xc014bb4540)
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/blip_api_delta_sync_test.go:1485 +0x60a
github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run.func2(0xc014bb4540)
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/utilities_testing_blip_client.go:1082 +0x105
testing.tRunner(0xc014bb4540, 0xc019fc7170)
	/home/ubuntu/sdk/go1.25.8/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 659940
	/home/ubuntu/sdk/go1.25.8/src/testing/testing.go:1997 +0x465

...

goroutine 659940 [chan receive, 34 minutes]:
testing.(*T).Run(0xc014bb4000, {0x1bf4ad5?, 0x1bf4ad5?}, 0xc019fc7170)
	/home/ubuntu/sdk/go1.25.8/src/testing/testing.go:2005 +0x485
github.com/couchbase/sync_gateway/rest.(*BlipTestClientRunner).Run(0xc00fc1c380, 0xc019fc7158)
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/utilities_testing_blip_client.go:1080 +0x16c
github.com/couchbase/sync_gateway/rest.TestDeltaReplicationWithBypassRevCacheSendDeltaWhenInFlightRevChanged(0xc014bb4000)
	/home/ubuntu/workspace/SyncGatewayIntegration/rest/blip_api_delta_sync_test.go:1444 +0x2d2
testing.tRunner(0xc014bb4000, 0x1cc92a8)
	/home/ubuntu/sdk/go1.25.8/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
	/home/ubuntu/sdk/go1.25.8/src/testing/testing.go:1997 +0x465
```

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/375/
