### PR TITLE
[4.0.4 backport] CBG-5173 don't panic when db is offline initializing indexes

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -596,6 +596,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	dbContext.ResyncManager = NewResyncManagerDCP(metadataStore, dbContext.UseXattrs(), metaKeys)
+	dbContext.AsyncIndexInitManager = NewAsyncIndexInitManager(dbContext.MetadataStore, dbContext.MetadataKeys)
 
 	return dbContext, nil
 }
@@ -2491,7 +2492,6 @@ func (db *DatabaseContext) StartOnlineProcesses(ctx context.Context) (returnedEr
 
 	db.TombstoneCompactionManager = NewTombstoneCompactionManager()
 	db.AttachmentCompactionManager = NewAttachmentCompactionManager(db.MetadataStore, db.MetadataKeys)
-	db.AsyncIndexInitManager = NewAsyncIndexInitManager(db.MetadataStore, db.MetadataKeys)
 
 	db.startReplications(ctx)
 

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -278,7 +278,7 @@ func TestChangeIndexPartitionsDbOffline(t *testing.T) {
 	// requires index init
 	base.LongRunningTest(t)
 
-	rt := rest.NewRestTesterPersistentConfigNoDB(t)
+	rt := rest.NewRestTesterPersistentConfig(t)
 	defer rt.Close()
 
 	rt.TakeDbOffline()

--- a/rest/indextest/index_init_api_test.go
+++ b/rest/indextest/index_init_api_test.go
@@ -278,7 +278,7 @@ func TestChangeIndexPartitionsDbOffline(t *testing.T) {
 	// requires index init
 	base.LongRunningTest(t)
 
-	rt := rest.NewRestTester(t, nil)
+	rt := rest.NewRestTesterPersistentConfigNoDB(t)
 	defer rt.Close()
 
 	rt.TakeDbOffline()


### PR DESCRIPTION
[4.0.4 backport] CBG-5173 don't panic when db is offline initializing indexes

cherry-pick of c9a4e07c84bed38e9c4df9c7719b5a30b85b2007

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/392/ (one test failed, fixed and tested manually)
