### PR TITLE
CBG-5213 implement private API for rosmar bucket deletion

### DIFF
--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -188,6 +188,12 @@ paths:
     $ref: './paths/common/db-_ensure_full_commit.yaml'
   /_logging:
     $ref: ./paths/admin/_logging.yaml
+  /_rosmar:
+    x-internal: true
+    $ref: ./paths/admin/_rosmar.yaml
+  '/_rosmar/{bucketkeyspace}':
+    x-internal: true
+    $ref: './paths/admin/_rosmar-bucketkeyspace.yaml'
 tags:
   - name: Authentication
     description: Manage authentication

--- a/docs/api/admin.yaml
+++ b/docs/api/admin.yaml
@@ -188,7 +188,7 @@ paths:
     $ref: './paths/common/db-_ensure_full_commit.yaml'
   /_logging:
     $ref: ./paths/admin/_logging.yaml
-  /_rosmar:
+  /_rosmar/:
     x-internal: true
     $ref: ./paths/admin/_rosmar.yaml
   '/_rosmar/{bucketkeyspace}':

--- a/docs/api/paths/admin/_rosmar-bucketkeyspace.yaml
+++ b/docs/api/paths/admin/_rosmar-bucketkeyspace.yaml
@@ -12,7 +12,7 @@ delete:
     Deletes the specified bucket, scope, or collection in the connected Rosmar server.
     The resource must follow one of these formats: 'bucket', 'bucket.scope', or 'bucket.scope.collection'.
 
-    Deleting a non existing scope or collection will 404 but deleting a non existing bucket returns 200.
+    Deleting a non existing bucket or collection will 404 but deleting a non existing collection returns 200.
   parameters:
     - name: bucketkeyspace
       in: path
@@ -25,7 +25,7 @@ delete:
     '400':
       description: Invalid bucketkeyspace format, or server is not a Rosmar bucket, or requires persistent config
     '404':
-      description: The specified scope, or collection was not found
+      description: The specified bucket or scope was not found
     '500':
       description: Internal Server Error
   tags:

--- a/docs/api/paths/admin/_rosmar-bucketkeyspace.yaml
+++ b/docs/api/paths/admin/_rosmar-bucketkeyspace.yaml
@@ -1,0 +1,35 @@
+# Copyright 2026-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+delete:
+  x-internal: true
+  summary: Delete a Rosmar bucket, scope, or collection
+  description: |-
+    Deletes the specified bucket, scope, or collection in the connected Rosmar server.
+    The resource must follow one of these formats: 'bucket', 'bucket.scope', or 'bucket.scope.collection'.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Dev Ops
+  parameters:
+    - name: bucketkeyspace
+      in: path
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Successfully deleted the bucket, scope, or collection
+    '400':
+      description: Invalid bucketkeyspace format, or server is not a Rosmar bucket, or requires persistent config
+    '404':
+      description: The specified bucket, scope, or collection was not found
+    '500':
+      description: Internal Server Error
+  tags:
+    - Unsupported
+  operationId: delete__rosmar_bucketkeyspace

--- a/docs/api/paths/admin/_rosmar-bucketkeyspace.yaml
+++ b/docs/api/paths/admin/_rosmar-bucketkeyspace.yaml
@@ -12,9 +12,7 @@ delete:
     Deletes the specified bucket, scope, or collection in the connected Rosmar server.
     The resource must follow one of these formats: 'bucket', 'bucket.scope', or 'bucket.scope.collection'.
 
-    Required Sync Gateway RBAC roles:
-
-    * Sync Gateway Dev Ops
+    Deleting a non existing scope or collection will 404 but deleting a non existing bucket returns 200.
   parameters:
     - name: bucketkeyspace
       in: path
@@ -27,7 +25,7 @@ delete:
     '400':
       description: Invalid bucketkeyspace format, or server is not a Rosmar bucket, or requires persistent config
     '404':
-      description: The specified bucket, scope, or collection was not found
+      description: The specified scope, or collection was not found
     '500':
       description: Internal Server Error
   tags:

--- a/docs/api/paths/admin/_rosmar.yaml
+++ b/docs/api/paths/admin/_rosmar.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included
+# in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+# in that file, in accordance with the Business Source License, use of this
+# software will be governed by the Apache License, Version 2.0, included in
+# the file licenses/APL2.txt.
+get:
+  x-internal: true
+  summary: Get a list of all Rosmar buckets, scopes, and collections
+  description: |-
+    This retrieves all the buckets, scopes, and collections from the connected Rosmar server.
+
+    Required Sync Gateway RBAC roles:
+
+    * Sync Gateway Dev Ops
+  responses:
+    '200':
+      description: Successfully retrieved all bucket, scope, and collection names
+      content:
+        application/json:
+          schema:
+            type: object
+            additionalProperties:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
+  tags:
+    - Unsupported
+  operationId: get__rosmar

