### PR TITLE
[4.0.4 backport] CBG-5164 test-only: use wait for stat to avoid flake

### DIFF
--- a/rest/importtest/collections_import_test.go
+++ b/rest/importtest/collections_import_test.go
@@ -324,7 +324,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, int64(docCount))
 
 	// update config to add second collection
 	twoCollectionConfig := rest.GetCollectionsConfig(t, testBucket, 2)
@@ -346,7 +346,7 @@ func TestMultiCollectionImportDynamicAddCollection(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, int64(docCount), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
+	base.RequireWaitForStat(t, rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value, int64(docCount))
 
 	response = rt.SendAdminRequest(http.MethodPut, "/{{.db}}/_config", fmt.Sprintf(collectionsDbConfig, testBucket.GetName(), string(twoCollectionConfigJSON)))
 	rest.RequireStatus(t, response, http.StatusCreated)


### PR DESCRIPTION
[4.0.4 backport] CBG-5164 test-only: use wait for stat to avoid flake

cherry-pick of ebc74b4e266f1b439554f32489e4ab7bd87e196d
