### PR TITLE
[4.0.4 backport] CBG-5161 test-only: fix flake

### DIFF
--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -2123,7 +2123,12 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "rt2", body["source"])
 
-		assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus(ctx1).LastSeqPull)
+		// replication status updates just after the document has been written in a blip handler callback, so the
+		// document can exist before stat is updated
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			status := ar.GetStatus(ctx1)
+			assert.Equal(c, strconv.FormatUint(remoteDoc.Sequence, 10), status.LastSeqPull, "status=%#+v", status)
+		}, 5*time.Second, 10*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
[4.0.4 backport] CBG-5161 test-only: fix flake

cherry-pick of 8a19b164afa98b2a18c101504e4f37d703178c48

