### PR TITLE
CBG-5192 add some log fixes for RTE errors

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1400,9 +1400,9 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 			// If incoming doc has RTE CV we should check that this isn't derived from our local revID, if so we don't need this rev
 			if doc.HLV.SourceID == encodedRevTreeSourceID {
 				// convert our current rev to RTE and compare
-				encodedCV, encodedErr := LegacyRevToRevTreeEncodedVersion(doc.GetRevTreeID())
-				if encodedErr != nil {
-					return nil, nil, false, nil, fmt.Errorf("failed to encode rev tree ID for doc %s, %v", base.UD(doc.ID), encodedCV)
+				encodedCV, err := LegacyRevToRevTreeEncodedVersion(doc.GetRevTreeID())
+				if err != nil {
+					return nil, nil, false, nil, base.RedactErrorf("failed to encode rev tree ID for doc %s, %v", base.UD(doc.ID), err)
 				}
 				if encodedCV.Equal(*doc.HLV.ExtractCurrentVersionFromHLV()) {
 					base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add. Incoming revision tree generated CV %#v is equal to local revID %s", base.UD(opts.NewDoc.ID), doc.HLV, doc.GetRevTreeID())
@@ -3717,8 +3717,8 @@ func (db *DatabaseCollectionWithUser) CheckProposedVersion(ctx context.Context, 
 		if proposedVersion.SourceID == encodedRevTreeSourceID {
 			// If we have encoded CV proposed to us and local CV is not encoded, check if proposed encoded CV
 			// is derived from the local current revID. If so we already have this rev.
-			localEncodedCV, encodedErr := LegacyRevToRevTreeEncodedVersion(syncData.GetRevTreeID())
-			if encodedErr != nil {
+			localEncodedCV, err := LegacyRevToRevTreeEncodedVersion(syncData.GetRevTreeID())
+			if err != nil {
 				base.DebugfCtx(ctx, base.KeyCRUD, "Failed to parse local revID to encoded CV for doc %q / %q: %v", base.UD(docid), previousRev, err)
 				return ProposedRev_Error, ""
 			}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1402,7 +1402,7 @@ func (db *DatabaseCollectionWithUser) PutExistingCurrentVersion(ctx context.Cont
 				// convert our current rev to RTE and compare
 				encodedCV, err := LegacyRevToRevTreeEncodedVersion(doc.GetRevTreeID())
 				if err != nil {
-					return nil, nil, false, nil, base.RedactErrorf("failed to encode rev tree ID for doc %s, %v", base.UD(doc.ID), err)
+					return nil, nil, false, nil, base.RedactErrorf("failed to encode rev tree ID for doc %s, %w", base.UD(doc.ID), err)
 				}
 				if encodedCV.Equal(*doc.HLV.ExtractCurrentVersionFromHLV()) {
 					base.DebugfCtx(ctx, base.KeyCRUD, "PutExistingCurrentVersion(%q): No new versions to add. Incoming revision tree generated CV %#v is equal to local revID %s", base.UD(opts.NewDoc.ID), doc.HLV, doc.GetRevTreeID())

--- a/rest/blip_legacy_revid_test.go
+++ b/rest/blip_legacy_revid_test.go
@@ -317,7 +317,8 @@ func TestSendUnsolicitedRevWithRTEDerivedFromLocalRevID(t *testing.T) {
 	defer bt.Close()
 	rt := bt.restTester
 
-	doc := rt.CreateDocNoHLV(t.Name(), db.Body{"key": "val"})
+	docID := SafeDocumentName(t, t.Name())
+	doc := rt.CreateDocNoHLV(docID, db.Body{"key": "val"})
 	sgwVersion := doc.ExtractDocVersion()
 
 	encodedVersion, err := db.LegacyRevToRevTreeEncodedVersion(sgwVersion.RevTreeID)
@@ -328,7 +329,7 @@ func TestSendUnsolicitedRevWithRTEDerivedFromLocalRevID(t *testing.T) {
 
 	// send unsolicited rev
 	bt.SendRev(
-		t.Name(),
+		docID,
 		cvStr,
 		[]byte(`{"key": "val"}`),
 		blip.Properties{},
@@ -344,7 +345,7 @@ func TestSendUnsolicitedRevWithRTEDerivedFromLocalRevID(t *testing.T) {
 	rt.WaitForVersion("foo", DocVersion{RevTreeID: "1-abc"})
 
 	// assert that rev with cv encoded from same revID server has is not synced
-	docVersion, _ := rt.GetDoc(t.Name())
+	docVersion, _ := rt.GetDoc(docID)
 	assert.Equal(t, sgwVersion.RevTreeID, docVersion.RevTreeID)
 	assert.True(t, docVersion.CV.IsEmpty())
 }

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -1610,7 +1610,7 @@ type blipTesterUpsertOptions struct {
 	body               []byte
 	isDelete           bool
 	revType            blipRevType    // legacy, RTE or normal HLV
-	specificNewVersion *db.DocVersion // if specified, use this digest for the revision
+	specificNewVersion *db.DocVersion // if specified, use this exact version for the revision
 }
 
 // upsertDoc will create or update the doc based on whether parentVersion is passed or not. Enforces MVCC update.
@@ -1649,6 +1649,7 @@ func (btcc *BlipTesterCollectionClient) upsertDoc(docID string, opts blipTesterU
 	if btcc.UseHLV() && opts.revType != blipRevLegacyRevType {
 		var newVersion db.Version
 		if opts.revType == blipRevTreeEncodedCVRevType {
+			require.NotNil(btcc.TB(), opts.specificNewVersion, "specificNewVersion must be set when using blipRevTreeEncodedCVRevType")
 			newVersion = opts.specificNewVersion.CV
 		} else {
 			newVersion = db.Version{SourceID: btcc.parent.SourceID, Value: uint64(btcc.hlc.Now())}


### PR DESCRIPTION
CBG-5192 add some log fixes followup to 692310dcb71f6a768001fb359eb0434578fcc09b

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
