### PR TITLE
CBG-5231: Clean up GH Action unit testing CI outputs

### DIFF
--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -28,12 +28,15 @@ if ! jq -es 'true' "$JSON_FILE" > /dev/null 2>&1; then
 fi
 
 # Count test-level and package-level results in a single pass
-eval "$(jq -s '
+eval "$(jq -sr '
     { passed:     [.[] | select(.Test != null and .Action == "pass")]  | length,
       failed:     [.[] | select(.Test != null and .Action == "fail")]  | length,
       skipped:    [.[] | select(.Test != null and .Action == "skip")]  | length,
       pkg_failed: [.[] | select(.Test == null  and .Action == "fail")] | length }
-    | "PASSED=\(.passed)\nFAILED=\(.failed)\nSKIPPED=\(.skipped)\nPKG_FAILED=\(.pkg_failed)"
+    | "PASSED=\(.passed)
+FAILED=\(.failed)
+SKIPPED=\(.skipped)
+PKG_FAILED=\(.pkg_failed)"
 ' "$JSON_FILE")"
 
 if [ "$FAILED" -gt 0 ] || [ "$PKG_FAILED" -gt 0 ]; then

--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Copyright 2026-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
+# Generates a GitHub Actions job summary from gotestsum JSON output (test.json).
+# Writes to $GITHUB_STEP_SUMMARY with pass/fail/skip counts and collapsible
+# failed test output.
+
+set -euo pipefail
+
+MAX_OUTPUT_LINES=500
+JSON_FILE="${1:-test.json}"
+
+if [ ! -f "$JSON_FILE" ]; then
+    echo "⚠️ No test results found (missing $JSON_FILE)" >> "$GITHUB_STEP_SUMMARY"
+    exit 0
+fi
+
+# Count test-level results (exclude package-level events by requiring .Test)
+PASSED=$(jq -s '[.[] | select(.Test != null and .Action == "pass")] | length' "$JSON_FILE")
+FAILED=$(jq -s '[.[] | select(.Test != null and .Action == "fail")] | length' "$JSON_FILE")
+SKIPPED=$(jq -s '[.[] | select(.Test != null and .Action == "skip")] | length' "$JSON_FILE")
+
+if [ "$FAILED" -gt 0 ]; then
+    echo "## ❌ $FAILED failed, $PASSED passed, $SKIPPED skipped" >> "$GITHUB_STEP_SUMMARY"
+else
+    echo "## ✅ $PASSED passed, $SKIPPED skipped" >> "$GITHUB_STEP_SUMMARY"
+    exit 0
+fi
+
+echo "" >> "$GITHUB_STEP_SUMMARY"
+
+# List each top-level failed test with its output in a collapsible section.
+# Only top-level tests (no "/" in name) to avoid duplicating subtest output.
+jq -s -r '
+    [.[] | select(.Test != null and .Action == "fail" and (.Test | contains("/") | not))]
+    | unique_by(.Package, .Test)
+    | sort_by(.Package, .Test)
+    | .[]
+    | "\(.Package)\t\(.Test)"
+' "$JSON_FILE" | while IFS=$'\t' read -r pkg test; do
+    {
+        echo "<details>"
+        echo "<summary><strong>FAIL: $test</strong> — <code>$pkg</code></summary>"
+        echo ""
+        echo '```'
+    } >> "$GITHUB_STEP_SUMMARY"
+
+    # Collect output for the failed test and all its subtests
+    jq -s -r --arg t "$test" --arg p "$pkg" '
+        [.[] | select(
+            .Package == $p
+            and .Action == "output"
+            and .Test != null
+            and (.Test == $t or (.Test | startswith($t + "/")))
+        )]
+        | .[].Output // empty
+    ' "$JSON_FILE" | head -"$MAX_OUTPUT_LINES" >> "$GITHUB_STEP_SUMMARY"
+
+    {
+        echo '```'
+        echo "</details>"
+        echo ""
+    } >> "$GITHUB_STEP_SUMMARY"
+done

