### PR TITLE
CBG-5235: orchectration layer for revision and delta cache access

### DIFF
--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -91,7 +91,7 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 		return NewShardedLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
 	}
 
-	return NewCompositeRevisionCache(NewLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat))
+	return NewRevisionCacheOrchestrator(NewLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat))
 }
 
 type RevisionCacheOptions struct {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -61,6 +61,7 @@ const (
 var _ RevisionCache = &LRURevisionCache{}
 var _ RevisionCache = &ShardedLRURevisionCache{}
 var _ RevisionCache = &BypassRevisionCache{}
+var _ RevisionCache = &RevisionCacheOrchestrator{}
 
 // NewRevisionCache returns a RevisionCache implementation for the given config options.
 func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheStats *base.CacheStats) RevisionCache {
@@ -90,7 +91,7 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 		return NewShardedLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
 	}
 
-	return NewLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
+	return NewCompositeRevisionCache(NewLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat))
 }
 
 type RevisionCacheOptions struct {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -22,14 +22,14 @@ import (
 )
 
 type ShardedLRURevisionCache struct {
-	caches    []*LRURevisionCache
+	caches    []*RevisionCacheOrchestrator
 	numShards uint16
 }
 
 // Creates a sharded revision cache with the given capacity and an optional loader function.
 func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat *base.SgwIntStat) *ShardedLRURevisionCache {
 
-	caches := make([]*LRURevisionCache, revCacheOptions.ShardCount)
+	caches := make([]*RevisionCacheOrchestrator, revCacheOptions.ShardCount)
 	// Add 10% to per-shared cache capacity to ensure overall capacity is reached under non-ideal shard hashing
 	perCacheCapacity := 1.1 * float32(revCacheOptions.MaxItemCount) / float32(revCacheOptions.ShardCount)
 	revCacheOptions.MaxItemCount = uint32(perCacheCapacity)
@@ -40,7 +40,8 @@ func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingSt
 	}
 
 	for i := 0; i < int(revCacheOptions.ShardCount); i++ {
-		caches[i] = NewLRURevisionCache(revCacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
+		cacheForShard := NewLRURevisionCache(revCacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
+		caches[i] = NewCompositeRevisionCache(cacheForShard)
 	}
 
 	return &ShardedLRURevisionCache{
@@ -49,7 +50,7 @@ func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingSt
 	}
 }
 
-func (sc *ShardedLRURevisionCache) getShard(docID string) *LRURevisionCache {
+func (sc *ShardedLRURevisionCache) getShard(docID string) *RevisionCacheOrchestrator {
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -41,7 +41,7 @@ func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingSt
 
 	for i := 0; i < int(revCacheOptions.ShardCount); i++ {
 		cacheForShard := NewLRURevisionCache(revCacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
-		caches[i] = NewCompositeRevisionCache(cacheForShard)
+		caches[i] = NewRevisionCacheOrchestrator(cacheForShard)
 	}
 
 	return &ShardedLRURevisionCache{

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -25,20 +25,16 @@ func NewRevisionCacheOrchestrator(bodyCache *LRURevisionCache) *RevisionCacheOrc
 	}
 }
 
-func (c *RevisionCacheOrchestrator) GetWithRev(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error) {
-	return c.revisionCache.GetWithRev(ctx, docID, revID, collectionID, includeDelta)
-}
-
-func (c *RevisionCacheOrchestrator) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
-	return c.revisionCache.GetWithCV(ctx, docID, cv, collectionID, includeDelta, loadBackup)
+func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (DocumentRevision, error) {
+	return c.revisionCache.Get(ctx, docID, versionString, collectionID, includeDelta, loadBackup)
 }
 
 func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
 	return c.revisionCache.GetActive(ctx, docID, collectionID)
 }
 
-func (c *RevisionCacheOrchestrator) Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool) {
-	return c.revisionCache.Peek(ctx, docID, revID, collectionID)
+func (c *RevisionCacheOrchestrator) Peek(ctx context.Context, docID, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {
+	return c.revisionCache.Peek(ctx, docID, versionString, collectionID)
 }
 
 func (c *RevisionCacheOrchestrator) Put(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
@@ -49,26 +45,10 @@ func (c *RevisionCacheOrchestrator) Upsert(ctx context.Context, docRev DocumentR
 	c.revisionCache.Upsert(ctx, docRev, collectionID)
 }
 
-func (c *RevisionCacheOrchestrator) RemoveWithRev(ctx context.Context, docID, revID string, collectionID uint32) {
-	c.revisionCache.RemoveWithRev(ctx, docID, revID, collectionID)
-}
-
-func (c *RevisionCacheOrchestrator) RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	c.revisionCache.RemoveWithCV(ctx, docID, cv, collectionID)
-}
-
-func (c *RevisionCacheOrchestrator) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
-	c.revisionCache.RemoveRevOnly(ctx, docID, revID, collectionID)
-}
-
-func (c *RevisionCacheOrchestrator) RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32) {
-	c.revisionCache.RemoveCVOnly(ctx, docID, cv, collectionID)
+func (c *RevisionCacheOrchestrator) Remove(ctx context.Context, docID, versionString string, collectionID uint32) {
+	c.revisionCache.Remove(ctx, docID, versionString, collectionID)
 }
 
 func (c *RevisionCacheOrchestrator) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
 	c.revisionCache.UpdateDelta(ctx, docID, revID, collectionID, toDelta)
-}
-
-func (c *RevisionCacheOrchestrator) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, collectionID uint32, toDelta RevisionDelta) {
-	c.revisionCache.UpdateDeltaCV(ctx, docID, cv, collectionID, toDelta)
 }

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import "context"
+
+// RevisionCacheOrchestrator orchestrates between the revisionCache and a deltaCache.
+type RevisionCacheOrchestrator struct {
+	revisionCache *LRURevisionCache
+	// delta cache to be implemented: CBG-5234
+}
+
+// NewCompositeRevisionCache creates a new RevisionCacheOrchestrator.
+func NewCompositeRevisionCache(bodyCache *LRURevisionCache) *RevisionCacheOrchestrator {
+	return &RevisionCacheOrchestrator{
+		revisionCache: bodyCache,
+	}
+}
+
+func (c *RevisionCacheOrchestrator) GetWithRev(ctx context.Context, docID, revID string, collectionID uint32, includeDelta bool) (DocumentRevision, error) {
+	return c.revisionCache.GetWithRev(ctx, docID, revID, collectionID, includeDelta)
+}
+
+func (c *RevisionCacheOrchestrator) GetWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32, includeDelta bool, loadBackup bool) (DocumentRevision, error) {
+	return c.revisionCache.GetWithCV(ctx, docID, cv, collectionID, includeDelta, loadBackup)
+}
+
+func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
+	return c.revisionCache.GetActive(ctx, docID, collectionID)
+}
+
+func (c *RevisionCacheOrchestrator) Peek(ctx context.Context, docID, revID string, collectionID uint32) (docRev DocumentRevision, found bool) {
+	return c.revisionCache.Peek(ctx, docID, revID, collectionID)
+}
+
+func (c *RevisionCacheOrchestrator) Put(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
+	c.revisionCache.Put(ctx, docRev, collectionID)
+}
+
+func (c *RevisionCacheOrchestrator) Upsert(ctx context.Context, docRev DocumentRevision, collectionID uint32) {
+	c.revisionCache.Upsert(ctx, docRev, collectionID)
+}
+
+func (c *RevisionCacheOrchestrator) RemoveWithRev(ctx context.Context, docID, revID string, collectionID uint32) {
+	c.revisionCache.RemoveWithRev(ctx, docID, revID, collectionID)
+}
+
+func (c *RevisionCacheOrchestrator) RemoveWithCV(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+	c.revisionCache.RemoveWithCV(ctx, docID, cv, collectionID)
+}
+
+func (c *RevisionCacheOrchestrator) RemoveRevOnly(ctx context.Context, docID, revID string, collectionID uint32) {
+	c.revisionCache.RemoveRevOnly(ctx, docID, revID, collectionID)
+}
+
+func (c *RevisionCacheOrchestrator) RemoveCVOnly(ctx context.Context, docID string, cv *Version, collectionID uint32) {
+	c.revisionCache.RemoveCVOnly(ctx, docID, cv, collectionID)
+}
+
+func (c *RevisionCacheOrchestrator) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
+	c.revisionCache.UpdateDelta(ctx, docID, revID, collectionID, toDelta)
+}
+
+func (c *RevisionCacheOrchestrator) UpdateDeltaCV(ctx context.Context, docID string, cv *Version, collectionID uint32, toDelta RevisionDelta) {
+	c.revisionCache.UpdateDeltaCV(ctx, docID, cv, collectionID, toDelta)
+}

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -18,8 +18,8 @@ type RevisionCacheOrchestrator struct {
 	// delta cache to be implemented: CBG-5234
 }
 
