### PR TITLE
CBG-5234: create delta only cache

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -791,7 +791,7 @@ type DeltaSyncStats struct {
 	DeltaCacheHit *SgwIntStat `json:"delta_cache_hit"`
 	// The total number of requested deltas that were not available in the revision cache.
 	DeltaCacheMiss *SgwIntStat `json:"delta_cache_miss"`
-	// DeltaCacheNumItems numer of items in delta cache
+	// DeltaCacheNumItems number of items in delta cache
 	DeltaCacheNumItems *SgwIntStat `json:"delta_cache_num_items"`
 	// The number of delta replications that have been run.
 	DeltaPullReplicationCount *SgwIntStat `json:"delta_pull_replication_count"`

--- a/base/stats.go
+++ b/base/stats.go
@@ -2080,6 +2080,7 @@ func (d *DbStats) unregisterDeltaSyncStats() {
 	prometheus.Unregister(d.DeltaSyncStats.DeltaCacheHit)
 	prometheus.Unregister(d.DeltaSyncStats.DeltaCacheMiss)
 	prometheus.Unregister(d.DeltaSyncStats.DeltaPushDocCount)
+	prometheus.Unregister(d.DeltaSyncStats.DeltaCacheNumItems)
 }
 
 func (d *DbStats) DeltaSync() *DeltaSyncStats {

--- a/base/stats.go
+++ b/base/stats.go
@@ -93,6 +93,7 @@ const (
 	StatAddedVersion3dot2dot4     = "3.2.4"
 	StatAddedVersion3dot3dot0     = "3.3.0"
 	StatAddedVersion4dot0dot0     = "4.0.0"
+	StatAddedVersion4dot1dot0     = "4.1.0"
 
 	StatDeprecatedVersionNotDeprecated = ""
 	StatDeprecatedVersion3dot2dot0     = "3.2.0"
@@ -790,6 +791,8 @@ type DeltaSyncStats struct {
 	DeltaCacheHit *SgwIntStat `json:"delta_cache_hit"`
 	// The total number of requested deltas that were not available in the revision cache.
 	DeltaCacheMiss *SgwIntStat `json:"delta_cache_miss"`
+	// DeltaCacheNumItems numer of items in delta cache
+	DeltaCacheNumItems *SgwIntStat `json:"delta_cache_num_items"`
 	// The number of delta replications that have been run.
 	DeltaPullReplicationCount *SgwIntStat `json:"delta_pull_replication_count"`
 	// The total number of documents pushed as a delta from a previous revision.
@@ -2054,6 +2057,10 @@ func (d *DbStats) InitDeltaSyncStats() error {
 		return err
 	}
 	resUtil.DeltaCacheMiss, err = NewIntStat(SubsystemDeltaSyncKey, "delta_sync_miss", StatUnitNoUnits, DeltaCacheMissDesc, StatAddedVersion3dot0dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	if err != nil {
+		return err
+	}
+	resUtil.DeltaCacheNumItems, err = NewIntStat(SubsystemDeltaSyncKey, "delta_cache_num_items", StatUnitNoUnits, DeltaCacheNumItemsDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats.go
+++ b/base/stats.go
@@ -2060,7 +2060,7 @@ func (d *DbStats) InitDeltaSyncStats() error {
 	if err != nil {
 		return err
 	}
-	resUtil.DeltaCacheNumItems, err = NewIntStat(SubsystemDeltaSyncKey, "delta_cache_num_items", StatUnitNoUnits, DeltaCacheNumItemsDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.CounterValue, 0)
+	resUtil.DeltaCacheNumItems, err = NewIntStat(SubsystemDeltaSyncKey, "delta_cache_num_items", StatUnitNoUnits, DeltaCacheNumItemsDesc, StatAddedVersion4dot1dot0, StatDeprecatedVersionNotDeprecated, StatStabilityCommitted, labelKeys, labelVals, prometheus.GaugeValue, 0)
 	if err != nil {
 		return err
 	}

--- a/base/stats_descriptions.go
+++ b/base/stats_descriptions.go
@@ -353,6 +353,8 @@ const (
 
 	DeltaCacheMissDesc = "The total number of requested deltas that were not available in the revision cache."
 
+	DeltaCacheNumItemsDesc = "The total number of deltas stored in the delta cache."
+
 	DeltaPullReplicationCountDesc = "The number of delta replications that have been run."
 
 	DeltaPushDocCountDesc = "The total number of documents pushed as a delta from a previous revision."

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -135,7 +135,7 @@ func TestGetBackupRevisionWhenCurrentRevisionHasAttachments(t *testing.T) {
 	// can remove in CBG-4542
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.revisionCache.Get(ctx, "doc1", doc1.HLV.GetCurrentVersionString(), false, true)
+	docRev, err := collection.revisionCache.Get(ctx, "doc1", doc1.HLV.GetCurrentVersionString(), true)
 	require.NoError(t, err)
 
 	// assert version is fetched and attachments is empty

--- a/db/crud.go
+++ b/db/crud.go
@@ -347,7 +347,7 @@ func (db *DatabaseCollectionWithUser) getRev(ctx context.Context, docid, revOrCV
 	if revOrCV != "" {
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
-		revision, getErr = db.revisionCache.Get(ctx, docid, revOrCV, RevCacheOmitDelta, base.IsRevTreeID(revOrCV))
+		revision, getErr = db.revisionCache.Get(ctx, docid, revOrCV, base.IsRevTreeID(revOrCV))
 	} else {
 		// No rev given, so load active revision
 		revision, getErr = db.revisionCache.GetActive(ctx, docid)
@@ -426,7 +426,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 	}
 
 	var initialFromRevision DocumentRevision
-	initialFromRevision, err = db.revisionCache.Get(ctx, docID, fromRev, RevCacheIncludeDelta, true)
+	initialFromRevision, err = db.revisionCache.GetWithDelta(ctx, docID, fromRev, toRev)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -460,7 +460,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 
 		// fromRevisionForDiff is a version of the fromRevision that is guarded by the delta lock that we will use to generate the delta (or check again for a newly cached delta)
 		var fromRevisionForDiff DocumentRevision
-		fromRevisionForDiff, err = db.revisionCache.Get(ctx, docID, fromRev, RevCacheIncludeDelta, true)
+		fromRevisionForDiff, err = db.revisionCache.GetWithDelta(ctx, docID, fromRev, toRev)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -483,7 +483,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		// Need to generate delta and cache it for others.
 		db.dbStats().DeltaSync().DeltaCacheMiss.Add(1)
 		var toRevision DocumentRevision
-		toRevision, err = db.revisionCache.Get(ctx, docID, toRev, RevCacheIncludeDelta, false)
+		toRevision, err = db.revisionCache.Get(ctx, docID, toRev, RevCacheDontLoadBackupRev)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -501,7 +501,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		// If the revision we're generating a delta to is a tombstone, mark it as such and don't bother generating a delta.
 		if deleted {
 			revCacheDelta := newRevCacheDelta([]byte(base.EmptyDocument), fromRev, toRevision, deleted, nil)
-			db.revisionCache.UpdateDelta(ctx, docID, fromRev, revCacheDelta)
+			db.revisionCache.UpdateDelta(ctx, docID, fromRev, toRev, revCacheDelta)
 			return &revCacheDelta, nil, nil
 		}
 
@@ -541,7 +541,7 @@ func (db *DatabaseCollectionWithUser) GetDelta(ctx context.Context, docID, fromR
 		revCacheDelta := newRevCacheDelta(deltaBytes, fromRev, toRevision, deleted, toRevAttStorageMeta)
 
 		// Write the newly calculated delta back into the cache before returning.
-		db.revisionCache.UpdateDelta(ctx, docID, fromRev, revCacheDelta)
+		db.revisionCache.UpdateDelta(ctx, docID, fromRev, toRev, revCacheDelta)
 		return &revCacheDelta, nil, nil
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -594,11 +594,7 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	}
 
 	// Init the rev cache
-	dbContext.revisionCache = NewRevisionCache(
-		dbContext.Options.RevisionCacheOptions,
-		collectionIDToRevCacheBackingStore,
-		dbContext.DbStats.Cache(),
-	)
+	dbContext.revisionCache = NewRevisionCache(dbContext.Options.RevisionCacheOptions, collectionIDToRevCacheBackingStore, dbContext.DbStats.Cache(), dbContext.DbStats.DeltaSyncStats, options.DeltaSyncOptions.Enabled)
 
 	if syncFunctionsChanged {
 		base.InfofCtx(ctx, base.KeyAll, "**NOTE:** %q's sync function has changed. The new function may assign different channels to documents, or permissions to users. You may want to re-sync the database to update these.", base.MD(dbContext.Name))

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -814,7 +814,13 @@ func TestGetRemovedAsUser(t *testing.T) {
 		MaxItemCount: DefaultRevisionCacheSize,
 		ShardCount:   DefaultRevisionCacheShardCount,
 	}
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStat)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      cacheHitCounter,
+		cacheMissStat:     cacheMissCounter,
+		cacheNumItemsStat: cacheNumItems,
+		cacheMemoryStat:   memoryCacheStat,
+	}
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, &base.DeltaSyncStats{}, false)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -1089,7 +1095,7 @@ func TestFetchCurrentRevAfterFetchBackupRevByCV(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch backup rev by cv and ensure we have no revID populated (no way to get revID from backup rev in CV)
-	docRev, err := collection.revisionCache.Get(ctx, "doc1", doc.HLV.GetCurrentVersionString(), false, true)
+	docRev, err := collection.revisionCache.Get(ctx, "doc1", doc.HLV.GetCurrentVersionString(), RevCacheLoadBackupRev)
 	require.NoError(t, err, "Error fetching backup revision CV")
 	assert.Equal(t, "", docRev.RevID)
 	assert.Equal(t, `{"k1":"v1"}`, string(docRev.BodyBytes))
@@ -1623,7 +1629,13 @@ func TestGetRemoved(t *testing.T) {
 		MaxItemCount: DefaultRevisionCacheSize,
 		ShardCount:   DefaultRevisionCacheShardCount,
 	}
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStat)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      cacheHitCounter,
+		cacheMissStat:     cacheMissCounter,
+		cacheNumItemsStat: cacheNumItems,
+		cacheMemoryStat:   memoryCacheStat,
+	}
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, &base.DeltaSyncStats{}, false)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -1695,7 +1707,13 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 		MaxItemCount: DefaultRevisionCacheSize,
 		ShardCount:   DefaultRevisionCacheShardCount,
 	}
-	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, cacheHitCounter, cacheMissCounter, cacheNumItems, memoryCacheStats)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      cacheHitCounter,
+		cacheMissStat:     cacheMissCounter,
+		cacheNumItemsStat: cacheNumItems,
+		cacheMemoryStat:   memoryCacheStats,
+	}
+	collection.dbCtx.revisionCache = NewShardedLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats, &base.DeltaSyncStats{}, false)
 	err = collection.PurgeOldRevisionJSON(ctx, "doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -25,7 +25,7 @@ type LRUDeltaCache struct {
 	cacheHits      *base.SgwIntStat
 	cacheMisses    *base.SgwIntStat
 	cacheNumDeltas *base.SgwIntStat
-	lock           sync.RWMutex
+	lock           sync.Mutex
 	capacity       uint32 // Max number of items capacity of LRUDeltaCache
 }
 
@@ -104,8 +104,8 @@ func (dc *LRUDeltaCache) getCachedDelta(ctx context.Context, docID, fromVersionS
 		return nil
 	}
 	key := createDeltaCacheKey(docID, fromVersionString, toVersionString, collectionID)
-	dc.lock.RLock()
-	defer dc.lock.RUnlock()
+	dc.lock.Lock()
+	defer dc.lock.Unlock()
 	var deltaValue *RevisionDelta
 	if elem := dc.cache[key]; elem != nil {
 		dc.lruList.MoveToFront(elem)

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -67,6 +67,7 @@ func (dc *LRUDeltaCache) addDelta(ctx context.Context, docID, fromVersionString,
 	dc.lock.Lock()
 	defer dc.lock.Unlock()
 	if elem := dc.cache[key]; elem != nil {
+		dc.lruList.MoveToFront(elem)
 		return
 	}
 	value := &deltaCacheValue{delta: &toDelta, itemKey: key}

--- a/db/delta_cache_lru.go
+++ b/db/delta_cache_lru.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import (
+	"container/list"
+	"context"
+	"sync"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+type LRUDeltaCache struct {
+	backingStores  map[uint32]RevisionCacheBackingStore
+	cache          map[deltaCacheKey]*list.Element
+	lruList        *list.List
+	cacheHits      *base.SgwIntStat
+	cacheMisses    *base.SgwIntStat
+	cacheNumDeltas *base.SgwIntStat
+	lock           sync.RWMutex
+	capacity       uint32 // Max number of items capacity of LRUDeltaCache
+}
+
+// deltaCacheValue is the delta cache payload data. Stored as the Value of a list Element.
+type deltaCacheValue struct {
+	delta   *RevisionDelta
+	itemKey deltaCacheKey
+}
+
+type deltaCacheKey struct {
+	docID          string
+	toDocVersion   string
+	fromDocVersion string
+	collectionID   uint32
+}
+
+func createDeltaCacheKey(docID string, fromVersionString, toVersionString string, collectionID uint32) deltaCacheKey {
+	return deltaCacheKey{docID: docID, fromDocVersion: fromVersionString, toDocVersion: toVersionString, collectionID: collectionID}
+}
+
+func NewLRUDeltaCache(revCacheOptions *RevisionCacheOptions, deltaSyncStats *base.DeltaSyncStats, backingStores map[uint32]RevisionCacheBackingStore) *LRUDeltaCache {
+	return &LRUDeltaCache{
+		cache:          map[deltaCacheKey]*list.Element{},
+		lruList:        list.New(),
+		capacity:       revCacheOptions.MaxItemCount,
+		backingStores:  backingStores,
+		cacheHits:      deltaSyncStats.DeltaCacheHit,
+		cacheMisses:    deltaSyncStats.DeltaCacheMiss,
+		cacheNumDeltas: deltaSyncStats.DeltaCacheNumItems,
+	}
+}
+
+// addDelta will cache a newly generated delta
+func (dc *LRUDeltaCache) addDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32, toDelta RevisionDelta) {
+	if docID == "" || fromVersionString == "" || toVersionString == "" {
+		return
+	}
+	key := createDeltaCacheKey(docID, fromVersionString, toVersionString, collectionID)
+	dc.lock.Lock()
+	defer dc.lock.Unlock()
+	if elem := dc.cache[key]; elem != nil {
+		return
+	}
+	value := &deltaCacheValue{delta: &toDelta, itemKey: key}
+	elem := dc.lruList.PushFront(value)
+	dc.cache[key] = elem
+	dc.cacheNumDeltas.Add(1)
+	numItemsRemoved := dc._numberCapacityEviction()
+	if numItemsRemoved > 0 {
+		dc.cacheNumDeltas.Add(-numItemsRemoved)
+	}
+}
+
+// _numberCapacityEviction will iterate removing the last element in cache til we fall below the maximum number of items
+// threshold for this shard, returning the number of items evicted
+func (dc *LRUDeltaCache) _numberCapacityEviction() (numItemsEvicted int64) {
+	for dc.lruList.Len() > int(dc.capacity) {
+		value := dc.lruList.Back()
+		if value == nil {
+			// no items to remove
+			break
+		}
+		deltaValue := value.Value.(*deltaCacheValue)
+		dc.lruList.Remove(value)
+		// delete item from lookup map
+		delete(dc.cache, deltaValue.itemKey)
+		numItemsEvicted++
+	}
+	return numItemsEvicted
+}
+
+// getCachedDelta will retrieve a delta if cached
+func (dc *LRUDeltaCache) getCachedDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) *RevisionDelta {
+	if docID == "" || fromVersionString == "" || toVersionString == "" {
+		return nil
+	}
+	key := createDeltaCacheKey(docID, fromVersionString, toVersionString, collectionID)
+	dc.lock.RLock()
+	defer dc.lock.RUnlock()
+	var deltaValue *RevisionDelta
+	if elem := dc.cache[key]; elem != nil {
+		dc.lruList.MoveToFront(elem)
+		cachedDelta := elem.Value.(*deltaCacheValue)
+		deltaValue = cachedDelta.delta
+	}
+	return deltaValue
+}
+
+// CalculateDeltaBytes will calculate bytes from delta channels, delta revisions and delta body
+func (delta *RevisionDelta) CalculateDeltaBytes() {
+	var totalBytes int
+	for v := range delta.ToChannels {
+		bytes := len([]byte(v))
+		totalBytes += bytes
+	}
+	// history calculation
+	historyBytes := 32 * len(delta.RevisionHistory)
+	totalBytes += historyBytes
+
+	// account for delta body
+	totalBytes += len(delta.DeltaBytes)
+
+	delta.totalDeltaBytes = int64(totalBytes)
+}

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -130,6 +130,9 @@ func TestNumberBasedEvictionForDeltaCache(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("delta sync requires enterprise edition")
 	}
+	if base.TestDisableRevCache() {
+		t.Skip("test requires delta cache to be in use")
+	}
 	dbcOptions := DatabaseContextOptions{
 		RevisionCacheOptions: &RevisionCacheOptions{
 			MaxItemCount: 5,

--- a/db/delta_cache_test.go
+++ b/db/delta_cache_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package db
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeltaCacheStats verifies that DeltaCacheNumItems, DeltaCacheHit and DeltaCacheMiss
+// are correctly incremented as deltas are generated and subsequently retrieved from the cache.
+func TestDeltaCacheStats(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta sync require enterprise edition")
+	}
+	if base.TestDisableRevCache() {
+		t.Skip("test requires delta cache to be in use")
+	}
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxItemCount: 10,
+		},
+		DeltaSyncOptions: DeltaSyncOptions{
+			Enabled:          true,
+			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	docID := SafeDocumentName(t, t.Name())
+	rev1ID, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
+	require.NoError(t, err)
+	rev1CV := doc1.HLV.GetCurrentVersionString()
+
+	_, doc2, err := collection.Put(ctx, docID, Body{"foo": "baz", BodyRev: rev1ID})
+	require.NoError(t, err)
+	rev2CV := doc2.HLV.GetCurrentVersionString()
+
+	// All stats should start at zero.
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+
+	// First call: no delta is cached so one is generated and stored — a cache miss.
+	delta, _, err := collection.GetDelta(ctx, docID, rev1CV, rev2CV)
+	require.NoError(t, err)
+	require.NotNil(t, delta)
+	assert.Equal(t, int64(1), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(1), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+
+	// Second call with the same rev pair: the generated delta is now cached — a cache hit.
+	delta, _, err = collection.GetDelta(ctx, docID, rev1CV, rev2CV)
+	require.NoError(t, err)
+	require.NotNil(t, delta)
+	assert.Equal(t, int64(1), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(1), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+	assert.Equal(t, int64(1), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+}
+
+// TestDeltaCacheStatsWithBypassRevisionCache verifies delta cache stat behaviour when the revision
+// cache is bypassed (MaxItemCount == 0). With BypassRevisionCache, UpdateDelta is a no-op so deltas
+// are never stored; every GetDelta call must regenerate the delta (always a cache miss) and
+// DeltaCacheNumItems remains 0.
+func TestDeltaCacheStatsWithBypassRevisionCache(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta sync requires enterprise edition")
+	}
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxItemCount: 0, // triggers BypassRevisionCache
+		},
+		DeltaSyncOptions: DeltaSyncOptions{
+			Enabled:          true,
+			RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	docID := SafeDocumentName(t, t.Name())
+	rev1ID, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
+	require.NoError(t, err)
+	rev1CV := doc1.HLV.GetCurrentVersionString()
+
+	_, doc2, err := collection.Put(ctx, docID, Body{"foo": "baz", BodyRev: rev1ID})
+	require.NoError(t, err)
+	rev2CV := doc2.HLV.GetCurrentVersionString()
+
+	// All stats should start at zero.
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+
+	// First call: delta is generated but not stored (UpdateDelta is a no-op) — a cache miss.
+	delta, _, err := collection.GetDelta(ctx, docID, rev1CV, rev2CV)
+	require.NoError(t, err)
+	require.NotNil(t, delta)
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(1), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+
+	// Second call with the same rev pair: delta is still not cached, so another cache miss.
+	delta, _, err = collection.GetDelta(ctx, docID, rev1CV, rev2CV)
+	require.NoError(t, err)
+	require.NotNil(t, delta)
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+	assert.Equal(t, int64(2), db.DbStats.DeltaSync().DeltaCacheMiss.Value())
+	assert.Equal(t, int64(0), db.DbStats.DeltaSync().DeltaCacheHit.Value())
+}
+
+func TestNumberBasedEvictionForDeltaCache(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skip("delta sync requires enterprise edition")
+	}
+	dbcOptions := DatabaseContextOptions{
+		RevisionCacheOptions: &RevisionCacheOptions{
+			MaxItemCount: 5,
+		},
+		DeltaSyncOptions: DeltaSyncOptions{
+			Enabled: true,
+		},
+	}
+	db, ctx := SetupTestDBWithOptions(t, dbcOptions)
+	defer db.Close(ctx)
+
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	docID := SafeDocumentName(t, t.Name())
+	_, doc, err := collection.Put(ctx, docID, Body{"test": "data"})
+	require.NoError(t, err)
+
+	docRev1, err := collection.getRev(ctx, docID, doc.HLV.GetCurrentVersionString(), 0, nil)
+	require.NoError(t, err)
+
+	deltaBytes := make([]byte, 0)
+	testDelta := newRevCacheDelta(bytes.Repeat(deltaBytes, 10), doc.HLV.GetCurrentVersionString(), docRev1, false, nil)
+
+	fromCV := Version{
+		SourceID: "from",
+		Value:    1,
+	}
+	originalFrom := fromCV
+	toCV := Version{
+		SourceID: "to",
+		Value:    100,
+	}
+	originalTo := toCV
+	for i := 0; i < 5; i++ {
+		db.revisionCache.UpdateDelta(ctx, docID, fromCV.String(), toCV.String(), collection.GetCollectionID(), testDelta)
+		fromCV.Value++
+		toCV.Value++
+	}
+	// assert that num items in delta is 5
+	assert.Equal(t, int64(5), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+	// attempt to add a delta version that already exsits in the cache
+	db.revisionCache.UpdateDelta(ctx, docID, fromCV.String(), toCV.String(), collection.GetCollectionID(), testDelta)
+	// assert that num items in delta is still 5
+	assert.Equal(t, int64(5), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+
+	// now add a new version and assert count is still 5
+	fromCV.Value++
+	toCV.Value++
+	db.revisionCache.UpdateDelta(ctx, docID, fromCV.String(), toCV.String(), collection.GetCollectionID(), testDelta)
+	assert.Equal(t, int64(5), db.DbStats.DeltaSync().DeltaCacheNumItems.Value())
+
+	// assert that first item is no longer present in cache — adding one more entry beyond
+	// capacity evicts the LRU item, which was originalFrom→originalTo (added first).
+	orchestrator, ok := db.revisionCache.(*RevisionCacheOrchestrator)
+	require.True(t, ok, "expected RevisionCacheOrchestrator")
+	evictedDelta := orchestrator.deltaCache.getCachedDelta(ctx, docID, originalFrom.String(), originalTo.String(), collection.GetCollectionID())
+	assert.Nil(t, evictedDelta, "first delta should have been evicted from the cache")
+}
+
+func TestUpdateDeltaWhenNoDeltaCacheInit(t *testing.T) {
+
+	// setup db with no delta sync enabled, no delta cache will be initialised
+	db, ctx := setupTestDB(t)
+	defer db.Close(ctx)
+	collection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
+
+	docID := SafeDocumentName(t, t.Name())
+	rev1ID, doc1, err := collection.Put(ctx, docID, Body{"foo": "bar"})
+	require.NoError(t, err)
+	rev1CV := doc1.HLV.GetCurrentVersionString()
+
+	_, doc2, err := collection.Put(ctx, docID, Body{"foo": "baz", BodyRev: rev1ID})
+	require.NoError(t, err)
+	rev2CV := doc2.HLV.GetCurrentVersionString()
+	docRev, err := db.revisionCache.Get(ctx, docID, doc2.HLV.GetCurrentVersionString(), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
+	require.NoError(t, err)
+
+	// try adding delta when delta sync is off
+	deltaBytes := make([]byte, 0)
+	testDelta := newRevCacheDelta(bytes.Repeat(deltaBytes, 10), doc1.HLV.GetCurrentVersionString(), docRev, false, nil)
+	db.revisionCache.UpdateDelta(ctx, docID, rev1CV, rev2CV, collection.GetCollectionID(), testDelta)
+}

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -32,7 +32,7 @@ func NewBypassRevisionCache(backingStores map[uint32]RevisionCacheBackingStore, 
 }
 
 // Get fetches the revision for the given docID and revID immediately from the bucket.
-func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (docRev DocumentRevision, err error) {
+func (rc *BypassRevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, err error) {
 	doc, err := rc.backingStores[collectionID].GetDocument(ctx, docID, DocUnmarshalSync)
 	if err != nil {
 		return DocumentRevision{}, err
@@ -120,6 +120,15 @@ func (rc *BypassRevisionCache) Remove(ctx context.Context, docID, versionString 
 }
 
 // UpdateDelta is a no-op for a BypassRevisionCache
-func (rc *BypassRevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
+func (rc *BypassRevisionCache) UpdateDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32, toDelta RevisionDelta) {
 	// no-op
+}
+
+func (rc *BypassRevisionCache) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
+	docRev, err := rc.Get(ctx, docID, fromVersionString, collectionID, true)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+	// no-op for delta cache fetch
+	return docRev, nil
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -31,7 +31,7 @@ type RevisionCache interface {
 
 	// Get returns the given revision, and stores if not already cached.
 	// When includeDelta=true, the returned DocumentRevision will include delta - requires additional locking during retrieval.
-	Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (DocumentRevision, error)
+	Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, error)
 
 	// GetActive returns the current revision for the given doc ID, and stores if not already cached.
 	GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error)
@@ -49,12 +49,15 @@ type RevisionCache interface {
 	Remove(ctx context.Context, docID, versionString string, collectionID uint32)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
-	UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta)
+	UpdateDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32, toDelta RevisionDelta)
+
+	// GetWithDelta will fetch revision and its associated delta from the independent revision cache and delta revision cache
+	GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error)
 }
 
 const (
-	RevCacheIncludeDelta = true
-	RevCacheOmitDelta    = false
+	RevCacheLoadBackupRev     = true
+	RevCacheDontLoadBackupRev = false
 )
 
 // Force compile-time check of all RevisionCache types for interface
@@ -63,8 +66,16 @@ var _ RevisionCache = &ShardedLRURevisionCache{}
 var _ RevisionCache = &BypassRevisionCache{}
 var _ RevisionCache = &RevisionCacheOrchestrator{}
 
+// revisionCacheStats holds references to stats needed for the revision cache
+type revisionCacheStats struct {
+	cacheHitStat      *base.SgwIntStat
+	cacheMissStat     *base.SgwIntStat
+	cacheNumItemsStat *base.SgwIntStat
+	cacheMemoryStat   *base.SgwIntStat
+}
+
 // NewRevisionCache returns a RevisionCache implementation for the given config options.
-func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheStats *base.CacheStats) RevisionCache {
+func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheStats *base.CacheStats, deltaSyncStats *base.DeltaSyncStats, initDeltaCache bool) RevisionCache {
 
 	// If cacheOptions is not passed in, use defaults
 	if cacheOptions == nil {
@@ -76,22 +87,32 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStores map[uint
 		return NewBypassRevisionCache(backingStores, bypassStat)
 	}
 
-	cacheHitStat := cacheStats.RevisionCacheHits
-	cacheMissStat := cacheStats.RevisionCacheMisses
-	cacheNumItemsStat := cacheStats.RevisionCacheNumItems
-	cacheMemoryStat := cacheStats.RevisionCacheTotalMemory
-	if cacheNumItemsStat.Value() != 0 {
-		cacheNumItemsStat.Set(0)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      cacheStats.RevisionCacheHits,
+		cacheMissStat:     cacheStats.RevisionCacheMisses,
+		cacheNumItemsStat: cacheStats.RevisionCacheNumItems,
+		cacheMemoryStat:   cacheStats.RevisionCacheTotalMemory,
 	}
-	if cacheMemoryStat.Value() != 0 {
-		cacheMemoryStat.Set(0)
+	if revCacheStats.cacheNumItemsStat.Value() != 0 {
+		revCacheStats.cacheNumItemsStat.Set(0)
+	}
+	if revCacheStats.cacheMemoryStat.Value() != 0 {
+		revCacheStats.cacheMemoryStat.Set(0)
+	}
+	if deltaSyncStats != nil && deltaSyncStats.DeltaCacheNumItems.Value() != 0 {
+		deltaSyncStats.DeltaCacheNumItems.Set(0)
 	}
 
 	if cacheOptions.ShardCount > 1 {
-		return NewShardedLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
+		return NewShardedLRURevisionCache(cacheOptions, backingStores, revCacheStats, deltaSyncStats, initDeltaCache)
 	}
 
-	return NewRevisionCacheOrchestrator(NewLRURevisionCache(cacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat))
+	var deltaCache *LRUDeltaCache
+	if initDeltaCache {
+		deltaCache = NewLRUDeltaCache(cacheOptions, deltaSyncStats, backingStores)
+	}
+
+	return NewRevisionCacheOrchestrator(NewLRURevisionCache(cacheOptions, backingStores, revCacheStats), deltaCache)
 }
 
 type RevisionCacheOptions struct {
@@ -130,8 +151,8 @@ func newCollectionRevisionCache(revCache *RevisionCache, collectionID uint32) co
 }
 
 // Get is for per collection access to Get method
-func (c *collectionRevisionCache) Get(ctx context.Context, docID, versionString string, includeDelta, loadBackup bool) (DocumentRevision, error) {
-	return (*c.revCache).Get(ctx, docID, versionString, c.collectionID, includeDelta, loadBackup)
+func (c *collectionRevisionCache) Get(ctx context.Context, docID, versionString string, loadBackup bool) (DocumentRevision, error) {
+	return (*c.revCache).Get(ctx, docID, versionString, c.collectionID, loadBackup)
 }
 
 // GetActive is for per collection access to GetActive method
@@ -159,8 +180,12 @@ func (c *collectionRevisionCache) Remove(ctx context.Context, docID, versionStri
 }
 
 // UpdateDelta is for per collection access to UpdateDelta method
-func (c *collectionRevisionCache) UpdateDelta(ctx context.Context, docID, revID string, toDelta RevisionDelta) {
-	(*c.revCache).UpdateDelta(ctx, docID, revID, c.collectionID, toDelta)
+func (c *collectionRevisionCache) UpdateDelta(ctx context.Context, docID, fromVersionString, toVersionString string, toDelta RevisionDelta) {
+	(*c.revCache).UpdateDelta(ctx, docID, fromVersionString, toVersionString, c.collectionID, toDelta)
+}
+
+func (c *collectionRevisionCache) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string) (DocumentRevision, error) {
+	return (*c.revCache).GetWithDelta(ctx, docID, fromVersionString, toVersionString, c.collectionID)
 }
 
 // DocumentRevision stored and returned by the rev cache

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -27,7 +27,7 @@ type ShardedLRURevisionCache struct {
 }
 
 // Creates a sharded revision cache with the given capacity and an optional loader function.
-func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat *base.SgwIntStat) *ShardedLRURevisionCache {
+func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, revCacheStats revisionCacheStats, deltaSyncStats *base.DeltaSyncStats, initDeltaCache bool) *ShardedLRURevisionCache {
 
 	caches := make([]*RevisionCacheOrchestrator, revCacheOptions.ShardCount)
 	// Add 10% to per-shared cache capacity to ensure overall capacity is reached under non-ideal shard hashing
@@ -40,8 +40,12 @@ func NewShardedLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingSt
 	}
 
 	for i := 0; i < int(revCacheOptions.ShardCount); i++ {
-		cacheForShard := NewLRURevisionCache(revCacheOptions, backingStores, cacheHitStat, cacheMissStat, cacheNumItemsStat, cacheMemoryStat)
-		caches[i] = NewRevisionCacheOrchestrator(cacheForShard)
+		cacheForShard := NewLRURevisionCache(revCacheOptions, backingStores, revCacheStats)
+		var deltaCacheForShard *LRUDeltaCache
+		if initDeltaCache {
+			deltaCacheForShard = NewLRUDeltaCache(revCacheOptions, deltaSyncStats, backingStores)
+		}
+		caches[i] = NewRevisionCacheOrchestrator(cacheForShard, deltaCacheForShard)
 	}
 
 	return &ShardedLRURevisionCache{
@@ -54,16 +58,16 @@ func (sc *ShardedLRURevisionCache) getShard(docID string) *RevisionCacheOrchestr
 	return sc.caches[sgbucket.VBHash(docID, sc.numShards)]
 }
 
-func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (docRev DocumentRevision, err error) {
-	return sc.getShard(docID).Get(ctx, docID, versionString, collectionID, includeDelta, loadBackup)
+func (sc *ShardedLRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (docRev DocumentRevision, err error) {
+	return sc.getShard(docID).Get(ctx, docID, versionString, collectionID, loadBackup)
 }
 
 func (sc *ShardedLRURevisionCache) Peek(ctx context.Context, docID string, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {
 	return sc.getShard(docID).Peek(ctx, docID, versionString, collectionID)
 }
 
-func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
-	sc.getShard(docID).UpdateDelta(ctx, docID, revID, collectionID, toDelta)
+func (sc *ShardedLRURevisionCache) UpdateDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32, toDelta RevisionDelta) {
+	sc.getShard(docID).UpdateDelta(ctx, docID, fromVersionString, toVersionString, collectionID, toDelta)
 }
 
 func (sc *ShardedLRURevisionCache) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
@@ -80,6 +84,10 @@ func (sc *ShardedLRURevisionCache) Upsert(ctx context.Context, docRev DocumentRe
 
 func (sc *ShardedLRURevisionCache) Remove(ctx context.Context, docID, versionString string, collectionID uint32) {
 	sc.getShard(docID).Remove(ctx, docID, versionString, collectionID)
+}
+
+func (sc *ShardedLRURevisionCache) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
+	return sc.getShard(docID).GetWithDelta(ctx, docID, fromVersionString, toVersionString, collectionID)
 }
 
 // An LRU cache of document revision bodies, together with their channel access.
@@ -104,7 +112,6 @@ type revCacheValue struct {
 	channels     base.Set
 	expiry       *time.Time
 	attachments  AttachmentsMeta
-	delta        *RevisionDelta
 	id           string
 	itemKey      revCacheKey
 	cv           Version
@@ -121,17 +128,17 @@ type revCacheValue struct {
 }
 
 // Creates a revision cache with the given capacity and an optional loader function.
-func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, cacheHitStat *base.SgwIntStat, cacheMissStat *base.SgwIntStat, cacheNumItemsStat *base.SgwIntStat, revCacheMemoryStat *base.SgwIntStat) *LRURevisionCache {
+func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores map[uint32]RevisionCacheBackingStore, revCacheStats revisionCacheStats) *LRURevisionCache {
 
 	return &LRURevisionCache{
 		cache:                map[revCacheKey]*list.Element{},
 		lruList:              list.New(),
 		capacity:             revCacheOptions.MaxItemCount,
 		backingStores:        backingStores,
-		cacheHits:            cacheHitStat,
-		cacheMisses:          cacheMissStat,
-		cacheNumItems:        cacheNumItemsStat,
-		cacheMemoryBytesStat: revCacheMemoryStat,
+		cacheHits:            revCacheStats.cacheHitStat,
+		cacheMisses:          revCacheStats.cacheMissStat,
+		cacheNumItems:        revCacheStats.cacheNumItemsStat,
+		cacheMemoryBytesStat: revCacheStats.cacheMemoryStat,
 		memoryCapacity:       revCacheOptions.MaxBytes,
 	}
 }
@@ -140,13 +147,13 @@ func NewLRURevisionCache(revCacheOptions *RevisionCacheOptions, backingStores ma
 // Returns the body of the revision, its history, and the set of channels it's in.
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
-func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (DocumentRevision, error) {
+func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, error) {
 	value := rc.getValue(ctx, docID, versionString, collectionID, true)
 	if value == nil {
 		return DocumentRevision{}, nil
 	}
 
-	docRev, cacheHit, err := value.load(ctx, rc.backingStores[collectionID], includeDelta, loadBackup)
+	docRev, cacheHit, err := value.load(ctx, rc.backingStores[collectionID], loadBackup)
 	rc.statsRecorderFunc(cacheHit)
 
 	if !cacheHit && err == nil {
@@ -163,6 +170,11 @@ func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string
 	return docRev, err
 }
 
+func (rc *LRURevisionCache) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
+	// no-op, here to complete interface
+	return DocumentRevision{}, nil
+}
+
 // Looks up a revision from the cache only.  Will not fall back to loader function if not
 // present in the cache.
 func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, versionString string, collectionID uint32) (docRev DocumentRevision, found bool) {
@@ -177,19 +189,8 @@ func (rc *LRURevisionCache) Peek(ctx context.Context, docID string, versionStrin
 	return docRev, docRev.BodyBytes != nil
 }
 
-// Attempt to update the delta on a revision cache entry.  If the entry is no longer resident in the cache,
-// fails silently
-func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
-	value := rc.getValue(ctx, docID, revID, collectionID, false)
-	if value != nil {
-		outGoingBytes := value.updateDelta(toDelta)
-		if outGoingBytes != 0 {
-			rc.currMemoryUsage.Add(outGoingBytes)
-			rc.cacheMemoryBytesStat.Add(outGoingBytes)
-		}
-		// check for memory based eviction
-		rc.revCacheMemoryBasedEviction(ctx)
-	}
+func (rc *LRURevisionCache) UpdateDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32, toDelta RevisionDelta) {
+	// no-op
 }
 
 // Attempts to retrieve the active revision for a document from the cache.  Requires retrieval
@@ -408,7 +409,7 @@ func (rc *LRURevisionCache) _numberCapacityEviction() (numItemsEvicted int64, nu
 // Gets the body etc. out of a revCacheValue. If they aren't present already, the loader func
 // will be called. This is synchronized so that the loader will only be called once even if
 // multiple goroutines try to load at the same time.
-func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCacheBackingStore, includeDelta bool, loadBackup bool) (docRev DocumentRevision, cacheHit bool, err error) {
+func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCacheBackingStore, loadBackup bool) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	// Reading the delta from the revCacheValue requires holding the read lock, so it's managed outside asDocumentRevision,
 	// to reduce locking when includeDelta=false
@@ -418,9 +419,6 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 	// Attempt to read cached value.
 	value.lock.RLock()
 	if value.bodyBytes != nil || value.err != nil {
-		if includeDelta {
-			delta = value.delta
-		}
 		value.lock.RUnlock()
 
 		docRev, err = value.asDocumentRevision(delta)
@@ -462,10 +460,6 @@ func (value *revCacheValue) load(ctx context.Context, backingStore RevisionCache
 				value.hlvHistory = hlv.ToHistoryForHLV()
 			}
 		}
-	}
-
-	if includeDelta {
-		delta = value.delta
 	}
 
 	docRev, err = value.asDocumentRevision(delta)
@@ -574,22 +568,6 @@ func (value *revCacheValue) store(docRev DocumentRevision) {
 	value.itemLoaded.Store(true) // now we have stored the doc revision in the cache, we can allow eviction
 }
 
-func (value *revCacheValue) updateDelta(toDelta RevisionDelta) (diffInBytes int64) {
-	value.lock.Lock()
-	defer value.lock.Unlock()
-	var previousDeltaBytes int64
-	if value.delta != nil {
-		// delta exists, need to pull this to update overall memory size correctly
-		previousDeltaBytes = value.delta.totalDeltaBytes
-	}
-	diffInBytes = toDelta.totalDeltaBytes - previousDeltaBytes
-	value.delta = &toDelta
-	if diffInBytes != 0 {
-		value.itemBytes.Add(diffInBytes)
-	}
-	return diffInBytes
-}
-
 // getItemBytes atomically retrieves the rev cache items overall memory footprint
 func (value *revCacheValue) getItemBytes() int64 {
 	return value.itemBytes.Load()
@@ -611,23 +589,6 @@ func (rev *DocumentRevision) CalculateBytes() {
 
 	// convert the int to int64 type and assign to document revision
 	rev.MemoryBytes = int64(totalBytes)
-}
-
-// CalculateDeltaBytes will calculate bytes from delta channels, delta revisions and delta body
-func (delta *RevisionDelta) CalculateDeltaBytes() {
-	var totalBytes int
-	for v := range delta.ToChannels {
-		bytes := len([]byte(v))
-		totalBytes += bytes
-	}
-	// history calculation
-	historyBytes := 32 * len(delta.RevisionHistory)
-	totalBytes += historyBytes
-
-	// account for delta body
-	totalBytes += len(delta.DeltaBytes)
-
-	delta.totalDeltaBytes = int64(totalBytes)
 }
 
 // revCacheMemoryBasedEviction checks for rev cache eviction, if required calls performEviction which will acquire lock to evict

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -171,7 +171,8 @@ func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string
 }
 
 func (rc *LRURevisionCache) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
-	// no-op, here to complete interface
+	// GetWithDelta is not supported directly by LRURevisionCache;
+	// use RevisionCacheOrchestrator for delta support.
 	return DocumentRevision{}, nil
 }
 

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -13,6 +13,7 @@ package db
 import (
 	"container/list"
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -173,7 +174,7 @@ func (rc *LRURevisionCache) Get(ctx context.Context, docID, versionString string
 func (rc *LRURevisionCache) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
 	// GetWithDelta is not supported directly by LRURevisionCache;
 	// use RevisionCacheOrchestrator for delta support.
-	return DocumentRevision{}, nil
+	return DocumentRevision{}, errors.New("delta retrieval not supported via LRURevisionCache, use RevisionCacheOrchestrator")
 }
 
 // Looks up a revision from the cache only.  Will not fall back to loader function if not

--- a/db/revision_cache_orchestrator.go
+++ b/db/revision_cache_orchestrator.go
@@ -15,18 +15,19 @@ import "context"
 // RevisionCacheOrchestrator orchestrates between the revisionCache and a deltaCache.
 type RevisionCacheOrchestrator struct {
 	revisionCache *LRURevisionCache
-	// delta cache to be implemented: CBG-5234
+	deltaCache    *LRUDeltaCache
 }
 
 // NewRevisionCacheOrchestrator creates a new RevisionCacheOrchestrator.
-func NewRevisionCacheOrchestrator(revisionCache *LRURevisionCache) *RevisionCacheOrchestrator {
+func NewRevisionCacheOrchestrator(revisionCache *LRURevisionCache, deltaCache *LRUDeltaCache) *RevisionCacheOrchestrator {
 	return &RevisionCacheOrchestrator{
 		revisionCache: revisionCache,
+		deltaCache:    deltaCache,
 	}
 }
 
-func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, includeDelta, loadBackup bool) (DocumentRevision, error) {
-	return c.revisionCache.Get(ctx, docID, versionString, collectionID, includeDelta, loadBackup)
+func (c *RevisionCacheOrchestrator) Get(ctx context.Context, docID, versionString string, collectionID uint32, loadBackup bool) (DocumentRevision, error) {
+	return c.revisionCache.Get(ctx, docID, versionString, collectionID, loadBackup)
 }
 
 func (c *RevisionCacheOrchestrator) GetActive(ctx context.Context, docID string, collectionID uint32) (docRev DocumentRevision, err error) {
@@ -49,6 +50,21 @@ func (c *RevisionCacheOrchestrator) Remove(ctx context.Context, docID, versionSt
 	c.revisionCache.Remove(ctx, docID, versionString, collectionID)
 }
 
-func (c *RevisionCacheOrchestrator) UpdateDelta(ctx context.Context, docID, revID string, collectionID uint32, toDelta RevisionDelta) {
-	c.revisionCache.UpdateDelta(ctx, docID, revID, collectionID, toDelta)
+func (c *RevisionCacheOrchestrator) UpdateDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32, toDelta RevisionDelta) {
+	if c.deltaCache == nil {
+		return
+	}
+	c.deltaCache.addDelta(ctx, docID, fromVersionString, toVersionString, collectionID, toDelta)
+}
+
+func (c *RevisionCacheOrchestrator) GetWithDelta(ctx context.Context, docID, fromVersionString, toVersionString string, collectionID uint32) (DocumentRevision, error) {
+	docRev, err := c.revisionCache.Get(ctx, docID, fromVersionString, collectionID, RevCacheLoadBackupRev)
+	if err != nil {
+		return docRev, err
+	}
+	if c.deltaCache != nil {
+		cachedDelta := c.deltaCache.getCachedDelta(ctx, docID, fromVersionString, toVersionString, collectionID)
+		docRev.Delta = cachedDelta
+	}
+	return docRev, nil
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package db
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -151,7 +150,13 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 				MaxItemCount: 10,
 				MaxBytes:     0,
 			}
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+			revCacheStats := revisionCacheStats{
+				cacheHitStat:      &cacheHitCounter,
+				cacheMissStat:     &cacheMissCounter,
+				cacheNumItemsStat: &cacheNumItems,
+				cacheMemoryStat:   &memoryBytesCounted,
+			}
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 			ctx := base.TestCtx(t)
 
@@ -161,11 +166,11 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			for docID := range 10 {
 				id := strconv.Itoa(docID)
 				if testCase.useCVKey {
-					_, err := cache.Get(ctx, id, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+					_, err := cache.Get(ctx, id, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 					require.NoError(t, err)
 					keysAdded = append(keysAdded, Version{Value: 123, SourceID: "test"}.String())
 				} else {
-					_, err := cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta, false)
+					_, err := cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 					require.NoError(t, err)
 					keysAdded = append(keysAdded, "1-abc")
 				}
@@ -180,9 +185,9 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 				var err error
 				docID := strconv.Itoa(i)
 				if testCase.useCVKey {
-					docRev, err = cache.Get(ctx, docID, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+					docRev, err = cache.Get(ctx, docID, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				} else {
-					docRev, err = cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta, false)
+					docRev, err = cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				}
 				assert.NoError(t, err)
 				assert.NotNil(t, docRev.BodyBytes, "nil body for %s", docID)
@@ -196,10 +201,10 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 			for i := 10; i < 13; i++ {
 				docID := strconv.Itoa(i)
 				if testCase.useCVKey {
-					_, err := cache.Get(ctx, docID, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+					_, err := cache.Get(ctx, docID, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 					require.NoError(t, err)
 				} else {
-					_, err := cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheOmitDelta, false)
+					_, err := cache.Get(ctx, docID, "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 					require.NoError(t, err)
 				}
 			}
@@ -228,10 +233,10 @@ func TestLRURevisionCacheEviction(t *testing.T) {
 				var err error
 				id := strconv.Itoa(i + 3)
 				if testCase.useCVKey {
-					docRev, err = cache.Get(ctx, id, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+					docRev, err = cache.Get(ctx, id, Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 					assert.NoError(t, err)
 				} else {
-					docRev, err = cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheOmitDelta, false)
+					docRev, err = cache.Get(ctx, id, "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 					assert.NoError(t, err)
 				}
 				assert.NotNil(t, docRev.BodyBytes, "nil body for %s", id)
@@ -295,10 +300,10 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 			docSize, rev, docVersion := createDocAndReturnSizeAndRev(t, ctx, "11", collection, smallBody, testCase.UseCVKey)
 			// load into cache
 			if testCase.UseCVKey {
-				_, err := db.revisionCache.Get(ctx, "11", docVersion.String(), collection.GetCollectionID(), RevCacheOmitDelta, false)
+				_, err := db.revisionCache.Get(ctx, "11", docVersion.String(), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				_, err := db.revisionCache.Get(ctx, "11", rev, collection.GetCollectionID(), RevCacheOmitDelta, false)
+				_, err := db.revisionCache.Get(ctx, "11", rev, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			expValue += int64(docSize)
@@ -348,9 +353,9 @@ func TestLRURevisionCacheEvictionMemoryBased(t *testing.T) {
 
 			// load into cache
 			if testCase.UseCVKey {
-				_, err = db.revisionCache.Get(ctx, "12", doc.HLV.GetCurrentVersionString(), collection.GetCollectionID(), RevCacheOmitDelta, false)
+				_, err = db.revisionCache.Get(ctx, "12", doc.HLV.GetCurrentVersionString(), collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 			} else {
-				_, err = db.revisionCache.Get(ctx, "12", revID, collection.GetCollectionID(), RevCacheOmitDelta, false)
+				_, err = db.revisionCache.Get(ctx, "12", revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 			}
 			require.NoError(t, err)
 
@@ -395,16 +400,22 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 				MaxItemCount: 10,
 				MaxBytes:     maxBytes,
 			}
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+			revCacheStats := revisionCacheStats{
+				cacheHitStat:      &cacheHitCounter,
+				cacheMissStat:     &cacheMissCounter,
+				cacheNumItemsStat: &cacheNumItems,
+				cacheMemoryStat:   &memoryBytesCounted,
+			}
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 			ctx := base.TestCtx(t)
 			var err error
 
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc1", docRev.DocID)
@@ -428,10 +439,10 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 
 			// test fail load event doesn't increment memory stat
 			if testCase.UseCVCache {
-				docRev, err = cache.Get(ctx, "doc2", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc2", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				assertHTTPError(t, err, 404)
 			} else {
-				docRev, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				assertHTTPError(t, err, 404)
 			}
 			assert.Nil(t, docRev.BodyBytes)
@@ -443,10 +454,10 @@ func TestBackingStoreMemoryCalculation(t *testing.T) {
 			memStatBeforeThirdLoad := memoryBytesCounted.Value()
 			// test another load from bucket but doing so should trigger memory based eviction
 			if testCase.UseCVCache {
-				docRev, err = cache.Get(ctx, "doc3", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc3", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.Get(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc3", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc3", docRev.DocID)
@@ -477,10 +488,16 @@ func TestBackingStore(t *testing.T) {
 		MaxItemCount: 10,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
-	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+	docRev, err := cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -491,7 +508,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
-	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -500,7 +517,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev is already resident, but still issue GetDocument to check for later revisions
-	docRev, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "Jens", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, "Jens", docRev.DocID)
 	assert.NotNil(t, docRev.History)
@@ -511,7 +528,7 @@ func TestBackingStore(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "Peter", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -533,11 +550,17 @@ func TestBackingStoreCV(t *testing.T) {
 		MaxItemCount: 10,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 	// Get Rev for the first time - miss cache, but fetch the doc and revision to store
 	cv := Version{SourceID: "test", Value: 123}
-	docRev, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
+	docRev, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.NotNil(t, docRev.Channels)
@@ -549,7 +572,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Perform a get on the same doc as above, check that we get cache hit
-	docRev, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, "test", docRev.CV.SourceID)
@@ -561,7 +584,7 @@ func TestBackingStoreCV(t *testing.T) {
 
 	// Doc doesn't exist, so miss the cache, and fail when getting the doc
 	cv = Version{SourceID: "test11", Value: 100}
-	docRev, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
@@ -571,7 +594,7 @@ func TestBackingStoreCV(t *testing.T) {
 	assert.Equal(t, int64(1), getRevisionCounter.Value())
 
 	// Rev still doesn't exist, make sure it wasn't cached
-	docRev, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "not_found", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	assertHTTPError(t, err, 404)
 	assert.Nil(t, docRev.BodyBytes)
 	assert.Equal(t, int64(1), cacheHitCounter.Value())
@@ -664,15 +687,15 @@ func TestBypassRevisionCache(t *testing.T) {
 	assert.False(t, ok)
 
 	// Get non-existing doc
-	_, err = rc.Get(base.TestCtx(t), "invalid", rev1, testCollectionID, RevCacheOmitDelta, false)
+	_, err = rc.Get(base.TestCtx(t), "invalid", rev1, testCollectionID, false)
 	assert.True(t, base.IsDocNotFoundError(err))
 
 	// Get non-existing revision
-	_, err = rc.Get(base.TestCtx(t), key, "3-abc", testCollectionID, RevCacheOmitDelta, false)
+	_, err = rc.Get(base.TestCtx(t), key, "3-abc", testCollectionID, false)
 	assertHTTPError(t, err, 404)
 
 	// Get specific revision
-	doc, err := rc.Get(base.TestCtx(t), key, rev1, testCollectionID, RevCacheOmitDelta, false)
+	doc, err := rc.Get(base.TestCtx(t), key, rev1, testCollectionID, false)
 	assert.NoError(t, err)
 	require.NotNil(t, doc)
 	assert.Equal(t, `{"value":1234}`, string(doc.BodyBytes))
@@ -776,7 +799,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)
 
 	// Get the raw document directly from the revcache, validate _attachments property isn't found
-	docRevision, err := collection.revisionCache.Get(base.TestCtx(t), docKey, rev2id, RevCacheOmitDelta, true)
+	docRevision, err := collection.revisionCache.Get(base.TestCtx(t), docKey, rev2id, RevCacheLoadBackupRev)
 	assert.NoError(t, err, "Unexpected error calling collection.revisionCache.Get")
 	assert.NotContains(t, docRevision.BodyBytes, BodyAttachments, "_attachments property still present in document body retrieved from rev cache: %#v", bucketBody)
 	_, ok = docRevision.Attachments["myatt"]
@@ -797,34 +820,48 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 // Ensure subsequent updates to delta don't mutate previously retrieved deltas
 func TestRevisionImmutableDelta(t *testing.T) {
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
+	deltaCacheHit, deltaCacheMiss, deltaCacheCount := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
 	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
 	cacheOptions := &RevisionCacheOptions{
 		MaxItemCount: 10,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	deltaStats := &base.DeltaSyncStats{
+		DeltaCacheMiss:     &deltaCacheMiss,
+		DeltaCacheHit:      &deltaCacheHit,
+		DeltaCacheNumItems: &deltaCacheCount,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
+	deltaCache := NewLRUDeltaCache(cacheOptions, deltaStats, backingStoreMap)
+	orchestrator := NewRevisionCacheOrchestrator(cache, deltaCache)
 
 	firstDelta := []byte("delta")
 	secondDelta := []byte("modified delta")
 
 	// Trigger load into cache
-	_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
+	_, err := orchestrator.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
 	assert.NoError(t, err, "Error adding to cache")
-	cache.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevisionDelta{ToRevID: "rev2", DeltaBytes: firstDelta})
+	orchestrator.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", "rev2", testCollectionID, RevisionDelta{ToRevID: "rev2", DeltaBytes: firstDelta})
 
 	// Retrieve from cache
-	retrievedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
+	retrievedRev, err := orchestrator.GetWithDelta(base.TestCtx(t), "doc1", "1-abc", "rev2", testCollectionID)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Update delta again, validate data in retrievedRev isn't mutated
-	cache.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevisionDelta{ToRevID: "rev3", DeltaBytes: secondDelta})
+	orchestrator.UpdateDelta(base.TestCtx(t), "doc1", "1-abc", "rev3", testCollectionID, RevisionDelta{ToRevID: "rev3", DeltaBytes: secondDelta})
 	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Retrieve again, validate delta is correct
-	updatedRev, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
+	updatedRev, err := orchestrator.GetWithDelta(base.TestCtx(t), "doc1", "1-abc", "rev3", testCollectionID)
 	assert.NoError(t, err, "Error retrieving from cache")
 	assert.Equal(t, "rev3", updatedRev.Delta.ToRevID)
 	assert.Equal(t, secondDelta, updatedRev.Delta.DeltaBytes)
@@ -835,6 +872,8 @@ func TestRevisionImmutableDelta(t *testing.T) {
 }
 
 func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
+	t.Skip("pending CBG-5234")
+
 	testCases := []struct {
 		name     string
 		useCVKey bool
@@ -856,7 +895,13 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 				MaxItemCount: 10,
 				MaxBytes:     140,
 			}
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+			revCacheStats := revisionCacheStats{
+				cacheHitStat:      &cacheHitCounter,
+				cacheMissStat:     &cacheMissCounter,
+				cacheNumItemsStat: &cacheNumItems,
+				cacheMemoryStat:   &memoryBytesCounted,
+			}
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 			firstDelta := []byte("delta")
 			secondDelta := []byte("modified delta")
@@ -867,19 +912,19 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 			var docRev DocumentRevision
 			var err error
 			if testCase.useCVKey {
-				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err, "Error adding to cache")
 			} else {
-				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err, "Error adding to cache")
 			}
 
 			revCacheMem := memoryBytesCounted.Value()
 			revCacheDelta := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
 			if testCase.useCVKey {
-				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), docRev.CV.String(), testCollectionID, revCacheDelta)
 			} else {
-				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", "1-abc", docRev.RevID, testCollectionID, revCacheDelta)
 			}
 			// assert that rev cache memory increases by expected amount
 			newMem := revCacheMem + revCacheDelta.totalDeltaBytes
@@ -889,9 +934,9 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 			newMem = memoryBytesCounted.Value()
 			revCacheDelta = newRevCacheDelta(secondDelta, "1-abc", docRev, false, nil)
 			if testCase.useCVKey {
-				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), docRev.CV.String(), testCollectionID, revCacheDelta)
 			} else {
-				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", "1-abc", docRev.RevID, testCollectionID, revCacheDelta)
 			}
 
 			// assert the overall memory stat is correctly updated (by the diff between the old delta and the new delta)
@@ -900,9 +945,9 @@ func TestUpdateDeltaRevCacheMemoryStat(t *testing.T) {
 
 			revCacheDelta = newRevCacheDelta(thirdDelta, "1-abc", docRev, false, nil)
 			if testCase.useCVKey {
-				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), docRev.CV.String(), testCollectionID, revCacheDelta)
 			} else {
-				cache.UpdateDelta(ctx, "doc1", "1-abc", testCollectionID, revCacheDelta)
+				cache.UpdateDelta(ctx, "doc1", "1-abc", docRev.RevID, testCollectionID, revCacheDelta)
 			}
 
 			// assert that eviction took place and as result stat is now 0 (only item in cache was doc1)
@@ -934,9 +979,15 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 				MaxItemCount: 10,
 				MaxBytes:     10,
 			}
+			revCacheStats := revisionCacheStats{
+				cacheHitStat:      &cacheHitCounter,
+				cacheMissStat:     &cacheMissCounter,
+				cacheNumItemsStat: &cacheNumItems,
+				cacheMemoryStat:   &memoryBytesCounted,
+			}
 			ctx := base.TestCtx(t)
 			var err error
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 			cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{"some":"test"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 
@@ -947,9 +998,9 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 
 			if !testCase.UseCVCache {
 				// fetch each doc added to load into cache
-				_, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+				_, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
-				_, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+				_, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 
@@ -959,10 +1010,10 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			// assert we can still fetch this upsert doc
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = cache.Get(ctx, "doc2", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc2", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, false, false)
+				docRev, err = cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, "doc2", docRev.DocID)
@@ -972,10 +1023,10 @@ func TestImmediateRevCacheMemoryBasedEviction(t *testing.T) {
 			assert.Equal(t, int64(0), cacheNumItems.Value())
 
 			if testCase.UseCVCache {
-				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1122,7 +1173,14 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 			ctx := base.TestCtx(t)
 			var err error
 
-			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+			revCacheStats := revisionCacheStats{
+				cacheHitStat:      &cacheHitCounter,
+				cacheMissStat:     &cacheMissCounter,
+				cacheNumItemsStat: &cacheNumItems,
+				cacheMemoryStat:   &memoryBytesCounted,
+			}
+
+			cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 			// load up item to hit max capacity
 			cache.Put(ctx, DocumentRevision{BodyBytes: []byte(`{"some":"test"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 
@@ -1139,10 +1197,10 @@ func TestImmediateRevCacheItemBasedEviction(t *testing.T) {
 
 			var docRev DocumentRevision
 			if testCase.useCVKey {
-				docRev, err = cache.Get(ctx, "doc3", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc3", Version{Value: 123, SourceID: "test"}.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				docRev, err = cache.Get(ctx, "doc3", "1-abc", testCollectionID, RevCacheOmitDelta, false)
+				docRev, err = cache.Get(ctx, "doc3", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1228,10 +1286,10 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			// Test Get with item in the cache
 			var docRev DocumentRevision
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.Get(ctx, "doc1", docCV.String(), collctionID, false, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc1", docCV.String(), collctionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				docRev, err = db.revisionCache.Get(ctx, "doc1", revID, collctionID, RevCacheOmitDelta, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc1", revID, collctionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1241,10 +1299,10 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 
 			// get again and ensure memory stat doesn't change
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.Get(ctx, "doc1", docCV.String(), collctionID, false, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc1", docCV.String(), collctionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				docRev, err = db.revisionCache.Get(ctx, "doc1", revID, collctionID, RevCacheOmitDelta, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc1", revID, collctionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.Equal(t, int64(docSize), cacheStats.RevisionCacheTotalMemory.Value())
@@ -1254,10 +1312,10 @@ func TestBasicOperationsOnCacheWithMemoryStat(t *testing.T) {
 			revDoc2 := createThenRemoveFromRevCache(t, ctx, "doc2", db, collection)
 			// load from doc from bucket
 			if testCase.UseCVCache {
-				docRev, err = db.revisionCache.Get(ctx, "doc2", revDoc2.CV.String(), collctionID, false, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc2", revDoc2.CV.String(), collctionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			} else {
-				docRev, err = db.revisionCache.Get(ctx, "doc2", docRev.RevID, collctionID, RevCacheOmitDelta, false)
+				docRev, err = db.revisionCache.Get(ctx, "doc2", docRev.RevID, collctionID, RevCacheDontLoadBackupRev)
 				require.NoError(t, err)
 			}
 			assert.NotNil(t, docRev.BodyBytes)
@@ -1360,10 +1418,16 @@ func TestSingleLoad(t *testing.T) {
 		MaxBytes:      0,
 		InsertOnWrite: true,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc123", RevID: "1-abc", CV: &Version{Value: 123, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
-	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false, false)
+	_, err := cache.Get(base.TestCtx(t), "doc123", "1-abc", testCollectionID, false)
 
 	assert.NoError(t, err)
 }
@@ -1377,7 +1441,13 @@ func TestConcurrentLoad(t *testing.T) {
 		MaxBytes:      0,
 		InsertOnWrite: true,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 	cache.Put(base.TestCtx(t), DocumentRevision{BodyBytes: []byte(`{"test":"1234"}`), DocID: "doc1", RevID: "1-abc", CV: &Version{Value: 1234, SourceID: "test"}, History: Revisions{"start": 1}}, testCollectionID)
 
@@ -1386,7 +1456,7 @@ func TestConcurrentLoad(t *testing.T) {
 	wg.Add(20)
 	for range 20 {
 		go func() {
-			_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false, false)
+			_, err := cache.Get(base.TestCtx(t), "doc1", "1-abc", testCollectionID, false)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -1407,14 +1477,14 @@ func TestRevisionCacheRemove(t *testing.T) {
 	rev1id, _, err := collection.Put(ctx, "doc", Body{"val": 123})
 	assert.NoError(t, err)
 
-	docRev, err := collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, true, true)
+	docRev, err := collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, RevCacheLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
 
 	collection.revisionCache.Remove(ctx, "doc", rev1id)
 
-	docRev, err = collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, true, true)
+	docRev, err = collection.revisionCache.Get(base.TestCtx(t), "doc", rev1id, RevCacheLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, rev1id, docRev.RevID)
 	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
@@ -1580,10 +1650,13 @@ func TestRevCacheCapacityStat(t *testing.T) {
 				&testBackingStore{[]string{"badDoc"}, &getDocumentCounter, &getRevisionCounter},
 				testCollectionID,
 			)
-			cache := NewLRURevisionCache(
-				&RevisionCacheOptions{MaxItemCount: 5, MaxBytes: 0},
-				backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &cacheMemoryStat,
-			)
+			revCacheStats := revisionCacheStats{
+				cacheHitStat:      &cacheHitCounter,
+				cacheMissStat:     &cacheMissCounter,
+				cacheNumItemsStat: &cacheNumItems,
+				cacheMemoryStat:   &cacheMemoryStat,
+			}
+			cache := NewLRURevisionCache(&RevisionCacheOptions{MaxItemCount: 5, MaxBytes: 0}, backingStoreMap, revCacheStats)
 			ctx := base.TestCtx(t)
 			cv := &Version{SourceID: "test", Value: 123}
 			const revID = "1-abc"
@@ -1598,9 +1671,9 @@ func TestRevCacheCapacityStat(t *testing.T) {
 			// getDoc abstracts over the two lookup pathways under test.
 			getDoc := func(docID string) (DocumentRevision, error) {
 				if tc.useCVCache {
-					return cache.Get(ctx, docID, cv.String(), testCollectionID, RevCacheOmitDelta, false)
+					return cache.Get(ctx, docID, cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 				}
-				return cache.Get(ctx, docID, revID, testCollectionID, RevCacheOmitDelta, true)
+				return cache.Get(ctx, docID, revID, testCollectionID, RevCacheLoadBackupRev)
 			}
 
 			// removeDoc removes an entry using the key type appropriate to the pathway under test.
@@ -1728,7 +1801,7 @@ func TestRevCacheOnDemand(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -1775,7 +1848,13 @@ func TestRevCacheOperationsCV(t *testing.T) {
 		MaxItemCount: 10,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats)
 
 	cv := Version{SourceID: "test", Value: 123}
 	documentRevision := DocumentRevision{
@@ -1788,7 +1867,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 	}
 	cache.Put(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
+	docRev, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1801,7 +1880,7 @@ func TestRevCacheOperationsCV(t *testing.T) {
 
 	cache.Upsert(base.TestCtx(t), documentRevision, testCollectionID)
 
-	docRev, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
+	docRev, err = cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	require.NoError(t, err)
 	assert.Equal(t, "doc1", docRev.DocID)
 	assert.Equal(t, base.SetOf("chan1"), docRev.Channels)
@@ -1826,13 +1905,19 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		MaxItemCount: DefaultRevisionCacheSize,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 	ctx := base.TestCtx(b)
 
 	// trigger load into cache
 	for i := range 5000 {
-		_, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheOmitDelta, false)
+		_, _ = cache.Get(ctx, fmt.Sprintf("doc%d", i), "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 	}
 
 	b.ResetTimer()
@@ -1840,7 +1925,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		// GET the document until test run has completed
 		for pb.Next() {
 			docId := fmt.Sprintf("doc%d", rand.Intn(5000))
-			_, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheOmitDelta, false)
+			_, _ = cache.Get(ctx, docId, "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 		}
 	})
 }
@@ -1924,7 +2009,7 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 				case <-ctx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -1972,7 +2057,7 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -1997,12 +2082,18 @@ func TestLoaderMismatchInCV(t *testing.T) {
 		MaxItemCount: 10,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats)
 
 	// create cv with incorrect version to the one stored in backing store
 	cv := Version{SourceID: "test", Value: 1234}
 
-	_, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheOmitDelta, false)
+	_, err := cache.Get(base.TestCtx(t), "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 	require.Error(t, err)
 	require.Error(t, err, base.ErrNotFound)
 	assert.Equal(t, int64(0), cacheHitCounter.Value())
@@ -2022,7 +2113,13 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 		MaxItemCount: 10,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats)
 
 	ctx := base.TestCtx(t)
 
@@ -2031,13 +2128,13 @@ func TestConcurrentLoadByCVAndRevOnCache(t *testing.T) {
 
 	cv := Version{SourceID: "test", Value: 123}
 	go func() {
-		_, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
+		_, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheDontLoadBackupRev)
 		require.NoError(t, err)
 		wg.Done()
 	}()
 
 	go func() {
-		_, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheIncludeDelta, false)
+		_, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 		require.NoError(t, err)
 		wg.Done()
 	}()
@@ -2093,7 +2190,13 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 		MaxItemCount: 10,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, CreateTestSingleBackingStoreMap(&testBackingStore{[]string{"test_doc"}, &getDocumentCounter, &getRevisionCounter}, testCollectionID), revCacheStats)
 
 	ctx := base.TestCtx(t)
 
@@ -2111,7 +2214,7 @@ func TestConcurrentPutAndGetOnRevCache(t *testing.T) {
 	}
 
 	go func() {
-		_, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheIncludeDelta, false)
+		_, err := cache.Get(ctx, "doc1", cv.String(), testCollectionID, RevCacheDontLoadBackupRev)
 		require.NoError(t, err)
 		wg.Done()
 	}()
@@ -2175,7 +2278,7 @@ func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -2230,7 +2333,7 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -2239,7 +2342,7 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 	var getErr error
 	go func() {
 		for range 100 {
-			_, getErr = db.revisionCache.Get(ctx, docID, rev1ID, collection.GetCollectionID(), true, false)
+			_, getErr = db.revisionCache.Get(ctx, docID, rev1ID, collection.GetCollectionID(), RevCacheDontLoadBackupRev)
 			if getErr != nil {
 				break
 			}
@@ -2281,7 +2384,7 @@ func TestPutRevHighRevCacheChurn(t *testing.T) {
 				case <-testCtx.Done():
 					return
 				default:
-					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheOmitDelta, false) //nolint:errcheck
+					_, err = db.revisionCache.Get(ctx, docID, revID, collection.GetCollectionID(), RevCacheDontLoadBackupRev) //nolint:errcheck
 				}
 			}
 		}()
@@ -2362,7 +2465,7 @@ func TestFetchBackupWithDeletedFlag(t *testing.T) {
 	// flush cache
 	db.FlushRevisionCacheForTest()
 
-	docRev, err := collection.revisionCache.Get(ctx, docID, doc1.HLV.GetCurrentVersionString(), false, true)
+	docRev, err := collection.revisionCache.Get(ctx, docID, doc1.HLV.GetCurrentVersionString(), RevCacheLoadBackupRev)
 	require.NoError(t, err)
 
 	assert.Equal(t, doc1.HLV.GetCurrentVersionString(), docRev.CV.String())
@@ -2377,7 +2480,7 @@ func TestFetchBackupWithDeletedFlag(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch deleted, will get backup rev and assert that the deleted flag is true
-	docRev, err = collection.revisionCache.Get(ctx, docID, deleteDoc.HLV.GetCurrentVersionString(), false, true)
+	docRev, err = collection.revisionCache.Get(ctx, docID, deleteDoc.HLV.GetCurrentVersionString(), RevCacheLoadBackupRev)
 	require.NoError(t, err)
 
 	assert.Equal(t, deleteDoc.HLV.GetCurrentVersionString(), docRev.CV.String())
@@ -2419,7 +2522,7 @@ func TestCorrectHLVWhenFetchingBackupRev(t *testing.T) {
 	db.FlushRevisionCacheForTest()
 
 	// fetch using lower level cache fetch with load from bucket bool true to get the backup rev
-	docRev, err = collection.revisionCache.Get(ctx, docID, docRev.CV.String(), RevCacheOmitDelta, true)
+	docRev, err = collection.revisionCache.Get(ctx, docID, docRev.CV.String(), RevCacheLoadBackupRev)
 	require.NoError(t, err)
 
 	// hlv history should be empty as we are fetching from backup rev
@@ -2488,7 +2591,13 @@ func TestRaceRemovingStaleCVValue(t *testing.T) {
 		MaxItemCount: 10,
 		MaxBytes:     0,
 	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
+	revCacheStats := revisionCacheStats{
+		cacheHitStat:      &cacheHitCounter,
+		cacheMissStat:     &cacheMissCounter,
+		cacheNumItemsStat: &cacheNumItems,
+		cacheMemoryStat:   &memoryBytesCounted,
+	}
+	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, revCacheStats)
 
 	ctx := base.TestCtx(t)
 
@@ -2507,93 +2616,6 @@ func TestRaceRemovingStaleCVValue(t *testing.T) {
 
 	wg.Wait()
 
-}
-
-// TestUpdateDeltaRevCacheMemoryStatPanic:
-//   - Test will interleave underlying rev cache operations for UpdateDelta process and Remove item process to reproduce a race between
-//     threads updating a delta (and that thread updating the cache memory stats) and the underlying value being removed/evicted from the cache
-func TestUpdateDeltaRevCacheMemoryStatPanicSingleEntry(t *testing.T) {
-	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
-	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
-	cacheOptions := &RevisionCacheOptions{
-		MaxItemCount: 5000,
-		MaxBytes:     500,
-	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
-
-	firstDelta := bytes.Repeat([]byte("a"), 1000)
-	ctx := base.TestCtx(t)
-
-	// Trigger load into cache.
-	docRev, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
-	require.NoError(t, err, "Error adding to cache")
-
-	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev, false, nil)
-
-	// Thread 1: UpdateDelta - start
-	value := cache.getValue(ctx, "doc1", "1-abc", testCollectionID, false)
-	if value != nil {
-		// Thread 2: Remove - start - drop value underneath UpdateDelta thread
-		cache.Remove(ctx, "doc1", "1-abc", testCollectionID)
-		// Thread 2: Remove - end
-		outGoingBytes := value.updateDelta(revCacheDelta2)
-		if outGoingBytes != 0 {
-			cache.currMemoryUsage.Add(outGoingBytes)
-			cache.cacheMemoryBytesStat.Add(outGoingBytes)
-		}
-		// check for memory based eviction
-		cache.revCacheMemoryBasedEviction(ctx)
-	}
-	// Thread 1: UpdateDelta - end
-
-	assert.Equal(t, 0, cache.lruList.Len())
-	assert.Equal(t, int64(0), memoryBytesCounted.Value())
-}
-
-// TestUpdateDeltaRevCacheMemoryStatPanic:
-//   - Test will interleave underlying rev cache operations for UpdateDelta process and Remove item process to reproduce a race between
-//     threads updating a delta (and that thread updating the cache memory stats) and the underlying value being removed/evicted from the cache
-func TestUpdateDeltaRevCacheMemoryStatPanicMultipleEntries(t *testing.T) {
-	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter, cacheNumItems, memoryBytesCounted := base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}, base.SgwIntStat{}
-	backingStoreMap := CreateTestSingleBackingStoreMap(&testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, testCollectionID)
-	cacheOptions := &RevisionCacheOptions{
-		MaxItemCount: 5000,
-		MaxBytes:     500,
-	}
-	cache := NewLRURevisionCache(cacheOptions, backingStoreMap, &cacheHitCounter, &cacheMissCounter, &cacheNumItems, &memoryBytesCounted)
-
-	firstDelta := bytes.Repeat([]byte("a"), 1000)
-	ctx := base.TestCtx(t)
-
-	// Trigger load into cache.  Add one revision (doc1) without a delta that's less than 500 bytes, then a
-	// revision (doc2) with a delta update that will exceed memory limit
-	// when added.  Both should be removed and cache memory stats should be zero.
-	_, err := cache.Get(ctx, "doc1", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
-	require.NoError(t, err, "Error adding to cache")
-
-	docRev2, err := cache.Get(ctx, "doc2", "1-abc", testCollectionID, RevCacheIncludeDelta, false)
-	require.NoError(t, err, "Error adding to cache")
-
-	revCacheDelta2 := newRevCacheDelta(firstDelta, "1-abc", docRev2, false, nil)
-
-	// Thread 1: UpdateDelta - start
-	value := cache.getValue(ctx, "doc2", "1-abc", testCollectionID, false)
-	if value != nil {
-		// Thread 2: Remove - start - drop value underneath UpdateDelta thread
-		cache.Remove(ctx, "doc2", "1-abc", testCollectionID)
-		// Thread 2: Remove - end
-		outGoingBytes := value.updateDelta(revCacheDelta2)
-		if outGoingBytes != 0 {
-			cache.currMemoryUsage.Add(outGoingBytes)
-			cache.cacheMemoryBytesStat.Add(outGoingBytes)
-		}
-		// check for memory based eviction
-		cache.revCacheMemoryBasedEviction(ctx)
-	}
-	// Thread 1: UpdateDelta - end
-
-	assert.Equal(t, 0, cache.lruList.Len())
-	assert.Equal(t, int64(0), memoryBytesCounted.Value())
 }
 
 func TestItemResidentInCacheBackupRevLoaded(t *testing.T) {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -510,11 +510,7 @@ func (db *DatabaseContext) FlushRevisionCacheForTest() {
 		backingStores[i] = v
 	}
 
-	db.revisionCache = NewRevisionCache(
-		db.Options.RevisionCacheOptions,
-		backingStores,
-		db.DbStats.Cache(),
-	)
+	db.revisionCache = NewRevisionCache(db.Options.RevisionCacheOptions, backingStores, db.DbStats.Cache(), db.DbStats.DeltaSync(), db.DeltaSyncEnabled())
 
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3501,7 +3501,7 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	// flush cache to ensure we're reading from the bucket
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
-	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docID, createVersion.CV.String(), false, true)
+	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docID, createVersion.CV.String(), db.RevCacheLoadBackupRev)
 	require.NoError(t, err)
 	// assert doc is not deleted
 	assert.False(t, docRev.Deleted)
@@ -3514,7 +3514,7 @@ func TestFetchBackupWhenOppositeRevIsDeleted(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// fetch rev 2 which is deleted
-	docRev, err = collection.GetRevisionCacheForTest().Get(ctx, docID, deleteVrs.CV.String(), false, true)
+	docRev, err = collection.GetRevisionCacheForTest().Get(ctx, docID, deleteVrs.CV.String(), db.RevCacheLoadBackupRev)
 	require.NoError(t, err)
 	assert.True(t, docRev.Deleted)
 	// assert deleted property is there
@@ -3642,7 +3642,7 @@ func TestFetchBackupRevisionWithAttachmentWhenCurrentHasNone(t *testing.T) {
 	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// fetch rev 1 by its CV, which should include the attachment
-	docRev, err := coll.GetRevisionCacheForTest().Get(ctx, docID, createVersion.CV.String(), false, true)
+	docRev, err := coll.GetRevisionCacheForTest().Get(ctx, docID, createVersion.CV.String(), db.RevCacheLoadBackupRev)
 	require.NoError(t, err)
 
 	assert.Len(t, docRev.Attachments, 1)

--- a/rest/blip_api_delta_sync_test.go
+++ b/rest/blip_api_delta_sync_test.go
@@ -1001,7 +1001,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 			collection, ctx := rt.GetSingleTestDatabaseCollection()
 			// Validate that generation of a delta didn't mutate the revision body in the revision cache
-			docRev, cacheErr := collection.GetRevisionCacheForTest().Get(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheOmitDelta, true)
+			docRev, cacheErr := collection.GetRevisionCacheForTest().Get(ctx, "doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.RevCacheLoadBackupRev)
 			assert.NoError(t, cacheErr)
 			assert.NotContains(t, docRev.BodyBytes, "bob")
 		} else {

--- a/rest/importuserxattrtest/revid_import_test.go
+++ b/rest/importuserxattrtest/revid_import_test.go
@@ -59,7 +59,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData))
 
 	collection, ctx := rt.GetSingleTestDatabaseCollection()
-	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.GetRevTreeID(), false, true)
+	docRev, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.GetRevTreeID(), db.RevCacheLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Len(t, docRev.Channels.ToArray(), 0)
 	assert.Equal(t, syncData.GetRevTreeID(), docRev.RevID)
@@ -81,7 +81,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	require.Contains(t, xattrs, base.SyncXattrName)
 	assert.NoError(t, base.JSONUnmarshal(xattrs[base.SyncXattrName], &syncData2))
 
-	docRev2, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.GetRevTreeID(), false, true)
+	docRev2, err := collection.GetRevisionCacheForTest().Get(ctx, docKey, syncData.GetRevTreeID(), db.RevCacheLoadBackupRev)
 	assert.NoError(t, err)
 	assert.Equal(t, syncData2.GetRevTreeID(), docRev2.RevID)
 

--- a/rest/replicatortest/replicator_conflict_test.go
+++ b/rest/replicatortest/replicator_conflict_test.go
@@ -2094,7 +2094,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		_, ok := collectionActive1.GetRevisionCacheForTest().Peek(ctxActive1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
 		// no peek for cv so fetch by cv, which in turn loads from bucket so assert item has correct history on it
-		docRev, err := collectionActive1.GetRevisionCacheForTest().Get(ctxActive1, docID, rt1Version.CV.String(), false, false)
+		docRev, err := collectionActive1.GetRevisionCacheForTest().Get(ctxActive1, docID, rt1Version.CV.String(), db.RevCacheDontLoadBackupRev)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 
@@ -2102,7 +2102,7 @@ func TestActiveReplicatorConflictRemoveCVFromCache(t *testing.T) {
 		collectionRT1, ctxRT1 := rt1.GetSingleTestDatabaseCollectionWithUser()
 		_, ok = collectionRT1.GetRevisionCacheForTest().Peek(ctxRT1, docID, rt1Version.RevTreeID)
 		require.False(t, ok)
-		docRev, err = collectionRT1.GetRevisionCacheForTest().Get(ctxRT1, docID, rt1Version.CV.String(), false, false)
+		docRev, err = collectionRT1.GetRevisionCacheForTest().Get(ctxRT1, docID, rt1Version.CV.String(), db.RevCacheDontLoadBackupRev)
 		require.NoError(t, err)
 		assert.Equal(t, rt2Version.CV.String(), docRev.HlvHistory)
 	})


### PR DESCRIPTION
CBG-5234

Initialise a delta cache when delta sync is enabled. Some minor refactor for passing down stats into cache. New stat added for num items in delta cache. New method added to get revision and delta in one call. 

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/430/ (disable rev cache)
- [x] https://jenkins.sgwdev.com/job/SyncGatewayIntegration/429/
