### PR TITLE
CBG-5233: have single key type on revision cache

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -135,7 +135,7 @@ func TestGetBackupRevisionWhenCurrentRevisionHasAttachments(t *testing.T) {
 	// can remove in CBG-4542
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.revisionCache.GetUsingCV(ctx, "doc1", doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
+	docRev, err := collection.revisionCache.Get(ctx, "doc1", doc1.HLV.GetCurrentVersionString(), false, true)
 	require.NoError(t, err)
 
 	// assert version is fetched and attachments is empty

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -135,7 +135,7 @@ func TestGetBackupRevisionWhenCurrentRevisionHasAttachments(t *testing.T) {
 	// can remove in CBG-4542
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.revisionCache.GetWithCV(ctx, "doc1", doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
+	docRev, err := collection.revisionCache.GetUsingCV(ctx, "doc1", doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
 	require.NoError(t, err)
 
 	// assert version is fetched and attachments is empty

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -508,7 +508,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.RemoveRevOnly(ctx, docID, syncData.GetRevTreeID())
+		collection.revisionCache.RemoveUsingRevID(ctx, docID, syncData.GetRevTreeID())
 	}
 	// remove the local doc from the revision cache if the change is a result of a conflict resolution that resulted
 	// in local wins, given the HLV will have been updated but CV not changed
@@ -517,7 +517,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 			SourceID: syncData.RevAndVersion.CurrentSource,
 			Value:    base.HexCasToUint64(syncData.RevAndVersion.CurrentVersion),
 		}
-		collection.revisionCache.RemoveCVOnly(ctx, docID, &vrs)
+		collection.revisionCache.RemoveUsingCV(ctx, docID, &vrs)
 	}
 
 	change := &LogEntry{

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -508,7 +508,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 
 	// Now add the entry for the new doc revision:
 	if len(rawUserXattr) > 0 {
-		collection.revisionCache.RemoveUsingRevID(ctx, docID, syncData.GetRevTreeID())
+		collection.revisionCache.Remove(ctx, docID, syncData.GetRevTreeID())
 	}
 	// remove the local doc from the revision cache if the change is a result of a conflict resolution that resulted
 	// in local wins, given the HLV will have been updated but CV not changed
@@ -517,7 +517,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent, docType DocumentType)
 			SourceID: syncData.RevAndVersion.CurrentSource,
 			Value:    base.HexCasToUint64(syncData.RevAndVersion.CurrentVersion),
 		}
-		collection.revisionCache.RemoveUsingCV(ctx, docID, &vrs)
+		collection.revisionCache.Remove(ctx, docID, vrs.String())
 	}
 
 	change := &LogEntry{

--- a/db/crud.go
+++ b/db/crud.go
@@ -354,10 +354,10 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revOrCV
 		if currentVersion, parseErr := ParseVersion(revOrCV); parseErr != nil {
 			// try as a rev ID
 			revID = &revOrCV
-			revision, getErr = db.revisionCache.GetWithRev(ctx, docid, *revID, RevCacheOmitDelta)
+			revision, getErr = db.revisionCache.GetUsingRevID(ctx, docid, *revID, RevCacheOmitDelta)
 		} else {
 			cv = &currentVersion
-			revision, getErr = db.revisionCache.GetWithCV(ctx, docid, cv, RevCacheOmitDelta, false)
+			revision, getErr = db.revisionCache.GetUsingCV(ctx, docid, cv, RevCacheOmitDelta, false)
 		}
 	} else {
 		// No rev given, so load active revision
@@ -432,7 +432,7 @@ func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Con
 
 func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *Version, revTreeHistory bool) (revision DocumentRevision, err error) {
 	if cv != nil {
-		revision, err = db.revisionCache.GetWithCV(ctx, docid, cv, RevCacheOmitDelta, false)
+		revision, err = db.revisionCache.GetUsingCV(ctx, docid, cv, RevCacheOmitDelta, false)
 	} else {
 		revision, err = db.revisionCache.GetActive(ctx, docid)
 	}
@@ -463,12 +463,12 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 			return nil, nil, err
 		}
 		// It is possible delta source will not be resident in the cache and we may want to lookup to the bucket for a backup revision