--- a/docs/api/paths/admin/_rosmar.yaml
+++ b/docs/api/paths/admin/_rosmar.yaml
@@ -29,7 +29,7 @@ get:
                 type: array
                 items:
                   type: string
-                  example: ["collectionname1", "collectionname2"]
+                example: ["collectionname1", "collectionname2"]
   tags:
     - Unsupported
   operationId: get__rosmar

--- a/docs/api/paths/admin/_rosmar.yaml
+++ b/docs/api/paths/admin/_rosmar.yaml
@@ -22,11 +22,14 @@ get:
           schema:
             type: object
             additionalProperties:
+              x-additionalPropertiesName: bucketname
               type: object
               additionalProperties:
+                x-additionalPropertiesName: scopename
                 type: array
                 items:
                   type: string
+                  example: ["collectionname1", "collectionname2"]
   tags:
     - Unsupported
   operationId: get__rosmar

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -163,7 +163,9 @@ func registerConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]con
 		"unsupported.audit_info_provider.global_info_env_var_name": {config: &config.Unsupported.AuditInfoProvider.GlobalInfoEnvVarName, flagValue: fs.String("unsupported.audit_info_provider.global_info_env_var_name", "", "Environment variable name to get global audit event info from")},
 		"unsupported.audit_info_provider.request_info_header_name": {config: &config.Unsupported.AuditInfoProvider.RequestInfoHeaderName, flagValue: fs.String("unsupported.audit_info_provider.request_info_header_name", "", "Header name to get request audit event info from")},
 		"unsupported.effective_user_header_name":                   {config: &config.Unsupported.EffectiveUserHeaderName, flagValue: fs.String("unsupported.effective_user_header_name", "", "HTTP header name to get effective user id from")},
