### PR TITLE
DOC-14086: Cleanup Prometheus metrics OpenAPI spec

### DIFF
--- a/docs/api/components/responses.yaml
+++ b/docs/api/components/responses.yaml
@@ -213,7 +213,7 @@ expvar_reponses:
   '200':
     description: |-
       Successfully returned statistics.
-      For details, see [JSON Metrics](stats-monitoring-json.html).
+      For details, see [JSON Metrics](../monitoring/stats-monitoring-json.html).
     content:
       application/json:
         schema:

--- a/docs/api/components/responses.yaml
+++ b/docs/api/components/responses.yaml
@@ -218,3 +218,24 @@ expvar_reponses:
       application/json:
         schema:
           $ref: ./schemas.yaml#/ExpVars
+prometheus_metrics_responses:
+  '200':
+    content:
+      text/plain:
+        example: |-
+          # HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
+          # TYPE go_gc_duration_seconds summary
+          go_gc_duration_seconds{quantile="0"} 3.2374e-05
+          go_gc_duration_seconds{quantile="0.25"} 3.6417e-05
+          go_gc_duration_seconds{quantile="0.5"} 7.9875e-05
+          go_gc_duration_seconds{quantile="0.75"} 0.000152499
+          go_gc_duration_seconds{quantile="1"} 0.001503708
+          go_gc_duration_seconds_sum 0.002018457
+          go_gc_duration_seconds_count 7
+          # HELP go_gc_gogc_percent Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent
+          # TYPE go_gc_gogc_percent gauge
+          go_gc_gogc_percent 100
+          ...
+    description: |-
+      Successfully returned statistics.
+      For detailed metrics descriptions, see [Prometheus Metrics](../monitoring/stats-monitoring-prometheus.html).

--- a/docs/api/components/responses.yaml
+++ b/docs/api/components/responses.yaml
@@ -213,7 +213,7 @@ expvar_reponses:
   '200':
     description: |-
       Successfully returned statistics.
-      For details, see [JSON Metrics](../monitoring/stats-monitoring-json.html).
+      For details, see [JSON Metrics](../manage/stats-monitoring-json.html).
     content:
       application/json:
         schema:
@@ -238,4 +238,4 @@ prometheus_metrics_responses:
           ...
     description: |-
       Successfully returned statistics.
-      For detailed metrics descriptions, see [Prometheus Metrics](../monitoring/stats-monitoring-prometheus.html).
+      For detailed metrics descriptions, see [Prometheus Metrics](../manage/stats-monitoring-prometheus.html).

--- a/docs/api/metric.yaml
+++ b/docs/api/metric.yaml
@@ -35,7 +35,7 @@ paths:
   /_ping:
     $ref: ./paths/common/_ping.yaml
   /_metrics:
-    $ref: ./paths/metric/metrics.yaml
+    $ref: ./paths/metric/metrics_deprecated.yaml
     x-internal: true
   /metrics:
     $ref: ./paths/metric/metrics.yaml

--- a/docs/api/paths/metric/_expvar.yaml
+++ b/docs/api/paths/metric/_expvar.yaml
@@ -13,7 +13,7 @@ get:
 
     This includes per database stats, replication stats, and server stats.
 
-    For details, see [JSON Metrics](../monitoring/stats-monitoring-json.html).
+    For details, see [JSON Metrics](../manage/stats-monitoring-json.html).
 
     Required Sync Gateway RBAC roles:
 

--- a/docs/api/paths/metric/_expvar.yaml
+++ b/docs/api/paths/metric/_expvar.yaml
@@ -13,6 +13,8 @@ get:
 
     This includes per database stats, replication stats, and server stats.
 
+    For details, see [JSON Metrics](../monitoring/stats-monitoring-json.html).
+
     Required Sync Gateway RBAC roles:
 
     * Sync Gateway Architect

--- a/docs/api/paths/metric/metrics.yaml
+++ b/docs/api/paths/metric/metrics.yaml
@@ -10,7 +10,7 @@ get:
   description: |-
     Returns Sync Gateway statistics and other runtime variables in Prometheus Exposition format.
 
-    For detailed metrics descriptions, see [Prometheus Metrics](../monitoring/stats-monitoring-prometheus.html).
+    For detailed metrics descriptions, see [Prometheus Metrics](../manage/stats-monitoring-prometheus.html).
 
     Required Sync Gateway RBAC roles:
 

