### PR TITLE
Create sharded dcp options struct

### DIFF
--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -65,7 +65,8 @@ func TestDCPNameLength(t *testing.T) {
 
 	for _, dbName := range dbNames {
 		t.Run("cbgt-index-"+dbName, func(t *testing.T) {
-			indexName := GenerateIndexName(dbName)
+			indexName, err := GenerateImportIndexName(dbName)
+			require.NoError(t, err)
 
 			// Verify we pass CBGT's index name validation
 			matched, err := regexp.Match(cbgt.INDEX_NAME_REGEXP, []byte(indexName))

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -167,7 +167,7 @@ type SGFeedIndexParams struct {
 
 // cbgtFeedParams returns marshalled cbgt.DCPFeedParams as string, to be passed as feedparams during cbgt.Manager init.
 // Used to pass basic auth credentials and xattr flag to cbgt.
-func cbgtFeedParams(ctx context.Context, scope string, collections []string, dbName string) (string, error) {
+func cbgtFeedParams(ctx context.Context, collections CollectionNames, dbName string) (string, error) {
 	feedParams := &SGFeedSourceParams{
 		DbName: dbName,
 		DCPFeedParams: cbgt.DCPFeedParams{
@@ -175,10 +175,13 @@ func cbgtFeedParams(ctx context.Context, scope string, collections []string, dbN
 			IncludeXAttrs:              true,
 		},
 	}
-
-	if len(collections) > 0 {
-		feedParams.Scope = scope
-		feedParams.Collections = collections
+	if len(collections) > 1 {
+		return "", RedactErrorf("cbgtFeedParams: multiple scopes not supported, got %v", MD(collections))
+	} else if len(collections) > 0 {
+		for s, c := range collections {
+			feedParams.Scope = s
+			feedParams.Collections = c
+		}
 	}
 
 	paramBytes, err := JSONMarshal(feedParams)

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -55,17 +55,82 @@ type CbgtContext struct {
 	heartbeater       Heartbeater              // Heartbeater used for failed node detection
 	heartbeatListener *importHeartbeatListener // Listener subscribed to failed node alerts from heartbeater
 	eventHandlers     *sgMgrEventHandlers      // Event handler callbacks
-	ctx               context.Context          // Log context
 	dbName            string                   // Database name
 	sourceName        string                   // cbgt source name. Store on CbgtContext for access during teardown
 	sourceUUID        string                   // cbgt source UUID.  Store on CbgtContext for access during teardown
 }
 
+// ShardedDCPOptions contains options for starting a DCP feed for cbgt.
+type ShardedDCPOptions struct {
+	Bucket            Bucket          // bucket to target
+	Cfg               cbgt.Cfg        // cbgt cfg used to coordinate cbgt documents
+	Collections       CollectionNames // collection names to target
+	DBName            string          // database name is used to look up credentials
+	DestKey           string          // key used in indexParams for this feed, used to look up the feed destination in cbgtDestFactories
+	Heartbeater       Heartbeater     // heartbeater to use to find nodes
+	IndexName         string          // cbgt.Manger.IndexName, used to uniquely identify the index
+	IndexType         string          // cbgt.Manager.IndexType, matches name used by cbgt.RegisterPIndexImplType
+	NumPartitions     uint16          // number of cbgt partitions to use, if 0 will default to DefaultImportPartitions
+	PreviousIndexName string          // previous index name. If specified, marks IndexName as as a replacement for this name.
+	UUID              string          // database uuid, used to uniquely identify nodes
+}
+
+// Validate makes sure that all options are specified.
+func (opts ShardedDCPOptions) Validate() error {
+	if opts.Bucket == nil {
+		return fmt.Errorf("bucket must be provided to start sharded DCP feed")
+	}
+	if opts.Cfg == nil {
+		return fmt.Errorf("cbgt cfg must be provided to start sharded DCP feed")
+	}
+	if opts.Heartbeater == nil {
+		return fmt.Errorf("heartbeater must be provided to start sharded DCP feed")
+	}
+	if opts.IndexName == "" {
+		return fmt.Errorf("index name must be provided to start sharded DCP feed")
+	}
+	if opts.IndexType == "" {
+		return fmt.Errorf("index type must be provided to start sharded DCP feed")
+	}
+	if opts.DBName == "" {
+		return fmt.Errorf("database name must be provided to start sharded DCP feed")
+	}
+	if opts.UUID == "" {
+		return fmt.Errorf("UUID to identify a node must be provided to start sharded DCP feed")
+	}
+	if opts.DestKey == "" {
+		return fmt.Errorf("destKey must be provided to start sharded DCP feed")
+	}
+	if len(opts.Collections) == 0 {
+		return fmt.Errorf("at least one collection must be specified to start a sharded DCP feed")
+	} else if len(opts.Collections) > 1 {
+		return fmt.Errorf("only one scope is currently supported for ")
+	}
+	return nil
+}
+
+// scopeAndCollections returns a single scope name and a sorted list of all collections.
+func (opts ShardedDCPOptions) scopeAndCollections() (string, []string) {
+	var scopeName string
+	var collections []string
+	for s, c := range opts.Collections {
+		scopeName = s
+		collections = c
+	}
+	return scopeName, collections
+}
+
 // StartShardedDCPFeed initializes and starts a CBGT Manager targeting the provided bucket.
 // dbName is used to define a unique path name for local file storage of pindex files
-func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string, uuid string, heartbeater Heartbeater, bucket Bucket, scope string, collections []string, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
+func StartShardedDCPFeed(ctx context.Context, opts ShardedDCPOptions) (*CbgtContext, error) {
+	err := opts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	_, collections := opts.scopeAndCollections()
 	// Ensure we don't try to start collections-enabled feed if there are any pre-collection SG nodes in the cluster.
-	minVersion, err := getMinNodeVersion(cfg)
+	minVersion, err := getMinNodeVersion(opts.Cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get minimum node version in cluster: %w", err)
 	}
@@ -76,72 +141,76 @@ func StartShardedDCPFeed(ctx context.Context, dbName string, configGroup string,
 		}
 	}
 
-	b, err := AsGocbV2Bucket(bucket)
+	b, err := AsGocbV2Bucket(opts.Bucket)
 	if err != nil {
 		return nil, fmt.Errorf("error asserting bucket as gocb v2 bucket: %w", err)
 	}
 
-	cbgtContext, err := initCBGTManager(ctx, bucket, b.GetSpec(), cfg, uuid, dbName)
+	cbgtContext, err := initCBGTManager(ctx, opts.Bucket, b.GetSpec(), opts.Cfg, opts.UUID, opts.DBName)
 	if err != nil {
 		return nil, err
 	}
 
 	// Start Manager.  Registers this node in the cfg
-	err = cbgtContext.StartManager(ctx, dbName, configGroup, bucket, scope, collections, numPartitions)
+	err = cbgtContext.StartManager(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	// Register heartbeat listener to trigger removal from cfg when
 	// other SG nodes stop sending heartbeats.
-	listener, err := registerHeartbeatListener(ctx, heartbeater, cbgtContext)
+	listener, err := registerHeartbeatListener(ctx, opts.Heartbeater, cbgtContext)
 	if err != nil {
 		return nil, err
 	}
 
-	cbgtContext.heartbeater = heartbeater
+	cbgtContext.heartbeater = opts.Heartbeater
 	cbgtContext.heartbeatListener = listener
 
 	return cbgtContext, nil
 }
 
-// Given a dbName, generate a unique and length-constrained index name for CBGT to use as part of their DCP name.
-func GenerateIndexName(dbName string) string {
+// GenerateImportIndexName creates an index name for cbgt using the database name suitable for the import feed.
+func GenerateImportIndexName(dbName string) (string, error) {
 	// Index names *must* start with a letter, so we'll prepend 'db' before the per-database checksum (which starts with '0x')
 	// Don't use Crc32cHashString here because this is intentionally non zero padded to match
 	// existing values.
-	return fmt.Sprintf("db0x%x_index", Crc32cHash([]byte(dbName)))
+	i := fmt.Sprintf("db0x%x_index", Crc32cHash([]byte(dbName)))
+	if len(i) > 200 {
+		return "", fmt.Errorf("generated index name %q is too long for CBGT DCP stream (max 200 characters)", i)
+	}
+	return i, nil
 }
 
-// Given a dbName, generates a name based on the approach used prior to CBG-626.  Used for upgrade handling
-func GenerateLegacyIndexName(dbName string) string {
+// GenerateLegacyImportIndexName returns the name of a cbgt index from a pre-Sync Gateway 2.8 database. See CBG-626.
+func GenerateLegacyImportIndexName(dbName string) string {
 	return dbName + "_import"
 }
 
-// Creates a CBGT index definition for the specified bucket.  This adds the index definition
-// to the manager's cbgt cfg.  Nodes that have registered for this indexType with the manager via
+// createCBGTIndex adds an a CBGT index definition for the specified bucket to to the manager's cbgt cfg.  Nodes that have registered for this indexType with the manager via
 // RegisterPIndexImplType (see importListener.RegisterImportPindexImpl)
-// will receive PIndexImpl callbacks (New, Open) for assigned PIndex to initiate DCP processing.
-func createCBGTIndex(ctx context.Context, c *CbgtContext, dbName string, configGroupID string, bucket Bucket, scope string, collections []string, numPartitions uint16) error {
+// will receive PIndexImpl callbacks (New) for assigned PIndex to initiate DCP processing.
+func createCBGTIndex(ctx context.Context, c *CbgtContext, opts ShardedDCPOptions) error {
 	sourceType := SOURCE_DCP_SG
 
-	sourceParams, err := cbgtFeedParams(ctx, scope, collections, dbName)
+	sourceParams, err := cbgtFeedParams(ctx, opts.Collections, opts.DBName)
 	if err != nil {
 		return err
 	}
 
-	indexParams, err := cbgtIndexParams(ImportDestKey(dbName, scope, collections))
+	indexParams, err := cbgtIndexParams(opts.DestKey)
 	if err != nil {
 		return err
 	}
 
-	vbNo, err := bucket.GetMaxVbno()
+	vbNo, err := opts.Bucket.GetMaxVbno()
 	if err != nil {
-		return errors.Wrapf(err, "Unable to retrieve maxVbNo for bucket %s", MD(bucket.GetName()).Redact())
+		return errors.Wrapf(err, "Unable to retrieve maxVbNo for bucket %s", MD(opts.Bucket.GetName()).Redact())
 	}
 
+	numPartitions := opts.NumPartitions
 	// Calculate partitionsPerPIndex required to hit target DefaultImportPartitions
-	if numPartitions == 0 || numPartitions > vbNo {
+	if opts.NumPartitions == 0 || opts.NumPartitions > vbNo {
 		numPartitions = DefaultImportPartitions
 	}
 
@@ -153,19 +222,18 @@ func createCBGTIndex(ctx context.Context, c *CbgtContext, dbName string, configG
 	}
 
 	// Determine index name and UUID
-	indexName, previousIndexUUID := dcpSafeIndexName(ctx, c, dbName)
-	InfofCtx(ctx, KeyDCP, "Creating cbgt index %q for db %q", indexName, MD(dbName))
+	indexName, previousIndexUUID := c.getIndexNameAndUUID(ctx, opts.IndexName, opts.PreviousIndexName)
+	InfofCtx(ctx, KeyDCP, "Creating cbgt index %q for db %q", opts.IndexName, MD(opts.DBName))
 
 	// Index types are namespaced by configGroupID to support delete and create of a database targeting the
 	// same bucket in a config group
-	indexType := CBGTIndexTypeSyncGatewayImport + configGroupID
 	err = c.Manager.CreateIndex(
 		sourceType,        // sourceType
 		c.sourceName,      // bucket name
 		c.sourceUUID,      // bucket UUID
 		sourceParams,      // sourceParams
-		indexType,         // indexType
-		indexName,         // indexName
+		opts.IndexType,    // indexType
+		opts.IndexName,    // indexName
 		indexParams,       // indexParams
 		planParams,        // planParams
 		previousIndexUUID, // prevIndexUUID
@@ -177,16 +245,14 @@ func createCBGTIndex(ctx context.Context, c *CbgtContext, dbName string, configG
 
 }
 
-// dcpSafeIndexName returns an index name and previousIndexUUID to handle upgrade scenarios from the
-// legacy index name format ("dbname_import") to the new length-safe format ("db[crc32]_index").
+// getIndexNameAndUUID returns an index name and the uuid of any existing index.
+//
+// Handle upgrade scenarios from an old an legacy index name format ("dbname_import") to the new length-safe format ("db[crc32]_index").
+//
 // Handles removal of legacy index definitions, except for the case where the legacy index is
 // the only index defined, and the name is safe.  In that case, continue using legacy index name
 // to avoid restarting the import processing from zero
-func dcpSafeIndexName(ctx context.Context, c *CbgtContext, dbName string) (safeIndexName, previousUUID string) {
-
-	indexName := GenerateIndexName(dbName)
-	legacyIndexName := GenerateLegacyIndexName(dbName)
-
+func (c *CbgtContext) getIndexNameAndUUID(ctx context.Context, indexName string, legacyIndexName string) (name string, uuid string) {
 	indexUUID, _ := getCBGTIndexUUID(c.Manager, indexName)
 	legacyIndexUUID, _ := getCBGTIndexUUID(c.Manager, legacyIndexName)
 
@@ -333,7 +399,6 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 		Manager:       mgr,
 		Cfg:           cfgSG,
 		eventHandlers: eventHandlers,
-		ctx:           ctx,
 		dbName:        dbName,
 		sourceName:    bucket.GetName(),
 		sourceUUID:    bucketUUID,
@@ -363,7 +428,7 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 }
 
 // StartManager registers this node with cbgt, and the janitor will start feeds on this node.
-func (c *CbgtContext) StartManager(ctx context.Context, dbName string, configGroup string, bucket Bucket, scope string, collections []string, numPartitions uint16) (err error) {
+func (c *CbgtContext) StartManager(ctx context.Context, opts ShardedDCPOptions) error {
 	// TODO: Clarify the functional difference between registering the manager as 'wanted' vs 'known'.
 	registerType := cbgt.NODE_DEFS_WANTED
 	if err := c.Manager.Start(registerType); err != nil {
@@ -372,7 +437,7 @@ func (c *CbgtContext) StartManager(ctx context.Context, dbName string, configGro
 	}
 
 	// Add the index definition for this feed to the cbgt cfg, in case it's not already present.
-	err = createCBGTIndex(ctx, c, dbName, configGroup, bucket, scope, collections, numPartitions)
+	err := createCBGTIndex(ctx, c, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "an index with the same name already exists") {
 			InfofCtx(ctx, KeyCluster, "Duplicate cbgt index detected during index creation (concurrent creation), using existing")
@@ -427,7 +492,7 @@ func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableBuildVersion, error) {
 }
 
 // Stop unregisters the listener from the heartbeater, and stops it and associated handlers.
-func (c *CbgtContext) Stop() {
+func (c *CbgtContext) Stop(ctx context.Context) {
 	if c.eventHandlers != nil {
 		c.eventHandlers.ctxCancel()
 	}
@@ -442,7 +507,7 @@ func (c *CbgtContext) Stop() {
 	for _, pIndex := range pindexes {
 		err := c.Manager.ClosePIndex(pIndex)
 		if err != nil {
-			DebugfCtx(c.ctx, KeyDCP, "Error closing pindex: %v", err)
+			DebugfCtx(ctx, KeyDCP, "Error closing pindex: %v", err)
 		}
 	}
 	// ClosePIndex calls are synchronous, so can stop manager once they've completed

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -104,7 +106,7 @@ func (opts ShardedDCPOptions) Validate() error {
 	if len(opts.Collections) == 0 {
 		return fmt.Errorf("at least one collection must be specified to start a sharded DCP feed")
 	} else if len(opts.Collections) > 1 {
-		return fmt.Errorf("only one scope is currently supported for ")
+		return RedactErrorf("only one scope is currently supported for sharded DCP feed, found %s", MD(slices.Collect(maps.Keys(opts.Collections))))
 	}
 	return nil
 }
@@ -117,6 +119,7 @@ func (opts ShardedDCPOptions) scopeAndCollections() (string, []string) {
 		scopeName = s
 		collections = c
 	}
+	slices.Sort(collections)
 	return scopeName, collections
 }
 
@@ -223,7 +226,7 @@ func createCBGTIndex(ctx context.Context, c *CbgtContext, opts ShardedDCPOptions
 
 	// Determine index name and UUID
 	indexName, previousIndexUUID := c.getIndexNameAndUUID(ctx, opts.IndexName, opts.PreviousIndexName)
-	InfofCtx(ctx, KeyDCP, "Creating cbgt index %q for db %q", opts.IndexName, MD(opts.DBName))
+	InfofCtx(ctx, KeyDCP, "Creating cbgt index %q for db %q", indexName, MD(opts.DBName))
 
 	// Index types are namespaced by configGroupID to support delete and create of a database targeting the
 	// same bucket in a config group
@@ -233,7 +236,7 @@ func createCBGTIndex(ctx context.Context, c *CbgtContext, opts ShardedDCPOptions
 		c.sourceUUID,      // bucket UUID
 		sourceParams,      // sourceParams
 		opts.IndexType,    // indexType
-		opts.IndexName,    // indexName
+		indexName,         // indexName
 		indexParams,       // indexParams
 		planParams,        // planParams
 		previousIndexUUID, // prevIndexUUID

--- a/base/dcp_sharded_test.go
+++ b/base/dcp_sharded_test.go
@@ -31,7 +31,10 @@ func TestIndexName(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("dbName %s -> indexName %s", test.indexName, test.dbName), func(t *testing.T) {
-			require.Equal(t, test.indexName, GenerateIndexName(test.dbName))
+			indexName, err := GenerateImportIndexName(test.dbName)
+			require.NoError(t, err)
+
+			require.Equal(t, test.indexName, indexName)
 		})
 	}
 }

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -13,7 +13,9 @@ package base
 import (
 	"fmt"
 	"log"
+	"maps"
 	"math/rand"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -145,11 +147,14 @@ func TestCBGTIndexCreation(t *testing.T) {
 	}
 
 	shortDbName := "testDB"
+	shortDbIndexName, err := GenerateImportIndexName(shortDbName)
+	require.NoError(t, err)
 	longDbName := "testDB" +
 		"01234567890123456789012345678901234567890123456789" +
 		"01234567890123456789012345678901234567890123456789" +
 		"01234567890123456789012345678901234567890123456789"
-
+	longDbIndexName, err := GenerateImportIndexName(longDbName)
+	require.NoError(t, err)
 	for _, tc := range []struct {
 		name                 string
 		dbName               string
@@ -162,49 +167,21 @@ func TestCBGTIndexCreation(t *testing.T) {
 			dbName:               shortDbName,
 			existingLegacyIndex:  false,
 			existingCurrentIndex: false,
-			expectedIndexName:    GenerateIndexName(shortDbName),
+			expectedIndexName:    shortDbIndexName,
 		},
 		{
 			name:                 "nonUpgradeRestart",
 			dbName:               shortDbName,
 			existingLegacyIndex:  false,
 			existingCurrentIndex: true,
-			expectedIndexName:    GenerateIndexName(shortDbName),
+			expectedIndexName:    shortDbIndexName,
 		},
 		{
 			name:                 "nonUpgradeUnsafeName",
 			dbName:               longDbName,
 			existingLegacyIndex:  false,
 			existingCurrentIndex: false,
-			expectedIndexName:    GenerateIndexName(longDbName),
-		},
-		{
-			name:                 "upgradeFromSafeLegacy",
-			dbName:               shortDbName,
-			existingLegacyIndex:  true,
-			existingCurrentIndex: false,
-			expectedIndexName:    GenerateLegacyIndexName(shortDbName),
-		},
-		{
-			name:                 "upgradeFromUnsafeLegacy",
-			dbName:               longDbName,
-			existingLegacyIndex:  true,
-			existingCurrentIndex: false,
-			expectedIndexName:    GenerateIndexName(longDbName),
-		},
-		{
-			name:                 "upgradeFromSafeDualIndex",
-			dbName:               shortDbName,
-			existingLegacyIndex:  true,
-			existingCurrentIndex: true,
-			expectedIndexName:    GenerateIndexName(shortDbName),
-		},
-		{
-			name:                 "upgradeFromUnsafeDualIndex",
-			dbName:               longDbName,
-			existingLegacyIndex:  true,
-			existingCurrentIndex: true,
-			expectedIndexName:    GenerateIndexName(longDbName),
+			expectedIndexName:    longDbIndexName,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -234,42 +211,13 @@ func TestCBGTIndexCreation(t *testing.T) {
 			cbgt.RegisterPIndexImplType(indexType,
 				&cbgt.PIndexImplType{})
 
-			// Create existing index in legacy format
-			if tc.existingLegacyIndex {
-				// initCBGTManager will set up the manager with a couchbase:// connection string,
-				// while go-couchbase expects a http:// string, causing test setup to fail.
-				t.Skip("TODO: can't create indexes of type cbgt.SOURCE_GOCOUCHBASE")
-				// Define a CBGT index with legacy naming
-				bucketUUID, _ := bucket.UUID()
-				sourceParams, err := legacyFeedParams(spec)
-				require.NoError(t, err)
-				legacyIndexName := GenerateLegacyIndexName(tc.dbName)
-				indexParams := `{"name": "` + tc.dbName + `"}`
-				planParams := cbgt.PlanParams{
-					MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
-					NumReplicas:            0,  // No replicas required for SG sharded feed
-				}
-
-				err = context.Manager.CreateIndex(
-					cbgt.SOURCE_GOCOUCHBASE, // sourceType
-					bucket.GetName(),        // sourceName
-					bucketUUID,              // sourceUUID
-					sourceParams,            // sourceParams
-					indexType,               // indexType
-					legacyIndexName,         // indexName
-					indexParams,             // indexParams
-					planParams,              // planParams
-					"",                      // prevIndexUUID
-				)
-				require.NoError(t, err, "Unable to create legacy-style index")
-			}
-
 			if tc.existingCurrentIndex {
 				// Define an existing CBGT index with current naming
 				bucketUUID, _ := bucket.UUID()
-				sourceParams, err := cbgtFeedParams(ctx, "", nil, tc.dbName)
+				sourceParams, err := cbgtFeedParams(ctx, nil, tc.dbName)
 				require.NoError(t, err)
-				legacyIndexName := GenerateIndexName(tc.dbName)
+				legacyIndexName, err := GenerateImportIndexName(tc.dbName)
+				require.NoError(t, err)
 				indexParams := `{"name": "` + tc.dbName + `"}`
 				planParams := cbgt.PlanParams{
 					MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
@@ -290,16 +238,25 @@ func TestCBGTIndexCreation(t *testing.T) {
 				require.NoError(t, err, "Unable to create legacy-style index")
 			}
 
+			indexName, err := GenerateImportIndexName(tc.dbName)
+			require.NoError(t, err)
+
 			// Create cbgt index via SG handling
-			err = createCBGTIndex(ctx, context, tc.dbName, configGroup, bucket, "", nil, 16)
+			err = createCBGTIndex(ctx, context, ShardedDCPOptions{
+				DBName:            tc.dbName,
+				Bucket:            bucket,
+				NumPartitions:     16,
+				IndexName:         indexName,
+				PreviousIndexName: GenerateLegacyImportIndexName(tc.dbName),
+				IndexType:         indexType,
+			})
 			require.NoError(t, err)
 
 			// Verify single index exists, and matches expected naming
 			_, indexDefsMap, err := context.Manager.GetIndexDefs(true)
 			require.NoError(t, err)
-			assert.Len(t, indexDefsMap, 1)
-			indexDef, ok := indexDefsMap[tc.expectedIndexName]
-			assert.True(t, ok, "Expected index name"+tc.expectedIndexName+"not found")
+			require.Contains(t, indexDefsMap, tc.expectedIndexName)
+			indexDef := indexDefsMap[tc.expectedIndexName]
 
 			assert.False(t, strings.Contains(indexDef.SourceParams, "authUser"), "sourceParams should not include authUser")
 			assert.False(t, strings.Contains(indexDef.SourceParams, "authPassword"), "sourceParams should not include authPassword")
@@ -340,9 +297,9 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 
 	// Define a CBGT index with legacy naming within safe limits
 	bucketUUID, _ := bucket.UUID()
-	sourceParams, err := cbgtFeedParams(ctx, "", nil, testDbName)
+	sourceParams, err := cbgtFeedParams(ctx, nil, testDbName)
 	require.NoError(t, err)
-	legacyIndexName := GenerateLegacyIndexName(testDbName)
+	legacyIndexName := GenerateLegacyImportIndexName(testDbName)
 	indexParams := `{"name": "` + testDbName + `"}`
 	planParams := cbgt.PlanParams{
 		MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
@@ -362,8 +319,15 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	)
 	require.NoError(t, err, "Unable to create legacy-style index")
 
+	opts := ShardedDCPOptions{
+		DBName:        testDbName,
+		Bucket:        bucket,
+		NumPartitions: 16,
+		IndexType:     indexType,
+		IndexName:     legacyIndexName, // use legacy name as the primary name for this test
+	}
 	// Create cbgt index
-	err = createCBGTIndex(ctx, context, testDbName, configGroup, bucket, "", nil, 16)
+	err = createCBGTIndex(ctx, context, opts)
 	require.NoError(t, err)
 
 	// Verify single index created
@@ -372,15 +336,13 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	assert.Len(t, indexDefsMap, 1)
 
 	// Attempt to recreate index
-	err = createCBGTIndex(ctx, context, testDbName, configGroup, bucket, "", nil, 16)
+	err = createCBGTIndex(ctx, context, opts)
 	require.NoError(t, err)
 
 	// Verify single index defined (acts as upsert to existing)
 	_, indexDefsMap, err = context.Manager.GetIndexDefs(true)
 	require.NoError(t, err)
-	assert.Len(t, indexDefsMap, 1)
-	_, ok := indexDefsMap[legacyIndexName]
-	assert.True(t, ok)
+	require.Contains(t, indexDefsMap, legacyIndexName)
 }
 
 func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
@@ -418,9 +380,9 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 
 	// Define a CBGT index with legacy naming not within safe limits
 	bucketUUID, _ := bucket.UUID()
-	sourceParams, err := cbgtFeedParams(ctx, "", nil, unsafeTestDBName)
+	sourceParams, err := cbgtFeedParams(ctx, nil, unsafeTestDBName)
 	require.NoError(t, err)
-	legacyIndexName := GenerateLegacyIndexName(unsafeTestDBName)
+	legacyIndexName := GenerateLegacyImportIndexName(unsafeTestDBName)
 	indexParams := `{"name": "` + unsafeTestDBName + `"}`
 	planParams := cbgt.PlanParams{
 		MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
@@ -440,8 +402,19 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	)
 	require.NoError(t, err, "Unable to create legacy-style index")
 
+	indexName, err := GenerateImportIndexName(unsafeTestDBName)
+	require.NoError(t, err)
+
+	opts := ShardedDCPOptions{
+		DBName:            unsafeTestDBName,
+		Bucket:            bucket,
+		NumPartitions:     16,
+		IndexType:         indexType,
+		IndexName:         indexName, // use legacy name as the primary name for this test
+		PreviousIndexName: legacyIndexName,
+	}
 	// Create cbgt index
-	err = createCBGTIndex(ctx, context, unsafeTestDBName, configGroup, bucket, "", nil, 16)
+	err = createCBGTIndex(ctx, context, opts)
 	require.NoError(t, err)
 
 	// Verify single index created
@@ -450,17 +423,13 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	assert.Len(t, indexDefsMap, 1)
 
 	// Attempt to recreate index
-	err = createCBGTIndex(ctx, context, unsafeTestDBName, configGroup, bucket, "", nil, 16)
+	err = createCBGTIndex(ctx, context, opts)
 	require.NoError(t, err)
 
 	// Verify single index defined (acts as upsert to existing)
 	_, indexDefsMap, err = context.Manager.GetIndexDefs(true)
 	require.NoError(t, err)
-	assert.Len(t, indexDefsMap, 1)
-	_, ok := indexDefsMap[legacyIndexName]
-	assert.False(t, ok)
-	_, ok = indexDefsMap[GenerateIndexName(unsafeTestDBName)]
-	assert.True(t, ok)
+	require.Equal(t, []string{indexName}, slices.Collect(maps.Keys(indexDefsMap)))
 }
 
 func TestConcurrentCBGTIndexCreation(t *testing.T) {
@@ -507,8 +476,17 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 
 			// StartManager starts the manager and creates the index
 			log.Printf("Starting manager for %s", managerUUID)
-			startErr := context.StartManager(ctx, testDBName, configGroup, bucket, "", nil, DefaultImportPartitions)
-			assert.NoError(t, startErr)
+			indexName, err := GenerateImportIndexName(testDBName)
+			require.NoError(t, err)
+			opts := ShardedDCPOptions{
+				DBName:        testDBName,
+				Bucket:        bucket,
+				NumPartitions: DefaultImportPartitions,
+				IndexType:     indexType,
+				IndexName:     indexName,
+			}
+			startErr := context.StartManager(ctx, opts)
+			require.NoError(t, startErr)
 			managerWg.Done()
 
 			// ensure all goroutines start the manager before we start closing them
@@ -525,28 +503,6 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 	close(terminator)
 }
 
-// legacyFeedParams format with credentials included
-func legacyFeedParams(spec BucketSpec) (string, error) {
-	feedParams := cbgt.NewDCPFeedParams()
-
-	// check for basic auth
-	if spec.Certpath == "" && spec.Auth != nil {
-		username, password, _ := spec.Auth.GetCredentials()
-		feedParams.AuthUser = username
-		feedParams.AuthPassword = password
-	}
-
-	if spec.UseXattrs {
-		feedParams.IncludeXAttrs = true
-	}
-
-	paramBytes, err := JSONMarshal(feedParams)
-	if err != nil {
-		return "", err
-	}
-	return string(paramBytes), nil
-}
-
 func TestCBGTKvPoolSize(t *testing.T) {
 	ctx := TestCtx(t)
 	bucket := GetTestBucket(t)
@@ -559,6 +515,6 @@ func TestCBGTKvPoolSize(t *testing.T) {
 	require.NoError(t, err)
 	cbgtContext, err := initCBGTManager(ctx, bucket, spec, cfg, t.Name(), "fakeDb")
 	assert.NoError(t, err)
-	defer cbgtContext.Stop()
+	defer cbgtContext.Stop(ctx)
 	require.Contains(t, cbgtContext.Manager.Server(), "kv_pool_size=1")
 }

--- a/db/database.go
+++ b/db/database.go
@@ -640,7 +640,7 @@ func (db *DatabaseContext) _stopOnlineProcesses(ctx context.Context) {
 	db.mutationListener.Stop(ctx)
 	db.changeCache.Stop(ctx)
 	if db.ImportListener != nil {
-		db.ImportListener.Stop()
+		db.ImportListener.Stop(ctx)
 		db.ImportListener = nil
 	}
 	if db.Heartbeater != nil {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime/debug"
 	"strings"
 
@@ -91,8 +92,24 @@ func (il *importListener) StartImportFeed(dbContext *DatabaseContext) (err error
 		return dbContext.Bucket.StartDCPFeed(il.loggingCtx, feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map)
 	}
 
-	il.cbgtContext, err = base.StartShardedDCPFeed(il.loggingCtx, dbContext.Name, dbContext.Options.GroupID, dbContext.UUID, dbContext.Heartbeater,
-		dbContext.Bucket, dbContext.scopeName, collectionNamesByScope[dbContext.scopeName], dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
+	indexName, err := base.GenerateImportIndexName(dbContext.Name)
+	if err != nil {
+		return fmt.Errorf("Could not determine index name for import feed: %w", err)
+	}
+	opts := base.ShardedDCPOptions{
+		DBName:            dbContext.Name,
+		UUID:              dbContext.UUID,
+		NumPartitions:     dbContext.Options.ImportOptions.ImportPartitions,
+		Collections:       collectionNamesByScope,
+		Cfg:               dbContext.CfgSG,
+		Heartbeater:       dbContext.Heartbeater,
+		Bucket:            dbContext.Bucket,
+		IndexType:         base.CBGTIndexTypeSyncGatewayImport + dbContext.Options.GroupID,
+		DestKey:           il.importDestKey,
+		IndexName:         indexName,
+		PreviousIndexName: base.GenerateLegacyImportIndexName(dbContext.Name),
+	}
+	il.cbgtContext, err = base.StartShardedDCPFeed(il.loggingCtx, opts)
 	return err
 }
 
@@ -226,10 +243,11 @@ func (il *importListener) ImportFeedEvent(ctx context.Context, collection *Datab
 	}
 }
 
-func (il *importListener) Stop() {
+// Stop triggers closing the import listener DCP feed and removes the node from shared DCP feed. This function is asynchronous.
+func (il *importListener) Stop(ctx context.Context) {
 	if il != nil {
 		if il.cbgtContext != nil {
-			il.cbgtContext.Stop()
+			il.cbgtContext.Stop(ctx)
 
 			// Remove entry from global listener directory
 			base.RemoveDestFactory(il.importDestKey)


### PR DESCRIPTION
Create sharded dcp options struct

The goal of this is remove coupling of options that are specific to import from inside `StartShardedDCPFeed`. This moves the requirement to set the following to the caller:

1. IndexName: unique name for index (per db), shorter than 150 characters
2. PreviousIndexName: pre Sync Gateway 2.8 index name. This would only be used for import. The way this is used is that if this name is found in the `cbgt.Manager` as active in another node, the index is upgraded to the `IndexName`. This upgrade procedure was used since the old index names were oversized and would fail for gocb DCP feeds.
3. IndexType: this is the name used by `cbgt.RegisterPIndexImplType`. This name is shared across all resync processes on any number of databases.

This is inspired by https://github.com/couchbase/sync_gateway/pull/8057 but does not have to be merged before that PR. They will conflict. I think it will make the work in that ticket more clear.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/387/
