### PR TITLE
[3.3.4 backport] CBG-5158: Add EdDSA to set of supported algorithms for OIDC/JWTs

### DIFF
--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -38,6 +38,7 @@ var SupportedAlgorithms = map[jose.SignatureAlgorithm]bool{
 	jose.PS256: true,
 	jose.PS384: true,
 	jose.PS512: true,
+	jose.EdDSA: true,
 }
 
 // Full list of supported algorithms is used to initially parse the JWT.  The more restricted list (based
@@ -52,6 +53,7 @@ var SupportedAlgorithmsSlice = []jose.SignatureAlgorithm{
 	jose.PS256,
 	jose.PS384,
 	jose.PS512,
+	jose.EdDSA,
 }
 
 // JWTConfigCommon groups together configuration options common to both OIDC and local JWT authentication.


### PR DESCRIPTION
[3.3.4 backport] CBG-5158: Add EdDSA to set of supported algorithms for OIDC/JWTs

cherry-pick of 61b9e4ac1844bbd9bae7bb88cd5ac00b572e32c4