-
+		"unsupported.rosmar_bucket_management": {
+			config: &config.Unsupported.RosmarBucketManagement, flagValue: fs.Bool("unsupported.rosmar_bucket_management", false, "Allow API to manage rosmar buckets"),
+		},
 		// Note: These flags are X.509-only. Username/passwords are rejected if specified, as we are not allowing them to be used in the command line flags, only the config file.
 		"database_credentials": {config: &config.DatabaseCredentials, flagValue: fs.String("database_credentials", "null", "JSON-encoded per-database credentials (X.509 only), that can be used instead of the bootstrap ones. This will override bucket_credentials that target the bucket that the database is in.")},
 		"bucket_credentials":   {config: &config.BucketCredentials, flagValue: fs.String("bucket_credentials", "null", "JSON-encoded per-bucket credentials (X.509 only), that can be used instead of the bootstrap ones.")},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -166,6 +166,7 @@ type UnsupportedConfig struct {
 	DiagnosticInterface     string                   `json:"diagnostic_interface,omitempty"    help:"Network interface to bind diagnostic API to"`
 	EffectiveUserHeaderName *string                  `json:"effective_user_header_name,omitempty" help:"HTTP header name to get effective user id from"`
 	AuditInfoProvider       *AuditInfoProviderConfig `json:"audit_info_provider,omitempty"     help:"Configuration for audit info provider"`
+	RosmarBucketManagement  *bool                    `json:"rosmar_bucket_management,omitempty" help:"Enable Rosmar bucket management REST API"`
 }
 
 type AuditInfoProviderConfig struct {

--- a/rest/rosmar_api.go
+++ b/rest/rosmar_api.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/rosmar"
+)
+
+// GET /_rosmar/
+func (h *handler) handleRosmarGet() error {
+	if h.server.BootstrapContext == nil || h.server.BootstrapContext.Connection == nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "This requires persistent config")
+	}
+
+	serverURL := h.server.Config.Bootstrap.Server
+	if !base.ServerIsWalrus(serverURL) {
+		return base.HTTPErrorf(http.StatusBadRequest, "This is not a rosmar bucket")
+	}
+
+	bucketNames, err := h.server.BootstrapContext.Connection.GetConfigBuckets(h.ctx())
+	if err != nil {
+		return err
+	}
+	result := make(map[string]base.CollectionNames)
+
+	for _, bucketName := range bucketNames {
+		bucket, err := rosmar.OpenBucketIn(serverURL, bucketName, rosmar.ReOpenExisting)
+		if err != nil {
+			return err
+		}
+		defer bucket.Close(h.ctx())
+
+		dsNames, err := bucket.ListDataStores()
+		if err != nil {
+			continue
+		}
+
+		result[bucketName] = base.NewCollectionNames(dsNames...)
+	}
+	h.writeJSON(result)
+	return nil
+}
+
+// DELETE /_rosmar/{bucketkeyspace}
+func (h *handler) handleRosmarDelete() error {
+	if h.server.BootstrapContext == nil || h.server.BootstrapContext.Connection == nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "This requires persistent config")
+	}
+
+	serverURL := h.server.Config.Bootstrap.Server
+	if !base.ServerIsWalrus(serverURL) {
+		return base.HTTPErrorf(http.StatusBadRequest, "This is not a rosmar bucket")
+	}
+
+	bucketkeyspace := h.PathVar("bucketkeyspace")
+	parts := strings.Split(bucketkeyspace, ".")
+	bucketName := parts[0]
+
+	// Check if the bucket exists
+	bucketNames, err := h.server.BootstrapContext.Connection.GetConfigBuckets(h.ctx())
+	if err != nil {
+		return err
+	}
+
+	existsInCluster := false
+	for _, b := range bucketNames {
+		if b == bucketName {
+			existsInCluster = true
+			break
+		}
+	}
+
+	if !existsInCluster {
+		return base.HTTPErrorf(http.StatusNotFound, "Bucket %s not found", bucketName)
+	}
+
+	bucket, err := rosmar.OpenBucketIn(serverURL, bucketName, rosmar.ReOpenExisting)
+	if err != nil {
+		return fmt.Errorf("could not open bucket: %w", err)
+	}
+	defer bucket.Close(h.ctx())
+
+	switch len(parts) {
+	case 1:
+		// DELETE /_rosmar/bucketname
+		return bucket.CloseAndDelete(h.ctx())
+	case 2:
+		// DELETE /_rosmar/bucketname.scopename
+		scopeName := parts[1]
+
+		dsNames, err := bucket.ListDataStores()
+		if err != nil {
+			return err
+		}
+
+		droppedAny := false
+		for _, ds := range dsNames {
+			if ds.ScopeName() == scopeName {
+				droppedAny = true
+				if err := bucket.DropDataStore(ds); err != nil {
+					return err
+				}
+			}
+		}
+
+		if !droppedAny {
+			return base.HTTPErrorf(http.StatusNotFound, "Scope %s not found", scopeName)
+		}
+		return nil
+	case 3:
+		// DELETE /_rosmar/bucketname.scopename.collectionname
+		scopeName := parts[1]
+		collectionName := parts[2]
+
+		err = bucket.DropDataStore(base.NewScopeAndCollectionName(scopeName, collectionName))
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	return base.HTTPErrorf(http.StatusBadRequest, "Invalid bucketkeyspace format. Expected formats are: 'bucket', 'bucket.scope', or 'bucket.scope.collection'")
+}

--- a/rest/rosmar_api.go
+++ b/rest/rosmar_api.go
@@ -67,6 +67,22 @@ func (h *handler) handleRosmarDelete() error {
 
 	bucketkeyspace := h.PathVar("bucketkeyspace")
 	parts := strings.Split(bucketkeyspace, ".")
+	switch len(parts) {
+	case 1:
+		if parts[0] == "" {
+			return base.HTTPErrorf(http.StatusBadRequest, "Invalid bucketkeyspace format. Expected formats are: 'bucket', 'bucket.scope', or 'bucket.scope.collection'")
+		}
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return base.HTTPErrorf(http.StatusBadRequest, "Invalid bucketkeyspace format. Expected formats are: 'bucket', 'bucket.scope', or 'bucket.scope.collection'")
+		}
+	case 3:
+		if parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			return base.HTTPErrorf(http.StatusBadRequest, "Invalid bucketkeyspace format. Expected formats are: 'bucket', 'bucket.scope', or 'bucket.scope.collection'")
+		}
+	default:
+		return base.HTTPErrorf(http.StatusBadRequest, "Invalid bucketkeyspace format. Expected formats are: 'bucket', 'bucket.scope', or 'bucket.scope.collection'")
+	}
 	bucketName := parts[0]
 
 	// Check if the bucket exists

