### PR TITLE
[4.0.4 backport] CBG-5202: add ability to identify if pushed encoded CV is derived from our local revID

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1414,9 +1414,9 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 			// If incoming doc has RTE CV we should check that this isn't derived from our local revID, if so we don't need this rev
 			if doc.HLV.SourceID == encodedRevTreeSourceID {
 				// convert our current rev to RTE and compare
-				encodedCV, encodedErr := LegacyRevToRevTreeEncodedVersion(doc.GetRevTreeID())
-				if encodedErr != nil {
-					return nil, nil, false, nil, fmt.Errorf("failed to encode rev tree ID for doc %s, %v", base.UD(doc.ID), encodedCV)
+				encodedCV, err := LegacyRevToRevTreeEncodedVersion(doc.GetRevTreeID())
+				if err != nil {
+					return nil, nil, false, nil, base.RedactErrorf("failed to encode rev tree ID for doc %s, %w", base.UD(doc.ID), err)
 				}
 				if encodedCV.Equal(*doc.HLV.ExtractCurrentVersionFromHLV()) {
 					base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add. Incoming revision tree generated CV %#v is equal to local revID %s", base.UD(opts.NewDoc.ID), doc.HLV, doc.GetRevTreeID())
@@ -3735,8 +3735,8 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 		if proposedVersion.SourceID == encodedRevTreeSourceID {
 			// If we have encoded CV proposed to us and local CV is not encoded, check if proposed encoded CV
 			// is derived from the local current revID. If so we already have this rev.
-			localEncodedCV, encodedErr := LegacyRevToRevTreeEncodedVersion(syncData.GetRevTreeID())
-			if encodedErr != nil {
+			localEncodedCV, err := LegacyRevToRevTreeEncodedVersion(syncData.GetRevTreeID())
+			if err != nil {
 				base.DebugfCtx(ctx, base.KeyCRUD, "Failed to parse local revID to encoded CV for doc %q / %q: %v", base.UD(docid), previousRev, err)
 				return ProposedRev_Error, ""
 			}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1411,6 +1411,18 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				doc.HLV = NewHybridLogicalVector()
 			}
 			doc.HLV.UpdateWithIncomingHLV(opts.NewDocHLV)
+			// If incoming doc has RTE CV we should check that this isn't derived from our local revID, if so we don't need this rev
+			if doc.HLV.SourceID == encodedRevTreeSourceID {
+				// convert our current rev to RTE and compare
+				encodedCV, encodedErr := LegacyRevToRevTreeEncodedVersion(doc.GetRevTreeID())
+				if encodedErr != nil {
+					return nil, nil, false, nil, fmt.Errorf("failed to encode rev tree ID for doc %s, %v", base.UD(doc.ID), encodedCV)
+				}
+				if encodedCV.Equal(*doc.HLV.ExtractCurrentVersionFromHLV()) {
+					base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add. Incoming revision tree generated CV %#v is equal to local revID %s", base.UD(opts.NewDoc.ID), doc.HLV, doc.GetRevTreeID())
+					return nil, nil, false, nil, base.ErrUpdateCancel // No new revisions to add
+				}
+			}
 			if opts.ISGRWrite {
 				err := doc.alignRevTreeHistoryForHLVWrite(ctx, db, opts.NewDoc, opts.RevTreeHistory, opts.ForceAllowConflictingTombstone)
 				if err != nil {
@@ -3720,6 +3732,18 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 		// New document not found on server
 		return ProposedRev_OK_IsNew, ""
 	} else if previousRevFormat == "revTreeID" && syncData.GetRevTreeID() == previousRev {
+		if proposedVersion.SourceID == encodedRevTreeSourceID {
+			// If we have encoded CV proposed to us and local CV is not encoded, check if proposed encoded CV
+			// is derived from the local current revID. If so we already have this rev.
+			localEncodedCV, encodedErr := LegacyRevToRevTreeEncodedVersion(syncData.GetRevTreeID())
+			if encodedErr != nil {
+				base.DebugfCtx(ctx, base.KeyCRUD, "Failed to parse local revID to encoded CV for doc %q / %q: %v", base.UD(docid), previousRev, err)
+				return ProposedRev_Error, ""
+			}
+			if localEncodedCV.Equal(proposedVersion) {
+				return ProposedRev_Exists, ""
+			}
+		}
 		// Non-conflicting update, client's previous legacy revTreeID is server's currentRev
 		return ProposedRev_OK, ""
 	} else if hlv == nil {

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -320,7 +320,8 @@ func TestSendUnsolicitedRevWithRTEDerivedFromLocalRevID(t *testing.T) {
 	defer bt.Close()
 	rt := bt.restTester
 
-	doc := rt.CreateDocNoHLV(t.Name(), db.Body{"key": "val"})
+	docID := SafeDocumentName(t, t.Name())
+	doc := rt.CreateDocNoHLV(docID, db.Body{"key": "val"})
 	sgwVersion := doc.ExtractDocVersion()
 
 	encodedVersion, err := db.LegacyRevToRevTreeEncodedVersion(sgwVersion.RevTreeID)
@@ -331,7 +332,7 @@ func TestSendUnsolicitedRevWithRTEDerivedFromLocalRevID(t *testing.T) {
 
 	// send unsolicited rev
 	_, _, _, err = bt.SendRev(
-		t.Name(),
+		docID,
 		cvStr,
 		[]byte(`{"key": "val"}`),
 		blip.Properties{},
@@ -349,7 +350,7 @@ func TestSendUnsolicitedRevWithRTEDerivedFromLocalRevID(t *testing.T) {
 	rt.WaitForVersion("foo", DocVersion{RevTreeID: "1-abc"})
 
 	// assert that rev with cv encoded from same revID server has is not synced
-	docVersion, _ := rt.GetDoc(t.Name())
+	docVersion, _ := rt.GetDoc(docID)
 	assert.Equal(t, sgwVersion.RevTreeID, docVersion.RevTreeID)
 	assert.True(t, docVersion.CV.IsEmpty())
 }

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -311,6 +311,49 @@ func TestProcessLegacyRev(t *testing.T) {
 	})
 }
 
+func TestSendUnsolicitedRevWithRTEDerivedFromLocalRevID(t *testing.T) {
+	bt := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		allowConflicts: false,
+		GuestEnabled:   true,
+		blipProtocols:  []string{db.CBMobileReplicationV4.SubprotocolString()},
+	})
+	defer bt.Close()
+	rt := bt.restTester
+
+	doc := rt.CreateDocNoHLV(t.Name(), db.Body{"key": "val"})
+	sgwVersion := doc.ExtractDocVersion()
+
+	encodedVersion, err := db.LegacyRevToRevTreeEncodedVersion(sgwVersion.RevTreeID)
+	require.NoError(t, err)
+
+	// convert to transport format
+	cvStr := encodedVersion.String()
+
+	// send unsolicited rev
+	_, _, _, err = bt.SendRev(
+		t.Name(),
+		cvStr,
+		[]byte(`{"key": "val"}`),
+		blip.Properties{},
+	)
+	require.NoError(t, err)
+
+	// send marker rev
+	_, _, _, err = bt.SendRev(
+		"foo",
+		"1-abc",
+		[]byte(`{"key": "val"}`),
+		blip.Properties{},
+	)
+	require.NoError(t, err)
+	rt.WaitForVersion("foo", DocVersion{RevTreeID: "1-abc"})
+
+	// assert that rev with cv encoded from same revID server has is not synced
+	docVersion, _ := rt.GetDoc(t.Name())
+	assert.Equal(t, sgwVersion.RevTreeID, docVersion.RevTreeID)
+	assert.True(t, docVersion.CV.IsEmpty())
+}
+
 // TestProcessRevWithLegacyHistory:
 //   - 1. CBL sends rev=1010@CBL1, history=1-abc when SGW has current rev 1-abc (document underwent an update before being pushed to SGW)
 //   - 2. CBL sends rev=1010@CBL1, history=1000@CBL2,1-abc when SGW has current rev 1-abc (document underwent multiple p2p updates before being pushed to SGW)
@@ -1032,7 +1075,7 @@ func TestLegacyRevBlipTesterClient(t *testing.T) {
 			defer btcRunner.StopPush(client.id)
 
 			docID := SafeDocumentName(t, t.Name())
-			cblDocVersion1 := btcRunner.AddRevTreeRev(client.id, docID, "abc", EmptyDocVersion(), []byte(`{"action": "create"}`))
+			cblDocVersion1 := btcRunner.AddRevTreeRev(client.id, docID, "1-abc", EmptyDocVersion(), []byte(`{"action": "create"}`))
 			rt.WaitForVersion(docID, cblDocVersion1)
 
 			cblDocVersion2 := btcRunner.AddRev(client.id, docID, &cblDocVersion1, []byte(`{"action": "update"}`))
@@ -1064,9 +1107,7 @@ func TestLegacyRevBlipTesterClient(t *testing.T) {
 			docID := SafeDocumentName(t, t.Name())
 			dbc, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 			sgVersion1, _ := dbc.CreateDocNoHLV(t, ctx, docID, db.Body{"action": "create"})
-			generation, digest := db.ParseRevID(ctx, sgVersion1)
-			require.Equal(t, 1, generation)
-			cblVersion1 := btcRunner.AddRevTreeRev(client.id, docID, digest, EmptyDocVersion(), []byte(`{"action": "create"}`))
+			cblVersion1 := btcRunner.AddRevTreeRev(client.id, docID, sgVersion1, EmptyDocVersion(), []byte(`{"action": "create"}`))
 			require.Equal(t, sgVersion1, cblVersion1.RevTreeID)
 			sgVersion2, _ := dbc.CreateDocNoHLV(t, ctx, docID, db.Body{"_rev": sgVersion1, "action": "update"})
 			btcRunner.StartPull(client.id)
@@ -1076,16 +1117,49 @@ func TestLegacyRevBlipTesterClient(t *testing.T) {
 			docID := SafeDocumentName(t, t.Name())
 			dbc, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
 			sgVersion1, _ := dbc.CreateDocNoHLV(t, ctx, docID, db.Body{"action": "create"})
-			generation, digest := db.ParseRevID(ctx, sgVersion1)
-			require.Equal(t, 1, generation)
-			cblVersion1 := btcRunner.AddRevTreeRev(client.id, docID, digest, EmptyDocVersion(), []byte(`{"action": "create"}`))
+			cblVersion1 := btcRunner.AddRevTreeRev(client.id, docID, sgVersion1, EmptyDocVersion(), []byte(`{"action": "create"}`))
 			require.Equal(t, sgVersion1, cblVersion1.RevTreeID)
 
-			cblVersion2 := btcRunner.AddRevTreeRev(client.id, docID, "bcd", &cblVersion1, []byte(`{"action": "update"}`))
+			cblVersion2 := btcRunner.AddRevTreeRev(client.id, docID, "2-bcd", &cblVersion1, []byte(`{"action": "update"}`))
 
 			btcRunner.StartPush(client.id)
 			rt.WaitForVersion(docID, cblVersion2)
 		})
+	})
+}
+
+func TestCBLPushEncodedCVDerivedFromSGWLocalRevID(t *testing.T) {
+	btcRunner := NewBlipTesterClientRunner(t)
+
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true // vv specific test
+	btcRunner.Run(func(t *testing.T) {
+		rt := NewRestTester(t, &RestTesterConfig{
+			GuestEnabled: true,
+		})
+		defer rt.Close()
+
+		btc := btcRunner.NewBlipTesterClientOptsWithRT(rt, nil)
+		defer btc.Close()
+
+		docID := SafeDocumentName(t, t.Name())
+
+		// add legacy rev on SGW
+		doc := rt.CreateDocNoHLV(docID, db.Body{"key": "val"})
+		originalSGWVersion := doc.ExtractDocVersion()
+
+		cblVersion := btcRunner.AddEncodedCVRev(btc.id, docID, originalSGWVersion.RevTreeID, EmptyDocVersion(), []byte(`{"key":"val"}`))
+		require.Equal(t, "Revision+Tree+Encoding", cblVersion.CV.SourceID) // we must be saving this rev as legacy encoded cv on client
+
+		btcRunner.StartPush(btc.id)
+
+		// add marker doc
+		markerVersion := btcRunner.AddRev(btc.id, "markerDoc", EmptyDocVersion(), []byte(`{"marker":"doc"}`))
+		rt.WaitForVersion("markerDoc", markerVersion)
+
+		// assert doc on SGW is still original rev added and not saved as new encoded CV from CBL
+		sgwVersion, _ := rt.GetDoc(docID)
+		assert.Equal(t, originalSGWVersion.RevTreeID, sgwVersion.RevTreeID)
+		assert.True(t, sgwVersion.CV.IsEmpty(), "CV should be empty")
 	})
 }
 

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1606,7 +1606,7 @@ type blipTesterUpsertOptions struct {
 	body               []byte
 	isDelete           bool
 	revType            blipRevType    // legacy, RTE or normal HLV
-	specificNewVersion *db.DocVersion // if specified, use this digest for the revision
+	specificNewVersion *db.DocVersion // if specified, use this exact version for the revision
 }
 
 // upsertDoc will create or update the doc based on whether parentVersion is passed or not. Enforces MVCC update.
@@ -1645,6 +1645,7 @@ func (btcc *BlipTesterCollectionClient) upsertDoc(docID string, opts blipTesterU
 	if btcc.UseHLV() && opts.revType != blipRevLegacyRevType {
 		var newVersion db.Version
 		if opts.revType == blipRevTreeEncodedCVRevType {
+			require.NotNil(btcc.TB(), opts.specificNewVersion, "specificNewVersion must be set when using blipRevTreeEncodedCVRevType")
 			newVersion = opts.specificNewVersion.CV
 		} else {
 			newVersion = db.Version{SourceID: btcc.parent.SourceID, Value: uint64(btcc.hlc.Now())}

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1592,13 +1592,21 @@ func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) {
 	btr.storeMessage(msg)
 }
 
+type blipRevType uint8
+
+const (
+	blipRevAutoRevType          blipRevType = iota // create a new revision based on the expected format of blip tester configuration (either revtree or hlv)
+	blipRevLegacyRevType                           // force a 1-abc type rev
+	blipRevTreeEncodedCVRevType                    // force a RTE encoded CV
+)
+
 // blipTesterUpsertOptions contains options for adding a document to a local BlipTesterCollectionClient
 type blipTesterUpsertOptions struct {
-	parentVersion  *DocVersion
-	body           []byte
-	isDelete       bool
-	legacyRev      bool   // if true, create a legacy revtree revision even if client is using HLV
-	specificDigest string // if specified, use this digest for the revision
+	parentVersion      *DocVersion
+	body               []byte
+	isDelete           bool
+	revType            blipRevType    // legacy, RTE or normal HLV
+	specificNewVersion *db.DocVersion // if specified, use this digest for the revision
 }
 
 // upsertDoc will create or update the doc based on whether parentVersion is passed or not. Enforces MVCC update.
@@ -1623,7 +1631,7 @@ func (btcc *BlipTesterCollectionClient) upsertDoc(docID string, opts blipTesterU
 		latestRev := doc._latestRev(btcc.TB())
 		latestVersion := latestRev.version
 		require.True(btcc.TB(), opts.parentVersion.CV == latestVersion.CV || opts.parentVersion.RevTreeID == latestVersion.RevTreeID, "latest version for docID: %v is %v, expected parentVersion: %v", docID, latestVersion, opts.parentVersion)
-		if btcc.UseHLV() && !opts.legacyRev {
+		if btcc.UseHLV() && opts.revType != blipRevLegacyRevType {
 			hlv = latestRev.HLV
 		} else {
 			parentGen, _ := db.ParseRevID(btcc.ctx, opts.parentVersion.RevTreeID)
@@ -1634,15 +1642,22 @@ func (btcc *BlipTesterCollectionClient) upsertDoc(docID string, opts blipTesterU
 	body := btcc.ProcessInlineAttachments(opts.body, newGen)
 
 	var docVersion DocVersion
-	if btcc.UseHLV() && !opts.legacyRev {
-		newVersion := db.Version{SourceID: btcc.parent.SourceID, Value: uint64(btcc.hlc.Now())}
+	if btcc.UseHLV() && opts.revType != blipRevLegacyRevType {
+		var newVersion db.Version
+		if opts.revType == blipRevTreeEncodedCVRevType {
+			newVersion = opts.specificNewVersion.CV
+		} else {
+			newVersion = db.Version{SourceID: btcc.parent.SourceID, Value: uint64(btcc.hlc.Now())}
+		}
 		require.NoError(btcc.TB(), hlv.AddVersion(newVersion))
 		docVersion = DocVersion{CV: *hlv.ExtractCurrentVersionFromHLV()}
+	} else if opts.specificNewVersion != nil {
+		require.NotEmpty(btcc.TB(), opts.specificNewVersion.RevTreeID, "specificNewVersion must have RevTreeID set")
+		generation, _ := db.ParseRevID(btcc.ctx, opts.specificNewVersion.RevTreeID)
+		require.GreaterOrEqual(btcc.TB(), generation, newGen, "specificNewVersion generation %q must be greater than or equal to version stored in blip tester: %d", opts.specificNewVersion.RevTreeID, newGen-1)
+		docVersion = *opts.specificNewVersion
 	} else {
 		digest := "abc" // TODO: Generate rev ID digest based on body hash?
-		if opts.specificDigest != "" {
-			digest = opts.specificDigest
-		}
 		newRevID := fmt.Sprintf("%d-%s", newGen, digest)
 		docVersion = DocVersion{RevTreeID: newRevID}
 	}
@@ -1668,7 +1683,6 @@ func (btcc *BlipTesterCollectionClient) Delete(docID string, parentVersion *DocV
 		parentVersion: parentVersion,
 		body:          []byte(`{}`),
 		isDelete:      true,
-		legacyRev:     false,
 	})
 	return newRev.version, &newRev.HLV
 }
@@ -1680,20 +1694,36 @@ func (btcc *BlipTesterCollectionClient) AddRev(docID string, parentVersion *DocV
 		parentVersion: parentVersion,
 		body:          body,
 		isDelete:      false,
-		legacyRev:     false,
+	})
+	return newRev.version
+}
+
+func (btcc *BlipTesterCollectionClient) AddRevEncodedCVRevision(docID string, newRevTreeID string, parentVersion *DocVersion, body []byte) DocVersion {
+	encodedCV, err := db.LegacyRevToRevTreeEncodedVersion(newRevTreeID)
+	require.NoError(btcc.TB(), err)
+	newRev := btcc.upsertDoc(docID, blipTesterUpsertOptions{
+		parentVersion: parentVersion,
+		body:          body,
+		isDelete:      false,
+		specificNewVersion: &db.DocVersion{
+			CV: encodedCV,
+		},
+		revType: blipRevTreeEncodedCVRevType,
 	})
 	return newRev.version
 }
 
 // AddRevTreeRev creates a revision on the client in legacy revision tree format. This is used to create legacy
 // revisions to push to CBL.
-func (btcc *BlipTesterCollectionClient) AddRevTreeRev(docID string, digest string, parentVersion *DocVersion, body []byte) DocVersion {
+func (btcc *BlipTesterCollectionClient) AddRevTreeRev(docID string, revTreeID string, parentVersion *DocVersion, body []byte) DocVersion {
 	newRev := btcc.upsertDoc(docID, blipTesterUpsertOptions{
-		parentVersion:  parentVersion,
-		body:           body,
-		isDelete:       false,
-		legacyRev:      true, // force legacy revtree even though client is using HLV
-		specificDigest: digest,
+		parentVersion: parentVersion,
+		body:          body,
+		isDelete:      false,
+		specificNewVersion: &db.DocVersion{
+			RevTreeID: revTreeID,
+		},
+		revType: blipRevLegacyRevType, // force legacy revtree even though client is using HLV
 	})
 	return newRev.version
 }
@@ -1704,7 +1734,6 @@ func (btc *BlipTesterCollectionClient) AddHLVRev(docID string, parentVersion *Do
 		parentVersion: parentVersion,
 		body:          body,
 		isDelete:      false,
-		legacyRev:     false,
 	})
 	return newRev.version, &newRev.HLV
 }
@@ -2072,6 +2101,11 @@ func (btcRunner *BlipTestClientRunner) StartOneshotPull(clientID uint32) {
 // The rev ID is always: "N-abc", where N is rev generation for predictability.
 func (btcRunner *BlipTestClientRunner) AddRev(clientID uint32, docID string, version *DocVersion, body []byte) DocVersion {
 	return btcRunner.SingleCollection(clientID).AddRev(docID, version, body)
+}
+
+// AddEncodedCVRev create a rev on client with CV generated form revID supplied.
+func (btcRunner *BlipTestClientRunner) AddEncodedCVRev(clientID uint32, docID, digest string, version *DocVersion, body []byte) DocVersion {
+	return btcRunner.SingleCollection(clientID).AddRevEncodedCVRevision(docID, digest, version, body)
 }
 
 // AddRevTreeRev creates a revision on the client in revtree format. This revision can not have any HLV revisions.


### PR DESCRIPTION
[4.0.4 backport] CBG-5202: add ability to identify if pushed encoded CV is derived from our local revID

cherry-pick of 692310dcb71f6a768001fb359eb0434578fcc09b
