### PR TITLE
[3.3.4] CBG-5200: Add guardrail to prevent disabling of xattrs

### DIFF
--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -3998,3 +3998,23 @@ func RequireEventCount(t *testing.T, runtimeConfig *rest.RuntimeDatabaseConfig, 
 	}
 	require.Equal(t, expectedCount, actualCount)
 }
+
+// TestDisableXattrs verifies that disabling xattrs (extended attributes) on a database
+// is handled correctly through the admin API. It ensures that the configuration change
+// is applied and that the database behaves as expected when xattrs are disabled.
+func TestDisableXattrs(t *testing.T) {
+	for _, persistent := range []bool{true, false} {
+		rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+			PersistentConfig: persistent,
+		})
+		defer rt.Close()
+
+		dbConfig := rt.NewDbConfig()
+		dbConfig.EnableXattrs = base.Ptr(true)
+
+		rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+
+		dbConfig.EnableXattrs = base.Ptr(false)
+		rest.RequireStatus(t, rt.UpsertDbConfig("db1", dbConfig), http.StatusBadRequest)
+	}
+}

--- a/rest/adminapitest/admin_api_test.go
+++ b/rest/adminapitest/admin_api_test.go
@@ -4004,17 +4004,19 @@ func RequireEventCount(t *testing.T, runtimeConfig *rest.RuntimeDatabaseConfig, 
 // is applied and that the database behaves as expected when xattrs are disabled.
 func TestDisableXattrs(t *testing.T) {
 	for _, persistent := range []bool{true, false} {
-		rt := rest.NewRestTester(t, &rest.RestTesterConfig{
-			PersistentConfig: persistent,
+		t.Run(fmt.Sprintf("persistentConfig=%t", persistent), func(t *testing.T) {
+			rt := rest.NewRestTester(t, &rest.RestTesterConfig{
+				PersistentConfig: persistent,
+			})
+			defer rt.Close()
+
+			dbConfig := rt.NewDbConfig()
+			dbConfig.EnableXattrs = base.Ptr(true)
+
+			rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
+
+			dbConfig.EnableXattrs = base.Ptr(false)
+			rest.RequireStatus(t, rt.UpsertDbConfig("db1", dbConfig), http.StatusBadRequest)
 		})
-		defer rt.Close()
-
-		dbConfig := rt.NewDbConfig()
-		dbConfig.EnableXattrs = base.Ptr(true)
-
-		rest.RequireStatus(t, rt.CreateDatabase("db1", dbConfig), http.StatusCreated)
-
-		dbConfig.EnableXattrs = base.Ptr(false)
-		rest.RequireStatus(t, rt.UpsertDbConfig("db1", dbConfig), http.StatusBadRequest)
 	}
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -725,12 +725,12 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig
 // validateChanges compares the current DbConfig with the "old" config, and returns an error if any disallowed changes
 // are attempted.
 func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) error {
-	// add guardrails to prevent disabling enabled_shared_bucket_access.
+	// add guardrails to prevent disabling enable_shared_bucket_access.
 	// nil is treated as false (not enabled), so transitioning from explicitly-enabled to nil is also disallowed.
 	oldXattrsEnabled := old.EnableXattrs != nil && *old.EnableXattrs
 	newXattrsEnabled := dbConfig.EnableXattrs != nil && *dbConfig.EnableXattrs
 	if oldXattrsEnabled && !newXattrsEnabled {
-		return fmt.Errorf("cannot disable enabled_shared_bucket_access after enabling it")
+		return fmt.Errorf("cannot disable enable_shared_bucket_access after enabling it")
 	}
 	// allow switching from implicit `_default` to explicit `_default` scope
 	_, newIsDefaultScope := dbConfig.Scopes[base.DefaultScope]

--- a/rest/config.go
+++ b/rest/config.go
@@ -725,6 +725,10 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig
 // validateChanges compares the current DbConfig with the "old" config, and returns an error if any disallowed changes
 // are attempted.
 func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) error {
+	// add guardrails to prevent disabling enabled_shared_bucket_access
+	if *old.EnableXattrs && !(*dbConfig.EnableXattrs) {
+		return fmt.Errorf("cannot disable enabled_shared_bucket_access after enabling it")
+	}
 	// allow switching from implicit `_default` to explicit `_default` scope
 	_, newIsDefaultScope := dbConfig.Scopes[base.DefaultScope]
 	if old.Scopes == nil && len(dbConfig.Scopes) == 1 && newIsDefaultScope {

--- a/rest/config.go
+++ b/rest/config.go
@@ -76,6 +76,8 @@ const (
 	tapFeedType = "tap"
 )
 
+var errEnableSharedBucketAccessOneWay = errors.New("enable_shared_bucket_access=true is a one-way operation, cannot disable it after previously enabling it")
+
 // serverType indicates which type of HTTP server sync gateway is running
 type serverType string
 
@@ -725,12 +727,13 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig
 // validateChanges compares the current DbConfig with the "old" config, and returns an error if any disallowed changes
 // are attempted.
 func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) error {
-	// add guardrails to prevent disabling enable_shared_bucket_access.
-	// nil is treated as false (not enabled), so transitioning from explicitly-enabled to nil is also disallowed.
-	oldXattrsEnabled := old.EnableXattrs != nil && *old.EnableXattrs
-	newXattrsEnabled := dbConfig.EnableXattrs != nil && *dbConfig.EnableXattrs
+	// add guardrails to prevent disabling enable_shared_bucket_access if it was already enabled.
+	// In Sync Gateway <3.0 nil == false (not enabled)
+	// In Sync Gateway 3.0+ nil == true (enabled)
+	oldXattrsEnabled := old.EnableXattrs == nil || *old.EnableXattrs
+	newXattrsEnabled := dbConfig.EnableXattrs == nil || *dbConfig.EnableXattrs
 	if oldXattrsEnabled && !newXattrsEnabled {
-		return fmt.Errorf("cannot disable enable_shared_bucket_access after enabling it")
+		return errEnableSharedBucketAccessOneWay
 	}
 	// allow switching from implicit `_default` to explicit `_default` scope
 	_, newIsDefaultScope := dbConfig.Scopes[base.DefaultScope]

--- a/rest/config.go
+++ b/rest/config.go
@@ -725,8 +725,11 @@ func (dbConfig *DbConfig) validateConfigUpdate(ctx context.Context, old DbConfig
 // validateChanges compares the current DbConfig with the "old" config, and returns an error if any disallowed changes
 // are attempted.
 func (dbConfig *DbConfig) validateChanges(ctx context.Context, old DbConfig) error {
-	// add guardrails to prevent disabling enabled_shared_bucket_access
-	if *old.EnableXattrs && !(*dbConfig.EnableXattrs) {
+	// add guardrails to prevent disabling enabled_shared_bucket_access.
+	// nil is treated as false (not enabled), so transitioning from explicitly-enabled to nil is also disallowed.
+	oldXattrsEnabled := old.EnableXattrs != nil && *old.EnableXattrs
+	newXattrsEnabled := dbConfig.EnableXattrs != nil && *dbConfig.EnableXattrs
+	if oldXattrsEnabled && !newXattrsEnabled {
 		return fmt.Errorf("cannot disable enabled_shared_bucket_access after enabling it")
 	}
 	// allow switching from implicit `_default` to explicit `_default` scope

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -251,20 +251,20 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			name: "old xattrs nil, new xattrs disabled - valid",
+			name: "old xattrs nil, new xattrs disabled - invalid",
 			newDbConfig: DbConfig{
 				EnableXattrs: base.Ptr(false),
 			},
 			oldDbConfig:   DbConfig{},
-			expectedError: "",
+			expectedError: errEnableSharedBucketAccessOneWay.Error(),
 		},
 		{
-			name:        "old xattrs enabled, new xattrs nil - error",
+			name:        "old xattrs enabled, new xattrs nil",
 			newDbConfig: DbConfig{},
 			oldDbConfig: DbConfig{
 				EnableXattrs: base.Ptr(true),
 			},
-			expectedError: "cannot disable enable_shared_bucket_access after enabling it",
+			expectedError: "",
 		},
 		{
 			name:        "old xattrs disabled, new xattrs nil - valid",
@@ -312,9 +312,8 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 			oldDbConfig: DbConfig{
 				EnableXattrs: base.Ptr(true),
 			},
-			expectedError: "cannot disable enable_shared_bucket_access after enabling it",
+			expectedError: errEnableSharedBucketAccessOneWay.Error(),
 		},
-
 		// Scope validation
 		{
 			name: "implicit to explicit default scope - valid",

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -291,7 +291,7 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 				EnableXattrs: base.Ptr(true),
 			},
 			oldDbConfig: DbConfig{
-				Scopes: nil,
+				Scopes:       nil,
 				EnableXattrs: base.Ptr(true),
 			},
 			expectedError: "",

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -264,7 +264,7 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 			oldDbConfig: DbConfig{
 				EnableXattrs: base.Ptr(true),
 			},
-			expectedError: "cannot disable enabled_shared_bucket_access after enabling it",
+			expectedError: "cannot disable enable_shared_bucket_access after enabling it",
 		},
 		{
 			name:        "old xattrs disabled, new xattrs nil - valid",
@@ -312,7 +312,7 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 			oldDbConfig: DbConfig{
 				EnableXattrs: base.Ptr(true),
 			},
-			expectedError: "cannot disable enabled_shared_bucket_access after enabling it",
+			expectedError: "cannot disable enable_shared_bucket_access after enabling it",
 		},
 
 		// Scope validation

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -223,3 +223,223 @@ func TestDatabaseConfigValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestDatabaseConfigValidateChanges validates configuration changes allowed during a config update.
+// It specifically checks constraints around enabling shared bucket access XAttrs,
+// transitioning from implicit to explicit scopes, and ensures scope topology remains consistent.
+func TestDatabaseConfigValidateChanges(t *testing.T) {
+	ctx := base.TestCtx(t)
+	testCases := []struct {
+		name          string
+		newDbConfig   DbConfig
+		oldDbConfig   DbConfig
+		expectedError string
+	}{
+		// XATTR validation
+		{
+			name: "no changes - valid",
+			newDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "",
+		},
+		{
+			name: "xattrs remains disabled - valid",
+			newDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(false),
+			},
+			oldDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(false),
+			},
+			expectedError: "",
+		},
+		{
+			name: "enabling xattrs when previously disabled - valid",
+			newDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(false),
+			},
+			expectedError: "",
+		},
+		{
+			name: "disabling xattrs when previously enabled - error",
+			newDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(false),
+			},
+			oldDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "cannot disable enabled_shared_bucket_access after enabling it",
+		},
+
+		// Scope validation
+		{
+			name: "implicit to explicit default scope - valid",
+			newDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					base.DefaultScope: ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig: DbConfig{
+				Scopes: nil,
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "",
+		},
+		{
+			name: "implicit default scope to named scope - error",
+			newDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					"scope1": ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig: DbConfig{
+				Scopes:       nil,
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "cannot change scopes after database creation",
+		},
+		{
+			name: "implicit default scope to multiple scopes - error",
+			newDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					base.DefaultScope: ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+					"scope1": ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig: DbConfig{
+				Scopes:       nil,
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "cannot change scopes after database creation",
+		},
+		{
+			name: "adding new scope - error",
+			newDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					base.DefaultScope: ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+					"newscope": ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					base.DefaultScope: ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "cannot change scopes after database creation",
+		},
+		{
+			name: "removing scope - error",
+			newDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					base.DefaultScope: ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					base.DefaultScope: ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+					"oldscope": ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "cannot change scopes after database creation",
+		},
+		{
+			name: "different scope names with same count - error",
+			newDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					base.DefaultScope: ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+					"newscope": ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig: DbConfig{
+				Scopes: ScopesConfig{
+					base.DefaultScope: ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+					"oldscope": ScopeConfig{
+						Collections: CollectionsConfig{
+							base.DefaultCollection: &CollectionConfig{},
+						},
+					},
+				},
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "cannot change scopes after database creation",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.newDbConfig.validateChanges(ctx, tc.oldDbConfig)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/rest/config_database_test.go
+++ b/rest/config_database_test.go
@@ -237,6 +237,44 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 	}{
 		// XATTR validation
 		{
+			name:          "both xattrs nil - valid",
+			newDbConfig:   DbConfig{},
+			oldDbConfig:   DbConfig{},
+			expectedError: "",
+		},
+		{
+			name: "old xattrs nil, new xattrs enabled - valid",
+			newDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(true),
+			},
+			oldDbConfig:   DbConfig{},
+			expectedError: "",
+		},
+		{
+			name: "old xattrs nil, new xattrs disabled - valid",
+			newDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(false),
+			},
+			oldDbConfig:   DbConfig{},
+			expectedError: "",
+		},
+		{
+			name:        "old xattrs enabled, new xattrs nil - error",
+			newDbConfig: DbConfig{},
+			oldDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(true),
+			},
+			expectedError: "cannot disable enabled_shared_bucket_access after enabling it",
+		},
+		{
+			name:        "old xattrs disabled, new xattrs nil - valid",
+			newDbConfig: DbConfig{},
+			oldDbConfig: DbConfig{
+				EnableXattrs: base.Ptr(false),
+			},
+			expectedError: "",
+		},
+		{
 			name: "no changes - valid",
 			newDbConfig: DbConfig{
 				EnableXattrs: base.Ptr(true),
@@ -288,11 +326,9 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			oldDbConfig: DbConfig{
-				Scopes:       nil,
-				EnableXattrs: base.Ptr(true),
+				Scopes: nil,
 			},
 			expectedError: "",
 		},
@@ -306,11 +342,9 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			oldDbConfig: DbConfig{
-				Scopes:       nil,
-				EnableXattrs: base.Ptr(true),
+				Scopes: nil,
 			},
 			expectedError: "cannot change scopes after database creation",
 		},
@@ -329,11 +363,9 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			oldDbConfig: DbConfig{
-				Scopes:       nil,
-				EnableXattrs: base.Ptr(true),
+				Scopes: nil,
 			},
 			expectedError: "cannot change scopes after database creation",
 		},
@@ -352,7 +384,6 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			oldDbConfig: DbConfig{
 				Scopes: ScopesConfig{
@@ -362,7 +393,6 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			expectedError: "cannot change scopes after database creation",
 		},
@@ -376,7 +406,6 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			oldDbConfig: DbConfig{
 				Scopes: ScopesConfig{
@@ -391,7 +420,6 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			expectedError: "cannot change scopes after database creation",
 		},
@@ -410,7 +438,6 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			oldDbConfig: DbConfig{
 				Scopes: ScopesConfig{
@@ -425,7 +452,6 @@ func TestDatabaseConfigValidateChanges(t *testing.T) {
 						},
 					},
 				},
-				EnableXattrs: base.Ptr(true),
 			},
 			expectedError: "cannot change scopes after database creation",
 		},


### PR DESCRIPTION
CBG-5200

Describe your PR here...
- Add guardrails to prevent disabling of xattrs
- Added unit tests

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/390