--- a/rest/rosmar_api.go
+++ b/rest/rosmar_api.go
@@ -45,7 +45,7 @@ func (h *handler) handleRosmarGet() error {
 
 		dsNames, err := bucket.ListDataStores()
 		if err != nil {
-			continue
+			return err
 		}
 
 		result[bucketName] = base.NewCollectionNames(dsNames...)

--- a/rest/rosmar_api_test.go
+++ b/rest/rosmar_api_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026-Present Couchbase, Inc.
+
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/rosmar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRosmarManagementAPI(t *testing.T) {
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Rosmar/Walrus")
+	}
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		PersistentConfig: true,
+		MutateStartupConfig: func(config *StartupConfig) {
+			config.Unsupported.RosmarBucketManagement = base.Ptr(true)
+		},
+	})
+	defer rt.Close()
+
+	bucketName := rt.Bucket().GetName()
+
+	// GET /_rosmar/
+	t.Run("GetRosmarBuckets", func(t *testing.T) {
+		resp := rt.SendAdminRequest(http.MethodGet, "/_rosmar/", "")
+		RequireStatus(t, resp, http.StatusOK)
+		var body map[string]base.CollectionNames
+		require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &body))
+		assert.Contains(t, body, bucketName)
+		// Should have default scope/collection at least
+		assert.Contains(t, body[bucketName], base.DefaultScope)
+	})
+
+	// DELETE scope
+	t.Run("DeleteScope", func(t *testing.T) {
+		// Create a new scope/collection first
+		scopeName := "testscope"
+		collectionName := "testcoll"
+		dynamicBucket, ok := rt.Bucket().(sgbucket.DynamicDataStoreBucket)
+		require.True(t, ok)
+		err := dynamicBucket.CreateDataStore(rt.Context(), base.NewScopeAndCollectionName(scopeName, collectionName))
+		require.NoError(t, err)
+
+		// Verify it exists in GET /_rosmar/
+		resp := rt.SendAdminRequest(http.MethodGet, "/_rosmar/", "")
+		var body map[string]base.CollectionNames
+		require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &body))
+		assert.Contains(t, body, bucketName)
+		assert.Contains(t, body[bucketName], scopeName)
+
+		// DELETE /_rosmar/bucket.scope
+		resp = rt.SendAdminRequest(http.MethodDelete, fmt.Sprintf("/_rosmar/%s.%s", bucketName, scopeName), "")
+		RequireStatus(t, resp, http.StatusOK)
+
+		// Verify it's gone
+		resp = rt.SendAdminRequest(http.MethodGet, "/_rosmar/", "")
+		require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &body))
+		assert.NotContains(t, body[bucketName], scopeName)
+	})
+
+	// DELETE collection
+	t.Run("DeleteCollection", func(t *testing.T) {
+		scopeName := "testscope2"
+		collectionName := "testcoll2"
+		dynamicBucket, ok := rt.Bucket().(sgbucket.DynamicDataStoreBucket)
+		require.True(t, ok)
+		err := dynamicBucket.CreateDataStore(rt.Context(), base.NewScopeAndCollectionName(scopeName, collectionName))
+		require.NoError(t, err)
+
+		// DELETE /_rosmar/bucket.scope.collection
+		resp := rt.SendAdminRequest(http.MethodDelete, fmt.Sprintf("/_rosmar/%s.%s.%s", bucketName, scopeName, collectionName), "")
+		RequireStatus(t, resp, http.StatusOK)
+
+		// Verify it's gone from ListDataStores
+		dsNames, err := rt.Bucket().ListDataStores()
+		require.NoError(t, err)
+		for _, ds := range dsNames {
+			if ds.ScopeName() == scopeName && ds.CollectionName() == collectionName {
+				t.Fatalf("Collection should have been deleted")
+			}
+		}
+	})
+
+	// DELETE bucket
+	t.Run("DeleteBucket", func(t *testing.T) {
+		newBucketName := "deleteme"
+		_, err := rosmar.OpenBucketIn(rt.ServerContext().Config.Bootstrap.Server, newBucketName, rosmar.CreateOrOpen)
+		require.NoError(t, err)
+
+		// DELETE /_rosmar/bucket
+		resp := rt.SendAdminRequest(http.MethodDelete, "/_rosmar/"+newBucketName, "")
+		RequireStatus(t, resp, http.StatusOK)
+
+		// Verify it's gone from rosmar.GetBucketNames
+		bucketNames := rosmar.GetBucketNames()
+		found := false
+		for _, b := range bucketNames {
+			if b == newBucketName {
+				found = true
+				break
+			}
+		}
+		assert.False(t, found, "Bucket should have been deleted")
+	})
+
+	// DropDataStore behavior cases
+	t.Run("DropDataStoreBehavior", func(t *testing.T) {
+		resp := rt.SendAdminRequest(http.MethodDelete, "/_rosmar/nonexistent", "")
+		RequireStatus(t, resp, http.StatusNotFound)
+
+		// Scope drop fails with 404 since it doesn't contain collections
+		resp = rt.SendAdminRequest(http.MethodDelete, fmt.Sprintf("/_rosmar/%s.nonexistent", bucketName), "")
+		RequireStatus(t, resp, http.StatusNotFound)
+
+		// Collection drop silently succeeds even if not found in Rosmar
+		resp = rt.SendAdminRequest(http.MethodDelete, fmt.Sprintf("/_rosmar/%s._default.nonexistent", bucketName), "")
+		RequireStatus(t, resp, http.StatusOK)
+	})
+}

