### PR TITLE
CBG-5257: remove GetCV function

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -1155,7 +1155,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 	newDoc.UpdateBodyBytes(bodyBytes)
 
 	injectedAttachmentsForDelta := false
-	if deltaSrcRevID, isDelta := revMessage.DeltaSrc(); isDelta && !revMessage.Deleted() {
+	if deltaSrcRevString, isDelta := revMessage.DeltaSrc(); isDelta && !revMessage.Deleted() {
 		if !bh.sgCanUseDeltas {
 			return base.HTTPErrorf(http.StatusBadRequest, "Deltas are disabled for this peer")
 		}
@@ -1167,35 +1167,27 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		//        (otherwise we don't have information needed to do downloadOrVerifyAttachments below prior to PutExistingRev)
 
 		// Note: Using GetRevCopy here, and not direct rev cache retrieval, because it's still necessary to apply access check
-		//       while retrieving deltaSrcRevID.  Couchbase Lite replication guarantees client has access to deltaSrcRevID,
+		//       while retrieving deltaSrcRevString.  Couchbase Lite replication guarantees client has access to deltaSrcRevString,
 		//       due to no-conflict write restriction, but we still need to enforce security here to prevent leaking data about previous
 		//       revisions to malicious actors (in the scenario where that user has write but not read access).
 		var deltaSrcRev DocumentRevision
-		if bh.useHLV() && !base.IsRevTreeID(deltaSrcRevID) {
-			deltaSrcVersion, parseErr := ParseVersion(deltaSrcRevID)
-			if parseErr != nil {
-				return base.HTTPErrorf(http.StatusUnprocessableEntity, "Unable to parse version for delta source for doc %s, error: %v", base.UD(docID), parseErr)
-			}
-			deltaSrcRev, err = bh.collection.GetCV(bh.loggingCtx, docID, &deltaSrcVersion, false)
-		} else {
-			deltaSrcRev, err = bh.collection.GetRev(bh.loggingCtx, docID, deltaSrcRevID, false, nil)
-		}
+		deltaSrcRev, err = bh.collection.GetRev(bh.loggingCtx, docID, deltaSrcRevString, false, nil)
 		if err != nil {
-			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't fetch doc %s for deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't fetch doc %s for deltaSrc=%s %v", base.UD(docID), deltaSrcRevString, err)
 		}
 
 		// Receiving a delta to be applied on top of a tombstone is not valid.
 		if deltaSrcRev.Deleted {
-			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't use delta. Found tombstone for doc %s deltaSrc=%s", base.UD(docID), deltaSrcRevID)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't use delta. Found tombstone for doc %s deltaSrc=%s", base.UD(docID), deltaSrcRevString)
 		}
 
 		deltaSrcBody, err := deltaSrcRev.MutableBody()
 		if err != nil {
-			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Unable to unmarshal mutable body for doc %s deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Unable to unmarshal mutable body for doc %s deltaSrc=%s %v", base.UD(docID), deltaSrcRevString, err)
 		}
 
 		if deltaSrcBody[BodyRemoved] != nil {
-			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't use delta. Found _removed property for doc %s deltaSrc=%s", base.UD(docID), deltaSrcRevID)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't use delta. Found _removed property for doc %s deltaSrc=%s", base.UD(docID), deltaSrcRevString)
 		}
 		// Stamp attachments so we can patch them
 		if len(deltaSrcRev.Attachments) > 0 {
@@ -1208,7 +1200,7 @@ func (bh *blipHandler) processRev(rq *blip.Message, stats *processRevStats) (err
 		// err should only ever be a FleeceDeltaError here - but to be defensive, handle other errors too (e.g. somehow reaching this code in a CE build)
 		if err != nil {
 			// Something went wrong in the diffing library. We want to know about this!
-			base.WarnfCtx(bh.loggingCtx, "Error patching deltaSrc %s with %s for doc %s with delta - err: %v", deltaSrcRevID, rev, base.UD(docID), err)
+			base.WarnfCtx(bh.loggingCtx, "Error patching deltaSrc %s with %s for doc %s with delta - err: %v", deltaSrcRevString, rev, base.UD(docID), err)
 			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Error patching deltaSrc with delta: %s", err)
 		}
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -672,20 +672,8 @@ func (bsc *BlipSyncContext) sendRevision(ctx context.Context, sender *blip.Sende
 
 	var originalErr error
 	var docRev DocumentRevision
-	var localIsLegacyRev bool
-	if base.IsRevTreeID(revID) {
-		localIsLegacyRev = true
-	}
-	if !bsc.useHLV() || localIsLegacyRev {
-		docRev, originalErr = handleChangesResponseCollection.GetRev(ctx, docID, revID, true, nil)
-	} else {
-		// extract CV string rev representation
-		version, vrsErr := ParseVersion(revID)
-		if vrsErr != nil {
-			return vrsErr
-		}
-		docRev, originalErr = handleChangesResponseCollection.GetCV(ctx, docID, &version, true)
-	}
+	localIsLegacyRev := base.IsRevTreeID(revID)
+	docRev, originalErr = handleChangesResponseCollection.GetRev(ctx, docID, revID, true, nil)
 
 	// set if we find an alternative revision to send in the event the originally requested rev is unavailable
 	var replacedRevID string

--- a/db/crud.go
+++ b/db/crud.go
@@ -418,25 +418,6 @@ func (db *DatabaseCollectionWithUser) documentRevisionForRequest(ctx context.Con
 	return revision, nil
 }
 
-func (db *DatabaseCollectionWithUser) GetCV(ctx context.Context, docid string, cv *Version, revTreeHistory bool) (revision DocumentRevision, err error) {
-	var requestRevision string
-	if cv != nil {
-		revision, err = db.revisionCache.Get(ctx, docid, cv.String(), RevCacheOmitDelta, false)
-		requestRevision = cv.String()
-	} else {
-		revision, err = db.revisionCache.GetActive(ctx, docid)
-	}
-	if err != nil {
-		return DocumentRevision{}, err
-	}
-	maxHistory := 0
-	if revTreeHistory {
-		maxHistory = math.MaxInt32
-	}
-
-	return db.documentRevisionForRequest(ctx, docid, revision, requestRevision, maxHistory, nil)
-}
-
 // GetDelta attempts to return the delta between fromRevId and toRevId. If the delta can't be generated, returns nil.
 // Delta generation is synchronized per fromRev via a shared revision cache value lock to avoid multiple clients generating the same delta simultaneously.
 func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromRev, toRev string) (delta *RevisionDelta, redactedRev *DocumentRevision, err error) {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1941,12 +1941,12 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 	assert.Equal(t, "1-3a208ea66e84121b528f05b5457d1134", doc.SyncData.GetRevTreeID())
 }
 
-// TestGetCVWithDocResidentInCache:
+// TestGetRevWithCVDocResidentInCache:
 //   - Two test cases, one with doc a user will have access to, one without
-//   - Purpose is to have a doc that is resident in rev cache and use the GetCV function to retrieve these docs
+//   - Purpose is to have a doc that is resident in rev cache and use the GetRev function to retrieve these docs
 //   - Assert that the doc the user has access to is corrected fetched
 //   - Assert the doc the user doesn't have access to is fetched but correctly redacted
-func TestGetCVWithDocResidentInCache(t *testing.T) {
+func TestGetRevWithCVDocResidentInCache(t *testing.T) {
 	const docID = "doc1"
 
 	testCases := []struct {
@@ -1988,7 +1988,7 @@ func TestGetCVWithDocResidentInCache(t *testing.T) {
 			vrs := doc.HLV.Version
 			src := doc.HLV.SourceID
 			sv := &Version{Value: vrs, SourceID: src}
-			revision, err := collection.GetCV(ctx, docID, sv, false)
+			revision, err := collection.GetRev(ctx, docID, sv.String(), false, nil)
 			require.NoError(t, err)
 			if testCase.access {
 				assert.Equal(t, rev, revision.RevID)
@@ -2005,13 +2005,12 @@ func TestGetCVWithDocResidentInCache(t *testing.T) {
 	}
 }
 
-// TestGetByCVForDocNotResidentInCache:
+// TestGetRevWithCVForDocNotResidentInCache:
 //   - Setup db with rev cache size of 1
 //   - Put two docs forcing eviction of the first doc
-//   - Use GetCV function to fetch the first doc, forcing the rev cache to load the doc from bucket
+//   - Use GetRev function to fetch the first doc, forcing the rev cache to load the doc from bucket
 //   - Assert the doc revision fetched is correct to the first doc we created
-func TestGetByCVForDocNotResidentInCache(t *testing.T) {
-	t.Skip("")
+func TestGetRevWithCVForDocNotResidentInCache(t *testing.T) {
 
 	db, ctx := SetupTestDBWithOptions(t, DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
@@ -2047,23 +2046,25 @@ func TestGetByCVForDocNotResidentInCache(t *testing.T) {
 	vrs := doc.HLV.Version
 	src := doc.HLV.SourceID
 	sv := &Version{Value: vrs, SourceID: src}
-	revision, err := collection.GetCV(ctx, doc1ID, sv, false)
+	revision, err := collection.GetRev(ctx, doc1ID, sv.String(), false, nil)
 	require.NoError(t, err)
 
 	// assert the fetched doc is the first doc we added and assert that we did in fact get cache miss
-	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
+	if !base.TestDisableRevCache() {
+		assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
+	}
 	assert.Equal(t, rev, revision.RevID)
 	assert.Equal(t, sv, revision.CV)
 	assert.Equal(t, doc1ID, revision.DocID)
 	assert.Equal(t, []byte(`{"channels":["A"]}`), revision.BodyBytes)
 }
 
-// TestGetCVActivePathway:
+// TestGetRevWithCVActivePathway:
 //   - Two test cases, one with doc a user will have access to, one without
-//   - Purpose is top specify nil CV to the GetCV function to force the GetActive code pathway
+//   - Purpose is to specify an empty revOrCV to the GetRev function to force the GetActive code pathway
 //   - Assert doc that is created is fetched correctly when user has access to doc
 //   - Assert that correct error is returned when user has no access to the doc
-func TestGetCVActivePathway(t *testing.T) {
+func TestGetRevWithCVActivePathway(t *testing.T) {
 	const docID = "doc1"
 
 	testCases := []struct {
@@ -2101,7 +2102,7 @@ func TestGetCVActivePathway(t *testing.T) {
 			revBody := Body{"channels": testCase.docChannels}
 			rev, doc, err := collection.Put(ctx, docID, revBody)
 			require.NoError(t, err)
-			revision, err := collection.GetCV(ctx, docID, nil, false)
+			revision, err := collection.GetRev(ctx, docID, "", false, nil)
 
 			if testCase.access == true {
 				require.NoError(t, err)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1944,7 +1944,7 @@ func TestPutExistingCurrentVersionWithNoExistingDoc(t *testing.T) {
 // TestGetRevWithCVDocResidentInCache:
 //   - Two test cases, one with doc a user will have access to, one without
 //   - Purpose is to have a doc that is resident in rev cache and use the GetRev function to retrieve these docs
-//   - Assert that the doc the user has access to is corrected fetched
+//   - Assert that the doc the user has access to is correctly fetched
 //   - Assert the doc the user doesn't have access to is fetched but correctly redacted
 func TestGetRevWithCVDocResidentInCache(t *testing.T) {
 	const docID = "doc1"

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -58,6 +58,9 @@ func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString str
 		return DocumentRevision{}, err
 	}
 	if hlv != nil {
+		if docRev.CV == nil {
+			docRev.CV = hlv.ExtractCurrentVersionFromHLV()
+		}
 		docRev.HlvHistory = hlv.ToHistoryForHLV()
 	}
 


### PR DESCRIPTION
CBG-5257

- Remove GetCV function and use GetRev instead. We now have single string version we can pass down to rev cache so this function seems not necessary now. 
- Including a fix for bypass revision cache not populating cv when requesting by revID 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`


## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