-		initialFromRevision, err = db.revisionCache.GetWithCV(ctx, docID, &fromRevVrs, RevCacheIncludeDelta, true)
+		initialFromRevision, err = db.revisionCache.GetUsingCV(ctx, docID, &fromRevVrs, RevCacheIncludeDelta, true)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
-		initialFromRevision, err = db.revisionCache.GetWithRev(ctx, docID, fromRev, RevCacheIncludeDelta)
+		initialFromRevision, err = db.revisionCache.GetUsingRevID(ctx, docID, fromRev, RevCacheIncludeDelta)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -504,12 +504,12 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		// fromRevisionForDiff is a version of the fromRevision that is guarded by the delta lock that we will use to generate the delta (or check again for a newly cached delta)
 		var fromRevisionForDiff DocumentRevision
 		if fromRevIsCV {
-			fromRevisionForDiff, err = db.revisionCache.GetWithCV(ctx, docID, &fromRevVrs, RevCacheIncludeDelta, true)
+			fromRevisionForDiff, err = db.revisionCache.GetUsingCV(ctx, docID, &fromRevVrs, RevCacheIncludeDelta, true)
 			if err != nil {
 				return nil, nil, err
 			}
 		} else {
-			fromRevisionForDiff, err = db.revisionCache.GetWithRev(ctx, docID, fromRev, RevCacheIncludeDelta)
+			fromRevisionForDiff, err = db.revisionCache.GetUsingRevID(ctx, docID, fromRev, RevCacheIncludeDelta)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -538,12 +538,12 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 			if err != nil {
 				return nil, nil, err
 			}
-			toRevision, err = db.revisionCache.GetWithCV(ctx, docID, &cv, RevCacheIncludeDelta, false)
+			toRevision, err = db.revisionCache.GetUsingCV(ctx, docID, &cv, RevCacheIncludeDelta, false)
 			if err != nil {
 				return nil, nil, err
 			}
 		} else {
-			toRevision, err = db.revisionCache.GetWithRev(ctx, docID, toRev, RevCacheIncludeDelta)
+			toRevision, err = db.revisionCache.GetUsingRevID(ctx, docID, toRev, RevCacheIncludeDelta)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -2131,7 +2131,7 @@ func (db *DatabaseCollectionWithUser) resolveLocalWinsHLV(ctx context.Context, l
 
 	// remove the local doc from the revision cache, given the hlv is changing but the CV is staying same so the old reference
 	// to this cv in rev cache is stale
-	db.revisionCache.RemoveWithCV(ctx, localDoc.ID, localDoc.HLV.ExtractCurrentVersionFromHLV())
+	db.revisionCache.RemoveUsingCV(ctx, localDoc.ID, localDoc.HLV.ExtractCurrentVersionFromHLV())
 	localDoc.localWinsConflict = true
 
 	localWinsConflictResolutionDocumentHandling(ctx, localDoc, remoteDoc, revTreeHistory, docBodyBytes, newRevID)
@@ -2814,7 +2814,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.RemoveRevOnly(ctx, doc.ID, doc.GetRevTreeID())
+				db.revisionCache.RemoveUsingRevID(ctx, doc.ID, doc.GetRevTreeID())
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.GetRevTreeID())
@@ -2925,6 +2925,9 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 		if db.dbCtx.Options.RevisionCacheOptions != nil && db.dbCtx.Options.RevisionCacheOptions.InsertOnWrite {
 			if updateRevCache {
 				if createNewRevIDSkipped {
+					// remove revisionID entry if it exists
+					db.revisionCache.RemoveUsingRevID(ctx, documentRevision.DocID, documentRevision.RevID)
+					// upsert entry to the cache, this will upsert using CV as key
 					db.revisionCache.Upsert(ctx, documentRevision)
 				} else {
 					db.revisionCache.Put(ctx, documentRevision)

--- a/db/crud.go
+++ b/db/crud.go
@@ -340,25 +340,24 @@ func (db *DatabaseCollectionWithUser) Get1xRevBodyWithHistory(ctx context.Contex
 //     that hasn't changed since one of those revisions will be returned as a stub.
 func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revOrCV string, maxHistory int, historyFrom []string) (DocumentRevision, error) {
 	var (
-		revID *string
-		cv    *Version
-	)
-
-	var (
+		revID    *string
+		cv       *Version
 		revision DocumentRevision
 		getErr   error
+		isRevID  bool
 	)
+
 	if revOrCV != "" {
-		// Get a specific revision body and history from the revision cache
-		// (which will load them if necessary, by calling revCacheLoader, above)
 		if currentVersion, parseErr := ParseVersion(revOrCV); parseErr != nil {
 			// try as a rev ID
 			revID = &revOrCV
-			revision, getErr = db.revisionCache.GetUsingRevID(ctx, docid, *revID, RevCacheOmitDelta)
+			isRevID = true
 		} else {
 			cv = &currentVersion
-			revision, getErr = db.revisionCache.GetUsingCV(ctx, docid, cv, RevCacheOmitDelta, false)
 		}
+		// Get a specific revision body and history from the revision cache
+		// (which will load them if necessary, by calling revCacheLoader, above)
+		revision, getErr = db.revisionCache.Get(ctx, docid, revOrCV, RevCacheOmitDelta, isRevID)
 	} else {
 		// No rev given, so load active revision
 		revision, getErr = db.revisionCache.GetActive(ctx, docid)
@@ -432,7 +431,7 @@ func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Con
 
 func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *Version, revTreeHistory bool) (revision DocumentRevision, err error) {
 	if cv != nil {
-		revision, err = db.revisionCache.GetUsingCV(ctx, docid, cv, RevCacheOmitDelta, false)
+		revision, err = db.revisionCache.Get(ctx, docid, cv.String(), RevCacheOmitDelta, false)
 	} else {
 		revision, err = db.revisionCache.GetActive(ctx, docid)
 	}
@@ -455,23 +454,9 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 	}
 
 	var initialFromRevision DocumentRevision
-	var fromRevVrs Version
-	fromRevIsCV := !base.IsRevTreeID(fromRev)
-	if fromRevIsCV {
-		fromRevVrs, err = ParseVersion(fromRev)
-		if err != nil {
-			return nil, nil, err
-		}
-		// It is possible delta source will not be resident in the cache and we may want to lookup to the bucket for a backup revision
-		initialFromRevision, err = db.revisionCache.GetUsingCV(ctx, docID, &fromRevVrs, RevCacheIncludeDelta, true)
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		initialFromRevision, err = db.revisionCache.GetUsingRevID(ctx, docID, fromRev, RevCacheIncludeDelta)
-		if err != nil {
-			return nil, nil, err
-		}
+	initialFromRevision, err = db.revisionCache.Get(ctx, docID, fromRev, RevCacheIncludeDelta, true)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// If the fromRevision is a removal cache entry (no body), but the user has access to that removal, then just
@@ -503,16 +488,9 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		// fromRevisionForDiff is a version of the fromRevision that is guarded by the delta lock that we will use to generate the delta (or check again for a newly cached delta)
 		var fromRevisionForDiff DocumentRevision
-		if fromRevIsCV {
-			fromRevisionForDiff, err = db.revisionCache.GetUsingCV(ctx, docID, &fromRevVrs, RevCacheIncludeDelta, true)
-			if err != nil {
-				return nil, nil, err
-			}
-		} else {
-			fromRevisionForDiff, err = db.revisionCache.GetUsingRevID(ctx, docID, fromRev, RevCacheIncludeDelta)
-			if err != nil {
-				return nil, nil, err
-			}
+		fromRevisionForDiff, err = db.revisionCache.Get(ctx, docID, fromRev, RevCacheIncludeDelta, true)
+		if err != nil {
+			return nil, nil, err
 		}
 
 		// Check if another writer beat us to generating the delta and caching it.
@@ -533,20 +511,9 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		// Need to generate delta and cache it for others.
 		db.dbStats().DeltaSync().DeltaCacheMiss.Add(1)
 		var toRevision DocumentRevision
-		if !base.IsRevTreeID(toRev) {
-			cv, err := ParseVersion(toRev)
-			if err != nil {
-				return nil, nil, err
-			}
-			toRevision, err = db.revisionCache.GetUsingCV(ctx, docID, &cv, RevCacheIncludeDelta, false)
-			if err != nil {
-				return nil, nil, err
-			}
-		} else {
-			toRevision, err = db.revisionCache.GetUsingRevID(ctx, docID, toRev, RevCacheIncludeDelta)
-			if err != nil {
-				return nil, nil, err
-			}
+		toRevision, err = db.revisionCache.Get(ctx, docID, toRev, RevCacheIncludeDelta, false)
+		if err != nil {
+			return nil, nil, err
 		}
 
 		deleted := toRevision.Deleted
@@ -562,11 +529,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		// If the revision we're generating a delta to is a tombstone, mark it as such and don't bother generating a delta.
 		if deleted {
 			revCacheDelta := newRevCacheDelta([]byte(base.EmptyDocument), fromRev, toRevision, deleted, nil)
-			if fromRevIsCV {
-				db.revisionCache.UpdateDeltaCV(ctx, docID, &fromRevVrs, revCacheDelta)
-			} else {
-				db.revisionCache.UpdateDelta(ctx, docID, fromRev, revCacheDelta)
-			}
+			db.revisionCache.UpdateDelta(ctx, docID, fromRev, revCacheDelta)
 			return &revCacheDelta, nil, nil
 		}
 
@@ -606,11 +569,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		revCacheDelta := newRevCacheDelta(deltaBytes, fromRev, toRevision, deleted, toRevAttStorageMeta)
 
 		// Write the newly calculated delta back into the cache before returning.
-		if fromRevIsCV {
-			db.revisionCache.UpdateDeltaCV(ctx, docID, &fromRevVrs, revCacheDelta)
-		} else {
-			db.revisionCache.UpdateDelta(ctx, docID, fromRev, revCacheDelta)
-		}
+		db.revisionCache.UpdateDelta(ctx, docID, fromRev, revCacheDelta)
 		return &revCacheDelta, nil, nil
 	}
 
@@ -2131,7 +2090,7 @@ func (db *DatabaseCollectionWithUser) resolveLocalWinsHLV(ctx context.Context, l
 
 	// remove the local doc from the revision cache, given the hlv is changing but the CV is staying same so the old reference
 	// to this cv in rev cache is stale
-	db.revisionCache.RemoveUsingCV(ctx, localDoc.ID, localDoc.HLV.ExtractCurrentVersionFromHLV())
+	db.revisionCache.Remove(ctx, localDoc.ID, localDoc.HLV.GetCurrentVersionString())
 	localDoc.localWinsConflict = true
 
 	localWinsConflictResolutionDocumentHandling(ctx, localDoc, remoteDoc, revTreeHistory, docBodyBytes, newRevID)
@@ -2814,7 +2773,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 
 			// Prior to saving doc, remove the revision in cache
 			if createNewRevIDSkipped {
-				db.revisionCache.RemoveUsingRevID(ctx, doc.ID, doc.GetRevTreeID())
+				db.revisionCache.Remove(ctx, doc.ID, doc.GetRevTreeID())
 			}
 
 			base.DebugfCtx(ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.GetRevTreeID())
@@ -2926,7 +2885,7 @@ func (db *DatabaseCollectionWithUser) updateAndReturnDoc(ctx context.Context, do
 			if updateRevCache {
 				if createNewRevIDSkipped {
 					// remove revisionID entry if it exists
-					db.revisionCache.RemoveUsingRevID(ctx, documentRevision.DocID, documentRevision.RevID)
+					db.revisionCache.Remove(ctx, documentRevision.DocID, documentRevision.RevID)
 					// upsert entry to the cache, this will upsert using CV as key
 					db.revisionCache.Upsert(ctx, documentRevision)
 				} else {

--- a/db/crud.go
+++ b/db/crud.go
@@ -340,24 +340,14 @@ func (db *DatabaseCollectionWithUser) Get1xRevBodyWithHistory(ctx context.Contex
 //     that hasn't changed since one of those revisions will be returned as a stub.
 func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revOrCV string, maxHistory int, historyFrom []string) (DocumentRevision, error) {
 	var (
-		revID    *string
-		cv       *Version
 		revision DocumentRevision
 		getErr   error
-		isRevID  bool
 	)
 
 	if revOrCV != "" {
-		if currentVersion, parseErr := ParseVersion(revOrCV); parseErr != nil {
-			// try as a rev ID
-			revID = &revOrCV
-			isRevID = true
-		} else {
-			cv = &currentVersion
-		}
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
-		revision, getErr = db.revisionCache.Get(ctx, docid, revOrCV, RevCacheOmitDelta, isRevID)
+		revision, getErr = db.revisionCache.Get(ctx, docid, revOrCV, RevCacheOmitDelta, base.IsRevTreeID(revOrCV))
 	} else {
 		// No rev given, so load active revision
 		revision, getErr = db.revisionCache.GetActive(ctx, docid)
@@ -366,20 +356,19 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revOrCV
 		return DocumentRevision{}, getErr
 	}
 
-	return db.documentRevisionForRequest(ctx, docid, revision, revID, cv, maxHistory, historyFrom)
+	return db.documentRevisionForRequest(ctx, docid, revision, revOrCV, maxHistory, historyFrom)
 }
 
 // documentRevisionForRequest processes the given DocumentRevision and returns a version of it for a given client request, depending on access, deleted, etc.
-func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Context, docID string, revision DocumentRevision, revID *string, cv *Version, maxHistory int, historyFrom []string) (DocumentRevision, error) {
-	// ensure only one of cv or revID is specified
-	if cv != nil && revID != nil {
-		return DocumentRevision{}, fmt.Errorf("must have one of cv or revID in documentRevisionForRequest (had cv=%v revID=%v)", cv, revID)
-	}
-	var requestedVersion string
-	if revID != nil {
-		requestedVersion = *revID
-	} else if cv != nil {
-		requestedVersion = cv.String()
+func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Context, docID string, revision DocumentRevision, requestedVersion string, maxHistory int, historyFrom []string) (DocumentRevision, error) {
+	var cv *Version
+	isRevID := base.IsRevTreeID(requestedVersion)
+	if !isRevID && requestedVersion != "" {
+		currentVersion, err := ParseVersion(requestedVersion)
+		if err != nil {
+			return DocumentRevision{}, err
+		}
+		cv = &currentVersion
 	}
 
 	if revision.BodyBytes == nil {
@@ -430,8 +419,10 @@ func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Con
 }
 
 func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *Version, revTreeHistory bool) (revision DocumentRevision, err error) {
+	var requestRevision string
 	if cv != nil {
 		revision, err = db.revisionCache.Get(ctx, docid, cv.String(), RevCacheOmitDelta, false)
+		requestRevision = cv.String()
 	} else {
 		revision, err = db.revisionCache.GetActive(ctx, docid)
 	}
@@ -443,7 +434,7 @@ func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, c
 		maxHistory = math.MaxInt32
 	}
 
-	return db.documentRevisionForRequest(ctx, docid, revision, nil, cv, maxHistory, nil)
+	return db.documentRevisionForRequest(ctx, docid, revision, requestRevision, maxHistory, nil)
 }
 
 // GetDelta attempts to return the delta between fromRevId and toRevId. If the delta can't be generated, returns nil.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1089,7 +1089,7 @@ func TestFetchCurrentRevAfterFetchBackupRevByCV(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch backup rev by cv and ensure we have no revID populated (no way to get revID from backup rev in CV)
-	docRev, err := collection.revisionCache.GetWithCV(ctx, "doc1", doc.HLV.ExtractCurrentVersionFromHLV(), false, true)
+	docRev, err := collection.revisionCache.GetUsingCV(ctx, "doc1", doc.HLV.ExtractCurrentVersionFromHLV(), false, true)
 	require.NoError(t, err, "Error fetching backup revision CV")
 	assert.Equal(t, "", docRev.RevID)
 	assert.Equal(t, `{"k1":"v1"}`, string(docRev.BodyBytes))

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1089,7 +1089,7 @@ func TestFetchCurrentRevAfterFetchBackupRevByCV(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch backup rev by cv and ensure we have no revID populated (no way to get revID from backup rev in CV)
-	docRev, err := collection.revisionCache.GetUsingCV(ctx, "doc1", doc.HLV.ExtractCurrentVersionFromHLV(), false, true)
+	docRev, err := collection.revisionCache.Get(ctx, "doc1", doc.HLV.GetCurrentVersionString(), false, true)
 	require.NoError(t, err, "Error fetching backup revision CV")
 	assert.Equal(t, "", docRev.RevID)
 	assert.Equal(t, `{"k1":"v1"}`, string(docRev.BodyBytes))

--- a/db/import.go
+++ b/db/import.go
@@ -458,7 +458,7 @@ func (db *DatabaseCollectionWithUser) backupPreImportRevision(ctx context.Contex
 		return nil
 	}
 
-	previousRev, ok := db.revisionCache.Peek(ctx, docid, CreateRevisionCacheRevIDKey(docid, revid, db.GetCollectionID()))
+	previousRev, ok := db.revisionCache.Peek(ctx, docid, revid)
 	if !ok {
 		return nil
 	}

--- a/db/import.go
+++ b/db/import.go
@@ -458,7 +458,7 @@ func (db *DatabaseCollectionWithUser) backupPreImportRevision(ctx context.Contex
 		return nil
 	}
 
-	previousRev, ok := db.revisionCache.Peek(ctx, docid, revid)
+	previousRev, ok := db.revisionCache.Peek(ctx, docid, CreateRevisionCacheRevIDKey(docid, revid, db.GetCollectionID()))
 	if !ok {
 		return nil
 	}

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -118,7 +118,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 }
 
 // Peek is a no-op for a BypassRevisionCache, and always returns a false 'found' value.
-func (rc *BypassRevisionCache) Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool) {
+func (rc *BypassRevisionCache) Peek(ctx context.Context, docID string, key RevCacheKey) (docRev DocumentRevision, found bool) {
 	return DocumentRevision{}, false
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -32,48 +32,28 @@ func NewBypassRevisionCache(backingStores map[uint32]RevisionCacheBackingStore, 
 }
 
 // GetUsingRevID fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) GetUsingRevID(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (docRev DocumentRevision, err error) {
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
 
 	docRev = DocumentRevision{
-		RevID:                  revID,
 		DocID:                  docID,
 		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
 	}
-	var hlv *HybridLogicalVector
-	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, hlv, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, revID)
-	if err != nil {
-		return DocumentRevision{}, err
-	}
-	if hlv != nil {
-		docRev.CV = hlv.ExtractCurrentVersionFromHLV()
-		docRev.HlvHistory = hlv.ToHistoryForHLV()
-	}
-
-	rc.bypassStat.Add(1)
-
-	return docRev, nil
-}
-
-// GetUsingCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
-
-	docRev = DocumentRevision{
-		CV:                     cv,
-		DocID:                  docID,
-		RevCacheValueDeltaLock: &sync.Mutex{}, // initialize the mutex for delta updates
-	}
-
-	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
-	if err != nil {
-		return DocumentRevision{}, err
+	if version, err := ParseVersion(versionString); err != nil {
+		docRev.RevID = versionString
+	} else {
+		docRev.CV = &version
 	}
 
 	var hlv *HybridLogicalVector
-	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, hlv, err = revCacheLoaderForDocumentCV(ctx, rc.backingStores[collectionID], doc, *cv, loadBackup)
+	if docRev.RevID != "" {
+		docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, hlv, err = revCacheLoaderForDocument(ctx, rc.backingStores[collectionID], doc, versionString)
+	} else {
+		docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, docRev.RevID, hlv, err = revCacheLoaderForDocumentCV(ctx, rc.backingStores[collectionID], doc, *docRev.CV, loadBackup)
+	}
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -118,7 +98,7 @@ func (rc *BypassRevisionCache) GetActive(ctx context.Context, docID string, coll
 }
 
 // Peek is a no-op for a BypassRevisionCache, and always returns a false 'found' value.
-func (rc *BypassRevisionCache) Peek(ctx context.Context, docID string, key RevCacheKey) (docRev DocumentRevision, found bool) {
+func (rc *BypassRevisionCache) Peek(ctx context.Context, docID string, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {
 	return DocumentRevision{}, false
 }
 
@@ -132,11 +112,7 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID string, collectionID uint32) {
-	// no-op
-}
-
-func (rc *BypassRevisionCache) RemoveUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+func (rc *BypassRevisionCache) Remove(ctx context.Context, docID, versionString string, collectionID uint32) {
 	// no-op
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -31,8 +31,8 @@ func NewBypassRevisionCache(backingStores map[uint32]RevisionCacheBackingStore, 
 	}
 }
 
-// GetWithRev fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
+// GetUsingRevID fetches the revision for the given docID and revID immediately from the bucket.
+func (rc *BypassRevisionCache) GetUsingRevID(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
 		return DocumentRevision{}, err
@@ -58,8 +58,8 @@ func (rc *BypassRevisionCache) GetWithRev(ctx context.Context, docID, revID stri
 	return docRev, nil
 }
 
-// GetWithCV fetches the Current Version for the given docID and CV immediately from the bucket.
-func (rc *BypassRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
+// GetUsingCV fetches the Current Version for the given docID and CV immediately from the bucket.
+func (rc *BypassRevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
 
 	docRev = DocumentRevision{
 		CV:                     cv,
@@ -132,19 +132,11 @@ func (rc *BypassRevisionCache) Upsert(ctx context.Context, docRev DocumentRevisi
 	// no-op
 }
 
-func (rc *BypassRevisionCache) RemoveWithRev(ctx context.Context, docID, revID string, collectionID uint32) {
+func (rc *BypassRevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID string, collectionID uint32) {
 	// no-op
 }
 
-func (rc *BypassRevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
-	// no-op
-}
-
-func (rc *BypassRevisionCache) RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	// no-op
-}
-
-func (rc *BypassRevisionCache) RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+func (rc *BypassRevisionCache) RemoveUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
 	// no-op
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -31,7 +31,7 @@ func NewBypassRevisionCache(backingStores map[uint32]RevisionCacheBackingStore, 
 	}
 }
 
-// GetUsingRevID fetches the revision for the given docID and revID immediately from the bucket.
+// Get fetches the revision for the given docID and revID immediately from the bucket.
 func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (docRev DocumentRevision, err error) {
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -120,8 +120,3 @@ func (rc *BypassRevisionCache) Remove(ctx context.Context, docID, versionString 
 func (rc *BypassRevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
 	// no-op
 }
-
-// UpdateDeltaCV is a no-op for a BypassRevisionCache
-func (rc *BypassRevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, collectionID uint32, toDelta RevisionDelta) {
-	// no-op
-}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -12,7 +12,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -43,7 +42,7 @@ type RevisionCache interface {
 	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
 
 	// Peek returns the given revision if present in the cache
-	Peek(ctx context.Context, docID string, key string, collectionID uint32) (docRev DocumentRevision, found bool)
+	Peek(ctx context.Context, docID string, key RevCacheKey) (docRev DocumentRevision, found bool)
 
 	// Put will store the given docRev in the cache
 	Put(ctx context.Context, docRev DocumentRevision, collectionID uint32)
@@ -156,8 +155,8 @@ func (c *collectionRevisionCache) GetActive(ctx context.Context, docID string) (
 }
 
 // Peek is for per collection access to Peek method
-func (c *collectionRevisionCache) Peek(ctx context.Context, docID, key string) (DocumentRevision, bool) {
-	return (*c.revCache).Peek(ctx, docID, key, c.collectionID)
+func (c *collectionRevisionCache) Peek(ctx context.Context, docID string, key RevCacheKey) (DocumentRevision, bool) {
+	return (*c.revCache).Peek(ctx, docID, key)
 }
 
 // Put is for per collection access to Put method
@@ -510,10 +509,16 @@ func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Documen
 	return bodyBytes, attachments, channels, deleted, err
 }
 
-func CreateRevisionCacheRevIDKey(docID, revID string, collectionID uint32) string {
-	return fmt.Sprintf("%s:%s:%d", docID, revID, collectionID)
+type RevCacheKey struct {
+	docID        string
+	docVersion   string
+	collectionID uint32
 }
 
-func CreateRevisionCacheCVKey(docID string, cv *Version, collectionID uint32) string {
-	return fmt.Sprintf("%s:%s:%d", docID, cv.String(), collectionID)
+func CreateRevisionCacheRevIDKey(docID, revID string, collectionID uint32) RevCacheKey {
+	return RevCacheKey{docID: docID, docVersion: revID, collectionID: collectionID}
+}
+
+func CreateRevisionCacheCVKey(docID string, cv *Version, collectionID uint32) RevCacheKey {
+	return RevCacheKey{docID: docID, docVersion: cv.String(), collectionID: collectionID}
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -31,18 +31,13 @@ type RevisionCache interface {
 
 	// GetUsingRevID returns the given revision, and stores if not already cached.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	GetUsingRevID(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
-
-	// GetUsingCV returns the given revision by CV, and stores if not already cached.
-	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	// When loadBackup=true, will load from backup revisions if requested version is not active document
-	GetUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error)
+	Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
 
 	// Peek returns the given revision if present in the cache
-	Peek(ctx context.Context, docID string, key RevCacheKey) (docRev DocumentRevision, found bool)
+	Peek(ctx context.Context, docID string, versionString string, collectionID uint32) (docRev DocumentRevision, found bool)
 
 	// Put will store the given docRev in the cache
 	Put(ctx context.Context, docRev DocumentRevision, collectionID uint32)
@@ -50,11 +45,8 @@ type RevisionCache interface {
 	// Upsert will remove existing value and re-create new one
 	Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32)
 
-	// RemoveUsingRevID removes the specified revID key from the cache if it exists
-	RemoveUsingRevID(ctx context.Context, docID, revID string, collectionID uint32)
-
-	// RemoveUsingCV removes the specified CV key from the cache if it exists
-	RemoveUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32)
+	// Remove removes the specified revID key from the cache if it exists
+	Remove(ctx context.Context, docID, versionString string, collectionID uint32)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta)
@@ -140,13 +132,8 @@ func newCollectionRevisionCache(revCache *RevisionCache, collectionID uint32) co
 }
 
 // Get is for per collection access to Get method
-func (c *collectionRevisionCache) GetUsingRevID(ctx context.Context, docID, revID string, includeDelta bool) (DocumentRevision, error) {
-	return (*c.revCache).GetUsingRevID(ctx, docID, revID, c.collectionID, includeDelta)
-}
-
-// Get is for per collection access to Get method
-func (c *collectionRevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Version, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
-	return (*c.revCache).GetUsingCV(ctx, docID, cv, c.collectionID, includeDelta, loadBackup)
+func (c *collectionRevisionCache) Get(ctx context.Context, docID, versionString string, includeDelta, loadBackup bool) (DocumentRevision, error) {
+	return (*c.revCache).Get(ctx, docID, versionString, c.collectionID, includeDelta, loadBackup)
 }
 
 // GetActive is for per collection access to GetActive method
@@ -155,8 +142,8 @@ func (c *collectionRevisionCache) GetActive(ctx context.Context, docID string) (
 }
 
 // Peek is for per collection access to Peek method
-func (c *collectionRevisionCache) Peek(ctx context.Context, docID string, key RevCacheKey) (DocumentRevision, bool) {
-	return (*c.revCache).Peek(ctx, docID, key)
+func (c *collectionRevisionCache) Peek(ctx context.Context, docID string, versionString string) (DocumentRevision, bool) {
+	return (*c.revCache).Peek(ctx, docID, versionString, c.collectionID)
 }
 
 // Put is for per collection access to Put method
@@ -169,12 +156,8 @@ func (c *collectionRevisionCache) Upsert(ctx context.Context, docRev DocumentRev
 	(*c.revCache).Upsert(ctx, docRev, c.collectionID)
 }
 
-func (c *collectionRevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID string) {
-	(*c.revCache).RemoveUsingRevID(ctx, docID, revID, c.collectionID)
-}
-
-func (c *collectionRevisionCache) RemoveUsingCV(ctx context.Context, docID string, cv *Version) {
-	(*c.revCache).RemoveUsingCV(ctx, docID, cv, c.collectionID)
+func (c *collectionRevisionCache) Remove(ctx context.Context, docID, versionString string) {
+	(*c.revCache).Remove(ctx, docID, versionString, c.collectionID)
 }
 
 // UpdateDelta is for per collection access to UpdateDelta method
@@ -515,10 +498,6 @@ type RevCacheKey struct {
 	collectionID uint32
 }
 
-func CreateRevisionCacheRevIDKey(docID, revID string, collectionID uint32) RevCacheKey {
-	return RevCacheKey{docID: docID, docVersion: revID, collectionID: collectionID}
-}
-
-func CreateRevisionCacheCVKey(docID string, cv *Version, collectionID uint32) RevCacheKey {
-	return RevCacheKey{docID: docID, docVersion: cv.String(), collectionID: collectionID}
+func CreateRevisionCacheKey(docID string, versionString string, collectionID uint32) RevCacheKey {
+	return RevCacheKey{docID: docID, docVersion: versionString, collectionID: collectionID}
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -29,7 +29,7 @@ const (
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
 
-	// GetUsingRevID returns the given revision, and stores if not already cached.
+	// Get returns the given revision, and stores if not already cached.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
 	Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (DocumentRevision, error)
 
@@ -484,12 +484,12 @@ func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Documen
 	return bodyBytes, attachments, channels, deleted, err
 }
 
-type RevCacheKey struct {
+type revCacheKey struct {
 	docID        string
 	docVersion   string
 	collectionID uint32
 }
 
-func CreateRevisionCacheKey(docID string, versionString string, collectionID uint32) RevCacheKey {
-	return RevCacheKey{docID: docID, docVersion: versionString, collectionID: collectionID}
+func CreateRevisionCacheKey(docID string, versionString string, collectionID uint32) revCacheKey {
+	return revCacheKey{docID: docID, docVersion: versionString, collectionID: collectionID}
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -29,20 +30,20 @@ const (
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
 
-	// GetWithRev returns the given revision, and stores if not already cached.
+	// GetUsingRevID returns the given revision, and stores if not already cached.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	GetWithRev(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
+	GetUsingRevID(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error)
 
-	// GetWithCV returns the given revision by CV, and stores if not already cached.
+	// GetUsingCV returns the given revision by CV, and stores if not already cached.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
 	// When loadBackup=true, will load from backup revisions if requested version is not active document
-	GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error)
+	GetUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
 
 	// Peek returns the given revision if present in the cache
-	Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool)
+	Peek(ctx context.Context, docID string, key string, collectionID uint32) (docRev DocumentRevision, found bool)
 
 	// Put will store the given docRev in the cache
 	Put(ctx context.Context, docRev DocumentRevision, collectionID uint32)
@@ -50,17 +51,11 @@ type RevisionCache interface {
 	// Upsert will remove existing value and re-create new one
 	Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32)
 
-	// RemoveWithRev evicts a revision from the cache using its revID.
-	RemoveWithRev(ctx context.Context, docID, revID string, collectionID uint32)
+	// RemoveUsingRevID removes the specified revID key from the cache if it exists
+	RemoveUsingRevID(ctx context.Context, docID, revID string, collectionID uint32)
 
-	// RemoveWithCV evicts a revision from the cache using its current version.
-	RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32)
-
-	// RemoveRevOnly removes the specified key from the revID lookup map in the cache
-	RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32)
-
-	// RemoveCVOnly removes the specified key from the HLV lookup map in the cache
-	RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32)
+	// RemoveUsingCV removes the specified CV key from the cache if it exists
+	RemoveUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta)
@@ -146,13 +141,13 @@ func newCollectionRevisionCache(revCache *RevisionCache, collectionID uint32) co
 }
 
 // Get is for per collection access to Get method
-func (c *collectionRevisionCache) GetWithRev(ctx context.Context, docID, revID string, includeDelta bool) (DocumentRevision, error) {
-	return (*c.revCache).GetWithRev(ctx, docID, revID, c.collectionID, includeDelta)
+func (c *collectionRevisionCache) GetUsingRevID(ctx context.Context, docID, revID string, includeDelta bool) (DocumentRevision, error) {
+	return (*c.revCache).GetUsingRevID(ctx, docID, revID, c.collectionID, includeDelta)
 }
 
 // Get is for per collection access to Get method
-func (c *collectionRevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
-	return (*c.revCache).GetWithCV(ctx, docID, cv, c.collectionID, includeDelta, loadBackup)
+func (c *collectionRevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Version, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
+	return (*c.revCache).GetUsingCV(ctx, docID, cv, c.collectionID, includeDelta, loadBackup)
 }
 
 // GetActive is for per collection access to GetActive method
@@ -161,8 +156,8 @@ func (c *collectionRevisionCache) GetActive(ctx context.Context, docID string) (
 }
 
 // Peek is for per collection access to Peek method
-func (c *collectionRevisionCache) Peek(ctx context.Context, docID, revID string) (DocumentRevision, bool) {
-	return (*c.revCache).Peek(ctx, docID, revID, c.collectionID)
+func (c *collectionRevisionCache) Peek(ctx context.Context, docID, key string) (DocumentRevision, bool) {
+	return (*c.revCache).Peek(ctx, docID, key, c.collectionID)
 }
 
 // Put is for per collection access to Put method
@@ -175,22 +170,12 @@ func (c *collectionRevisionCache) Upsert(ctx context.Context, docRev DocumentRev
 	(*c.revCache).Upsert(ctx, docRev, c.collectionID)
 }
 
-// RemoveWithRev is for per collection access to Remove method
-func (c *collectionRevisionCache) RemoveWithRev(ctx context.Context, docID, revID string) {
-	(*c.revCache).RemoveWithRev(ctx, docID, revID, c.collectionID)
+func (c *collectionRevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID string) {
+	(*c.revCache).RemoveUsingRevID(ctx, docID, revID, c.collectionID)
 }
 
-func (c *collectionRevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string) {
-	(*c.revCache).RemoveRevOnly(ctx, docID, revID, c.collectionID)
-}
-
-func (c *collectionRevisionCache) RemoveCVOnly(ctx context.Context, docID string, cv *Version) {
-	(*c.revCache).RemoveCVOnly(ctx, docID, cv, c.collectionID)
-}
-
-// RemoveWithCV is for per collection access to Remove method
-func (c *collectionRevisionCache) RemoveWithCV(ctx context.Context, docID string, cv *Version) {
-	(*c.revCache).RemoveWithCV(ctx, docID, cv, c.collectionID)
+func (c *collectionRevisionCache) RemoveUsingCV(ctx context.Context, docID string, cv *Version) {
+	(*c.revCache).RemoveUsingCV(ctx, docID, cv, c.collectionID)
 }
 
 // UpdateDelta is for per collection access to UpdateDelta method
@@ -523,4 +508,12 @@ func (c *DatabaseCollection) getCurrentVersion(ctx context.Context, doc *Documen
 		bodyBytes = cleanBodyBytes
 	}
 	return bodyBytes, attachments, channels, deleted, err
+}
+
+func CreateRevisionCacheRevIDKey(docID, revID string, collectionID uint32) string {
+	return fmt.Sprintf("%s:%s:%d", docID, revID, collectionID)
+}
+
+func CreateRevisionCacheCVKey(docID string, cv *Version, collectionID uint32) string {
+	return fmt.Sprintf("%s:%s:%d", docID, cv.String(), collectionID)
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -50,9 +50,6 @@ type RevisionCache interface {
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta)
-
-	// UpdateDeltaCV stores the given toDelta value in the given rev if cached but will look up in cache by cv
-	UpdateDeltaCV(ctx context.Context, docID string, cv *Version, collectionID uint32, toDelta RevisionDelta)
 }
 
 const (
@@ -163,11 +160,6 @@ func (c *collectionRevisionCache) Remove(ctx context.Context, docID, versionStri
 // UpdateDelta is for per collection access to UpdateDelta method
 func (c *collectionRevisionCache) UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta) {
 	(*c.revCache).UpdateDelta(ctx, docID, revID, c.collectionID, toDelta)
-}
-
-// UpdateDeltaCV is for per collection access to UpdateDeltaCV method
-func (c *collectionRevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, toDelta RevisionDelta) {
-	(*c.revCache).UpdateDeltaCV(ctx, docID, cv, c.collectionID, toDelta)
 }
 
 // DocumentRevision stored and returned by the rev cache

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -53,16 +53,16 @@ func (sc *ShardedLRURevisionCache) getShard(docID string) *LRURevisionCache {
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 
-func (sc *ShardedLRURevisionCache) GetWithRev(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).GetWithRev(ctx, docID, revID, collectionID, includeDelta)
+func (sc *ShardedLRURevisionCache) GetUsingRevID(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetUsingRevID(ctx, docID, revID, collectionID, includeDelta)
 }
 
-func (sc *ShardedLRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).GetWithCV(ctx, docID, cv, collectionID, includeDelta, loadBackup)
+func (sc *ShardedLRURevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).GetUsingCV(ctx, docID, cv, collectionID, includeDelta, loadBackup)
 }
 
-func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool) {
-	return sc.getShard(docID).Peek(ctx, docID, revID, collectionID)
+func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID string, key string, collectionID uint32) (docRev DocumentRevision, found bool) {
+	return sc.getShard(docID).Peek(ctx, docID, key, collectionID)
 }
 
 func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
@@ -85,27 +85,18 @@ func (sc *ShardedLRURevisionCache) Upsert(ctx context.Context, docRev DocumentRe
 	sc.getShard(docRev.DocID).Upsert(ctx, docRev, collectionID)
 }
 
-func (sc *ShardedLRURevisionCache) RemoveWithRev(ctx context.Context, docID, revID string, collectionID uint32) {
-	sc.getShard(docID).RemoveWithRev(ctx, docID, revID, collectionID)
+func (sc *ShardedLRURevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID string, collectionID uint32) {
+	sc.getShard(docID).RemoveUsingRevID(ctx, docID, revID, collectionID)
 }
 
-func (sc *ShardedLRURevisionCache) RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	sc.getShard(docID).RemoveWithCV(ctx, docID, cv, collectionID)
-}
-
-func (sc *ShardedLRURevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
-	sc.getShard(docID).RemoveRevOnly(ctx, docID, revID, collectionID)
-}
-
-func (sc *ShardedLRURevisionCache) RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	sc.getShard(docID).RemoveCVOnly(ctx, docID, cv, collectionID)
+func (sc *ShardedLRURevisionCache) RemoveUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+	sc.getShard(docID).RemoveUsingCV(ctx, docID, cv, collectionID)
 }
 
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	backingStores        map[uint32]RevisionCacheBackingStore
-	cache                map[IDAndRev]*list.Element
-	hlvCache             map[IDandCV]*list.Element
+	cache                map[string]*list.Element
 	lruList              *list.List
 	cacheHits            *base.SgwIntStat
 	cacheMisses          *base.SgwIntStat
@@ -126,6 +117,7 @@ type revCacheValue struct {
 	attachments  AttachmentsMeta
 	delta        *RevisionDelta
 	id           string
+	itemKey      string
 	cv           Version
 	hlvHistory   string
 	revID        string
@@ -135,7 +127,7 @@ type revCacheValue struct {
 	removed      bool
 	itemBytes    atomic.Int64
 	collectionID uint32
-	canEvict     atomic.Bool
+	itemLoaded   atomic.Bool
 	deltaLock    sync.Mutex // synchronizes GetDelta across multiple clients for each fromRevision
 }
 
@@ -143,8 +135,7 @@ type revCacheValue struct {
 func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat *base.SgwIntStat, cacheMissStat *base.SgwIntStat, cacheNumItemsStat *base.SgwIntStat, revCacheMemoryStat *base.SgwIntStat) *LRURevisionCache {
 
 	return &LRURevisionCache{
-		cache:                map[IDAndRev]*list.Element{},
-		hlvCache:             map[IDandCV]*list.Element{},
+		cache:                map[string]*list.Element{},
 		lruList:              list.New(),
 		capacity:             revCacheOptions.MaxItemCount,
 		backingStores:        backingStores,
@@ -160,18 +151,22 @@ func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores ma
 // Returns the body of the revision, its history, and the set of channels it's in.
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
-func (rc *LRURevisionCache) GetWithRev(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error) {
-	return rc.getFromCacheByRev(ctx, docID, revID, collectionID, true, includeDelta)
+func (rc *LRURevisionCache) GetUsingRevID(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error) {
+	return rc.getFromCache(ctx, docID, revID, nil, collectionID, true, includeDelta, true)
 }
 
-func (rc *LRURevisionCache) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
-	return rc.getFromCacheByCV(ctx, docID, cv, collectionID, true, includeDelta, loadBackup)
+func (rc *LRURevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
+	return rc.getFromCache(ctx, docID, "", cv, collectionID, true, includeDelta, loadBackup)
 }
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
 // present in the cache.
-func (rc *LRURevisionCache) Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool) {
-	docRev, err := rc.getFromCacheByRev(ctx, docID, revID, collectionID, false, RevCacheOmitDelta)
+func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, key string, collectionID uint32) (docRev DocumentRevision, found bool) {
+	value := rc.peekCacheForKey(ctx, key)
+	if value == nil {
+		return DocumentRevision{}, false
+	}
+	docRev, err := value.asDocumentRevision(nil)
 	if err != nil {
 		return DocumentRevision{}, false
 	}
@@ -181,7 +176,7 @@ func (rc *LRURevisionCache) Peek(ctx context.Context, docID, revID string, colle
 // Attempt to update the delta on a revision cache entry.  If the entry is no longer resident in the cache,
 // fails silently
 func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
-	value := rc.getValue(ctx, docID, revID, collectionID, false)
+	value := rc.getValue(ctx, docID, revID, nil, collectionID, false)
 	if value != nil {
 		outGoingBytes := value.updateDelta(toDelta)
 		if outGoingBytes != 0 {
@@ -194,7 +189,7 @@ func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string
 }
 
 func (rc *LRURevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, collectionID uint32, toDelta RevisionDelta) {
-	value := rc.getValueByCV(ctx, docID, cv, collectionID, false)
+	value := rc.getValue(ctx, docID, "", cv, collectionID, false)
 	if value != nil {
 		outGoingBytes := value.updateDelta(toDelta)
 		if outGoingBytes != 0 {
@@ -206,54 +201,24 @@ func (rc *LRURevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv 
 	}
 }
 
-func (rc *LRURevisionCache) getFromCacheByRev(ctx context.Context, docID, revID string, collectionID uint32, loadOnCacheMiss, includeDelta bool) (DocumentRevision, error) {
-	value := rc.getValue(ctx, docID, revID, collectionID, loadOnCacheMiss)
+func (rc *LRURevisionCache) getFromCache(ctx context.Context, docID, revID string, cv *Version, collectionID uint32, loadCacheOnMiss, includeDelta, loadBackup bool) (DocumentRevision, error) {
+	value := rc.getValue(ctx, docID, revID, cv, collectionID, loadCacheOnMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
 	}
 
-	// for revID pathway we should always load from backup if required
-	docRev, statEvent, err := value.load(ctx, rc.backingStores[collectionID], includeDelta, true)
-	rc.statsRecorderFunc(statEvent)
-
-	if !statEvent && err == nil {
-		// cache miss so we had to load doc, increment memory count
-		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
-		// check for memory based eviction
-		rc.revCacheMemoryBasedEviction(ctx)
-		// given err is nil if we get to this code we can safely assign error returned from addToHLVMapPostLoad to err
-		// and in the event we do error adding to the HLV map post load we will remove the value from the rev cache below
-		// and return the error to the caller
-		rc.addToHLVMapPostLoad(ctx, docID, docRev.RevID, docRev.CV, collectionID)
-	}
-
-	if err != nil {
-		rc.removeValue(value, collectionID) // don't keep failed loads in the cache
-	}
-
-	return docRev, err
-}
-
-func (rc *LRURevisionCache) getFromCacheByCV(ctx context.Context, docID string, cv *Version, collectionID uint32, loadCacheOnMiss bool, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
-	value := rc.getValueByCV(ctx, docID, cv, collectionID, loadCacheOnMiss)
-	if value == nil {
-		return DocumentRevision{}, nil
-	}
-
-	// for CV pathway we respect the loadBackup flag passed in
 	docRev, cacheHit, err := value.load(ctx, rc.backingStores[collectionID], includeDelta, loadBackup)
 	rc.statsRecorderFunc(cacheHit)
-
-	if err != nil {
-		rc.removeValue(value, collectionID) // don't keep failed loads in the cache
-	}
 
 	if !cacheHit && err == nil {
 		// cache miss so we had to load doc, increment memory count
 		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
 		// check for memory based eviction
 		rc.revCacheMemoryBasedEviction(ctx)
-		rc.addToRevMapPostLoad(ctx, docID, docRev.RevID, docRev.CV, collectionID)
+	}
+
+	if err != nil {
+		rc.removeValue(value) // don't keep failed loads in the cache
 	}
 
 	return docRev, err
@@ -279,7 +244,7 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 	// Retrieve from or add to rev cache
 	// We need to use revisionID here as not every document in the bucket is yet guaranteed to
 	// have a HLV assigned to it.
-	value := rc.getValue(ctx, docID, bucketDoc.GetRevTreeID(), collectionID, true)
+	value := rc.getValue(ctx, docID, bucketDoc.GetRevTreeID(), nil, collectionID, true)
 
 	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStores[collectionID], bucketDoc)
 	rc.statsRecorderFunc(statEvent)
@@ -289,15 +254,10 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
 		// check for rev cache memory based eviction
 		rc.revCacheMemoryBasedEviction(ctx)
-		// add successfully fetched value to CV lookup map too
-		// given err is nil if we get to this code we can safely assign error returned from addToHLVMapPostLoad to err
-		// and in the event we do error adding to the HLV map post load we will remove the value from the rev cache below
-		// and return the error to the caller
-		rc.addToHLVMapPostLoad(ctx, docID, docRev.RevID, docRev.CV, collectionID)
 	}
 
 	if err != nil {
-		rc.removeValue(value, collectionID) // don't keep failed loads in the cache
+		rc.removeValue(value) // don't keep failed loads in the cache
 	}
 
 	return docRev, err
@@ -312,35 +272,28 @@ func (rc *LRURevisionCache) statsRecorderFunc(cacheHit bool) {
 	}
 }
 
-// Adds a revision to the cache.
+// Put adds a revision to the cache. NOTE: this function only adds an entry keyed by CV
 func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
 	if docRev.History == nil {
 		// TODO: CBG-1948
 		panic("Missing history for RevisionCache.Put")
 	}
 
-	// doc should always have a cv present in a PUT operation on the cache (update HLV is called before hand in doc update process)
-	// thus we can call getValueByCV directly the update the rev lookup post this
-	value := rc.getValueByCV(ctx, docRev.DocID, docRev.CV, collectionID, true)
+	value := rc.getValue(ctx, docRev.DocID, docRev.RevID, docRev.CV, collectionID, true)
 	// increment incoming bytes
 	docRev.CalculateBytes()
 	rc.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
 	value.store(docRev)
 
-	// add new doc version to the rev id lookup map
-	rc.addToRevMapPostLoad(ctx, docRev.DocID, docRev.RevID, docRev.CV, collectionID)
-
 	// check for rev cache memory based eviction
 	rc.revCacheMemoryBasedEviction(ctx)
 }
 
-// Upsert a revision in the cache.
+// Upsert a revision in the cache. This function only upserts for CV key
 func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
-	// similar to PUT operation we should have the CV defined by this point (updateHLV is called before calling this)
-	key := IDandCV{DocID: docRev.DocID, Source: docRev.CV.SourceID, Version: docRev.CV.Value, CollectionID: collectionID}
-	legacyKey := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID, CollectionID: collectionID}
+	cvKey := CreateRevisionCacheCVKey(docRev.DocID, docRev.CV, collectionID)
 
-	numItemsRemoved, value := rc.upsertDocToCache(ctx, key, legacyKey, docRev, collectionID)
+	numItemsRemoved, cvValue := rc.upsertDocToCache(ctx, cvKey, docRev, collectionID)
 	if numItemsRemoved > 0 {
 		rc.cacheNumItems.Add(-numItemsRemoved)
 	}
@@ -348,13 +301,13 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 	docRev.CalculateBytes()
 	// add new item bytes to overall count
 	rc.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
-	value.store(docRev)
+	cvValue.store(docRev)
 
 	// check we aren't over memory capacity, if so perform eviction
 	rc.revCacheMemoryBasedEviction(ctx)
 }
 
-func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey IDandCV, legacyKey IDAndRev, docRev DocumentRevision, collectionID uint32) (int64, *revCacheValue) {
+func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey string, docRev DocumentRevision, collectionID uint32) (int64, *revCacheValue) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 
@@ -362,10 +315,7 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey IDandCV,
 	// lookup for element in hlv lookup map, if not found for some reason try rev lookup map
 	var existingElem *list.Element
 	var found bool
-	existingElem, found = rc.hlvCache[cvKey]
-	if !found {
-		existingElem, found = rc.cache[legacyKey]
-	}
+	existingElem, found = rc.cache[cvKey]
 	if found {
 		revItem := existingElem.Value.(*revCacheValue)
 		// decrement item bytes by the removed item
@@ -376,10 +326,9 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey IDandCV,
 
 	// Add new value and overwrite existing cache key, pushing to front to maintain order
 	// also ensure we add to rev id lookup map too
-	value := &revCacheValue{id: docRev.DocID, cv: *docRev.CV, collectionID: collectionID}
-	elem := rc.lruList.PushFront(value)
-	rc.hlvCache[cvKey] = elem
-	rc.cache[legacyKey] = elem
+	cvValue := &revCacheValue{id: docRev.DocID, cv: *docRev.CV, collectionID: collectionID, itemKey: cvKey}
+	elem := rc.lruList.PushFront(cvValue)
+	rc.cache[cvKey] = elem
 
 	// only increment if we are inserting new item to cache
 	if newItem {
@@ -391,23 +340,40 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey IDandCV,
 	if numBytesEvicted > 0 {
 		rc._decrRevCacheMemoryUsage(ctx, -numBytesEvicted)
 	}
-	return numItemsRemoved, value
+	return numItemsRemoved, cvValue
 }
 
-func (rc *LRURevisionCache) getValue(ctx context.Context, docID, revID string, collectionID uint32, create bool) (value *revCacheValue) {
-	if docID == "" || revID == "" {
-		// TODO: CBG-1948
-		panic("RevisionCache: invalid empty doc/rev id")
+func (rc *LRURevisionCache) peekCacheForKey(ctx context.Context, key string) (value *revCacheValue) {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	if elem := rc.cache[key]; elem != nil {
+		rc.lruList.MoveToFront(elem)
+		value = elem.Value.(*revCacheValue)
 	}
-	key := IDAndRev{DocID: docID, RevID: revID, CollectionID: collectionID}
+	return
+}
+
+func (rc *LRURevisionCache) getValue(ctx context.Context, docID, revID string, cv *Version, collectionID uint32, create bool) (value *revCacheValue) {
+	if docID == "" || (revID == "" && cv == nil) {
+		return nil
+	}
+	var key string
+	if cv == nil {
+		key = CreateRevisionCacheRevIDKey(docID, revID, collectionID)
+	} else {
+		key = CreateRevisionCacheCVKey(docID, cv, collectionID)
+	}
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	if elem := rc.cache[key]; elem != nil {
 		rc.lruList.MoveToFront(elem)
 		value = elem.Value.(*revCacheValue)
 	} else if create {
-		value = &revCacheValue{id: docID, revID: revID, collectionID: collectionID}
-		value.canEvict.Store(false)
+		value = &revCacheValue{id: docID, revID: revID, collectionID: collectionID, itemKey: key}
+		if cv != nil {
+			value.cv = *cv
+		}
+		value.itemLoaded.Store(false)
 		rc.cache[key] = rc.lruList.PushFront(value)
 		rc.cacheNumItems.Add(1)
 
@@ -422,198 +388,43 @@ func (rc *LRURevisionCache) getValue(ctx context.Context, docID, revID string, c
 	return
 }
 
-func (rc *LRURevisionCache) getValueByCV(ctx context.Context, docID string, cv *Version, collectionID uint32, create bool) (value *revCacheValue) {
-	if docID == "" || cv == nil {
-		return nil
-	}
+func (rc *LRURevisionCache) RemoveUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+	rc.removeFromRevCache(ctx, CreateRevisionCacheCVKey(docID, cv, collectionID))
 
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
+}
+
+// RemoveUsingRevID removes a rev from revision cache lookup map, if present.
+func (rc *LRURevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID string, collectionID uint32) {
+	rc.removeFromRevCache(ctx, CreateRevisionCacheRevIDKey(docID, revID, collectionID))
+}
+
+func (rc *LRURevisionCache) removeFromRevCache(ctx context.Context, key string) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
-	if elem := rc.hlvCache[key]; elem != nil {
-		rc.lruList.MoveToFront(elem)
-		value = elem.Value.(*revCacheValue)
-	} else if create {
-		value = &revCacheValue{id: docID, cv: *cv, collectionID: collectionID}
-		value.canEvict.Store(false)
-		newElem := rc.lruList.PushFront(value)
-		rc.hlvCache[key] = newElem
-		rc.cacheNumItems.Add(1)
-
-		// evict if over number capacity
-		numItemsRemoved, numBytesEvicted := rc._numberCapacityEviction()
-		if numBytesEvicted > 0 {
-			rc._decrRevCacheMemoryUsage(ctx, -numBytesEvicted)
-		}
-
-		if numItemsRemoved > 0 {
-			rc.cacheNumItems.Add(-numItemsRemoved)
-		}
-	}
-	return
-}
-
-// addToRevMapPostLoad will generate and entry in the Rev lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToRevMapPostLoad(ctx context.Context, docID, revID string, cv *Version, collectionID uint32) {
-	if revID == "" {
-		// no revID to map to, exit early
-		return
-	}
-	legacyKey := IDAndRev{DocID: docID, RevID: revID, CollectionID: collectionID}
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
-
-	rc.lock.Lock()
-	defer rc.lock.Unlock()
-	// check for existing value in rev cache map (due to concurrent fetch by rev ID)
-	cvElem, cvFound := rc.hlvCache[key]
-	_, revFound := rc.cache[legacyKey]
-	if !cvFound {
-		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
-		// need to return doc revision to caller still but no need repopulate the cache
-		return
-	}
-	// Check if another goroutine has already updated the rev map
-	if !revFound {
-		// if not found we need to add the element to the rev lookup (for PUT code path)
-		rc.cache[legacyKey] = cvElem
-	}
-}
-
-// addToHLVMapPostLoad will generate and entry in the CV lookup map for a new document entering the cache
-func (rc *LRURevisionCache) addToHLVMapPostLoad(ctx context.Context, docID, revID string, cv *Version, collectionID uint32) {
-	legacyKey := IDAndRev{DocID: docID, RevID: revID, CollectionID: collectionID}
-
-	if cv == nil {
-		// no cv defined to populate lookup map, exit early
-		return
-	}
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
-
-	rc.lock.Lock()
-	defer rc.lock.Unlock()
-	// check for existing value in rev cache map (due to concurrent fetch by rev ID)
-	_, cvFound := rc.hlvCache[key]
-	revElem, revFound := rc.cache[legacyKey]
-	if !revFound {
-		// its possible the element has been evicted if we don't find the element above (high churn on rev cache)
-		// need to return doc revision to caller still but no need repopulate the cache
-		return
-	}
-	// Check if another goroutine has already updated the cv map
-	if !cvFound {
-		// if not found we need to add the element to the hlv lookup
-		rc.hlvCache[key] = revElem
-	}
-}
-
-// Remove removes a value from the revision cache, if present.
-func (rc *LRURevisionCache) RemoveWithRev(ctx context.Context, docID, revID string, collectionID uint32) {
-	rc.removeFromCacheByRev(ctx, docID, revID, collectionID)
-}
-
-// RemoveWithCV removes a value from rev cache by CV reference if present
-func (rc *LRURevisionCache) RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	rc.removeFromCacheByCV(ctx, docID, cv, collectionID)
-}
-
-func (rc *LRURevisionCache) RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	rc.removeFromCVLookup(ctx, docID, cv, collectionID)
-}
-
-// RemoveRevOnly removes a rev from revision cache lookup map, if present.
-func (rc *LRURevisionCache) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
-	// This will only remove the entry from the rev lookup map, not the lru list
-	rc.removeFromRevLookup(ctx, docID, revID, collectionID)
-}
-
-// removeFromCacheByCV removes an entry from rev cache by CV
-func (rc *LRURevisionCache) removeFromCacheByCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
-	rc.lock.Lock()
-	defer rc.lock.Unlock()
-	element, ok := rc.hlvCache[key]
+	elem, ok := rc.cache[key]
 	if !ok {
 		return
 	}
-	// grab the revid key from the value to enable us to remove the reference from the rev lookup map too
-	elem, ok := element.Value.(*revCacheValue)
+	revValue, ok := elem.Value.(*revCacheValue)
 	if !ok {
 		return
 	}
-
-	legacyKey := IDAndRev{DocID: docID, RevID: elem.revID, CollectionID: collectionID}
-	rc.lruList.Remove(element)
-	delete(rc.hlvCache, key)
-	// remove from rev lookup map too
-	delete(rc.cache, legacyKey)
-	rc._decrRevCacheMemoryUsage(ctx, -elem.getItemBytes())
+	rc._decrRevCacheMemoryUsage(ctx, -revValue.getItemBytes())
+	rc.lruList.Remove(elem)
 	rc.cacheNumItems.Add(-1)
-}
-
-// removeFromCacheByRev removes an entry from rev cache by revID
-func (rc *LRURevisionCache) removeFromCacheByRev(ctx context.Context, docID, revID string, collectionID uint32) {
-	key := IDAndRev{DocID: docID, RevID: revID, CollectionID: collectionID}
-	rc.lock.Lock()
-	defer rc.lock.Unlock()
-	element, ok := rc.cache[key]
-	if !ok {
-		return
-	}
-	// grab the cv key from the value to enable us to remove the reference from the rev lookup map too
-	elem, ok := element.Value.(*revCacheValue)
-	if !ok {
-		return
-	}
-
-	hlvKey := IDandCV{DocID: docID, Source: elem.cv.SourceID, Version: elem.cv.Value, CollectionID: collectionID}
-	rc.lruList.Remove(element)
-	// decrement the overall memory bytes count
-	rc._decrRevCacheMemoryUsage(ctx, -elem.getItemBytes())
 	delete(rc.cache, key)
-	// remove from CV lookup map too
-	delete(rc.hlvCache, hlvKey)
-	rc.cacheNumItems.Add(-1)
-}
-
-// removeFromRevLookup will only remove the entry from the rev lookup map, if present. Underlying element must stay in list for eviction to work.
-func (rc *LRURevisionCache) removeFromRevLookup(ctx context.Context, docID, revID string, collectionID uint32) {
-	key := IDAndRev{DocID: docID, RevID: revID, CollectionID: collectionID}
-	rc.lock.Lock()
-	defer rc.lock.Unlock()
-	// only delete from rev lookup map, if we delete underlying element in list, the elem in the HLV lookup map
-	// will never be evicted leading to potential unbounded growth of HLV lookup map
-	delete(rc.cache, key)
-}
-
-// removeFromCVLookup will only remove the entry from the CV lookup map, if present. Underlying element must stay in list for eviction to work.
-func (rc *LRURevisionCache) removeFromCVLookup(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	key := IDandCV{DocID: docID, Source: cv.SourceID, Version: cv.Value, CollectionID: collectionID}
-	rc.lock.Lock()
-	defer rc.lock.Unlock()
-	// only delete from cv lookup map, if we delete underlying element in list, the item left in the revID lookup map for
-	// this item will never be evicted leading to potential unbounded growth of revID lookup map
-	delete(rc.hlvCache, key)
 }
 
 // removeValue removes a value from the revision cache, if present and the value matches the the value. If there's an item in the revision cache with a matching docID and revID but the document is different, this item will not be removed from the rev cache.
-func (rc *LRURevisionCache) removeValue(value *revCacheValue, collectionID uint32) {
+func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
-	revKey := IDAndRev{DocID: value.id, RevID: value.revID, CollectionID: collectionID}
 	var itemRemoved bool
-	if element := rc.cache[revKey]; element != nil && element.Value == value {
+	if element := rc.cache[value.itemKey]; element != nil && element.Value == value {
 		rc.lruList.Remove(element)
-		delete(rc.cache, revKey)
+		delete(rc.cache, value.itemKey)
 		itemRemoved = true
 	}
-	// need to also check hlv lookup cache map
-	hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Value, CollectionID: collectionID}
-	if element := rc.hlvCache[hlvKey]; element != nil && element.Value == value {
-		rc.lruList.Remove(element)
-		delete(rc.hlvCache, hlvKey)
-		itemRemoved = true
-	}
-
 	if itemRemoved {
 		rc.cacheNumItems.Add(-1)
 	}
@@ -628,28 +439,8 @@ func (rc *LRURevisionCache) _numberCapacityEviction() (numItemsEvicted int64, nu
 			// no more ready for eviction
 			break
 		}
-		hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Value, CollectionID: value.collectionID}
-		revKey := IDAndRev{DocID: value.id, RevID: value.revID, CollectionID: value.collectionID}
-		if elem := rc.hlvCache[hlvKey]; elem != nil {
-			revValue := elem.Value.(*revCacheValue)
-			// we need to check if the value pointed to by the cv lookup map is the same value we're evicting, this is
-			// because we can currently have two items with the same docID and CV, but different revIDs due to
-			// local wins conflict resolution not generating a new CV but generating a new revID.
-			if revValue.revID == value.revID {
-				// this cv lookup item matches the value we're evicting, so remove it
-				delete(rc.hlvCache, hlvKey)
-			}
-		}
-		if elem := rc.cache[revKey]; elem != nil {
-			revValue := elem.Value.(*revCacheValue)
-			// we need to check if the value pointed to by the rev lookup map is the same value we're evicting, this is
-			// because we can have can currently have two items with the same docID and revID, but different CVs due to
-			// a new HLV being generated for user xattr updates where we don't generate a new revID.
-			if revValue.cv.String() == value.cv.String() {
-				// this rev lookup item matches the value we're evicting, so remove it
-				delete(rc.cache, revKey)
-			}
-		}
+		// delete item from lookup map
+		delete(rc.cache, value.itemKey)
 		numItemsEvicted++
 		numBytesEvicted += value.getItemBytes()
 	}
@@ -689,7 +480,7 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 		// we only want to set can evict if we are having to load the doc from the bucket into value,
 		// avoiding setting this value multiple times in the case other goroutines are loading the same value
 		defer func() {
-			value.canEvict.Store(true) // once done loading doc we can set the value to be ready for eviction
+			value.itemLoaded.Store(true) // once done loading doc we can set the value to be ready for eviction
 		}()
 
 		cacheHit = false
@@ -778,7 +569,7 @@ func (value *revCacheValue) loadForDoc(ctx context.Context, backingStore Revisio
 		// we only want to set can evict if we are having to load the doc from the bucket into value,
 		// avoiding setting this value multiple times in the case other goroutines are loading the same value
 		defer func() {
-			value.canEvict.Store(true) // once done loading doc we can set the value to be ready for eviction
+			value.itemLoaded.Store(true) // once done loading doc we can set the value to be ready for eviction
 		}()
 
 		cacheHit = false
@@ -822,7 +613,7 @@ func (value *revCacheValue) store(docRev DocumentRevision) {
 		value.itemBytes.Store(docRev.MemoryBytes)
 		value.hlvHistory = docRev.HlvHistory
 	}
-	value.canEvict.Store(true) // now we have stored the doc revision in the cache, we can allow eviction
+	value.itemLoaded.Store(true) // now we have stored the doc revision in the cache, we can allow eviction
 }
 
 func (value *revCacheValue) updateDelta(toDelta RevisionDelta) (diffInBytes int64) {
@@ -919,29 +710,7 @@ func (rc *LRURevisionCache) evictBasedOffMemoryUsage(ctx context.Context) int64 
 					return numItemsRemoved
 				}
 			}
-			revKey := IDAndRev{DocID: value.id, RevID: value.revID, CollectionID: value.collectionID}
-			hlvKey := IDandCV{DocID: value.id, Source: value.cv.SourceID, Version: value.cv.Value, CollectionID: value.collectionID}
-			// same below but for hlv lookup map
-			if elem := rc.hlvCache[hlvKey]; elem != nil {
-				revValue := elem.Value.(*revCacheValue)
-				// we need to check if the value pointed to by the cv lookup map is the same value we're evicting, this is
-				// because we can currently have two items with the same docID and CV, but different revIDs due to
-				// local wins conflict resolution not generating a new CV but generating a new revID.
-				if revValue.revID == value.revID {
-					// this cv lookup item matches the value we're evicting, so remove it
-					delete(rc.hlvCache, hlvKey)
-				}
-			}
-			if elem := rc.cache[revKey]; elem != nil {
-				revValue := elem.Value.(*revCacheValue)
-				// we need to check if the value pointed to by the rev lookup map is the same value we're evicting, this is
-				// because we can have can currently have two items with the same docID and revID, but different CVs due to
-				// a new HLV being generated for user xattr updates where we don't generate a new revID.
-				if revValue.cv.String() == value.cv.String() {
-					// this rev lookup item matches the value we're evicting, so remove it
-					delete(rc.cache, revKey)
-				}
-			}
+			delete(rc.cache, value.itemKey)
 			numItemsRemoved++
 			valueBytes := value.getItemBytes()
 			numBytesRemoved += valueBytes
@@ -993,7 +762,7 @@ func (rc *LRURevisionCache) _findEvictionValue() *revCacheValue {
 		return nil
 	}
 
-	if revItem.canEvict.Load() {
+	if revItem.itemLoaded.Load() {
 		rc.lruList.Remove(evictionCandidate)
 		return revItem
 	}
@@ -1002,7 +771,7 @@ func (rc *LRURevisionCache) _findEvictionValue() *revCacheValue {
 	evictionCandidate = evictionCandidate.Prev()
 	for evictionCandidate != nil {
 		revItem = evictionCandidate.Value.(*revCacheValue)
-		if revItem.canEvict.Load() {
+		if revItem.itemLoaded.Load() {
 			rc.lruList.Remove(evictionCandidate)
 			return revItem
 		}

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -65,10 +65,6 @@ func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, revID
 	sc.getShard(docID).UpdateDelta(ctx, docID, revID, collectionID, toDelta)
 }
 
-func (sc *ShardedLRURevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, collectionID uint32, toDelta RevisionDelta) {
-	sc.getShard(docID).UpdateDeltaCV(ctx, docID, cv, collectionID, toDelta)
-}
-
 func (sc *ShardedLRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
 	return sc.getShard(docID).GetActive(ctx, docID, collectionID)
 }
@@ -165,19 +161,6 @@ func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, versionStrin
 // fails silently
 func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
 	value := rc.getValue(ctx, docID, revID, collectionID, false)
-	if value != nil {
-		outGoingBytes := value.updateDelta(toDelta)
-		if outGoingBytes != 0 {
-			rc.currMemoryUsage.Add(outGoingBytes)
-			rc.cacheMemoryBytesStat.Add(outGoingBytes)
-		}
-		// check for memory based eviction
-		rc.revCacheMemoryBasedEviction(ctx)
-	}
-}
-
-func (rc *LRURevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, collectionID uint32, toDelta RevisionDelta) {
-	value := rc.getValue(ctx, docID, "", collectionID, false)
 	if value != nil {
 		outGoingBytes := value.updateDelta(toDelta)
 		if outGoingBytes != 0 {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -53,16 +53,12 @@ func (sc *ShardedLRURevisionCache) getShard(docID string) *LRURevisionCache {
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 
-func (sc *ShardedLRURevisionCache) GetUsingRevID(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).GetUsingRevID(ctx, docID, revID, collectionID, includeDelta)
+func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).Get(ctx, docID, versionString, collectionID, includeDelta, loadBackup)
 }
 
-func (sc *ShardedLRURevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).GetUsingCV(ctx, docID, cv, collectionID, includeDelta, loadBackup)
-}
-
-func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID string, key RevCacheKey) (docRev DocumentRevision, found bool) {
-	return sc.getShard(docID).Peek(ctx, docID, key)
+func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID string, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {
+	return sc.getShard(docID).Peek(ctx, docID, versionString, collectionID)
 }
 
 func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
@@ -85,12 +81,8 @@ func (sc *ShardedLRURevisionCache) Upsert(ctx context.Context, docRev DocumentRe
 	sc.getShard(docRev.DocID).Upsert(ctx, docRev, collectionID)
 }
 
-func (sc *ShardedLRURevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID string, collectionID uint32) {
-	sc.getShard(docID).RemoveUsingRevID(ctx, docID, revID, collectionID)
-}
-
-func (sc *ShardedLRURevisionCache) RemoveUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	sc.getShard(docID).RemoveUsingCV(ctx, docID, cv, collectionID)
+func (sc *ShardedLRURevisionCache) Remove(ctx context.Context, docID, versionString string, collectionID uint32) {
+	sc.getShard(docID).Remove(ctx, docID, versionString, collectionID)
 }
 
 // An LRU cache of document revision bodies, together with their channel access.
@@ -151,18 +143,14 @@ func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores ma
 // Returns the body of the revision, its history, and the set of channels it's in.
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
-func (rc *LRURevisionCache) GetUsingRevID(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error) {
-	return rc.getFromCache(ctx, docID, revID, nil, collectionID, true, includeDelta, true)
-}
-
-func (rc *LRURevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
-	return rc.getFromCache(ctx, docID, "", cv, collectionID, true, includeDelta, loadBackup)
+func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (DocumentRevision, error) {
+	return rc.getFromCache(ctx, docID, versionString, collectionID, true, includeDelta, loadBackup)
 }
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
 // present in the cache.
-func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, key RevCacheKey) (docRev DocumentRevision, found bool) {
-	value := rc.peekCacheForKey(ctx, key)
+func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {
+	value := rc.peekCacheForKey(ctx, CreateRevisionCacheKey(docID, versionString, collectionID))
 	if value == nil {
 		return DocumentRevision{}, false
 	}
@@ -176,7 +164,7 @@ func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, key RevCache
 // Attempt to update the delta on a revision cache entry.  If the entry is no longer resident in the cache,
 // fails silently
 func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
-	value := rc.getValue(ctx, docID, revID, nil, collectionID, false)
+	value := rc.getValue(ctx, docID, revID, collectionID, false)
 	if value != nil {
 		outGoingBytes := value.updateDelta(toDelta)
 		if outGoingBytes != 0 {
@@ -189,7 +177,7 @@ func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string
 }
 
 func (rc *LRURevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, collectionID uint32, toDelta RevisionDelta) {
-	value := rc.getValue(ctx, docID, "", cv, collectionID, false)
+	value := rc.getValue(ctx, docID, "", collectionID, false)
 	if value != nil {
 		outGoingBytes := value.updateDelta(toDelta)
 		if outGoingBytes != 0 {
@@ -201,8 +189,8 @@ func (rc *LRURevisionCache) UpdateDeltaCV(ctx context.Context, docID string, cv 
 	}
 }
 
-func (rc *LRURevisionCache) getFromCache(ctx context.Context, docID, revID string, cv *Version, collectionID uint32, loadCacheOnMiss, includeDelta, loadBackup bool) (DocumentRevision, error) {
-	value := rc.getValue(ctx, docID, revID, cv, collectionID, loadCacheOnMiss)
+func (rc *LRURevisionCache) getFromCache(ctx context.Context, docID, docVersionString string, collectionID uint32, loadCacheOnMiss, includeDelta, loadBackup bool) (DocumentRevision, error) {
+	value := rc.getValue(ctx, docID, docVersionString, collectionID, loadCacheOnMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
 	}
@@ -244,7 +232,7 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 	// Retrieve from or add to rev cache
 	// We need to use revisionID here as not every document in the bucket is yet guaranteed to
 	// have a HLV assigned to it.
-	value := rc.getValue(ctx, docID, bucketDoc.GetRevTreeID(), nil, collectionID, true)
+	value := rc.getValue(ctx, docID, bucketDoc.GetRevTreeID(), collectionID, true)
 
 	docRev, statEvent, err := value.loadForDoc(ctx, rc.backingStores[collectionID], bucketDoc)
 	rc.statsRecorderFunc(statEvent)
@@ -279,7 +267,7 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision, co
 		panic("Missing history for RevisionCache.Put")
 	}
 
-	value := rc.getValue(ctx, docRev.DocID, docRev.RevID, docRev.CV, collectionID, true)
+	value := rc.getValue(ctx, docRev.DocID, docRev.CV.String(), collectionID, true)
 	// increment incoming bytes
 	docRev.CalculateBytes()
 	rc.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
@@ -291,7 +279,7 @@ func (rc *LRURevisionCache) Put(ctx context.Context, docRev DocumentRevision, co
 
 // Upsert a revision in the cache. This function only upserts for CV key
 func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
-	cvKey := CreateRevisionCacheCVKey(docRev.DocID, docRev.CV, collectionID)
+	cvKey := CreateRevisionCacheKey(docRev.DocID, docRev.CV.String(), collectionID)
 
 	numItemsRemoved, cvValue := rc.upsertDocToCache(ctx, cvKey, docRev, collectionID)
 	if numItemsRemoved > 0 {
@@ -353,25 +341,26 @@ func (rc *LRURevisionCache) peekCacheForKey(ctx context.Context, key RevCacheKey
 	return
 }
 
-func (rc *LRURevisionCache) getValue(ctx context.Context, docID, revID string, cv *Version, collectionID uint32, create bool) (value *revCacheValue) {
-	if docID == "" || (revID == "" && cv == nil) {
+func (rc *LRURevisionCache) getValue(ctx context.Context, docID, docVersionString string, collectionID uint32, create bool) (value *revCacheValue) {
+	if docID == "" || docVersionString == "" {
 		return nil
 	}
-	var key RevCacheKey
-	if cv == nil {
-		key = CreateRevisionCacheRevIDKey(docID, revID, collectionID)
-	} else {
-		key = CreateRevisionCacheCVKey(docID, cv, collectionID)
-	}
+	key := CreateRevisionCacheKey(docID, docVersionString, collectionID)
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	if elem := rc.cache[key]; elem != nil {
 		rc.lruList.MoveToFront(elem)
 		value = elem.Value.(*revCacheValue)
 	} else if create {
-		value = &revCacheValue{id: docID, revID: revID, collectionID: collectionID, itemKey: key}
-		if cv != nil {
-			value.cv = *cv
+		value = &revCacheValue{id: docID, collectionID: collectionID, itemKey: key}
+		if base.IsRevTreeID(docVersionString) {
+			value.revID = docVersionString
+		} else {
+			cv, err := ParseVersion(docVersionString)
+			if err != nil {
+				return nil
+			}
+			value.cv = cv
 		}
 		value.itemLoaded.Store(false)
 		rc.cache[key] = rc.lruList.PushFront(value)
@@ -388,14 +377,9 @@ func (rc *LRURevisionCache) getValue(ctx context.Context, docID, revID string, c
 	return
 }
 
-func (rc *LRURevisionCache) RemoveUsingCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	rc.removeFromRevCache(ctx, CreateRevisionCacheCVKey(docID, cv, collectionID))
-
-}
-
-// RemoveUsingRevID removes a rev from revision cache lookup map, if present.
-func (rc *LRURevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID string, collectionID uint32) {
-	rc.removeFromRevCache(ctx, CreateRevisionCacheRevIDKey(docID, revID, collectionID))
+// Remove removes a rev from revision cache lookup map, if present.
+func (rc *LRURevisionCache) Remove(ctx context.Context, docID, versionString string, collectionID uint32) {
+	rc.removeFromRevCache(ctx, CreateRevisionCacheKey(docID, versionString, collectionID))
 }
 
 func (rc *LRURevisionCache) removeFromRevCache(ctx context.Context, key RevCacheKey) {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -61,8 +61,8 @@ func (sc *ShardedLRURevisionCache) GetUsingCV(ctx context.Context, docID string,
 	return sc.getShard(docID).GetUsingCV(ctx, docID, cv, collectionID, includeDelta, loadBackup)
 }
 
-func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID string, key string, collectionID uint32) (docRev DocumentRevision, found bool) {
-	return sc.getShard(docID).Peek(ctx, docID, key, collectionID)
+func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID string, key RevCacheKey) (docRev DocumentRevision, found bool) {
+	return sc.getShard(docID).Peek(ctx, docID, key)
 }
 
 func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
@@ -96,7 +96,7 @@ func (sc *ShardedLRURevisionCache) RemoveUsingCV(ctx context.Context, docID stri
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	backingStores        map[uint32]RevisionCacheBackingStore
-	cache                map[string]*list.Element
+	cache                map[RevCacheKey]*list.Element
 	lruList              *list.List
 	cacheHits            *base.SgwIntStat
 	cacheMisses          *base.SgwIntStat
@@ -117,7 +117,7 @@ type revCacheValue struct {
 	attachments  AttachmentsMeta
 	delta        *RevisionDelta
 	id           string
-	itemKey      string
+	itemKey      RevCacheKey
 	cv           Version
 	hlvHistory   string
 	revID        string
@@ -135,7 +135,7 @@ type revCacheValue struct {
 func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat *base.SgwIntStat, cacheMissStat *base.SgwIntStat, cacheNumItemsStat *base.SgwIntStat, revCacheMemoryStat *base.SgwIntStat) *LRURevisionCache {
 
 	return &LRURevisionCache{
-		cache:                map[string]*list.Element{},
+		cache:                map[RevCacheKey]*list.Element{},
 		lruList:              list.New(),
 		capacity:             revCacheOptions.MaxItemCount,
 		backingStores:        backingStores,
@@ -161,7 +161,7 @@ func (rc *LRURevisionCache) GetUsingCV(ctx context.Context, docID string, cv *Ve
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
 // present in the cache.
-func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, key string, collectionID uint32) (docRev DocumentRevision, found bool) {
+func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, key RevCacheKey) (docRev DocumentRevision, found bool) {
 	value := rc.peekCacheForKey(ctx, key)
 	if value == nil {
 		return DocumentRevision{}, false
@@ -307,7 +307,7 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 	rc.revCacheMemoryBasedEviction(ctx)
 }
 
-func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey string, docRev DocumentRevision, collectionID uint32) (int64, *revCacheValue) {
+func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey RevCacheKey, docRev DocumentRevision, collectionID uint32) (int64, *revCacheValue) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 
@@ -343,7 +343,7 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey string, 
 	return numItemsRemoved, cvValue
 }
 
-func (rc *LRURevisionCache) peekCacheForKey(ctx context.Context, key string) (value *revCacheValue) {
+func (rc *LRURevisionCache) peekCacheForKey(ctx context.Context, key RevCacheKey) (value *revCacheValue) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	if elem := rc.cache[key]; elem != nil {
@@ -357,7 +357,7 @@ func (rc *LRURevisionCache) getValue(ctx context.Context, docID, revID string, c
 	if docID == "" || (revID == "" && cv == nil) {
 		return nil
 	}
-	var key string
+	var key RevCacheKey
 	if cv == nil {
 		key = CreateRevisionCacheRevIDKey(docID, revID, collectionID)
 	} else {
@@ -398,7 +398,7 @@ func (rc *LRURevisionCache) RemoveUsingRevID(ctx context.Context, docID, revID s
 	rc.removeFromRevCache(ctx, CreateRevisionCacheRevIDKey(docID, revID, collectionID))
 }
 
-func (rc *LRURevisionCache) removeFromRevCache(ctx context.Context, key string) {
+func (rc *LRURevisionCache) removeFromRevCache(ctx context.Context, key RevCacheKey) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	elem, ok := rc.cache[key]

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -84,7 +84,7 @@ func (sc *ShardedLRURevisionCache) Remove(ctx context.Context, docID, versionStr
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	backingStores        map[uint32]RevisionCacheBackingStore
-	cache                map[RevCacheKey]*list.Element
+	cache                map[revCacheKey]*list.Element
 	lruList              *list.List
 	cacheHits            *base.SgwIntStat
 	cacheMisses          *base.SgwIntStat
@@ -105,7 +105,7 @@ type revCacheValue struct {
 	attachments  AttachmentsMeta
 	delta        *RevisionDelta
 	id           string
-	itemKey      RevCacheKey
+	itemKey      revCacheKey
 	cv           Version
 	hlvHistory   string
 	revID        string
@@ -123,7 +123,7 @@ type revCacheValue struct {
 func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat *base.SgwIntStat, cacheMissStat *base.SgwIntStat, cacheNumItemsStat *base.SgwIntStat, revCacheMemoryStat *base.SgwIntStat) *LRURevisionCache {
 
 	return &LRURevisionCache{
-		cache:                map[RevCacheKey]*list.Element{},
+		cache:                map[revCacheKey]*list.Element{},
 		lruList:              list.New(),
 		capacity:             revCacheOptions.MaxItemCount,
 		backingStores:        backingStores,
@@ -140,7 +140,26 @@ func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores ma
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
 func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (DocumentRevision, error) {
-	return rc.getFromCache(ctx, docID, versionString, collectionID, true, includeDelta, loadBackup)
+	value := rc.getValue(ctx, docID, versionString, collectionID, true)
+	if value == nil {
+		return DocumentRevision{}, nil
+	}
+
+	docRev, cacheHit, err := value.load(ctx, rc.backingStores[collectionID], includeDelta, loadBackup)
+	rc.statsRecorderFunc(cacheHit)
+
+	if !cacheHit && err == nil {
+		// cache miss so we had to load doc, increment memory count
+		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
+		// check for memory based eviction
+		rc.revCacheMemoryBasedEviction(ctx)
+	}
+
+	if err != nil {
+		rc.removeValueForFailedLoad(value) // don't keep failed loads in the cache
+	}
+
+	return docRev, err
 }
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
@@ -170,29 +189,6 @@ func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string
 		// check for memory based eviction
 		rc.revCacheMemoryBasedEviction(ctx)
 	}
-}
-
-func (rc *LRURevisionCache) getFromCache(ctx context.Context, docID, docVersionString string, collectionID uint32, loadCacheOnMiss, includeDelta, loadBackup bool) (DocumentRevision, error) {
-	value := rc.getValue(ctx, docID, docVersionString, collectionID, loadCacheOnMiss)
-	if value == nil {
-		return DocumentRevision{}, nil
-	}
-
-	docRev, cacheHit, err := value.load(ctx, rc.backingStores[collectionID], includeDelta, loadBackup)
-	rc.statsRecorderFunc(cacheHit)
-
-	if !cacheHit && err == nil {
-		// cache miss so we had to load doc, increment memory count
-		rc.incrRevCacheMemoryUsage(ctx, value.getItemBytes())
-		// check for memory based eviction
-		rc.revCacheMemoryBasedEviction(ctx)
-	}
-
-	if err != nil {
-		rc.removeValue(value) // don't keep failed loads in the cache
-	}
-
-	return docRev, err
 }
 
 // Attempts to retrieve the active revision for a document from the cache.  Requires retrieval
@@ -228,7 +224,7 @@ func (rc *LRURevisionCache) GetActive(ctx context.Context, docID string, collect
 	}
 
 	if err != nil {
-		rc.removeValue(value) // don't keep failed loads in the cache
+		rc.removeValueForFailedLoad(value) // don't keep failed loads in the cache
 	}
 
 	return docRev, err
@@ -278,7 +274,7 @@ func (rc *LRURevisionCache) Upsert(ctx context.Context, docRev DocumentRevision,
 	rc.revCacheMemoryBasedEviction(ctx)
 }
 
-func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey RevCacheKey, docRev DocumentRevision, collectionID uint32) (int64, *revCacheValue) {
+func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey revCacheKey, docRev DocumentRevision, collectionID uint32) (int64, *revCacheValue) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 
@@ -314,7 +310,7 @@ func (rc *LRURevisionCache) upsertDocToCache(ctx context.Context, cvKey RevCache
 	return numItemsRemoved, cvValue
 }
 
-func (rc *LRURevisionCache) peekCacheForKey(ctx context.Context, key RevCacheKey) (value *revCacheValue) {
+func (rc *LRURevisionCache) peekCacheForKey(ctx context.Context, key revCacheKey) (value *revCacheValue) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	if elem := rc.cache[key]; elem != nil {
@@ -336,14 +332,10 @@ func (rc *LRURevisionCache) getValue(ctx context.Context, docID, docVersionStrin
 		value = elem.Value.(*revCacheValue)
 	} else if create {
 		value = &revCacheValue{id: docID, collectionID: collectionID, itemKey: key}
-		if base.IsRevTreeID(docVersionString) {
+		if currentVersion, parseErr := ParseVersion(docVersionString); parseErr != nil {
 			value.revID = docVersionString
 		} else {
-			cv, err := ParseVersion(docVersionString)
-			if err != nil {
-				return nil
-			}
-			value.cv = cv
+			value.cv = currentVersion
 		}
 		value.itemLoaded.Store(false)
 		rc.cache[key] = rc.lruList.PushFront(value)
@@ -362,10 +354,7 @@ func (rc *LRURevisionCache) getValue(ctx context.Context, docID, docVersionStrin
 
 // Remove removes a rev from revision cache lookup map, if present.
 func (rc *LRURevisionCache) Remove(ctx context.Context, docID, versionString string, collectionID uint32) {
-	rc.removeFromRevCache(ctx, CreateRevisionCacheKey(docID, versionString, collectionID))
-}
-
-func (rc *LRURevisionCache) removeFromRevCache(ctx context.Context, key RevCacheKey) {
+	key := CreateRevisionCacheKey(docID, versionString, collectionID)
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	elem, ok := rc.cache[key]
@@ -382,8 +371,9 @@ func (rc *LRURevisionCache) removeFromRevCache(ctx context.Context, key RevCache
 	delete(rc.cache, key)
 }
 
-// removeValue removes a value from the revision cache, if present and the value matches the the value. If there's an item in the revision cache with a matching docID and revID but the document is different, this item will not be removed from the rev cache.
-func (rc *LRURevisionCache) removeValue(value *revCacheValue) {
+// removeValueForFailedLoad removes a value from after a failed load. NOTE this mist only be called for failed load, rto remove an item from the rev cache you must call Remove.
+// No decrement of memory stats needed as failed loads don't increment memory stats.
+func (rc *LRURevisionCache) removeValueForFailedLoad(value *revCacheValue) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 	var itemRemoved bool

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1167,7 +1167,7 @@ func TestResetRevCache(t *testing.T) {
 	}
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
-			MaxBytes:      100,
+			MaxBytes:      90,
 			MaxItemCount:  10,
 			InsertOnWrite: true,
 		},

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -2690,3 +2690,48 @@ func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {
 		})
 	}
 }
+
+// TestMultipleRevCacheItemsForSameDocs:
+// - Tests fetching same doc by revID and CV will create separate entries for the same doc
+func TestMultipleRevCacheItemsForSameDocs(t *testing.T) {
+	if base.TestDisableRevCache() {
+		t.Skip("test requires rev cache enabled")
+	}
+
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	docID := SafeDocumentName(t, t.Name())
+	docID2 := SafeDocumentName(t, t.Name()+"_2")
+
+	_, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
+	require.NoError(t, err)
+
+	doc2Rev, doc2, err := collection.Put(ctx, docID2, Body{"foo": "bar"})
+	require.NoError(t, err)
+
+	// get active docID, get active uses revID so will populate rev cache with revID key
+	_, err = collection.getRev(ctx, docID, "", 0, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
+
+	// get by cv value
+	_, err = collection.getRev(ctx, docID, doc1.HLV.GetCurrentVersionString(), 0, nil)
+	require.NoError(t, err)
+	// asset that two items are in cache now (both for same docID)
+	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
+
+	// fetch docID2 by revID
+	_, err = collection.getRev(ctx, docID2, doc2Rev, 0, nil)
+	require.NoError(t, err)
+	// asset that three items are in cache now
+	assert.Equal(t, int64(3), db.DbStats.Cache().RevisionCacheNumItems.Value())
+
+	// fetch docID2 by CV
+	_, err = collection.getRev(ctx, docID2, doc2.HLV.GetCurrentVersionString(), 0, nil)
+	require.NoError(t, err)
+	// assert four items now in cache
+	assert.Equal(t, int64(4), db.DbStats.Cache().RevisionCacheNumItems.Value())
+}

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -129,151 +129,118 @@ func CreateTestSingleBackingStoreMap(backingStore RevisionCacheBackingStore, col
 
 // Tests the eviction from the LRURevisionCache
 func TestLRURevisionCacheEviction(t *testing.T) {
-	cacheHitCounter, cacheMissCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
-	backingStoreMap := CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID)
-	cacheOptions := &RevisionCacheOptions{
-		MaxItemCount: 10,
-		MaxBytes:     0,
+
+	testCases := []struct {
+		name     string
+		useCVKey bool
+	}{
+		{
+			name:     "revID key",
+			useCVKey: false,
+		},
+		{
+			name:     "cv key",
+			useCVKey: true,
+		},
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cacheHitCounter, cacheMissCounter, cacheNumItems, getDocumentCounter, getRevisionCounter, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+			backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
+			cacheOptions := &RevisionCacheOptions{
+				MaxItemCount: 10,
+				MaxBytes:     0,
+			}
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
 
-	ctx := base.TestCtx(t)
+			ctx := base.TestCtx(t)
 
-	// Fill up the rev cache with the first 10 docs
-	for docID := range 10 {
-		id := strconv.Itoa(docID)
-		vrs := uint64(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
+			keysAdded := make([]string, 0)
+
+			// Fill up the rev cache with the first 10 docs
+			for docID := range 10 {
+				id := strconv.Itoa(docID)
+				if testCase.useCVKey {
+					_, err := cache.GetUsingCV(ctx, id, &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+					require.NoError(t, err)
+					keysAdded = append(keysAdded, CreateRevisionCacheCVKey(id, &Version{Value: 123, SourceID: "test"}, testCollectionID))
+				} else {
+					_, err := cache.GetUsingRevID(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta)
+					require.NoError(t, err)
+					keysAdded = append(keysAdded, CreateRevisionCacheRevIDKey(id, "1-abc", testCollectionID))
+				}
+			}
+			assert.Equal(t, int64(10), cacheNumItems.Value())
+			assert.Equal(t, int64(1150), memoryBytesCounted.Value())
+			assert.Equal(t, 10, len(cache.cache))
+
+			// Get them back out
+			for i := range 10 {
+				var docRev DocumentRevision
+				var err error
+				docID := strconv.Itoa(i)
+				if testCase.useCVKey {
+					docRev, err = cache.GetUsingCV(ctx, docID, &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				} else {
+					docRev, err = cache.GetUsingRevID(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta)
+				}
+				assert.NoError(t, err)
+				assert.NotNil(t, docRev.BodyBytes, "nil body for %s", docID)
+				assert.Equal(t, docID, docRev.DocID)
+			}
+			assert.Equal(t, int64(10), cacheNumItems.Value())
+			assert.Equal(t, int64(1150), memoryBytesCounted.Value())
+			assert.Equal(t, 10, len(cache.cache))
+
+			// Add 3 more docs to the now full revcache
+			for i := 10; i < 13; i++ {
+				docID := strconv.Itoa(i)
+				if testCase.useCVKey {
+					_, err := cache.GetUsingCV(ctx, docID, &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+					require.NoError(t, err)
+				} else {
+					_, err := cache.GetUsingRevID(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta)
+					require.NoError(t, err)
+				}
+			}
+			assert.Equal(t, int64(10), cacheNumItems.Value())
+			assert.Equal(t, int64(1153), memoryBytesCounted.Value())
+			assert.Equal(t, 10, len(cache.cache))
+
+			// Check that the first 3 docs were evicted
+			prevCacheHitCount := cacheHitCounter.Value()
+			prevCacheMissCount := cacheMissCounter.Value()
+			for i := range 3 {
+				docID := strconv.Itoa(i)
+				docRev, ok := cache.Peek(ctx, docID, keysAdded[i], testCollectionID)
+				assert.False(t, ok)
+				assert.Nil(t, docRev.BodyBytes)
+				assert.Equal(t, prevCacheMissCount, cacheMissCounter.Value()) // peek incurs no cache miss if not found
+				assert.Equal(t, prevCacheHitCount, cacheHitCounter.Value())
+			}
+			assert.Equal(t, int64(10), cacheNumItems.Value())
+			assert.Equal(t, int64(1153), memoryBytesCounted.Value())
+			assert.Equal(t, 10, len(cache.cache))
+
+			// and check we can Get up to and including the last 3 we put in
+			for i := range 10 {
+				var docRev DocumentRevision
+				var err error
+				id := strconv.Itoa(i + 3)
+				if testCase.useCVKey {
+					docRev, err = cache.GetUsingCV(ctx, id, &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+					assert.NoError(t, err)
+				} else {
+					docRev, err = cache.GetUsingRevID(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta)
+					assert.NoError(t, err)
+				}
+				assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
+				assert.Equal(t, id, docRev.DocID)
+				assert.Equal(t, prevCacheMissCount, cacheMissCounter.Value())
+				assert.Equal(t, prevCacheHitCount+int64(i)+1, cacheHitCounter.Value())
+			}
+		})
 	}
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
-	assert.Equal(t, 10, len(cache.cache))
-	assert.Equal(t, 10, len(cache.hlvCache))
-
-	// Get them back out
-	for i := range 10 {
-		docID := strconv.Itoa(i)
-		docRev, err := cache.GetWithRev(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta)
-		assert.NoError(t, err)
-		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", docID)
-		assert.Equal(t, docID, docRev.DocID)
-		assert.Equal(t, int64(0), cacheMissCounter.Value())
-		assert.Equal(t, int64(i+1), cacheHitCounter.Value())
-	}
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
-	assert.Equal(t, 10, len(cache.cache))
-	assert.Equal(t, 10, len(cache.hlvCache))
-
-	// Add 3 more docs to the now full revcache
-	for i := 10; i < 13; i++ {
-		docID := strconv.Itoa(i)
-		vrs := uint64(i)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: docID, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	}
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
-	assert.Equal(t, 10, len(cache.cache))
-	assert.Equal(t, 10, len(cache.hlvCache))
-
-	// Check that the first 3 docs were evicted
-	prevCacheHitCount := cacheHitCounter.Value()
-	for i := range 3 {
-		docID := strconv.Itoa(i)
-		docRev, ok := cache.Peek(ctx, docID, "1-abc", testCollectionID)
-		assert.False(t, ok)
-		assert.Nil(t, docRev.BodyBytes)
-		assert.Equal(t, int64(0), cacheMissCounter.Value()) // peek incurs no cache miss if not found
-		assert.Equal(t, prevCacheHitCount, cacheHitCounter.Value())
-	}
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
-	assert.Equal(t, 10, len(cache.cache))
-	assert.Equal(t, 10, len(cache.hlvCache))
-
-	// and check we can Get up to and including the last 3 we put in
-	for i := range 10 {
-		id := strconv.Itoa(i + 3)
-		docRev, err := cache.GetWithRev(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta)
-		assert.NoError(t, err)
-		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
-		assert.Equal(t, id, docRev.DocID)
-		assert.Equal(t, int64(0), cacheMissCounter.Value())
-		assert.Equal(t, prevCacheHitCount+int64(i)+1, cacheHitCounter.Value())
-	}
-}
-
-// TestLRURevisionCacheEvictionMixedRevAndCV:
-//   - Add 10 docs to the cache
-//   - Assert that the cache list and relevant lookup maps have correct lengths
-//   - Add 3 more docs
-//   - Assert that lookup maps and the cache list still only have 10 elements in
-//   - Perform a Get with CV specified on all 10 elements in the cache and assert we get a hit for each element and no misses,
-//     testing the eviction worked correct
-//   - Then do the same but for rev lookup
-func TestLRURevisionCacheEvictionMixedRevAndCV(t *testing.T) {
-
-	cacheHitCounter, cacheMissCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
-	backingStoreMap := CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID)
-	cacheOptions := &RevisionCacheOptions{
-		MaxItemCount: 10,
-		MaxBytes:     0,
-	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
-
-	ctx := base.TestCtx(t)
-
-	// Fill up the rev cache with the first 10 docs
-	for docID := range 10 {
-		id := strconv.Itoa(docID)
-		vrs := uint64(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	}
-
-	// assert that the list has 10 elements along with both lookup maps
-	assert.Equal(t, 10, len(cache.hlvCache))
-	assert.Equal(t, 10, len(cache.cache))
-	assert.Equal(t, 10, cache.lruList.Len())
-
-	// Add 3 more docs to the now full rev cache to trigger eviction
-	for docID := 10; docID < 13; docID++ {
-		id := strconv.Itoa(docID)
-		vrs := uint64(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	}
-	// assert the cache and associated lookup maps only have 10 items in them (i.e.e is eviction working?)
-	assert.Equal(t, 10, len(cache.hlvCache))
-	assert.Equal(t, 10, len(cache.cache))
-	assert.Equal(t, 10, cache.lruList.Len())
-
-	// assert we can get a hit on all 10 elements in the cache by CV lookup
-	prevCacheHitCount := cacheHitCounter.Value()
-	for i := range 10 {
-		id := strconv.Itoa(i + 3)
-		vrs := uint64(i + 3)
-		cv := Version{Value: vrs, SourceID: "test"}
-		docRev, err := cache.GetWithCV(ctx, id, &cv, testCollectionID, RevCacheOmitDelta, false)
-
-		assert.NoError(t, err)
-		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
-		assert.Equal(t, id, docRev.DocID)
-		assert.Equal(t, int64(0), cacheMissCounter.Value())
-		assert.Equal(t, prevCacheHitCount+int64(i)+1, cacheHitCounter.Value())
-	}
-
-	// now do same but for rev lookup
-	prevCacheHitCount = cacheHitCounter.Value()
-	for i := range 10 {
-		id := strconv.Itoa(i + 3)
-		docRev, err := cache.GetWithRev(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta)
-		assert.NoError(t, err)
-		assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
-		assert.Equal(t, id, docRev.DocID)
-		assert.Equal(t, int64(0), cacheMissCounter.Value())
-		assert.Equal(t, prevCacheHitCount+int64(i)+1, cacheHitCounter.Value())
-	}
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
 }
 
 func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
@@ -281,25 +248,24 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 		t.Skip("Revision cache disabled, eviction test needs revision cache enabled")
 	}
 	testCases := []struct {
-		name       string
-		UseCVCache bool
+		name     string
+		UseCVKey bool
 	}{
 		{
-			name:       "Rev cache pathway",
-			UseCVCache: false,
+			name:     "Rev cache pathway",
+			UseCVKey: false,
 		},
 		{
-			name:       "CV cache pathway",
-			UseCVCache: true,
+			name:     "CV cache pathway",
+			UseCVKey: true,
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			dbcOptions := DatabaseContextOptions{
 				RevisionCacheOptions: &RevisionCacheOptions{
-					MaxBytes:      725,
-					MaxItemCount:  10,
-					InsertOnWrite: true, // for ease of testing, have insert on write enabled
+					MaxBytes:     725,
+					MaxItemCount: 10,
 				},
 			}
 			db, ctx := SetupTestDBWithOptions(t, dbcOptions)
@@ -312,26 +278,38 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 			}
 
 			var currMem, expValue, revZeroSize int64
-			var rev1Version *Version
+			var versions []*Version
 			for i := range 10 {
 				currMem = cacheStats.RevisionCacheTotalMemory.Value()
-				revSize, _, docVersion := createDocAndReturnSizeAndRev(t, ctx, fmt.Sprint(i), collection, smallBody)
+				revSize, _, docVersion := createDocAndReturnSizeAndRev(t, ctx, fmt.Sprint(i), collection, smallBody, testCase.UseCVKey)
 				if i == 0 {
 					revZeroSize = int64(revSize)
 				}
-				if i == 1 {
-					rev1Version = docVersion
-				}
+				versions = append(versions, docVersion)
 				expValue = currMem + int64(revSize)
 				assert.Equal(t, expValue, cacheStats.RevisionCacheTotalMemory.Value())
 			}
 
 			// test eviction by number of items (adding new doc from createDocAndReturnSizeAndRev shouldn't take memory over threshold defined as 730 bytes)
 			expValue -= revZeroSize // for doc being evicted
-			docSize, rev, _ := createDocAndReturnSizeAndRev(t, ctx, fmt.Sprint(11), collection, smallBody)
+			docSize, rev, docVersion := createDocAndReturnSizeAndRev(t, ctx, "11", collection, smallBody, testCase.UseCVKey)
+			// load into cache
+			if testCase.UseCVKey {
+				_, err := db.revisionCache.GetUsingCV(ctx, "11", docVersion, collection.GetCollectionID(), RevCacheOmitDelta, false)
+				require.NoError(t, err)
+			} else {
+				_, err := db.revisionCache.GetUsingRevID(ctx, "11", rev, collection.GetCollectionID(), RevCacheOmitDelta)
+				require.NoError(t, err)
+			}
 			expValue += int64(docSize)
 			// assert doc 0 been evicted
-			docRev, ok := db.revisionCache.Peek(ctx, "0", rev, collection.GetCollectionID())
+			var peekKey string
+			if testCase.UseCVKey {
+				peekKey = CreateRevisionCacheCVKey("0", versions[0], collection.GetCollectionID())
+			} else {
+				peekKey = CreateRevisionCacheRevIDKey("0", rev, collection.GetCollectionID())
+			}
+			docRev, ok := db.revisionCache.Peek(ctx, "0", peekKey, collection.GetCollectionID())
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -340,12 +318,14 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 			assert.Equal(t, expValue, currMem)
 
 			// remove doc "1" to give headroom for memory based eviction
-			if testCase.UseCVCache {
-				db.revisionCache.RemoveWithCV(ctx, "1", rev1Version, collection.GetCollectionID())
+			if testCase.UseCVKey {
+				db.revisionCache.RemoveUsingCV(ctx, "1", versions[1], collection.GetCollectionID())
+				peekKey = CreateRevisionCacheCVKey("1", versions[1], collection.GetCollectionID())
 			} else {
-				db.revisionCache.RemoveWithRev(ctx, "1", rev, collection.GetCollectionID())
+				db.revisionCache.RemoveUsingRevID(ctx, "1", rev, collection.GetCollectionID())
+				peekKey = CreateRevisionCacheRevIDKey("1", rev, collection.GetCollectionID())
 			}
-			docRev, ok = db.revisionCache.Peek(ctx, "1", rev, collection.GetCollectionID())
+			docRev, ok = db.revisionCache.Peek(ctx, "1", peekKey, collection.GetCollectionID())
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -363,12 +343,25 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 				"for":      "eviction",
 				"channels": "_default", // add channel for default sync func in default collection test runs
 			}
-			_, _, err := collection.Put(ctx, "12", largeBody)
+			revID, doc, err := collection.Put(ctx, "12", largeBody)
+			require.NoError(t, err)
+
+			// load into cache
+			if testCase.UseCVKey {
+				_, err = db.revisionCache.GetUsingCV(ctx, "12", doc.HLV.ExtractCurrentVersionFromHLV(), collection.GetCollectionID(), RevCacheOmitDelta, false)
+			} else {
+				_, err = db.revisionCache.GetUsingRevID(ctx, "12", revID, collection.GetCollectionID(), RevCacheOmitDelta)
+			}
 			require.NoError(t, err)
 
 			// assert doc "2" has been evicted even though we only have 9 items in cache with capacity of 10, so memory based
 			// eviction took place
-			docRev, ok = db.revisionCache.Peek(ctx, "2", rev, collection.GetCollectionID())
+			if testCase.UseCVKey {
+				peekKey = CreateRevisionCacheCVKey("2", versions[2], collection.GetCollectionID())
+			} else {
+				peekKey = CreateRevisionCacheRevIDKey("2", rev, collection.GetCollectionID())
+			}
+			docRev, ok = db.revisionCache.Peek(ctx, "2", peekKey, collection.GetCollectionID())
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -408,10 +401,10 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.GetUsingCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc1", docRev.DocID)
@@ -435,10 +428,10 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 
 			// test fail load event doesn't increment memory stat
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.GetUsingCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				assertHTTPError(t, err, 404)
 			} else {
-				docRev, err = cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetUsingRevID(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta)
 				assertHTTPError(t, err, 404)
 			}
 			assert.Nil(t, docRev.BodyBytes)
@@ -450,10 +443,10 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			memStatBeforeThirdLoad := memoryBytesCounted.Value()
 			// test another load from bucket but doing so should trigger memory based eviction
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.GetUsingCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetWithRev(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetUsingRevID(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc3", docRev.DocID)
@@ -464,7 +457,13 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			assert.Equal(t, 2, cache.lruList.Len())
 			memStatAfterEviction := (memStatBeforeThirdLoad + docRev.MemoryBytes) - currMemStat
 			assert.Equal(t, memStatAfterEviction, memoryBytesCounted.Value())
-			_, ok := cache.Peek(ctx, "doc1", "1-abc", testCollectionID)
+			var peekKey string
+			if testCase.UseCVCache {
+				peekKey = CreateRevisionCacheCVKey("doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID)
+			} else {
+				peekKey = CreateRevisionCacheRevIDKey("doc1", "1-abc", testCollectionID)
+			}
+			_, ok := cache.Peek(ctx, "doc1", peekKey, testCollectionID)
 			assert.False(t, ok)
 		})
 	}
@@ -481,7 +480,7 @@ func TestBackingStore(t *testing.T) {
 	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	docRev, err := cache.GetWithRev(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
+	docRev, err := cache.GetUsingRevID(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -492,7 +491,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	docRev, err = cache.GetWithRev(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.GetUsingRevID(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -501,7 +500,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev is already resident, but still issue GetDocument to check for later revisions
-	docRev, err = cache.GetWithRev(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.GetUsingRevID(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -512,7 +511,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.GetWithRev(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.GetUsingRevID(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -538,7 +537,7 @@ func TestBackingStoreCV(t *testing.T) {
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
 	cv := Version{SourceID: "test", Value: 123}
-	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err := cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
@@ -550,7 +549,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Perform a get on the same doc as above, check that we get cache hit
-	docRev, err = cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
@@ -562,7 +561,7 @@ func TestBackingStoreCV(t *testing.T) {
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
 	cv = Version{SourceID: "test11", Value: 100}
-	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.GetUsingCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta, false)
 
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -572,7 +571,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.GetWithCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.GetUsingCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta, false)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -604,6 +603,10 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 	if ok {
 		t.Error("_revisions property still present in document retrieved directly from bucket.")
 	}
+
+	// fetch doc as it won't be resident in cache after Put
+	_, err = collection.getRev(ctx, "doc1", rev1id, 0, nil)
+	require.NoError(t, err)
 
 	// Get the doc while still resident in the rev cache w/ history=false, validate _revisions property isn't found
 	body, err := collection.Get1xRevBody(ctx, "doc1", rev1id, false, nil)
@@ -661,15 +664,15 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.False(t, ok)
 
 	// Get non-existing doc
-	_, err = rc.GetWithRev(base.TestCtx(t), "invalid", rev1, testCollectionID, RevCacheOmitDelta)
+	_, err = rc.GetUsingRevID(base.TestCtx(t), "invalid", rev1, testCollectionID, RevCacheOmitDelta)
 	assert.True(t, base.IsDocNotFoundError(err))
 
 	// Get non-existing revision
-	_, err = rc.GetWithRev(base.TestCtx(t), key, "3-abc", testCollectionID, RevCacheOmitDelta)
+	_, err = rc.GetUsingRevID(base.TestCtx(t), key, "3-abc", testCollectionID, RevCacheOmitDelta)
 	assertHTTPError(t, err, 404)
 
 	// Get specific revision
-	doc, err := rc.GetWithRev(base.TestCtx(t), key, rev1, testCollectionID, RevCacheOmitDelta)
+	doc, err := rc.GetUsingRevID(base.TestCtx(t), key, rev1, testCollectionID, RevCacheOmitDelta)
 	assert.NoError(t, err)
 	require.NotNil(t, doc)
 	assert.Equal(t, `{"value":1234}`, string(doc.BodyBytes))
@@ -722,7 +725,8 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)
 
 	// Get the raw document directly from the revcache, validate _attachments property isn't found
-	docRevision, ok := collection.revisionCache.Peek(ctx, rev1key, rev1id)
+	peekKey := CreateRevisionCacheRevIDKey(rev1key, rev1id, collection.GetCollectionID())
+	docRevision, ok := collection.revisionCache.Peek(ctx, rev1key, peekKey)
 	assert.True(t, ok)
 	assert.NotContains(t, docRevision.BodyBytes, BodyAttachments, "_attachments property still present in document body retrieved from rev cache: %#v", bucketBody)
 	_, ok = docRevision.Attachments["myatt"]
@@ -754,6 +758,9 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 	rev1id, _, err := collection.Put(ctx, docKey, rev1body)
 	assert.NoError(t, err, "Unexpected error calling collection.Put")
 
+	_, err = collection.getRev(ctx, docKey, rev1id, 0, nil) // preload rev cache
+	require.NoError(t, err)
+
 	rev2id := "2-xxx"
 	rev2body := Body{
 		"value":         1235,
@@ -770,7 +777,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)
 
 	// Get the raw document directly from the revcache, validate _attachments property isn't found
-	docRevision, err := collection.revisionCache.GetWithRev(base.TestCtx(t), docKey, rev2id, RevCacheOmitDelta)
+	docRevision, err := collection.revisionCache.GetUsingRevID(base.TestCtx(t), docKey, rev2id, RevCacheOmitDelta)
 	assert.NoError(t, err, "Unexpected error calling collection.revisionCache.Get")
 	assert.NotContains(t, docRevision.BodyBytes, BodyAttachments, "_attachments property still present in document body retrieved from rev cache: %#v", bucketBody)
 	_, ok = docRevision.Attachments["myatt"]
@@ -802,12 +809,12 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	secondDelta := []byte("modified delta")
 
 	// Trigger load into cache
-	_, err := cache.GetWithRev(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	_, err := cache.GetUsingRevID(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error adding to cache")
 	cache.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevisionDelta{ToRevID: "rev2", DeltaBytes: firstDelta})
 
 	// Retrieve from cache
-	retrievedRev, err := cache.GetWithRev(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	retrievedRev, err := cache.GetUsingRevID(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
@@ -818,7 +825,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Retrieve again, validate delta is correct
-	updatedRev, err := cache.GetWithRev(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	updatedRev, err := cache.GetUsingRevID(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev3", updatedRev.Delta.ToRevID)
 	assert.Equal(t, secondDelta, updatedRev.Delta.DeltaBytes)
@@ -830,16 +837,16 @@ func TestRevisionImmutableDelta(t *testing.T) {
 
 func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 	testCases := []struct {
-		name       string
-		UseCVCache bool
+		name     string
+		useCVKey bool
 	}{
 		{
-			name:       "Rev cache pathway",
-			UseCVCache: false,
+			name:     "revID key",
+			useCVKey: false,
 		},
 		{
-			name:       "CV cache pathway",
-			UseCVCache: true,
+			name:     "cv key",
+			useCVKey: true,
 		},
 	}
 	for _, testCase := range testCases {
@@ -858,12 +865,23 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 			ctx := base.TestCtx(t)
 
 			// Trigger load into cache
-			docRev, err := cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
-			assert.NoError(t, err, "Error adding to cache")
+			var docRev DocumentRevision
+			var err error
+			if testCase.useCVKey {
+				docRev, err = cache.GetUsingCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				require.NoError(t, err, "Error adding to cache")
+			} else {
+				docRev, err = cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+				require.NoError(t, err, "Error adding to cache")
+			}
 
 			revCacheMem := memoryBytesCounted.Value()
 			revCacheDelta := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
-			cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+			if testCase.useCVKey {
+				cache.UpdateDeltaCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, revCacheDelta)
+			} else {
+				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+			}
 			// assert that rev cache memory increases by expected amount
 			newMem := revCacheMem + revCacheDelta.totalDeltaBytes
 			assert.Equal(t, newMem, memoryBytesCounted.Value())
@@ -871,14 +889,22 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 
 			newMem = memoryBytesCounted.Value()
 			revCacheDelta = newRevCacheDelta(secondDelta, "1-abc", docRev, false, nil)
-			cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+			if testCase.useCVKey {
+				cache.UpdateDeltaCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, revCacheDelta)
+			} else {
+				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+			}
 
 			// assert the overall memory stat is correctly updated (by the diff between the old delta and the new delta)
 			newMem += revCacheDelta.totalDeltaBytes - oldDeltaSize
 			assert.Equal(t, newMem, memoryBytesCounted.Value())
 
 			revCacheDelta = newRevCacheDelta(thirdDelta, "1-abc", docRev, false, nil)
-			cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+			if testCase.useCVKey {
+				cache.UpdateDeltaCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, revCacheDelta)
+			} else {
+				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+			}
 
 			// assert that eviction took place and as result stat is now 0 (only item in cache was doc1)
 			assert.Equal(t, int64(0), memoryBytesCounted.Value())
@@ -920,16 +946,24 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 
 			cache.Upsert(ctx, DocumentRevision{BodyBytes: []byte(`{"some":"test"}`), DocID: "doc2", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 
+			if !testCase.UseCVCache {
+				// fetch each doc added to load into cache
+				_, err = cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
+				require.NoError(t, err)
+				_, err = cache.GetUsingRevID(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta)
+				require.NoError(t, err)
+			}
+
 			assert.Equal(t, int64(0), memoryBytesCounted.Value())
 			assert.Equal(t, int64(0), cacheNumItems.Value())
 
 			// assert we can still fetch this upsert doc
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.GetUsingCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, false)
+				docRev, err = cache.GetUsingRevID(ctx, "doc2", "1-abc", testCollectionID, false)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc2", docRev.DocID)
@@ -939,10 +973,10 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			assert.Equal(t, int64(0), cacheNumItems.Value())
 
 			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.GetUsingCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -971,9 +1005,10 @@ func TestShardedMemoryEviction(t *testing.T) {
 	}
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
-			MaxBytes:     160,
-			MaxItemCount: 10,
-			ShardCount:   2,
+			MaxBytes:      160,
+			MaxItemCount:  10,
+			ShardCount:    2,
+			InsertOnWrite: true,
 		},
 	}
 	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
@@ -986,7 +1021,7 @@ func TestShardedMemoryEviction(t *testing.T) {
 	}
 
 	// add doc that will be added to one shard
-	size, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc1", collection, docBody)
+	size, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc1", collection, docBody, false)
 	assert.Equal(t, int64(size), cacheStats.RevisionCacheTotalMemory.Value())
 	// grab this particular shard + assert that the shard memory usage is as expected
 	shardedCache := db.revisionCache.(*ShardedLRURevisionCache)
@@ -994,7 +1029,7 @@ func TestShardedMemoryEviction(t *testing.T) {
 	assert.Equal(t, int64(size), doc1Shard.currMemoryUsage.Value())
 
 	// add new doc in diff shard + assert that the shard memory usage is as expected
-	size, _, _ = createDocAndReturnSizeAndRev(t, ctx, "doc2", collection, docBody)
+	size, _, _ = createDocAndReturnSizeAndRev(t, ctx, "doc2", collection, docBody, false)
 	doc2Shard := shardedCache.getShard("doc2")
 	assert.Equal(t, int64(size), doc2Shard.currMemoryUsage.Value())
 	// overall mem usage should be combination oif the two added docs
@@ -1008,7 +1043,7 @@ func TestShardedMemoryEviction(t *testing.T) {
 		"some":     "field",
 	}
 	// add new doc to trigger eviction and assert stats are as expected
-	newDocSize, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc3", collection, docBody)
+	newDocSize, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc3", collection, docBody, false)
 	doc3Shard := shardedCache.getShard("doc3")
 	assert.Equal(t, int64(newDocSize), doc3Shard.currMemoryUsage.Value())
 	assert.Equal(t, int64(2), cacheStats.RevisionCacheNumItems.Value())
@@ -1024,9 +1059,10 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 	}
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
-			MaxBytes:     100,
-			MaxItemCount: 10,
-			ShardCount:   2,
+			MaxBytes:      100,
+			MaxItemCount:  10,
+			ShardCount:    2,
+			InsertOnWrite: true,
 		},
 	}
 	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
@@ -1063,16 +1099,16 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 
 func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 	testCases := []struct {
-		name       string
-		UseCVCache bool
+		name     string
+		useCVKey bool
 	}{
 		{
-			name:       "Rev cache pathway",
-			UseCVCache: false,
+			name:     "revID key",
+			useCVKey: false,
 		},
 		{
-			name:       "CV cache pathway",
-			UseCVCache: true,
+			name:     "cv key",
+			useCVKey: true,
 		},
 	}
 	for _, testCase := range testCases {
@@ -1080,8 +1116,9 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 			cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 			backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
 			cacheOptions := &RevisionCacheOptions{
-				MaxItemCount: 1,
-				MaxBytes:     0, // turn off memory based eviction
+				MaxItemCount:  1,
+				MaxBytes:      0, // turn off memory based eviction
+				InsertOnWrite: true,
 			}
 			ctx := base.TestCtx(t)
 			var err error
@@ -1102,11 +1139,11 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 			assert.Equal(t, int64(1), cacheNumItems.Value())
 
 			var docRev DocumentRevision
-			if testCase.UseCVCache {
-				docRev, err = cache.GetWithCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+			if testCase.useCVKey {
+				docRev, err = cache.GetUsingCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetWithRev(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.GetUsingRevID(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1130,8 +1167,9 @@ func TestResetRevCache(t *testing.T) {
 	}
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
-			MaxBytes:     100,
-			MaxItemCount: 10,
+			MaxBytes:      100,
+			MaxItemCount:  10,
+			InsertOnWrite: true,
 		},
 	}
 	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
@@ -1140,7 +1178,7 @@ func TestResetRevCache(t *testing.T) {
 	cacheStats := db.DbStats.Cache()
 
 	// add a doc
-	docSize, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc1", collection, Body{"test": "doc"})
+	docSize, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc1", collection, Body{"test": "doc"}, false)
 	assert.Equal(t, int64(docSize), cacheStats.RevisionCacheTotalMemory.Value())
 	assert.Equal(t, int64(1), cacheStats.RevisionCacheNumItems.Value())
 
@@ -1185,16 +1223,16 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			var err error
 
 			// Test Put on new doc
-			docSize, revID, docCV := createDocAndReturnSizeAndRev(t, ctx, "doc1", collection, Body{"test": "doc"})
+			docSize, revID, docCV := createDocAndReturnSizeAndRev(t, ctx, "doc1", collection, Body{"test": "doc"}, testCase.UseCVCache)
 			assert.Equal(t, int64(docSize), cacheStats.RevisionCacheTotalMemory.Value())
 
 			// Test Get with item in the cache
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.GetWithCV(ctx, "doc1", docCV, collctionID, false, false)
+				docRev, err = db.revisionCache.GetUsingCV(ctx, "doc1", docCV, collctionID, false, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = db.revisionCache.GetWithRev(ctx, "doc1", revID, collctionID, RevCacheOmitDelta)
+				docRev, err = db.revisionCache.GetUsingRevID(ctx, "doc1", revID, collctionID, RevCacheOmitDelta)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1202,15 +1240,25 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			revIDDoc1 := docRev.RevID
 			cvDoc1 := docRev.CV
 
+			// get again and ensure memory stat doesn't change
+			if testCase.UseCVCache {
+				docRev, err = db.revisionCache.GetUsingCV(ctx, "doc1", docCV, collctionID, false, false)
+				require.NoError(t, err)
+			} else {
+				docRev, err = db.revisionCache.GetUsingRevID(ctx, "doc1", revID, collctionID, RevCacheOmitDelta)
+				require.NoError(t, err)
+			}
+			assert.Equal(t, int64(docSize), cacheStats.RevisionCacheTotalMemory.Value())
+
 			// Test Get operation with load from bucket, need to first create and remove from rev cache
 			prevMemStat := cacheStats.RevisionCacheTotalMemory.Value()
 			revDoc2 := createThenRemoveFromRevCache(t, ctx, "doc2", db, collection)
 			// load from doc from bucket
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.GetWithCV(ctx, "doc2", &revDoc2.CV, collctionID, false, false)
+				docRev, err = db.revisionCache.GetUsingCV(ctx, "doc2", &revDoc2.CV, collctionID, false, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = db.revisionCache.GetWithRev(ctx, "doc2", docRev.RevID, collctionID, RevCacheOmitDelta)
+				docRev, err = db.revisionCache.GetUsingRevID(ctx, "doc2", docRev.RevID, collctionID, RevCacheOmitDelta)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1221,8 +1269,17 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
 			docRev, err = db.revisionCache.GetActive(ctx, "doc2", collctionID)
 			require.NoError(t, err)
-			assert.Equal(t, "doc2", docRev.DocID)
-			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
+			var doc2RevID string
+			if testCase.UseCVCache {
+				// GetActive loads by revID and will key by revID as result
+				docRev.CalculateBytes()
+				assert.Equal(t, "doc2", docRev.DocID)
+				assert.Equal(t, prevMemStat+docRev.MemoryBytes, cacheStats.RevisionCacheTotalMemory.Value())
+				doc2RevID = docRev.RevID
+			} else {
+				assert.Equal(t, "doc2", docRev.DocID)
+				assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
+			}
 
 			// Test Get active with item to be loaded from bucket, need to first create and remove from rev cache
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
@@ -1231,74 +1288,61 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "doc3", docRev.DocID)
 			assert.Greater(t, cacheStats.RevisionCacheTotalMemory.Value(), prevMemStat)
+			var doc3RevID string
+			if testCase.UseCVCache {
+				doc3RevID = docRev.RevID
+			}
 
 			// Test Peek at item not in cache, assert stats unchanged
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
-			docRev, ok := db.revisionCache.Peek(ctx, "doc4", "1-abc", collctionID)
+			var peekKey string
+			if testCase.UseCVCache {
+				peekKey = CreateRevisionCacheCVKey("doc4", &Version{SourceID: "test", Value: 123}, collctionID)
+			} else {
+				peekKey = CreateRevisionCacheRevIDKey("doc4", "1-abc", collctionID)
+			}
+			docRev, ok := db.revisionCache.Peek(ctx, "doc4", peekKey, collctionID)
 			require.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
 
 			// Test Peek in cache, assert stat unchanged
-			docRev, ok = db.revisionCache.Peek(ctx, "doc3", revDoc3.RevTreeID, collctionID)
-			require.True(t, ok)
-			assert.Equal(t, "doc3", docRev.DocID)
-			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
-
-			// Test Upsert with item in cache + assert stat is expected
-			docRev.CalculateBytes()
-			doc3Size := docRev.MemoryBytes
-			expMem := cacheStats.RevisionCacheTotalMemory.Value() - doc3Size
-			newDocRev := documentRevisionForCacheTestUpdate("doc3", `"some": "body"`, revDoc3)
-
-			expMem = expMem + 14 // size for above doc rev
-			db.revisionCache.Upsert(ctx, newDocRev, collctionID)
-			assert.Equal(t, expMem, cacheStats.RevisionCacheTotalMemory.Value())
-
-			// Test Upsert with item not in cache, assert stat is as expected
-			newDocRev = documentRevisionForCacheTest("doc5", `"some": "body"`)
-			expMem = cacheStats.RevisionCacheTotalMemory.Value() + 14 // size for above doc rev
-			db.revisionCache.Upsert(ctx, newDocRev, collctionID)
-			assert.Equal(t, expMem, cacheStats.RevisionCacheTotalMemory.Value())
-
-			// Test Remove with something in cache, assert stat decrements by expected value
 			if testCase.UseCVCache {
-				db.revisionCache.RemoveWithCV(ctx, "doc5", newDocRev.CV, collctionID)
+				peekKey = CreateRevisionCacheCVKey("doc3", &revDoc3.CV, collctionID)
 			} else {
-				db.revisionCache.RemoveWithRev(ctx, "doc5", "1-abc", collctionID)
+				peekKey = CreateRevisionCacheRevIDKey("doc3", revDoc3.RevTreeID, collctionID)
 			}
-			expMem -= 14
-			assert.Equal(t, expMem, cacheStats.RevisionCacheTotalMemory.Value())
+			docRev, ok = db.revisionCache.Peek(ctx, "doc3", peekKey, collctionID)
+			if testCase.UseCVCache {
+				require.False(t, ok)
+			} else {
+				require.True(t, ok)
+				assert.Equal(t, "doc3", docRev.DocID)
+			}
+			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
 
 			// Test Remove with item not in cache, assert stat is unchanged
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
 			if testCase.UseCVCache {
 				cv := Version{SourceID: "test", Value: 123}
-				db.revisionCache.RemoveWithCV(ctx, "doc6", &cv, collctionID)
+				db.revisionCache.RemoveUsingCV(ctx, "doc6", &cv, collctionID)
 			} else {
-				db.revisionCache.RemoveWithRev(ctx, "doc6", "1-abc", collctionID)
+				db.revisionCache.RemoveUsingRevID(ctx, "doc6", "1-abc", collctionID)
 			}
 			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
 
-			// Test Update Delta, assert stat increases as expected
-			revDelta := newRevCacheDelta([]byte(`"rev":"delta"`), "1-abc", newDocRev, false, nil)
-			expMem = prevMemStat + revDelta.totalDeltaBytes
-			if testCase.UseCVCache {
-				db.revisionCache.UpdateDeltaCV(ctx, "doc3", &revDoc3.CV, collctionID, revDelta)
-			} else {
-				db.revisionCache.UpdateDelta(ctx, "doc3", revDoc3.RevTreeID, collctionID, revDelta)
-			}
-			assert.Equal(t, expMem, cacheStats.RevisionCacheTotalMemory.Value())
-
 			// Empty cache and see memory stat is 0
 			if testCase.UseCVCache {
-				db.revisionCache.RemoveWithCV(ctx, "doc3", &revDoc3.CV, collctionID)
-				db.revisionCache.RemoveWithCV(ctx, "doc2", &revDoc2.CV, collctionID)
-				db.revisionCache.RemoveWithCV(ctx, "doc1", cvDoc1, collctionID)
+				db.revisionCache.RemoveUsingCV(ctx, "doc3", &revDoc3.CV, collctionID)
+				db.revisionCache.RemoveUsingCV(ctx, "doc2", &revDoc2.CV, collctionID)
+				db.revisionCache.RemoveUsingCV(ctx, "doc1", cvDoc1, collctionID)
+				// remove items added by GetActive calls
+				db.revisionCache.RemoveUsingRevID(ctx, "doc3", doc3RevID, collctionID)
+				db.revisionCache.RemoveUsingRevID(ctx, "doc2", doc2RevID, collctionID)
 			} else {
-				db.revisionCache.RemoveWithRev(ctx, "doc3", revDoc3.RevTreeID, collctionID)
-				db.revisionCache.RemoveWithRev(ctx, "doc2", revDoc2.RevTreeID, collctionID)
-				db.revisionCache.RemoveWithRev(ctx, "doc1", revIDDoc1, collctionID)
+				db.revisionCache.RemoveUsingRevID(ctx, "doc3", revDoc3.RevTreeID, collctionID)
+				db.revisionCache.RemoveUsingRevID(ctx, "doc2", revDoc2.RevTreeID, collctionID)
+				db.revisionCache.RemoveUsingRevID(ctx, "doc1", revIDDoc1, collctionID)
 			}
 
 			assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
@@ -1313,13 +1357,14 @@ func TestSingleLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
 	cacheOptions := &RevisionCacheOptions{
-		MaxItemCount: 10,
-		MaxBytes:     0,
+		MaxItemCount:  10,
+		MaxBytes:      0,
+		InsertOnWrite: true,
 	}
 	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	_, err := cache.GetWithRev(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
+	_, err := cache.GetUsingRevID(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
 
 	assert.NoError(t, err)
 }
@@ -1329,8 +1374,9 @@ func TestConcurrentLoad(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
 	cacheOptions := &RevisionCacheOptions{
-		MaxItemCount: 10,
-		MaxBytes:     0,
+		MaxItemCount:  10,
+		MaxBytes:      0,
+		InsertOnWrite: true,
 	}
 	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
 
@@ -1341,7 +1387,7 @@ func TestConcurrentLoad(t *testing.T) {
 	wg.Add(20)
 	for range 20 {
 		go func() {
-			_, err := cache.GetWithRev(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
+			_, err := cache.GetUsingRevID(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -1362,14 +1408,14 @@ func TestRevisionCacheRemove(t *testing.T) {
 	rev1id, _, err := collection.Put(ctx, "doc", Body{"val": 123})
 	assert.NoError(t, err)
 
-	docRev, err := collection.revisionCache.GetWithRev(base.TestCtx(t), "doc", rev1id, true)
+	docRev, err := collection.revisionCache.GetUsingRevID(base.TestCtx(t), "doc", rev1id, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 
-	collection.revisionCache.RemoveWithRev(ctx, "doc", rev1id)
+	collection.revisionCache.RemoveUsingRevID(ctx, "doc", rev1id)
 
-	docRev, err = collection.revisionCache.GetWithRev(base.TestCtx(t), "doc", rev1id, true)
+	docRev, err = collection.revisionCache.GetUsingRevID(base.TestCtx(t), "doc", rev1id, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
@@ -1463,7 +1509,9 @@ func TestRevCacheHitMultiCollection(t *testing.T) {
 //   - Perform Get on that second doc to trigger load from the bucket, assert doc is as expected
 func TestRevCacheHitMultiCollectionLoadFromBucket(t *testing.T) {
 
-	t.Skip("Pending CBG-4164")
+	if base.TestDisableRevCache() {
+		t.Skip("test requires use of revision cache")
+	}
 	base.TestRequiresCollections(t)
 
 	tb := base.GetTestBucket(t)
@@ -1520,140 +1568,130 @@ func TestRevCacheHitMultiCollectionLoadFromBucket(t *testing.T) {
 func TestRevCacheCapacityStat(t *testing.T) {
 	testCases := []struct {
 		name       string
-		UseCVCache bool
+		useCVCache bool
 	}{
-		{
-			name:       "Rev cache pathway",
-			UseCVCache: false,
-		},
-		{
-			name:       "CV cache pathway",
-			UseCVCache: true,
-		},
+		{name: "revID key", useCVCache: false},
+		{name: "cv key", useCVCache: true},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, cacheMemoryStat := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
-			backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"badDoc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
-			cacheOptions := &RevisionCacheOptions{
-				MaxItemCount: 4,
-				MaxBytes:     0,
-			}
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &cacheMemoryStat)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+			cacheNumItems, cacheMemoryStat := base.SgwIntStat{}, base.SgwIntStat{}
+			backingStoreMap := CreateTestSingleBackingStoreMap(
+				&testBackingStore{[]string{"badDoc"}, &getDocumentCounter, &getRevisionCounter},
+				testCollectionID,
+			)
+			cache := NewLRURevisionCache(
+				&RevisionCacheOptions{MaxItemCount: 5, MaxBytes: 0},
+				backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &cacheMemoryStat,
+			)
 			ctx := base.TestCtx(t)
-			var err error
+			cv := &Version{SourceID: "test", Value: 123}
+			const revID = "1-abc"
 
-			assert.Equal(t, int64(0), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
-
-			// Create a new doc + asert num items increments
-			cache.Put(ctx, documentRevisionForCacheTest("doc1", `{"test":"1234"}`), testCollectionID)
-			assert.Equal(t, int64(1), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
-
-			// test not found doc, assert that the stat isn't incremented
-			if testCase.UseCVCache {
-				cv := Version{SourceID: "test", Value: 123}
-				_, err = cache.GetWithCV(ctx, "badDoc", &cv, testCollectionID, false, false)
-				require.Error(t, err)
-			} else {
-				_, err = cache.GetWithRev(ctx, "badDoc", "1-abc", testCollectionID, false)
-				require.Error(t, err)
+			// assertItems checks both the stat and the underlying map stay consistent.
+			assertItems := func(expected int64) {
+				t.Helper()
+				assert.Equal(t, expected, cacheNumItems.Value())
+				assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
 			}
-			assert.Equal(t, int64(1), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
 
-			// Get on a doc that doesn't exist in cache, assert num items increments
-			var docRev DocumentRevision
-			if testCase.UseCVCache {
-				cv := Version{SourceID: "test", Value: 123}
-				docRev, err = cache.GetWithCV(ctx, "doc2", &cv, testCollectionID, false, false)
-				require.NoError(t, err)
-			} else {
-				docRev, err = cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, false)
-				require.NoError(t, err)
+			// getDoc abstracts over the two lookup pathways under test.
+			getDoc := func(docID string) (DocumentRevision, error) {
+				if tc.useCVCache {
+					return cache.GetUsingCV(ctx, docID, cv, testCollectionID, RevCacheOmitDelta, false)
+				}
+				return cache.GetUsingRevID(ctx, docID, revID, testCollectionID, RevCacheOmitDelta)
 			}
+
+			// removeDoc removes an entry using the key type appropriate to the pathway under test.
+			removeDoc := func(docID string) {
+				if tc.useCVCache {
+					cache.RemoveUsingCV(ctx, docID, cv, testCollectionID)
+				} else {
+					cache.RemoveUsingRevID(ctx, docID, revID, testCollectionID)
+				}
+			}
+
+			assertItems(0)
+
+			// Put adds a CV-keyed entry.
+			cache.Put(ctx, documentRevisionForCacheTest("doc1", `{"test":"1"}`), testCollectionID)
+			assertItems(1)
+
+			// A failed load does not leave a stale entry in the cache.
+			_, err := getDoc("badDoc")
+			require.Error(t, err)
+			assertItems(1)
+
+			// Cache miss: entry is loaded from the backing store and added to the cache.
+			docRev, err := getDoc("doc2")
+			require.NoError(t, err)
 			assert.Equal(t, "doc2", docRev.DocID)
-			assert.Equal(t, int64(2), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+			assertItems(2)
 
-			// Get on item in cache, assert num items remains the same
-			if testCase.UseCVCache {
-				cv := Version{SourceID: "test", Value: 123}
-				docRev, err = cache.GetWithCV(ctx, "doc1", &cv, testCollectionID, false, false)
-				require.NoError(t, err)
-			} else {
-				docRev, err = cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, false)
-				require.NoError(t, err)
-			}
-			assert.Equal(t, "doc1", docRev.DocID)
-			assert.Equal(t, int64(2), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+			// Cache hit: count is unchanged.
+			docRev, err = getDoc("doc2")
+			require.NoError(t, err)
+			assert.Equal(t, "doc2", docRev.DocID)
+			assertItems(2)
 
-			// Get Active on doc not in cache, assert num items increments
+			// GetActive cache miss: loads from backing store via a revID key.
 			docRev, err = cache.GetActive(ctx, "doc3", testCollectionID)
 			require.NoError(t, err)
 			assert.Equal(t, "doc3", docRev.DocID)
-			assert.Equal(t, int64(3), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+			assertItems(3)
 
-			// Get Active on doc in the cache, assert that the num items stat remains unchanged
-			docRev, err = cache.GetActive(ctx, "doc1", testCollectionID)
+			// GetActive cache hit: count is unchanged.
+			docRev, err = cache.GetActive(ctx, "doc3", testCollectionID)
 			require.NoError(t, err)
-			assert.Equal(t, "doc1", docRev.DocID)
-			assert.Equal(t, int64(3), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+			assert.Equal(t, "doc3", docRev.DocID)
+			assertItems(3)
 
-			// Upsert a doc resident in cache, assert stat is unchanged
-			cache.Upsert(ctx, documentRevisionForCacheTest("doc1", `{"test":"12345"}`), testCollectionID)
-			assert.Equal(t, int64(3), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+			// Upsert on an existing doc replaces its entry without incrementing the count.
+			cache.Upsert(ctx, documentRevisionForCacheTest("doc1", `{"test":"updated"}`), testCollectionID)
+			assertItems(3)
 
-			// Upsert new doc, assert the num items stat increments
-			cache.Upsert(ctx, documentRevisionForCacheTest("doc4", `{"test":"1234}`), testCollectionID)
-			assert.Equal(t, int64(4), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+			// Upsert on a new doc increments the count.
+			cache.Upsert(ctx, documentRevisionForCacheTest("doc4", `{"test":"4"}`), testCollectionID)
+			assertItems(4)
 
-			// Peek a doc that is resident in cache, assert stat is unchanged
-			docRev, ok := cache.Peek(ctx, "doc4", "1-abc", testCollectionID)
-			require.True(t, ok)
-			assert.Equal(t, "doc4", docRev.DocID)
-			assert.Equal(t, int64(4), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
-
-			// Peek a doc that is not resident in cache, assert stat is unchanged
-			docRev, ok = cache.Peek(ctx, "doc5", "1-abc", testCollectionID)
-			require.False(t, ok)
-			assert.Equal(t, int64(4), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
-
-			// Eviction situation and assert stat doesn't go over the capacity set
-			cache.Put(ctx, documentRevisionForCacheTest("doc5", `{"test":"1234"}`), testCollectionID)
-			assert.Equal(t, int64(4), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
-
-			// test case of eviction for upsert
-			cache.Upsert(ctx, documentRevisionForCacheTest("doc6", `{"test":"12345"}`), testCollectionID)
-			assert.Equal(t, int64(4), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
-
-			// Empty cache
-			if testCase.UseCVCache {
-				cv := Version{SourceID: "test", Value: 123}
-				cache.RemoveWithCV(ctx, "doc1", &cv, testCollectionID)
-				cache.RemoveWithCV(ctx, "doc4", &cv, testCollectionID)
-				cache.RemoveWithCV(ctx, "doc5", &cv, testCollectionID)
-				cache.RemoveWithCV(ctx, "doc6", &cv, testCollectionID)
-			} else {
-				cache.RemoveWithRev(ctx, "doc1", "1-abc", testCollectionID)
-				cache.RemoveWithRev(ctx, "doc4", "1-abc", testCollectionID)
-				cache.RemoveWithRev(ctx, "doc5", "1-abc", testCollectionID)
-				cache.RemoveWithRev(ctx, "doc6", "1-abc", testCollectionID)
+			// Peek on a cached doc does not modify the count.
+			peekKey := CreateRevisionCacheCVKey("doc2", cv, testCollectionID)
+			if !tc.useCVCache {
+				peekKey = CreateRevisionCacheRevIDKey("doc2", revID, testCollectionID)
 			}
+			docRev, ok := cache.Peek(ctx, "doc2", peekKey, testCollectionID)
+			require.True(t, ok)
+			assert.Equal(t, "doc2", docRev.DocID)
+			assertItems(4)
 
-			// Assert num items goes back to 0
-			assert.Equal(t, int64(0), cacheNumItems.Value())
-			assert.Equal(t, int64(len(cache.cache)), cacheNumItems.Value())
+			// Peek on a non-cached doc does not modify the count.
+			notFoundKey := CreateRevisionCacheCVKey("doc5", cv, testCollectionID)
+			if !tc.useCVCache {
+				notFoundKey = CreateRevisionCacheRevIDKey("doc5", revID, testCollectionID)
+			}
+			_, ok = cache.Peek(ctx, "doc5", notFoundKey, testCollectionID)
+			require.False(t, ok)
+			assertItems(4)
+
+			// Put a new doc reaching capacity: count increments but no eviction occurs.
+			cache.Put(ctx, documentRevisionForCacheTest("doc5", `{"test":"5"}`), testCollectionID)
+			assertItems(5)
+
+			// Upsert a new doc beyond capacity: the LRU entry (doc3) is evicted to stay within the limit.
+			cache.Upsert(ctx, documentRevisionForCacheTest("doc6", `{"test":"6"}`), testCollectionID)
+			assertItems(5)
+
+			// Remove all remaining entries. doc3 was evicted above so its removal is a no-op.
+			// doc1, doc4, doc5, doc6 were always Put/Upserted (CV key). doc2 follows the test pathway key type.
+			cache.RemoveUsingRevID(ctx, "doc3", revID, testCollectionID)
+			cache.RemoveUsingCV(ctx, "doc1", cv, testCollectionID)
+			removeDoc("doc2")
+			cache.RemoveUsingCV(ctx, "doc4", cv, testCollectionID)
+			cache.RemoveUsingCV(ctx, "doc5", cv, testCollectionID)
+			cache.RemoveUsingCV(ctx, "doc6", cv, testCollectionID)
+			assertItems(0)
 		})
 	}
 }
@@ -1673,6 +1711,8 @@ func TestRevCacheOnDemand(t *testing.T) {
 	docID := "doc1"
 	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
 	require.NoError(t, err)
+	_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+	require.NoError(t, err)
 
 	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
 	defer testCtxCancel()
@@ -1681,13 +1721,15 @@ func TestRevCacheOnDemand(t *testing.T) {
 		docID := fmt.Sprintf("extraDoc%d", i)
 		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
 		require.NoError(t, err)
+		_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+		require.NoError(t, err)
 		go func() {
 			for {
 				select {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetWithRev(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 				}
 			}
 		}()
@@ -1719,19 +1761,6 @@ func documentRevisionForCacheTest(key string, body string) DocumentRevision {
 	}
 }
 
-// documentRevisionForCacheTestUpsert creates a document revision with the specified body and key and Version
-//
-//	History: Revisions{"start": 1}}
-func documentRevisionForCacheTestUpdate(key string, body string, version DocVersion) DocumentRevision {
-	return DocumentRevision{
-		BodyBytes: []byte(body),
-		DocID:     key,
-		RevID:     version.RevTreeID,
-		History:   Revisions{"start": 1},
-		CV:        &version.CV,
-	}
-}
-
 // TestRevCacheOperationsCV:
 //   - Create doc revision, put the revision into the cache
 //   - Perform a get on that doc by cv and assert that it has correctly been handled
@@ -1760,7 +1789,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	}
 	cache.Put(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err := cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1773,7 +1802,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 
 	cache.Upsert(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err = cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1784,9 +1813,8 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
 	// remove the doc rev from the cache and assert that the document is no longer present in cache
-	cache.RemoveWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID)
+	cache.RemoveUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID)
 	assert.Equal(t, 0, len(cache.cache))
-	assert.Equal(t, 0, len(cache.hlvCache))
 	assert.Equal(t, 0, cache.lruList.Len())
 }
 
@@ -1805,7 +1833,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 
 	// trigger load into cache
 	for i := range 5000 {
-		_, _ = cache.GetWithRev(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitDelta)
+		_, _ = cache.GetUsingRevID(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitDelta)
 	}
 
 	b.ResetTimer()
@@ -1813,7 +1841,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		// GET the document until test run has completed
 		for pb.Next() {
 			docId := fmt.Sprintf("doc%d", rand.Intn(5000))
-			_, _ = cache.GetWithRev(ctx, docId, "1-abc", testCollectionID, RevCacheOmitDelta)
+			_, _ = cache.GetUsingRevID(ctx, docId, "1-abc", testCollectionID, RevCacheOmitDelta)
 		}
 	})
 }
@@ -1823,7 +1851,7 @@ func createThenRemoveFromRevCache(t *testing.T, ctx context.Context, docID strin
 	revIDDoc, doc, err := collection.Put(ctx, docID, Body{"test": "doc"})
 	require.NoError(t, err)
 
-	db.revisionCache.RemoveWithRev(ctx, docID, revIDDoc, collection.GetCollectionID())
+	db.revisionCache.RemoveUsingRevID(ctx, docID, revIDDoc, collection.GetCollectionID())
 	docVersion := DocVersion{
 		RevTreeID: doc.GetRevTreeID(),
 	}
@@ -1834,7 +1862,7 @@ func createThenRemoveFromRevCache(t *testing.T, ctx context.Context, docID strin
 }
 
 // createDocAndReturnSizeAndRev creates a rev and measures its size based on rev cache measurements
-func createDocAndReturnSizeAndRev(t *testing.T, ctx context.Context, docID string, collection *DatabaseCollectionWithUser, body Body) (int, string, *Version) {
+func createDocAndReturnSizeAndRev(t *testing.T, ctx context.Context, docID string, collection *DatabaseCollectionWithUser, body Body, useCvKey bool) (int, string, *Version) {
 
 	rev, doc, err := collection.Put(ctx, docID, body)
 	require.NoError(t, err)
@@ -1853,8 +1881,12 @@ func createDocAndReturnSizeAndRev(t *testing.T, ctx context.Context, docID strin
 		expectedSize += len([]byte(v))
 	}
 
-	// do fetch ro load into cache
-	_, err = collection.getRev(ctx, docID, rev, 0, nil)
+	// do fetch to load into cache
+	if useCvKey {
+		_, err = collection.getRev(ctx, docID, doc.HLV.GetCurrentVersionString(), 0, nil)
+	} else {
+		_, err = collection.getRev(ctx, docID, rev, 0, nil)
+	}
 	require.NoError(t, err)
 
 	return expectedSize, rev, doc.HLV.ExtractCurrentVersionFromHLV()
@@ -1875,6 +1907,8 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 	docID := "doc1"
 	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
 	require.NoError(t, err)
+	_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+	require.NoError(t, err)
 
 	ctx, testCtxCancel := context.WithCancel(ctx)
 	defer testCtxCancel()
@@ -1883,13 +1917,15 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 		docID := fmt.Sprintf("extraDoc%d", i)
 		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
 		require.NoError(t, err)
+		_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+		require.NoError(t, err)
 		go func() {
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetWithRev(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 				}
 			}
 		}()
@@ -1919,6 +1955,8 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 	docID := "doc1"
 	revID, _, err := collection.Put(ctx, docID, Body{"ver": "1"})
 	require.NoError(t, err)
+	_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+	require.NoError(t, err)
 
 	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
 	defer testCtxCancel()
@@ -1927,13 +1965,15 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 		docID := fmt.Sprintf("extraDoc%d", i)
 		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
 		require.NoError(t, err)
+		_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+		require.NoError(t, err)
 		go func() {
 			for {
 				select {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetWithRev(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 				}
 			}
 		}()
@@ -1963,13 +2003,12 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	// create cv with incorrect version to the one stored in backing store
 	cv := Version{SourceID: "test", Value: 1234}
 
-	_, err := cache.GetWithCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	_, err := cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
 	require.Error(t, err)
 	require.Error(t, err, base.ErrNotFound)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
 	assert.Equal(t, int64(1), cacheMissCounter.Value())
 	assert.Equal(t, 0, cache.lruList.Len())
-	assert.Equal(t, 0, len(cache.hlvCache))
 	assert.Equal(t, 0, len(cache.cache))
 }
 
@@ -1977,11 +2016,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 //   - Create cache
 //   - Now perform two concurrent Gets, one by CV and one by revid on a document that doesn't exist in the cache
 //   - This will trigger two concurrent loads from bucket in the CV code path and revid code path
-//   - In doing so we will have two processes trying to update lookup maps at the same time and a race condition will appear
-//   - In doing so will cause us to potentially have two of the same elements the cache, one with nothing referencing it
-//   - Assert after both gets are processed, that the cache only has one element in it and that both lookup maps have only one
-//     element
-//   - Grab the single element in the list and assert that both maps point to that element in the cache list
+//   - Ending up with two elements in the cache for the same document, one keyed by revID and the other keyed by cv
 func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, cacheNumItems, memoryBytesCounted, getDocumentCounter, getRevisionCounter := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	cacheOptions := &RevisionCacheOptions{
@@ -1997,39 +2032,26 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 
 	cv := Version{SourceID: "test", Value: 123}
 	go func() {
-		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+		_, err := cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 		require.NoError(t, err)
 		wg.Done()
 	}()
 
 	go func() {
-		_, err := cache.GetWithCV(ctx, "doc1", &cv, testCollectionID, RevCacheIncludeDelta, false)
+		_, err := cache.GetUsingCV(ctx, "doc1", &cv, testCollectionID, RevCacheIncludeDelta, false)
 		require.NoError(t, err)
 		wg.Done()
 	}()
 
 	wg.Wait()
 
-	revElement := cache.cache[IDAndRev{RevID: "1-abc", DocID: "doc1"}].Value.(*revCacheValue)
-	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123}].Value.(*revCacheValue)
-	// we may have concurrent loads that lead to the same doc being loaded into two
-	// rev cache items but only one reference to one or the other in the maps
-	//	┌──────────┐   ┌──────────┐
-	//	│          │   │          │
-	//	│  Doc1    │   │   Doc1   │
-	//	│          │   │          │
-	//	└──────────┘   └──────────┘
-	//	    ▲               ▲
-	//	    │               │
-	//	    │               │
-	//	┌──────┐       ┌──────┐
-	//	│ HLV  │       │ REV  │
-	//	│ MAP  │       │ MAP  │
-	//	└──────┘       └──────┘
+	cvKey := CreateRevisionCacheCVKey("doc1", &cv, testCollectionID)
+	revKey := CreateRevisionCacheRevIDKey("doc1", "1-abc", testCollectionID)
+	revElement := cache.cache[revKey].Value.(*revCacheValue)
+	cvElement := cache.cache[cvKey].Value.(*revCacheValue)
 
 	assert.LessOrEqual(t, cache.lruList.Len(), 2)
-	assert.Equal(t, 1, len(cache.cache))
-	assert.Equal(t, 1, len(cache.hlvCache))
+	assert.Equal(t, 2, len(cache.cache))
 	assert.Equal(t, revElement.revID, cvElement.revID)
 	assert.Equal(t, revElement.id, cvElement.id)
 	assert.Equal(t, revElement.cv.String(), cvElement.cv.String())
@@ -2053,7 +2075,7 @@ func TestGetActive(t *testing.T) {
 	}
 
 	// remove the entry form the rev cache to force the cache to not have the active version in it
-	collection.revisionCache.RemoveWithCV(ctx, "doc", &expectedCV)
+	collection.revisionCache.RemoveUsingCV(ctx, "doc", &expectedCV)
 
 	// call get active to get the active version from the bucket
 	docRev, err := collection.revisionCache.GetActive(base.TestCtx(t), "doc")
@@ -2090,7 +2112,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	}
 
 	go func() {
-		_, err := cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+		_, err := cache.GetUsingCV(ctx, "doc1", &cv, testCollectionID, RevCacheIncludeDelta, false)
 		require.NoError(t, err)
 		wg.Done()
 	}()
@@ -2102,22 +2124,21 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 
 	wg.Wait()
 
-	revElement := cache.cache[IDAndRev{RevID: "1-abc", DocID: "doc1"}].Value.(*revCacheValue)
-	cvElement := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123}].Value.(*revCacheValue)
+	key := CreateRevisionCacheCVKey("doc1", &cv, testCollectionID)
+	elem := cache.cache[key].Value.(*revCacheValue)
 
-	assert.LessOrEqual(t, cache.lruList.Len(), 2)
+	assert.Equal(t, cache.lruList.Len(), 1)
 	assert.Equal(t, 1, len(cache.cache))
-	assert.Equal(t, 1, len(cache.hlvCache))
-	assert.Equal(t, revElement.revID, cvElement.revID)
-	assert.Equal(t, revElement.id, cvElement.id)
-	assert.Equal(t, revElement.cv.String(), cvElement.cv.String())
-	var revElem Body
-	var cvElem Body
-	err := base.JSONUnmarshal(revElement.bodyBytes, &revElem)
+	assert.Equal(t, docRev.RevID, elem.revID)
+	assert.Equal(t, docRev.DocID, elem.id)
+	assert.Equal(t, docRev.CV.String(), elem.cv.String())
+	var docRevElem Body
+	var cacheElem Body
+	err := base.JSONUnmarshal(docRev.BodyBytes, &docRevElem)
 	require.NoError(t, err)
-	err = base.JSONUnmarshal(cvElement.bodyBytes, &cvElem)
+	err = base.JSONUnmarshal(elem.bodyBytes, &cacheElem)
 	require.NoError(t, err)
-	assert.Equal(t, revElem["testing"].(bool), cvElem["testing"].(bool))
+	assert.Equal(t, docRevElem["testing"].(bool), cacheElem["testing"].(bool))
 }
 
 func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
@@ -2134,7 +2155,9 @@ func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
 	defer db.Close(ctx)
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	docID := "doc1"
-	_, _, err := collection.Put(ctx, docID, Body{"ver": "0"})
+	revID, _, err := collection.Put(ctx, docID, Body{"ver": "0"})
+	require.NoError(t, err)
+	_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
 	require.NoError(t, err)
 	wg.Add(1)
 
@@ -2145,13 +2168,15 @@ func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
 		docID := fmt.Sprintf("extraDoc%d", i)
 		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
 		require.NoError(t, err)
+		_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+		require.NoError(t, err)
 		go func() {
 			for {
 				select {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetWithRev(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 				}
 			}
 		}()
@@ -2187,6 +2212,8 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 	docID := "doc1"
 	rev1ID, _, err := collection.Put(ctx, docID, Body{"ver": "0"})
 	require.NoError(t, err)
+	_, err = collection.getRev(ctx, docID, rev1ID, 0, nil) // load into cache
+	require.NoError(t, err)
 	wg.Add(1)
 
 	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
@@ -2196,13 +2223,15 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 		docID := fmt.Sprintf("extraDoc%d", i)
 		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
 		require.NoError(t, err)
+		_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+		require.NoError(t, err)
 		go func() {
 			for {
 				select {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetWithRev(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 				}
 			}
 		}()
@@ -2211,7 +2240,7 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 	var getErr error
 	go func() {
 		for range 100 {
-			_, getErr = db.revisionCache.GetWithRev(ctx, docID, rev1ID, collection.GetCollectionID(), true)
+			_, getErr = db.revisionCache.GetUsingRevID(ctx, docID, rev1ID, collection.GetCollectionID(), true)
 			if getErr != nil {
 				break
 			}
@@ -2245,13 +2274,15 @@ func TestPutRevHighRevCacheChurn(t *testing.T) {
 		docID := fmt.Sprintf("extraDoc%d", i)
 		revID, _, err := collection.Put(ctx, docID, Body{"fake": "body"})
 		require.NoError(t, err)
+		_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
+		require.NoError(t, err)
 		go func() {
 			for {
 				select {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetWithRev(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
 				}
 			}
 		}()
@@ -2278,32 +2309,41 @@ func TestRevCacheOnDemandImportNoCache(t *testing.T) {
 	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 
 	docID := "doc1"
-	revID1, _, err := collection.Put(ctx, docID, Body{"foo": "bar"})
+	revID1, doc, err := collection.Put(ctx, docID, Body{"foo": "bar"})
 	require.NoError(t, err)
+	cv := doc.HLV.ExtractCurrentVersionFromHLV()
 
-	// rev 1 is not in cache given we don;t write to cache on write
-	_, exists := collection.revisionCache.Peek(ctx, docID, revID1)
+	// rev 1 is not in cache given we don't write to cache on write
+	peekKeyRevID := CreateRevisionCacheRevIDKey(docID, revID1, collection.GetCollectionID())
+	peekKeyCV := CreateRevisionCacheCVKey(docID, cv, collection.GetCollectionID())
+	_, exists := collection.revisionCache.Peek(ctx, docID, peekKeyRevID)
+	require.False(t, exists)
+	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyCV)
 	require.False(t, exists)
 
 	require.NoError(t, collection.dataStore.Set(docID, 0, nil, []byte(`{"foo": "baz"}`)))
 
-	doc, err := collection.GetDocument(ctx, docID, DocUnmarshalSync)
+	doc, err = collection.GetDocument(ctx, docID, DocUnmarshalSync)
 	require.NoError(t, err)
 	require.Equal(t, Body{"foo": "baz"}, doc.Body(ctx))
 
-	// rev1 still won;t exist in cache
-	_, exists = collection.revisionCache.Peek(ctx, docID, revID1)
+	// rev1 still won't exist in cache
+	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyRevID)
+	require.False(t, exists)
+	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyCV)
 	require.False(t, exists)
 
 	// rev2 is not in cache but is on server
-	_, exists = collection.revisionCache.Peek(ctx, docID, doc.GetRevTreeID())
+	peekKeyRevID = CreateRevisionCacheRevIDKey(docID, revID1, collection.GetCollectionID())
+	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyRevID)
+	require.False(t, exists)
+	peekKeyCV = CreateRevisionCacheCVKey(docID, doc.HLV.ExtractCurrentVersionFromHLV(), collection.GetCollectionID())
+	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyCV)
 	require.False(t, exists)
 }
 
 func TestFetchBackupWithDeletedFlag(t *testing.T) {
-	if base.TestDisableRevCache() {
-		t.Skip("pending fix in CBG-5141")
-	}
+
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		// enable delta sync so CV revs are backed up
 		DeltaSyncOptions: DeltaSyncOptions{
@@ -2327,7 +2367,7 @@ func TestFetchBackupWithDeletedFlag(t *testing.T) {
 	// flush cache
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.revisionCache.GetWithCV(ctx, docID, doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
+	docRev, err := collection.revisionCache.GetUsingCV(ctx, docID, doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, doc1.HLV.GetCurrentVersionString(), docRev.CV.String())
@@ -2342,7 +2382,7 @@ func TestFetchBackupWithDeletedFlag(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch deleted, will get backup rev and assert that the deleted flag is true
-	docRev, err = collection.revisionCache.GetWithCV(ctx, docID, deleteDoc.HLV.ExtractCurrentVersionFromHLV(), false, true)
+	docRev, err = collection.revisionCache.GetUsingCV(ctx, docID, deleteDoc.HLV.ExtractCurrentVersionFromHLV(), false, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, deleteDoc.HLV.GetCurrentVersionString(), docRev.CV.String())
@@ -2384,64 +2424,12 @@ func TestCorrectHLVWhenFetchingBackupRev(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch using lower level cache fetch with load from bucket bool true to get the backup rev
-	docRev, err = collection.revisionCache.GetWithCV(ctx, docID, docRev.CV, RevCacheOmitDelta, true)
+	docRev, err = collection.revisionCache.GetUsingCV(ctx, docID, docRev.CV, RevCacheOmitDelta, true)
 	require.NoError(t, err)
 
 	// hlv history should be empty as we are fetching from backup rev
 	assert.Empty(t, docRev.HlvHistory)
 	assert.Equal(t, cv, docRev.CV.String())
-}
-
-func TestRemoveFromRevLookup(t *testing.T) {
-	cacheHitCounter, cacheMissCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
-	backingStoreMap := CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID)
-	cacheOptions := &RevisionCacheOptions{
-		MaxItemCount: 10,
-		MaxBytes:     0,
-	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
-
-	ctx := base.TestCtx(t)
-
-	// Fill up the rev cache with the first 10 docs
-	for docID := range 10 {
-		id := strconv.Itoa(docID)
-		vrs := uint64(docID)
-		cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: id, RevID: "1-abc", CV: &Version{Value: vrs, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	}
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
-	assert.Equal(t, 10, len(cache.cache))
-	assert.Equal(t, 10, len(cache.hlvCache))
-
-	// simulate a user xattr update:
-	// 1. Removes form rev lookup cache
-	// 2. Enter new entry with same revID and docID but diff CV
-	// 3. Assert that eviction eventually aligns the cache items in each lookup map
-	cache.RemoveRevOnly(ctx, "1", "1-abc", testCollectionID)
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
-	assert.Equal(t, 10, cache.lruList.Len())
-	assert.Equal(t, 9, len(cache.cache))
-	assert.Equal(t, 10, len(cache.hlvCache))
-
-	// add new entry to cache for docID 1 with a different CV but same revID
-	cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: "1", RevID: "1-abc", CV: &Version{Value: 1234, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
-	assert.Equal(t, 10, cache.lruList.Len())
-	assert.Equal(t, 9, len(cache.cache)) // we should have 9 items in the rev lookup as we removed one item above
-	assert.Equal(t, 10, len(cache.hlvCache))
-
-	// add new doc to trigger eviction of old doc "1" value in the cache that has entry in hlv cache to an item but the revID lookup
-	// for this item will be to a different value (given the simulation of user xattr update above). This means that this
-	// will trigger an eviction from CV lookup but no revID lookup thus aligning the lookup maps once again.
-	cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{}`), DocID: "someNewDoc", RevID: "1-abc", CV: &Version{Value: 123456, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	assert.Equal(t, int64(10), cacheNumItems.Value())
-	assert.Equal(t, int64(20), memoryBytesCounted.Value())
-	assert.Equal(t, 10, cache.lruList.Len())
-	assert.Equal(t, 10, len(cache.cache)) // we should now have 10 items in rev lookup given the item above aligned the lookups after eviction
-	assert.Equal(t, 10, len(cache.hlvCache))
 }
 
 func TestLoadFromBucketLegacyRevsThatAreBackedUpPreUpgrade(t *testing.T) {
@@ -2487,7 +2475,8 @@ func TestLoadFromBucketLegacyRevsThatAreBackedUpPreUpgrade(t *testing.T) {
 
 	// assert that each legacy rev is populated in rev lookup
 	for _, revID := range revIDs {
-		docRev, ok := collection.revisionCache.Peek(ctx, docID, revID)
+		peekKey := CreateRevisionCacheRevIDKey(docID, revID, collection.GetCollectionID())
+		docRev, ok := collection.revisionCache.Peek(ctx, docID, peekKey)
 		require.True(t, ok)
 		assert.Equal(t, revID, docRev.RevID)
 	}
@@ -2518,53 +2507,12 @@ func TestRaceRemovingStaleCVValue(t *testing.T) {
 	}()
 
 	go func() {
-		cache.RemoveCVOnly(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID)
+		cache.RemoveUsingCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID)
 		wg.Done()
 	}()
 
 	wg.Wait()
 
-}
-
-func TestEvictionWhenStaleCVRemoved(t *testing.T) {
-	cacheHitCounter, cacheMissCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
-	backingStoreMap := CreateTestSingleBackingStoreMap(&noopBackingStore{}, testCollectionID)
-	cacheOptions := &RevisionCacheOptions{
-		MaxItemCount: 2,
-		MaxBytes:     0,
-	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
-
-	ctx := base.TestCtx(t)
-
-	cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{"some":"data"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{"some":"data"}`), DocID: "doc2", RevID: "1-abc", CV: &Version{Value: 1245, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-
-	// remove cv from lookup map for doc1
-	cache.RemoveCVOnly(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID)
-
-	assert.Equal(t, 2, cache.lruList.Len())
-	assert.Equal(t, 2, len(cache.cache))
-	assert.Equal(t, 1, len(cache.hlvCache))
-	// assert that doc2 is only item in hlv lookup
-	_, ok := cache.hlvCache[IDandCV{DocID: "doc2", Source: "test", Version: 1245, CollectionID: testCollectionID}]
-	assert.True(t, ok)
-
-	// add new doc revision for doc1 (same cv different revID simulating local wins scenario) to trigger eviction on doc1 first revision
-	cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{"some":"data"}`), DocID: "doc1", RevID: "2-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-
-	assert.Equal(t, 2, cache.lruList.Len())
-	assert.Equal(t, 2, len(cache.cache))
-	assert.Equal(t, 2, len(cache.hlvCache))
-
-	// assert doc1 entry in hlv map has revID 2-abc
-	val := cache.hlvCache[IDandCV{DocID: "doc1", Source: "test", Version: 123, CollectionID: testCollectionID}]
-	revValue := val.Value.(*revCacheValue)
-	assert.Equal(t, "2-abc", revValue.revID)
-	// assert doc1 entry in revID map has revID 2-abc
-	valRevEntry := cache.cache[IDAndRev{DocID: "doc1", RevID: "2-abc", CollectionID: testCollectionID}]
-	revValueRevEntry := valRevEntry.Value.(*revCacheValue)
-	assert.Equal(t, "2-abc", revValueRevEntry.revID)
 }
 
 // TestUpdateDeltaRevCacheMemoryStatPanic:
@@ -2583,16 +2531,16 @@ func TestUpdateDeltaRevCacheMemoryStatPanicSingleEntry(t *testing.T) {
 	ctx := base.TestCtx(t)
 
 	// Trigger load into cache.
-	docRev, err := cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	docRev, err := cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	require.NoError(t, err, "Error adding to cache")
 
 	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
 
 	// Thread 1: UpdateDelta - start
-	value := cache.getValue(ctx, "doc1", "1-abc", testCollectionID, false)
+	value := cache.getValue(ctx, "doc1", "1-abc", nil, testCollectionID, false)
 	if value != nil {
 		// Thread 2: Remove - start - drop value underneath UpdateDelta thread
-		cache.RemoveWithRev(ctx, "doc1", "1-abc", testCollectionID)
+		cache.RemoveUsingRevID(ctx, "doc1", "1-abc", testCollectionID)
 		// Thread 2: Remove - end
 		outGoingBytes := value.updateDelta(revCacheDelta2)
 		if outGoingBytes != 0 {
@@ -2626,19 +2574,19 @@ func TestUpdateDeltaRevCacheMemoryStatPanicMultipleEntries(t *testing.T) {
 	// Trigger load into cache.  Add one revision (doc1) without a delta that's less than 500 bytes, then a
 	// revision (doc2) with a delta update that will exceed memory limit
 	// when added.  Both should be removed and cache memory stats should be zero.
-	_, err := cache.GetWithRev(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	_, err := cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	require.NoError(t, err, "Error adding to cache")
 
-	docRev2, err := cache.GetWithRev(ctx, "doc2", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	docRev2, err := cache.GetUsingRevID(ctx, "doc2", "1-abc", testCollectionID, RevCacheIncludeDelta)
 	require.NoError(t, err, "Error adding to cache")
 
 	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev2, false, nil)
 
 	// Thread 1: UpdateDelta - start
-	value := cache.getValue(ctx, "doc2", "1-abc", testCollectionID, false)
+	value := cache.getValue(ctx, "doc2", "1-abc", nil, testCollectionID, false)
 	if value != nil {
 		// Thread 2: Remove - start - drop value underneath UpdateDelta thread
-		cache.RemoveWithRev(ctx, "doc2", "1-abc", testCollectionID)
+		cache.RemoveUsingRevID(ctx, "doc2", "1-abc", testCollectionID)
 		// Thread 2: Remove - end
 		outGoingBytes := value.updateDelta(revCacheDelta2)
 		if outGoingBytes != 0 {
@@ -2652,197 +2600,6 @@ func TestUpdateDeltaRevCacheMemoryStatPanicMultipleEntries(t *testing.T) {
 
 	assert.Equal(t, 0, cache.lruList.Len())
 	assert.Equal(t, int64(0), memoryBytesCounted.Value())
-}
-
-func TestEvictionOfRevIDKeysWhenNoItemInCVMap(t *testing.T) {
-	if base.TestDisableRevCache() {
-		t.Skip("test requires rev cache enabled for eviction to run")
-	}
-	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
-		OldRevExpirySeconds: base.DefaultOldRevExpirySeconds,
-		RevisionCacheOptions: &RevisionCacheOptions{
-			ShardCount:   1, // turn off sharding for simplicity
-			MaxItemCount: 1,
-			MaxBytes:     0, // turn off memory limit
-		},
-	})
-	defer db.Close(ctx)
-	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	// create a few legacy revs
-	docID := t.Name()
-	revIDs := make([]string, 0)
-	legacyRev, _, err := collection.Put(ctx, docID, Body{"foo": "bar"})
-	require.NoError(t, err)
-	revIDs = append(revIDs, legacyRev)
-	for range 2 {
-		newRev, _, err := collection.Put(ctx, docID, Body{BodyRev: legacyRev, "foo": "bar"})
-		require.NoError(t, err)
-		revIDs = append(revIDs, newRev)
-		legacyRev = newRev // OCC val
-	}
-	// simulate doc revs that are backed up to bucket pre upgrade
-	for i := range 2 {
-		err := collection.setOldRevisionJSONBody(ctx, docID, revIDs[i], []byte(`{"foo":"bar"}`), collection.oldRevExpirySeconds())
-		require.NoError(t, err)
-	}
-
-	// flush all revisions from rev cache to force load from bucket
-	db.FlushRevisionCacheForTest()
-
-	// fetch all three legacy revisions, first two should be loaded from old backup revisions
-	for i := range 3 {
-		docRev, err := collection.getRev(ctx, docID, revIDs[i], 0, nil)
-		require.NoError(t, err)
-		assert.Equal(t, revIDs[i], docRev.RevID)
-	}
-	// at this point we have loaded 3 revs into a cache that can only hold 1 item
-	// assert that only 1 item exists in rev lookup (revID3 from above)
-	_, ok := collection.revisionCache.Peek(ctx, docID, revIDs[2])
-	require.True(t, ok)
-	// assert peek is false for revID1 and revID2
-	for i := range 2 {
-		_, ok := collection.revisionCache.Peek(ctx, docID, revIDs[i])
-		require.False(t, ok)
-	}
-
-	// rev cache num items should be 1
-	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
-}
-
-func TestEvictionOfCVKeysWhenNoItemInRevMap(t *testing.T) {
-	if base.TestDisableRevCache() {
-		t.Skip("test requires rev cache enabled for eviction to run")
-	}
-	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
-		OldRevExpirySeconds: base.DefaultOldRevExpirySeconds,
-		RevisionCacheOptions: &RevisionCacheOptions{
-			ShardCount:   1, // turn off sharding for simplicity
-			MaxItemCount: 1,
-			MaxBytes:     0, // turn off memory limit
-		},
-		DeltaSyncOptions: DeltaSyncOptions{
-			Enabled:          true,
-			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
-		},
-	})
-	defer db.Close(ctx)
-	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	// create a few revs
-	docID := t.Name()
-	docCVs := make([]*Version, 0)
-	rev, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
-	require.NoError(t, err)
-	docCVs = append(docCVs, doc1.HLV.ExtractCurrentVersionFromHLV())
-	for range 2 {
-		newRev, doc, err := collection.Put(ctx, docID, Body{BodyRev: rev, "foo": "bar"})
-		require.NoError(t, err)
-		docCVs = append(docCVs, doc.HLV.ExtractCurrentVersionFromHLV())
-		rev = newRev // OCC val
-	}
-	// simulate doc revs that are backed up to bucket pre upgrade
-	for i := range 2 {
-		revHash := base.Crc32cHashString([]byte(docCVs[i].String()))
-		err := collection.setOldRevisionJSONBody(ctx, docID, revHash, []byte(`{"foo":"bar"}`), collection.oldRevExpirySeconds())
-		require.NoError(t, err)
-	}
-
-	// flush all revisions from rev cache to force load from bucket
-	db.FlushRevisionCacheForTest()
-
-	// fetch all three legacy revisions, first two should be loaded from old backup revisions
-	for i := range 3 {
-		docRev, err := collection.revisionCache.GetWithCV(ctx, docID, docCVs[i], false, true)
-		require.NoError(t, err)
-		assert.Equal(t, docCVs[i].String(), docRev.CV.String())
-	}
-	// at this point we have loaded 3 revs into a cache that can only hold 1 item
-	// assert that only 1 item exists in rev lookup (revID3 from above)
-	// to do so delete backup revs and fetch through rev cache assert first two have 404 errors whilst last one should succeed (resident in cache)
-	for i := range 2 {
-		revHash := base.Crc32cHashString([]byte(docCVs[i].String()))
-		err := collection.PurgeOldRevisionJSON(ctx, docID, revHash)
-		require.NoError(t, err)
-	}
-	for i := range 2 {
-		_, err := collection.getRev(ctx, docID, docCVs[i].String(), 0, nil)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "missing")
-	}
-	// last one should succeed
-	docRev, err := collection.getRev(ctx, docID, docCVs[2].String(), 0, nil)
-	require.NoError(t, err)
-	assert.Equal(t, docCVs[2].String(), docRev.CV.String())
-
-	// we should have one item in cache
-	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
-}
-
-func TestBasicLoadBackupRevCacheOnlyPopulateOneMap(t *testing.T) {
-
-	if base.TestDisableRevCache() {
-		t.Skip("test requires rev cache enabled")
-	}
-	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
-		OldRevExpirySeconds: base.DefaultOldRevExpirySeconds,
-		RevisionCacheOptions: &RevisionCacheOptions{
-			ShardCount:   1,  // turn off sharding for simplicity
-			MaxItemCount: 10, // turn off size based eviction
-			MaxBytes:     0,  // turn off memory limit
-		},
-		DeltaSyncOptions: DeltaSyncOptions{
-			Enabled:          true,
-			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
-		},
-	})
-	defer db.Close(ctx)
-	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
-
-	docID := SafeDocumentName(t, t.Name())
-	var firstRevisionID, firstCVStr string
-	_, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
-	require.NoError(t, err)
-
-	firstRevisionID = doc1.GetRevTreeID()
-	firstCVStr = doc1.HLV.GetCurrentVersionString()
-	firstCV := doc1.HLV.ExtractCurrentVersionFromHLV()
-
-	// make revision 2
-	_, _, err = collection.Put(ctx, docID, Body{BodyRev: firstRevisionID, "foo": "bar"})
-	require.NoError(t, err)
-
-	// flush all revisions from rev cache to force load from bucket, this can be removed pending CBG-4542
-	db.FlushRevisionCacheForTest()
-
-	_, err = collection.getRev(ctx, docID, firstRevisionID, 0, nil)
-	require.NoError(t, err)
-
-	// assert on fetch by revID that we have one item in rev cache and 1 miss but 0 hits
-	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
-	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
-	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheHits.Value())
-
-	// now fetch by CV for backup rev, should load rev and only populate CV map and not revID map but
-	// should have essentially two items in underlying cache that are the same doc
-	// we need to use GetWithCV with load from bucket true to force load from backup rev
-	_, err = collection.revisionCache.GetWithCV(ctx, docID, firstCV, false, true)
-	require.NoError(t, err)
-	// assert on fetch by CV that we have two items in rev cache and 2 miss but 0 hits
-	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
-	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
-	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheHits.Value())
-
-	// now fetch by revID and CV again and assert that we have hits now meaning they are loaded fine into lookup maps
-	_, err = collection.getRev(ctx, docID, firstRevisionID, 0, nil)
-	require.NoError(t, err)
-	_, err = collection.getRev(ctx, docID, firstCVStr, 0, nil)
-	require.NoError(t, err)
-
-	// assert we get two hits now
-	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
-	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
-	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheHits.Value())
 }
 
 func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {
@@ -2924,12 +2681,12 @@ func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {
 			assert.Equal(t, doc1.HLV.GetCurrentVersionString(), docRev.CV.String())
 			assert.JSONEq(t, `{"foo": "baz"}`, string(docRev.BodyBytes))
 			if tc.useRevID {
-				assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
+				assert.Equal(t, int64(3), db.DbStats.Cache().RevisionCacheNumItems.Value())
 			} else {
-				assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheNumItems.Value())
+				assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
 			}
-			assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
-			assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheHits.Value())
+			assert.Equal(t, int64(3), db.DbStats.Cache().RevisionCacheMisses.Value())
+			assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheHits.Value())
 		})
 	}
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -155,19 +155,19 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 
 			ctx := base.TestCtx(t)
 
-			keysAdded := make([]RevCacheKey, 0)
+			keysAdded := make([]string, 0)
 
 			// Fill up the rev cache with the first 10 docs
 			for docID := range 10 {
 				id := strconv.Itoa(docID)
 				if testCase.useCVKey {
-					_, err := cache.GetUsingCV(ctx, id, &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+					_, err := cache.Get(ctx, id, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 					require.NoError(t, err)
-					keysAdded = append(keysAdded, CreateRevisionCacheCVKey(id, &Version{Value: 123, SourceID: "test"}, testCollectionID))
+					keysAdded = append(keysAdded, Version{Value: 123, SourceID: "test"}.String())
 				} else {
-					_, err := cache.GetUsingRevID(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta)
+					_, err := cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta, false)
 					require.NoError(t, err)
-					keysAdded = append(keysAdded, CreateRevisionCacheRevIDKey(id, "1-abc", testCollectionID))
+					keysAdded = append(keysAdded, "1-abc")
 				}
 			}
 			assert.Equal(t, int64(10), cacheNumItems.Value())
@@ -180,9 +180,9 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 				var err error
 				docID := strconv.Itoa(i)
 				if testCase.useCVKey {
-					docRev, err = cache.GetUsingCV(ctx, docID, &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+					docRev, err = cache.Get(ctx, docID, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 				} else {
-					docRev, err = cache.GetUsingRevID(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta)
+					docRev, err = cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta, false)
 				}
 				assert.NoError(t, err)
 				assert.NotNil(t, docRev.BodyBytes, "nil body for %s", docID)
@@ -196,10 +196,10 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			for i := 10; i < 13; i++ {
 				docID := strconv.Itoa(i)
 				if testCase.useCVKey {
-					_, err := cache.GetUsingCV(ctx, docID, &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+					_, err := cache.Get(ctx, docID, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 					require.NoError(t, err)
 				} else {
-					_, err := cache.GetUsingRevID(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta)
+					_, err := cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta, false)
 					require.NoError(t, err)
 				}
 			}
@@ -212,7 +212,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			prevCacheMissCount := cacheMissCounter.Value()
 			for i := range 3 {
 				docID := strconv.Itoa(i)
-				docRev, ok := cache.Peek(ctx, docID, keysAdded[i])
+				docRev, ok := cache.Peek(ctx, docID, keysAdded[i], 0)
 				assert.False(t, ok)
 				assert.Nil(t, docRev.BodyBytes)
 				assert.Equal(t, prevCacheMissCount, cacheMissCounter.Value()) // peek incurs no cache miss if not found
@@ -228,10 +228,10 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 				var err error
 				id := strconv.Itoa(i + 3)
 				if testCase.useCVKey {
-					docRev, err = cache.GetUsingCV(ctx, id, &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+					docRev, err = cache.Get(ctx, id, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 					assert.NoError(t, err)
 				} else {
-					docRev, err = cache.GetUsingRevID(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta)
+					docRev, err = cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta, false)
 					assert.NoError(t, err)
 				}
 				assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -295,21 +295,21 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 			docSize, rev, docVersion := createDocAndReturnSizeAndRev(t, ctx, "11", collection, smallBody, testCase.UseCVKey)
 			// load into cache
 			if testCase.UseCVKey {
-				_, err := db.revisionCache.GetUsingCV(ctx, "11", docVersion, collection.GetCollectionID(), RevCacheOmitDelta, false)
+				_, err := db.revisionCache.Get(ctx, "11", docVersion.String(), collection.GetCollectionID(), RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				_, err := db.revisionCache.GetUsingRevID(ctx, "11", rev, collection.GetCollectionID(), RevCacheOmitDelta)
+				_, err := db.revisionCache.Get(ctx, "11", rev, collection.GetCollectionID(), RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 			expValue += int64(docSize)
 			// assert doc 0 been evicted
-			var peekKey RevCacheKey
+			var peekKey string
 			if testCase.UseCVKey {
-				peekKey = CreateRevisionCacheCVKey("0", versions[0], collection.GetCollectionID())
+				peekKey = versions[0].String()
 			} else {
-				peekKey = CreateRevisionCacheRevIDKey("0", rev, collection.GetCollectionID())
+				peekKey = rev
 			}
-			docRev, ok := db.revisionCache.Peek(ctx, "0", peekKey)
+			docRev, ok := db.revisionCache.Peek(ctx, "0", peekKey, 0)
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -319,13 +319,13 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 
 			// remove doc "1" to give headroom for memory based eviction
 			if testCase.UseCVKey {
-				db.revisionCache.RemoveUsingCV(ctx, "1", versions[1], collection.GetCollectionID())
-				peekKey = CreateRevisionCacheCVKey("1", versions[1], collection.GetCollectionID())
+				db.revisionCache.Remove(ctx, "1", versions[1].String(), collection.GetCollectionID())
+				peekKey = versions[1].String()
 			} else {
-				db.revisionCache.RemoveUsingRevID(ctx, "1", rev, collection.GetCollectionID())
-				peekKey = CreateRevisionCacheRevIDKey("1", rev, collection.GetCollectionID())
+				db.revisionCache.Remove(ctx, "1", rev, collection.GetCollectionID())
+				peekKey = rev
 			}
-			docRev, ok = db.revisionCache.Peek(ctx, "1", peekKey)
+			docRev, ok = db.revisionCache.Peek(ctx, "1", peekKey, 0)
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -348,20 +348,20 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 
 			// load into cache
 			if testCase.UseCVKey {
-				_, err = db.revisionCache.GetUsingCV(ctx, "12", doc.HLV.ExtractCurrentVersionFromHLV(), collection.GetCollectionID(), RevCacheOmitDelta, false)
+				_, err = db.revisionCache.Get(ctx, "12", doc.HLV.GetCurrentVersionString(), collection.GetCollectionID(), RevCacheOmitDelta, false)
 			} else {
-				_, err = db.revisionCache.GetUsingRevID(ctx, "12", revID, collection.GetCollectionID(), RevCacheOmitDelta)
+				_, err = db.revisionCache.Get(ctx, "12", revID, collection.GetCollectionID(), RevCacheOmitDelta, false)
 			}
 			require.NoError(t, err)
 
 			// assert doc "2" has been evicted even though we only have 9 items in cache with capacity of 10, so memory based
 			// eviction took place
 			if testCase.UseCVKey {
-				peekKey = CreateRevisionCacheCVKey("2", versions[2], collection.GetCollectionID())
+				peekKey = versions[2].String()
 			} else {
-				peekKey = CreateRevisionCacheRevIDKey("2", rev, collection.GetCollectionID())
+				peekKey = rev
 			}
-			docRev, ok = db.revisionCache.Peek(ctx, "2", peekKey)
+			docRev, ok = db.revisionCache.Peek(ctx, "2", peekKey, 0)
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -401,10 +401,10 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.GetUsingCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc1", docRev.DocID)
@@ -428,10 +428,10 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 
 			// test fail load event doesn't increment memory stat
 			if testCase.UseCVCache {
-				docRev, err = cache.GetUsingCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc2", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 				assertHTTPError(t, err, 404)
 			} else {
-				docRev, err = cache.GetUsingRevID(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 				assertHTTPError(t, err, 404)
 			}
 			assert.Nil(t, docRev.BodyBytes)
@@ -443,10 +443,10 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			memStatBeforeThirdLoad := memoryBytesCounted.Value()
 			// test another load from bucket but doing so should trigger memory based eviction
 			if testCase.UseCVCache {
-				docRev, err = cache.GetUsingCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc3", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetUsingRevID(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.Get(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc3", docRev.DocID)
@@ -457,13 +457,13 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			assert.Equal(t, 2, cache.lruList.Len())
 			memStatAfterEviction := (memStatBeforeThirdLoad + docRev.MemoryBytes) - currMemStat
 			assert.Equal(t, memStatAfterEviction, memoryBytesCounted.Value())
-			var peekKey RevCacheKey
+			var peekKey string
 			if testCase.UseCVCache {
-				peekKey = CreateRevisionCacheCVKey("doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID)
+				peekKey = Version{Value: 123, SourceID: "test"}.String()
 			} else {
-				peekKey = CreateRevisionCacheRevIDKey("doc1", "1-abc", testCollectionID)
+				peekKey = "1-abc"
 			}
-			_, ok := cache.Peek(ctx, "doc1", peekKey)
+			_, ok := cache.Peek(ctx, "doc1", peekKey, 0)
 			assert.False(t, ok)
 		})
 	}
@@ -480,7 +480,7 @@ func TestBackingStore(t *testing.T) {
 	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	docRev, err := cache.GetUsingRevID(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
+	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -491,7 +491,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	docRev, err = cache.GetUsingRevID(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -500,7 +500,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev is already resident, but still issue GetDocument to check for later revisions
-	docRev, err = cache.GetUsingRevID(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -511,7 +511,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.GetUsingRevID(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta)
+	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -537,7 +537,7 @@ func TestBackingStoreCV(t *testing.T) {
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
 	cv := Version{SourceID: "test", Value: 123}
-	docRev, err := cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
@@ -549,7 +549,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Perform a get on the same doc as above, check that we get cache hit
-	docRev, err = cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
@@ -561,7 +561,7 @@ func TestBackingStoreCV(t *testing.T) {
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
 	cv = Version{SourceID: "test11", Value: 100}
-	docRev, err = cache.GetUsingCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheOmitDelta, false)
 
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -571,7 +571,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.GetUsingCV(base.TestCtx(t), "not_found", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheOmitDelta, false)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -658,37 +658,34 @@ func TestBypassRevisionCache(t *testing.T) {
 	rc := NewBypassRevisionCache(backingStoreMap, &bypassStat)
 
 	// Peek always returns false for BypassRevisionCache
-	peekKey := CreateRevisionCacheRevIDKey(key, rev1, testCollectionID)
-	_, ok := rc.Peek(ctx, key, peekKey)
+	_, ok := rc.Peek(ctx, key, rev1, 0)
 	assert.False(t, ok)
-	peekKey = CreateRevisionCacheRevIDKey(key, rev2, testCollectionID)
-	_, ok = rc.Peek(ctx, key, peekKey)
+	_, ok = rc.Peek(ctx, key, rev2, 0)
 	assert.False(t, ok)
 
 	// Get non-existing doc
-	_, err = rc.GetUsingRevID(base.TestCtx(t), "invalid", rev1, testCollectionID, RevCacheOmitDelta)
+	_, err = rc.Get(base.TestCtx(t), "invalid", rev1, testCollectionID, RevCacheOmitDelta, false)
 	assert.True(t, base.IsDocNotFoundError(err))
 
 	// Get non-existing revision
-	_, err = rc.GetUsingRevID(base.TestCtx(t), key, "3-abc", testCollectionID, RevCacheOmitDelta)
+	_, err = rc.Get(base.TestCtx(t), key, "3-abc", testCollectionID, RevCacheOmitDelta, false)
 	assertHTTPError(t, err, 404)
 
 	// Get specific revision
-	doc, err := rc.GetUsingRevID(base.TestCtx(t), key, rev1, testCollectionID, RevCacheOmitDelta)
+	doc, err := rc.Get(base.TestCtx(t), key, rev1, testCollectionID, RevCacheOmitDelta, false)
 	assert.NoError(t, err)
 	require.NotNil(t, doc)
 	assert.Equal(t, `{"value":1234}`, string(doc.BodyBytes))
 
 	// Check peek is still returning false for "Get"
-	peekKey = CreateRevisionCacheRevIDKey(key, rev1, testCollectionID)
-	_, ok = rc.Peek(ctx, key, peekKey)
+	_, ok = rc.Peek(ctx, key, rev1, 0)
 	assert.False(t, ok)
 
 	// Put no-ops
 	rc.Put(ctx, doc, testCollectionID)
 
 	// Check peek is still returning false for "Put"
-	_, ok = rc.Peek(ctx, key, peekKey)
+	_, ok = rc.Peek(ctx, key, rev1, 0)
 	assert.False(t, ok)
 
 	// Get active revision
@@ -728,8 +725,7 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)
 
 	// Get the raw document directly from the revcache, validate _attachments property isn't found
-	peekKey := CreateRevisionCacheRevIDKey(rev1key, rev1id, collection.GetCollectionID())
-	docRevision, ok := collection.revisionCache.Peek(ctx, rev1key, peekKey)
+	docRevision, ok := collection.revisionCache.Peek(ctx, rev1key, rev1id)
 	assert.True(t, ok)
 	assert.NotContains(t, docRevision.BodyBytes, BodyAttachments, "_attachments property still present in document body retrieved from rev cache: %#v", bucketBody)
 	_, ok = docRevision.Attachments["myatt"]
@@ -780,7 +776,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)
 
 	// Get the raw document directly from the revcache, validate _attachments property isn't found
-	docRevision, err := collection.revisionCache.GetUsingRevID(base.TestCtx(t), docKey, rev2id, RevCacheOmitDelta)
+	docRevision, err := collection.revisionCache.Get(base.TestCtx(t), docKey, rev2id, RevCacheOmitDelta, true)
 	assert.NoError(t, err, "Unexpected error calling collection.revisionCache.Get")
 	assert.NotContains(t, docRevision.BodyBytes, BodyAttachments, "_attachments property still present in document body retrieved from rev cache: %#v", bucketBody)
 	_, ok = docRevision.Attachments["myatt"]
@@ -812,12 +808,12 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	secondDelta := []byte("modified delta")
 
 	// Trigger load into cache
-	_, err := cache.GetUsingRevID(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
 	assert.NoError(t, err, "Error adding to cache")
 	cache.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevisionDelta{ToRevID: "rev2", DeltaBytes: firstDelta})
 
 	// Retrieve from cache
-	retrievedRev, err := cache.GetUsingRevID(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	retrievedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
@@ -828,7 +824,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Retrieve again, validate delta is correct
-	updatedRev, err := cache.GetUsingRevID(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	updatedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev3", updatedRev.Delta.ToRevID)
 	assert.Equal(t, secondDelta, updatedRev.Delta.DeltaBytes)
@@ -871,17 +867,17 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 			var docRev DocumentRevision
 			var err error
 			if testCase.useCVKey {
-				docRev, err = cache.GetUsingCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err, "Error adding to cache")
 			} else {
-				docRev, err = cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
 				require.NoError(t, err, "Error adding to cache")
 			}
 
 			revCacheMem := memoryBytesCounted.Value()
 			revCacheDelta := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
 			if testCase.useCVKey {
-				cache.UpdateDeltaCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, revCacheDelta)
 			} else {
 				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
 			}
@@ -893,7 +889,7 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 			newMem = memoryBytesCounted.Value()
 			revCacheDelta = newRevCacheDelta(secondDelta, "1-abc", docRev, false, nil)
 			if testCase.useCVKey {
-				cache.UpdateDeltaCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, revCacheDelta)
 			} else {
 				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
 			}
@@ -904,7 +900,7 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 
 			revCacheDelta = newRevCacheDelta(thirdDelta, "1-abc", docRev, false, nil)
 			if testCase.useCVKey {
-				cache.UpdateDeltaCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, revCacheDelta)
 			} else {
 				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
 			}
@@ -951,9 +947,9 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 
 			if !testCase.UseCVCache {
 				// fetch each doc added to load into cache
-				_, err = cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
+				_, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
-				_, err = cache.GetUsingRevID(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta)
+				_, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 
@@ -963,10 +959,10 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			// assert we can still fetch this upsert doc
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.GetUsingCV(ctx, "doc2", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc2", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetUsingRevID(ctx, "doc2", "1-abc", testCollectionID, false)
+				docRev, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, false, false)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc2", docRev.DocID)
@@ -976,10 +972,10 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			assert.Equal(t, int64(0), cacheNumItems.Value())
 
 			if testCase.UseCVCache {
-				docRev, err = cache.GetUsingCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1143,10 +1139,10 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 
 			var docRev DocumentRevision
 			if testCase.useCVKey {
-				docRev, err = cache.GetUsingCV(ctx, "doc3", &Version{Value: 123, SourceID: "test"}, testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc3", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.GetUsingRevID(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta)
+				docRev, err = cache.Get(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1232,10 +1228,10 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			// Test Get with item in the cache
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.GetUsingCV(ctx, "doc1", docCV, collctionID, false, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc1", docCV.String(), collctionID, false, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = db.revisionCache.GetUsingRevID(ctx, "doc1", revID, collctionID, RevCacheOmitDelta)
+				docRev, err = db.revisionCache.Get(ctx, "doc1", revID, collctionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1245,10 +1241,10 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 
 			// get again and ensure memory stat doesn't change
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.GetUsingCV(ctx, "doc1", docCV, collctionID, false, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc1", docCV.String(), collctionID, false, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = db.revisionCache.GetUsingRevID(ctx, "doc1", revID, collctionID, RevCacheOmitDelta)
+				docRev, err = db.revisionCache.Get(ctx, "doc1", revID, collctionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, int64(docSize), cacheStats.RevisionCacheTotalMemory.Value())
@@ -1258,10 +1254,10 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			revDoc2 := createThenRemoveFromRevCache(t, ctx, "doc2", db, collection)
 			// load from doc from bucket
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.GetUsingCV(ctx, "doc2", &revDoc2.CV, collctionID, false, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc2", revDoc2.CV.String(), collctionID, false, false)
 				require.NoError(t, err)
 			} else {
-				docRev, err = db.revisionCache.GetUsingRevID(ctx, "doc2", docRev.RevID, collctionID, RevCacheOmitDelta)
+				docRev, err = db.revisionCache.Get(ctx, "doc2", docRev.RevID, collctionID, RevCacheOmitDelta, false)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1298,24 +1294,24 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 
 			// Test Peek at item not in cache, assert stats unchanged
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
-			var peekKey RevCacheKey
+			var peekKey string
 			if testCase.UseCVCache {
-				peekKey = CreateRevisionCacheCVKey("doc4", &Version{SourceID: "test", Value: 123}, collctionID)
+				peekKey = Version{SourceID: "test", Value: 123}.String()
 			} else {
-				peekKey = CreateRevisionCacheRevIDKey("doc4", "1-abc", collctionID)
+				peekKey = "1-abc"
 			}
-			docRev, ok := db.revisionCache.Peek(ctx, "doc4", peekKey)
+			docRev, ok := db.revisionCache.Peek(ctx, "doc4", peekKey, collctionID)
 			require.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
 
 			// Test Peek in cache, assert stat unchanged
 			if testCase.UseCVCache {
-				peekKey = CreateRevisionCacheCVKey("doc3", &revDoc3.CV, collctionID)
+				peekKey = revDoc3.CV.String()
 			} else {
-				peekKey = CreateRevisionCacheRevIDKey("doc3", revDoc3.RevTreeID, collctionID)
+				peekKey = revDoc3.RevTreeID
 			}
-			docRev, ok = db.revisionCache.Peek(ctx, "doc3", peekKey)
+			docRev, ok = db.revisionCache.Peek(ctx, "doc3", peekKey, collctionID)
 			if testCase.UseCVCache {
 				require.False(t, ok)
 			} else {
@@ -1328,24 +1324,24 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
 			if testCase.UseCVCache {
 				cv := Version{SourceID: "test", Value: 123}
-				db.revisionCache.RemoveUsingCV(ctx, "doc6", &cv, collctionID)
+				db.revisionCache.Remove(ctx, "doc6", cv.String(), collctionID)
 			} else {
-				db.revisionCache.RemoveUsingRevID(ctx, "doc6", "1-abc", collctionID)
+				db.revisionCache.Remove(ctx, "doc6", "1-abc", collctionID)
 			}
 			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
 
 			// Empty cache and see memory stat is 0
 			if testCase.UseCVCache {
-				db.revisionCache.RemoveUsingCV(ctx, "doc3", &revDoc3.CV, collctionID)
-				db.revisionCache.RemoveUsingCV(ctx, "doc2", &revDoc2.CV, collctionID)
-				db.revisionCache.RemoveUsingCV(ctx, "doc1", cvDoc1, collctionID)
+				db.revisionCache.Remove(ctx, "doc3", revDoc3.CV.String(), collctionID)
+				db.revisionCache.Remove(ctx, "doc2", revDoc2.CV.String(), collctionID)
+				db.revisionCache.Remove(ctx, "doc1", cvDoc1.String(), collctionID)
 				// remove items added by GetActive calls
-				db.revisionCache.RemoveUsingRevID(ctx, "doc3", doc3RevID, collctionID)
-				db.revisionCache.RemoveUsingRevID(ctx, "doc2", doc2RevID, collctionID)
+				db.revisionCache.Remove(ctx, "doc3", doc3RevID, collctionID)
+				db.revisionCache.Remove(ctx, "doc2", doc2RevID, collctionID)
 			} else {
-				db.revisionCache.RemoveUsingRevID(ctx, "doc3", revDoc3.RevTreeID, collctionID)
-				db.revisionCache.RemoveUsingRevID(ctx, "doc2", revDoc2.RevTreeID, collctionID)
-				db.revisionCache.RemoveUsingRevID(ctx, "doc1", revIDDoc1, collctionID)
+				db.revisionCache.Remove(ctx, "doc3", revDoc3.RevTreeID, collctionID)
+				db.revisionCache.Remove(ctx, "doc2", revDoc2.RevTreeID, collctionID)
+				db.revisionCache.Remove(ctx, "doc1", revIDDoc1, collctionID)
 			}
 
 			assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
@@ -1367,7 +1363,7 @@ func TestSingleLoad(t *testing.T) {
 	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	_, err := cache.GetUsingRevID(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
+	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false, false)
 
 	assert.NoError(t, err)
 }
@@ -1390,7 +1386,7 @@ func TestConcurrentLoad(t *testing.T) {
 	wg.Add(20)
 	for range 20 {
 		go func() {
-			_, err := cache.GetUsingRevID(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
+			_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false, false)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -1411,14 +1407,14 @@ func TestRevisionCacheRemove(t *testing.T) {
 	rev1id, _, err := collection.Put(ctx, "doc", Body{"val": 123})
 	assert.NoError(t, err)
 
-	docRev, err := collection.revisionCache.GetUsingRevID(base.TestCtx(t), "doc", rev1id, true)
+	docRev, err := collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, true, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 
-	collection.revisionCache.RemoveUsingRevID(ctx, "doc", rev1id)
+	collection.revisionCache.Remove(ctx, "doc", rev1id)
 
-	docRev, err = collection.revisionCache.GetUsingRevID(base.TestCtx(t), "doc", rev1id, true)
+	docRev, err = collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, true, true)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
@@ -1602,17 +1598,17 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			// getDoc abstracts over the two lookup pathways under test.
 			getDoc := func(docID string) (DocumentRevision, error) {
 				if tc.useCVCache {
-					return cache.GetUsingCV(ctx, docID, cv, testCollectionID, RevCacheOmitDelta, false)
+					return cache.Get(ctx, docID, cv.String(), testCollectionID, RevCacheOmitDelta, false)
 				}
-				return cache.GetUsingRevID(ctx, docID, revID, testCollectionID, RevCacheOmitDelta)
+				return cache.Get(ctx, docID, revID, testCollectionID, RevCacheOmitDelta, true)
 			}
 
 			// removeDoc removes an entry using the key type appropriate to the pathway under test.
 			removeDoc := func(docID string) {
 				if tc.useCVCache {
-					cache.RemoveUsingCV(ctx, docID, cv, testCollectionID)
+					cache.Remove(ctx, docID, cv.String(), testCollectionID)
 				} else {
-					cache.RemoveUsingRevID(ctx, docID, revID, testCollectionID)
+					cache.Remove(ctx, docID, revID, testCollectionID)
 				}
 			}
 
@@ -1660,21 +1656,21 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			assertItems(4)
 
 			// Peek on a cached doc does not modify the count.
-			peekKey := CreateRevisionCacheCVKey("doc2", cv, testCollectionID)
+			peekKey := cv.String()
 			if !tc.useCVCache {
-				peekKey = CreateRevisionCacheRevIDKey("doc2", revID, testCollectionID)
+				peekKey = revID
 			}
-			docRev, ok := cache.Peek(ctx, "doc2", peekKey)
+			docRev, ok := cache.Peek(ctx, "doc2", peekKey, 0)
 			require.True(t, ok)
 			assert.Equal(t, "doc2", docRev.DocID)
 			assertItems(4)
 
 			// Peek on a non-cached doc does not modify the count.
-			notFoundKey := CreateRevisionCacheCVKey("doc5", cv, testCollectionID)
+			notFoundKey := cv.String()
 			if !tc.useCVCache {
-				notFoundKey = CreateRevisionCacheRevIDKey("doc5", revID, testCollectionID)
+				notFoundKey = revID
 			}
-			_, ok = cache.Peek(ctx, "doc5", notFoundKey)
+			_, ok = cache.Peek(ctx, "doc5", notFoundKey, 0)
 			require.False(t, ok)
 			assertItems(4)
 
@@ -1688,12 +1684,12 @@ func TestRevCacheCapacityStat(t *testing.T) {
 
 			// Remove all remaining entries. doc3 was evicted above so its removal is a no-op.
 			// doc1, doc4, doc5, doc6 were always Put/Upserted (CV key). doc2 follows the test pathway key type.
-			cache.RemoveUsingRevID(ctx, "doc3", revID, testCollectionID)
-			cache.RemoveUsingCV(ctx, "doc1", cv, testCollectionID)
+			cache.Remove(ctx, "doc3", revID, testCollectionID)
+			cache.Remove(ctx, "doc1", cv.String(), testCollectionID)
 			removeDoc("doc2")
-			cache.RemoveUsingCV(ctx, "doc4", cv, testCollectionID)
-			cache.RemoveUsingCV(ctx, "doc5", cv, testCollectionID)
-			cache.RemoveUsingCV(ctx, "doc6", cv, testCollectionID)
+			cache.Remove(ctx, "doc4", cv.String(), testCollectionID)
+			cache.Remove(ctx, "doc5", cv.String(), testCollectionID)
+			cache.Remove(ctx, "doc6", cv.String(), testCollectionID)
 			assertItems(0)
 		})
 	}
@@ -1732,7 +1728,7 @@ func TestRevCacheOnDemand(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
 				}
 			}
 		}()
@@ -1792,7 +1788,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	}
 	cache.Put(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err := cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1805,7 +1801,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 
 	cache.Upsert(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err = cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1816,7 +1812,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	assert.Equal(t, int64(0), cacheMissCounter.Value())
 
 	// remove the doc rev from the cache and assert that the document is no longer present in cache
-	cache.RemoveUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID)
+	cache.Remove(base.TestCtx(t), "doc1", cv.String(), testCollectionID)
 	assert.Equal(t, 0, len(cache.cache))
 	assert.Equal(t, 0, cache.lruList.Len())
 }
@@ -1836,7 +1832,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 
 	// trigger load into cache
 	for i := range 5000 {
-		_, _ = cache.GetUsingRevID(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitDelta)
+		_, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitDelta, false)
 	}
 
 	b.ResetTimer()
@@ -1844,7 +1840,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		// GET the document until test run has completed
 		for pb.Next() {
 			docId := fmt.Sprintf("doc%d", rand.Intn(5000))
-			_, _ = cache.GetUsingRevID(ctx, docId, "1-abc", testCollectionID, RevCacheOmitDelta)
+			_, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheOmitDelta, false)
 		}
 	})
 }
@@ -1854,7 +1850,7 @@ func createThenRemoveFromRevCache(t *testing.T, ctx context.Context, docID strin
 	revIDDoc, doc, err := collection.Put(ctx, docID, Body{"test": "doc"})
 	require.NoError(t, err)
 
-	db.revisionCache.RemoveUsingRevID(ctx, docID, revIDDoc, collection.GetCollectionID())
+	db.revisionCache.Remove(ctx, docID, revIDDoc, collection.GetCollectionID())
 	docVersion := DocVersion{
 		RevTreeID: doc.GetRevTreeID(),
 	}
@@ -1928,7 +1924,7 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 				case <-ctx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
 				}
 			}
 		}()
@@ -1976,7 +1972,7 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
 				}
 			}
 		}()
@@ -2006,7 +2002,7 @@ func TestLoaderMismatchInCV(t *testing.T) {
 	// create cv with incorrect version to the one stored in backing store
 	cv := Version{SourceID: "test", Value: 1234}
 
-	_, err := cache.GetUsingCV(base.TestCtx(t), "doc1", &cv, testCollectionID, RevCacheOmitDelta, false)
+	_, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
 	require.Error(t, err)
 	require.Error(t, err, base.ErrNotFound)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -2035,21 +2031,21 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 
 	cv := Version{SourceID: "test", Value: 123}
 	go func() {
-		_, err := cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+		_, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
 		require.NoError(t, err)
 		wg.Done()
 	}()
 
 	go func() {
-		_, err := cache.GetUsingCV(ctx, "doc1", &cv, testCollectionID, RevCacheIncludeDelta, false)
+		_, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheIncludeDelta, false)
 		require.NoError(t, err)
 		wg.Done()
 	}()
 
 	wg.Wait()
 
-	cvKey := CreateRevisionCacheCVKey("doc1", &cv, testCollectionID)
-	revKey := CreateRevisionCacheRevIDKey("doc1", "1-abc", testCollectionID)
+	cvKey := CreateRevisionCacheKey("doc1", cv.String(), testCollectionID)
+	revKey := CreateRevisionCacheKey("doc1", "1-abc", testCollectionID)
 	revElement := cache.cache[revKey].Value.(*revCacheValue)
 	cvElement := cache.cache[cvKey].Value.(*revCacheValue)
 
@@ -2078,7 +2074,7 @@ func TestGetActive(t *testing.T) {
 	}
 
 	// remove the entry form the rev cache to force the cache to not have the active version in it
-	collection.revisionCache.RemoveUsingCV(ctx, "doc", &expectedCV)
+	collection.revisionCache.Remove(ctx, "doc", expectedCV.String())
 
 	// call get active to get the active version from the bucket
 	docRev, err := collection.revisionCache.GetActive(base.TestCtx(t), "doc")
@@ -2115,7 +2111,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	}
 
 	go func() {
-		_, err := cache.GetUsingCV(ctx, "doc1", &cv, testCollectionID, RevCacheIncludeDelta, false)
+		_, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheIncludeDelta, false)
 		require.NoError(t, err)
 		wg.Done()
 	}()
@@ -2127,7 +2123,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 
 	wg.Wait()
 
-	key := CreateRevisionCacheCVKey("doc1", &cv, testCollectionID)
+	key := CreateRevisionCacheKey("doc1", cv.String(), testCollectionID)
 	elem := cache.cache[key].Value.(*revCacheValue)
 
 	assert.Equal(t, cache.lruList.Len(), 1)
@@ -2179,7 +2175,7 @@ func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
 				}
 			}
 		}()
@@ -2234,7 +2230,7 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
 				}
 			}
 		}()
@@ -2243,7 +2239,7 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 	var getErr error
 	go func() {
 		for range 100 {
-			_, getErr = db.revisionCache.GetUsingRevID(ctx, docID, rev1ID, collection.GetCollectionID(), true)
+			_, getErr = db.revisionCache.Get(ctx, docID, rev1ID, collection.GetCollectionID(), true, false)
 			if getErr != nil {
 				break
 			}
@@ -2285,7 +2281,7 @@ func TestPutRevHighRevCacheChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.GetUsingRevID(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
 				}
 			}
 		}()
@@ -2317,11 +2313,9 @@ func TestRevCacheOnDemandImportNoCache(t *testing.T) {
 	cv := doc.HLV.ExtractCurrentVersionFromHLV()
 
 	// rev 1 is not in cache given we don't write to cache on write
-	peekKeyRevID := CreateRevisionCacheRevIDKey(docID, revID1, collection.GetCollectionID())
-	peekKeyCV := CreateRevisionCacheCVKey(docID, cv, collection.GetCollectionID())
-	_, exists := collection.revisionCache.Peek(ctx, docID, peekKeyRevID)
+	_, exists := collection.revisionCache.Peek(ctx, docID, revID1)
 	require.False(t, exists)
-	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyCV)
+	_, exists = collection.revisionCache.Peek(ctx, docID, cv.String())
 	require.False(t, exists)
 
 	require.NoError(t, collection.dataStore.Set(docID, 0, nil, []byte(`{"foo": "baz"}`)))
@@ -2331,17 +2325,15 @@ func TestRevCacheOnDemandImportNoCache(t *testing.T) {
 	require.Equal(t, Body{"foo": "baz"}, doc.Body(ctx))
 
 	// rev1 still won't exist in cache
-	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyRevID)
+	_, exists = collection.revisionCache.Peek(ctx, docID, revID1)
 	require.False(t, exists)
-	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyCV)
+	_, exists = collection.revisionCache.Peek(ctx, docID, cv.String())
 	require.False(t, exists)
 
 	// rev2 is not in cache but is on server
-	peekKeyRevID = CreateRevisionCacheRevIDKey(docID, revID1, collection.GetCollectionID())
-	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyRevID)
+	_, exists = collection.revisionCache.Peek(ctx, docID, doc.GetRevTreeID())
 	require.False(t, exists)
-	peekKeyCV = CreateRevisionCacheCVKey(docID, doc.HLV.ExtractCurrentVersionFromHLV(), collection.GetCollectionID())
-	_, exists = collection.revisionCache.Peek(ctx, docID, peekKeyCV)
+	_, exists = collection.revisionCache.Peek(ctx, docID, doc.HLV.GetCurrentVersionString())
 	require.False(t, exists)
 }
 
@@ -2370,7 +2362,7 @@ func TestFetchBackupWithDeletedFlag(t *testing.T) {
 	// flush cache
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.revisionCache.GetUsingCV(ctx, docID, doc1.HLV.ExtractCurrentVersionFromHLV(), false, true)
+	docRev, err := collection.revisionCache.Get(ctx, docID, doc1.HLV.GetCurrentVersionString(), false, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, doc1.HLV.GetCurrentVersionString(), docRev.CV.String())
@@ -2385,7 +2377,7 @@ func TestFetchBackupWithDeletedFlag(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch deleted, will get backup rev and assert that the deleted flag is true
-	docRev, err = collection.revisionCache.GetUsingCV(ctx, docID, deleteDoc.HLV.ExtractCurrentVersionFromHLV(), false, true)
+	docRev, err = collection.revisionCache.Get(ctx, docID, deleteDoc.HLV.GetCurrentVersionString(), false, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, deleteDoc.HLV.GetCurrentVersionString(), docRev.CV.String())
@@ -2427,7 +2419,7 @@ func TestCorrectHLVWhenFetchingBackupRev(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch using lower level cache fetch with load from bucket bool true to get the backup rev
-	docRev, err = collection.revisionCache.GetUsingCV(ctx, docID, docRev.CV, RevCacheOmitDelta, true)
+	docRev, err = collection.revisionCache.Get(ctx, docID, docRev.CV.String(), RevCacheOmitDelta, true)
 	require.NoError(t, err)
 
 	// hlv history should be empty as we are fetching from backup rev
@@ -2478,8 +2470,7 @@ func TestLoadFromBucketLegacyRevsThatAreBackedUpPreUpgrade(t *testing.T) {
 
 	// assert that each legacy rev is populated in rev lookup
 	for _, revID := range revIDs {
-		peekKey := CreateRevisionCacheRevIDKey(docID, revID, collection.GetCollectionID())
-		docRev, ok := collection.revisionCache.Peek(ctx, docID, peekKey)
+		docRev, ok := collection.revisionCache.Peek(ctx, docID, revID)
 		require.True(t, ok)
 		assert.Equal(t, revID, docRev.RevID)
 	}
@@ -2510,7 +2501,7 @@ func TestRaceRemovingStaleCVValue(t *testing.T) {
 	}()
 
 	go func() {
-		cache.RemoveUsingCV(ctx, "doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID)
+		cache.Remove(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID)
 		wg.Done()
 	}()
 
@@ -2534,16 +2525,16 @@ func TestUpdateDeltaRevCacheMemoryStatPanicSingleEntry(t *testing.T) {
 	ctx := base.TestCtx(t)
 
 	// Trigger load into cache.
-	docRev, err := cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	docRev, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
 	require.NoError(t, err, "Error adding to cache")
 
 	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
 
 	// Thread 1: UpdateDelta - start
-	value := cache.getValue(ctx, "doc1", "1-abc", nil, testCollectionID, false)
+	value := cache.getValue(ctx, "doc1", "1-abc", testCollectionID, false)
 	if value != nil {
 		// Thread 2: Remove - start - drop value underneath UpdateDelta thread
-		cache.RemoveUsingRevID(ctx, "doc1", "1-abc", testCollectionID)
+		cache.Remove(ctx, "doc1", "1-abc", testCollectionID)
 		// Thread 2: Remove - end
 		outGoingBytes := value.updateDelta(revCacheDelta2)
 		if outGoingBytes != 0 {
@@ -2577,19 +2568,19 @@ func TestUpdateDeltaRevCacheMemoryStatPanicMultipleEntries(t *testing.T) {
 	// Trigger load into cache.  Add one revision (doc1) without a delta that's less than 500 bytes, then a
 	// revision (doc2) with a delta update that will exceed memory limit
 	// when added.  Both should be removed and cache memory stats should be zero.
-	_, err := cache.GetUsingRevID(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	_, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
 	require.NoError(t, err, "Error adding to cache")
 
-	docRev2, err := cache.GetUsingRevID(ctx, "doc2", "1-abc", testCollectionID, RevCacheIncludeDelta)
+	docRev2, err := cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
 	require.NoError(t, err, "Error adding to cache")
 
 	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev2, false, nil)
 
 	// Thread 1: UpdateDelta - start
-	value := cache.getValue(ctx, "doc2", "1-abc", nil, testCollectionID, false)
+	value := cache.getValue(ctx, "doc2", "1-abc", testCollectionID, false)
 	if value != nil {
 		// Thread 2: Remove - start - drop value underneath UpdateDelta thread
-		cache.RemoveUsingRevID(ctx, "doc2", "1-abc", testCollectionID)
+		cache.Remove(ctx, "doc2", "1-abc", testCollectionID)
 		// Thread 2: Remove - end
 		outGoingBytes := value.updateDelta(revCacheDelta2)
 		if outGoingBytes != 0 {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -155,7 +155,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 
 			ctx := base.TestCtx(t)
 
-			keysAdded := make([]string, 0)
+			keysAdded := make([]RevCacheKey, 0)
 
 			// Fill up the rev cache with the first 10 docs
 			for docID := range 10 {
@@ -212,7 +212,7 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			prevCacheMissCount := cacheMissCounter.Value()
 			for i := range 3 {
 				docID := strconv.Itoa(i)
-				docRev, ok := cache.Peek(ctx, docID, keysAdded[i], testCollectionID)
+				docRev, ok := cache.Peek(ctx, docID, keysAdded[i])
 				assert.False(t, ok)
 				assert.Nil(t, docRev.BodyBytes)
 				assert.Equal(t, prevCacheMissCount, cacheMissCounter.Value()) // peek incurs no cache miss if not found
@@ -303,13 +303,13 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 			}
 			expValue += int64(docSize)
 			// assert doc 0 been evicted
-			var peekKey string
+			var peekKey RevCacheKey
 			if testCase.UseCVKey {
 				peekKey = CreateRevisionCacheCVKey("0", versions[0], collection.GetCollectionID())
 			} else {
 				peekKey = CreateRevisionCacheRevIDKey("0", rev, collection.GetCollectionID())
 			}
-			docRev, ok := db.revisionCache.Peek(ctx, "0", peekKey, collection.GetCollectionID())
+			docRev, ok := db.revisionCache.Peek(ctx, "0", peekKey)
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -325,7 +325,7 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 				db.revisionCache.RemoveUsingRevID(ctx, "1", rev, collection.GetCollectionID())
 				peekKey = CreateRevisionCacheRevIDKey("1", rev, collection.GetCollectionID())
 			}
-			docRev, ok = db.revisionCache.Peek(ctx, "1", peekKey, collection.GetCollectionID())
+			docRev, ok = db.revisionCache.Peek(ctx, "1", peekKey)
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -361,7 +361,7 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 			} else {
 				peekKey = CreateRevisionCacheRevIDKey("2", rev, collection.GetCollectionID())
 			}
-			docRev, ok = db.revisionCache.Peek(ctx, "2", peekKey, collection.GetCollectionID())
+			docRev, ok = db.revisionCache.Peek(ctx, "2", peekKey)
 			assert.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 
@@ -457,13 +457,13 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			assert.Equal(t, 2, cache.lruList.Len())
 			memStatAfterEviction := (memStatBeforeThirdLoad + docRev.MemoryBytes) - currMemStat
 			assert.Equal(t, memStatAfterEviction, memoryBytesCounted.Value())
-			var peekKey string
+			var peekKey RevCacheKey
 			if testCase.UseCVCache {
 				peekKey = CreateRevisionCacheCVKey("doc1", &Version{Value: 123, SourceID: "test"}, testCollectionID)
 			} else {
 				peekKey = CreateRevisionCacheRevIDKey("doc1", "1-abc", testCollectionID)
 			}
-			_, ok := cache.Peek(ctx, "doc1", peekKey, testCollectionID)
+			_, ok := cache.Peek(ctx, "doc1", peekKey)
 			assert.False(t, ok)
 		})
 	}
@@ -658,9 +658,11 @@ func TestBypassRevisionCache(t *testing.T) {
 	rc := NewBypassRevisionCache(backingStoreMap, &bypassStat)
 
 	// Peek always returns false for BypassRevisionCache
-	_, ok := rc.Peek(ctx, key, rev1, 0)
+	peekKey := CreateRevisionCacheRevIDKey(key, rev1, testCollectionID)
+	_, ok := rc.Peek(ctx, key, peekKey)
 	assert.False(t, ok)
-	_, ok = rc.Peek(ctx, key, rev2, 0)
+	peekKey = CreateRevisionCacheRevIDKey(key, rev2, testCollectionID)
+	_, ok = rc.Peek(ctx, key, peekKey)
 	assert.False(t, ok)
 
 	// Get non-existing doc
@@ -678,14 +680,15 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.Equal(t, `{"value":1234}`, string(doc.BodyBytes))
 
 	// Check peek is still returning false for "Get"
-	_, ok = rc.Peek(ctx, key, rev1, testCollectionID)
+	peekKey = CreateRevisionCacheRevIDKey(key, rev1, testCollectionID)
+	_, ok = rc.Peek(ctx, key, peekKey)
 	assert.False(t, ok)
 
 	// Put no-ops
 	rc.Put(ctx, doc, testCollectionID)
 
 	// Check peek is still returning false for "Put"
-	_, ok = rc.Peek(ctx, key, rev1, testCollectionID)
+	_, ok = rc.Peek(ctx, key, peekKey)
 	assert.False(t, ok)
 
 	// Get active revision
@@ -1295,13 +1298,13 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 
 			// Test Peek at item not in cache, assert stats unchanged
 			prevMemStat = cacheStats.RevisionCacheTotalMemory.Value()
-			var peekKey string
+			var peekKey RevCacheKey
 			if testCase.UseCVCache {
 				peekKey = CreateRevisionCacheCVKey("doc4", &Version{SourceID: "test", Value: 123}, collctionID)
 			} else {
 				peekKey = CreateRevisionCacheRevIDKey("doc4", "1-abc", collctionID)
 			}
-			docRev, ok := db.revisionCache.Peek(ctx, "doc4", peekKey, collctionID)
+			docRev, ok := db.revisionCache.Peek(ctx, "doc4", peekKey)
 			require.False(t, ok)
 			assert.Nil(t, docRev.BodyBytes)
 			assert.Equal(t, prevMemStat, cacheStats.RevisionCacheTotalMemory.Value())
@@ -1312,7 +1315,7 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			} else {
 				peekKey = CreateRevisionCacheRevIDKey("doc3", revDoc3.RevTreeID, collctionID)
 			}
-			docRev, ok = db.revisionCache.Peek(ctx, "doc3", peekKey, collctionID)
+			docRev, ok = db.revisionCache.Peek(ctx, "doc3", peekKey)
 			if testCase.UseCVCache {
 				require.False(t, ok)
 			} else {
@@ -1661,7 +1664,7 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			if !tc.useCVCache {
 				peekKey = CreateRevisionCacheRevIDKey("doc2", revID, testCollectionID)
 			}
-			docRev, ok := cache.Peek(ctx, "doc2", peekKey, testCollectionID)
+			docRev, ok := cache.Peek(ctx, "doc2", peekKey)
 			require.True(t, ok)
 			assert.Equal(t, "doc2", docRev.DocID)
 			assertItems(4)
@@ -1671,7 +1674,7 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			if !tc.useCVCache {
 				notFoundKey = CreateRevisionCacheRevIDKey("doc5", revID, testCollectionID)
 			}
-			_, ok = cache.Peek(ctx, "doc5", notFoundKey, testCollectionID)
+			_, ok = cache.Peek(ctx, "doc5", notFoundKey)
 			require.False(t, ok)
 			assertItems(4)
 
@@ -2720,13 +2723,13 @@ func TestMultipleRevCacheItemsForSameDocs(t *testing.T) {
 	// get by cv value
 	_, err = collection.getRev(ctx, docID, doc1.HLV.GetCurrentVersionString(), 0, nil)
 	require.NoError(t, err)
-	// asset that two items are in cache now (both for same docID)
+	// assert that two items are in cache now (both for same docID)
 	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheNumItems.Value())
 
 	// fetch docID2 by revID
 	_, err = collection.getRev(ctx, docID2, doc2Rev, 0, nil)
 	require.NoError(t, err)
-	// asset that three items are in cache now
+	// assert that three items are in cache now
 	assert.Equal(t, int64(3), db.DbStats.Cache().RevisionCacheNumItems.Value())
 
 	// fetch docID2 by CV

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1116,8 +1116,8 @@ func (c *collectionRevisionCache) PutRevEntry(t *testing.T, ctx context.Context,
 		cache = (*c.revCache).(*LRURevisionCache)
 	}
 	// Remove any existing entry so that store() below is not a no-op.
-	cache.RemoveUsingRevID(ctx, docRev.DocID, docRev.RevID, c.collectionID)
-	value := cache.getValue(ctx, docRev.DocID, docRev.RevID, nil, c.collectionID, true)
+	cache.Remove(ctx, docRev.DocID, docRev.RevID, c.collectionID)
+	value := cache.getValue(ctx, docRev.DocID, docRev.RevID, c.collectionID, true)
 	docRev.CalculateBytes()
 	cache.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
 	value.store(docRev)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1103,3 +1103,23 @@ func GetCachingFeedDelayFactor(t testing.TB) time.Duration {
 	require.GreaterOrEqual(t, factor, time.Duration(1), "Caching feed delay factor must be greater than 0, or wait functions will not work. Modify the factor value")
 	return factor
 }
+
+// PutRevEntry inserts a DocumentRevision into the cache under its revID key.
+// Use this in tests to populate the revID lookup path directly (e.g. to inject a corrupt body).
+// NOTE this should be test only use.
+func (c *collectionRevisionCache) PutRevEntry(t *testing.T, ctx context.Context, docRev DocumentRevision) {
+	var cache *LRURevisionCache
+	shard, ok := (*c.revCache).(*ShardedLRURevisionCache)
+	if ok {
+		cache = shard.getShard(docRev.DocID)
+	} else {
+		cache = (*c.revCache).(*LRURevisionCache)
+	}
+	// Remove any existing entry so that store() below is not a no-op.
+	cache.RemoveUsingRevID(ctx, docRev.DocID, docRev.RevID, c.collectionID)
+	value := cache.getValue(ctx, docRev.DocID, docRev.RevID, nil, c.collectionID, true)
+	docRev.CalculateBytes()
+	cache.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
+	value.store(docRev)
+	cache.revCacheMemoryBasedEviction(ctx)
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3501,7 +3501,7 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	// flush cache to ensure we're reading from the bucket
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
-	docRev, err := collection.GetRevisionCacheForTest().GetUsingCV(ctx, docID, &createVersion.CV, false, true)
+	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docID, createVersion.CV.String(), false, true)
 	require.NoError(t, err)
 	// assert doc is not deleted
 	assert.False(t, docRev.Deleted)
@@ -3514,7 +3514,7 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// fetch rev 2 which is deleted
-	docRev, err = collection.GetRevisionCacheForTest().GetUsingCV(ctx, docID, &deleteVrs.CV, false, true)
+	docRev, err = collection.GetRevisionCacheForTest().Get(ctx, docID, deleteVrs.CV.String(), false, true)
 	require.NoError(t, err)
 	assert.True(t, docRev.Deleted)
 	// assert deleted property is there
@@ -3642,7 +3642,7 @@ func TestFetchBackupRevisionWithAttachmentWhenCurrentHasNone(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// fetch rev 1 by its CV, which should include the attachment
-	docRev, err := coll.GetRevisionCacheForTest().GetUsingCV(ctx, docID, &createVersion.CV, false, true)
+	docRev, err := coll.GetRevisionCacheForTest().Get(ctx, docID, createVersion.CV.String(), false, true)
 	require.NoError(t, err)
 
 	assert.Len(t, docRev.Attachments, 1)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3427,10 +3427,18 @@ func TestDocCRUDWithCV(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
 	const docID = "doc1"
 	createVersion := rt.PutDoc(docID, `{"create":true}`)
 
-	getDocVersion, _ := rt.GetDoc(docID)
+	// fetch above version to load into cache
+	docRev, err := collection.GetRev(ctx, docID, createVersion.CV.String(), false, nil)
+	require.NoError(t, err)
+	getDocVersion := DocVersion{
+		CV:        *docRev.CV,
+		RevTreeID: docRev.RevID,
+	}
 	require.Equal(t, createVersion, getDocVersion)
 
 	revIDGen := func(v DocVersion) int {
@@ -3493,7 +3501,7 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	// flush cache to ensure we're reading from the bucket
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
-	docRev, err := collection.GetRevisionCacheForTest().GetWithCV(ctx, docID, &createVersion.CV, false, true)
+	docRev, err := collection.GetRevisionCacheForTest().GetUsingCV(ctx, docID, &createVersion.CV, false, true)
 	require.NoError(t, err)
 	// assert doc is not deleted
 	assert.False(t, docRev.Deleted)
@@ -3506,7 +3514,7 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// fetch rev 2 which is deleted
-	docRev, err = collection.GetRevisionCacheForTest().GetWithCV(ctx, docID, &deleteVrs.CV, false, true)
+	docRev, err = collection.GetRevisionCacheForTest().GetUsingCV(ctx, docID, &deleteVrs.CV, false, true)
 	require.NoError(t, err)
 	assert.True(t, docRev.Deleted)
 	// assert deleted property is there
@@ -3634,7 +3642,7 @@ func TestFetchBackupRevisionWithAttachmentWhenCurrentHasNone(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// fetch rev 1 by its CV, which should include the attachment
-	docRev, err := coll.GetRevisionCacheForTest().GetWithCV(ctx, docID, &createVersion.CV, false, true)
+	docRev, err := coll.GetRevisionCacheForTest().GetUsingCV(ctx, docID, &createVersion.CV, false, true)
 	require.NoError(t, err)
 
 	assert.Len(t, docRev.Attachments, 1)

--- a/rest/attachment_test.go
+++ b/rest/attachment_test.go
@@ -2971,6 +2971,8 @@ func TestGetNonWinningRevisionAttachmentLeak(t *testing.T) {
 
 	rt.CreateUser("alice", []string{"ABC"})
 
+	collection, ctx := rt.GetSingleTestDatabaseCollectionWithUser()
+
 	for _, revType := range []string{"RevTreeID", "CV"} {
 		t.Run(revType, func(t *testing.T) {
 			for _, flushCache := range []bool{false, true} {
@@ -2988,7 +2990,12 @@ func TestGetNonWinningRevisionAttachmentLeak(t *testing.T) {
 
 					if !flushCache {
 						// ensure revision is cached
-						_, _ = rt.GetDoc(docID)
+						fetchVersion := version1.CV.String()
+						if revType == "RevTreeID" {
+							fetchVersion = version1.RevTreeID
+						}
+						_, err := collection.GetRev(ctx, docID, fetchVersion, false, nil)
+						require.NoError(t, err)
 					}
 
 					// version 2 moves to channel B (alice has no access) with an attachment

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1001,7 +1001,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 			collection, ctx := rt.GetSingleTestDatabaseCollection()
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := collection.GetRevisionCacheForTest().GetUsingRevID(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta)
+			docRev, cacheErr := collection.GetRevisionCacheForTest().Get(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta, true)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {
@@ -1285,6 +1285,7 @@ func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
+	btcRunner.SkipSubtest[RevtreeSubtestName] = true
 	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t,
 			rtConfig)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1285,7 +1285,6 @@ func TestDeltaGenerationWithBypassRevCache(t *testing.T) {
 		SyncFn: channels.DocChannelsSyncFunction,
 	}
 	btcRunner := NewBlipTesterClientRunner(t)
-	btcRunner.SkipSubtest[RevtreeSubtestName] = true
 	btcRunner.Run(func(t *testing.T) {
 		rt := NewRestTester(t,
 			rtConfig)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1001,7 +1001,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 			collection, ctx := rt.GetSingleTestDatabaseCollection()
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := collection.GetRevisionCacheForTest().GetWithRev(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta)
+			docRev, cacheErr := collection.GetRevisionCacheForTest().GetUsingRevID(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -59,7 +59,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
 
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	docRev, err := collection.GetRevisionCacheForTest().GetWithRev(ctx, docKey, syncData.GetRevTreeID(), false)
+	docRev, err := collection.GetRevisionCacheForTest().GetUsingRevID(ctx, docKey, syncData.GetRevTreeID(), false)
 	assert.NoError(t, err)
 	assert.Len(t, docRev.Channels.ToArray(), 0)
 	assert.Equal(t, syncData.GetRevTreeID(), docRev.RevID)
@@ -81,7 +81,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData2))
 
-	docRev2, err := collection.GetRevisionCacheForTest().GetWithRev(ctx, docKey, syncData.GetRevTreeID(), false)
+	docRev2, err := collection.GetRevisionCacheForTest().GetUsingRevID(ctx, docKey, syncData.GetRevTreeID(), false)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.GetRevTreeID(), docRev2.RevID)
 

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -59,7 +59,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
 
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	docRev, err := collection.GetRevisionCacheForTest().GetUsingRevID(ctx, docKey, syncData.GetRevTreeID(), false)
+	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.GetRevTreeID(), false, true)
 	assert.NoError(t, err)
 	assert.Len(t, docRev.Channels.ToArray(), 0)
 	assert.Equal(t, syncData.GetRevTreeID(), docRev.RevID)
@@ -81,7 +81,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData2))
 
-	docRev2, err := collection.GetRevisionCacheForTest().GetUsingRevID(ctx, docKey, syncData.GetRevTreeID(), false)
+	docRev2, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.GetRevTreeID(), false, true)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.GetRevTreeID(), docRev2.RevID)
 

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -2091,18 +2091,18 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 
 		// assert we cannot keep old cache entry for original wrote (before conflict resolution) on active cluster rest testers
 		collectionActive1, ctxActive1 := active.GetSingleTestDatabaseCollectionWithUser()
-		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, db.CreateRevisionCacheRevIDKey(docID, rt1Version.RevTreeID, collectionActive1.GetCollectionID()))
+		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
 		// no peek for cv so fetch by cv, which in turn loads from bucket so assert item has correct history on it
-		docRev, err := collectionActive1.GetRevisionCacheForTest().GetUsingCV(ctxActive1, docID, &rt1Version.CV, false, false)
+		docRev, err := collectionActive1.GetRevisionCacheForTest().Get(ctxActive1, docID, rt1Version.CV.String(), false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 
 		// same for other active rest tester
 		collectionRT1, ctxRT1 := rt1.GetSingleTestDatabaseCollectionWithUser()
-		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, db.CreateRevisionCacheRevIDKey(docID, rt1Version.RevTreeID, collectionRT1.GetCollectionID()))
+		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
-		docRev, err = collectionRT1.GetRevisionCacheForTest().GetUsingCV(ctxRT1, docID, &rt1Version.CV, false, false)
+		docRev, err = collectionRT1.GetRevisionCacheForTest().Get(ctxRT1, docID, rt1Version.CV.String(), false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 	})

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -2091,16 +2091,16 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 
 		// assert we cannot keep old cache entry for original wrote (before conflict resolution) on active cluster rest testers
 		collectionActive1, ctxActive1 := active.GetSingleTestDatabaseCollectionWithUser()
-		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, rt1Version.RevTreeID)
+		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, db.CreateRevisionCacheRevIDKey(docID, rt1Version.RevTreeID, collectionActive1.GetCollectionID()))
 		require.False(t, ok)
-		// no peek for cv so fetch by cv, which in turn loads from bucket so assert item ahs correct history on it
+		// no peek for cv so fetch by cv, which in turn loads from bucket so assert item has correct history on it
 		docRev, err := collectionActive1.GetRevisionCacheForTest().GetUsingCV(ctxActive1, docID, &rt1Version.CV, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 
 		// same for other active rest tester
 		collectionRT1, ctxRT1 := rt1.GetSingleTestDatabaseCollectionWithUser()
-		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, rt1Version.RevTreeID)
+		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, db.CreateRevisionCacheRevIDKey(docID, rt1Version.RevTreeID, collectionRT1.GetCollectionID()))
 		require.False(t, ok)
 		docRev, err = collectionRT1.GetRevisionCacheForTest().GetUsingCV(ctxRT1, docID, &rt1Version.CV, false, false)
 		require.NoError(t, err)

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -2094,7 +2094,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
 		// no peek for cv so fetch by cv, which in turn loads from bucket so assert item ahs correct history on it
-		docRev, err := collectionActive1.GetRevisionCacheForTest().GetWithCV(ctxActive1, docID, &rt1Version.CV, false, false)
+		docRev, err := collectionActive1.GetRevisionCacheForTest().GetUsingCV(ctxActive1, docID, &rt1Version.CV, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 
@@ -2102,7 +2102,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		collectionRT1, ctxRT1 := rt1.GetSingleTestDatabaseCollectionWithUser()
 		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
-		docRev, err = collectionRT1.GetRevisionCacheForTest().GetWithCV(ctxRT1, docID, &rt1Version.CV, false, false)
+		docRev, err = collectionRT1.GetRevisionCacheForTest().GetUsingCV(ctxRT1, docID, &rt1Version.CV, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 	})

--- a/rest/replicatortest/replicator_test.go
+++ b/rest/replicatortest/replicator_test.go
@@ -6954,7 +6954,9 @@ func TestUnprocessableDeltas(t *testing.T) {
 		// Making body invalid to trigger log "Unable to unmarshal mutable body for doc" in handleRev
 		// Which should give a HTTP 422
 		rev.BodyBytes = []byte("{invalid}")
-		passiveRTCollection.GetRevisionCacheForTest().Upsert(base.TestCtx(t), rev)
+		cache := passiveRTCollection.GetRevisionCacheForTest()
+		cache.Upsert(base.TestCtx(t), rev)         // CV key  → found by v4 GetWithCV
+		cache.PutRevEntry(t, base.TestCtx(t), rev) // revID key → found by v3 GetWithRev
 
 		base.AssertLogContains(t, "Unable to unmarshal mutable body for doc test", func() {
 			require.NoError(t, ar.Start(activeCtx))


### PR DESCRIPTION
CBG-5233

- remove revID lookup and hlv lookup and have single lookup by string to list element
- This means two items can correspond to the same doc if a fetch is done by revID then CV
- For Put and Upsert, these only operate on CV as it stands. I think this makes sense instead of a Put or Upsert potentially adding two new items for one doc. In any case this is off by default.
- Some refactoring to make code shared
- Kept lookup map keyed by struct type, to avoid string formatting

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/410/ (disable rev cache)
- [x] `GSI=true,xattrs=true` https://jenkins.sgwdev.com/job/SyncGatewayIntegration/409/ (flaky test failure) 