--- a/rest/rosmar_api_test.go
+++ b/rest/rosmar_api_test.go
@@ -104,7 +104,9 @@ func TestRosmarManagementAPI(t *testing.T) {
 		b, err := rosmar.OpenBucketIn(rt.ServerContext().Config.Bootstrap.Server, newBucketName, rosmar.CreateOrOpen)
 		require.NoError(t, err)
 		ctx := base.TestCtx(t)
-		defer b.CloseAndDelete(ctx)
+		defer func() {
+			assert.NoError(t, b.CloseAndDelete(ctx))
+		}()
 
 		// DELETE /_rosmar/bucket
 		resp := rt.SendAdminRequest(http.MethodDelete, "/_rosmar/"+newBucketName, "")

--- a/rest/rosmar_api_test.go
+++ b/rest/rosmar_api_test.go
@@ -101,8 +101,10 @@ func TestRosmarManagementAPI(t *testing.T) {
 	// DELETE bucket
 	t.Run("DeleteBucket", func(t *testing.T) {
 		newBucketName := "deleteme"
-		_, err := rosmar.OpenBucketIn(rt.ServerContext().Config.Bootstrap.Server, newBucketName, rosmar.CreateOrOpen)
+		b, err := rosmar.OpenBucketIn(rt.ServerContext().Config.Bootstrap.Server, newBucketName, rosmar.CreateOrOpen)
 		require.NoError(t, err)
+		ctx := base.TestCtx(t)
+		defer b.CloseAndDelete(ctx)
 
 		// DELETE /_rosmar/bucket
 		resp := rt.SendAdminRequest(http.MethodDelete, "/_rosmar/"+newBucketName, "")

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -342,6 +342,12 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	r.Handle("/_all_dbs",
 		makeHandlerWithOptions(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleAllDbs, handlerOptions{sgcollect: true})).Methods("GET", "HEAD")
 
+	// Rosmar bucket management API
+	if sc.Config.Unsupported.RosmarBucketManagement != nil && *sc.Config.Unsupported.RosmarBucketManagement {
+		r.Handle("/_rosmar/", makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleRosmarGet)).Methods("GET")
+		r.Handle("/_rosmar/{bucketkeyspace}", makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleRosmarDelete)).Methods("DELETE")
+	}
+
 	return r
 }
 


### PR DESCRIPTION
CBG-5213 implement private API for rosmar bucket deletion

The purpose is to support running couchbase-lite-tests e2e tests, which reuse bucket names between test runs and there is no ability to clear out buckets. This code is hidden behind unsupported API flag.

Written with gemini code assist and tested with a small change couchbase-lite-tests - all e2e tests pass. The only API that is actually used is `DELETE /_rosmar/bucketname` but I added ability to list buckets/collections. I'm neutral/negative on the API support to delete a scope or collection in rosmar. This is not needed for couchbase-lite-tests so I can remove this if it's complicated. It's a keyspace of `bucket.scope.collection` in the way that Couchbase Server uses the term keyspace but not in the way that Sync Gateway does of `database.scope.collection`

In rosmar, scopes are implicitly if a collection exists, and collections are created on the fly if they don't exist, so there is no need to manually create one.

## Pre-review checklist
- [x] Removed debug logging (`fmt.Print`, `log.Print`, ...)
- [x] Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)
- [x] Updated relevant information in the API specifications (such as endpoint descriptions, schemas, ...) in `docs/api`

