### PR TITLE
CBG-4771 use context.WithCancelCause

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,8 @@ When performing a code review, if a log message includes User Data, ensure the v
 
 When performing a code review, be mindful of performance implications, such as mutex contention, race conditions, and other concurrency-related issues.
 
-When performing a code review, ensure code comments explain the *intent* or *reasoning* behind an implementation, rather than just restating what the code does.
+When performing a code review, ensure code comments explain the _intent_ or _reasoning_ behind an implementation, rather than just restating what the code does.
 
 When performing a code review, ensure `for` loops have sufficient exit conditions and are not prone to infinite loops. Prefer expressing the exit condition in the loop declaration itself, rather than relying on `break` statements within the loop body.
+
+When performing a code review, make sure context.WithCancelCause is used used in favor of context.WithCancel.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,4 +10,4 @@ When performing a code review, ensure code comments explain the _intent_ or _rea
 
 When performing a code review, ensure `for` loops have sufficient exit conditions and are not prone to infinite loops. Prefer expressing the exit condition in the loop declaration itself, rather than relying on `break` statements within the loop body.
 
-When performing a code review, make sure context.WithCancelCause is used used in favor of context.WithCancel.
+When performing a code review, make sure context.WithCancelCause is used instead of context.WithCancel.

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -366,7 +366,7 @@ func initCBGTManager(ctx context.Context, bucket Bucket, spec BucketSpec, cfgSG 
 	//   avoids file system usage, in conjunction with managerLoadDataDir=false in options.
 	dataDir := ""
 
-	eventHandlersCtx, eventHandlersCancel := context.WithCancel(ctx)
+	eventHandlersCtx, eventHandlersCancel := context.WithCancelCause(ctx)
 	eventHandlers := &sgMgrEventHandlers{ctx: eventHandlersCtx, ctxCancel: eventHandlersCancel}
 
 	// Specify one feed per pindex
@@ -513,7 +513,7 @@ func getMinNodeVersion(cfg cbgt.Cfg) (*ComparableBuildVersion, error) {
 // Stop unregisters the listener from the heartbeater, and stops it and associated handlers.
 func (c *CbgtContext) Stop(ctx context.Context) {
 	if c.eventHandlers != nil {
-		c.eventHandlers.ctxCancel()
+		c.eventHandlers.ctxCancel(errors.New("CbgtContext is stopping, cancelling event handlers"))
 	}
 
 	if c.heartbeatListener != nil {
@@ -763,7 +763,7 @@ func GetDefaultImportPartitions(serverless bool) uint16 {
 
 type sgMgrEventHandlers struct {
 	ctx       context.Context
-	ctxCancel context.CancelFunc
+	ctxCancel context.CancelCauseFunc
 	manager   *cbgt.Manager
 }
 

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -53,12 +53,12 @@ func NewConsoleLogger(ctx context.Context, shouldLogLocation bool, config *Conso
 		config = &ConsoleLoggerConfig{}
 	}
 
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	cancelCtx, cancelFunc := context.WithCancelCause(ctx)
 
 	// validate and set defaults
 	rotationDoneChan, err := config.init(cancelCtx)
 	if err != nil {
-		defer cancelFunc()
+		defer cancelFunc(errors.New("ConsoleLogger failed to initialize"))
 		return nil, err
 	}
 

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -64,8 +64,8 @@ type FileLogger struct {
 	output           io.Writer
 	logger           *log.Logger
 	buffer           strings.Builder
-	cancelFunc       context.CancelFunc // cancelFunc is used to stop the log rotation goroutine
-	rotationDoneChan chan struct{}      // rotationDoneChan is used to signal when the log rotation goroutine has stopped
+	cancelFunc       context.CancelCauseFunc // cancelFunc is used to stop the log rotation goroutine
+	rotationDoneChan chan struct{}           // rotationDoneChan is used to signal when the log rotation goroutine has stopped
 
 	// FileLoggerConfig stores the initial config used to instantiate FileLogger
 	config FileLoggerConfig
@@ -94,12 +94,12 @@ func NewFileLogger(ctx context.Context, config *FileLoggerConfig, level LogLevel
 		config = &FileLoggerConfig{}
 	}
 
-	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	cancelCtx, cancelFunc := context.WithCancelCause(ctx)
 
 	// validate and set defaults
 	rotationDoneChan, err := config.init(cancelCtx, level, name, logFilePath, minAge, defaultMaxAgeOverride)
 	if err != nil {
-		cancelFunc()
+		cancelFunc(errors.New("FileLogger failed to initialize"))
 		return nil, err
 	}
 
@@ -165,7 +165,7 @@ func (l *FileLogger) Close() error {
 	defer close(l.closed)
 	// cancel the log rotation goroutine and wait for it to stop
 	if l.cancelFunc != nil {
-		l.cancelFunc()
+		l.cancelFunc(errors.New("FileLogger closed"))
 	}
 	// wait for the rotation goroutine to stop
 	if l.rotationDoneChan != nil {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -12,6 +12,7 @@ package base
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -176,8 +177,10 @@ func NewTaskID(contextID string, taskName string) string {
 
 // TestCtx creates a context for the given test which is also cancelled once the test has completed.
 func TestCtx(t testing.TB) context.Context {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	t.Cleanup(cancelCtx)
+	ctx, cancelCtx := context.WithCancelCause(context.Background())
+	t.Cleanup(func() {
+		cancelCtx(errors.New("TestCtx t.Cleanup canceled"))
+	})
 	return LogContextWith(ctx, &LogContext{TestName: t.Name()})
 }
 

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -82,7 +82,7 @@ type TestBucketPool struct {
 	bucketReadierWaitGroup *sync.WaitGroup
 	// bucketCreationDoneChan is closed when all buckets have been created and run through bucketInitFunc
 	bucketCreationDoneChan chan struct{}
-	ctxCancelFunc          context.CancelFunc
+	ctxCancelFunc          context.CancelCauseFunc
 
 	bucketInitFunc TBPBucketInitFunc
 
@@ -149,7 +149,7 @@ func NewTestBucketPoolWithOptions(ctx context.Context, bucketReadierFunc TBPBuck
 	}
 
 	// Used to manage cancellation of worker goroutines
-	ctx, ctxCancelFunc := context.WithCancel(ctx)
+	ctx, ctxCancelFunc := context.WithCancelCause(ctx)
 
 	_, err := SetMaxFileDescriptors(ctx, 5000)
 	if err != nil {
@@ -473,7 +473,7 @@ func (tbp *TestBucketPool) Close(ctx context.Context) {
 	tbp.Logf(ctx, "Closing TestBucketPool and closing all buckets")
 	// Cancel async workers
 	if tbp.ctxCancelFunc != nil {
-		tbp.ctxCancelFunc()
+		tbp.ctxCancelFunc(errors.New("TestBucketPool.Close called"))
 		tbp.Logf(ctx, "Waiting for bucket readier to finish")
 		tbp.bucketReadierWaitGroup.Wait()
 		tbp.Logf(ctx, "Waiting for bucket creation to finish")

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -450,7 +450,7 @@ func SetUpGlobalTestMemoryWatermark(m *testing.M, memWatermarkThresholdMB uint64
 
 	var inuseHighWaterMarkMB float64
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	ctx, ctxCancel := context.WithCancelCause(context.Background())
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
@@ -485,7 +485,7 @@ func SetUpGlobalTestMemoryWatermark(m *testing.M, memWatermarkThresholdMB uint64
 	}(ctx)
 
 	return func() {
-		ctxCancel()
+		ctxCancel(errors.New("SetUpGlobalTestMemoryWatermark teardown"))
 		wg.Wait()
 
 		if inuseHighWaterMarkMB > float64(memWatermarkThresholdMB) {
@@ -528,7 +528,7 @@ func SetUpGlobalTestProfiling(m *testing.M) (teardownFn func()) {
 
 	log.Printf("TEST: profiling for %v with frequency: %v", profiles, freq)
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	ctx, ctxCancel := context.WithCancelCause(context.Background())
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
@@ -570,7 +570,7 @@ func SetUpGlobalTestProfiling(m *testing.M) (teardownFn func()) {
 	}(ctx)
 
 	return func() {
-		ctxCancel()
+		ctxCancel(errors.New("SetUpGlobalTestProfiling teardown"))
 		wg.Wait()
 	}
 }

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -219,7 +219,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 		ctx = arc.config.ActiveDB.AddBucketUserLogContext(ctx)
 	}
 
-	cancelCtx, cancelFunc := context.WithCancel(context.WithoutCancel(ctx)) // separate cancel context from parent cancel context
+	cancelCtx, cancelFunc := context.WithCancelCause(context.WithoutCancel(ctx)) // separate cancel context from parent cancel context
 
 	var originPatterns []string // no origin headers for ISGR
 	var blipContext *blip.Context
@@ -231,7 +231,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 		ctx, blipContext, err = NewSGBlipContext(ctx, arc.config.ID+idSuffix, originPatterns, cancelCtx)
 	}
 	if err != nil {
-		cancelFunc()
+		cancelFunc(errors.New("failed to create blip context"))
 		return nil, nil, err
 	}
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -39,7 +39,7 @@ type activeReplicatorCommon struct {
 	blipSender                      *blip.Sender
 	Stats                           expvar.Map
 	checkpointerCtx                 context.Context
-	checkpointerCtxCancel           context.CancelFunc
+	checkpointerCtxCancel           context.CancelCauseFunc
 	CheckpointID                    string // Used for checkpoint retrieval when Checkpointer isn't available
 	initialStatus                   *ReplicationStatus
 	statusKey                       string // key used when persisting replication status
@@ -52,7 +52,7 @@ type activeReplicatorCommon struct {
 	onReplicatorComplete            ReplicatorCompleteFunc
 	lock                            sync.RWMutex
 	ctx                             context.Context
-	ctxCancel                       context.CancelFunc
+	ctxCancel                       context.CancelCauseFunc
 	reconnectActive                 base.AtomicBool                                             // Tracks whether reconnect goroutine is active
 	replicatorConnectFn             func() error                                                // the function called inside reconnect.
 	registerCheckpointerCallbacksFn func(*activeReplicatorCollection) error                     // function to register checkpointer callbacks
@@ -152,7 +152,7 @@ func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
 	arc.setState(ReplicationStateStarting)
 	logCtx := base.CorrelationIDLogCtx(ctx,
 		arc.config.ID+"-"+string(arc.direction))
-	arc.ctx, arc.ctxCancel = context.WithCancel(logCtx)
+	arc.ctx, arc.ctxCancel = context.WithCancelCause(logCtx)
 
 	arc.startStatusReporter(arc.ctx)
 
@@ -162,7 +162,7 @@ func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
 		base.WarnfCtx(arc.ctx, "Couldn't connect: %s", err)
 		if errors.Is(err, fatalReplicatorConnectError) {
 			base.WarnfCtx(arc.ctx, "Stopping replication connection attempt")
-			defer arc.ctxCancel()
+			defer arc.ctxCancel(errors.New("stopping after fatal replicator connection error"))
 		} else {
 			base.InfofCtx(arc.ctx, base.KeyReplicate, "Attempting to reconnect in background: %v", err)
 			arc.reconnect()
@@ -175,7 +175,7 @@ func (arc *activeReplicatorCommon) Start(ctx context.Context) error {
 // initCheckpointer starts a checkpointer. The remoteCheckpoints are only for collections and indexed by the blip collectionIdx. If using default collection only, replicationCheckpoints is an empty array.
 func (arc *activeReplicatorCommon) _initCheckpointer(remoteCheckpoints []replicationCheckpoint) error {
 	// wrap the replicator context with a cancelFunc that can be called to abort the checkpointer from _disconnect
-	arc.checkpointerCtx, arc.checkpointerCtxCancel = context.WithCancel(arc.ctx)
+	arc.checkpointerCtx, arc.checkpointerCtxCancel = context.WithCancelCause(arc.ctx)
 
 	err := arc.forEachCollection(func(c *activeReplicatorCollection) error {
 		checkpointHash, hashErr := arc.config.CheckpointHash(c.collectionIdx)
@@ -340,7 +340,7 @@ func (arc *activeReplicatorCommon) synchronousReconnect() {
 	// use setState to preserve last error from retry loop set by setLastError
 	arc.setState(ReplicationStateError)
 	arc._publishStatus()
-	arc._stop()
+	arc._stop("stopping after failed reconnect attempts: " + retryErr.Error())
 }
 
 // disconnect will disconnect and stop the replicator, but not set the state - such that it will be reassigned and started again.
@@ -356,7 +356,7 @@ func (arc *activeReplicatorCommon) disconnect() error {
 // stopAndDisconnect runs _disconnect and _stop on the replicator, and sets the Stopped replication state.
 func (arc *activeReplicatorCommon) stopAndDisconnect() error {
 	arc.lock.Lock()
-	arc._stop()
+	arc._stop("stopping replicator from stopAndDisconnect()")
 	base.TracefCtx(arc.ctx, base.KeyReplicate, "Calling _stop and _disconnect from stopAndDisconnect()")
 	err := arc._disconnect()
 	arc.setState(ReplicationStateStopped)
@@ -380,7 +380,7 @@ func (arc *activeReplicatorCommon) _disconnect() error {
 
 	if arc.checkpointerCtx != nil {
 		base.TracefCtx(arc.ctx, base.KeyReplicate, "cancelling checkpointer context inside _disconnect")
-		arc.checkpointerCtxCancel()
+		arc.checkpointerCtxCancel(errors.New("cancelling checkpointer context from _disconnect"))
 		_ = arc.forEachCollection(func(c *activeReplicatorCollection) error {
 			c.Checkpointer.closeWg.Wait()
 			c.Checkpointer.CheckpointNow()
@@ -405,10 +405,10 @@ func (arc *activeReplicatorCommon) _disconnect() error {
 }
 
 // _stop aborts any replicator processes that run outside of a running replication connection (e.g: async reconnect handling, statsreporter)
-func (arc *activeReplicatorCommon) _stop() {
+func (arc *activeReplicatorCommon) _stop(message string) {
 	if arc.ctxCancel != nil {
 		base.TracefCtx(arc.ctx, base.KeyReplicate, "cancelling context on activeReplicatorCommon in _stop()")
-		arc.ctxCancel()
+		arc.ctxCancel(errors.New(message))
 	}
 }
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"errors"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -96,7 +97,7 @@ func (apr *ActivePullReplicator) _startPullNonCollection() error {
 
 	if err := apr._subChanges(nil, since); err != nil {
 		base.TracefCtx(apr.ctx, base.KeyReplicate, "cancelling the checkpointer context inside _connect where we send blip request")
-		apr.checkpointerCtxCancel()
+		apr.checkpointerCtxCancel(errors.New("error sending subChanges request: "))
 		apr.checkpointerCtx = nil
 		apr.blipSender.Close()
 		apr.blipSyncContext.Close()
@@ -136,7 +137,7 @@ func (apr *ActivePullReplicator) Complete() {
 		return nil
 	})
 
-	apr._stop()
+	apr._stop("Pull replicator completed")
 
 	base.TracefCtx(apr.ctx, base.KeyReplicate, "Calling disconnect from Complete() in active replicator pull")
 	stopErr := apr._disconnect()

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -12,7 +12,7 @@ package db
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -97,7 +97,7 @@ func (apr *ActivePullReplicator) _startPullNonCollection() error {
 
 	if err := apr._subChanges(nil, since); err != nil {
 		base.TracefCtx(apr.ctx, base.KeyReplicate, "cancelling the checkpointer context inside _connect where we send blip request")
-		apr.checkpointerCtxCancel(errors.New("error sending subChanges request: "))
+		apr.checkpointerCtxCancel(fmt.Errorf("error sending subChanges request: %w", err))
 		apr.checkpointerCtx = nil
 		apr.blipSender.Close()
 		apr.blipSyncContext.Close()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -251,7 +251,7 @@ func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since Seq
 		})
 		if err != nil {
 			base.InfofCtx(apr.ctx, base.KeyReplicate, "Terminating blip connection due to changes feed error: %v", err)
-			bh.ctxCancelFunc(errors.New("ISGR push replicator changes feed error"))
+			bh.ctxCancelFunc(fmt.Errorf("ISGR push replicator changes feed error: %w", err))
 			apr.setError(err)
 			apr.publishStatus()
 			return

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -88,7 +88,7 @@ func (apr *ActivePushReplicator) Complete() {
 		return nil
 	})
 
-	apr._stop()
+	apr._stop("push replication complete")
 
 	stopErr := apr._disconnect()
 	if stopErr != nil {
@@ -251,7 +251,7 @@ func (apr *ActivePushReplicator) _startSendingChanges(bh *blipHandler, since Seq
 		})
 		if err != nil {
 			base.InfofCtx(apr.ctx, base.KeyReplicate, "Terminating blip connection due to changes feed error: %v", err)
-			bh.ctxCancelFunc()
+			bh.ctxCancelFunc(errors.New("ISGR push replicator changes feed error"))
 			apr.setError(err)
 			apr.publishStatus()
 			return

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime/debug"
 	"strings"
 	"sync/atomic"

--- a/db/blip_collection_context.go
+++ b/db/blip_collection_context.go
@@ -21,8 +21,8 @@ type blipSyncCollectionContext struct {
 	dbCollection          *DatabaseCollection
 	activeSubChanges      base.AtomicBool // Flag for whether there is a subChanges subscription currently active.  Atomic access
 	changesCtxLock        sync.Mutex
-	changesCtx            context.Context    // Used for the unsub changes Blip message to check if the subChanges feed should stop
-	changesCtxCancel      context.CancelFunc // Cancel function for changesCtx to cancel subChanges being sent
+	changesCtx            context.Context         // Used for the unsub changes Blip message to check if the subChanges feed should stop
+	changesCtxCancel      context.CancelCauseFunc // Cancel function for changesCtx to cancel subChanges being sent
 	pendingInsertionsLock sync.Mutex
 	pendingInsertions     base.Set // DocIDs from handleProposeChanges that aren't in the db
 
@@ -58,7 +58,7 @@ func newBlipSyncCollectionContext(ctx context.Context, dbCollection *DatabaseCol
 		dbCollection:      dbCollection,
 		pendingInsertions: base.Set{},
 	}
-	c.changesCtx, c.changesCtxCancel = context.WithCancel(base.KeyspaceLogCtx(ctx, dbCollection.bucketName(), dbCollection.ScopeName, dbCollection.Name))
+	c.changesCtx, c.changesCtxCancel = context.WithCancelCause(base.KeyspaceLogCtx(ctx, dbCollection.bucketName(), dbCollection.ScopeName, dbCollection.Name))
 	return c
 }
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -287,7 +287,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 
 	// Create ctx if it has been cancelled
 	if collectionCtx.changesCtx.Err() != nil {
-		collectionCtx.changesCtx, collectionCtx.changesCtxCancel = context.WithCancel(bh.loggingCtx)
+		collectionCtx.changesCtx, collectionCtx.changesCtxCancel = context.WithCancelCause(bh.loggingCtx)
 	}
 
 	if len(subChangesParams.docIDs()) > 0 && subChangesParams.continuous() {
@@ -355,7 +355,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		}
 
 		defer func() {
-			collectionCtx.changesCtxCancel()
+			collectionCtx.changesCtxCancel(errors.New("changes feed ended"))
 			collectionCtx.activeSubChanges.Set(false)
 		}()
 		// sendChanges runs until blip context closes, or fails due to error
@@ -375,7 +375,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		})
 		if err != nil {
 			base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "Closing blip connection due to changes feed error %+v\n", err)
-			bh.ctxCancelFunc()
+			bh.ctxCancelFunc(fmt.Errorf("changes feed returned error: %w", err))
 		}
 		base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Type:%s   --> Time:%v", bh.serialNumber, rq.Profile(), time.Since(startTime))
 	}()
@@ -406,7 +406,7 @@ func (bh *blipHandler) handleUnsubChanges(rq *blip.Message) error {
 	collectionCtx := bh.collectionCtx
 	collectionCtx.changesCtxLock.Lock()
 	defer collectionCtx.changesCtxLock.Unlock()
-	collectionCtx.changesCtxCancel()
+	collectionCtx.changesCtxCancel(errors.New("unsubChanges called"))
 	return nil
 }
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -35,7 +35,7 @@ const (
 var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 
 // NewBlipSyncContext creates a new BlipSyncContext for a given database and register the handlers. This does not make a connection.
-func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, replicationStats *BlipSyncStats, ctxCancelFunc context.CancelFunc) (*BlipSyncContext, error) {
+func NewBlipSyncContext(ctx context.Context, bc *blip.Context, db *Database, replicationStats *BlipSyncStats, ctxCancelFunc context.CancelCauseFunc) (*BlipSyncContext, error) {
 	if ctxCancelFunc == nil {
 		return nil, errors.New("cancelCtxFunc is required")
 	}
@@ -141,7 +141,7 @@ type BlipSyncContext struct {
 
 	stats blipSyncStats // internal structure to store stats
 
-	ctxCancelFunc context.CancelFunc // function to cancel a blip replication
+	ctxCancelFunc context.CancelCauseFunc // function to cancel a blip replication
 }
 
 // blipSyncStats has support structures to support reporting stats at regular interval
@@ -253,11 +253,11 @@ func (bsc *BlipSyncContext) Close() {
 			collection.changesCtxLock.Lock()
 			defer collection.changesCtxLock.Unlock()
 
-			collection.changesCtxCancel()
+			collection.changesCtxCancel(errors.New("BlipSyncContext.Close called"))
 		}
 		bsc.reportStats(true)
 		close(bsc.terminator)
-		bsc.ctxCancelFunc()
+		bsc.ctxCancelFunc(errors.New("BlipSyncContext.Close called"))
 	})
 }
 

--- a/db/blip_test.go
+++ b/db/blip_test.go
@@ -10,6 +10,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -31,8 +32,8 @@ func TestSubprotocolString(t *testing.T) {
 func TestBlipCorrelationID(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close(ctx)
-	ctx, cancelFunc := context.WithCancel(ctx)
-	defer cancelFunc()
+	ctx, cancelFunc := context.WithCancelCause(ctx)
+	defer cancelFunc(errors.New("test teardown"))
 
 	base.SetUpTestLogging(t, base.LevelInfo, base.KeyWebSocket)
 	for _, explicitTestID := range []bool{true, false} {

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -248,9 +248,9 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	// Start continuous changes feed
 	var options ChangesOptions
 	options.Since = SequenceID{Seq: 0}
-	ctx, changesCtxCancel := context.WithCancel(ctx)
+	ctx, changesCtxCancel := context.WithCancelCause(ctx)
 	options.ChangesCtx = ctx
-	defer changesCtxCancel()
+	defer changesCtxCancel(errors.New("test teardown"))
 	options.Continuous = true
 	options.Wait = true
 	feed, err := dbCollection.MultiChangesFeed(ctx, base.SetOf("ABC"), options)
@@ -362,7 +362,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 
 	caughtUpStart := db.DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value()
 
-	changesCtx, changesCtxCancel := context.WithCancel(ctx)
+	changesCtx, changesCtxCancel := context.WithCancelCause(ctx)
 	var changesFeedsWg sync.WaitGroup
 	var seq1Wg, seq2Wg, seq3Wg sync.WaitGroup
 	// Start 100 continuous changes feeds
@@ -448,7 +448,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 	require.NoError(t, db.WaitForCaughtUp(caughtUpStart+int64(100)))
 
 	// Cancel the changes context
-	changesCtxCancel()
+	changesCtxCancel(errors.New("cancel changes context after changes are caught up"))
 
 	log.Printf("terminator is closed")
 
@@ -605,11 +605,11 @@ func TestContinuousChangesBackfill(t *testing.T) {
 	// Start changes feed
 	var options ChangesOptions
 	options.Since = SequenceID{Seq: 0}
-	ctx, changesCtxCancel := context.WithCancel(ctx)
+	ctx, changesCtxCancel := context.WithCancelCause(ctx)
 	options.ChangesCtx = ctx
 	options.Continuous = true
 	options.Wait = true
-	defer changesCtxCancel()
+	defer changesCtxCancel(errors.New("test teardown"))
 
 	dbCollection, ctx := GetSingleDatabaseCollectionWithUser(ctx, t, db)
 	feed, err := dbCollection.MultiChangesFeed(ctx, base.SetOf("*"), options)
@@ -708,9 +708,9 @@ func TestLowSequenceHandling(t *testing.T) {
 
 	var options ChangesOptions
 	options.Since = SequenceID{Seq: 0}
-	changesCtx, changesCtxCancel := context.WithCancel(base.TestCtx(t))
+	changesCtx, changesCtxCancel := context.WithCancelCause(base.TestCtx(t))
 	options.ChangesCtx = changesCtx
-	defer changesCtxCancel()
+	defer changesCtxCancel(errors.New("test teardown"))
 	options.Continuous = true
 	options.Wait = true
 	feed, err := dbCollection.MultiChangesFeed(ctx, base.SetOf("*"), options)
@@ -773,7 +773,8 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 
 	var options ChangesOptions
 	options.Since = SequenceID{Seq: 0}
-	ctx, changesCtxCancel := context.WithCancel(ctx)
+	ctx, changesCtxCancel := context.WithCancelCause(ctx)
+	defer changesCtxCancel(errors.New("test teardown"))
 	options.ChangesCtx = ctx
 	options.Continuous = true
 	options.Wait = true
@@ -790,8 +791,6 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 
 	_, err = verifySequencesInFeed(feed, []uint64{9})
 	assert.True(t, err == nil)
-
-	changesCtxCancel()
 }
 
 // Test low sequence handling of late arriving sequences to a continuous changes feed, when the
@@ -830,7 +829,8 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
 	var options ChangesOptions
 	options.Since = SequenceID{Seq: 0}
-	ctx, changesCtxCancel := context.WithCancel(ctx)
+	ctx, changesCtxCancel := context.WithCancelCause(ctx)
+	defer changesCtxCancel(errors.New("test teardown"))
 	options.ChangesCtx = ctx
 	options.Continuous = true
 	options.Wait = true
@@ -878,8 +878,6 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	// 1. 2::8 is the user sequence
 	// 2. The duplicate send of sequence '6' is the standard behaviour when a channel is added - we don't know
 	// whether the user has already seen the documents on the channel previously, so it gets resent
-
-	changesCtxCancel()
 }
 
 // Tests channel cache backfill with slow query, validates that a request that is terminated while
@@ -968,7 +966,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 	initialPendingQueries := db.DbStats.Cache().ChannelCachePendingQueries.Value()
 
 	// Start a second goroutine that should block waiting for the view lock
-	changesCtx, changesCtxCancel := context.WithCancel(base.TestCtx(t))
+	changesCtx, changesCtxCancel := context.WithCancelCause(base.TestCtx(t))
 	changesWg.Add(1)
 	go func() {
 		defer changesWg.Done()
@@ -993,7 +991,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 	assert.True(t, pendingQueries > initialPendingQueries, "Pending queries (%d) didn't exceed initialPendingQueries (%d) after 10s", pendingQueries, initialPendingQueries)
 
 	// Terminate the second changes request
-	changesCtxCancel()
+	changesCtxCancel(errors.New("Terminate second changes request"))
 
 	// Unblock the first goroutine
 	queryWg.Done()
@@ -1055,7 +1053,8 @@ func TestChannelRace(t *testing.T) {
 
 	var options ChangesOptions
 	options.Since = SequenceID{Seq: 0}
-	ctx, changesCtxCancel := context.WithCancel(ctx)
+	ctx, changesCtxCancel := context.WithCancelCause(ctx)
+	defer changesCtxCancel(errors.New("test teardown"))
 	options.ChangesCtx = ctx
 	options.Continuous = true
 	options.Wait = true
@@ -1121,8 +1120,6 @@ func TestChannelRace(t *testing.T) {
 	}
 	changes.lock.RUnlock()
 	fmt.Println("changes: ", changesString)
-
-	changesCtxCancel()
 }
 
 // Test that housekeeping goroutines get terminated when change cache is stopped

--- a/db/database.go
+++ b/db/database.go
@@ -137,7 +137,7 @@ type DatabaseContext struct {
 	CompactState                 uint32                         // Status of database compaction
 	terminator                   chan bool                      // Signal termination of background goroutines
 	CancelContext                context.Context                // Cancelled when the database is closed - used to notify associated processes (e.g. blipContext)
-	cancelContextFunc            context.CancelFunc             // Cancel function for cancelContext
+	cancelContextFunc            context.CancelCauseFunc        // Cancel function for cancelContext
 	backgroundTasks              []BackgroundTask               // List of background tasks that are initiated.
 	activeChannels               *channels.ActiveChannels       // Tracks active replications by channel
 	CfgSG                        cbgt.Cfg                       // Sync Gateway cluster shared config
@@ -457,9 +457,9 @@ func NewDatabaseContext(ctx context.Context, dbName string, bucket base.Bucket, 
 	// set up cancellable context based on the background context (context lifecycle for the database
 	// must be distinct from the request context associated with the db create/update).  Used to trigger
 	// teardown of connected replications on database close.
-	dbContext.CancelContext, dbContext.cancelContextFunc = context.WithCancel(context.Background())
+	dbContext.CancelContext, dbContext.cancelContextFunc = context.WithCancelCause(context.Background())
 	cleanupFunctions = append(cleanupFunctions, func() {
-		dbContext.cancelContextFunc()
+		dbContext.cancelContextFunc(errors.New("DatabaseContext failed to initialize"))
 	})
 
 	// Check if server version supports multi-xattr operations, required for mou handling
@@ -655,7 +655,7 @@ func (context *DatabaseContext) Close(ctx context.Context) {
 	context.OIDCProviders.Stop()
 	close(context.terminator)
 	if context.cancelContextFunc != nil {
-		context.cancelContextFunc()
+		context.cancelContextFunc(errors.New("Database is closing"))
 	}
 
 	// Stop All background processors

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -11,6 +11,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"runtime"
@@ -1821,9 +1822,9 @@ func TestAllDocsOnly(t *testing.T) {
 
 	// Now check the changes feed:
 	var options ChangesOptions
-	changesCtx, changesCtxCancel := context.WithCancel(base.TestCtx(t))
+	changesCtx, changesCtxCancel := context.WithCancelCause(base.TestCtx(t))
 	options.ChangesCtx = changesCtx
-	defer changesCtxCancel()
+	defer changesCtxCancel(errors.New("test teardown"))
 	changes := getChanges(t, collection, channels.BaseSetOf(t, "all"), options)
 	require.Len(t, changes, 100)
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -1690,8 +1691,8 @@ func TestRevCacheOnDemand(t *testing.T) {
 	_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
 	require.NoError(t, err)
 
-	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
-	defer testCtxCancel()
+	testCtx, testCtxCancel := context.WithCancelCause(base.TestCtx(t))
+	defer testCtxCancel(errors.New("test teardown"))
 
 	for i := range 2 {
 		docID := fmt.Sprintf("extraDoc%d", i)
@@ -1899,8 +1900,8 @@ func TestRevCacheOnDemandImport(t *testing.T) {
 	_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
 	require.NoError(t, err)
 
-	ctx, testCtxCancel := context.WithCancel(ctx)
-	defer testCtxCancel()
+	ctx, testCtxCancel := context.WithCancelCause(ctx)
+	defer testCtxCancel(errors.New("test teardown"))
 
 	for i := range 2 {
 		docID := fmt.Sprintf("extraDoc%d", i)
@@ -1947,8 +1948,8 @@ func TestRevCacheOnDemandMemoryEviction(t *testing.T) {
 	_, err = collection.getRev(ctx, docID, revID, 0, nil) // load into cache
 	require.NoError(t, err)
 
-	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
-	defer testCtxCancel()
+	testCtx, testCtxCancel := context.WithCancelCause(base.TestCtx(t))
+	defer testCtxCancel(errors.New("test teardown"))
 
 	for i := range 2 {
 		docID := fmt.Sprintf("extraDoc%d", i)
@@ -2168,8 +2169,8 @@ func TestLoadActiveDocFromBucketRevCacheChurn(t *testing.T) {
 	require.NoError(t, err)
 	wg.Add(1)
 
-	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
-	defer testCtxCancel()
+	testCtx, testCtxCancel := context.WithCancelCause(base.TestCtx(t))
+	defer testCtxCancel(errors.New("test teardown"))
 
 	for i := range 2 {
 		docID := fmt.Sprintf("extraDoc%d", i)
@@ -2223,8 +2224,8 @@ func TestLoadRequestedRevFromBucketHighChurn(t *testing.T) {
 	require.NoError(t, err)
 	wg.Add(1)
 
-	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
-	defer testCtxCancel()
+	testCtx, testCtxCancel := context.WithCancelCause(base.TestCtx(t))
+	defer testCtxCancel(errors.New("test teardown"))
 
 	for i := range 2 {
 		docID := fmt.Sprintf("extraDoc%d", i)
@@ -2274,8 +2275,8 @@ func TestPutRevHighRevCacheChurn(t *testing.T) {
 	docID := "doc1"
 	wg.Add(1)
 
-	testCtx, testCtxCancel := context.WithCancel(base.TestCtx(t))
-	defer testCtxCancel()
+	testCtx, testCtxCancel := context.WithCancelCause(base.TestCtx(t))
+	defer testCtxCancel(errors.New("test teardown"))
 
 	for i := range 2 {
 		docID := fmt.Sprintf("extraDoc%d", i)

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -12,6 +12,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -783,7 +784,7 @@ func TestVariableRateAllocators(t *testing.T) {
 	require.NoError(t, err)
 
 	// All test allocators are stopped when allocatorCtx is closed
-	allocatorCtx, cancelFunc := context.WithCancel(ctx)
+	allocatorCtx, cancelFunc := context.WithCancelCause(ctx)
 
 	// Start import node allocator, performing 10000 allocations/second.
 	var allocatorWg sync.WaitGroup
@@ -827,7 +828,7 @@ func TestVariableRateAllocators(t *testing.T) {
 	updateWg.Wait()
 
 	// Stop background allocation goroutines, wait for them to close
-	cancelFunc()
+	cancelFunc(errors.New("force sequence allocators stop"))
 	allocatorWg.Wait()
 
 	log.Printf("expectedSequence (num allocations):%v", atomic.LoadUint64(&expectedAllocations))

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -12,7 +12,6 @@ package rest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -61,7 +60,7 @@ func (h *handler) handleBLIPSync() error {
 	// Create a BLIP context:
 	ctx, blipContext, err := db.NewSGBlipContext(h.ctx(), "", originPatterns, cancelCtx)
 	if err != nil {
-		cancelCtxFunc(errors.New("_blipsync handler could not initialize a BlipContext"))
+		cancelCtxFunc(fmt.Errorf("_blipsync handler could not initialize a BlipContext: %w", err))
 		return err
 	}
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -12,6 +12,7 @@ package rest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -56,11 +57,11 @@ func (h *handler) handleBLIPSync() error {
 	// error is checked at the time of database load, and ignored at this time
 	originPatterns, _ := hostOnlyCORS(h.db.CORS.Origin)
 
-	cancelCtx, cancelCtxFunc := context.WithCancel(h.db.DatabaseContext.CancelContext)
+	cancelCtx, cancelCtxFunc := context.WithCancelCause(h.db.DatabaseContext.CancelContext)
 	// Create a BLIP context:
 	ctx, blipContext, err := db.NewSGBlipContext(h.ctx(), "", originPatterns, cancelCtx)
 	if err != nil {
-		cancelCtxFunc()
+		cancelCtxFunc(errors.New("_blipsync handler could not initialize a BlipContext"))
 		return err
 	}
 

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -326,7 +327,7 @@ func (h *handler) handleChanges() error {
 	h.db.DatabaseContext.DbStats.Database().NumReplicationsTotal.Add(1)
 	defer h.db.DatabaseContext.DbStats.Database().NumReplicationsActive.Add(-1)
 
-	changesCtx, changesCtxCancel := context.WithCancel(h.ctx())
+	changesCtx, changesCtxCancel := context.WithCancelCause(h.ctx())
 	options.ChangesCtx = changesCtx
 
 	forceClose := false
@@ -353,7 +354,7 @@ func (h *handler) handleChanges() error {
 		forceClose = false
 	}
 
-	changesCtxCancel()
+	changesCtxCancel(errors.New("_changes request completed"))
 
 	// On forceClose, send notify to trigger immediate exit from change waiter
 	if forceClose {

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -63,7 +63,7 @@ type sgCollectOutputStream struct {
 
 // sgCollect manages the state of a running sgcollect_info process.
 type sgCollect struct {
-	cancel           context.CancelFunc // Function to cancel a running sgcollect_info process, set when status == sgRunning
+	cancel           context.CancelCauseFunc // Function to cancel a running sgcollect_info process, set when status == sgRunning
 	status           *uint32
 	sgPath           string    // Path to the Sync Gateway executable
 	SGCollectPath    []string  // Path to the sgcollect_info executable
@@ -108,7 +108,7 @@ func (sg *sgCollect) Start(ctx context.Context, logFilePath string, zipFilename 
 	cmdline = append(cmdline, "--sync-gateway-executable", sg.sgPath)
 	cmdline = append(cmdline, zipPath)
 
-	ctx, sg.cancel = context.WithCancel(ctx)
+	ctx, sg.cancel = context.WithCancelCause(ctx)
 	cmd := exec.CommandContext(ctx, cmdline[0], cmdline[1:]...)
 
 	err := sg.createNewToken()
@@ -162,7 +162,7 @@ func (sg *sgCollect) Stop() error {
 		return ErrSGCollectInfoNotRunning
 	}
 
-	sg.cancel()
+	sg.cancel(errors.New("/_sgcollect_info stop requested"))
 	atomic.StoreUint32(sg.status, sgStopped)
 
 	return nil

--- a/rest/utilities_testing_blip_client.go
+++ b/rest/utilities_testing_blip_client.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"iter"
 	"net/http"
@@ -369,12 +370,12 @@ type BlipTesterCollectionClient struct {
 	parent *BlipTesterClient
 
 	ctx       context.Context
-	ctxCancel context.CancelFunc
+	ctxCancel context.CancelCauseFunc
 
 	pushRunning     base.AtomicBool
 	pushGoroutineWg sync.WaitGroup
 	pushCtx         context.Context
-	pushCtxCancel   context.CancelFunc
+	pushCtxCancel   context.CancelCauseFunc
 
 	collection    string
 	collectionIdx int
@@ -1295,7 +1296,7 @@ func (e proposeChangeBatchEntry) GoString() string {
 func (btcc *BlipTesterCollectionClient) StartPushWithOpts(opts BlipTesterPushOptions) {
 	require.True(btcc.TB(), btcc.pushRunning.CASRetry(false, true), "push replication already running")
 
-	btcc.pushCtx, btcc.pushCtxCancel = context.WithCancel(btcc.ctx)
+	btcc.pushCtx, btcc.pushCtxCancel = context.WithCancelCause(btcc.ctx)
 	ctx := btcc.pushCtx
 	sinceFromStr, err := db.ParsePlainSequenceID(opts.Since)
 	require.NoError(btcc.TB(), err)
@@ -1526,7 +1527,7 @@ func (btcc *BlipTesterCollectionClient) StartPullSince(options BlipTesterPullOpt
 
 func (btcc *BlipTesterCollectionClient) StopPush() {
 	require.True(btcc.TB(), btcc.pushRunning.IsTrue(), "can't stop push replication - not running")
-	btcc.pushCtxCancel()
+	btcc.pushCtxCancel(errors.New("StopPush called"))
 
 	// Wake up any waiting push loops to check for cancellation
 	btcc._seqCond.Broadcast()
@@ -1554,7 +1555,7 @@ func (btcc *BlipTesterCollectionClient) UnsubPullChanges() {
 
 // NewBlipTesterCollectionClient creates a collection specific client from a BlipTesterClient
 func NewBlipTesterCollectionClient(ctx context.Context, btc *BlipTesterClient) *BlipTesterCollectionClient {
-	ctx, ctxCancel := context.WithCancel(ctx)
+	ctx, ctxCancel := context.WithCancelCause(ctx)
 	l := sync.RWMutex{}
 	c := &BlipTesterCollectionClient{
 		ctx:           ctx,
@@ -1573,7 +1574,7 @@ func NewBlipTesterCollectionClient(ctx context.Context, btc *BlipTesterClient) *
 
 // Close will empty the stored docs and close the underlying replications.
 func (btcc *BlipTesterCollectionClient) Close() {
-	btcc.ctxCancel()
+	btcc.ctxCancel(errors.New("BlipTesterCollectionClient closed"))
 
 	// wake up changes feeds to exit - don't need lock for sync.Cond
 	btcc._seqCond.Broadcast()

--- a/tools/cache_perf_tool/main.go
+++ b/tools/cache_perf_tool/main.go
@@ -11,6 +11,7 @@ package main // main.go
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -94,7 +95,7 @@ func main() {
 	}
 
 	parentCtx := context.Background()
-	ctx, cancelFunc := context.WithCancel(parentCtx)
+	ctx, cancelFunc := context.WithCancelCause(parentCtx)
 
 	// Need a bucket type for creating the database context
 	var walrusBucket *rosmar.Bucket
@@ -228,7 +229,7 @@ outerloop:
 	for {
 		select {
 		case <-ticker.C:
-			cancelFunc()
+			cancelFunc(errors.New("test duration complete"))
 			break outerloop
 		}
 	}


### PR DESCRIPTION
CBG-4771 use context.WithCancelCause

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- [x]  https://jenkins.sgwdev.com/job/SyncGatewayIntegration/452/