-// NewCompositeRevisionCache creates a new RevisionCacheOrchestrator.
-func NewCompositeRevisionCache(bodyCache *LRURevisionCache) *RevisionCacheOrchestrator {
+// NewRevisionCacheOrchestrator creates a new RevisionCacheOrchestrator.
+func NewRevisionCacheOrchestrator(bodyCache *LRURevisionCache) *RevisionCacheOrchestrator {
 	return &RevisionCacheOrchestrator{
 		revisionCache: bodyCache,
 	}

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -19,9 +19,9 @@ type RevisionCacheOrchestrator struct {
 }
 
 // NewRevisionCacheOrchestrator creates a new RevisionCacheOrchestrator.
-func NewRevisionCacheOrchestrator(bodyCache *LRURevisionCache) *RevisionCacheOrchestrator {
+func NewRevisionCacheOrchestrator(revisionCache *LRURevisionCache) *RevisionCacheOrchestrator {
 	return &RevisionCacheOrchestrator{
-		revisionCache: bodyCache,
+		revisionCache: revisionCache,
 	}
 }
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -1025,12 +1025,12 @@ func TestShardedMemoryEviction(t *testing.T) {
 	// grab this particular shard + assert that the shard memory usage is as expected
 	shardedCache := db.revisionCache.(*ShardedLRURevisionCache)
 	doc1Shard := shardedCache.getShard("doc1")
-	assert.Equal(t, int64(size), doc1Shard.currMemoryUsage.Value())
+	assert.Equal(t, int64(size), doc1Shard.revisionCache.currMemoryUsage.Value())
 
 	// add new doc in diff shard + assert that the shard memory usage is as expected
 	size, _, _ = createDocAndReturnSizeAndRev(t, ctx, "doc2", collection, docBody, false)
 	doc2Shard := shardedCache.getShard("doc2")
-	assert.Equal(t, int64(size), doc2Shard.currMemoryUsage.Value())
+	assert.Equal(t, int64(size), doc2Shard.revisionCache.currMemoryUsage.Value())
 	// overall mem usage should be combination oif the two added docs
 	assert.Equal(t, int64(size*2), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -1044,7 +1044,7 @@ func TestShardedMemoryEviction(t *testing.T) {
 	// add new doc to trigger eviction and assert stats are as expected
 	newDocSize, _, _ := createDocAndReturnSizeAndRev(t, ctx, "doc3", collection, docBody, false)
 	doc3Shard := shardedCache.getShard("doc3")
-	assert.Equal(t, int64(newDocSize), doc3Shard.currMemoryUsage.Value())
+	assert.Equal(t, int64(newDocSize), doc3Shard.revisionCache.currMemoryUsage.Value())
 	assert.Equal(t, int64(2), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(size+newDocSize), cacheStats.RevisionCacheTotalMemory.Value())
 }
@@ -1080,7 +1080,7 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 
 	// assert that doc was not added to cache as it's too large
 	doc1Shard := shardedCache.getShard("doc1")
-	assert.Equal(t, int64(0), doc1Shard.currMemoryUsage.Value())
+	assert.Equal(t, int64(0), doc1Shard.revisionCache.currMemoryUsage.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
 
@@ -1091,7 +1091,7 @@ func TestShardedMemoryEvictionWhenShardEmpty(t *testing.T) {
 	assert.NotNil(t, docRev.BodyBytes)
 
 	// assert rev cache is still empty
-	assert.Equal(t, int64(0), doc1Shard.currMemoryUsage.Value())
+	assert.Equal(t, int64(0), doc1Shard.revisionCache.currMemoryUsage.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheNumItems.Value())
 	assert.Equal(t, int64(0), cacheStats.RevisionCacheTotalMemory.Value())
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1108,18 +1108,18 @@ func GetCachingFeedDelayFactor(t testing.TB) time.Duration {
 // Use this in tests to populate the revID lookup path directly (e.g. to inject a corrupt body).
 // NOTE this should be test only use.
 func (c *collectionRevisionCache) PutRevEntry(t *testing.T, ctx context.Context, docRev DocumentRevision) {
-	var cache *LRURevisionCache
+	var cache *RevisionCacheOrchestrator
 	shard, ok := (*c.revCache).(*ShardedLRURevisionCache)
 	if ok {
 		cache = shard.getShard(docRev.DocID)
 	} else {
-		cache = (*c.revCache).(*LRURevisionCache)
+		cache = (*c.revCache).(*RevisionCacheOrchestrator)
 	}
 	// Remove any existing entry so that store() below is not a no-op.
 	cache.Remove(ctx, docRev.DocID, docRev.RevID, c.collectionID)
-	value := cache.getValue(ctx, docRev.DocID, docRev.RevID, c.collectionID, true)
+	value := cache.revisionCache.getValue(ctx, docRev.DocID, docRev.RevID, c.collectionID, true)
 	docRev.CalculateBytes()
-	cache.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
+	cache.revisionCache.incrRevCacheMemoryUsage(ctx, docRev.MemoryBytes)
 	value.store(docRev)
-	cache.revCacheMemoryBasedEviction(ctx)
+	cache.revisionCache.revCacheMemoryBasedEviction(ctx)
 }


### PR DESCRIPTION
CBG-5235

- Create an orchestration layer that will hold both revision cache and delta cache. Have the interface implemented for api access 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/415/ (disable rev cache)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/414/ (flakey test, reported)
