### PR TITLE
CBG-5263 workaround TestNewlyCreateSGWPermissions failure

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -1010,9 +1010,11 @@ func TestNewlyCreateSGWPermissions(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		AdminInterfaceAuthentication:    true,
 		enableAdminAuthPermissionsCheck: true,
+		PersistentConfig:                true,
 	})
 	defer rt.Close()
 
+	RequireStatus(t, rt.CreateDatabase("db", rt.NewDbConfig()), http.StatusCreated)
 	bucketName := rt.Bucket().GetName()
 
 	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
@@ -1389,16 +1391,6 @@ func TestNewlyCreateSGWPermissions(t *testing.T) {
 			Users:    []string{syncGatewayDevOps},
 		},
 		{
-			Method:   "POST",
-			Endpoint: "/db/_offline",
-			Users:    []string{syncGatewayConfigurator},
-		},
-		{
-			Method:   "POST",
-			Endpoint: "/db/_online",
-			Users:    []string{syncGatewayConfigurator},
-		},
-		{
 			Method:   "GET",
 			Endpoint: "/db/_dump/view",
 			Users:    []string{syncGatewayApp, syncGatewayAppRo},
@@ -1432,6 +1424,16 @@ func TestNewlyCreateSGWPermissions(t *testing.T) {
 			Method:   "GET",
 			Endpoint: "/_all_dbs",
 			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_offline",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_online",
+			Users:    []string{syncGatewayConfigurator},
 		},
 	}
 


### PR DESCRIPTION
CBG-5263 workaround TestNewlyCreateSGWPermissions failure

If you keep persistent config but move the online call back to the original location, this intermittent test failure is consistently reproduced.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`