--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-MAX_OUTPUT_LINES=500
+MAX_OUTPUT_LINES=10000
 JSON_FILE="${1:-test.json}"
 
 if [ ! -f "$JSON_FILE" ]; then
@@ -64,16 +64,17 @@ jq -s -r '
         echo '```'
     } >> "$GITHUB_STEP_SUMMARY"
 
-    # Collect output for the failed test and all its subtests
-    jq -s -r --arg t "$test" --arg p "$pkg" '
+    # Collect output for the failed test and all its subtests (limit to MAX_OUTPUT_LINES)
+    jq -s -r --argjson max "$MAX_OUTPUT_LINES" --arg t "$test" --arg p "$pkg" '
         [.[] | select(
             .Package == $p
             and .Action == "output"
             and .Test != null
             and (.Test == $t or (.Test | startswith($t + "/")))
         )]
+        | .[:$max]
         | .[].Output // empty
-    ' "$JSON_FILE" | head -"$MAX_OUTPUT_LINES" >> "$GITHUB_STEP_SUMMARY"
+    ' "$JSON_FILE" >> "$GITHUB_STEP_SUMMARY"
 
     {
         echo '```'
@@ -97,10 +98,11 @@ if [ "$PKG_FAILED" -gt 0 ]; then
             echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
 
-        jq -s -r --arg p "$pkg" '
+        jq -s -r --argjson max "$MAX_OUTPUT_LINES" --arg p "$pkg" '
             [.[] | select(.Package == $p and .Test == null and .Action == "output")]
+            | .[:$max]
             | .[].Output // empty
-        ' "$JSON_FILE" | head -"$MAX_OUTPUT_LINES" >> "$GITHUB_STEP_SUMMARY"
+        ' "$JSON_FILE" >> "$GITHUB_STEP_SUMMARY"
 
         {
             echo '```'

--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -27,8 +27,11 @@ PASSED=$(jq -s '[.[] | select(.Test != null and .Action == "pass")] | length' "$
 FAILED=$(jq -s '[.[] | select(.Test != null and .Action == "fail")] | length' "$JSON_FILE")
 SKIPPED=$(jq -s '[.[] | select(.Test != null and .Action == "skip")] | length' "$JSON_FILE")
 
-if [ "$FAILED" -gt 0 ]; then
-    echo "## ❌ $FAILED failed, $PASSED passed, $SKIPPED skipped" >> "$GITHUB_STEP_SUMMARY"
+# Count package-level failures (e.g. build/compile errors) where .Test is null
+PKG_FAILED=$(jq -s '[.[] | select(.Test == null and .Action == "fail")] | length' "$JSON_FILE")
+
+if [ "$FAILED" -gt 0 ] || [ "$PKG_FAILED" -gt 0 ]; then
+    echo "## ❌ $FAILED failed, $PASSED passed, $SKIPPED skipped (${PKG_FAILED} package failure(s))" >> "$GITHUB_STEP_SUMMARY"
 else
     echo "## ✅ $PASSED passed, $SKIPPED skipped" >> "$GITHUB_STEP_SUMMARY"
     exit 0
@@ -69,3 +72,31 @@ jq -s -r '
         echo ""
     } >> "$GITHUB_STEP_SUMMARY"
 done
+
+# Show package-level failures (build/compile errors, init failures)
+if [ "$PKG_FAILED" -gt 0 ]; then
+    jq -s -r '
+        [.[] | select(.Test == null and .Action == "fail")]
+        | unique_by(.Package)
+        | sort_by(.Package)
+        | .[].Package
+    ' "$JSON_FILE" | while read -r pkg; do
+        {
+            echo "<details>"
+            echo "<summary><strong>FAIL: package</strong> — <code>$pkg</code></summary>"
+            echo ""
+            echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        jq -s -r --arg p "$pkg" '
+            [.[] | select(.Package == $p and .Test == null and .Action == "output")]
+            | .[].Output // empty
+        ' "$JSON_FILE" | head -"$MAX_OUTPUT_LINES" >> "$GITHUB_STEP_SUMMARY"
+
+        {
+            echo '```'
+            echo "</details>"
+            echo ""
+        } >> "$GITHUB_STEP_SUMMARY"
+    done
+fi

--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -22,13 +22,19 @@ if [ ! -f "$JSON_FILE" ]; then
     exit 0
 fi
 
-# Count test-level results (exclude package-level events by requiring .Test)
-PASSED=$(jq -s '[.[] | select(.Test != null and .Action == "pass")] | length' "$JSON_FILE")
-FAILED=$(jq -s '[.[] | select(.Test != null and .Action == "fail")] | length' "$JSON_FILE")
-SKIPPED=$(jq -s '[.[] | select(.Test != null and .Action == "skip")] | length' "$JSON_FILE")
+# Warn if JSON is truncated/malformed (e.g. from OOM or timeout kill)
+if ! jq -es 'true' "$JSON_FILE" > /dev/null 2>&1; then
+    echo "⚠️ Warning: test results ($JSON_FILE) may be truncated — summary may be incomplete" >> "$GITHUB_STEP_SUMMARY"
+fi
 
-# Count package-level failures (e.g. build/compile errors) where .Test is null
-PKG_FAILED=$(jq -s '[.[] | select(.Test == null and .Action == "fail")] | length' "$JSON_FILE")
+# Count test-level and package-level results in a single pass
+eval "$(jq -s '
+    { passed:     [.[] | select(.Test != null and .Action == "pass")]  | length,
+      failed:     [.[] | select(.Test != null and .Action == "fail")]  | length,
+      skipped:    [.[] | select(.Test != null and .Action == "skip")]  | length,
+      pkg_failed: [.[] | select(.Test == null  and .Action == "fail")] | length }
+    | "PASSED=\(.passed)\nFAILED=\(.failed)\nSKIPPED=\(.skipped)\nPKG_FAILED=\(.pkg_failed)"
+' "$JSON_FILE")"
 
 if [ "$FAILED" -gt 0 ] || [ "$PKG_FAILED" -gt 0 ]; then
     echo "## ❌ $FAILED failed, $PASSED passed, $SKIPPED skipped (${PKG_FAILED} package failure(s))" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -113,7 +113,7 @@ jobs:
         with:
           go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
@@ -133,7 +133,7 @@ jobs:
         with:
           go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
@@ -151,7 +151,7 @@ jobs:
         with:
           go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -short -bench=. -benchtime=1x -run '!' "./..."
         shell: bash
@@ -172,7 +172,7 @@ jobs:
         with:
           go-version: 1.25.6
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
@@ -223,7 +223,7 @@ jobs:
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.13.0
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -shuffle=on -timeout=5m -count=1 "./tools/stats-definition-exporter"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ concurrency:
 
 env:
   GO_VERSION: &go_version 1.25.8
-  GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.8.0
 
 jobs:
   build:
@@ -92,16 +91,17 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: *go_version
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
-      - name: Annotate Failures
+      - name: Test Summary
         if: always()
-        uses: *go_test_annotations_version
-        with:
-          test-results: test.json
+        shell: bash
+        run: .github/scripts/test-summary.sh
 
   test-race:
     runs-on: ubuntu-latest
@@ -112,14 +112,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: *go_version
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: go test -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
-      - name: Annotate Failures
+      - name: Test Summary
         if: always()
-        uses: *go_test_annotations_version
-        with:
-          test-results: test.json
+        shell: bash
+        run: .github/scripts/test-summary.sh
 
   test-default-collection:
     runs-on: ubuntu-latest
@@ -131,14 +132,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: *go_version
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
-      - name: Annotate Failures
+      - name: Test Summary
         if: always()
-        uses: *go_test_annotations_version
-        with:
-          test-results: test.json
+        shell: bash
+        run: .github/scripts/test-summary.sh
   test-benchmark-compile:
     runs-on: ubuntu-latest
     env:
@@ -148,14 +150,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: *go_version
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -short -bench=. -benchtime=1x -run '!' -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -short -bench=. -benchtime=1x -run '!' "./..."
         shell: bash
-      - name: Annotate Failures
+      - name: Test Summary
         if: always()
-        uses: *go_test_annotations_version
-        with:
-          test-results: test.json
+        shell: bash
+        run: .github/scripts/test-summary.sh
 
 
   test-disable-rev-cache:
@@ -168,14 +171,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.25.6
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: go test -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -json -v "./..." | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
-      - name: Annotate Failures
+      - name: Test Summary
         if: always()
-        uses: guyarb/golang-test-annotations@v0.8.0
-        with:
-          test-results: test.json
+        shell: bash
+        run: .github/scripts/test-summary.sh
 
   python-format:
     runs-on: ubuntu-latest
@@ -218,9 +222,15 @@ jobs:
           go-version: *go_version
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: go test -shuffle=on -timeout=5m -count=1 -json -v "./tools/stats-definition-exporter" | tee test.json | jq -s -jr 'sort_by(.Package,.Time) | .[].Output | select (. != null )'
+        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -shuffle=on -timeout=5m -count=1 "./tools/stats-definition-exporter"
         shell: bash
+      - name: Test Summary
+        if: always()
+        shell: bash
+        run: .github/scripts/test-summary.sh
   cache_perf_tool_build:
     runs-on: ubuntu-latest
     name: build cache perf tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
-        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
+        run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
       - name: Test Summary
         if: always()
@@ -115,7 +115,7 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 "./..."
+        run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
       - name: Test Summary
         if: always()
@@ -135,7 +135,7 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
+        run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
       - name: Test Summary
         if: always()
@@ -153,7 +153,7 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -short -bench=. -benchtime=1x -run '!' "./..."
+        run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -short -bench=. -benchtime=1x -run '!' "./..."
         shell: bash
       - name: Test Summary
         if: always()
@@ -174,7 +174,7 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
+        run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
       - name: Test Summary
         if: always()
@@ -225,7 +225,7 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
       - name: Run Tests
-        run: gotestsum --format pkgname-and-test-fails --jsonfile test.json -- -shuffle=on -timeout=5m -count=1 "./tools/stats-definition-exporter"
+        run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -shuffle=on -timeout=5m -count=1 "./tools/stats-definition-exporter"
         shell: bash
       - name: Test Summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ concurrency:
 env:
   GO_VERSION: &go_version 1.25.8
   GOTESTSUM_VERSION: 1.13.0
+  GO_TEST_ANNOTATIONS_VERSION: &go_test_annotations_version guyarb/golang-test-annotations@v0.8.0
 
 jobs:
   build:
@@ -103,6 +104,11 @@ jobs:
         if: always()
         shell: bash
         run: .github/scripts/test-summary.sh
+      - name: Annotate Failures
+        if: always()
+        uses: *go_test_annotations_version
+        with:
+          test-results: test.json
 
   test-race:
     runs-on: ubuntu-latest
@@ -122,6 +128,11 @@ jobs:
         if: always()
         shell: bash
         run: .github/scripts/test-summary.sh
+      - name: Annotate Failures
+        if: always()
+        uses: *go_test_annotations_version
+        with:
+          test-results: test.json
 
   test-default-collection:
     runs-on: ubuntu-latest
@@ -142,6 +153,11 @@ jobs:
         if: always()
         shell: bash
         run: .github/scripts/test-summary.sh
+      - name: Annotate Failures
+        if: always()
+        uses: *go_test_annotations_version
+        with:
+          test-results: test.json
   test-benchmark-compile:
     runs-on: ubuntu-latest
     env:
@@ -160,6 +176,11 @@ jobs:
         if: always()
         shell: bash
         run: .github/scripts/test-summary.sh
+      - name: Annotate Failures
+        if: always()
+        uses: *go_test_annotations_version
+        with:
+          test-results: test.json
 
 
   test-disable-rev-cache:
@@ -181,6 +202,11 @@ jobs:
         if: always()
         shell: bash
         run: .github/scripts/test-summary.sh
+      - name: Annotate Failures
+        if: always()
+        uses: *go_test_annotations_version
+        with:
+          test-results: test.json
 
   python-format:
     runs-on: ubuntu-latest
@@ -232,6 +258,11 @@ jobs:
         if: always()
         shell: bash
         run: .github/scripts/test-summary.sh
+      - name: Annotate Failures
+        if: always()
+        uses: *go_test_annotations_version
+        with:
+          test-results: test.json
   cache_perf_tool_build:
     runs-on: ubuntu-latest
     name: build cache perf tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ concurrency:
 
 env:
   GO_VERSION: &go_version 1.25.8
+  GOTESTSUM_VERSION: 1.13.0
 
 jobs:
   build:
@@ -92,7 +93,7 @@ jobs:
         with:
           go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Build
         run: go build -v "./..."
       - name: Run Tests
@@ -113,7 +114,7 @@ jobs:
         with:
           go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -race -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
@@ -133,7 +134,7 @@ jobs:
         with:
           go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
@@ -151,7 +152,7 @@ jobs:
         with:
           go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 -short -bench=. -benchtime=1x -run '!' "./..."
         shell: bash
@@ -170,9 +171,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.6
+          go-version: *go_version
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -tags cb_sg_devmode -shuffle=on -timeout=30m -count=1 "./..."
         shell: bash
@@ -223,7 +224,7 @@ jobs:
       - name: Build
         run: go build -v "./tools/stats-definition-exporter"
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Run Tests
         run: gotestsum --format pkgname-and-test-fails --hide-summary=output --jsonfile test.json -- -shuffle=on -timeout=5m -count=1 "./tools/stats-definition-exporter"
         shell: bash


### PR DESCRIPTION
CBG-5231

Run with `gotestsum` and produce a formatted summary to make it easier to determine why a CI test failed instead of trawling through huge logs of mostly passing test names.

---

# Output summary examples:

## ✅ 4898 passed, 296 skipped

## ❌ 2 failed, 302 passed, 2 skipped

<details>
<summary><strong>FAIL: TestJWTVerifyToken</strong> — <code>github.com/couchbase/sync_gateway/auth</code></summary>

```
=== RUN   TestJWTVerifyToken

    jwt_test.go:32: intentional failure

2026-03-13T18:25:55.453Z [INF] auth.TestJWTVerifyToken: Setup logging: level: debug - keys: [Auth]

2026-03-13T18:25:55.570Z [WRN] t:TestJWTVerifyToken Unable to parse issuer URI when initializing user prefix - using provider name -- auth.(*LocalJWTAuthProvider).initUserPrefix() at jwt.go:237

2026-03-13T18:25:55.570Z [WRN] t:TestJWTVerifyToken Unable to parse issuer URI when initializing user prefix - using provider name -- auth.(*LocalJWTAuthProvider).initUserPrefix() at jwt.go:237

=== RUN   TestJWTVerifyToken/garbage

--- PASS: TestJWTVerifyToken/garbage (0.00s)

=== RUN   TestJWTVerifyToken/string_with_two_dots

--- PASS: TestJWTVerifyToken/string_with_two_dots (0.00s)

=== RUN   TestJWTVerifyToken/empty_JSON_objects

--- PASS: TestJWTVerifyToken/empty_JSON_objects (0.00s)

=== RUN   TestJWTVerifyToken/valid_RSA

2026-03-13T18:25:55.571Z [DBG] Auth+: t:TestJWTVerifyToken/valid_RSA Local JWT ID Token successfully parsed and verified (iss: <ud>testIssuer</ud>; sub: <ud></ud>)

--- PASS: TestJWTVerifyToken/valid_RSA (0.00s)

=== RUN   TestJWTVerifyToken/valid_EC

2026-03-13T18:25:55.572Z [DBG] Auth+: t:TestJWTVerifyToken/valid_EC Local JWT ID Token successfully parsed and verified (iss: <ud>testIssuer</ud>; sub: <ud></ud>)

--- PASS: TestJWTVerifyToken/valid_EC (0.00s)

=== RUN   TestJWTVerifyToken/valid_+_expiry_check

2026-03-13T18:25:55.573Z [DBG] Auth+: t:TestJWTVerifyToken/valid_+_expiry_check Local JWT ID Token successfully parsed and verified (iss: <ud>testIssuer</ud>; sub: <ud></ud>)

--- PASS: TestJWTVerifyToken/valid_+_expiry_check (0.00s)

=== RUN   TestJWTVerifyToken/valid_but_expired

--- PASS: TestJWTVerifyToken/valid_but_expired (0.00s)

=== RUN   TestJWTVerifyToken/valid_but_issued_in_the_future

--- PASS: TestJWTVerifyToken/valid_but_issued_in_the_future (0.00s)

=== RUN   TestJWTVerifyToken/valid_JWT_invalid_signature

--- PASS: TestJWTVerifyToken/valid_JWT_invalid_signature (0.00s)

=== RUN   TestJWTVerifyToken/valid_JWT_signed_with_an_unknown_key

2026-03-13T18:25:55.577Z [DBG] Auth+: t:TestJWTVerifyToken/valid_JWT_signed_with_an_unknown_key Rejecting JWT - JWS verify failed: go-jose/go-jose: error in cryptographic primitive

--- PASS: TestJWTVerifyToken/valid_JWT_signed_with_an_unknown_key (0.00s)

=== RUN   TestJWTVerifyToken/valid_JWT_signed_with_a_mismatching_KID

2026-03-13T18:25:55.578Z [DBG] Auth+: t:TestJWTVerifyToken/valid_JWT_signed_with_a_mismatching_KID Rejecting JWT - JWS verify failed: go-jose/go-jose: error in cryptographic primitive

--- PASS: TestJWTVerifyToken/valid_JWT_signed_with_a_mismatching_KID (0.00s)

=== RUN   TestJWTVerifyToken/valid_RSA_signed_with_key_with_use=enc

2026-03-13T18:25:55.579Z [DBG] Auth+: t:TestJWTVerifyToken/valid_RSA_signed_with_key_with_use=enc Rejecting JWT - no matching keys found (token alg: RS256, kid: <ud>rsa-enc</ud>)

--- PASS: TestJWTVerifyToken/valid_RSA_signed_with_key_with_use=enc (0.00s)

=== RUN   TestJWTVerifyToken/valid_JWT_with_alg_none

--- PASS: TestJWTVerifyToken/valid_JWT_with_alg_none (0.00s)

=== RUN   TestJWTVerifyToken/valid_JWT_with_alg_HS256

--- PASS: TestJWTVerifyToken/valid_JWT_with_alg_HS256 (0.00s)

=== RUN   TestJWTVerifyToken/valid_JWT_with_no_signature

2026-03-13T18:25:55.580Z [DBG] Auth+: t:TestJWTVerifyToken/valid_JWT_with_no_signature Rejecting JWT - JWS verify failed: go-jose/go-jose: error in cryptographic primitive

--- PASS: TestJWTVerifyToken/valid_JWT_with_no_signature (0.00s)

=== RUN   TestJWTVerifyToken/valid_RSA_with_invalid_issuer

--- PASS: TestJWTVerifyToken/valid_RSA_with_invalid_issuer (0.00s)

2026-03-13T18:25:55.581Z [INF] auth.TestJWTVerifyToken: Reset logging

--- FAIL: TestJWTVerifyToken (0.13s)

```
</details>

<details>
<summary><strong>FAIL: TestWillFail</strong> — <code>github.com/couchbase/sync_gateway/auth/pkg2</code></summary>

```
=== RUN   TestWillFail

    main_test.go:6: intentional failure

--- FAIL: TestWillFail (0.00s)

```
</details>
