### PR TITLE
fix TestCBGTIndexCreationUnsafeLegacyName

### DIFF
--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -435,7 +435,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	)
 	require.NoError(t, err, "Unable to create legacy-style index")
 
-	indexName, err := GenerateCBGTIndexName(unsafeTestDBName, CBGTIndexTypeSyncGatewayImport)
+	indexName, err := GenerateCBGTIndexName(unsafeTestDBName, ShardedDCPFeedTypeImport)
 	require.NoError(t, err)
 
 	opts := ShardedDCPOptions{


### PR DESCRIPTION
Describe your PR here...
- Fix test

## Pre-review checklist
- [ ] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [ ] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [ ] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Update Go module dependencies when merged

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [ ]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/0000/