--- a/docs/api/paths/metric/metrics_deprecated.yaml
+++ b/docs/api/paths/metric/metrics_deprecated.yaml
@@ -13,7 +13,7 @@ get:
 
     Returns Sync Gateway statistics and other runtime variables in Prometheus Exposition format.
 
-    For detailed metrics descriptions, see [Prometheus Metrics](../monitoring/stats-monitoring-prometheus.html).
+    For detailed metrics descriptions, see [Prometheus Metrics](../manage/stats-monitoring-prometheus.html).
 
     Required Sync Gateway RBAC roles:
 

--- a/docs/api/paths/metric/metrics_deprecated.yaml
+++ b/docs/api/paths/metric/metrics_deprecated.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-Present Couchbase, Inc.
+# Copyright 2026-Present Couchbase, Inc.
 #
 # Use of this software is governed by the Business Source License included
 # in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
@@ -6,8 +6,11 @@
 # software will be governed by the Apache License, Version 2.0, included in
 # the file licenses/APL2.txt.
 get:
+  deprecated: true
   summary: Get debugging and monitoring runtime stats in Prometheus Exposition format
   description: |-
+    **Deprecated: Use the [`/metrics`](#tag/Prometheus/operation/get_metrics) endpoint instead.**
+
     Returns Sync Gateway statistics and other runtime variables in Prometheus Exposition format.
 
     For detailed metrics descriptions, see [Prometheus Metrics](../monitoring/stats-monitoring-prometheus.html).
@@ -21,4 +24,4 @@ get:
     $ref: ../../components/responses.yaml#/prometheus_metrics_responses
   tags:
     - Prometheus
-  operationId: get_metrics
+  operationId: get__metrics

--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -4,7 +4,7 @@ With Sync Gateway version 2.8, a new endpoint is provided that exposes stats in 
 
 In order to make the installation and setup process easier we have provided both a `prometheus.yml` file and a set of rules under `rules/sync-gateway.rules.yml`.
 
-The `prometheus.yml` file specifies the configuration required to scrape the Sync Gateway metrics target. The provided `prometheus.yml` file points to the `metricsInterface` being accessible on `sync_gateway:4986/_metrics`. This can be changed to a different host or multiple targets can be added if required.
+The `prometheus.yml` file specifies the configuration required to scrape the Sync Gateway metrics target. The provided `prometheus.yml` file points to the `metricsInterface` being accessible on `sync_gateway:4986/metrics`. This can be changed to a different host or multiple targets can be added if required.
 
 Within this file a rules directory is provided which contains some pre-configured rules:
  - A total queries record that adds up all query counts and saves it as `sgw::gsi::total_queries`

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -124,7 +124,7 @@ func TestPublicRESTStatCount(t *testing.T) {
 	defer srv.Close()
 
 	// test metrics endpoint
-	response, err := http.Get(srv.URL + "/_metrics")
+	response, err := http.Get(srv.URL + "/metrics")
 	require.NoError(t, err)
 	require.NoError(t, response.Body.Close())
 	assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -2749,7 +2749,7 @@ func TestMetricsHandler(t *testing.T) {
 		base.SkipPrometheusStatsRegistration = true
 	}()
 
-	// Create and remove a databaseion
+	// Create and remove a database
 	// This ensures that creation and removal of a DB is possible without a re-registration issue ( the below rest tester will re-register "db")
 	ctx := base.TestCtx(t)
 	tBucket := base.GetTestBucket(t)
@@ -2766,14 +2766,13 @@ func TestMetricsHandler(t *testing.T) {
 	defer srv.Close()
 
 	// Ensure metrics endpoint is accessible and that db database has entries
-	resp, err := http.Get(srv.URL + "/_metrics")
+	resp, err := http.Get(srv.URL + "/metrics")
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	bodyString, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
 	assert.Contains(t, string(bodyString), `database="db"`)
-	err = resp.Body.Close()
-	assert.NoError(t, err)
 
 	// Initialize another database to ensure both are registered successfully
 	tBucket2 := base.GetTestBucket(t)
@@ -2782,22 +2781,29 @@ func TestMetricsHandler(t *testing.T) {
 	defer context.Close(context.AddDatabaseLogContext(ctx))
 
 	// Validate that metrics still works with both db and db2 databases and that they have entries
-	resp, err = http.Get(srv.URL + "/_metrics")
+	resp, err = http.Get(srv.URL + "/metrics")
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	bodyString, err = io.ReadAll(resp.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
 	assert.Contains(t, string(bodyString), `database="db"`)
 	assert.Contains(t, string(bodyString), `database="db2"`)
-	err = resp.Body.Close()
-	assert.NoError(t, err)
+
+	// check /_metrics 'alias'
+	resp, err = http.Get(srv.URL + "/_metrics")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	aliasedBodyString, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, string(aliasedBodyString), string(bodyString))
 
 	// Ensure metrics endpoint is not serving any other routes
 	resp, err = http.Get(srv.URL + "/" + rt.GetSingleKeyspace() + "/")
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	err = resp.Body.Close()
-	assert.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
 }
 
 func TestDocChannelSetPruning(t *testing.T) {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2794,10 +2794,11 @@ func TestMetricsHandler(t *testing.T) {
 	resp, err = http.Get(srv.URL + "/_metrics")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	aliasedBodyString, err := io.ReadAll(resp.Body)
+	bodyString, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, string(aliasedBodyString), string(bodyString))
+	assert.Contains(t, string(bodyString), `database="db"`)
+	assert.Contains(t, string(bodyString), `database="db2"`)
 
 	// Ensure metrics endpoint is not serving any other routes
 	resp, err = http.Get(srv.URL + "/" + rt.GetSingleKeyspace() + "/")

--- a/rest/audit_test.go
+++ b/rest/audit_test.go
@@ -445,7 +445,7 @@ func TestAuditLoggingFields(t *testing.T) {
 				headers := map[string]string{
 					"Authorization": GetBasicAuthHeader(t, base.TestClusterUsername(), base.TestClusterPassword()),
 				}
-				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", headers), http.StatusOK)
+				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/metrics", "", headers), http.StatusOK)
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDSyncGatewayStats: {
@@ -459,7 +459,7 @@ func TestAuditLoggingFields(t *testing.T) {
 				if !rt.AdminInterfaceAuthentication {
 					t.Skip("Skipping subtest that requires admin auth to be enabled")
 				}
-				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", nil), http.StatusUnauthorized)
+				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/metrics", "", nil), http.StatusUnauthorized)
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDAdminUserAuthenticationFailed: {
@@ -476,7 +476,7 @@ func TestAuditLoggingFields(t *testing.T) {
 				headers := map[string]string{
 					"Authorization": GetBasicAuthHeader(t, "notauser", base.TestClusterPassword()),
 				}
-				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/_metrics", "", headers), http.StatusUnauthorized)
+				RequireStatus(t, rt.SendMetricsRequestWithHeaders(http.MethodGet, "/metrics", "", headers), http.StatusUnauthorized)
 			},
 			expectedAuditEventFields: map[base.AuditID]base.AuditFields{
 				base.AuditIDAdminUserAuthenticationFailed: {

--- a/rest/bytes_read_public_api_test.go
+++ b/rest/bytes_read_public_api_test.go
@@ -70,7 +70,7 @@ func TestBytesReadDocOperations(t *testing.T) {
 	defer srv.Close()
 
 	// test metrics endpoint, assert the stat doesn't increment
-	response, err := http.Get(srv.URL + "/_metrics")
+	response, err := http.Get(srv.URL + "/metrics")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	require.NoError(t, response.Body.Close())

--- a/rest/stats_context_test.go
+++ b/rest/stats_context_test.go
@@ -54,7 +54,7 @@ func TestDescriptionPopulation(t *testing.T) {
 	defer srv.Close()
 
 	// Ensure metrics endpoint is accessible and that db database has entries
-	resp, err := http.Get(srv.URL + "/_metrics")
+	resp, err := http.Get(srv.URL + "/metrics")
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, resp.Body.Close())


### PR DESCRIPTION
DOC-14086

Cleanup Prometheus metrics OpenAPI spec

- Deprecate `/_metrics` in OpenAPI spec and point people towards the standarized `/metrics` endpoint alias.
- Provide truncated plain text example of Prometheus output.
- Move tests to standardized `/metrics` endpoint. Add single assertion case for `/_metrics` alias.
- Fix link to the on-prem docs for detailed Prometheus Metrics page.

## Docs preview:

<img width="1898" height="2014" alt="Screenshot 2026-04-08 at 12 29 58" src="https://github.com/user-attachments/assets/0e57b82b-0524-4740-9f42-8b343da57364" />

## [Integration Tests](https://jenkins.sgwdev.com/job/SyncGatewayIntegration/build?delay=0sec)
- n/a